### PR TITLE
fix(install): resolve REPO_DIR via fileURLToPath for paths with spaces

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -17,10 +17,11 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { fileURLToPath } from 'url'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const SCRIPTS_DIR = path.join(GLOBAL_DIR, 'scripts')
-const REPO_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_DIR = path.dirname(fileURLToPath(import.meta.url))
 const REPO_SCRIPTS = path.join(REPO_DIR, 'scripts')
 const REPO_INSTRUCTIONS = path.join(REPO_DIR, 'instructions')
 


### PR DESCRIPTION
## Summary

- `install.mjs` fails when the repo is cloned into a directory whose absolute path contains a space (e.g. `~/Documents/New project 3/`).
- Root cause: `new URL(import.meta.url).pathname` returns a percent-encoded path (`/Users/x/Documents/New%20project%203/.../install.mjs`). `fs.readdirSync(REPO_SCRIPTS)` then fails because `New%20project%203` isn't a real directory.
- Fix: use `fileURLToPath` from Node's `url` module — the canonical API for converting `import.meta.url` to a filesystem path. Handles spaces, Windows drive letters, and other URL-encoding edge cases.

## Reproduction

```bash
cd ~
mkdir "spaces in path"
cd "spaces in path"
git clone https://github.com/lantisprime/episodic-memory.git
cd episodic-memory
node install.mjs --tool codex
# Before fix: ENOENT on .../spaces%20in%20path/.../scripts
# After fix:  Installed N scripts to ~/.episodic-memory/scripts
```

## Test plan

- [ ] Clone into a path **without** spaces — `node install.mjs --tool codex` still installs cleanly (no regression).
- [ ] Clone into a path **with** spaces — `node install.mjs --tool codex` installs cleanly (was failing before).
- [ ] Clone into a path with other URL-encodable characters (`#`, `&`) — install still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)