### PR TITLE
feat: RFC-002 Phase 1 — Violation Tracking

### DIFF
--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -196,14 +196,14 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 ### Acceptance tests (per phase)
 
 **Phase 1:**
-- [ ] `violation` category accepted by `em-store.mjs`
-- [ ] `em-violation.mjs` stores structured violation with pattern linkage via `violated:<pattern_id>` tag
-- [ ] `em-violation.mjs` validates pattern exists in `patterns/_index.json` (not `tags.json`)
-- [ ] `em-violation.mjs` rejects unknown pattern_id with error listing known patterns
-- [ ] `em-violation.mjs` auto-tags with `violation`, `behavioral-pattern`, and `violated:<pattern_id>`
-- [ ] Violation episodes searchable by `--category violation` and `--tag violated:<pattern_id>`
-- [ ] bp-009 updated to reference `em-violation.mjs` and structured fields
-- [ ] `em-session-end-prompt.mjs` hook script created and functional
+- [x] `violation` category accepted by `em-store.mjs`
+- [x] `em-violation.mjs` stores structured violation with pattern linkage via `violated:<pattern_id>` tag
+- [x] `em-violation.mjs` validates pattern exists in `patterns/_index.json` (not `tags.json`)
+- [x] `em-violation.mjs` rejects unknown pattern_id with error listing known patterns
+- [x] `em-violation.mjs` auto-tags with `violation`, `behavioral-pattern`, and `violated:<pattern_id>`
+- [x] Violation episodes searchable by `--category violation` and `--tag violated:<pattern_id>`
+- [x] bp-009 updated to reference `em-violation.mjs` and structured fields
+- [x] `em-session-end-prompt.mjs` hook script created and functional
 
 **Phase 2:**
 - [ ] `em-pattern-health.mjs` counts violations per pattern within rolling time window
@@ -260,7 +260,7 @@ graph TD
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| Phase 1: Violation Tracking | `em-store.mjs`, `em-violation.mjs` (new), `em-session-end-prompt.mjs` (new), `install.mjs`, bp-009 | 17 Phase 1 tests + 51 existing = 68 passed | Shells out to em-store (no SYNC copies). execFileSync for safety. Scope validation. Pattern validation with global fallback. Bugs: #19 (cmd injection), #20 (usage msg). |
 
 ---
 

--- a/docs/rfcs/RFC-002-phase1-plan.md
+++ b/docs/rfcs/RFC-002-phase1-plan.md
@@ -1,0 +1,138 @@
+# RFC-002 Phase 1: Violation Tracking — Implementation Plan
+
+**Status:** Revised after 2nd opinion review (9 findings applied)
+**Depends on:** Nothing (no blockers)
+**Branch:** `feat/rfc002-phase1-violation-tracking`
+
+---
+
+## Overview
+
+Structured violation tracking for behavioral patterns. New `violation` category, `em-violation.mjs` convenience wrapper, `em-session-end-prompt.mjs` hook script, bp-009 reconciliation.
+
+## Architecture
+
+### `em-violation.mjs` (~80 lines)
+
+**Shells out to `em-store.mjs`** via `execSync` (not inlined). Rationale: em-violation is a pure create — unlike em-revise which also modifies the original episode. Shelling out avoids adding a 6th SYNC copy of store internals. ~50ms subprocess cost is negligible for a user-flagged action.
+
+```
+node em-violation.mjs --pattern <pattern_id> --summary "<text>" --body "<text>"
+                      [--sequence "<action1,action2>"] [--correct "<action1,action2>"]
+                      [--project <name>] [--scope global|local]
+```
+
+**Pattern validation:**
+- Reads `patterns/_index.json` to get known pattern IDs
+- Path resolution: check `./patterns/_index.json` (project-local) first, then `~/.episodic-memory/patterns/_index.json` (global install)
+- On failure, output structured error:
+  ```json
+  {
+    "status": "error",
+    "message": "Unknown pattern \"bp-999\". Valid patterns: bp-001-implementation-workflow, bp-002-proactive-milestone-storage, ...",
+    "known_patterns": ["bp-001-implementation-workflow", ...]
+  }
+  ```
+
+**Auto-tagging:**
+- Always adds: `violation`, `behavioral-pattern`, `violated:<pattern_id>`
+- User can add extra tags via `--tags` (appended, not replaced)
+- Colon in `violated:` tag is safe — survives normalizeTags (comma-split, trim, lowercase), JSON storage, tags.json indexing, rebuild, and search
+
+**Body template** (structured markdown):
+```markdown
+# <summary>
+
+## What happened
+<body text>
+
+## Violation sequence
+<--sequence value, or "Not specified">
+
+## Correct sequence
+<--correct value, or "Not specified">
+```
+
+**Output:** `{ status, id, violated_pattern, file, scope }`
+
+### `em-session-end-prompt.mjs` (~40 lines)
+
+Outputs a JSON prompt template for SessionEnd hook consumption. The AI reads this output and asks the user; it is NOT interactive.
+
+```json
+{
+  "prompt": "Were any behavioral patterns violated this session?",
+  "known_patterns": [
+    { "pattern_id": "bp-001-implementation-workflow", "name": "Standard implementation workflow" },
+    ...
+  ],
+  "store_command": "node ~/.episodic-memory/scripts/em-violation.mjs --pattern <id> --summary \"...\" --body \"...\""
+}
+```
+
+- Reads `patterns/_index.json` (same path resolution as em-violation.mjs)
+- Hook registration: requires `--install-hooks` flag in installer (never auto-modifies settings.json)
+
+### em-store.mjs change
+
+Add `violation` to `VALID_CATEGORIES` array (line 48). Note: `lesson` already exists — no RFC-001 P4 coordination needed.
+
+### bp-009 reconciliation (4 specific changes)
+
+1. **Line 12:** Change "store the violation in episodic memory as a discovery" → "store the violation using `em-violation.mjs` (category: `violation`)"
+2. **Lines 14-19 (What to store):** Align with em-violation.mjs fields: `--pattern`, `--summary`, `--body`, `--sequence`, `--correct`
+3. **Line 41 (Scope):** Change "tags: violated rule name, `violation`, `learning`" → "auto-tagged: `violation`, `behavioral-pattern`, `violated:<pattern_id>`"
+4. **Frontmatter:** Bump version from `1.0.0` to `2.0.0`, update `_index.json` version to match
+
+### install.mjs changes
+
+1. Add `em-violation.mjs` and `em-session-end-prompt.mjs` to the script copy list
+2. Add `patterns/_index.json` copy to `~/.episodic-memory/patterns/` (new — needed for global pattern validation)
+3. Add `--install-hooks` flag: registers `em-session-end-prompt.mjs` as `SessionEnd` hook in `~/.claude/settings.json` (opt-in only)
+
+## Files
+
+| Action | File | Lines | Description |
+|--------|------|-------|-------------|
+| MODIFY | `scripts/em-store.mjs` | ~1 | Add `violation` to VALID_CATEGORIES |
+| CREATE | `scripts/em-violation.mjs` | ~80 | Structured violation storage, shells out to em-store |
+| CREATE | `scripts/em-session-end-prompt.mjs` | ~40 | SessionEnd hook prompt template |
+| MODIFY | `patterns/store-violations-as-evidence.md` | ~15 | bp-009 v2.0.0 reconciliation (4 changes) |
+| MODIFY | `patterns/_index.json` | ~1 | bp-009 version bump |
+| MODIFY | `install.mjs` | ~15 | Copy new scripts + patterns, --install-hooks flag |
+| CREATE | `tests/test-rfc002-phase1.mjs` | ~200 | Unit tests for all acceptance criteria |
+| MODIFY | `docs/rfcs/RFC-002-learning-loop.md` | ~5 | Mark Phase 1 status, update implementation table |
+
+## Acceptance Tests
+
+### From RFC
+1. `violation` category accepted by `em-store.mjs`
+2. `em-violation.mjs` stores structured violation with `violated:<pattern_id>` tag
+3. `em-violation.mjs` validates pattern exists in `patterns/_index.json`
+4. `em-violation.mjs` rejects unknown pattern_id with error listing known patterns
+5. `em-violation.mjs` auto-tags with `violation`, `behavioral-pattern`, `violated:<pattern_id>`
+6. Violation episodes searchable by `--category violation`
+7. Violation episodes searchable by `--tag violated:<pattern_id>`
+8. bp-009 updated to reference `em-violation.mjs`
+9. `em-session-end-prompt.mjs` outputs valid JSON with prompt + known patterns
+
+### Additional (from 2nd opinion)
+10. `violated:` tag round-trip: store → rebuild-index → search by tag returns the violation
+11. Extra `--tags` appended to auto-tags (not replaced)
+12. `--sequence` and `--correct` appear in structured body sections
+13. Missing `--pattern` flag rejected with usage error
+14. Missing `--summary` or `--body` rejected with usage error
+15. Pattern validation falls back to `~/.episodic-memory/patterns/_index.json` when local missing
+16. `em-session-end-prompt.mjs` includes `store_command` template in output
+17. Scope validation rejects invalid `--scope` values
+
+## Implementation Order
+
+1. Add `violation` to em-store.mjs VALID_CATEGORIES
+2. Write `em-violation.mjs` (shells out to em-store)
+3. Write `em-session-end-prompt.mjs`
+4. Write tests alongside (steps 2-3)
+5. Update bp-009 (4 changes + version bump)
+6. Update install.mjs (copy list + --install-hooks)
+7. Update RFC-002 implementation table
+8. Code review → fix bugs → E2E → log bugs to Issues

--- a/install.mjs
+++ b/install.mjs
@@ -34,6 +34,7 @@ function flag(name) {
 
 const tool = flag('--tool')
 const projectDir = flag('--project') || process.cwd()
+const installHooks = argv.includes('--install-hooks')
 
 if (!tool) {
   console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|windsurf|all> [--project <path>]
@@ -67,6 +68,15 @@ for (const file of scriptFiles) {
   fs.chmodSync(dst, 0o755)
 }
 console.log(`Installed ${scriptFiles.length} scripts to ${SCRIPTS_DIR}`)
+
+// 1b. Copy patterns/_index.json for global pattern validation
+const globalPatternsDir = path.join(GLOBAL_DIR, 'patterns')
+const repoPatternsIndex = path.join(REPO_DIR, 'patterns', '_index.json')
+if (fs.existsSync(repoPatternsIndex)) {
+  fs.mkdirSync(globalPatternsDir, { recursive: true })
+  fs.copyFileSync(repoPatternsIndex, path.join(globalPatternsDir, '_index.json'))
+  console.log(`Installed patterns/_index.json to ${globalPatternsDir}`)
+}
 
 // ---------------------------------------------------------------------------
 // 2. Create local .episodic-memory in target project
@@ -160,6 +170,37 @@ if (fs.existsSync(seedScript) && fs.existsSync(repoPatternsDir)) {
     }
   } catch {
     console.log('Note: behavioral pattern seeding skipped (non-fatal)')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Optional: install SessionEnd hook for violation prompting
+// ---------------------------------------------------------------------------
+if (installHooks) {
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+  try {
+    let settings = {}
+    if (fs.existsSync(settingsPath)) {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
+    }
+    if (!settings.hooks) settings.hooks = {}
+    if (!settings.hooks.SessionEnd) settings.hooks.SessionEnd = []
+
+    const hookCmd = `node ${path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs')}`
+    const alreadyInstalled = settings.hooks.SessionEnd.some(h => h.command && h.command.includes('em-session-end-prompt'))
+
+    if (!alreadyInstalled) {
+      settings.hooks.SessionEnd.push({
+        command: hookCmd,
+        description: 'Prompt for behavioral pattern violations at session end'
+      })
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8')
+      console.log('Installed SessionEnd hook for violation prompting')
+    } else {
+      console.log('SessionEnd hook already installed')
+    }
+  } catch (e) {
+    console.log(`Note: could not install SessionEnd hook: ${e.message}`)
   }
 }
 

--- a/patterns/_index.json
+++ b/patterns/_index.json
@@ -62,7 +62,7 @@
       "name": "Store rule violations as evidence for enforcement",
       "tags": ["behavioral-pattern", "discipline", "learning", "enforcement"],
       "scope": "global",
-      "version": "1.0.0"
+      "version": "2.0.0"
     },
     {
       "pattern_id": "bp-010-habits-override-knowledge",

--- a/patterns/implementation-workflow.md
+++ b/patterns/implementation-workflow.md
@@ -104,6 +104,7 @@ The planning-to-implementation transition is where violations cluster. After com
 
 ## Violation History (6 total; 5 most recent shown)
 
+- 2026-05-01 (session 3): Phase 3 implementation — skipped pre/post checkpoints, E2E testing, and bug logging; only corrected after user caught it
 - 2026-05-01 (session 2): RFC-002 status changed to accepted without review step
 - 2026-05-01 (session 2): RFC-002 text fixes (F1-F4) applied without final plan
 - 2026-05-01 (session 2): P3 fixes implemented without tests or code review

--- a/patterns/store-violations-as-evidence.md
+++ b/patterns/store-violations-as-evidence.md
@@ -4,20 +4,25 @@ name: "Store rule violations as evidence for enforcement"
 category: decision
 tags: [behavioral-pattern, bp-009-store-violations-as-evidence, discipline, learning, enforcement]
 scope: global
-version: 1.0.0
+version: 2.0.0
 ---
 
 # Store Rule Violations as Evidence for Enforcement
 
-When a rule is violated, store the violation in episodic memory as a discovery. The violation is data — it proves the rule needs mechanical enforcement, documents the failure pattern, and prevents the same mistake in future sessions.
+When a rule is violated, store the violation using `em-violation.mjs` (category: `violation`). The violation is data — it proves the rule needs mechanical enforcement, documents the failure pattern, and prevents the same mistake in future sessions.
 
-## What to store
+## How to store
 
-- Which rule was violated
-- The exact sequence of actions that led to the violation
-- Why the violation happened (flow state, urgency, forgot, didn't apply)
-- What the correct sequence should have been
-- Whether mechanical enforcement exists and whether it would have caught this
+```bash
+node ~/.episodic-memory/scripts/em-violation.mjs \
+  --pattern <pattern_id> \
+  --summary "<what happened>" \
+  --body "<why it happened, context>" \
+  --sequence "<action1,action2,...>" \
+  --correct "<action1,action2,...>"
+```
+
+The script auto-tags with `violation`, `behavioral-pattern`, and `violated:<pattern_id>`, validates the pattern exists, and builds a structured body with "What happened", "Violation sequence", and "Correct sequence" sections.
 
 ## Why this matters
 
@@ -38,4 +43,4 @@ When a rule is violated, store the violation in episodic memory as a discovery. 
 
 ## Scope
 
-All projects, all AI tools. Store as global episodes with tags: violated rule name, `violation`, `learning`.
+All projects, all AI tools. Store as global episodes. Auto-tagged: `violation`, `behavioral-pattern`, `violated:<pattern_id>` (e.g., `violated:bp-006-push-after-verify`).

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * em-session-end-prompt.mjs — SessionEnd hook script for violation flagging.
+ *
+ * Outputs a JSON prompt template that the AI reads and uses to ask the user
+ * whether any behavioral patterns were violated during the session.
+ *
+ * Usage:
+ *   node em-session-end-prompt.mjs
+ *
+ * Designed for Claude Code SessionEnd hook. Not interactive — outputs JSON
+ * for the AI to consume and act on.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+// ---------------------------------------------------------------------------
+// Load known patterns from _index.json
+// ---------------------------------------------------------------------------
+function loadPatternsIndex() {
+  const candidates = [
+    path.join(process.cwd(), 'patterns', '_index.json'),
+    path.join(os.homedir(), '.episodic-memory', 'patterns', '_index.json')
+  ]
+  for (const p of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+      if (data.patterns && Array.isArray(data.patterns)) return data.patterns
+    } catch {}
+  }
+  return []
+}
+
+const patterns = loadPatternsIndex()
+
+const knownPatterns = patterns.map(p => ({
+  pattern_id: p.pattern_id,
+  name: p.name
+}))
+
+const scriptsDir = path.join(os.homedir(), '.episodic-memory', 'scripts')
+
+console.log(JSON.stringify({
+  prompt: 'Were any behavioral patterns violated this session?',
+  known_patterns: knownPatterns,
+  store_command: `node ${path.join(scriptsDir, 'em-violation.mjs')} --pattern <id> --summary "..." --body "..."`
+}, null, 2))

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -37,15 +37,15 @@ const body = flag('--body')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
 
+const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation']
+
 if (!project || !category || !summary || !body) {
   console.log(JSON.stringify({
     status: 'error',
-    message: 'Missing required args. Usage: --project <name> --category <decision|discovery|milestone|context> --tags <t1,t2> --summary <text> --body <text> [--scope local|global]'
+    message: `Missing required args. Usage: --project <name> --category <${VALID_CATEGORIES.join('|')}> --tags <t1,t2> --summary <text> --body <text> [--scope local|global]`
   }))
   process.exit(1)
 }
-
-const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson']
 if (!VALID_CATEGORIES.includes(category)) {
   console.log(JSON.stringify({
     status: 'error',

--- a/scripts/em-violation.mjs
+++ b/scripts/em-violation.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * em-violation.mjs — Store a structured behavioral pattern violation.
+ *
+ * Usage:
+ *   node em-violation.mjs --pattern <pattern_id> --summary "<text>" --body "<text>"
+ *                         [--sequence "<action1,action2>"] [--correct "<action1,action2>"]
+ *                         [--project <name>] [--tags "<extra_tags>"] [--scope global|local]
+ *
+ * Validates pattern exists in patterns/_index.json, auto-tags with
+ * violation + behavioral-pattern + violated:<pattern_id>, builds structured
+ * body, then delegates to em-store.mjs.
+ *
+ * Outputs JSON: { status, id, violated_pattern, file, scope }
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execFileSync } from 'child_process'
+
+const SCRIPTS_DIR = path.dirname(new URL(import.meta.url).pathname)
+const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const argv = process.argv.slice(2)
+
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const patternId = flag('--pattern')
+const summary = flag('--summary')
+const bodyText = flag('--body')
+const sequence = flag('--sequence')
+const correct = flag('--correct')
+const project = flag('--project') || path.basename(process.cwd())
+const extraTags = flag('--tags')
+const scope = flag('--scope') || 'global'
+
+// ---------------------------------------------------------------------------
+// Validate scope
+// ---------------------------------------------------------------------------
+const VALID_SCOPES = ['global', 'local']
+if (!VALID_SCOPES.includes(scope)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Validate required args
+// ---------------------------------------------------------------------------
+if (!patternId || !summary || !bodyText) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: 'Missing required args. Usage: --pattern <pattern_id> --summary "<text>" --body "<text>" [--sequence "<actions>"] [--correct "<actions>"] [--project <name>] [--tags "<extra>"] [--scope global|local]'
+  }))
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Validate pattern exists in _index.json
+// ---------------------------------------------------------------------------
+function loadPatternsIndex() {
+  // Try project-local first, then global install
+  const candidates = [
+    path.join(process.cwd(), 'patterns', '_index.json'),
+    path.join(os.homedir(), '.episodic-memory', 'patterns', '_index.json')
+  ]
+  for (const p of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+      if (data.patterns && Array.isArray(data.patterns)) return data.patterns
+    } catch {}
+  }
+  return null
+}
+
+const patterns = loadPatternsIndex()
+const knownIds = patterns ? patterns.map(p => p.pattern_id) : []
+
+if (patterns && !knownIds.includes(patternId)) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: `Unknown pattern "${patternId}". Valid patterns: ${knownIds.join(', ')}`,
+    known_patterns: knownIds
+  }))
+  process.exit(1)
+}
+
+if (!patterns) {
+  // No _index.json found — warn but proceed (pattern might be valid)
+  // This can happen in repos without the patterns directory
+}
+
+// ---------------------------------------------------------------------------
+// Build auto-tags
+// ---------------------------------------------------------------------------
+const autoTags = ['violation', 'behavioral-pattern', `violated:${patternId}`]
+if (extraTags) {
+  const extras = extraTags.split(',').map(t => t.trim()).filter(Boolean)
+  autoTags.push(...extras)
+}
+const tagsStr = autoTags.join(',')
+
+// ---------------------------------------------------------------------------
+// Build structured body
+// ---------------------------------------------------------------------------
+const bodyParts = [`## What happened\n\n${bodyText}`]
+
+if (sequence) {
+  bodyParts.push(`## Violation sequence\n\n${sequence}`)
+} else {
+  bodyParts.push(`## Violation sequence\n\nNot specified`)
+}
+
+if (correct) {
+  bodyParts.push(`## Correct sequence\n\n${correct}`)
+} else {
+  bodyParts.push(`## Correct sequence\n\nNot specified`)
+}
+
+const structuredBody = bodyParts.join('\n\n')
+
+// ---------------------------------------------------------------------------
+// Shell out to em-store.mjs
+// ---------------------------------------------------------------------------
+const args = [
+  `--project`, project,
+  `--category`, `violation`,
+  `--tags`, tagsStr,
+  `--summary`, summary,
+  `--body`, structuredBody,
+  `--scope`, scope
+]
+
+try {
+  const result = execFileSync('node', [STORE_SCRIPT, ...args], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+  const parsed = JSON.parse(result)
+
+  if (parsed.status === 'ok') {
+    console.log(JSON.stringify({
+      status: 'ok',
+      id: parsed.id,
+      violated_pattern: patternId,
+      file: parsed.file,
+      scope: parsed.scope
+    }))
+  } else {
+    // Pass through em-store errors
+    console.log(result)
+    process.exit(1)
+  }
+} catch (e) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: `em-store.mjs failed: ${e.message}`
+  }))
+  process.exit(1)
+}

--- a/tests/test-rfc002-phase1.mjs
+++ b/tests/test-rfc002-phase1.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * test-rfc002-phase1.mjs — Tests for RFC-002 Phase 1: Violation Tracking
+ *
+ * Usage: node tests/test-rfc002-phase1.mjs
+ *
+ * Tests violation storage, pattern validation, auto-tagging, structured body,
+ * search round-trip, and session-end prompt.
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+const VIOLATION = path.join(SCRIPTS, 'em-violation.mjs')
+const SEARCH = path.join(SCRIPTS, 'em-search.mjs')
+const REBUILD = path.join(SCRIPTS, 'em-rebuild-index.mjs')
+const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup: isolated temp directories
+// ---------------------------------------------------------------------------
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p1-'))
+const tmpProject = path.join(tmpHome, 'project')
+fs.mkdirSync(tmpProject, { recursive: true })
+
+const globalDir = path.join(tmpHome, '.episodic-memory')
+const localDir = path.join(tmpProject, '.episodic-memory')
+
+const env = { ...process.env, HOME: tmpHome }
+
+// Copy patterns/_index.json to project dir for validation
+const patternsDir = path.join(tmpProject, 'patterns')
+fs.mkdirSync(patternsDir, { recursive: true })
+const srcIndex = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'patterns', '_index.json')
+fs.copyFileSync(srcIndex, path.join(patternsDir, '_index.json'))
+
+function store(args) {
+  const result = execSync(`node "${STORE}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function violation(args) {
+  const result = execSync(`node "${VIOLATION}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function violationFail(args) {
+  try {
+    execSync(`node "${VIOLATION}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env, stdio: ['pipe', 'pipe', 'pipe'] })
+    return null // should have failed
+  } catch (e) {
+    return e.stdout ? JSON.parse(e.stdout.trim()) : null
+  }
+}
+
+function search(args) {
+  const result = execSync(`node "${SEARCH}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+function rebuild(args = '') {
+  return execSync(`node "${REBUILD}" ${args}`, { encoding: 'utf8', cwd: tmpProject, env })
+}
+
+function sessionEnd() {
+  const result = execSync(`node "${SESSION_END}"`, { encoding: 'utf8', cwd: tmpProject, env })
+  return JSON.parse(result.trim())
+}
+
+// ===========================================================================
+console.log('\n--- RFC Acceptance Tests ---')
+// ===========================================================================
+
+test('1. violation category accepted by em-store.mjs', () => {
+  const r = store('--project test --category violation --tags "test" --summary "test violation" --body "test body"')
+  assert.strictEqual(r.status, 'ok')
+  assert.ok(r.id)
+})
+
+test('2. em-violation.mjs stores structured violation with violated:<pattern_id> tag', () => {
+  const r = violation('--pattern bp-001-implementation-workflow --summary "Skipped checkpoints" --body "Did not print pre-implementation checkpoint"')
+  assert.strictEqual(r.status, 'ok')
+  assert.strictEqual(r.violated_pattern, 'bp-001-implementation-workflow')
+  assert.ok(r.id)
+  assert.ok(r.file)
+})
+
+test('3. em-violation.mjs validates pattern exists in _index.json', () => {
+  // Valid pattern should succeed (already tested in test 2)
+  // This test verifies the validation mechanism itself
+  const r = violation('--pattern bp-006-push-after-verify --summary "Pushed without tests" --body "Pushed before running test suite"')
+  assert.strictEqual(r.status, 'ok')
+  assert.strictEqual(r.violated_pattern, 'bp-006-push-after-verify')
+})
+
+test('4. em-violation.mjs rejects unknown pattern_id with error listing known patterns', () => {
+  const r = violationFail('--pattern bp-999-nonexistent --summary "test" --body "test"')
+  assert.ok(r, 'Should have returned error output')
+  assert.strictEqual(r.status, 'error')
+  assert.ok(r.message.includes('bp-999-nonexistent'), 'Error should mention the invalid pattern')
+  assert.ok(r.known_patterns, 'Should include known_patterns array')
+  assert.ok(r.known_patterns.includes('bp-001-implementation-workflow'), 'Should list bp-001')
+})
+
+test('5. em-violation.mjs auto-tags with violation, behavioral-pattern, violated:<pattern_id>', () => {
+  // Search for the violation stored in test 2
+  const r = search('--category violation --tag "violated:bp-001-implementation-workflow" --limit 10')
+  assert.ok(r.count > 0, 'Should find at least one violation')
+  const ep = r.episodes[0]
+  assert.ok(ep.tags.includes('violation'), 'Should have violation tag')
+  assert.ok(ep.tags.includes('behavioral-pattern'), 'Should have behavioral-pattern tag')
+  assert.ok(ep.tags.some(t => t.startsWith('violated:')), 'Should have violated: tag')
+})
+
+test('6. Violation episodes searchable by --category violation', () => {
+  const r = search('--category violation --limit 20')
+  assert.ok(r.count >= 2, 'Should find violations stored in earlier tests')
+  for (const ep of r.episodes) {
+    assert.strictEqual(ep.category, 'violation')
+  }
+})
+
+test('7. Violation episodes searchable by --tag violated:<pattern_id>', () => {
+  const r = search('--tag "violated:bp-006-push-after-verify" --limit 10')
+  assert.ok(r.count > 0, 'Should find bp-006 violation')
+  assert.ok(r.episodes[0].tags.some(t => t.includes('bp-006')), 'Should match bp-006')
+})
+
+test('8. bp-009 updated to reference em-violation.mjs', () => {
+  // This is a documentation test — verify the file references em-violation.mjs
+  const bp009 = fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'patterns', 'store-violations-as-evidence.md'), 'utf8')
+  assert.ok(bp009.includes('em-violation.mjs'), 'bp-009 should reference em-violation.mjs')
+})
+
+test('9. em-session-end-prompt.mjs outputs valid JSON with prompt + known patterns', () => {
+  const r = sessionEnd()
+  assert.ok(r.prompt, 'Should have prompt field')
+  assert.ok(r.prompt.includes('violated'), 'Prompt should ask about violations')
+  assert.ok(Array.isArray(r.known_patterns), 'Should have known_patterns array')
+  assert.ok(r.known_patterns.length > 0, 'Should list at least one pattern')
+  assert.ok(r.known_patterns[0].pattern_id, 'Each pattern should have pattern_id')
+  assert.ok(r.known_patterns[0].name, 'Each pattern should have name')
+})
+
+// ===========================================================================
+console.log('\n--- Additional Tests (from 2nd opinion) ---')
+// ===========================================================================
+
+test('10. violated: tag round-trip through store → rebuild → search', () => {
+  // Rebuild index to ensure tags.json is fresh
+  rebuild('--scope all')
+  // Search by the violated: tag
+  const r = search('--tag "violated:bp-001-implementation-workflow" --limit 10')
+  assert.ok(r.count > 0, 'Should find violation after rebuild')
+  const ep = r.episodes[0]
+  assert.ok(ep.tags.some(t => t === 'violated:bp-001-implementation-workflow'), 'Exact tag should survive round-trip')
+})
+
+test('11. Extra --tags appended to auto-tags', () => {
+  const r = violation('--pattern bp-010-habits-override-knowledge --summary "Extra tags test" --body "Testing extra tags" --tags "session-3,urgent"')
+  assert.strictEqual(r.status, 'ok')
+  // Search and verify all tags present
+  const s = search('--tag "urgent" --limit 5')
+  assert.ok(s.count > 0, 'Should find by extra tag')
+  const ep = s.episodes.find(e => e.id === r.id)
+  assert.ok(ep, 'Should find the exact episode')
+  assert.ok(ep.tags.includes('violation'), 'Should have auto-tag: violation')
+  assert.ok(ep.tags.includes('session-3'), 'Should have extra tag: session-3')
+  assert.ok(ep.tags.includes('urgent'), 'Should have extra tag: urgent')
+})
+
+test('12. --sequence and --correct appear in structured body', () => {
+  const r = violation('--pattern bp-006-push-after-verify --summary "Sequence test" --body "Details here" --sequence "edit,push,test" --correct "edit,test,push"')
+  assert.strictEqual(r.status, 'ok')
+  // Read the episode file to verify body structure
+  const content = fs.readFileSync(r.file, 'utf8')
+  assert.ok(content.includes('## What happened'), 'Should have What happened section')
+  assert.ok(content.includes('## Violation sequence'), 'Should have Violation sequence section')
+  assert.ok(content.includes('edit,push,test'), 'Should contain the violation sequence')
+  assert.ok(content.includes('## Correct sequence'), 'Should have Correct sequence section')
+  assert.ok(content.includes('edit,test,push'), 'Should contain the correct sequence')
+})
+
+test('13. Missing --pattern rejected with usage error', () => {
+  const r = violationFail('--summary "no pattern" --body "test"')
+  assert.ok(r, 'Should have returned error output')
+  assert.strictEqual(r.status, 'error')
+  assert.ok(r.message.includes('Missing required'), 'Should mention missing args')
+})
+
+test('14. Missing --summary rejected with usage error', () => {
+  const r = violationFail('--pattern bp-001-implementation-workflow --body "test"')
+  assert.ok(r, 'Should have returned error output')
+  assert.strictEqual(r.status, 'error')
+})
+
+test('15. Pattern validation falls back to ~/.episodic-memory/patterns/_index.json', () => {
+  // Create a temp dir with no local patterns but global install
+  const noLocalDir = path.join(tmpHome, 'no-local-patterns')
+  fs.mkdirSync(noLocalDir, { recursive: true })
+  // Copy _index.json to global location
+  const globalPatternsDir = path.join(tmpHome, '.episodic-memory', 'patterns')
+  fs.mkdirSync(globalPatternsDir, { recursive: true })
+  fs.copyFileSync(srcIndex, path.join(globalPatternsDir, '_index.json'))
+
+  // Run violation from dir with no local patterns — should find global
+  const result = execSync(
+    `node "${VIOLATION}" --pattern bp-001-implementation-workflow --summary "fallback test" --body "testing global fallback"`,
+    { encoding: 'utf8', cwd: noLocalDir, env }
+  )
+  const r = JSON.parse(result.trim())
+  assert.strictEqual(r.status, 'ok')
+})
+
+test('16. em-session-end-prompt.mjs includes store_command template', () => {
+  const r = sessionEnd()
+  assert.ok(r.store_command, 'Should have store_command field')
+  assert.ok(r.store_command.includes('em-violation.mjs'), 'Command should reference em-violation.mjs')
+  assert.ok(r.store_command.includes('--pattern'), 'Command should include --pattern flag')
+})
+
+test('17. Scope validation rejects invalid --scope values', () => {
+  const r = violationFail('--pattern bp-001-implementation-workflow --summary "test" --body "test" --scope invalid')
+  assert.ok(r, 'Should have returned error output')
+  assert.strictEqual(r.status, 'error')
+  assert.ok(r.message.includes('Invalid --scope'), 'Error should mention invalid scope')
+})
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n' + '='.repeat(50))
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) {
+    console.log(`  - ${f.name}: ${f.error}`)
+  }
+}
+console.log('='.repeat(50))
+
+// Cleanup
+fs.rmSync(tmpHome, { recursive: true, force: true })
+
+process.exit(failed > 0 ? 1 : 0)


### PR DESCRIPTION
## Summary

- **`em-violation.mjs`** — structured violation storage: validates pattern in `_index.json`, auto-tags `violation` + `behavioral-pattern` + `violated:<pattern_id>`, builds structured body with sections, uses `execFileSync` (no shell injection risk)
- **`em-session-end-prompt.mjs`** — SessionEnd hook template: outputs JSON with prompt, known patterns, store command
- **`em-store.mjs`** — `violation` category added, usage message fixed (TDZ + stale categories)
- **`install.mjs`** — copies `_index.json` globally, `--install-hooks` for SessionEnd registration
- **bp-009 v2.0.0** — reconciled with `em-violation.mjs`
- **17 new tests**, 68 total passing
- **Rule 18 fully followed**: plan → 2nd opinion (9 findings) → approval → implement with tests → code review (3 bugs) → E2E → bugs logged (#19, #20)

## Test plan

- [ ] `node tests/test-rfc002-phase1.mjs` — 17 tests pass
- [ ] `node tests/test-phase3.mjs` — 20 tests pass (regression)
- [ ] `node tests/test-phase2.mjs` — 24 tests pass (regression)
- [ ] `node tests/test-p3-fixes.mjs` — 7 tests pass (regression)
- [ ] Manual: `node scripts/em-violation.mjs --pattern bp-001-implementation-workflow --summary "test" --body "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)