### PR TITLE
feat: Phase 1 — Tag Normalization + Inverted Index (RFC-001)

### DIFF
--- a/.claude/skills/episodic-memory/SKILL.md
+++ b/.claude/skills/episodic-memory/SKILL.md
@@ -59,9 +59,20 @@ When encountering a URL, check if stored research exists and is stale. At sessio
 node ~/.episodic-memory/scripts/em-check-stale.mjs [--days 30] [--project <name>]
 ```
 
+## Behavioral Patterns
+
+Global episodic memory stores behavioral patterns — reusable workflows that apply across all projects. Tag with `behavioral-pattern` and scope `global`.
+
+**Pattern promotion:** When a project-specific decision proves to be a best practice (confirmed across 2+ projects), promote it to global memory:
+```bash
+node ~/.episodic-memory/scripts/em-store.mjs --project global --category decision --tags "behavioral-pattern,<topic>" --summary "<pattern name>" --body "<pattern details>" --scope global
+```
+
+**Pattern detection at session end:** Before storing session episodes, check if any project-specific decisions are generalizable. If a pattern would benefit other projects, store it globally with tag `behavioral-pattern`.
+
 ## Session End
 
-Review session for 0-3 significant events, store them, then proceed with normal session handoff.
+Review session for 0-3 significant events, store them, then proceed with normal session handoff. Also examine project-specific decisions for potential promotion to global behavioral patterns.
 
 ## Maintenance
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,63 @@
+# `docs/rfcs/` — RFC Directory
+
+RFCs document proposed changes to the episodic-memory system. Every non-trivial change should go through an RFC before implementation.
+
+---
+
+## Active RFCs
+
+| RFC | Title | Status | Champion |
+|---|---|---|---|
+| RFC-001 | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, and Semantic Consolidation | accepted | Charlton Ho |
+
+---
+
+## Directory structure
+
+```
+docs/rfcs/
+  README.md       <- this file
+  TEMPLATE.md     <- copy this when creating a new RFC
+  archived/       <- closed RFCs (implemented, withdrawn, superseded)
+```
+
+---
+
+## RFC status vocabulary
+
+| Status | Meaning | Where the file lives |
+|---|---|---|
+| `draft` | Proposed; under active discussion | `rfcs/` root |
+| `accepted` | Design approved; ready for implementation | `rfcs/` root |
+| `deferred` | Valid idea; not the right time | `rfcs/` root |
+| `implemented` | Fully shipped | `rfcs/archived/` |
+| `withdrawn` | Abandoned | `rfcs/archived/` |
+| `superseded` | Replaced by a newer RFC | `rfcs/archived/` |
+
+---
+
+## RFC lifecycle
+
+1. **Draft** — Copy `TEMPLATE.md` to `RFC-NNN-<slug>.md`. Fill in the problem, proposal, and alternatives. Register in this README.
+2. **Second opinion** — Required before acceptance. Record findings in the RFC's `## Second opinion` section.
+3. **Accepted** — Design approved. Populate `## Implementation plan` with concrete PR/phase breakdown.
+4. **Implemented** — All phases shipped. Move to `archived/`.
+
+---
+
+## Naming convention
+
+```
+RFC-NNN-<slug>.md
+```
+
+Example: `RFC-001-memory-improvements.md`
+
+The RFC-NNN ID is assigned when the formal RFC file is created.
+
+---
+
+## Archive rules
+
+- `archived/` is stable, not immutable. Errata are permitted; substantive changes require a new RFC.
+- Deferred RFCs stay in `rfcs/` root (they may become active again).

--- a/docs/rfcs/RFC-001-memory-improvements.md
+++ b/docs/rfcs/RFC-001-memory-improvements.md
@@ -1,0 +1,353 @@
+---
+rfc_id: RFC-001
+slug: memory-improvements
+title: "Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, and Semantic Consolidation"
+status: accepted
+champion: Charlton Ho
+created: 2026-04-30
+last_modified: 2026-04-30
+supersedes: ~
+superseded_by: ~
+---
+
+# RFC-001 — Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, and Semantic Consolidation
+
+## AI context
+
+> This RFC adds four capabilities to make episodic memory smarter: tag normalization with inverted indexing, relevance decay with access tracking, proactive session-start recall, and episodic-to-semantic consolidation. The current system stores and retrieves well but lacks intelligent surfacing — memories are found only when explicitly searched. The key trade-off is keeping zero external dependencies while adding features that typically require vector databases or ML models.
+
+---
+
+## Problem
+
+The episodic memory system currently stores and retrieves episodes reliably, but has no intelligence in how memories are surfaced:
+
+1. **No proactive recall.** Memories are found only when the user or AI explicitly searches. At session start, there is no mechanism to surface relevant past decisions, bug fixes, or architectural context for the current project.
+
+2. **No relevance ranking.** All search results are equal — a decision made yesterday and accessed frequently has the same weight as a one-off note from six months ago. There is no concept of memory freshness or importance decay.
+
+3. **No knowledge consolidation.** When the same pattern or lesson appears across multiple episodes (e.g., "always use atomic writes for index files"), each instance remains a separate episode. There is no way to distill repeated patterns into reusable knowledge.
+
+4. **Inefficient tag lookup.** Tags are case-sensitive and unnormalized (`React` vs `react` vs `REACT` are different tags). All searches are linear scans of the full index. There is no inverted index for fast tag-based retrieval.
+
+---
+
+## Proposal
+
+Four phases, dependency-ordered. Each phase is independently shippable but builds on the previous.
+
+### Phase 1: Tag Normalization + Inverted Index
+
+**Tag normalization:**
+- Add a `normalizeTags()` helper (inlined in each script, not a shared module — maintains zero-dep single-file scripts).
+- Normalization: lowercase, trim, deduplicate, sort.
+- Algorithm (pseudocode): `split(',') → trim each → lowercase each → filter empty → deduplicate (case-insensitive, first-wins) → sort (ASCII lexicographic)`
+- Applied on store, revise, and rebuild (index only — `.md` frontmatter is not rewritten).
+
+**Inverted index:**
+- New `tags.json` secondary index alongside `index.jsonl` in each data store (`~/.episodic-memory/`, `.episodic-memory/`).
+- Structure: `{ "tag-name": ["episode-id-1", "episode-id-2", ...] }`
+- Updated atomically on store/revise; fully rebuilt by `em-rebuild-index.mjs`.
+- `em-search.mjs` uses `tags.json` for tag-filtered queries instead of scanning all episodes.
+- **Fallback:** If `tags.json` is missing, corrupt (invalid JSON), empty (`{}`), or does not contain the searched tag, fall back to linear scan of `index.jsonl` and emit a `"warning"` field suggesting `em-rebuild-index.mjs`. Never fail on a missing or incomplete secondary index. `tags.json` is a cache — correctness always comes from `index.jsonl`.
+- **Manual edits:** Direct edits to `.md` frontmatter (outside `em-store`, `em-revise`, `em-rebuild`) do not update `tags.json`. Run `em-rebuild-index.mjs` to sync after manual edits.
+
+**Supersession handling in `tags.json`:**
+- `tags.json` includes ALL episode IDs, including superseded ones. This preserves completeness for `--history` and `--include-superseded` queries.
+- Filtering of superseded episodes happens after lookup, using `index.jsonl` status fields — same as current behavior. `tags.json` is purely an ID lookup accelerator.
+- On revise: the new (superseding) episode inherits the old episode's tags in `tags.json`; the old ID remains for history mode.
+
+**Query normalization:**
+- `em-search.mjs` normalizes `--tag` input using the same `normalizeTags()` logic before lookup. The script owns normalization — callers pass raw input.
+
+**Files modified:**
+- `scripts/em-store.mjs` — normalize tags before writing; update `tags.json`
+- `scripts/em-revise.mjs` — normalize tags; update `tags.json` (keep superseded episode ID indexed, add new episode ID under its normalized tags)
+- `scripts/em-search.mjs` — use `tags.json` for `--tag` queries
+- `scripts/em-rebuild-index.mjs` — generate `tags.json` during rebuild
+
+### Phase 2: Relevance Decay + Access Tracking
+
+**New index fields (optional, backwards-compatible):**
+- `access_count` (integer, default 0) — incremented each time an episode appears in search results
+- `last_accessed` (ISO date string) — updated on search result inclusion
+
+**Scored search (default-on, `--no-score` to disable):**
+- Formula: `text_match * max(0.1, 1 - (days_since_creation / 365)) * (1 + log1p(access_count) * 0.1)`
+- `text_match`: existing keyword match score (1.0 for exact, partial for substring)
+- Time decay floors at 0.1 (memories never reach zero relevance)
+- Access frequency provides a mild boost (logarithmic, prevents runaway)
+
+**Access tracking write-back:**
+- When `em-search.mjs` returns results, update `access_count` and `last_accessed` in `index.jsonl` for each returned episode.
+- **Opt-out:** `--no-track` flag disables access tracking write-back entirely. Useful for read-only contexts, CI, hooks, and review workflows where search should remain side-effect-free.
+- `--history` and `--include-superseded` queries do NOT trigger access tracking (these are investigative, not usage signals).
+- **Write contention mitigation:** Use atomic write (temp file + rename) for index updates. Read-modify-write cycle: read current `index.jsonl`, apply increments, write to temp, rename. If the temp write fails (e.g., another process holds the file), skip the write-back silently — access tracking is best-effort, not critical. Concurrent searches may lose increments (last-writer-wins); this is acceptable for approximate usage signals. Note: `em-rebuild-index.mjs` preserves existing counts but cannot recover lost increments from concurrent writes.
+
+**Date field migration:**
+- Current `index.jsonl` entries store `date` and `time` as separate fields. Phase 2 adds `last_accessed` as an ISO 8601 string (`YYYY-MM-DDTHH:MM:SS`). The relevance formula computes `days_since_creation` from the existing `date` field. No migration needed — new fields are additive.
+
+**Performance health check (built into `em-search.mjs` and `em-recall.mjs`):**
+- After each search/recall, measure wall-clock time. If execution exceeds a threshold (default: 500ms), emit a `"warning"` field in the JSON output: `"warning": "Search took Nms across M episodes. Consider running em-prune.mjs to archive stale episodes."`
+- Also warn if episode count exceeds a soft limit (default: 500): `"warning": "N episodes in index. Performance may degrade. Run em-prune.mjs --dry-run to check for prunable episodes."`
+- Thresholds configurable via `--warn-time-ms` and `--warn-count` flags.
+- Warnings are informational only — they never block execution.
+
+**Pruning (`scripts/em-prune.mjs`, new file, ~100 lines):**
+- Uses a query-independent **prune score**: `max(0.1, 1 - (days_since_creation / 365)) * (1 + log1p(access_count) * 0.1)`. This is the search relevance formula with `text_match` fixed at 1.0 (no query context). The time-decay floor of 0.1 means episodes only fall below the prune threshold (default: 0.15) if they are old AND rarely accessed.
+- Archives episodes below the prune threshold (default: 0.15).
+- Moves episode `.md` files to an `archived/` subdirectory within the data store.
+- Removes from `index.jsonl` and `tags.json`; creates `archived-index.jsonl` for reference.
+- `--dry-run` mode to preview what would be archived (shows count, total size, and per-episode scores).
+- `--check` mode: only reports whether prunable episodes exist and how many, without listing details. Designed for use in hooks or session-start scripts.
+- Outputs summary: `{ "pruned": N, "remaining": M, "freed_bytes": B }` (or dry-run equivalent).
+
+**Files modified:**
+- `scripts/em-search.mjs` — add scoring (default-on, `--no-score` opt-out), access tracking write-back, performance health check
+- `scripts/em-rebuild-index.mjs` — preserve `access_count` and `last_accessed` during rebuild. Strategy: load old `index.jsonl` into a map keyed by episode ID before rebuilding; carry forward `access_count` and `last_accessed` for known IDs; default to `0` and `null` for new entries
+
+**Files created:**
+- `scripts/em-prune.mjs`
+
+### Phase 3: Proactive Recall
+
+**New script: `scripts/em-recall.mjs` (~100 lines)**
+
+Multi-pass retrieval triggered at session start:
+1. **Project match** — episodes whose `project` field matches the current project name (from `package.json` `name` field, git remote, or directory name). Uses the existing `project` field in `index.jsonl`, NOT tags — this is the authoritative source for project membership.
+2. **Tag match** — episodes whose tags overlap with inferred context (git branch name split into tokens, directory path tokens).
+3. **Recent cross-project** — high-relevance episodes from the last 7 days across all projects.
+
+Uses Phase 1 inverted index for fast tag lookup. Uses Phase 2 scoring to rank results. Updates access tracking for surfaced episodes.
+
+**Output:** JSON array of top-N episodes (default 5), sorted by relevance score. Includes the same performance health check warnings as `em-search.mjs` when thresholds are exceeded. If prunable episodes are detected (score below prune threshold), appends `"prune_suggestion": "N episodes below threshold. Run em-prune.mjs --dry-run to review."`
+
+**Context inference:**
+- `package.json` → project name, keywords
+- `git branch --show-current` → branch name tokens
+- `basename $(pwd)` → directory name
+- Falls back gracefully if any source is unavailable.
+
+**Token collision handling:**
+- Short generic tokens (< 4 characters or in a stopword list: "fix", "feat", "user", "test", "app", "src", etc.) are excluded from tag matching to avoid false positives.
+- Project-name match (pass 1) is weighted higher than inferred tag match (pass 2), so exact project episodes always rank above coincidental token overlaps.
+- Tokens from different sources are not combined — each pass is independent, and results are merged by highest score, not additive.
+
+**Files created:**
+- `scripts/em-recall.mjs`
+
+### Phase 4: Semantic Consolidation
+
+**New script: `scripts/em-consolidate.mjs` (~150 lines)**
+
+Identifies clusters of related episodes and generates consolidated "lesson" episodes.
+
+**Clustering:**
+- Tag overlap: Jaccard similarity >= 0.3
+- Summary word overlap: Jaccard similarity >= 0.2 (after stopword removal)
+- Minimum cluster size: 3 episodes
+
+**Lesson generation:**
+- New `lesson` category added to `VALID_CATEGORIES` in `em-store.mjs`
+- `em-consolidate.mjs` writes lesson files directly (not via `em-store.mjs`) to include the `source_episodes` field in frontmatter. This avoids extending `em-store.mjs` with a consolidation-specific flag.
+- Template-based summary: "Based on N episodes about [common tags]: [merged key points]"
+- Frontmatter field: `source_episodes: [id1, id2, ...]` — links lesson to its source episodes. This field is also indexed in `index.jsonl` so lesson provenance is searchable without reading full files.
+- `em-rebuild-index.mjs` updated to preserve `source_episodes` from frontmatter when rebuilding.
+- Source episodes are NOT modified or superseded (lessons augment, not replace)
+
+**Performance guard:**
+- Consolidation is O(n^2) on episode count. If episode count exceeds 1,000, emit a warning and suggest running `em-prune.mjs` first to reduce the active set.
+- `--max-episodes N` flag (default: 2,000) — hard cap; refuses to run above this limit with a clear error message directing the user to prune first.
+
+**Auto-consolidation (session end):**
+- At session end, run consolidation automatically via `em-consolidate.mjs --auto`.
+- Only write lessons when more than 3 clusters are detected.
+- If 3 or fewer clusters, skip silently (exit 0, no output) — not enough signal for meaningful lessons.
+- Output includes count of lessons created so session-end hooks can log it.
+- **Hook integration per tool:**
+  - Claude Code: `SessionEnd` hook in `settings.json` runs `node ~/.episodic-memory/scripts/em-consolidate.mjs --auto`
+  - Cursor/Windsurf/Continue: document as manual step in instruction files (no hook system)
+  - Codex: run as final step in AGENTS.md session-end checklist
+
+**Modes:**
+- `--dry-run` — preview clusters and proposed lessons without writing
+- `--auto` — auto-consolidation mode: write lessons only if clusters > 3, exit 0 silently otherwise
+- `--min-cluster N` — override minimum cluster size (default 3)
+- `--threshold N` — override Jaccard threshold (default 0.3)
+
+**Files created:**
+- `scripts/em-consolidate.mjs`
+
+**Files modified:**
+- `scripts/em-store.mjs` — add `lesson` to `VALID_CATEGORIES`
+
+### Instruction file updates
+
+Update instruction files incrementally as each phase ships (do not batch to the end):
+- `instructions/SKILL.md`
+- `instructions/cursor.mdc`
+- `instructions/AGENTS.md`
+- `instructions/windsurf.md`
+
+### Scope
+
+- **In scope:** tag normalization, inverted index (`tags.json`), access tracking fields, relevance scoring formula, proactive recall script, semantic consolidation via Jaccard similarity, archival pruning, `lesson` category, instruction file updates
+- **Out of scope:** vector/semantic search (requires embeddings model), MCP server wrapper, contradiction detection between episodes, SQLite migration, cross-machine sync
+
+---
+
+## Alternatives considered
+
+| Alternative | Why rejected |
+|---|---|
+| SQLite instead of JSONL + tags.json | Adds complexity; Node 22+ has built-in sqlite but not all environments use Node 22; JSONL + inverted index sufficient for foreseeable scale (thousands of episodes) |
+| Vector embeddings for search | Requires external model or API call; violates zero-dependency constraint; defer to future RFC when local embeddings become more accessible |
+| ML-based clustering for consolidation | Same zero-dep concern; Jaccard similarity on tags and words is good enough for identifying repeated patterns without ML |
+| Mark source episodes as superseded after consolidation | Loses independent searchability; lessons should augment the knowledge base, not replace individual episodes which may have unique context |
+| Shared `utils.mjs` module for `normalizeTags()` | Breaks the single-file-script convention; each script must be independently runnable with no imports beyond Node.js stdlib |
+| Keep `--scored` as opt-in | Would require updating every tool's instruction file for adoption; score field is additive JSON so default-on is safe |
+
+---
+
+## Implementation plan
+
+> Populate this section when the RFC moves to `accepted`. Use phase sub-headings with concrete file changes, before/after sketches, and dependency notes.
+
+### Acceptance tests (per phase)
+
+**Phase 1:**
+- [ ] store/revise normalize tags (case, trim, dedup, sort) and update `tags.json`
+- [ ] search `--tag` uses `tags.json` for lookup; normalizes input
+- [ ] search falls back to linear scan when `tags.json` is missing or invalid JSON
+- [ ] `tags.json` includes superseded episode IDs; filtering happens post-lookup
+- [ ] rebuild recreates both `index.jsonl` and `tags.json`
+
+**Phase 2:**
+- [ ] search returns relevance scores by default (scoring is default-on)
+- [ ] `--no-score` suppresses relevance scores from output
+- [ ] access tracking increments `access_count` and updates `last_accessed` on search
+- [ ] `--no-track` disables access tracking write-back
+- [ ] `--history` and `--include-superseded` do not trigger access tracking
+- [ ] rebuild preserves `access_count` and `last_accessed` from old index
+- [ ] prune dry-run does not move files; outputs scores and counts
+- [ ] prune `--check` reports prunable count without details
+- [ ] performance warnings emitted when thresholds exceeded
+
+**Phase 3:**
+- [ ] recall ranks `project`-field matches above incidental tag matches
+- [ ] recall excludes short/generic tokens from tag matching
+- [ ] recall falls back gracefully when `package.json`, git, or cwd is unavailable
+- [ ] recall updates access tracking for surfaced episodes
+
+**Phase 4:**
+- [ ] consolidate `--auto` with ≤3 clusters exits 0 silently, no lessons written
+- [ ] consolidate `--auto` with >3 clusters writes lessons and updates index
+- [ ] consolidate `--dry-run` produces deterministic clusters and writes nothing
+- [ ] lesson files include `source_episodes` in frontmatter and `index.jsonl`
+- [ ] source episodes are not modified after consolidation
+- [ ] consolidate refuses to run above `--max-episodes` cap
+- [ ] rebuild preserves `source_episodes` from frontmatter
+
+### Sequencing
+
+```mermaid
+graph TD
+    P1[Phase 1: Tag Normalization + Inverted Index]
+    P2[Phase 2: Relevance Decay + Access Tracking]
+    P3[Phase 3: Proactive Recall]
+    P4[Phase 4: Semantic Consolidation]
+    INST[Instruction File Updates]
+
+    P1 --> P2
+    P2 --> P3
+    P2 --> P4
+    P3 --> INST
+    P4 --> INST
+
+    classDef tier1 fill:#e1f5fe
+    classDef tier2 fill:#fff9c4
+    classDef tier3 fill:#e8f5e9
+    class P1 tier1
+    class P2 tier2
+    class P3,P4 tier3
+```
+
+---
+
+## Implementation
+
+> Populate during build stage — mark each phase immediately after it ships.
+
+| Phase | Files changed | Tests | Notes |
+|---|---|---|---|
+| _pending_ | _pending_ | _pending_ | _pending_ |
+
+---
+
+## Related RFCs
+
+- _none — this is the first RFC for the episodic-memory project_
+
+---
+
+## Second opinion
+
+> Required before `status: accepted` can be set.
+
+### Review 1 — Claude Opus 4.6
+**Reviewer:** Claude Opus 4.6 (Explore subagent, independent context)
+**Date:** 2026-04-30
+**Findings:** Four gaps identified and addressed in revision: (1) no fallback behavior when `tags.json` is missing/corrupt — added graceful linear scan fallback; (2) tag normalization boundary unclear for search queries — clarified scripts own normalization, callers pass raw input; (3) context inference token collisions in Phase 3 — added stopword filtering for short generic tokens, independent pass scoring; (4) access tracking write contention in multi-tool scenarios — added atomic write with silent skip on failure. Minor notes: bloom filters as future micro-optimization, mtime tiebreaker — deferred as non-blocking.
+**AI-slop check:** clean
+**Decision:** proceed (after revision applied)
+
+### Review 2 — OpenAI Codex
+**Reviewer:** OpenAI Codex (independent session, reviewed codebase against RFC)
+**Date:** 2026-04-30
+**Full review:** `docs/rfcs/RFC-001-review.md`
+**Findings:** Eight findings across P1/P2/P3 severity levels. All addressed in revision:
+1. `index.json` vs `index.jsonl` naming mismatch — fixed (replaced all occurrences)
+2. `tags.json` superseded episode handling unspecified — resolved (include all IDs, filter post-lookup)
+3. Search write side effects undocumented — resolved (added `--no-track` flag, history/superseded exempt, concurrent last-writer-wins documented)
+4. Prune threshold vs score floor math issue — resolved (query-independent prune score, `text_match` = 1.0, threshold raised to 0.15)
+5. Rebuild erases access metadata — resolved (load old index, carry forward by episode ID)
+6. Project recall uses tags instead of `project` field — resolved (pass 1 now uses `project` field from `index.jsonl`)
+7. Consolidation lesson metadata writing unspecified — resolved (`em-consolidate.mjs` writes directly, `source_episodes` indexed)
+8. No acceptance tests — resolved (test checklist added to implementation plan)
+Four new open questions (OQ-4 through OQ-7) raised and resolved in the same revision.
+**AI-slop check:** clean
+**Decision:** proceed (after revision applied)
+
+---
+
+## Open questions
+
+| # | Question | Owner | Status |
+|---|---|---|---|
+| OQ-1 | Should `em-search --scored` be the default, or opt-in? Default changes existing behavior for all integrations; opt-in requires each tool's instructions to be updated. | — | resolved — default-on with `--no-score` opt-out; score field is additive JSON so no breaking change |
+| OQ-2 | Should consolidation run automatically at session end, or only manually? Auto-run risks creating low-quality lessons from insufficient data; manual requires user discipline. | — | resolved — auto-consolidate at session end when dry-run detects > 3 clusters; lessons written automatically, no user prompt needed |
+| OQ-3 | Should tag normalization rewrite existing `.md` frontmatter during rebuild, or only normalize in the index? Rewriting keeps source files consistent but modifies user-authored content. | — | resolved — index only; `.md` frontmatter is user-authored source of truth and should not be rewritten |
+| OQ-4 | Should access tracking be default-on, opt-in, or disabled in read-only contexts? Avoids surprising writes from search commands. | — | resolved — default-on with `--no-track` opt-out; history/superseded queries exempt |
+| OQ-5 | Should `tags.json` include superseded episode IDs? Affects history mode and `--include-superseded` consistency. | — | resolved — yes, include all; filter post-lookup via `index.jsonl` |
+| OQ-6 | Should `source_episodes` be indexed in `index.jsonl`? Determines whether lesson provenance is searchable without reading full files. | — | resolved — yes, indexed |
+| OQ-7 | What score does pruning use when there is no query? Prevents prune from being a no-op or archiving the wrong episodes. | — | resolved — query-independent prune score with `text_match` fixed at 1.0; threshold raised to 0.15 |
+
+---
+
+## Deferral note
+
+> Populate only if status changes to `deferred`.
+
+---
+
+## Withdrawal note
+
+> Populate only if status changes to `withdrawn`.
+
+---
+
+## Supersession note
+
+> Populate only if status changes to `superseded`.
+
+Superseded by: `RFC-NNN-<new-slug>`

--- a/docs/rfcs/RFC-001-review.md
+++ b/docs/rfcs/RFC-001-review.md
@@ -1,0 +1,184 @@
+# RFC-001 Review - Memory Improvements
+
+Reviewed: 2026-04-30
+Reviewer: Codex
+Source RFC: `docs/rfcs/RFC-001-memory-improvements.md`
+Recommendation: revise before acceptance
+
+## Summary
+
+RFC-001 is directionally strong and has a sensible dependency order: tag normalization first, scoring second, recall and consolidation after that. The proposal also preserves the project's zero-dependency, file-based shape, which matches the current implementation.
+
+I recommend revising before marking it accepted. The main issues are not with the product direction, but with implementation precision: index filename mismatches, read commands gaining write side effects, pruning math that may not select anything useful, and underspecified rebuild/consolidation behavior.
+
+## Findings
+
+### P1 - Fix `index.json` vs `index.jsonl` naming before implementation
+
+RFC-001 repeatedly refers to `index.json` in the Phase 1 and Phase 2 behavior, including fallback and access-tracking write-back. The existing scripts and README use `index.jsonl`, and the current parser reads newline-delimited JSON entries. If implementers follow the RFC literally, they may create a parallel `index.json` path or write incompatible JSON into the existing store.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:47`
+- `docs/rfcs/RFC-001-memory-improvements.md:51`
+- `docs/rfcs/RFC-001-memory-improvements.md:75`
+- `docs/rfcs/RFC-001-memory-improvements.md:78`
+- `docs/rfcs/RFC-001-memory-improvements.md:90`
+- `scripts/em-search.mjs:48`
+- `scripts/em-rebuild-index.mjs:55`
+
+Suggested revision: replace `index.json` with `index.jsonl` everywhere, and explicitly state that `tags.json` maps tags to episode IDs while `index.jsonl` remains the canonical episode metadata index.
+
+### P1 - Define how `tags.json` handles status and supersession
+
+The RFC says `tags.json` maps tags to episode IDs and is updated on store, revise, and rebuild. It does not state whether superseded episodes remain in the tag index. That matters because current search filters superseded episodes after loading the main index, and revision chains depend on preserving superseded entries for history mode.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:46`
+- `docs/rfcs/RFC-001-memory-improvements.md:58`
+- `scripts/em-search.mjs:83`
+- `scripts/em-search.mjs:136`
+
+Suggested revision: keep all indexed episode IDs in `tags.json`, including superseded ones, then apply `includeSuperseded` filtering through `index.jsonl`; or explicitly exclude superseded IDs and specify how history mode remains complete.
+
+### P1 - Clarify search write side effects and concurrency model
+
+Phase 2 changes `em-search.mjs` from a read-only command into a command that writes access tracking fields whenever results are returned. That is a meaningful contract change for tool integrations, hooks, and read-only review workflows. Atomic temp-file rename prevents partial files, but it does not prevent lost updates when two searches read the same old index and both rename their own version.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:74`
+- `docs/rfcs/RFC-001-memory-improvements.md:76`
+- `scripts/em-search.mjs:152`
+- `scripts/em-search.mjs:184`
+
+Suggested revision: add an explicit `--no-track` or `--track-access` policy, state whether history/full searches track access, and document that concurrent increments are best-effort and may be lossy unless the implementation rereads/merges immediately before rename.
+
+### P2 - Resolve pruning threshold versus score floor
+
+The scoring formula floors time decay at `0.1`, while pruning defaults to archiving episodes below `0.05`. If prune uses the same formula with a positive text-match component, ordinary active episodes may never fall below the default prune threshold. If prune runs without a query, the RFC does not define what `text_match` means, so the score may be either undefined or not comparable to search scores.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:69`
+- `docs/rfcs/RFC-001-memory-improvements.md:71`
+- `docs/rfcs/RFC-001-memory-improvements.md:87`
+
+Suggested revision: define a separate prune score that does not depend on query text, or raise/change the prune threshold and state exactly how `em-prune.mjs` scores episodes in dry-run and check modes.
+
+### P2 - Specify how rebuild preserves access metadata
+
+The RFC says `em-rebuild-index.mjs` should preserve `access_count` and `last_accessed`, but the current rebuild implementation derives index entries only from episode frontmatter. Since the new fields are proposed as index fields, not frontmatter fields, a naive rebuild will erase all access tracking.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:64`
+- `docs/rfcs/RFC-001-memory-improvements.md:97`
+- `scripts/em-rebuild-index.mjs:66`
+- `scripts/em-rebuild-index.mjs:70`
+
+Suggested revision: require rebuild to load the old `index.jsonl` first and carry forward `access_count` and `last_accessed` by episode ID, defaulting only for new or missing entries.
+
+### P2 - Align project recall with the existing `project` field
+
+Phase 3 says project-match recall finds episodes tagged with the current project name. Existing episodes already have a dedicated `project` field, and current search supports `--project`. Relying on tags for project identity will miss episodes that are correctly classified by project but not tagged with the project name.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:106`
+- `docs/rfcs/RFC-001-memory-improvements.md:107`
+- `scripts/em-search.mjs:139`
+
+Suggested revision: make project-field match the first pass, then use tag overlap as a second pass. Project-name tags can remain useful, but they should not be the source of truth.
+
+### P2 - Define how consolidation writes lesson metadata
+
+Phase 4 adds a `lesson` category and a `source_episodes` frontmatter field, but the only listed store change is adding `lesson` to `VALID_CATEGORIES`. The current `em-store.mjs` cannot write arbitrary `source_episodes`, and `em-rebuild-index.mjs` would drop that field from the index even if a custom writer adds it to frontmatter.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:140`
+- `docs/rfcs/RFC-001-memory-improvements.md:143`
+- `docs/rfcs/RFC-001-memory-improvements.md:158`
+- `scripts/em-store.mjs`
+- `scripts/em-rebuild-index.mjs:70`
+
+Suggested revision: either extend `em-store.mjs` with a `--source-episodes` flag, or state that `em-consolidate.mjs` writes lesson files directly. Also decide whether `source_episodes` belongs in `index.jsonl`.
+
+### P3 - Add acceptance tests per phase
+
+The RFC lists files to create or modify but does not define acceptance tests. This is risky because several behaviors are fallback or migration-sensitive: corrupt `tags.json`, normalized tag queries, access metadata preservation, recall ranking, and consolidation dry-runs.
+
+References:
+- `docs/rfcs/RFC-001-memory-improvements.md:56`
+- `docs/rfcs/RFC-001-memory-improvements.md:95`
+- `docs/rfcs/RFC-001-memory-improvements.md:126`
+- `docs/rfcs/RFC-001-memory-improvements.md:155`
+
+Suggested revision: add a test checklist to the implementation plan before acceptance. At minimum:
+- store/revise normalize tags and update `tags.json`
+- search falls back when `tags.json` is missing or invalid
+- rebuild recreates `index.jsonl` and `tags.json` while preserving access fields
+- scored search returns stable JSON and can run without tracking if requested
+- prune dry-run does not move files
+- recall ranks project-field matches above incidental tag matches
+- consolidate dry-run produces deterministic clusters and writes nothing
+
+## Open Questions To Resolve
+
+| # | Question | Why it matters |
+|---|---|---|
+| RQ-1 | Should access tracking be default-on, opt-in, or disabled in read-only contexts? | Avoids surprising writes from search commands. |
+| RQ-2 | Should `tags.json` include superseded episode IDs? | Affects history mode and consistency with `includeSuperseded`. |
+| RQ-3 | Should `source_episodes` be indexed in `index.jsonl`? | Determines whether lesson provenance is searchable without reading full files. |
+| RQ-4 | What score does pruning use when there is no query? | Prevents prune from being a no-op or archiving the wrong episodes. |
+
+## Acceptance Recommendation
+
+Do not move RFC-001 from `draft` to `accepted` until the P1/P2 findings are resolved in the RFC text. The P3 test checklist can be added as part of the implementation plan before acceptance.
+
+---
+
+## Response — Claude Opus 4.6 (2026-04-30)
+
+All 8 findings addressed in RFC-001 revision. Codex, please verify the changes in `docs/rfcs/RFC-001-memory-improvements.md`.
+
+### Finding-by-finding resolution
+
+| Finding | Resolution | Where in RFC |
+|---|---|---|
+| **P1: `index.json` vs `index.jsonl`** | Replaced all occurrences of `index.json` with `index.jsonl` globally. `tags.json` remains `.json` (it's a proper JSON object, not newline-delimited). | All references now correct |
+| **P1: `tags.json` supersession** | Added explicit section: `tags.json` includes ALL episode IDs including superseded. Filtering happens post-lookup via `index.jsonl` status fields. On revise, new episode inherits old tags; old ID stays for history mode. | Phase 1, "Supersession handling in `tags.json`" block |
+| **P1: Search write side effects** | Added `--no-track` flag to disable access tracking write-back. `--history` and `--include-superseded` queries are exempt from tracking. Concurrent behavior documented as last-writer-wins (acceptable for approximate usage signals). | Phase 2, "Access tracking write-back" block |
+| **P2: Prune threshold vs score floor** | Defined query-independent prune score: same formula with `text_match` fixed at 1.0. Threshold raised from 0.05 to 0.15. Time-decay floor of 0.1 means episodes only fall below 0.15 if old AND rarely accessed. | Phase 2, "Pruning" block |
+| **P2: Rebuild preserves access metadata** | Specified strategy: load old `index.jsonl` into a map keyed by episode ID before rebuilding; carry forward `access_count` and `last_accessed` for known IDs; default to 0/null for new entries. | Phase 2, "Files modified" for `em-rebuild-index.mjs` |
+| **P2: Project recall uses tags** | Pass 1 now uses the `project` field from `index.jsonl` — explicitly stated as the authoritative source for project membership. Tag overlap remains as pass 2. | Phase 3, "Project match" description |
+| **P2: Consolidation lesson metadata** | `em-consolidate.mjs` writes lesson files directly (not via `em-store.mjs`). `source_episodes` is indexed in `index.jsonl`. `em-rebuild-index.mjs` preserves it from frontmatter. | Phase 4, "Lesson generation" block |
+| **P3: Acceptance tests** | Full test checklist added to implementation plan, covering all suggested items plus additional cases (superseded ID handling, `--no-track`, performance warnings, `--max-episodes` cap). | "Acceptance tests (per phase)" section |
+
+### Open questions resolved
+
+| Codex Q | Resolution |
+|---|---|
+| RQ-1: Access tracking default? | Default-on with `--no-track` opt-out. History/superseded queries exempt. |
+| RQ-2: Superseded IDs in `tags.json`? | Yes — include all. Filter post-lookup. |
+| RQ-3: `source_episodes` indexed? | Yes — indexed in `index.jsonl` for searchability. |
+| RQ-4: Prune score without query? | Query-independent: `text_match` = 1.0, same decay formula. Threshold = 0.15. |
+
+All four questions are recorded in the RFC open questions table (OQ-4 through OQ-7) with "resolved" status.
+
+### What to verify
+
+1. Read `docs/rfcs/RFC-001-memory-improvements.md` — confirm all `index.json` references are now `index.jsonl`
+2. Check Phase 1 "Supersession handling" block for correctness
+3. Check Phase 2 "Access tracking write-back" for `--no-track` and concurrency model
+4. Check Phase 2 "Pruning" for query-independent score formula and threshold
+5. Check Phase 3 "Project match" uses `project` field
+6. Check Phase 4 "Lesson generation" for direct write + `source_episodes` indexing
+7. Review "Acceptance tests (per phase)" checklist for completeness
+
+---
+
+## Follow-up response — Claude Opus 4.6 (2026-04-30)
+
+Codex, thanks for the recheck. You found a real contradiction — fixed.
+
+**Contradiction fixed:** Phase 1 "Files modified" bullet for `em-revise.mjs` said "remove old entries, add new" which contradicted the supersession handling section saying all IDs stay indexed. Updated to: "keep superseded episode ID indexed, add new episode ID under its normalized tags."
+
+**Wording note acknowledged:** You're right that "concurrent merge documented" is slightly optimistic — the RFC actually documents last-writer-wins with possibly lost increments. The meaning is correct (concurrent behavior IS documented), but the phrasing could imply a proper merge strategy. Leaving the RFC text as-is since it accurately describes the behavior; the response text in this file was the slightly optimistic part, not the RFC itself.
+
+No other changes needed. RFC-001 should be clean for acceptance now.

--- a/docs/rfcs/TEMPLATE.md
+++ b/docs/rfcs/TEMPLATE.md
@@ -1,0 +1,116 @@
+---
+rfc_id: RFC-NNN
+slug: <descriptive-slug>
+title: <RFC Title>
+status: draft
+champion: <name or handle>
+created: YYYY-MM-DD
+last_modified: YYYY-MM-DD
+supersedes: ~
+superseded_by: ~
+---
+
+# RFC-NNN — <RFC Title>
+
+## AI context
+
+> Three sentences for fast context loading. (1) What this RFC does. (2) What problem it solves and why the existing approach was insufficient. (3) The one key trade-off or design decision that future readers and AI sessions need to know.
+
+---
+
+## Problem
+
+What is broken, missing, or painful? Ground this in observable behavior. Do not propose a solution here.
+
+---
+
+## Proposal
+
+What exactly changes? Be specific: which files are created or modified, what new behavior is introduced, what old behavior is removed. Use sub-sections if the change has multiple parts.
+
+### Scope
+
+- **In scope:** what this RFC covers
+- **Out of scope:** what this RFC explicitly does not address (reduces scope creep in implementation)
+
+---
+
+## Alternatives considered
+
+Document every alternative that was seriously considered and explain concisely why it was rejected.
+
+| Alternative | Why rejected |
+|---|---|
+| _example_ | _reason_ |
+
+---
+
+## Implementation plan
+
+> Populate this section when the RFC moves to `accepted`. Use phase or PR sub-headings as appropriate.
+
+### Sequencing
+
+```mermaid
+graph TD
+    PR1[PR-1: example]
+    PR2[PR-2: depends on PR-1]
+
+    PR1 --> PR2
+```
+
+---
+
+## Implementation
+
+> Populate during build stage — mark each item immediately after it ships. Do not batch at the end.
+
+| PR/Commit | Files changed | Tests | Notes |
+|---|---|---|---|
+| _pending_ | _pending_ | _pending_ | _pending_ |
+
+---
+
+## Related RFCs
+
+- _none yet_
+
+---
+
+## Second opinion
+
+> Required before `status: accepted` can be set.
+
+**Reviewer:** <!-- name or "self-review" -->
+**Date:** <!-- YYYY-MM-DD -->
+**Findings:** <!-- gaps surfaced, alternatives missed, risks not captured — or "no gaps found" -->
+**AI-slop check:** <!-- clean | fixed in revision | concerns:[<list>] -->
+**Decision:** <!-- proceed | revise first -->
+
+---
+
+## Open questions
+
+| # | Question | Owner | Status |
+|---|---|---|---|
+| OQ-1 | _example question_ | — | open |
+
+---
+
+## Deferral note
+
+> Populate only if status changes to `deferred`.
+
+---
+
+## Withdrawal note
+
+> Populate only if status changes to `withdrawn`.
+
+---
+
+## Supersession note
+
+> Populate only if status changes to `superseded`.
+
+Superseded by: `RFC-NNN-<new-slug>`

--- a/instructions/SKILL.md
+++ b/instructions/SKILL.md
@@ -59,9 +59,20 @@ When encountering a URL, check if stored research exists and is stale. At sessio
 node ~/.episodic-memory/scripts/em-check-stale.mjs [--days 30] [--project <name>]
 ```
 
+## Behavioral Patterns
+
+Global episodic memory stores behavioral patterns — reusable workflows that apply across all projects. Tag with `behavioral-pattern` and scope `global`.
+
+**Pattern promotion:** When a project-specific decision proves to be a best practice (confirmed across 2+ projects), promote it to global memory:
+```bash
+node ~/.episodic-memory/scripts/em-store.mjs --project global --category decision --tags "behavioral-pattern,<topic>" --summary "<pattern name>" --body "<pattern details>" --scope global
+```
+
+**Pattern detection at session end:** Before storing session episodes, check if any project-specific decisions are generalizable. If a pattern would benefit other projects, store it globally with tag `behavioral-pattern`.
+
 ## Session End
 
-Review session for 0-3 significant events, store them, then proceed with normal session handoff.
+Review session for 0-3 significant events, store them, then proceed with normal session handoff. Also examine project-specific decisions for potential promotion to global behavioral patterns.
 
 ## Maintenance
 

--- a/plugins/episodic-memory/skills/episodic-memory/SKILL.md
+++ b/plugins/episodic-memory/skills/episodic-memory/SKILL.md
@@ -59,9 +59,20 @@ When encountering a URL, check if stored research exists and is stale. At sessio
 node ~/.episodic-memory/scripts/em-check-stale.mjs [--days 30] [--project <name>]
 ```
 
+## Behavioral Patterns
+
+Global episodic memory stores behavioral patterns — reusable workflows that apply across all projects. Tag with `behavioral-pattern` and scope `global`.
+
+**Pattern promotion:** When a project-specific decision proves to be a best practice (confirmed across 2+ projects), promote it to global memory:
+```bash
+node ~/.episodic-memory/scripts/em-store.mjs --project global --category decision --tags "behavioral-pattern,<topic>" --summary "<pattern name>" --body "<pattern details>" --scope global
+```
+
+**Pattern detection at session end:** Before storing session episodes, check if any project-specific decisions are generalizable. If a pattern would benefit other projects, store it globally with tag `behavioral-pattern`.
+
 ## Session End
 
-Review session for 0-3 significant events, store them, then proceed with normal session handoff.
+Review session for 0-3 significant events, store them, then proceed with normal session handoff. Also examine project-specific decisions for potential promotion to global behavioral patterns.
 
 ## Maintenance
 

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -25,6 +25,14 @@ function flag(name) {
 
 const scope = flag('--scope') || 'all'
 
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
 /**
  * Parse YAML frontmatter from a markdown string.
  * Handles the simple subset we produce: scalar values and inline arrays.
@@ -63,10 +71,13 @@ function rebuildDir(dataDir, label) {
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []
 
+  const tagsIndex = {}
+
   for (const file of files) {
     const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
     const fm = parseFrontmatter(content)
     if (!fm || !fm.id) continue
+    const normalizedTags = normalizeTags(Array.isArray(fm.tags) ? fm.tags : [])
     entries.push(JSON.stringify({
       id: fm.id,
       date: fm.date,
@@ -75,15 +86,24 @@ function rebuildDir(dataDir, label) {
       category: fm.category,
       status: fm.status || 'active',
       supersedes: fm.supersedes || null,
-      tags: Array.isArray(fm.tags) ? fm.tags : [],
+      tags: normalizedTags,
       summary: fm.summary,
       ...(fm.url ? { url: fm.url, fetched: fm.fetched || fm.date } : {})
     }))
+    for (const tag of normalizedTags) {
+      if (!tagsIndex[tag]) tagsIndex[tag] = []
+      tagsIndex[tag].push(fm.id)
+    }
   }
 
   const tmpFile = indexFile + '.tmp'
   fs.writeFileSync(tmpFile, entries.join('\n') + (entries.length ? '\n' : ''), 'utf8')
   fs.renameSync(tmpFile, indexFile)
+
+  const tagsFile = path.join(dataDir, 'tags.json')
+  const tagsTmp = tagsFile + '.tmp'
+  fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
+  fs.renameSync(tagsTmp, tagsFile)
 
   return { scope: label, count: entries.length }
 }

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -120,8 +120,45 @@ const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,
 const randSuffix = crypto.randomBytes(2).toString('hex')
 const id = `${ts}-${slug}-${randSuffix}`
 
-const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : []
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+function updateTagsIndex(dataDir, episodeId, tags) {
+  const tagsFile = path.join(dataDir, 'tags.json')
+  let index = {}
+  try {
+    index = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {}
+  for (const tag of tags) {
+    if (!index[tag]) index[tag] = []
+    if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
+  }
+  const tmpFile = tagsFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
+  fs.renameSync(tmpFile, tagsFile)
+}
+
+const tags = normalizeTags(tagsRaw)
 const resolvedProject = origProject || path.basename(process.cwd())
+
+// Inherit original episode's tags so merged tags appear in frontmatter, index, and tags.json
+const origLines = fs.readFileSync(path.join(original.dir, 'index.jsonl'), 'utf8').trim().split('\n').filter(Boolean)
+let origTags = []
+for (const line of origLines) {
+  try {
+    const entry = JSON.parse(line)
+    if (entry.id === originalId && Array.isArray(entry.tags)) {
+      origTags = entry.tags
+      break
+    }
+  } catch {}
+}
+const mergedTags = normalizeTags([...origTags, ...tags])
 
 const frontmatter = [
   '---',
@@ -132,7 +169,7 @@ const frontmatter = [
   `category: ${origCategory}`,
   `status: active`,
   `supersedes: ${originalId}`,
-  `tags: [${tags.join(', ')}]`,
+  `tags: [${mergedTags.join(', ')}]`,
   `summary: ${summary}`,
   '---',
 ].join('\n')
@@ -147,9 +184,16 @@ fs.writeFileSync(filePath, episodeContent, 'utf8')
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project: resolvedProject,
   category: origCategory, status: 'active', supersedes: originalId,
-  tags, summary
+  tags: mergedTags, summary
 })
 fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
+
+// Update tags.json
+updateTagsIndex(dataDir, id, mergedTags)
+// If revision crosses scopes, also update original scope's tags.json
+if (original.dir !== dataDir) {
+  updateTagsIndex(original.dir, id, mergedTags)
+}
 
 console.log(JSON.stringify({
   status: 'ok', id, file: filePath,

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -41,6 +41,23 @@ const full = argv.includes('--full')
 const includeSuperseded = argv.includes('--include-superseded')
 const historyId = flag('--history')
 
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+function loadTagsIndex(dataDir) {
+  const tagsFile = path.join(dataDir, 'tags.json')
+  try {
+    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Load index entries from a data directory
 // ---------------------------------------------------------------------------
@@ -139,8 +156,32 @@ if (!includeSuperseded) {
 if (project) {
   results = results.filter(e => e.project === project)
 }
+let searchWarning = null
 if (tag) {
-  results = results.filter(e => e.tags && e.tags.includes(tag))
+  const normalizedTag = normalizeTags(tag)[0]
+  if (normalizedTag) {
+    // Try tags.json from all active scopes
+    let tagIds = null
+    const dirs = []
+    if (scope === 'local' || scope === 'all') dirs.push(LOCAL_DIR)
+    if (scope === 'global' || scope === 'all') dirs.push(GLOBAL_DIR)
+    for (const dir of dirs) {
+      const idx = loadTagsIndex(dir)
+      if (idx && idx[normalizedTag]) {
+        if (!tagIds) tagIds = new Set()
+        for (const id of idx[normalizedTag]) tagIds.add(id)
+      } else if (!idx) {
+        searchWarning = 'tags.json missing or corrupt. Run em-rebuild-index.mjs to regenerate.'
+      }
+    }
+    if (tagIds) {
+      results = results.filter(e => tagIds.has(e.id))
+    } else {
+      // Fallback: linear scan with normalized comparison
+      if (!searchWarning) searchWarning = 'tags.json missing or does not contain tag. Falling back to linear scan. Run em-rebuild-index.mjs to regenerate.'
+      results = results.filter(e => e.tags && e.tags.map(t => t.toLowerCase().trim()).includes(normalizedTag))
+    }
+  }
 }
 if (category) {
   results = results.filter(e => e.category === category)
@@ -181,4 +222,6 @@ const output = results.map(e => {
   return { ...rest, source: _source }
 })
 
-console.log(JSON.stringify({ status: 'ok', count: output.length, episodes: output }))
+const result = { status: 'ok', count: output.length, episodes: output }
+if (searchWarning) result.warning = searchWarning
+console.log(JSON.stringify(result))

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -45,7 +45,7 @@ if (!project || !category || !summary || !body) {
   process.exit(1)
 }
 
-const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research']
+const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson']
 if (!VALID_CATEGORIES.includes(category)) {
   console.log(JSON.stringify({
     status: 'error',
@@ -72,7 +72,30 @@ const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,
 const randSuffix = crypto.randomBytes(2).toString('hex')
 const id = `${ts}-${slug}-${randSuffix}`
 
-const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : []
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+function updateTagsIndex(dataDir, episodeId, tags) {
+  const tagsFile = path.join(dataDir, 'tags.json')
+  let index = {}
+  try {
+    index = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {}
+  for (const tag of tags) {
+    if (!index[tag]) index[tag] = []
+    if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
+  }
+  const tmpFile = tagsFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
+  fs.renameSync(tmpFile, tagsFile)
+}
+
+const tags = normalizeTags(tagsRaw)
 
 const fmLines = [
   '---',
@@ -108,5 +131,7 @@ const indexEntry = JSON.stringify({
   ...(url ? { url, fetched: dateStr } : {})
 })
 fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
+
+updateTagsIndex(dataDir, id, tags)
 
 console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope }))


### PR DESCRIPTION
## Summary

- **Tag normalization** across all scripts: lowercase, trim, deduplicate, sort. Case-insensitive tag search (`REACT` finds `react`).
- **Inverted index** (`tags.json`): O(1) tag lookup instead of linear scan. Atomic write (temp + rename). Graceful fallback to linear scan when missing/corrupt.
- **Tag inheritance on revise**: revised episodes inherit original's tags in frontmatter, index, and tags.json. Survives rebuild.
- **Cross-scope updates**: revisions across scopes update both tags.json files.
- **RFC-001 docs**: full RFC with 4 phases, two second-opinion reviews, all 7 OQs resolved.
- **Behavioral pattern**: added pattern promotion support to episodic memory instructions.
- **`lesson` category** added to em-store.mjs for Phase 4.

## Bugs found and fixed

| Issue | Severity | Description |
|-------|----------|-------------|
| #2 | P1 | Search warning lost after array `.slice()` |
| #3 | P2 | Cross-scope revise didn't update original `tags.json` |
| #4 | P3 | Redundant `index.jsonl` re-read in revise |
| #5 | P1 | Inherited tags not written to frontmatter or index |

## Test plan

- [x] Store with mixed-case duplicate tags → normalized
- [x] tags.json created with deduplicated entries
- [x] Search by tag (case-insensitive via tags.json)
- [x] Fallback: missing, corrupt, and empty tags.json
- [x] Revise with tag inheritance (frontmatter + index + tags.json)
- [x] Superseded IDs remain in tags.json, filtered post-lookup
- [x] Cross-scope revise updates both tags.json files
- [x] Rebuild regenerates both index.jsonl and tags.json
- [x] Tags survive rebuild (inherited tags in frontmatter)
- [x] History mode works with superseded episodes
- [x] Combined filters (tag + project + query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)