### PR TITLE
feat: Pluggable behavioral patterns with seed script (v2)

### DIFF
--- a/docs/rfcs/RFC-001-memory-improvements.md
+++ b/docs/rfcs/RFC-001-memory-improvements.md
@@ -216,11 +216,11 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 ### Acceptance tests (per phase)
 
 **Phase 1:**
-- [ ] store/revise normalize tags (case, trim, dedup, sort) and update `tags.json`
-- [ ] search `--tag` uses `tags.json` for lookup; normalizes input
-- [ ] search falls back to linear scan when `tags.json` is missing or invalid JSON
-- [ ] `tags.json` includes superseded episode IDs; filtering happens post-lookup
-- [ ] rebuild recreates both `index.jsonl` and `tags.json`
+- [x] store/revise normalize tags (case, trim, dedup, sort) and update `tags.json`
+- [x] search `--tag` uses `tags.json` for lookup; normalizes input
+- [x] search falls back to linear scan when `tags.json` is missing or invalid JSON
+- [x] `tags.json` includes superseded episode IDs; filtering happens post-lookup
+- [x] rebuild recreates both `index.jsonl` and `tags.json`
 
 **Phase 2:**
 - [ ] search returns relevance scores by default (scoring is default-on)
@@ -280,7 +280,7 @@ graph TD
 
 | Phase | Files changed | Tests | Notes |
 |---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| Phase 1: Tag Normalization + Inverted Index | `em-store.mjs`, `em-revise.mjs`, `em-search.mjs`, `em-rebuild-index.mjs` | 16 E2E scenarios passed | Shipped in PR #6, commit `0e45e4d`. Bugs: #2 (P1), #3 (P2), #4 (P3), #5 (P1) — all fixed. |
 
 ---
 

--- a/install.mjs
+++ b/install.mjs
@@ -143,6 +143,26 @@ for (const t of tools) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// 4. Seed behavioral patterns
+// ---------------------------------------------------------------------------
+const seedScript = path.join(SCRIPTS_DIR, 'em-seed-patterns.mjs')
+const repoPatternsDir = path.join(REPO_DIR, 'patterns')
+if (fs.existsSync(seedScript) && fs.existsSync(repoPatternsDir)) {
+  try {
+    const { execSync } = await import('child_process')
+    const result = execSync(`node "${seedScript}" --dir "${repoPatternsDir}"`, { encoding: 'utf8' })
+    const parsed = JSON.parse(result.trim())
+    if (parsed.seeded > 0) {
+      console.log(`Seeded ${parsed.seeded} behavioral patterns (${parsed.skipped} already existed)`)
+    } else {
+      console.log(`All ${parsed.total} behavioral patterns already seeded`)
+    }
+  } catch {
+    console.log('Note: behavioral pattern seeding skipped (non-fatal)')
+  }
+}
+
 console.log('\nDone! Episodic memory is ready.')
 console.log(`Global data:  ${GLOBAL_DIR}/`)
 console.log(`Local data:   ${localDir}/`)

--- a/patterns/TEMPLATE.md
+++ b/patterns/TEMPLATE.md
@@ -1,0 +1,24 @@
+---
+pattern_id: bp-NNN-<slug>
+name: "<pattern name>"
+category: decision
+tags: [behavioral-pattern, bp-NNN-<slug>, <topic-tags>]
+scope: global
+version: 1.0.0
+---
+
+# <Pattern Name>
+
+<One-paragraph description of what this pattern is and when to apply it.>
+
+## Steps / Rules
+
+<Numbered steps or bullet points describing the pattern.>
+
+## Detection triggers
+
+<When should an AI tool activate this pattern? What signals indicate it's relevant?>
+
+## Scope
+
+<Who does this apply to? All projects? All tools? Specific contexts?>

--- a/patterns/_index.json
+++ b/patterns/_index.json
@@ -1,0 +1,52 @@
+{
+  "patterns": [
+    {
+      "pattern_id": "bp-001-implementation-workflow",
+      "file": "implementation-workflow.md",
+      "name": "Standard implementation workflow",
+      "tags": ["behavioral-pattern", "workflow", "sdlc", "testing", "code-review"],
+      "scope": "global",
+      "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-002-proactive-milestone-storage",
+      "file": "proactive-milestone-storage.md",
+      "name": "Proactive milestone storage",
+      "tags": ["behavioral-pattern", "episodic-memory", "milestone", "session-discipline"],
+      "scope": "global",
+      "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-003-pattern-promotion",
+      "file": "pattern-promotion.md",
+      "name": "Promote project-specific best practices to global memory",
+      "tags": ["behavioral-pattern", "global-memory", "best-practice"],
+      "scope": "global",
+      "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-004-machine-readable-index",
+      "file": "machine-readable-index.md",
+      "name": "Machine-readable index for token efficiency",
+      "tags": ["behavioral-pattern", "token-efficiency", "index"],
+      "scope": "global",
+      "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-005-enforcement-as-templates",
+      "file": "enforcement-as-templates.md",
+      "name": "Enforcement lives in consuming repos, not rule repos",
+      "tags": ["behavioral-pattern", "enforcement", "ci", "templates"],
+      "scope": "global",
+      "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-006-push-after-verify",
+      "file": "push-after-verify.md",
+      "name": "Push only after all verification steps complete",
+      "tags": ["behavioral-pattern", "workflow", "git", "discipline"],
+      "scope": "global",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/patterns/enforcement-as-templates.md
+++ b/patterns/enforcement-as-templates.md
@@ -1,0 +1,37 @@
+---
+pattern_id: bp-005-enforcement-as-templates
+name: "Enforcement lives in consuming repos, not rule repos"
+category: decision
+tags: [behavioral-pattern, bp-005-enforcement-as-templates, enforcement, ci, templates]
+scope: global
+version: 1.0.0
+---
+
+# Enforcement Lives in Consuming Repos
+
+When a rule repo (like user-preferences) defines behavioral rules, the enforcement mechanisms (CI workflows, hooks, PR templates) should ship as **copyable templates**, not as forced installations. Each consuming repo decides what to adopt.
+
+## The split
+
+| Layer | Where | What |
+|-------|-------|------|
+| Rule definition | Rule repo (user-preferences) | The rule text and rationale |
+| Reference templates | Rule repo (user-preferences) | CI workflow, PR template, hook scripts — as templates |
+| Actual enforcement | Consuming repo | Each project copies and adapts the templates it needs |
+
+## Why
+
+- Not every repo uses the same CI (GitHub Actions vs GitLab CI vs none)
+- Not every repo has the same structure (`scripts/` vs `src/` vs `lib/`)
+- Forcing CI workflows on install couples the rule repo to GitHub
+- Templates let projects adapt paths, thresholds, and exemptions
+
+## Detection triggers
+
+- Building enforcement for a cross-project rule
+- Tempted to add CI workflows to a shared/template repo's installer
+- User asks "should this enforcement go in repo X or repo Y?"
+
+## Scope
+
+All rule/template repos. The rule repo is the source of truth for **what** to enforce. The consuming repo is the source of truth for **how** to enforce it.

--- a/patterns/implementation-workflow.md
+++ b/patterns/implementation-workflow.md
@@ -1,0 +1,35 @@
+---
+pattern_id: bp-001-implementation-workflow
+name: "Standard implementation workflow"
+category: decision
+tags: [behavioral-pattern, bp-001-implementation-workflow, workflow, sdlc, testing, code-review]
+scope: global
+version: 1.0.0
+---
+
+# Standard Implementation Workflow
+
+Mandatory workflow for any non-trivial implementation across all projects and AI tools. Catches bugs at three stages: plan review (design gaps), code review (implementation bugs), and E2E testing (integration failures).
+
+## Steps (in order)
+
+1. Present implementation plan
+2. Second-opinion review on the plan (cross-AI or subagent)
+3. Fix all P1/P2 findings from the second review
+4. Show final plan, wait for explicit approval (plan-gate)
+5. Implement with unit tests written alongside code
+6. Code review the implementation
+7. Fix all code review bugs
+8. End-to-end testing
+9. Log all bugs to GitHub Issues with root cause + resolution (if connected)
+
+## Detection triggers
+
+- User requests a new feature or multi-file change
+- RFC phase is moving to implementation
+- Refactor with behavioral changes planned
+- Any change modifying more than 3 files
+
+## Scope
+
+All projects, all AI tools. Does NOT apply to trivial fixes (typo, one-liner, config change), documentation-only changes, or exploratory spikes.

--- a/patterns/machine-readable-index.md
+++ b/patterns/machine-readable-index.md
@@ -1,0 +1,51 @@
+---
+pattern_id: bp-004-machine-readable-index
+name: "Machine-readable index for token efficiency"
+category: decision
+tags: [behavioral-pattern, bp-004-machine-readable-index, token-efficiency, index]
+scope: global
+version: 1.0.0
+---
+
+# Machine-Readable Index for Token Efficiency
+
+When a directory contains multiple files that AI tools need to discover, include a machine-readable `_index.json` alongside any human-readable `README.md`. This allows AI tools to read one small file (~200 tokens) instead of scanning all files (~2k+ tokens).
+
+## When to apply
+
+- Any directory with 3+ files that AI tools need to discover or enumerate
+- Pattern directories, RFC directories, episode directories
+- Any collection where an AI tool would otherwise `ls` + read each file
+
+## Index structure
+
+```json
+{
+  "items": [
+    {
+      "id": "<unique-id>",
+      "file": "<filename>",
+      "name": "<human-readable name>",
+      "tags": ["<relevant>", "<tags>"],
+      "version": "<semver>"
+    }
+  ]
+}
+```
+
+## Key principles
+
+- Index is the discovery mechanism — AI reads index first, then individual files only when needed
+- Index must be updated in the same commit as any file addition/removal
+- Keep the index minimal — just enough to decide whether to read the full file
+- Human-readable README derives from the index, never maintained independently
+
+## Detection triggers
+
+- Creating a new directory with 3+ discoverable files
+- AI tool performing `ls` + sequential reads on a directory
+- Token budget concerns during session start
+
+## Scope
+
+All projects, all AI tools. Applies to any structured directory, not just episodic memory.

--- a/patterns/pattern-promotion.md
+++ b/patterns/pattern-promotion.md
@@ -1,0 +1,37 @@
+---
+pattern_id: bp-003-pattern-promotion
+name: "Promote project-specific best practices to global memory"
+category: decision
+tags: [behavioral-pattern, bp-003-pattern-promotion, global-memory, best-practice]
+scope: global
+version: 1.0.0
+---
+
+# Pattern Promotion
+
+When a project-specific decision or behavior proves to be a best practice, promote it to global episodic memory so all projects and tools benefit.
+
+## Detection criteria
+
+A project-specific behavior should be promoted to global when:
+
+1. It has been confirmed across 2+ projects (not a one-off)
+2. It represents a generalizable best practice (not project-specific tooling)
+3. It prevented bugs, saved time, or improved quality in a measurable way
+
+## Promotion workflow
+
+1. At session end, review project-specific episodes stored during the session
+2. Check if any represent generalizable patterns (not project-specific config/tooling)
+3. If yes, store a global episode with category 'decision' and tag 'behavioral-pattern'
+4. If the pattern is significant enough, create a pattern file in `patterns/` and update `_index.json`
+
+## Detection triggers
+
+- Session end review
+- User says "this should apply everywhere"
+- Same decision made independently in 2+ projects
+
+## Scope
+
+All projects, all AI tools. The promotion itself creates a global episode. Project-specific episodes remain unchanged.

--- a/patterns/proactive-milestone-storage.md
+++ b/patterns/proactive-milestone-storage.md
@@ -1,0 +1,30 @@
+---
+pattern_id: bp-002-proactive-milestone-storage
+name: "Proactive milestone storage"
+category: decision
+tags: [behavioral-pattern, bp-002-proactive-milestone-storage, episodic-memory, milestone, session-discipline]
+scope: global
+version: 1.0.0
+---
+
+# Proactive Milestone Storage
+
+When a milestone is reached, proactively offer to store it in local episodic memory. Do not wait for the user to ask.
+
+## Detection triggers
+
+- Phase or feature shipped and merged
+- PR merged
+- RFC status change (draft → accepted → implemented)
+- Significant bug found and fixed (with root cause)
+- Architecture decision made
+- CI/CD pipeline change
+- New rule or pattern established
+
+## Episode content
+
+The stored episode should include: what shipped, key decisions made, bugs found during the process, and what comes next.
+
+## Scope
+
+All projects, all AI tools. Store the milestone episode in local scope (project-specific). This pattern itself lives in global scope.

--- a/patterns/push-after-verify.md
+++ b/patterns/push-after-verify.md
@@ -1,0 +1,52 @@
+---
+pattern_id: bp-006-push-after-verify
+name: "Push only after all verification steps complete"
+category: decision
+tags: [behavioral-pattern, bp-006-push-after-verify, workflow, git, discipline]
+scope: global
+version: 1.0.0
+---
+
+# Push Only After All Verification Steps Complete
+
+Do not push code until all pre-push verification steps (unit tests, code review, E2E testing) are complete locally. The push is the deliverable — not a checkpoint.
+
+## The anti-pattern
+
+1. Implement code
+2. Push to PR immediately ("save progress")
+3. Write tests after pushing
+4. Do code review after pushing
+5. Fix bugs and push again
+
+This turns tests and reviews into remediation instead of quality gates. The mindset shifts from "building" to "patching."
+
+## The correct flow
+
+1. Implement code + write unit tests alongside (same step)
+2. Code review locally (read your own code critically)
+3. Fix code review findings
+4. Run E2E tests locally
+5. THEN push — one clean commit or commit series
+6. Create PR with confidence that all checks pass
+
+## Why this matters
+
+- Pushing before testing creates a false sense of completion
+- Once code is on a PR, the psychological pressure is to merge, not to rework
+- Tests written after pushing tend to verify what was built, not what should have been built
+- Code review after pushing becomes "find bugs to fix" instead of "catch design issues"
+
+## Detection triggers
+
+- About to run `git push` — pause and check: are all Rule 18 steps done?
+- Feeling the urge to "save progress" to remote — that's the signal to slow down
+- Multiple fix-up commits on a PR — sign that verification was done post-push
+
+## Scope
+
+All projects, all AI tools. This is a discipline pattern, not a tooling pattern.
+
+## Origin
+
+Discovered during episodic-memory Phase 1 + behavioral patterns implementation. Rule 18 was violated three times in one session while building the enforcement for it. Each violation followed the same push-before-verify anti-pattern.

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * em-seed-patterns.mjs — Seed behavioral patterns as global episodes.
+ *
+ * Usage:
+ *   node em-seed-patterns.mjs [--dir <patterns-dir>] [--dry-run]
+ *
+ * Reads _index.json from the patterns directory, checks for existing
+ * episodes by pattern_id tag, and stores new patterns as global episodes.
+ * Idempotent — safe to run multiple times.
+ *
+ * Outputs JSON: { status, seeded, skipped, total }
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const patternsDir = flag('--dir') || path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'patterns')
+const dryRun = argv.includes('--dry-run')
+
+// ---------------------------------------------------------------------------
+// Load _index.json
+// ---------------------------------------------------------------------------
+const indexFile = path.join(patternsDir, '_index.json')
+if (!fs.existsSync(indexFile)) {
+  console.log(JSON.stringify({ status: 'error', message: `No _index.json found at ${indexFile}` }))
+  process.exit(1)
+}
+
+let index
+try {
+  index = JSON.parse(fs.readFileSync(indexFile, 'utf8'))
+} catch (e) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid _index.json: ${e.message}` }))
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Load existing tags.json to check for already-seeded patterns
+// ---------------------------------------------------------------------------
+const tagsFile = path.join(GLOBAL_DIR, 'tags.json')
+let tagsIndex = {}
+try {
+  tagsIndex = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+} catch {}
+
+// ---------------------------------------------------------------------------
+// Parse frontmatter from a pattern .md file
+// ---------------------------------------------------------------------------
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+  const lines = match[1].split('\n')
+  const data = {}
+  for (const line of lines) {
+    const m = line.match(/^(\w+):\s*(.*)$/)
+    if (!m) continue
+    const [, key, raw] = m
+    const arrMatch = raw.match(/^\[(.*)\]$/)
+    if (arrMatch) {
+      data[key] = arrMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+    } else if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+      data[key] = raw.slice(1, -1)
+    } else {
+      data[key] = raw === 'null' ? null : raw
+    }
+  }
+  return data
+}
+
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+// Accumulate tag updates in memory, flush once at the end
+const pendingTagUpdates = []
+
+function queueTagsUpdate(episodeId, tags) {
+  pendingTagUpdates.push({ episodeId, tags })
+}
+
+function flushTagsIndex() {
+  if (pendingTagUpdates.length === 0) return
+  const tagsFile = path.join(GLOBAL_DIR, 'tags.json')
+  let idx = {}
+  try { idx = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+  for (const { episodeId, tags } of pendingTagUpdates) {
+    for (const tag of tags) {
+      if (!idx[tag]) idx[tag] = []
+      if (!idx[tag].includes(episodeId)) idx[tag].push(episodeId)
+    }
+  }
+  const tmpFile = tagsFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(idx, null, 2), 'utf8')
+  fs.renameSync(tmpFile, tagsFile)
+}
+
+// ---------------------------------------------------------------------------
+// Seed patterns
+// ---------------------------------------------------------------------------
+const episodesDir = path.join(GLOBAL_DIR, 'episodes')
+const globalIndexFile = path.join(GLOBAL_DIR, 'index.jsonl')
+fs.mkdirSync(episodesDir, { recursive: true })
+
+let seeded = 0
+let skipped = 0
+
+for (const entry of index.patterns || []) {
+  const { pattern_id, file } = entry
+
+  // Check if already seeded by pattern_id tag
+  if (tagsIndex[pattern_id] && tagsIndex[pattern_id].length > 0) {
+    skipped++
+    continue
+  }
+
+  // Read the pattern file
+  const filePath = path.join(patternsDir, file)
+  if (!fs.existsSync(filePath)) {
+    skipped++
+    continue
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8')
+  const fm = parseFrontmatter(content)
+  if (!fm) {
+    skipped++
+    continue
+  }
+
+  // Extract body (everything after frontmatter)
+  const parts = content.split('---')
+  const body = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
+
+  const tags = normalizeTags(fm.tags || [])
+  const summary = fm.name || entry.name || pattern_id
+  const project = 'global'
+  const category = fm.category || 'decision'
+
+  if (dryRun) {
+    seeded++
+    continue
+  }
+
+  // Generate episode
+  const now = new Date()
+  const dateStr = now.toISOString().slice(0, 10)
+  const timeStr = now.toISOString().slice(11, 16)
+  const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
+  const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
+  const randSuffix = crypto.randomBytes(2).toString('hex')
+  const id = `${ts}-${slug}-${randSuffix}`
+
+  const episodeFm = [
+    '---',
+    `id: ${id}`,
+    `date: ${dateStr}`,
+    `time: "${timeStr}"`,
+    `project: ${project}`,
+    `category: ${category}`,
+    `status: active`,
+    `tags: [${tags.join(', ')}]`,
+    `summary: ${summary}`,
+    '---',
+  ].join('\n')
+
+  const episodeContent = `${episodeFm}\n\n${body}\n`
+
+  // Write episode file
+  const episodeFilePath = path.join(episodesDir, `${id}.md`)
+  fs.writeFileSync(episodeFilePath, episodeContent, 'utf8')
+
+  // Append to index.jsonl
+  const indexEntry = JSON.stringify({
+    id, date: dateStr, time: timeStr, project, category,
+    status: 'active', supersedes: null, tags, summary
+  })
+  fs.appendFileSync(globalIndexFile, indexEntry + '\n', 'utf8')
+
+  // Queue tags.json update
+  queueTagsUpdate(id, tags)
+
+  seeded++
+}
+
+// Flush all tag updates in one atomic write
+flushTagsIndex()
+
+const total = (index.patterns || []).length
+console.log(JSON.stringify({
+  status: 'ok',
+  seeded,
+  skipped,
+  total,
+  ...(dryRun ? { dry_run: true } : {})
+}))

--- a/tests/test-seed-patterns.mjs
+++ b/tests/test-seed-patterns.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * test-seed-patterns.mjs — Unit tests for em-seed-patterns.mjs
+ *
+ * Usage: node tests/test-seed-patterns.mjs
+ *
+ * Tests the seed script against a temporary data directory.
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPT = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts', 'em-seed-patterns.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function run(args = '') {
+  const result = execSync(`node "${SCRIPT}" ${args}`, { encoding: 'utf8', env: { ...process.env, HOME: tmpHome } })
+  return JSON.parse(result.trim())
+}
+
+// ---------------------------------------------------------------------------
+// Setup: temp home dir with isolated .episodic-memory
+// ---------------------------------------------------------------------------
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-test-'))
+const tmpGlobalDir = path.join(tmpHome, '.episodic-memory')
+const tmpEpisodesDir = path.join(tmpGlobalDir, 'episodes')
+fs.mkdirSync(tmpEpisodesDir, { recursive: true })
+
+// Create a test patterns directory
+const tmpPatternsDir = path.join(tmpHome, 'patterns')
+fs.mkdirSync(tmpPatternsDir, { recursive: true })
+
+// Write test pattern files
+fs.writeFileSync(path.join(tmpPatternsDir, '_index.json'), JSON.stringify({
+  patterns: [
+    { pattern_id: 'test-bp-001', file: 'test-pattern-1.md', name: 'Test Pattern 1', tags: ['behavioral-pattern', 'test-bp-001'], scope: 'global', version: '1.0.0' },
+    { pattern_id: 'test-bp-002', file: 'test-pattern-2.md', name: 'Test Pattern 2', tags: ['behavioral-pattern', 'test-bp-002'], scope: 'global', version: '1.0.0' }
+  ]
+}, null, 2))
+
+fs.writeFileSync(path.join(tmpPatternsDir, 'test-pattern-1.md'), `---
+pattern_id: test-bp-001
+name: "Test Pattern 1"
+category: decision
+tags: [behavioral-pattern, test-bp-001, testing]
+scope: global
+version: 1.0.0
+---
+
+# Test Pattern 1
+
+This is a test behavioral pattern.
+`)
+
+fs.writeFileSync(path.join(tmpPatternsDir, 'test-pattern-2.md'), `---
+pattern_id: test-bp-002
+name: "Test Pattern 2"
+category: discovery
+tags: [behavioral-pattern, test-bp-002, testing]
+scope: global
+version: 1.0.0
+---
+
+# Test Pattern 2
+
+This is another test behavioral pattern.
+`)
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+console.log('\n=== em-seed-patterns.mjs unit tests ===\n')
+
+console.log('Dry-run mode:')
+
+test('dry-run seeds nothing, reports count', () => {
+  const result = run(`--dir "${tmpPatternsDir}" --dry-run`)
+  assert.strictEqual(result.status, 'ok')
+  assert.strictEqual(result.seeded, 2)
+  assert.strictEqual(result.skipped, 0)
+  assert.strictEqual(result.total, 2)
+  assert.strictEqual(result.dry_run, true)
+})
+
+test('dry-run creates no episode files', () => {
+  const files = fs.readdirSync(tmpEpisodesDir)
+  assert.strictEqual(files.length, 0, `Expected 0 files, got ${files.length}`)
+})
+
+console.log('\nFirst seed:')
+
+test('seeds 2 patterns on first run', () => {
+  const result = run(`--dir "${tmpPatternsDir}"`)
+  assert.strictEqual(result.status, 'ok')
+  assert.strictEqual(result.seeded, 2)
+  assert.strictEqual(result.skipped, 0)
+  assert.strictEqual(result.total, 2)
+})
+
+test('creates 2 episode files', () => {
+  const files = fs.readdirSync(tmpEpisodesDir).filter(f => f.endsWith('.md'))
+  assert.strictEqual(files.length, 2, `Expected 2 files, got ${files.length}`)
+})
+
+test('creates index.jsonl with 2 entries', () => {
+  const indexFile = path.join(tmpGlobalDir, 'index.jsonl')
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  assert.strictEqual(lines.length, 2)
+})
+
+test('creates tags.json with pattern_id tags', () => {
+  const tagsFile = path.join(tmpGlobalDir, 'tags.json')
+  const tags = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  assert.ok(tags['test-bp-001'], 'test-bp-001 tag missing')
+  assert.ok(tags['test-bp-002'], 'test-bp-002 tag missing')
+  assert.ok(tags['behavioral-pattern'], 'behavioral-pattern tag missing')
+  assert.strictEqual(tags['behavioral-pattern'].length, 2)
+})
+
+test('episode frontmatter has correct fields', () => {
+  const files = fs.readdirSync(tmpEpisodesDir).filter(f => f.endsWith('.md'))
+  const content = fs.readFileSync(path.join(tmpEpisodesDir, files[0]), 'utf8')
+  assert.ok(content.includes('category: decision') || content.includes('category: discovery'), 'Missing category')
+  assert.ok(content.includes('status: active'), 'Missing status')
+  assert.ok(content.includes('project: global'), 'Missing project')
+  assert.ok(content.includes('behavioral-pattern'), 'Missing behavioral-pattern tag')
+})
+
+test('episode body contains pattern content', () => {
+  const files = fs.readdirSync(tmpEpisodesDir).filter(f => f.endsWith('.md'))
+  const content = fs.readFileSync(path.join(tmpEpisodesDir, files[0]), 'utf8')
+  assert.ok(content.includes('test behavioral pattern'), 'Body content missing')
+})
+
+console.log('\nIdempotency:')
+
+test('second run skips all patterns', () => {
+  const result = run(`--dir "${tmpPatternsDir}"`)
+  assert.strictEqual(result.seeded, 0)
+  assert.strictEqual(result.skipped, 2)
+  assert.strictEqual(result.total, 2)
+})
+
+test('no duplicate episode files after second run', () => {
+  const files = fs.readdirSync(tmpEpisodesDir).filter(f => f.endsWith('.md'))
+  assert.strictEqual(files.length, 2)
+})
+
+test('no duplicate index.jsonl entries after second run', () => {
+  const indexFile = path.join(tmpGlobalDir, 'index.jsonl')
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  assert.strictEqual(lines.length, 2)
+})
+
+console.log('\nError handling:')
+
+test('missing _index.json returns error', () => {
+  try {
+    run(`--dir /tmp/nonexistent-${Date.now()}`)
+    assert.fail('Should have thrown')
+  } catch (e) {
+    assert.ok(e.message.includes('status') || e.status === 1, 'Should exit with error')
+  }
+})
+
+test('missing pattern file is skipped gracefully', () => {
+  const tmpDir2 = path.join(tmpHome, 'patterns-missing')
+  fs.mkdirSync(tmpDir2, { recursive: true })
+  fs.writeFileSync(path.join(tmpDir2, '_index.json'), JSON.stringify({
+    patterns: [{ pattern_id: 'bp-missing', file: 'does-not-exist.md', name: 'Missing', tags: ['behavioral-pattern'], scope: 'global', version: '1.0.0' }]
+  }))
+  const result = run(`--dir "${tmpDir2}"`)
+  assert.strictEqual(result.seeded, 0)
+  assert.strictEqual(result.skipped, 1)
+})
+
+test('invalid frontmatter is skipped gracefully', () => {
+  const tmpDir3 = path.join(tmpHome, 'patterns-bad-fm')
+  fs.mkdirSync(tmpDir3, { recursive: true })
+  fs.writeFileSync(path.join(tmpDir3, '_index.json'), JSON.stringify({
+    patterns: [{ pattern_id: 'bp-bad', file: 'bad.md', name: 'Bad', tags: ['behavioral-pattern'], scope: 'global', version: '1.0.0' }]
+  }))
+  fs.writeFileSync(path.join(tmpDir3, 'bad.md'), 'no frontmatter here, just text')
+  const result = run(`--dir "${tmpDir3}"`)
+  assert.strictEqual(result.seeded, 0)
+  assert.strictEqual(result.skipped, 1)
+})
+
+console.log('\nTag normalization:')
+
+test('tags are normalized (lowercase, sorted, deduped)', () => {
+  const tagsFile = path.join(tmpGlobalDir, 'tags.json')
+  const tags = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  const allKeys = Object.keys(tags)
+  const hasUpperCase = allKeys.some(k => k !== k.toLowerCase())
+  assert.ok(!hasUpperCase, `Found uppercase tags: ${allKeys.filter(k => k !== k.toLowerCase())}`)
+})
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+fs.rmSync(tmpHome, { recursive: true, force: true })
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- 6 behavioral patterns in `patterns/` with `_index.json` for token-efficient discovery
- `scripts/em-seed-patterns.mjs` — seeds patterns as global episodes, idempotent, `--dry-run`
- `install.mjs` — seeds at end of install (non-fatal)
- RFC-001 tracking table: Phase 1 marked shipped

## Rule 18 Checklist

- [x] Implementation plan presented and approved
- [x] Second-opinion review completed on the plan (twice)
- [x] Review findings fixed before implementation
- [x] Unit tests written alongside code (15 tests)
- [x] Code review completed after implementation (P3 only — no fix needed)
- [x] Code review bugs fixed (n/a)
- [x] End-to-end testing passed (7 scenarios)
- [x] Bugs logged to GitHub Issues with root cause + resolution (n/a — no bugs found)

> This PR replaces #7, which was closed because Rule 18 was not followed properly (code pushed before tests/review/E2E were complete).

## Patterns shipped

| ID | Pattern |
|----|---------|
| bp-001 | Standard implementation workflow (Rule 18) |
| bp-002 | Proactive milestone storage |
| bp-003 | Pattern promotion (project → global) |
| bp-004 | Machine-readable index for token efficiency |
| bp-005 | Enforcement as templates (consuming repos opt in) |
| bp-006 | Push only after all verification steps complete |

## Test plan

- [x] Dry-run reports count, writes nothing
- [x] First seed stores episodes in global scope
- [x] Second run skips all (idempotent)
- [x] All 6 patterns discoverable via `--tag behavioral-pattern`
- [x] Individual pattern_id tags work for lookup
- [x] Missing `_index.json` returns error
- [x] Missing/invalid pattern files skipped gracefully
- [x] Tags normalized (lowercase, sorted, deduped)
- [x] `_index.json` matches pattern files on disk
- [x] `install.mjs` integration reports seed results

🤖 Generated with [Claude Code](https://claude.com/claude-code)