### PR TITLE
feat: Phase 2 — Relevance Decay + Access Tracking (RFC-001)

### DIFF
--- a/docs/rfcs/RFC-001-memory-improvements.md
+++ b/docs/rfcs/RFC-001-memory-improvements.md
@@ -211,7 +211,39 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 
 ## Implementation plan
 
-> Populate this section when the RFC moves to `accepted`. Use phase sub-headings with concrete file changes, before/after sketches, and dependency notes.
+### Phase 1: Tag Normalization + Inverted Index — SHIPPED
+
+**Files modified:** `em-store.mjs`, `em-revise.mjs`, `em-search.mjs`, `em-rebuild-index.mjs`
+**Shipped:** PR #6, commit `0e45e4d`. Bugs #2–#5 found and fixed.
+
+### Phase 2: Relevance Decay + Access Tracking — IN PROGRESS
+
+**Files modified:**
+- `em-search.mjs` (~227→~340 lines) — scoring formula, `text_match` tiers (1.0 exact/0.7 substring/0.4 body-only), access tracking write-back with dual-scope handling (local + global `index.jsonl` independently), `--no-score`/`--no-track`/`--warn-time-ms`/`--warn-count` flags, performance health check
+- `em-rebuild-index.mjs` (~115→~140 lines) — load old index before rebuild, carry forward `access_count`/`last_accessed` for known IDs, default `0`/`null` for new
+
+**Files created:**
+- `em-prune.mjs` (~120 lines) — query-independent prune score, `--scope`/`--threshold`/`--dry-run`/`--check` flags, append to `archived-index.jsonl`, move `.md` to `archived/`
+
+**Key design decisions:**
+- `computeScore` defaults missing `access_count` to 0 (no `em-store.mjs` change needed)
+- Write-back re-reads `index.jsonl` before writing to narrow race window with concurrent appends; documented as best-effort
+- Score ALL results before applying `limit` (replaces date-based sort)
+- Health check for `em-recall.mjs` deferred to Phase 3 (script doesn't exist yet)
+
+**Detailed plan:** `docs/rfcs/RFC-001-phase2-plan.md`
+
+### Phase 3: Proactive Recall — NOT STARTED
+
+**Files created:** `em-recall.mjs` (~100 lines) — multi-pass retrieval (project match, tag match, recent cross-project), output as `{ "preflight_warnings": [], "episodes": [...] }` object wrapper (designed for RFC-002 Phase 3 extension)
+**Depends on:** Phase 2 (scoring + access tracking)
+
+### Phase 4: Semantic Consolidation — NOT STARTED
+
+**Files created:** `em-consolidate.mjs` (~150 lines) — Jaccard clustering, `lesson` category, `--auto`/`--dry-run`/`--max-episodes` modes
+**Files modified:** `em-store.mjs` (add `lesson` to VALID_CATEGORIES — coordinate with RFC-002 `violation` addition)
+**Depends on:** Phase 2 (scoring for cluster ranking)
+**Deferred details:** Hook/config/instruction integration to be specified when Phase 4 begins
 
 ### Acceptance tests (per phase)
 
@@ -286,7 +318,7 @@ graph TD
 
 ## Related RFCs
 
-- _none — this is the first RFC for the episodic-memory project_
+- RFC-002 — Learning Loop (Phase 3 extends `em-recall.mjs` built in this RFC's Phase 3)
 
 ---
 

--- a/docs/rfcs/RFC-001-phase2-plan.md
+++ b/docs/rfcs/RFC-001-phase2-plan.md
@@ -1,0 +1,129 @@
+# RFC-001 Phase 2 Implementation Plan — Relevance Decay + Access Tracking
+
+## Overview
+
+Add relevance scoring, access tracking, performance health checks, and pruning to the episodic memory system. All changes are backwards-compatible (new fields default gracefully).
+
+## Files modified (2)
+
+### `scripts/em-search.mjs` (~227 → ~340 lines)
+
+**1. New CLI flags:**
+- `--no-score` — suppress relevance scoring (return results without `score` field)
+- `--no-track` — disable access tracking write-back (side-effect-free search)
+- `--warn-time-ms N` — performance warning threshold in ms (default: 500)
+- `--warn-count N` — episode count warning threshold (default: 500)
+
+**2. `text_match` scoring tiers:**
+Current code uses boolean `includes()` for query matching. Phase 2 replaces this with numeric scoring:
+
+| Match type | Score | Condition |
+|------------|-------|-----------|
+| Exact summary match | 1.0 | `summary.toLowerCase() === query.toLowerCase()` |
+| Summary substring | 0.7 | `summary.toLowerCase().includes(query.toLowerCase())` |
+| Body-only match | 0.4 | query found in body but not summary |
+| Non-query search | 1.0 | tag/category/project filters without `--query` |
+
+**3. `computeScore(entry, textMatchScore)` function:**
+```
+score = textMatchScore * max(0.1, 1 - (days_since_creation / 365)) * (1 + log1p(access_count) * 0.1)
+```
+- `days_since_creation`: computed via `new Date(entry.date)` — sub-day precision unnecessary
+- `access_count`: defaults to `entry.access_count || 0` for backwards compat with pre-Phase-2 entries
+- Time decay floors at 0.1 (memories never reach zero)
+- Access boost is logarithmic (prevents runaway)
+
+**4. Result ordering change:**
+- Current: filter → sort by date descending → `slice(0, limit)`
+- Phase 2: filter → compute scores → sort by score descending → `slice(0, limit)` → output
+- When `--no-score`: keep current date-based sort
+
+**5. Access tracking write-back:**
+- After outputting results, update `access_count` and `last_accessed` in `index.jsonl`
+- **Dual-scope handling:** group results by their source `_dataDir`, perform separate read-modify-write for each scope's `index.jsonl`
+- **Atomic write:** re-read `index.jsonl` just before writing (narrow the race window with concurrent `em-store.mjs` appends), merge increments, write to temp, rename. Document the narrow race window in code comments — access tracking is best-effort, not critical.
+- **Skip write-back when:** `--no-track`, `--history`, or `--include-superseded`
+
+**6. Performance health check:**
+- Measure wall-clock time (`Date.now()` before/after search)
+- If execution > `--warn-time-ms` (default 500): add `"warning"` field to JSON output
+- If episode count > `--warn-count` (default 500): add `"warning"` field
+- Health check for `em-recall.mjs` deferred to Phase 3 (script does not exist yet)
+
+### `scripts/em-rebuild-index.mjs` (~115 → ~140 lines)
+
+1. Before rebuild: load old `index.jsonl` into a map keyed by episode ID
+2. During rebuild: carry forward `access_count` and `last_accessed` for known IDs
+3. Default to `0` and `null` for new entries
+4. Add comment confirming rebuild ignores `archived/` directory (already correct — `readdirSync(episodesDir)` only reads `episodes/`)
+
+## Files created (1)
+
+### `scripts/em-prune.mjs` (~120 lines)
+
+**Query-independent prune score:**
+```
+score = max(0.1, 1 - (days_since_creation / 365)) * (1 + log1p(access_count) * 0.1)
+```
+(Same as search formula with `text_match` fixed at 1.0)
+
+**CLI flags:**
+- `--threshold N` — prune score cutoff (default: 0.15)
+- `--scope local|global|all` — which data stores to prune (default: `all`)
+- `--dry-run` — preview pruneable episodes with scores, sizes; no file moves
+- `--check` — report count only, exit 1 if prunable episodes exist (for hooks/CI)
+
+**Behavior:**
+1. Load `index.jsonl`, compute prune score for each episode
+2. Episodes below threshold → move `.md` to `archived/` subdirectory
+3. Remove pruned entries from `index.jsonl` and `tags.json` (atomic writes)
+4. **Append** to `archived-index.jsonl` (read-merge-write, not overwrite — preserves previous prune runs)
+5. Output: `{ "pruned": N, "remaining": M, "freed_bytes": B }`
+
+**Breakpoint documentation:** Add comment noting episodes become prunable at ~310 days with 0 accesses at default threshold 0.15.
+
+## Files NOT modified (deliberate)
+
+- `em-store.mjs` — does NOT need to write `access_count`/`last_accessed` on new entries. Instead, `computeScore` defaults missing fields: `entry.access_count || 0`. New fields appear after first search access or next rebuild.
+
+## Unit tests: `tests/test-phase2.mjs`
+
+Written alongside implementation, following `test-seed-patterns.mjs` pattern (temp dir, `execSync`, JSON assertions).
+
+**Test cases:**
+
+1. Scoring with 0 `access_count` — no boost, pure time decay
+2. Scoring with missing `access_count` field — backwards compat, defaults to 0
+3. Time decay at 0 days — score near 1.0
+4. Time decay at 365 days — score at floor (0.1)
+5. Time decay at 730 days — score still at floor (0.1, not negative)
+6. `text_match` tiers — exact summary (1.0), substring (0.7), body-only (0.4)
+7. `--no-score` — results returned without `score` field, date-sorted
+8. `--no-track` — `index.jsonl` unchanged after search
+9. Access tracking increments — `access_count` increases, `last_accessed` updates
+10. `--history` and `--include-superseded` — no access tracking
+11. Dual-scope write-back — both local and global `index.jsonl` updated
+12. Result ordering — high-score old episode ranks above low-score recent episode
+13. Limit applied after scoring — top-N by score, not top-N by date
+14. Performance warning — emitted when episode count > threshold
+15. Prune `--dry-run` — reports scores, moves no files
+16. Prune `--check` — exits 1 when prunable episodes exist, 0 when none
+17. Prune default — moves files to `archived/`, updates indexes
+18. Prune appends to `archived-index.jsonl` — second prune preserves first batch
+19. Rebuild preserves `access_count` and `last_accessed`
+20. Rebuild defaults missing metadata to `0` / `null`
+
+## Dependency order
+
+1. `em-search.mjs` — scoring + write-back (core feature)
+2. `em-rebuild-index.mjs` — preserve metadata (needed before prune can rely on counts)
+3. `em-prune.mjs` — depends on scoring formula from search + preserved metadata from rebuild
+4. `tests/test-phase2.mjs` — written alongside each step above
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Concurrent `em-store.mjs` append during write-back | Re-read before write to narrow race window; document as known limitation; access tracking is best-effort |
+| Large index slows scoring | Performance health check warns at 500 episodes; prune provides escape valve |
+| Scoring changes result order (breaking for consumers) | `--no-score` opt-out preserves date-based sort |

--- a/patterns/_index.json
+++ b/patterns/_index.json
@@ -71,6 +71,14 @@
       "tags": ["behavioral-pattern", "discipline", "enforcement", "cognitive-bias"],
       "scope": "global",
       "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-011-local-before-git",
+      "file": "local-before-git.md",
+      "name": "Local files first, git only for reviewed content",
+      "tags": ["behavioral-pattern", "workflow", "git", "review", "discipline"],
+      "scope": "global",
+      "version": "1.0.0"
     }
   ]
 }

--- a/patterns/local-before-git.md
+++ b/patterns/local-before-git.md
@@ -1,0 +1,34 @@
+---
+pattern_id: bp-011-local-before-git
+name: "Local files first, git only for reviewed content"
+category: decision
+tags: [behavioral-pattern, bp-011-local-before-git, workflow, git, review, discipline]
+scope: global
+version: 1.0.0
+---
+
+# Local Files First, Git Only for Reviewed Content
+
+When creating plans, review requests, or draft documents, write to local project files first. Get reviews done locally (subagents, episodic memory). Only commit and push after the content is reviewed and stable. Git is for reviewed artifacts, not drafts.
+
+## Rules
+
+1. Write draft content to local files (e.g., `docs/rfcs/`, `memory/`)
+2. Run reviews locally (subagents, episodic memory search, local validation)
+3. Iterate on findings locally — no commits during review cycles
+4. Once content is stable and reviewed, commit and push
+5. **Exception:** when an external reviewer (e.g., Codex) can only access content via GitHub, push to a feature branch first — but use a draft PR or issue, not a main-branch commit
+
+## Detection triggers
+
+- About to `git add` a file that hasn't been reviewed yet
+- Creating a plan or RFC and reaching for `git commit` before getting a second opinion
+- Writing a review request directly as a GitHub issue before the content exists locally
+
+## Why this exists
+
+Pushing draft content to git creates unnecessary commits, merge conflicts, and noise. Each review iteration adds another commit. The result is a messy history that obscures the actual implementation work.
+
+## Scope
+
+All projects, all AI tools. Applies to any content that will go through review before implementation.

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * em-prune.mjs — Archive stale episodes below a relevance threshold.
+ *
+ * Usage:
+ *   node em-prune.mjs [--scope local|global|all] [--threshold <n>]
+ *                     [--dry-run] [--check]
+ *
+ * Prune score (query-independent):
+ *   max(0.1, 1 - (days_since_creation / 365)) * (1 + log1p(access_count) * 0.1)
+ *
+ * At default threshold 0.15, episodes become prunable at ~310 days with 0 accesses.
+ *
+ * Superseded episodes are scored identically to active ones — they are not pruned
+ * more aggressively. This is deliberate: superseded episodes participate in revision
+ * chains (--history) and may be needed for provenance even when old.
+ *
+ * --dry-run: preview what would be archived (no file moves)
+ * --check:  report count only, exit 1 if prunable episodes exist (for CI/hooks)
+ *
+ * Outputs JSON: { status, pruned, remaining, freed_bytes } or dry-run equivalent.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const scope = flag('--scope') || 'all'
+const threshold = parseFloat(flag('--threshold') || '0.15')
+const dryRun = argv.includes('--dry-run')
+const checkOnly = argv.includes('--check')
+
+function computePruneScore(entry) {
+  const accessCount = entry.access_count || 0
+  const created = new Date(entry.date)
+  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
+  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
+  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
+  return timeFactor * accessFactor
+}
+
+function loadTagsIndex(dataDir) {
+  const tagsFile = path.join(dataDir, 'tags.json')
+  try {
+    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+function pruneDir(dataDir, label) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const episodesDir = path.join(dataDir, 'episodes')
+  const archivedDir = path.join(dataDir, 'archived')
+  const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+
+  if (!fs.existsSync(indexFile)) {
+    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, episodes: [] }
+  }
+
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  const entries = lines.map(line => {
+    try { return JSON.parse(line) } catch { return null }
+  }).filter(Boolean)
+
+  const toPrune = []
+  const toKeep = []
+
+  for (const entry of entries) {
+    const score = computePruneScore(entry)
+    if (score < threshold) {
+      toPrune.push({ ...entry, _pruneScore: score })
+    } else {
+      toKeep.push(entry)
+    }
+  }
+
+  if (checkOnly) {
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length }
+  }
+
+  if (dryRun) {
+    let totalSize = 0
+    const preview = toPrune.map(e => {
+      const filePath = path.join(episodesDir, `${e.id}.md`)
+      let size = 0
+      try { size = fs.statSync(filePath).size } catch {}
+      totalSize += size
+      return { id: e.id, score: Math.round(e._pruneScore * 1000) / 1000, size }
+    })
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, episodes: preview }
+  }
+
+  // Actual prune
+  if (toPrune.length === 0) {
+    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0 }
+  }
+
+  fs.mkdirSync(archivedDir, { recursive: true })
+
+  let freedBytes = 0
+  const archivedEntries = []
+
+  for (const entry of toPrune) {
+    const srcFile = path.join(episodesDir, `${entry.id}.md`)
+    const dstFile = path.join(archivedDir, `${entry.id}.md`)
+    try {
+      const stat = fs.statSync(srcFile)
+      freedBytes += stat.size
+      fs.renameSync(srcFile, dstFile)
+    } catch {}
+    const { _pruneScore, ...clean } = entry
+    archivedEntries.push(JSON.stringify(clean))
+  }
+
+  // Update index.jsonl — keep only non-pruned entries
+  const tmpIndex = indexFile + '.tmp'
+  fs.writeFileSync(tmpIndex, toKeep.map(e => JSON.stringify(e)).join('\n') + (toKeep.length ? '\n' : ''), 'utf8')
+  fs.renameSync(tmpIndex, indexFile)
+
+  // Update tags.json — remove pruned episode IDs
+  const prunedIds = new Set(toPrune.map(e => e.id))
+  const tagsIndex = loadTagsIndex(dataDir)
+  for (const tag of Object.keys(tagsIndex)) {
+    tagsIndex[tag] = tagsIndex[tag].filter(id => !prunedIds.has(id))
+    if (tagsIndex[tag].length === 0) delete tagsIndex[tag]
+  }
+  const tagsFile = path.join(dataDir, 'tags.json')
+  const tagsTmp = tagsFile + '.tmp'
+  fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
+  fs.renameSync(tagsTmp, tagsFile)
+
+  // Append to archived-index.jsonl (read-merge-write, preserves previous prune runs)
+  // Note: prune has a read-rewrite race with em-store.mjs (same pattern as search write-back).
+  // A concurrent append between read and rename could lose the appended entry. This is a known
+  // limitation — prune is a maintenance operation, not a hot path.
+  const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
+  const archivedTmp = archivedIndexFile + '.tmp'
+  fs.writeFileSync(archivedTmp, existingArchived + archivedEntries.join('\n') + '\n', 'utf8')
+  fs.renameSync(archivedTmp, archivedIndexFile)
+
+  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes }
+}
+
+const results = []
+if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local'))
+if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global'))
+
+const totalPruned = results.reduce((sum, r) => sum + (r.pruned || r.prunable || 0), 0)
+
+if (checkOnly) {
+  console.log(JSON.stringify({ status: 'ok', results }))
+  process.exit(totalPruned > 0 ? 1 : 0)
+}
+
+console.log(JSON.stringify({ status: 'ok', results }))

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -5,7 +5,8 @@
  * Usage:
  *   node em-rebuild-index.mjs [--scope local|global|all]
  *
- * Reads all .md files, extracts frontmatter, writes fresh index.jsonl.
+ * Reads all .md files in episodes/ (ignores archived/), extracts frontmatter,
+ * writes fresh index.jsonl. Preserves access_count and last_accessed from old index.
  * Outputs JSON: { status, rebuilt: [{ scope, count }] }
  */
 
@@ -58,7 +59,27 @@ function parseFrontmatter(content) {
   return data
 }
 
+/**
+ * Load old index.jsonl into a map keyed by episode ID.
+ * Used to carry forward access_count and last_accessed during rebuild.
+ */
+function loadOldIndex(dataDir) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const map = new Map()
+  try {
+    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line)
+        if (entry.id) map.set(entry.id, entry)
+      } catch {}
+    }
+  } catch {}
+  return map
+}
+
 function rebuildDir(dataDir, label) {
+  // Scans episodes/ only — archived/ is intentionally ignored
   const episodesDir = path.join(dataDir, 'episodes')
   const indexFile = path.join(dataDir, 'index.jsonl')
 
@@ -67,6 +88,9 @@ function rebuildDir(dataDir, label) {
     fs.writeFileSync(indexFile, '', 'utf8')
     return { scope: label, count: 0 }
   }
+
+  // Load old index to preserve access metadata
+  const oldIndex = loadOldIndex(dataDir)
 
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []
@@ -78,6 +102,12 @@ function rebuildDir(dataDir, label) {
     const fm = parseFrontmatter(content)
     if (!fm || !fm.id) continue
     const normalizedTags = normalizeTags(Array.isArray(fm.tags) ? fm.tags : [])
+
+    // Carry forward access metadata from old index, default to 0/null for new entries
+    const old = oldIndex.get(fm.id)
+    const accessCount = old ? (old.access_count || 0) : 0
+    const lastAccessed = old ? (old.last_accessed || null) : null
+
     entries.push(JSON.stringify({
       id: fm.id,
       date: fm.date,
@@ -88,6 +118,8 @@ function rebuildDir(dataDir, label) {
       supersedes: fm.supersedes || null,
       tags: normalizedTags,
       summary: fm.summary,
+      access_count: accessCount,
+      last_accessed: lastAccessed,
       ...(fm.url ? { url: fm.url, fetched: fm.fetched || fm.date } : {})
     }))
     for (const tag of normalizedTags) {

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -7,8 +7,11 @@
  *                      [--query <text>] [--since <YYYY-MM-DD>] [--limit <n>]
  *                      [--scope local|global|all] [--include-superseded]
  *                      [--history <id>] [--full]
+ *                      [--no-score] [--no-track]
+ *                      [--warn-time-ms <n>] [--warn-count <n>]
  *
- * By default, searches local then global (scope=all) and hides superseded episodes.
+ * By default, searches local then global (scope=all), hides superseded episodes,
+ * scores results by relevance, and tracks access.
  * Outputs JSON: { status, count, episodes: [...] }
  */
 
@@ -40,6 +43,12 @@ const scope = flag('--scope') || 'all'
 const full = argv.includes('--full')
 const includeSuperseded = argv.includes('--include-superseded')
 const historyId = flag('--history')
+const noScore = argv.includes('--no-score')
+const noTrack = argv.includes('--no-track')
+const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
+const warnCount = parseInt(flag('--warn-count') || '500', 10)
+
+const searchStart = Date.now()
 
 function normalizeTags(raw) {
   if (!raw) return []
@@ -55,6 +64,58 @@ function loadTagsIndex(dataDir) {
     return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
   } catch {
     return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Relevance scoring
+// ---------------------------------------------------------------------------
+function computeScore(entry, textMatchScore) {
+  const accessCount = entry.access_count || 0
+  // Use new Date(entry.date) for decay — sub-day precision unnecessary
+  const created = new Date(entry.date)
+  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
+  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
+  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
+  return textMatchScore * timeFactor * accessFactor
+}
+
+// ---------------------------------------------------------------------------
+// Access tracking write-back
+// ---------------------------------------------------------------------------
+function writeBackAccessTracking(results) {
+  // Group results by source data directory
+  const byDir = new Map()
+  for (const e of results) {
+    if (!e._dataDir) continue
+    if (!byDir.has(e._dataDir)) byDir.set(e._dataDir, new Set())
+    byDir.get(e._dataDir).add(e.id)
+  }
+
+  const now = new Date().toISOString().slice(0, 19) + 'Z'
+
+  for (const [dataDir, ids] of byDir) {
+    const indexFile = path.join(dataDir, 'index.jsonl')
+    try {
+      // Re-read just before writing to narrow race window with concurrent em-store appends.
+      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
+      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      const updated = lines.map(line => {
+        try {
+          const entry = JSON.parse(line)
+          if (ids.has(entry.id)) {
+            entry.access_count = (entry.access_count || 0) + 1
+            entry.last_accessed = now
+          }
+          return JSON.stringify(entry)
+        } catch { return line }
+      })
+      const tmpFile = indexFile + '.tmp'
+      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
+      fs.renameSync(tmpFile, indexFile)
+    } catch {
+      // Access tracking is best-effort — skip silently on failure
+    }
   }
 }
 
@@ -85,6 +146,8 @@ if (scope === 'local' || scope === 'all') {
 if (scope === 'global' || scope === 'all') {
   results.push(...loadIndex(GLOBAL_DIR, 'global'))
 }
+
+const totalEpisodeCount = results.length
 
 // Dedupe by id (local takes priority)
 const seen = new Set()
@@ -143,6 +206,7 @@ if (historyId) {
     return rest
   })
 
+  // No access tracking for history queries (investigative, not usage signals)
   console.log(JSON.stringify({ status: 'ok', count: output.length, chain: output }))
   process.exit(0)
 }
@@ -190,38 +254,84 @@ if (since) {
   results = results.filter(e => e.date >= since)
 }
 
-// Full-text search in episode bodies
+// Full-text search in episode bodies + compute text_match scores
+const queryLower = query ? query.toLowerCase() : null
 if (query) {
-  const queryLower = query.toLowerCase()
   results = results.filter(e => {
-    if (e.summary.toLowerCase().includes(queryLower)) return true
+    const summaryLower = (e.summary || '').toLowerCase()
+    if (summaryLower.includes(queryLower)) {
+      e._textMatch = summaryLower === queryLower ? 1.0 : 0.7
+      return true
+    }
     const filePath = path.join(e._dataDir, 'episodes', `${e.id}.md`)
     if (fs.existsSync(filePath)) {
-      return fs.readFileSync(filePath, 'utf8').toLowerCase().includes(queryLower)
+      if (fs.readFileSync(filePath, 'utf8').toLowerCase().includes(queryLower)) {
+        e._textMatch = 0.4
+        return true
+      }
     }
     return false
   })
 }
 
-// Sort by date descending, apply limit
-results.sort((a, b) => (b.date + b.time).localeCompare(a.date + a.time))
+// ---------------------------------------------------------------------------
+// Score and sort
+// ---------------------------------------------------------------------------
+if (!noScore) {
+  for (const e of results) {
+    const textMatch = e._textMatch || 1.0
+    e._score = computeScore(e, textMatch)
+  }
+  results.sort((a, b) => b._score - a._score)
+} else {
+  // No scoring — keep date-based sort
+  results.sort((a, b) => (b.date + b.time).localeCompare(a.date + a.time))
+}
+
+// Apply limit AFTER scoring/sorting
 results = results.slice(0, limit)
 
-// Optionally include full body, clean internal fields
+// ---------------------------------------------------------------------------
+// Access tracking write-back
+// Skip for: --no-track, --include-superseded (investigative queries)
+// ---------------------------------------------------------------------------
+if (!noTrack && !includeSuperseded) {
+  writeBackAccessTracking(results)
+}
+
+// ---------------------------------------------------------------------------
+// Build output
+// ---------------------------------------------------------------------------
 const output = results.map(e => {
-  const { _dataDir, _source, ...rest } = e
+  const { _dataDir, _source, _textMatch, _score, ...rest } = e
+  const entry = { ...rest, source: _source }
+  if (!noScore && _score !== undefined) {
+    entry.score = Math.round(_score * 1000) / 1000
+  }
   if (full) {
     const filePath = path.join(_dataDir, 'episodes', `${e.id}.md`)
     if (fs.existsSync(filePath)) {
       const content = fs.readFileSync(filePath, 'utf8')
       const parts = content.split('---')
       const body = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
-      return { ...rest, body, source: _source }
+      entry.body = body
     }
   }
-  return { ...rest, source: _source }
+  return entry
 })
 
 const result = { status: 'ok', count: output.length, episodes: output }
-if (searchWarning) result.warning = searchWarning
+
+// Performance health check
+const elapsed = Date.now() - searchStart
+const warnings = []
+if (searchWarning) warnings.push(searchWarning)
+if (elapsed > warnTimeMs) {
+  warnings.push(`Search took ${elapsed}ms across ${totalEpisodeCount} episodes. Consider running em-prune.mjs to archive stale episodes.`)
+}
+if (totalEpisodeCount > warnCount) {
+  warnings.push(`${totalEpisodeCount} episodes in index. Performance may degrade. Run em-prune.mjs --dry-run to check for prunable episodes.`)
+}
+if (warnings.length) result.warning = warnings.join(' | ')
+
 console.log(JSON.stringify(result))

--- a/tests/test-phase2.mjs
+++ b/tests/test-phase2.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * test-phase2.mjs — Tests for RFC-001 Phase 2: Relevance Decay + Access Tracking
+ *
+ * Usage: node tests/test-phase2.mjs
+ *
+ * Tests scoring, access tracking, pruning, and rebuild metadata preservation.
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+const SEARCH = path.join(SCRIPTS, 'em-search.mjs')
+const REBUILD = path.join(SCRIPTS, 'em-rebuild-index.mjs')
+const PRUNE = path.join(SCRIPTS, 'em-prune.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup: isolated temp directories
+// ---------------------------------------------------------------------------
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-phase2-'))
+const tmpProject = path.join(tmpHome, 'project')
+fs.mkdirSync(tmpProject, { recursive: true })
+
+const globalDir = path.join(tmpHome, '.episodic-memory')
+const localDir = path.join(tmpProject, '.episodic-memory')
+
+const env = { ...process.env, HOME: tmpHome }
+
+function store(args) {
+  const result = execSync(`node "${STORE}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function search(args) {
+  const result = execSync(`node "${SEARCH}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function rebuild(args = '') {
+  const result = execSync(`node "${REBUILD}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function prune(args = '') {
+  const result = execSync(`node "${PRUNE}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env, stdio: ['pipe', 'pipe', 'pipe'] })
+  return JSON.parse(result.trim())
+}
+
+function pruneExitCode(args = '') {
+  try {
+    execSync(`node "${PRUNE}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env, stdio: ['pipe', 'pipe', 'pipe'] })
+    return 0
+  } catch (e) {
+    return e.status
+  }
+}
+
+function readIndex(dataDir) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l))
+}
+
+function writeOldEpisode(dataDir, id, date, summary, tags = 'test', accessCount = 0) {
+  const episodesDir = path.join(dataDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  const content = `---
+id: ${id}
+date: ${date}
+time: "12:00"
+project: test
+category: decision
+status: active
+tags: [${tags}]
+summary: ${summary}
+---
+
+# ${summary}
+
+Test body content for ${summary}.
+`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), content, 'utf8')
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const entry = JSON.stringify({ id, date, time: '12:00', project: 'test', category: 'decision', status: 'active', supersedes: null, tags: tags.split(',').map(t => t.trim()), summary, access_count: accessCount, last_accessed: null })
+  fs.appendFileSync(indexFile, entry + '\n', 'utf8')
+}
+
+// ---------------------------------------------------------------------------
+// Seed test data
+// ---------------------------------------------------------------------------
+console.log('\nPhase 2: Relevance Decay + Access Tracking')
+console.log('='.repeat(50))
+
+// Store some episodes for scoring tests
+const ep1 = store('--project test --category decision --tags "auth,security" --summary "Chose JWT for auth" --body "JWT simplifies stateless API"')
+const ep2 = store('--project test --category decision --tags "framework" --summary "Chose Express framework" --body "Express is mature and well-supported"')
+const ep3 = store('--project test --category discovery --tags "performance" --summary "Found N+1 query bug" --body "Database queries were not batched"')
+
+// ---------------------------------------------------------------------------
+// Scoring tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Scoring ---')
+
+test('1. Search returns score field by default', () => {
+  const r = search('--project test --no-track')
+  assert.ok(r.episodes.length > 0, 'should have results')
+  assert.ok(r.episodes[0].score !== undefined, 'should have score field')
+  assert.ok(typeof r.episodes[0].score === 'number', 'score should be a number')
+})
+
+test('2. Score with 0 access_count — pure time decay', () => {
+  const r = search('--project test --no-track')
+  // Fresh episodes (0 days old) should score near 1.0
+  for (const ep of r.episodes) {
+    assert.ok(ep.score > 0.9, `score ${ep.score} should be > 0.9 for fresh episode`)
+  }
+})
+
+test('3. --no-score suppresses score field', () => {
+  const r = search('--project test --no-score --no-track')
+  assert.ok(r.episodes.length > 0)
+  assert.strictEqual(r.episodes[0].score, undefined, 'should not have score field')
+})
+
+test('4. text_match: exact summary scores higher than substring', () => {
+  const exact = search('--project test --query "Chose JWT for auth" --no-track')
+  const substring = search('--project test --query "JWT" --no-track')
+  assert.ok(exact.episodes.length > 0 && substring.episodes.length > 0)
+  // Exact match (1.0) vs substring (0.7) — exact should score higher
+  const exactScore = exact.episodes.find(e => e.id === ep1.id)?.score
+  const subScore = substring.episodes.find(e => e.id === ep1.id)?.score
+  assert.ok(exactScore > subScore, `exact ${exactScore} should be > substring ${subScore}`)
+})
+
+test('5. text_match: body-only match scores lower than summary match', () => {
+  const summaryMatch = search('--project test --query "Express" --no-track')
+  const bodyOnly = search('--project test --query "stateless" --no-track')
+  assert.ok(summaryMatch.episodes.length > 0 && bodyOnly.episodes.length > 0)
+  const sumScore = summaryMatch.episodes[0].score
+  const bodyScore = bodyOnly.episodes[0].score
+  assert.ok(sumScore > bodyScore, `summary ${sumScore} should be > body ${bodyScore}`)
+})
+
+test('6. Results sorted by score descending', () => {
+  const r = search('--project test --no-track')
+  for (let i = 1; i < r.episodes.length; i++) {
+    assert.ok(r.episodes[i - 1].score >= r.episodes[i].score,
+      `score[${i-1}]=${r.episodes[i-1].score} should be >= score[${i}]=${r.episodes[i].score}`)
+  }
+})
+
+test('7. Time decay at 365 days — score at floor (0.1)', () => {
+  const oldDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  writeOldEpisode(globalDir, 'old-365-test', oldDate, 'Old episode 365 days')
+  const r = search('--query "Old episode 365" --no-track')
+  assert.ok(r.episodes.length > 0)
+  // text_match=0.7 (substring) * time=0.1 * access=1.0 = 0.07
+  assert.ok(r.episodes[0].score < 0.15, `365-day score ${r.episodes[0].score} should be < 0.15`)
+})
+
+test('8. Time decay at 730 days — score still at floor (not negative)', () => {
+  const oldDate = new Date(Date.now() - 730 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  writeOldEpisode(globalDir, 'old-730-test', oldDate, 'Old episode 730 days')
+  const r = search('--query "Old episode 730" --no-track')
+  assert.ok(r.episodes.length > 0)
+  assert.ok(r.episodes[0].score > 0, `730-day score ${r.episodes[0].score} should be > 0`)
+  assert.ok(r.episodes[0].score < 0.15, `730-day score ${r.episodes[0].score} should be < 0.15`)
+})
+
+test('9. Scoring with missing access_count field — backwards compat', () => {
+  // The old-365-test episode was written without access_count in frontmatter
+  // computeScore should default to 0
+  const r = search('--query "Old episode 365" --no-track')
+  assert.ok(r.episodes.length > 0, 'should find episode without access_count')
+})
+
+// ---------------------------------------------------------------------------
+// Access tracking tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Access Tracking ---')
+
+test('10. Access tracking increments access_count', () => {
+  // Search without --no-track
+  search('--project test --query "JWT"')
+  const entries = readIndex(globalDir)
+  const ep = entries.find(e => e.id === ep1.id)
+  assert.ok(ep, 'should find episode in index')
+  assert.ok(ep.access_count >= 1, `access_count ${ep.access_count} should be >= 1`)
+  assert.ok(ep.last_accessed, 'last_accessed should be set')
+})
+
+test('11. --no-track does not modify index', () => {
+  const before = readIndex(globalDir).find(e => e.id === ep2.id)
+  const beforeCount = before?.access_count || 0
+  search('--project test --query "Express" --no-track')
+  const after = readIndex(globalDir).find(e => e.id === ep2.id)
+  const afterCount = after?.access_count || 0
+  assert.strictEqual(afterCount, beforeCount, 'access_count should not change with --no-track')
+})
+
+test('12. --history does not trigger access tracking', () => {
+  const before = readIndex(globalDir).find(e => e.id === ep1.id)
+  const beforeCount = before?.access_count || 0
+  search(`--history ${ep1.id}`)
+  const after = readIndex(globalDir).find(e => e.id === ep1.id)
+  const afterCount = after?.access_count || 0
+  assert.strictEqual(afterCount, beforeCount, 'access_count should not change for --history')
+})
+
+test('13. --include-superseded does not trigger access tracking', () => {
+  const before = readIndex(globalDir).find(e => e.id === ep1.id)
+  const beforeCount = before?.access_count || 0
+  search('--project test --include-superseded')
+  const after = readIndex(globalDir).find(e => e.id === ep1.id)
+  const afterCount = after?.access_count || 0
+  assert.strictEqual(afterCount, beforeCount, 'access_count should not change for --include-superseded')
+})
+
+// ---------------------------------------------------------------------------
+// Limit after scoring tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Result Ordering ---')
+
+test('14. Limit applied after scoring — top-N by score, not date', () => {
+  // With --no-track to avoid side effects
+  const all = search('--project test --limit 100 --no-track')
+  const limited = search('--project test --limit 1 --no-track')
+  assert.strictEqual(limited.episodes.length, 1)
+  // The top-1 by score should be the same as the first from all
+  assert.strictEqual(limited.episodes[0].id, all.episodes[0].id)
+})
+
+// ---------------------------------------------------------------------------
+// Performance warning tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Performance Warnings ---')
+
+test('15. Warning emitted when episode count exceeds threshold', () => {
+  const r = search('--project test --warn-count 1 --no-track')
+  assert.ok(r.warning, 'should have warning field')
+  assert.ok(r.warning.includes('episodes in index'), 'warning should mention episode count')
+})
+
+// ---------------------------------------------------------------------------
+// Rebuild tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Rebuild ---')
+
+test('16. Rebuild preserves access_count and last_accessed', () => {
+  // Get current values
+  const before = readIndex(globalDir).find(e => e.id === ep1.id)
+  assert.ok(before.access_count >= 1, 'should have access_count before rebuild')
+
+  rebuild('--scope global')
+
+  const after = readIndex(globalDir).find(e => e.id === ep1.id)
+  assert.strictEqual(after.access_count, before.access_count, 'access_count should be preserved')
+  assert.strictEqual(after.last_accessed, before.last_accessed, 'last_accessed should be preserved')
+})
+
+test('17. Rebuild defaults missing metadata to 0/null', () => {
+  // old-365-test was created without access_count in the index
+  rebuild('--scope global')
+  const entry = readIndex(globalDir).find(e => e.id === 'old-365-test')
+  assert.ok(entry, 'should find old episode after rebuild')
+  assert.strictEqual(entry.access_count, 0, 'should default access_count to 0')
+  assert.strictEqual(entry.last_accessed, null, 'should default last_accessed to null')
+})
+
+// ---------------------------------------------------------------------------
+// Prune tests
+// ---------------------------------------------------------------------------
+console.log('\n--- Pruning ---')
+
+test('18. Prune --dry-run reports scores, moves no files', () => {
+  // old-365-test and old-730-test should be prunable
+  const r = prune('--scope global --dry-run')
+  const globalResult = r.results.find(x => x.scope === 'global')
+  assert.ok(globalResult.prunable >= 1, 'should find prunable episodes')
+  assert.ok(globalResult.episodes, 'dry-run should list episodes')
+  // Verify files still exist
+  assert.ok(fs.existsSync(path.join(globalDir, 'episodes', 'old-365-test.md')), 'file should still exist after dry-run')
+})
+
+test('19. Prune --check exits 1 when prunable episodes exist', () => {
+  const code = pruneExitCode('--scope global --check')
+  assert.strictEqual(code, 1, 'should exit 1 when prunable episodes exist')
+})
+
+test('20. Prune moves files to archived/, updates indexes', () => {
+  const beforeCount = readIndex(globalDir).length
+  const r = prune('--scope global')
+  const globalResult = r.results.find(x => x.scope === 'global')
+  assert.ok(globalResult.pruned >= 1, 'should prune at least 1 episode')
+  assert.ok(globalResult.freed_bytes > 0, 'should free bytes')
+
+  // Verify file moved
+  assert.ok(!fs.existsSync(path.join(globalDir, 'episodes', 'old-365-test.md')), 'should be removed from episodes/')
+  assert.ok(fs.existsSync(path.join(globalDir, 'archived', 'old-365-test.md')), 'should be in archived/')
+
+  // Verify index updated
+  const afterCount = readIndex(globalDir).length
+  assert.ok(afterCount < beforeCount, 'index should have fewer entries')
+
+  // Verify archived-index.jsonl exists
+  assert.ok(fs.existsSync(path.join(globalDir, 'archived-index.jsonl')), 'archived-index.jsonl should exist')
+})
+
+test('21. Prune appends to archived-index.jsonl on second run', () => {
+  // Add another old episode and prune again
+  const oldDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  writeOldEpisode(globalDir, 'old-400-test', oldDate, 'Old episode 400 days')
+  const beforeLines = fs.readFileSync(path.join(globalDir, 'archived-index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).length
+
+  prune('--scope global')
+
+  const afterLines = fs.readFileSync(path.join(globalDir, 'archived-index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).length
+  assert.ok(afterLines > beforeLines, `archived-index should grow: ${beforeLines} -> ${afterLines}`)
+})
+
+test('22. Prune --check exits 0 when no prunable episodes', () => {
+  // After pruning all old episodes, nothing should be prunable
+  const code = pruneExitCode('--scope global --check')
+  assert.strictEqual(code, 0, 'should exit 0 when nothing to prune')
+})
+
+// ---------------------------------------------------------------------------
+// Dual-scope write-back test
+// ---------------------------------------------------------------------------
+console.log('\n--- Dual-Scope ---')
+
+test('23. Dual-scope write-back updates both local and global indexes', () => {
+  // Store an episode locally
+  const localEp = store('--project test --category decision --tags "local-test" --summary "Local episode for dual scope" --body "test" --scope local')
+  // Search across both scopes (default) without --no-track
+  search('--project test --query "Local episode"')
+  // Both indexes should have been updated
+  const globalEntries = readIndex(globalDir)
+  const localEntries = readIndex(localDir)
+  const globalHit = globalEntries.find(e => e.id === ep1.id)
+  const localHit = localEntries.find(e => e.id === localEp.id)
+  assert.ok(globalHit?.access_count >= 1, 'global episode should have access_count >= 1')
+  assert.ok(localHit?.access_count >= 1, 'local episode should have access_count >= 1')
+})
+
+test('24. High-score old episode ranks above low-score recent with access boost', () => {
+  // Create an old episode with many accesses
+  const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  writeOldEpisode(globalDir, 'old-popular-test', oldDate, 'Popular old episode', 'test', 50)
+  // Create a fresh episode with 0 accesses (already done — ep3)
+  const r = search('--project test --no-track')
+  const oldEp = r.episodes.find(e => e.id === 'old-popular-test')
+  const freshEp = r.episodes.find(e => e.id === ep3.id)
+  assert.ok(oldEp && freshEp, 'should find both episodes')
+  // Old episode with 50 accesses should have access boost: (1 + log1p(50)*0.1) ≈ 1.39
+  // Time decay at 100 days: max(0.1, 1 - 100/365) ≈ 0.726
+  // Score ≈ 1.0 * 0.726 * 1.39 ≈ 1.01
+  // Fresh episode: 1.0 * 1.0 * 1.0 = 1.0
+  // So old popular should rank >= fresh
+  assert.ok(oldEp.score >= freshEp.score * 0.95, `old popular ${oldEp.score} should be competitive with fresh ${freshEp.score}`)
+})
+
+// ---------------------------------------------------------------------------
+// Cleanup & summary
+// ---------------------------------------------------------------------------
+fs.rmSync(tmpHome, { recursive: true, force: true })
+
+console.log(`\n${'='.repeat(50)}`)
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) {
+    console.log(`  - ${f.name}: ${f.error}`)
+  }
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Add relevance scoring to `em-search.mjs` with text_match tiers, time decay, and access boost
- Add access tracking with dual-scope write-back (local + global independently)
- Add `em-prune.mjs` for archiving stale episodes below a relevance threshold
- Update `em-rebuild-index.mjs` to preserve access metadata during rebuild
- Populate RFC-001 implementation plan for all 4 phases
- Add bp-011 (local-before-git) behavioral pattern

## Test plan

- [x] 24 Phase 2 tests pass (`node tests/test-phase2.mjs`)
- [x] 15 existing tests pass (`node tests/test-seed-patterns.mjs`)
- [x] E2E verified on real data (scored search, --no-score, prune --dry-run, rebuild)
- [x] Code review: all P1/P2 findings fixed
- [x] Second opinion (internal + Codex): consensus on plan
- [x] bp-001 compliance: all 9 steps completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)