### PR TITLE
feat: RFC-001 Phase 3 — Proactive Recall

### DIFF
--- a/docs/rfcs/RFC-001-memory-improvements.md
+++ b/docs/rfcs/RFC-001-memory-improvements.md
@@ -233,10 +233,11 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 
 **Detailed plan:** `docs/rfcs/RFC-001-phase2-plan.md`
 
-### Phase 3: Proactive Recall — NOT STARTED
+### Phase 3: Proactive Recall — IN PROGRESS
 
-**Files created:** `em-recall.mjs` (~100 lines) — multi-pass retrieval (project match, tag match, recent cross-project), output as `{ "preflight_warnings": [], "episodes": [...] }` object wrapper (designed for RFC-002 Phase 3 extension)
+**Files created:** `em-recall.mjs` (~260 lines) — multi-pass retrieval (project match, tag match, recent cross-project), output as `{ "preflight_warnings": [], "episodes": [...] }` object wrapper (designed for RFC-002 Phase 3 extension)
 **Depends on:** Phase 2 (scoring + access tracking)
+**Detailed plan:** `docs/rfcs/RFC-001-phase3-plan.md`
 
 ### Phase 4: Semantic Consolidation — NOT STARTED
 
@@ -266,10 +267,10 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [x] performance warnings emitted when thresholds exceeded
 
 **Phase 3:**
-- [ ] recall ranks `project`-field matches above incidental tag matches
-- [ ] recall excludes short/generic tokens from tag matching
-- [ ] recall falls back gracefully when `package.json`, git, or cwd is unavailable
-- [ ] recall updates access tracking for surfaced episodes
+- [x] recall ranks `project`-field matches above incidental tag matches
+- [x] recall excludes short/generic tokens from tag matching
+- [x] recall falls back gracefully when `package.json`, git, or cwd is unavailable
+- [x] recall updates access tracking for surfaced episodes
 
 **Phase 4:**
 - [ ] consolidate `--auto` with ≤3 clusters exits 0 silently, no lessons written
@@ -314,6 +315,7 @@ graph TD
 |---|---|---|---|
 | Phase 1: Tag Normalization + Inverted Index | `em-store.mjs`, `em-revise.mjs`, `em-search.mjs`, `em-rebuild-index.mjs` | 16 E2E scenarios passed | Shipped in PR #6, commit `0e45e4d`. Bugs: #2 (P1), #3 (P2), #4 (P3), #5 (P1) — all fixed. |
 | Phase 2: Relevance Decay + Access Tracking | `em-search.mjs`, `em-rebuild-index.mjs`, `em-prune.mjs` (new) | 24 Phase 2 tests + 15 existing = 39 passed | Shipped in PR #13. Scoring default-on, access tracking, pruning, performance health checks. BPs decoupled from user-preferences, bp-007 merged into bp-006, bp-011 added. |
+| Phase 3: Proactive Recall | `em-recall.mjs` (new) | 20 Phase 3 tests + 31 existing = 51 passed | Multi-pass retrieval (project, tag, recent cross-project). Context inference from package.json, git remote, git branch, cwd. Drift detection for inlined functions. 2nd opinion review applied (8 findings). |
 
 ---
 

--- a/docs/rfcs/RFC-001-phase3-plan.md
+++ b/docs/rfcs/RFC-001-phase3-plan.md
@@ -1,0 +1,128 @@
+# RFC-001 Phase 3: Proactive Recall — Implementation Plan
+
+**Status:** Awaiting review (2nd opinion + Codex)
+**Depends on:** Phase 2 (shipped in PR #13, #15)
+**Branch:** `feat/rfc001-phase3-proactive-recall`
+
+---
+
+## Overview
+
+New script `scripts/em-recall.mjs` (~120 lines) — multi-pass retrieval triggered at session start. Surfaces relevant episodes without explicit search queries by inferring context from the current project environment.
+
+## Architecture
+
+### Input: Context Inference (no CLI args required)
+
+Sources (all optional, graceful fallback):
+1. `package.json` → `name` field, `keywords` array
+2. `git branch --show-current` → branch name tokens (split on `/`, `-`, `_`)
+3. `basename(cwd)` → directory name
+4. Falls back to empty context if all sources unavailable
+
+### Processing: Three Independent Passes
+
+Each pass scores independently. Results merged by highest score (not additive).
+
+| Pass | Source | Match type | Base weight |
+|------|--------|-----------|-------------|
+| 1. Project match | `project` field in `index.jsonl` | Exact match on inferred project name | 1.0 (highest) |
+| 2. Tag match | `tags.json` inverted index | Overlap with inferred context tokens | 0.7 |
+| 3. Recent cross-project | All episodes from last 7 days | Date filter only | 0.5 |
+
+### Token Collision Handling
+
+Stopword list for tag matching (pass 2):
+```
+fix, feat, feature, bug, test, app, src, lib, dev, main, master, release,
+hotfix, docs, chore, refactor, style, ci, cd, build, user, data, add, update, new
+```
+
+Rules:
+- Tokens < 4 characters excluded
+- Tokens in stopword list excluded
+- Each pass independent — no cross-pass token combination
+
+### Output Format
+
+```json
+{
+  "status": "ok",
+  "context": {
+    "project": "episodic-memory",
+    "branch_tokens": ["feat", "rfc001", "phase3"],
+    "effective_tokens": ["rfc001", "phase3"]
+  },
+  "count": 5,
+  "episodes": [...],
+  "preflight_warnings": [],
+  "prune_suggestion": null
+}
+```
+
+- `preflight_warnings`: array of strings (performance, missing index, etc.)
+- `prune_suggestion`: string if prunable episodes detected, null otherwise
+- `context`: shows inferred context for transparency/debugging
+- Episodes include `source` and `score` fields (same as em-search)
+- Output wrapper designed for RFC-002 Phase 3 extension
+
+### CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--limit N` | 5 | Max episodes returned |
+| `--scope local\|global\|all` | all | Which stores to search |
+| `--days N` | 7 | Lookback window for pass 3 (recent cross-project) |
+| `--no-track` | false | Skip access tracking write-back |
+| `--project NAME` | auto-inferred | Override project name inference |
+| `--warn-time-ms N` | 500 | Performance warning threshold |
+| `--warn-count N` | 500 | Episode count warning threshold |
+
+### Shared Code (Inlined)
+
+From `em-search.mjs`, inline into `em-recall.mjs` (zero-dep convention):
+- `normalizeTags()`
+- `loadTagsIndex()`
+- `computeScore()`
+- `writeBackAccessTracking()`
+- `loadIndex()`
+
+### Prune Suggestion
+
+After collecting results, scan all loaded entries for scores below prune threshold (0.15). If any found:
+```
+"prune_suggestion": "12 episodes below threshold. Run em-prune.mjs --dry-run to review."
+```
+
+## Files
+
+| Action | File | Lines | Description |
+|--------|------|-------|-------------|
+| CREATE | `scripts/em-recall.mjs` | ~120 | Multi-pass proactive recall |
+| CREATE | `tests/test-phase3.mjs` | ~250 | Unit tests for all acceptance criteria |
+| MODIFY | `docs/rfcs/RFC-001-memory-improvements.md` | ~5 | Mark Phase 3 status, update implementation table |
+
+## Acceptance Tests (from RFC)
+
+1. Recall ranks `project`-field matches above incidental tag matches
+2. Recall excludes short/generic tokens from tag matching
+3. Recall falls back gracefully when `package.json`, git, or cwd is unavailable
+4. Recall updates access tracking for surfaced episodes
+
+## Additional Test Cases
+
+5. Empty store returns `{ status: "ok", count: 0, episodes: [] }` gracefully
+6. `--no-track` suppresses access tracking write-back
+7. `--project` override bypasses auto-inference
+8. Pass 3 (recent cross-project) respects `--days` window
+9. Stopword tokens filtered from branch name tokens
+10. Prune suggestion appears when low-score episodes exist
+11. Performance warnings emitted when thresholds exceeded
+12. Scope validation rejects invalid values
+
+## Implementation Order
+
+1. Write `em-recall.mjs` with all passes, context inference, output format
+2. Write `test-phase3.mjs` alongside (tests written during implementation, not deferred)
+3. Update RFC-001 implementation table
+4. Commit, push, PR

--- a/docs/rfcs/RFC-001-phase3-plan.md
+++ b/docs/rfcs/RFC-001-phase3-plan.md
@@ -1,6 +1,6 @@
 # RFC-001 Phase 3: Proactive Recall — Implementation Plan
 
-**Status:** Awaiting review (2nd opinion + Codex)
+**Status:** Revised after 2nd opinion review, awaiting Codex
 **Depends on:** Phase 2 (shipped in PR #13, #15)
 **Branch:** `feat/rfc001-phase3-proactive-recall`
 
@@ -14,28 +14,35 @@ New script `scripts/em-recall.mjs` (~120 lines) — multi-pass retrieval trigger
 
 ### Input: Context Inference (no CLI args required)
 
-Sources (all optional, graceful fallback):
-1. `package.json` → `name` field, `keywords` array
-2. `git branch --show-current` → branch name tokens (split on `/`, `-`, `_`)
+Sources for **project name** (first match wins, all optional):
+1. `package.json` → `name` field
+2. `git remote get-url origin` → parse repo name from URL (handles SSH `git@...:org/repo.git` and HTTPS `https://.../repo.git`)
 3. `basename(cwd)` → directory name
-4. Falls back to empty context if all sources unavailable
+
+Sources for **context tokens** (all merged, all optional):
+4. `package.json` → `keywords` array → fed into pass 2 tag matching (after stopword filtering)
+5. `git branch --show-current` → branch name tokens (split on `/`, `-`, `_`)
+6. Falls back to empty context if all sources unavailable (detached HEAD, bare repo, no .git → empty branch tokens)
 
 ### Processing: Three Independent Passes
 
-Each pass scores independently. Results merged by highest score (not additive).
+Indexes loaded **once** at startup (not per-pass). Each pass filters/scores the shared in-memory array independently. Results deduplicated by episode ID (highest score wins), then sorted and limited.
 
-| Pass | Source | Match type | Base weight |
+| Pass | Source | Match type | Base weight (as `textMatchScore`) |
 |------|--------|-----------|-------------|
 | 1. Project match | `project` field in `index.jsonl` | Exact match on inferred project name | 1.0 (highest) |
-| 2. Tag match | `tags.json` inverted index | Overlap with inferred context tokens | 0.7 |
-| 3. Recent cross-project | All episodes from last 7 days | Date filter only | 0.5 |
+| 2. Tag match | `tags.json` inverted index | Overlap with effective tokens (branch + keywords, stopword-filtered) | 0.7 |
+| 3. Recent cross-project | All episodes from last 7 days | Date filter, scored by `computeScore(entry, 0.5)` | 0.5 |
+
+All three passes feed their base weight into `computeScore(entry, baseWeight)` so time decay and access boost apply uniformly (per RFC: "Uses Phase 2 scoring to rank results").
 
 ### Token Collision Handling
 
 Stopword list for tag matching (pass 2):
 ```
 fix, feat, feature, bug, test, app, src, lib, dev, main, master, release,
-hotfix, docs, chore, refactor, style, ci, cd, build, user, data, add, update, new
+hotfix, docs, chore, refactor, style, ci, cd, build, user, data, add, update, new,
+phase, merge, pr, push, implement, wip, draft, rule, enforce, pattern
 ```
 
 Rules:
@@ -60,11 +67,11 @@ Rules:
 }
 ```
 
-- `preflight_warnings`: array of strings (performance, missing index, etc.)
-- `prune_suggestion`: string if prunable episodes detected, null otherwise
+- `preflight_warnings`: array of strings (performance, missing index, etc.). RFC-002 Phase 3 will extend these to structured objects with `pattern_id`, `violations_last_30d`, `last_violation`, `message`. Current string format is forward-compatible (consumers should handle both).
+- `prune_suggestion`: string if prunable episodes detected, null otherwise. Kept as separate top-level field (not inside `preflight_warnings`) — prune suggestions are operational, not behavioral warnings.
 - `context`: shows inferred context for transparency/debugging
 - Episodes include `source` and `score` fields (same as em-search)
-- Output wrapper designed for RFC-002 Phase 3 extension
+- **Reserved extension points (RFC-002):** `--task-type` CLI flag, structured `preflight_warnings`, violation-aware pre-flight pass
 
 ### CLI Flags
 
@@ -87,9 +94,11 @@ From `em-search.mjs`, inline into `em-recall.mjs` (zero-dep convention):
 - `writeBackAccessTracking()`
 - `loadIndex()`
 
+Each inlined function gets a `// SYNC: em-search.mjs:<functionName> — update both on change` comment. A drift-detection test in `test-phase3.mjs` extracts function bodies from both files and asserts they are identical.
+
 ### Prune Suggestion
 
-After collecting results, scan all loaded entries for scores below prune threshold (0.15). If any found:
+After collecting results, scan all loaded entries using `computeScore(entry, 1.0)` (query-independent, matching `em-prune.mjs` behavior) for scores below prune threshold (0.15). If any found:
 ```
 "prune_suggestion": "12 episodes below threshold. Run em-prune.mjs --dry-run to review."
 ```
@@ -99,7 +108,7 @@ After collecting results, scan all loaded entries for scores below prune thresho
 | Action | File | Lines | Description |
 |--------|------|-------|-------------|
 | CREATE | `scripts/em-recall.mjs` | ~120 | Multi-pass proactive recall |
-| CREATE | `tests/test-phase3.mjs` | ~250 | Unit tests for all acceptance criteria |
+| CREATE | `tests/test-phase3.mjs` | ~350 | Unit tests for all 20 acceptance criteria |
 | MODIFY | `docs/rfcs/RFC-001-memory-improvements.md` | ~5 | Mark Phase 3 status, update implementation table |
 
 ## Acceptance Tests (from RFC)
@@ -116,9 +125,17 @@ After collecting results, scan all loaded entries for scores below prune thresho
 7. `--project` override bypasses auto-inference
 8. Pass 3 (recent cross-project) respects `--days` window
 9. Stopword tokens filtered from branch name tokens
-10. Prune suggestion appears when low-score episodes exist
+10. Prune suggestion appears when low-score episodes exist (uses query-independent score)
 11. Performance warnings emitted when thresholds exceeded
 12. Scope validation rejects invalid values
+13. Deduplication: episode matching in multiple passes appears once with highest score
+14. `--limit` applied after merging and deduplicating all three passes
+15. `--days 0` returns no cross-project results without error
+16. Detached HEAD (empty branch output) — graceful fallback to empty branch tokens
+17. No `.git` directory — git commands fail silently, context still works from package.json/cwd
+18. `package.json` with no `name` field or `name: ""` — falls back to git remote / basename
+19. `package.json` keywords fed into pass 2 effective tokens (after stopword filtering)
+20. Inlined function drift detection: function bodies match between em-recall.mjs and em-search.mjs
 
 ## Implementation Order
 

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+/**
+ * em-recall.mjs — Proactive session-start recall via multi-pass retrieval.
+ *
+ * Usage:
+ *   node em-recall.mjs [--project <name>] [--scope local|global|all]
+ *                      [--limit <n>] [--days <n>] [--no-track]
+ *                      [--warn-time-ms <n>] [--warn-count <n>]
+ *
+ * Three passes:
+ *   1. Project match — episodes whose `project` field matches inferred project name
+ *   2. Tag match — episodes whose tags overlap with inferred context tokens
+ *   3. Recent cross-project — high-relevance episodes from last N days
+ *
+ * Outputs JSON: { status, context, count, episodes, preflight_warnings, prune_suggestion }
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const argv = process.argv.slice(2)
+
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const projectOverride = flag('--project')
+const scope = flag('--scope') || 'all'
+const limit = parseInt(flag('--limit') || '5', 10)
+const days = parseInt(flag('--days') || '7', 10)
+const noTrack = argv.includes('--no-track')
+const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
+const warnCount = parseInt(flag('--warn-count') || '500', 10)
+
+const VALID_SCOPES = ['local', 'global', 'all']
+if (!VALID_SCOPES.includes(scope)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(1)
+}
+
+const recallStart = Date.now()
+
+// ---------------------------------------------------------------------------
+// Stopword list for tag matching
+// ---------------------------------------------------------------------------
+const STOPWORDS = new Set([
+  'fix', 'feat', 'feature', 'bug', 'test', 'app', 'src', 'lib', 'dev',
+  'main', 'master', 'release', 'hotfix', 'docs', 'chore', 'refactor',
+  'style', 'ci', 'cd', 'build', 'user', 'data', 'add', 'update', 'new',
+  'phase', 'merge', 'pr', 'push', 'implement', 'wip', 'draft', 'rule',
+  'enforce', 'pattern'
+])
+
+// ---------------------------------------------------------------------------
+// SYNC: em-search.mjs:normalizeTags — update both on change
+// ---------------------------------------------------------------------------
+function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+// ---------------------------------------------------------------------------
+// SYNC: em-search.mjs:loadTagsIndex — update both on change
+// ---------------------------------------------------------------------------
+function loadTagsIndex(dataDir) {
+  const tagsFile = path.join(dataDir, 'tags.json')
+  try {
+    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SYNC: em-search.mjs:computeScore — update both on change
+// ---------------------------------------------------------------------------
+function computeScore(entry, textMatchScore) {
+  const accessCount = entry.access_count || 0
+  // Use new Date(entry.date) for decay — sub-day precision unnecessary
+  const created = new Date(entry.date)
+  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
+  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
+  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
+  return textMatchScore * timeFactor * accessFactor
+}
+
+// ---------------------------------------------------------------------------
+// SYNC: em-search.mjs:writeBackAccessTracking — update both on change
+// ---------------------------------------------------------------------------
+function writeBackAccessTracking(results) {
+  // Group results by source data directory
+  const byDir = new Map()
+  for (const e of results) {
+    if (!e._dataDir) continue
+    if (!byDir.has(e._dataDir)) byDir.set(e._dataDir, new Set())
+    byDir.get(e._dataDir).add(e.id)
+  }
+
+  const now = new Date().toISOString().slice(0, 19) + 'Z'
+
+  for (const [dataDir, ids] of byDir) {
+    const indexFile = path.join(dataDir, 'index.jsonl')
+    try {
+      // Re-read just before writing to narrow race window with concurrent em-store appends.
+      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
+      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      const updated = lines.map(line => {
+        try {
+          const entry = JSON.parse(line)
+          if (ids.has(entry.id)) {
+            entry.access_count = (entry.access_count || 0) + 1
+            entry.last_accessed = now
+          }
+          return JSON.stringify(entry)
+        } catch { return line }
+      })
+      const tmpFile = indexFile + '.tmp'
+      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
+      fs.renameSync(tmpFile, indexFile)
+    } catch {
+      // Access tracking is best-effort — skip silently on failure
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SYNC: em-search.mjs:loadIndex — update both on change
+// ---------------------------------------------------------------------------
+function loadIndex(dataDir, source) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+    try {
+      const entry = JSON.parse(line)
+      entry._source = source
+      entry._dataDir = dataDir
+      return entry
+    } catch { return null }
+  }).filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// Context inference
+// ---------------------------------------------------------------------------
+function inferContext() {
+  const ctx = { project: null, branch_tokens: [], keywords: [], effective_tokens: [] }
+
+  // Always read package.json for keywords (even when project is overridden)
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'))
+    if (Array.isArray(pkg.keywords)) ctx.keywords = pkg.keywords.map(k => k.toLowerCase().trim()).filter(Boolean)
+    if (!projectOverride && pkg.name && pkg.name.trim()) ctx.project = pkg.name.trim()
+  } catch {}
+
+  // 1. Project name: override → package.json (above) → git remote → basename(cwd)
+  if (projectOverride) {
+    ctx.project = projectOverride
+  } else if (!ctx.project) {
+    // Try git remote
+    try {
+      const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+      // SSH: git@github.com:org/repo.git → repo
+      // HTTPS: https://github.com/org/repo.git → repo
+      const match = remoteUrl.match(/\/([^/]+?)(?:\.git)?$/) || remoteUrl.match(/:([^/]+?)(?:\.git)?$/)
+      if (match) ctx.project = match[1]
+    } catch {}
+
+    // Fallback to basename(cwd)
+    if (!ctx.project) {
+      ctx.project = path.basename(process.cwd())
+    }
+  }
+
+  // 2. Branch tokens
+  try {
+    const branch = execSync('git branch --show-current', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+    if (branch) {
+      ctx.branch_tokens = branch.split(/[/\-_]/).filter(Boolean).map(t => t.toLowerCase())
+    }
+  } catch {}
+
+  // 3. Effective tokens: branch tokens + keywords, stopword-filtered
+  const allTokens = [...ctx.branch_tokens, ...ctx.keywords]
+  ctx.effective_tokens = [...new Set(
+    allTokens.filter(t => t.length >= 4 && !STOPWORDS.has(t))
+  )]
+
+  return ctx
+}
+
+// ---------------------------------------------------------------------------
+// Load all entries once
+// ---------------------------------------------------------------------------
+let allEntries = []
+
+if (scope === 'local' || scope === 'all') {
+  allEntries.push(...loadIndex(LOCAL_DIR, 'local'))
+}
+if (scope === 'global' || scope === 'all') {
+  allEntries.push(...loadIndex(GLOBAL_DIR, 'global'))
+}
+
+const totalEpisodeCount = allEntries.length
+
+// Dedupe by id (local takes priority)
+const seenIds = new Set()
+allEntries = allEntries.filter(e => {
+  if (seenIds.has(e.id)) return false
+  seenIds.add(e.id)
+  return true
+})
+
+// Filter out superseded
+const activeEntries = allEntries.filter(e => e.status !== 'superseded')
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+const context = inferContext()
+const preflight_warnings = []
+
+// ---------------------------------------------------------------------------
+// Pass 1: Project match
+// ---------------------------------------------------------------------------
+const pass1 = new Map()
+if (context.project) {
+  for (const e of activeEntries) {
+    if (e.project === context.project) {
+      const score = computeScore(e, 1.0)
+      pass1.set(e.id, { entry: e, score })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2: Tag match (using inverted index)
+// ---------------------------------------------------------------------------
+const pass2 = new Map()
+if (context.effective_tokens.length > 0) {
+  const normalizedTokens = normalizeTags(context.effective_tokens.join(','))
+
+  // Load tags indexes
+  const dirs = []
+  if (scope === 'local' || scope === 'all') dirs.push(LOCAL_DIR)
+  if (scope === 'global' || scope === 'all') dirs.push(GLOBAL_DIR)
+
+  const matchingIds = new Set()
+  let tagsIndexMissing = false
+
+  for (const dir of dirs) {
+    const idx = loadTagsIndex(dir)
+    if (!idx) {
+      tagsIndexMissing = true
+      continue
+    }
+    for (const token of normalizedTokens) {
+      if (idx[token]) {
+        for (const id of idx[token]) matchingIds.add(id)
+      }
+    }
+  }
+
+  if (tagsIndexMissing) {
+    // Fallback: linear scan
+    preflight_warnings.push('tags.json missing or corrupt in one or more stores. Run em-rebuild-index.mjs to regenerate.')
+    for (const e of activeEntries) {
+      if (e.tags) {
+        const eTags = e.tags.map(t => t.toLowerCase().trim())
+        if (normalizedTokens.some(t => eTags.includes(t))) {
+          matchingIds.add(e.id)
+        }
+      }
+    }
+  }
+
+  for (const e of activeEntries) {
+    if (matchingIds.has(e.id)) {
+      const score = computeScore(e, 0.7)
+      pass2.set(e.id, { entry: e, score })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pass 3: Recent cross-project (last N days)
+// ---------------------------------------------------------------------------
+const pass3 = new Map()
+if (days > 0) {
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - days)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  for (const e of activeEntries) {
+    if (e.date >= cutoffStr) {
+      const score = computeScore(e, 0.5)
+      pass3.set(e.id, { entry: e, score })
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Merge: deduplicate by episode ID, keep highest score
+// ---------------------------------------------------------------------------
+const merged = new Map()
+for (const pass of [pass1, pass2, pass3]) {
+  for (const [id, { entry, score }] of pass) {
+    if (!merged.has(id) || merged.get(id).score < score) {
+      merged.set(id, { entry, score })
+    }
+  }
+}
+
+// Sort by score descending, apply limit
+let results = [...merged.values()]
+  .sort((a, b) => b.score - a.score)
+  .slice(0, limit)
+
+// ---------------------------------------------------------------------------
+// Access tracking write-back
+// ---------------------------------------------------------------------------
+if (!noTrack && results.length > 0) {
+  writeBackAccessTracking(results.map(r => r.entry))
+}
+
+// ---------------------------------------------------------------------------
+// Prune suggestion (query-independent score, matching em-prune.mjs)
+// ---------------------------------------------------------------------------
+let prune_suggestion = null
+const PRUNE_THRESHOLD = 0.15
+let prunableCount = 0
+for (const e of allEntries) {
+  const pruneScore = computeScore(e, 1.0)
+  if (pruneScore < PRUNE_THRESHOLD) prunableCount++
+}
+if (prunableCount > 0) {
+  prune_suggestion = `${prunableCount} episodes below threshold. Run em-prune.mjs --dry-run to review.`
+}
+
+// ---------------------------------------------------------------------------
+// Build output
+// ---------------------------------------------------------------------------
+const episodes = results.map(({ entry, score }) => {
+  const { _dataDir, _source, ...rest } = entry
+  return { ...rest, source: _source, score: Math.round(score * 1000) / 1000 }
+})
+
+const result = {
+  status: 'ok',
+  context: {
+    project: context.project,
+    branch_tokens: context.branch_tokens,
+    effective_tokens: context.effective_tokens
+  },
+  count: episodes.length,
+  episodes,
+  preflight_warnings,
+  prune_suggestion
+}
+
+// Performance health check
+const elapsed = Date.now() - recallStart
+if (elapsed > warnTimeMs) {
+  preflight_warnings.push(`Recall took ${elapsed}ms across ${totalEpisodeCount} episodes. Consider running em-prune.mjs to archive stale episodes.`)
+}
+if (totalEpisodeCount > warnCount) {
+  preflight_warnings.push(`${totalEpisodeCount} episodes in index. Performance may degrade. Run em-prune.mjs --dry-run to check for prunable episodes.`)
+}
+
+console.log(JSON.stringify(result))

--- a/tests/test-phase3.mjs
+++ b/tests/test-phase3.mjs
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+/**
+ * test-phase3.mjs — Tests for RFC-001 Phase 3: Proactive Recall
+ *
+ * Usage: node tests/test-phase3.mjs
+ *
+ * Tests context inference, multi-pass retrieval, deduplication, access tracking,
+ * prune suggestions, and inlined function drift detection.
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
+const SEARCH = path.join(SCRIPTS, 'em-search.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup: isolated temp directories
+// ---------------------------------------------------------------------------
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-phase3-'))
+const tmpProject = path.join(tmpHome, 'project')
+fs.mkdirSync(tmpProject, { recursive: true })
+
+const globalDir = path.join(tmpHome, '.episodic-memory')
+const localDir = path.join(tmpProject, '.episodic-memory')
+
+const env = { ...process.env, HOME: tmpHome }
+
+function store(args, opts = {}) {
+  const cwd = opts.cwd || tmpProject
+  const result = execSync(`node "${STORE}" ${args}`, { encoding: 'utf8', cwd, env })
+  return JSON.parse(result.trim())
+}
+
+function recall(args = '', opts = {}) {
+  const cwd = opts.cwd || tmpProject
+  const result = execSync(`node "${RECALL}" ${args}`, { encoding: 'utf8', cwd, env })
+  return JSON.parse(result.trim())
+}
+
+// Helper: write an old episode directly (bypasses em-store to control dates)
+function writeOldEpisode(dataDir, { id, date, project, category, tags, summary, accessCount, status }) {
+  const episodesDir = path.join(dataDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  const normTags = (tags || []).map(t => t.toLowerCase().trim()).sort()
+  const entry = {
+    id, date, time: '12:00', project, category: category || 'decision',
+    status: status || 'active', supersedes: null, tags: normTags, summary,
+    access_count: accessCount || 0, last_accessed: null
+  }
+  fs.appendFileSync(path.join(dataDir, 'index.jsonl'), JSON.stringify(entry) + '\n', 'utf8')
+  const fm = `---\nid: ${id}\ndate: ${date}\ntime: "12:00"\nproject: ${project}\ncategory: ${category || 'decision'}\nstatus: ${status || 'active'}\ntags: [${normTags.join(', ')}]\nsummary: ${summary}\n---\n\n# ${summary}\n\nBody for ${id}.\n`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), fm, 'utf8')
+
+  // Update tags.json
+  const tagsFile = path.join(dataDir, 'tags.json')
+  let tagsIndex = {}
+  try { tagsIndex = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+  for (const tag of normTags) {
+    if (!tagsIndex[tag]) tagsIndex[tag] = []
+    if (!tagsIndex[tag].includes(id)) tagsIndex[tag].push(id)
+  }
+  fs.writeFileSync(tagsFile, JSON.stringify(tagsIndex, null, 2), 'utf8')
+  return entry
+}
+
+function readIndex(dataDir) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l))
+}
+
+// ---------------------------------------------------------------------------
+// Seed test data
+// ---------------------------------------------------------------------------
+const today = new Date().toISOString().slice(0, 10)
+const threeDaysAgo = new Date(Date.now() - 3 * 86400000).toISOString().slice(0, 10)
+const tenDaysAgo = new Date(Date.now() - 10 * 86400000).toISOString().slice(0, 10)
+const oldDate = new Date(Date.now() - 330 * 86400000).toISOString().slice(0, 10)
+
+// Global episodes
+writeOldEpisode(globalDir, { id: 'proj-match-1', date: today, project: 'project', category: 'decision', tags: ['architecture'], summary: 'Project-specific decision' })
+writeOldEpisode(globalDir, { id: 'proj-match-2', date: threeDaysAgo, project: 'project', category: 'discovery', tags: ['debugging'], summary: 'Project discovery' })
+writeOldEpisode(globalDir, { id: 'tag-match-1', date: today, project: 'other-proj', category: 'decision', tags: ['architecture', 'rfc001'], summary: 'Tagged with rfc001' })
+writeOldEpisode(globalDir, { id: 'recent-cross-1', date: threeDaysAgo, project: 'cross-proj', category: 'milestone', tags: ['shipping'], summary: 'Recent cross-project milestone' })
+writeOldEpisode(globalDir, { id: 'old-episode-1', date: tenDaysAgo, project: 'old-proj', category: 'context', tags: ['legacy'], summary: 'Older than 7 days' })
+writeOldEpisode(globalDir, { id: 'very-old-1', date: oldDate, project: 'ancient', category: 'decision', tags: ['forgotten'], summary: 'Very old episode', accessCount: 0 })
+
+// Write a package.json in the project dir for context inference
+fs.writeFileSync(path.join(tmpProject, 'package.json'), JSON.stringify({ name: 'project', keywords: ['architecture', 'memory'] }), 'utf8')
+
+// ===========================================================================
+console.log('\n--- RFC Acceptance Tests ---')
+// ===========================================================================
+
+test('1. Project-field matches rank above incidental tag matches', () => {
+  // proj-match-1 (project=project, weight=1.0) should rank above tag-match-1 (tag overlap, weight=0.7)
+  const r = recall('--project project --limit 10')
+  assert.strictEqual(r.status, 'ok')
+  const projIdx = r.episodes.findIndex(e => e.id === 'proj-match-1')
+  const tagIdx = r.episodes.findIndex(e => e.id === 'tag-match-1')
+  // tag-match-1 might appear via pass 3 (recent) but proj-match should rank higher
+  assert.ok(projIdx >= 0, 'proj-match-1 should appear')
+  if (tagIdx >= 0) {
+    assert.ok(projIdx < tagIdx, `proj-match-1 (idx=${projIdx}) should rank above tag-match-1 (idx=${tagIdx})`)
+  }
+})
+
+test('2. Short/generic tokens excluded from tag matching', () => {
+  const r = recall('--project project --limit 10')
+  // Stopwords like "fix", "feat", "bug" should not appear in effective_tokens
+  for (const t of r.context.effective_tokens) {
+    assert.ok(t.length >= 4, `Token "${t}" should be >= 4 chars`)
+  }
+})
+
+test('3. Graceful fallback when package.json/git unavailable', () => {
+  // Create a bare directory with no package.json, no .git
+  const bareDir = path.join(tmpHome, 'bare-project')
+  fs.mkdirSync(bareDir, { recursive: true })
+  const r = recall('--scope global', { cwd: bareDir })
+  assert.strictEqual(r.status, 'ok')
+  // Project should fall back to basename
+  assert.strictEqual(r.context.project, 'bare-project')
+  assert.deepStrictEqual(r.context.branch_tokens, [])
+})
+
+test('4. Access tracking updated for surfaced episodes', () => {
+  // Read index before recall
+  const before = readIndex(globalDir)
+  const projBefore = before.find(e => e.id === 'proj-match-1')
+  const accessBefore = projBefore ? (projBefore.access_count || 0) : 0
+
+  recall('--project project --limit 10')
+
+  const after = readIndex(globalDir)
+  const projAfter = after.find(e => e.id === 'proj-match-1')
+  assert.ok(projAfter.access_count > accessBefore, 'access_count should increment')
+  assert.ok(projAfter.last_accessed, 'last_accessed should be set')
+})
+
+// ===========================================================================
+console.log('\n--- Additional Test Cases ---')
+// ===========================================================================
+
+test('5. Empty store returns ok with 0 episodes', () => {
+  const emptyDir = path.join(tmpHome, 'empty-project')
+  fs.mkdirSync(emptyDir, { recursive: true })
+  const r = recall('--scope local', { cwd: emptyDir })
+  assert.strictEqual(r.status, 'ok')
+  assert.strictEqual(r.count, 0)
+  assert.deepStrictEqual(r.episodes, [])
+})
+
+test('6. --no-track suppresses access tracking', () => {
+  const before = readIndex(globalDir)
+  const ep = before.find(e => e.id === 'proj-match-2')
+  const accessBefore = ep ? (ep.access_count || 0) : 0
+
+  recall('--project project --no-track')
+
+  const after = readIndex(globalDir)
+  const epAfter = after.find(e => e.id === 'proj-match-2')
+  assert.strictEqual(epAfter.access_count || 0, accessBefore, 'access_count should not change with --no-track')
+})
+
+test('7. --project override bypasses auto-inference', () => {
+  const r = recall('--project cross-proj --no-track')
+  assert.strictEqual(r.context.project, 'cross-proj')
+  const hasCrossProj = r.episodes.some(e => e.project === 'cross-proj')
+  assert.ok(hasCrossProj, 'Should find cross-proj episodes')
+})
+
+test('8. Pass 3 respects --days window', () => {
+  // With --days 5, threeDaysAgo is included, tenDaysAgo is excluded
+  const r = recall('--project nonexistent --days 5 --no-track --limit 20')
+  const hasRecent = r.episodes.some(e => e.id === 'recent-cross-1')
+  const hasOld = r.episodes.some(e => e.id === 'old-episode-1')
+  assert.ok(hasRecent, 'recent-cross-1 (3 days old) should appear')
+  assert.ok(!hasOld, 'old-episode-1 (10 days old) should not appear with --days 5')
+})
+
+test('9. Stopword tokens filtered from branch tokens', () => {
+  // We can't control git branch in test, but we can verify the stopword list works
+  // via the context output — effective_tokens should exclude stopwords
+  const r = recall('--project project --no-track')
+  const stopwords = ['fix', 'feat', 'feature', 'bug', 'test', 'main', 'merge', 'phase', 'wip']
+  for (const t of r.context.effective_tokens) {
+    assert.ok(!stopwords.includes(t), `Stopword "${t}" should not be in effective_tokens`)
+  }
+})
+
+test('10. Prune suggestion for low-score episodes', () => {
+  // very-old-1 is 330 days old with 0 accesses — score ~0.096, below 0.15
+  const r = recall('--project project --no-track')
+  assert.ok(r.prune_suggestion, 'Should have prune suggestion for very old episode')
+  assert.ok(r.prune_suggestion.includes('em-prune.mjs --dry-run'), 'Should mention em-prune.mjs')
+})
+
+test('11. Performance warnings with low thresholds', () => {
+  const r = recall('--project project --no-track --warn-count 1')
+  const hasCountWarning = r.preflight_warnings.some(w => w.includes('episodes in index'))
+  assert.ok(hasCountWarning, 'Should warn about episode count')
+})
+
+test('12. Scope validation rejects invalid values', () => {
+  try {
+    recall('--scope invalid --no-track')
+    assert.fail('Should have thrown')
+  } catch (e) {
+    if (e.message === 'Should have thrown') throw e
+    // execSync throws on non-zero exit — expected
+    assert.ok(e.stderr?.includes('Invalid --scope') || e.stdout?.includes('Invalid --scope') || true)
+  }
+})
+
+test('13. Deduplication: episode in multiple passes appears once with highest score', () => {
+  // proj-match-1 matches pass 1 (project=project, weight=1.0) and could match pass 3 (recent, weight=0.5)
+  // It should appear only once with the higher score
+  const r = recall('--project project --no-track --limit 20')
+  const matches = r.episodes.filter(e => e.id === 'proj-match-1')
+  assert.strictEqual(matches.length, 1, 'Should appear exactly once')
+  // Score should reflect weight=1.0 (pass 1), not 0.5 (pass 3)
+  assert.ok(matches[0].score > 0.5, 'Score should use highest pass weight')
+})
+
+test('14. --limit applied after merge and dedup', () => {
+  // With limit=2, should get top 2 from merged results
+  const r = recall('--project project --no-track --limit 2')
+  assert.strictEqual(r.count, 2)
+  assert.strictEqual(r.episodes.length, 2)
+  // Verify they are sorted by score descending
+  assert.ok(r.episodes[0].score >= r.episodes[1].score, 'Should be sorted by score desc')
+})
+
+test('15. --days 0 returns no cross-project results', () => {
+  // With --days 0 and a nonexistent project, only tag match (pass 2) could contribute
+  const r = recall('--project nonexistent-xyz --days 0 --no-track --limit 20')
+  // No project match (nonexistent), no pass 3 (days=0)
+  // Only pass 2 (tag match) should contribute if any tokens match
+  // recent-cross-1 should NOT appear since pass 3 is disabled
+  const hasCross = r.episodes.some(e => e.id === 'recent-cross-1')
+  assert.ok(!hasCross, 'With --days 0, no cross-project results should appear')
+})
+
+test('16. Detached HEAD / no git — empty branch tokens', () => {
+  // bare-project has no .git
+  const bareDir = path.join(tmpHome, 'bare-project')
+  const r = recall('--scope global --no-track', { cwd: bareDir })
+  assert.deepStrictEqual(r.context.branch_tokens, [])
+})
+
+test('17. No .git directory — context still works from package.json/cwd', () => {
+  // Create project with package.json but no git
+  const noGitDir = path.join(tmpHome, 'no-git-project')
+  fs.mkdirSync(noGitDir, { recursive: true })
+  fs.writeFileSync(path.join(noGitDir, 'package.json'), JSON.stringify({ name: 'my-special-project' }), 'utf8')
+  const r = recall('--scope global --no-track', { cwd: noGitDir })
+  assert.strictEqual(r.context.project, 'my-special-project')
+})
+
+test('18. package.json with no name — falls back to basename', () => {
+  const noNameDir = path.join(tmpHome, 'fallback-dir')
+  fs.mkdirSync(noNameDir, { recursive: true })
+  fs.writeFileSync(path.join(noNameDir, 'package.json'), JSON.stringify({ version: '1.0.0' }), 'utf8')
+  const r = recall('--scope global --no-track', { cwd: noNameDir })
+  assert.strictEqual(r.context.project, 'fallback-dir')
+})
+
+test('19. package.json keywords fed into effective tokens', () => {
+  // tmpProject has package.json with keywords: ['architecture', 'memory']
+  const r = recall('--project project --no-track')
+  // 'architecture' (10 chars, not a stopword) should be in effective_tokens
+  assert.ok(r.context.effective_tokens.includes('architecture'), 'keyword "architecture" should be in effective_tokens')
+  assert.ok(r.context.effective_tokens.includes('memory'), 'keyword "memory" should be in effective_tokens')
+})
+
+// ===========================================================================
+console.log('\n--- Drift Detection ---')
+// ===========================================================================
+
+test('20. Inlined functions match em-search.mjs source', () => {
+  const recallSrc = fs.readFileSync(path.join(SCRIPTS, 'em-recall.mjs'), 'utf8')
+  const searchSrc = fs.readFileSync(path.join(SCRIPTS, 'em-search.mjs'), 'utf8')
+
+  // Extract function bodies by SYNC marker
+  const syncFunctions = ['normalizeTags', 'loadTagsIndex', 'computeScore', 'writeBackAccessTracking', 'loadIndex']
+
+  for (const fnName of syncFunctions) {
+    // Extract function body: from "function name(...) {" to the closing "}" at column 0
+    const fnRegex = new RegExp(`function ${fnName}\\([^)]*\\) \\{([\\s\\S]*?)\\n\\}`)
+
+    const recallMatch = recallSrc.match(fnRegex)
+    const searchMatch = searchSrc.match(fnRegex)
+
+    assert.ok(recallMatch, `${fnName} not found in em-recall.mjs`)
+    assert.ok(searchMatch, `${fnName} not found in em-search.mjs`)
+
+    // Verify SYNC marker exists in recall
+    assert.ok(recallSrc.includes(`// SYNC: em-search.mjs:${fnName}`), `${fnName} missing SYNC marker in em-recall.mjs`)
+
+    assert.strictEqual(recallMatch[1].trim(), searchMatch[1].trim(), `${fnName} body differs between em-recall.mjs and em-search.mjs`)
+  }
+})
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n' + '='.repeat(50))
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) {
+    console.log(`  - ${f.name}: ${f.error}`)
+  }
+}
+console.log('='.repeat(50))
+
+// Cleanup
+fs.rmSync(tmpHome, { recursive: true, force: true })
+
+process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-phase3.mjs
+++ b/tests/test-phase3.mjs
@@ -231,8 +231,9 @@ test('12. Scope validation rejects invalid values', () => {
     assert.fail('Should have thrown')
   } catch (e) {
     if (e.message === 'Should have thrown') throw e
-    // execSync throws on non-zero exit — expected
-    assert.ok(e.stderr?.includes('Invalid --scope') || e.stdout?.includes('Invalid --scope') || true)
+    // execSync throws on non-zero exit — verify error message
+    const output = (e.stdout || '') + (e.stderr || '') + (e.message || '')
+    assert.ok(output.includes('Invalid --scope'), 'Error should mention invalid scope')
   }
 })
 


### PR DESCRIPTION
## Summary

- **New script `em-recall.mjs`** — multi-pass session-start retrieval: project match (1.0), tag match via inverted index (0.7), recent cross-project (0.5)
- **Context inference** from package.json name/keywords, git remote URL, git branch tokens, cwd basename — all optional with graceful fallback
- **Dedup across passes** (highest score wins), `computeScore` on all passes, stopword filtering, RFC-002 extension points documented
- **Drift detection test** — asserts inlined function bodies match em-search.mjs source
- **20 new tests**, 51 total passing (20 Phase 3 + 24 Phase 2 + 7 P3 fixes)
- **2nd opinion review**: 8 findings (2 P1, 6 P2) all addressed
- **Code review**: 1 bug fixed (vacuous assertion), pass

## Test plan

- [ ] `node tests/test-phase3.mjs` — 20 tests pass
- [ ] `node tests/test-phase2.mjs` — 24 tests pass (regression)
- [ ] `node tests/test-p3-fixes.mjs` — 7 tests pass (regression)
- [ ] Manual: `node scripts/em-recall.mjs` in a real project with episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)