### PR TITLE
docs: RFC-002 Phase 3b spec + plan-gate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ node install.mjs --tool all --project /path/to/my-project
 
 The installer:
 1. Copies scripts to `~/.episodic-memory/scripts/`
-2. Creates `.episodic-memory/` in the target project for local episodes
-3. Copies the appropriate instruction file for your tool
+2. Copies `patterns/_index.json` to `~/.episodic-memory/patterns/` for global pattern validation
+3. Creates `.episodic-memory/` in the target project for local episodes
+4. Copies the appropriate instruction file for your tool
+5. With `--install-hooks`: registers SessionEnd + SessionStart hooks in `~/.claude/settings.json` (Claude Code only, opt-in)
 
 ## Supported Tools
 
@@ -87,6 +89,9 @@ The installer:
 | `discovery` | Bug root causes, undocumented behavior, insights |
 | `milestone` | Features shipped, migrations completed |
 | `context` | Constraints, dependencies, environment quirks |
+| `research` | Web research distilled for future reference |
+| `lesson` | Consolidated lessons from multiple episodes |
+| `violation` | Behavioral pattern violations with structured sequences |
 
 ## Data Locations
 
@@ -94,6 +99,7 @@ The installer:
 ~/.episodic-memory/           # Global (cross-project)
 ├── scripts/                  # Installed scripts
 ├── episodes/                 # Global episode .md files
+├── patterns/                 # Pattern registry (_index.json)
 ├── index.jsonl               # Global index
 └── tags.json                 # Inverted tag index
 
@@ -143,15 +149,24 @@ The system ships with behavioral patterns — reusable lessons learned from real
 | bp-008 | Redo properly instead of patching retroactively |
 | bp-009 | Store rule violations as evidence for enforcement |
 | bp-010 | Habits override knowledge — always add mechanical enforcement |
+| bp-011 | Local files first, external actions only after confirmation |
+| bp-012 | Complete session wrap-up — episodic memory, changes, handoff |
 
 Patterns are seeded into the global episode store via `em-seed-patterns.mjs` so they surface during normal search and recall. See `patterns/TEMPLATE.md` to create new ones.
 
 ### Enforcement
 
-Behavioral patterns are documentation — they tell AI assistants **what** to follow, but don't mechanically **prevent** violations. For mechanical enforcement (hooks, CI checks, PR templates), see [user-preferences](https://github.com/lantisprime/user-preferences) as an optional companion. It provides:
+Behavioral patterns are documentation — they tell AI assistants **what** to follow, but don't mechanically **prevent** violations. The system provides two layers of enforcement:
 
+**Built-in (episodic-memory):**
+- **Violation tracking** (`em-violation.mjs`) — structured storage with pattern linkage, searchable by `--category violation` and `--tag violated:<pattern_id>`
+- **Session-end prompt** (`em-session-end-prompt.mjs`) — SessionEnd hook that asks about violations
+- **Proactive recall** (`em-recall.mjs`) — surfaces past violations at session start as pre-flight warnings
+- **Checkpoint enforcement gate** (RFC-002 Phase 3b, coming) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done
+
+**External ([user-preferences](https://github.com/lantisprime/user-preferences)):**
 - **Pre-tool hooks** (e.g., `plan-gate.sh`) that block writes during the planning phase
-- **CI workflow templates** for status checks that enforce the implementation workflow
+- **CI workflow templates** for status checks
 - **PR templates** with checklists mapped to behavioral patterns
 
 Episodic-memory and user-preferences are fully independent — install either or both.
@@ -160,8 +175,8 @@ Episodic-memory and user-preferences are fully independent — install either or
 
 | RFC | Title | Status |
 |-----|-------|--------|
-| [RFC-001](docs/rfcs/RFC-001-memory-improvements.md) | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, Semantic Consolidation | Accepted |
-| [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Draft |
+| [RFC-001](docs/rfcs/RFC-001-memory-improvements.md) | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, Semantic Consolidation | Accepted (Phases 1-3 shipped) |
+| [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Accepted (Phase 1 shipped) |
 
 ## Scripts Reference
 
@@ -209,6 +224,35 @@ node ~/.episodic-memory/scripts/em-check-stale.mjs --project my-project
 ### Seed Patterns
 ```bash
 node ~/.episodic-memory/scripts/em-seed-patterns.mjs
+```
+
+### Recall (Proactive)
+```bash
+node ~/.episodic-memory/scripts/em-recall.mjs
+node ~/.episodic-memory/scripts/em-recall.mjs --project my-project --limit 5
+node ~/.episodic-memory/scripts/em-recall.mjs --days 14 --no-track
+```
+
+### Prune (Archive Stale Episodes)
+```bash
+node ~/.episodic-memory/scripts/em-prune.mjs --dry-run
+node ~/.episodic-memory/scripts/em-prune.mjs --scope global --threshold 0.15
+node ~/.episodic-memory/scripts/em-prune.mjs --check  # exit 1 if prunable episodes exist
+```
+
+### Violation Tracking
+```bash
+node ~/.episodic-memory/scripts/em-violation.mjs \
+  --pattern bp-001-implementation-workflow \
+  --summary "Skipped checkpoints" \
+  --body "Details..." \
+  --sequence "plan,code,push" \
+  --correct "plan,checkpoint,code,review,push"
+```
+
+### Session End Prompt
+```bash
+node ~/.episodic-memory/scripts/em-session-end-prompt.mjs
 ```
 
 ### Rebuild Index

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -17,6 +17,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 8: Switching Between Tools](#scenario-8-switching-between-tools)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
+- [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
 - [What Gets Stored and What Doesn't](#what-gets-stored-and-what-doesnt)
 - [Browsing Your Memories](#browsing-your-memories)
 - [Troubleshooting](#troubleshooting)
@@ -330,6 +331,38 @@ AI:   Heads up — I recall from a past session that parallel tests
 
 ---
 
+## Scenario 11: Tracking Rule Violations
+
+**What happens:** The AI skips a step in its workflow. You catch it and the system records the violation structurally — linking it to the specific rule that was broken.
+
+```
+You:  Did you follow the implementation workflow?
+
+AI:   No — I skipped the E2E testing step before pushing. That's a
+      violation of bp-001 (implementation workflow).
+
+      Stored violation: "Skipped E2E testing before push"
+      — Pattern: bp-001-implementation-workflow
+      — What happened: jumped from code review fixes to commit
+      — Correct sequence: code review → fix → E2E → bug logging → push
+```
+
+**In a future session:**
+
+```
+You:  Let's implement the new feature.
+
+AI:   ⚠️ Pre-flight warning: bp-001 (implementation workflow) was
+      violated 3 times in the last 30 days. Last violation: yesterday.
+
+      I'll make sure to follow all 9 steps this time, including
+      E2E testing and bug logging before pushing.
+```
+
+**What happened:** Violations are stored with the pattern ID, the wrong sequence, and the correct sequence. The system aggregates them and surfaces warnings when you start similar work. Over time, this drives enforcement improvements — if a rule is violated repeatedly, it gets a mechanical gate (hook) instead of relying on documentation.
+
+---
+
 ## What Gets Stored and What Doesn't
 
 ### Stored automatically
@@ -340,6 +373,8 @@ AI:   Heads up — I recall from a past session that parallel tests
 | **Discoveries** | Bug root causes, undocumented behaviors, performance insights |
 | **Milestones** | Feature shipped, migration completed, major refactor done |
 | **Context** | Environment quirks, client constraints, deployment details |
+| **Research** | Web research distilled for future reference (avoids re-fetching) |
+| **Violations** | When the AI broke a workflow rule — tracked structurally for pattern improvement |
 
 ### Never stored
 
@@ -475,6 +510,15 @@ Rebuild it — this regenerates the index from the actual episode files:
 
 ```bash
 node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
+```
+
+### "How do I track violations?"
+
+The AI can track rule violations automatically when you point them out. Just say "that was a violation of [rule name]" and the AI stores it with structured details. You can search for all violations:
+
+```bash
+node ~/.episodic-memory/scripts/em-search.mjs --category violation
+node ~/.episodic-memory/scripts/em-search.mjs --tag "violated:bp-001-implementation-workflow"
 ```
 
 ### "I want to start fresh"

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -246,10 +246,25 @@ Convenience wrapper (like `em-violation.mjs`) for storing successful pattern com
 **New category: `compliance`**
 - Added to `VALID_CATEGORIES` in `em-store.mjs`
 
+**Structured success counts in `patterns/_index.json`:**
+- `em-pattern-success.mjs` and `em-violation.mjs` increment persistent counters in `_index.json` on each store:
+  ```json
+  {
+    "pattern_id": "bp-001-implementation-workflow",
+    "compliance_count": 2,
+    "violation_count": 8,
+    "last_compliance": "2026-05-01",
+    "last_violation": "2026-05-01"
+  }
+  ```
+- All-time totals — always accurate, no scanning needed
+- Atomic update (read → increment → write with temp+rename), same pattern as `access_count` in `index.jsonl`
+- `em-rebuild-index.mjs` can recompute counts from episodes if `_index.json` drifts
+
 **Extend `em-pattern-health.mjs` (Phase 2):**
-- Add compliance tracking alongside violation tracking
-- For each pattern: count `complied:<pattern_id>` tags in the same rolling window
-- New fields in health report: `compliance_count`, `compliance_rate`, `streak` (consecutive successes), `success_factors` (most common factors from episode bodies)
+- Read persistent counts from `_index.json` for all-time totals (fast, no scan)
+- Scan episodes for rolling-window counts (30-day violations/compliances)
+- New fields in health report: `compliance_count` (all-time), `compliance_count_window` (30-day), `compliance_rate`, `streak` (consecutive successes), `success_factors` (most common factors from episode bodies)
 - New recommendation: `healthy-with-data` (pattern has both violations and compliances — the data shows what works)
 
 **Extend `em-recall.mjs` (Phase 3) pre-flight:**
@@ -273,8 +288,12 @@ Convenience wrapper (like `em-violation.mjs`) for storing successful pattern com
 
 **Files modified:**
 - `scripts/em-store.mjs` — add `compliance` to `VALID_CATEGORIES`
-- `scripts/em-pattern-health.mjs` (Phase 2) — add compliance tracking fields
+- `scripts/em-violation.mjs` — increment `violation_count` in `_index.json` on store
+- `scripts/em-pattern-success.mjs` — increment `compliance_count` in `_index.json` on store
+- `scripts/em-pattern-health.mjs` (Phase 2) — read persistent counts + rolling window scan
 - `scripts/em-recall.mjs` (Phase 3) — add compliance data to pre-flight output
+- `scripts/em-rebuild-index.mjs` — recompute compliance/violation counts from episodes
+- `patterns/_index.json` — add `compliance_count`, `violation_count`, `last_compliance`, `last_violation` fields
 
 **Depends on:** Phase 2 (health report) + Phase 3 (recall pre-flight output)
 
@@ -380,6 +399,10 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] `em-recall.mjs` pre-flight surfaces both violation and compliance counts
 - [ ] Pre-flight message includes success factors when compliance data exists
 - [ ] No compliance data does not break health report or pre-flight (graceful absence)
+- [ ] `em-pattern-success.mjs` increments `compliance_count` in `_index.json` atomically
+- [ ] `em-violation.mjs` increments `violation_count` in `_index.json` atomically
+- [ ] `_index.json` counts survive rebuild (recomputed from episodes)
+- [ ] Health report shows both all-time counts (from `_index.json`) and 30-day windowed counts (from scan)
 
 ### Sequencing
 

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -283,6 +283,11 @@ Convenience wrapper (like `em-violation.mjs`) for storing successful pattern com
   ```
 - Success context is actionable: "last time this worked, you classified as light and the plan-gate was active"
 
+**Extend bp-001 with mid-task reclassification guidance:**
+- When a mid-task addition introduces new schema fields, new files to modify, or new acceptance tests beyond the original plan — pause and reclassify
+- If the task has grown from light to full, stop and run the missing steps (2nd opinion, approval, etc.) before continuing
+- This is a classification refinement, not a new pattern — add to bp-001's Scope Tiers section as a "Mid-task scope change" subsection
+
 **Files created:**
 - `scripts/em-pattern-success.mjs`
 

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -222,7 +222,8 @@ Orphaned states (e.g., `.post-checkpoint-required` without `.checkpoint-required
 
 **Files modified:**
 - `scripts/em-recall.mjs` — add `.checkpoint-required` marker creation when bp-001 violations detected
-- `install.mjs` — register checkpoint-gate + SessionStart hooks with `--install-hooks`
+- `scripts/em-session-end-prompt.mjs` — extend with marker cleanup (all 4: `.checkpoint-required`, `.pre-checkpoint-done`, `.post-checkpoint-required`, `.post-checkpoint-done`)
+- `install.mjs` — register checkpoint-gate (PreToolUse) + SessionStart hooks with `--install-hooks`
 - `patterns/implementation-workflow.md` — add checkpoint-gate to bp-001 enforcement table (not a new pattern bp-012)
 
 **Depends on:** Phase 3 (violation-aware recall output)
@@ -307,7 +308,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] `install.mjs --install-hooks` registers checkpoint-gate + SessionStart hooks
 - [ ] Both plan-gate and checkpoint-gate active simultaneously — user sees two distinct error messages
 - [ ] `em-session-end-prompt.mjs` cleans up all markers at session end (extends Phase 1 script)
-- [ ] `.post-checkpoint-required` created when first code edit is allowed through pre-checkpoint gate
+- [ ] `.post-checkpoint-required` touched on every allowed write through pre-checkpoint gate (idempotent)
 - [ ] `git push` blocked when `.post-checkpoint-required` exists and `.post-checkpoint-done` absent/empty
 - [ ] Non-empty `.post-checkpoint-done` unblocks push
 - [ ] Empty `.post-checkpoint-done` does NOT unblock push

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -160,7 +160,7 @@ Add a violation-aware recall pass:
 
 ### Phase 3b: Checkpoint Enforcement Gate
 
-**Motivation:** Across 3+ sessions, bp-001 was violated 4+ times despite documentation in CLAUDE.md, bp-001 v2.0.0, MEMORY.md, and session handoffs. The only mechanism that ever prevented a violation was `plan-gate.sh` (a PreToolUse hook). Documentation-based enforcement fails under momentum — only mechanical gates work (bp-010).
+**Motivation:** Across 3+ sessions, bp-001 was violated 6+ times despite documentation in CLAUDE.md, bp-001 v2.0.0, MEMORY.md, and session handoffs. The only mechanism that ever prevented a violation was `plan-gate.sh` (a PreToolUse hook). Documentation-based enforcement fails under momentum — only mechanical gates work (bp-010). Two distinct failure modes observed: (1) skipping the pre-implementation checkpoint before coding starts, and (2) skipping E2E testing + bug logging before pushing — steps 8 and 9 are skipped 100% of the time because they come after the work "feels done."
 
 **New hook: `checkpoint-gate.sh`** — PreToolUse hook, follows `plan-gate.sh` architecture.
 
@@ -175,9 +175,20 @@ Add a violation-aware recall pass:
 - Allowlist: commands writing to `.pre-checkpoint-done` pass through the gate (prevents deadlock — same pattern as plan-gate.sh's `rm` allowlist)
 - Error message is distinct from plan-gate.sh: "Checkpoint required. Print the Rule 18 pre-implementation checkpoint block to proceed."
 
-**Cleanup:**
-- `SessionEnd` hook removes both `.checkpoint-required` and `.pre-checkpoint-done`
-- Hook also detects `git push` or `gh pr create` in Bash commands and triggers cleanup (task completed)
+**Push gate (post-implementation enforcement):**
+
+Evidence from session 3: steps 8 (E2E) and 9 (bug logging) are skipped 100% of the time because they come **after the work feels done** — momentum carries the AI from "fix findings" straight to "commit and push." The checkpoint-gate catches the start of a task; the push-gate catches the end.
+
+- `checkpoint-gate.sh` also blocks `git push` and `gh pr create` Bash commands when `.claude/.post-checkpoint-required` exists AND `.claude/.post-checkpoint-done` does not exist (or is empty)
+- `.post-checkpoint-required` is touched by `checkpoint-gate.sh` when it allows through the first code edit (the pre-checkpoint passed → implementation started → post-checkpoint will be needed)
+- `.post-checkpoint-done` must be **non-empty** — AI writes the Rule 18 post-implementation checkpoint into it
+- Allowlist: commands writing to `.post-checkpoint-done` pass through
+- Error message: "Post-implementation checkpoint required. Complete E2E testing and bug logging, then print the Rule 18 post-implementation checkpoint block to proceed."
+- This enforces bp-006 (push-after-verify) mechanically — no push until E2E + bug logging + post-checkpoint are done
+
+**Cleanup (two mechanisms):**
+- `SessionEnd` hook removes all markers (`.checkpoint-required`, `.pre-checkpoint-done`, `.post-checkpoint-required`, `.post-checkpoint-done`) as end-of-session sweep. Extends `em-session-end-prompt.mjs` from Phase 1 (single script, multiple responsibilities: violation prompt + marker cleanup).
+- `checkpoint-gate.sh` itself (PreToolUse) cleans up all markers when it detects and allows through a `git push` or `gh pr create` command (task completed). This is the same hook that does the gating — no additional PostToolUse hook needed.
 
 **Interaction with plan-gate.sh:**
 - Two independent PreToolUse hooks, compose correctly (both block independently)
@@ -273,12 +284,21 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] Non-empty `.pre-checkpoint-done` unblocks writes
 - [ ] Empty `.pre-checkpoint-done` (just `touch`) does NOT unblock
 - [ ] Write command to `.pre-checkpoint-done` allowed through (no deadlock)
-- [ ] SessionEnd hook cleans up both markers
-- [ ] `git push` / `gh pr create` in Bash triggers marker cleanup
+- [ ] SessionEnd hook cleans up all 4 markers
 - [ ] No gate when `.checkpoint-required` absent
 - [ ] Error message distinguishable from plan-gate.sh
 - [ ] SessionStart hook invokes `em-recall.mjs` mechanically
 - [ ] bp-001 enforcement table updated with checkpoint-gate
+- [ ] `install.mjs --install-hooks` registers checkpoint-gate + SessionStart hooks
+- [ ] Both plan-gate and checkpoint-gate active simultaneously — user sees two distinct error messages
+- [ ] `em-session-end-prompt.mjs` cleans up all markers at session end (extends Phase 1 script)
+- [ ] `.post-checkpoint-required` created when first code edit is allowed through pre-checkpoint gate
+- [ ] `git push` blocked when `.post-checkpoint-required` exists and `.post-checkpoint-done` absent/empty
+- [ ] Non-empty `.post-checkpoint-done` unblocks push
+- [ ] Empty `.post-checkpoint-done` does NOT unblock push
+- [ ] Write command to `.post-checkpoint-done` allowed through (no deadlock)
+- [ ] `git push` / `gh pr create` allowed through cleans up all 4 markers
+- [ ] Push-gate error message: mentions E2E, bug logging, and post-implementation checkpoint
 
 ### Sequencing
 

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -156,7 +156,50 @@ Add a violation-aware recall pass:
 - This is NOT instruction-level behavior alone — a `SessionEnd` hook ensures the prompt happens mechanically, not by AI memory
 
 **Files modified:**
-- `scripts/em-recall.mjs` (when built in RFC-001 Phase 3) — add pre-flight pass
+- `scripts/em-recall.mjs` (RFC-001 Phase 3, shipped) — add pre-flight violation pass; automatically touch `.claude/.checkpoint-required` when bp-001 violations are detected (Phase 3b activation)
+
+### Phase 3b: Checkpoint Enforcement Gate
+
+**Motivation:** Across 3+ sessions, bp-001 was violated 4+ times despite documentation in CLAUDE.md, bp-001 v2.0.0, MEMORY.md, and session handoffs. The only mechanism that ever prevented a violation was `plan-gate.sh` (a PreToolUse hook). Documentation-based enforcement fails under momentum — only mechanical gates work (bp-010).
+
+**New hook: `checkpoint-gate.sh`** — PreToolUse hook, follows `plan-gate.sh` architecture.
+
+**Activation (mechanical, no AI judgment in activation path):**
+- `em-recall.mjs` (Phase 3) detects recent bp-001 violations in pre-flight → automatically touches `.claude/.checkpoint-required`
+- `em-recall.mjs` invoked mechanically via **SessionStart hook** (not instructions, not AI memory) to close the race condition where recall is never called
+- Activation is fully script-driven — the AI does not decide whether to create the marker
+
+**Gate behavior:**
+- Blocks ALL write tools (Edit, Write, Bash) when `.checkpoint-required` exists AND `.pre-checkpoint-done` does NOT exist (or is empty)
+- `.pre-checkpoint-done` must be **non-empty** (`[ -s "$MARKER" ]`) — the AI writes the Rule 18 checkpoint text into it, not just `touch`
+- Allowlist: commands writing to `.pre-checkpoint-done` pass through the gate (prevents deadlock — same pattern as plan-gate.sh's `rm` allowlist)
+- Error message is distinct from plan-gate.sh: "Checkpoint required. Print the Rule 18 pre-implementation checkpoint block to proceed."
+
+**Cleanup:**
+- `SessionEnd` hook removes both `.checkpoint-required` and `.pre-checkpoint-done`
+- Hook also detects `git push` or `gh pr create` in Bash commands and triggers cleanup (task completed)
+
+**Interaction with plan-gate.sh:**
+- Two independent PreToolUse hooks, compose correctly (both block independently)
+- If both markers exist, user sees two distinct error messages
+- Implementation may evaluate merging into a single `write-gate.sh` (F-10) — decide during implementation, document the rationale either way
+
+**SessionStart hook for em-recall:**
+- New or extended SessionStart hook: `node ~/.episodic-memory/scripts/em-recall.mjs --project <inferred> --limit 5`
+- Output displayed to AI at session start — pre-flight warnings surface immediately
+- If pre-flight detects bp-001 violations → `.checkpoint-required` created before any user interaction
+- Registered via `install.mjs --install-hooks` (same opt-in pattern as SessionEnd)
+
+**Files created:**
+- `checkpoint-gate.sh` — PreToolUse hook
+- SessionStart hook script (or extension of existing hook)
+
+**Files modified:**
+- `scripts/em-recall.mjs` — add `.checkpoint-required` marker creation when bp-001 violations detected
+- `install.mjs` — register checkpoint-gate + SessionStart hooks with `--install-hooks`
+- `patterns/implementation-workflow.md` — add checkpoint-gate to bp-001 enforcement table (not a new pattern bp-012)
+
+**Depends on:** Phase 3 (violation-aware recall output)
 
 ### Instruction file updates
 
@@ -168,7 +211,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 
 ### Scope
 
-- **In scope:** violation category, structured violation storage, pattern health reports, violation-aware recall, pre-flight warnings, session-end violation prompt via `SessionEnd` hook, bp-009 reconciliation
+- **In scope:** violation category, structured violation storage, pattern health reports, violation-aware recall, pre-flight warnings, checkpoint enforcement gate (mechanical hook blocking code edits until checkpoint printed), SessionStart hook for recall invocation, session-end violation prompt via `SessionEnd` hook, bp-009 reconciliation
 - **Out of scope:** automatic violation detection (AI cannot reliably self-detect — see Problem section), punishment/penalty mechanisms, cross-user violation sharing, violation severity levels, automated pattern rewriting
 
 ---
@@ -223,34 +266,51 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] `--task-type` flag for explicit task context
 - [ ] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
 - [ ] SessionEnd hook prompts user for violation flagging (not instruction-only)
+- [ ] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
+
+**Phase 3b:**
+- [ ] `checkpoint-gate.sh` blocks all write tools when `.checkpoint-required` exists and `.pre-checkpoint-done` is absent or empty
+- [ ] Non-empty `.pre-checkpoint-done` unblocks writes
+- [ ] Empty `.pre-checkpoint-done` (just `touch`) does NOT unblock
+- [ ] Write command to `.pre-checkpoint-done` allowed through (no deadlock)
+- [ ] SessionEnd hook cleans up both markers
+- [ ] `git push` / `gh pr create` in Bash triggers marker cleanup
+- [ ] No gate when `.checkpoint-required` absent
+- [ ] Error message distinguishable from plan-gate.sh
+- [ ] SessionStart hook invokes `em-recall.mjs` mechanically
+- [ ] bp-001 enforcement table updated with checkpoint-gate
 
 ### Sequencing
 
 ```mermaid
 graph TD
-    RFC1P3[RFC-001 Phase 3: Proactive Recall<br/>HARD BLOCKER — must ship first]
+    RFC1P3[RFC-001 Phase 3: Proactive Recall<br/>SHIPPED]
     P1[Phase 1: Violation Tracking]
     P2[Phase 2: Pattern Refinement]
     P3[Phase 3: Actionable Recall]
+    P3b[Phase 3b: Checkpoint Enforcement Gate]
     INST[Instruction File Updates]
 
     P1 --> P2
     P1 --> P3
     RFC1P3 --> P3
+    P3 --> P3b
     P2 --> INST
-    P3 --> INST
+    P3b --> INST
 
-    classDef blocker fill:#ffcdd2
+    classDef shipped fill:#c8e6c9
     classDef tier1 fill:#e1f5fe
     classDef tier2 fill:#fff9c4
     classDef tier3 fill:#e8f5e9
-    class RFC1P3 blocker
+    classDef enforcement fill:#ffccbc
+    class RFC1P3 shipped
     class P1 tier1
     class P2,P3 tier2
+    class P3b enforcement
     class INST tier3
 ```
 
-> **Hard dependency:** Phase 3 of this RFC extends `em-recall.mjs`, which is built in RFC-001 Phase 3. RFC-001 Phase 3 must ship before RFC-002 Phase 3 can begin. Phases 1 and 2 of this RFC have no external blockers.
+> **Hard dependency:** Phase 3 extends `em-recall.mjs` (RFC-001 Phase 3, now shipped). Phase 3b depends on Phase 3's pre-flight output. Phases 1 and 2 have no external blockers.
 
 ---
 
@@ -306,6 +366,24 @@ graph TD
 P3s deferred to implementation (stored in episodic memory): F-9 (error UX), F-10 (markdown template), F-11 (data-driven task mapping), F-13 (dependency phrasing)
 **AI-slop flag:** "current file context" in task inference was vague for a CLI script — replaced with git branch keyword inference only
 **AI-slop check:** clean after revision
+**Decision:** proceed (after revision applied)
+
+### Review 3 — Claude Opus 4.6 (Phase 3b amendment)
+**Reviewer:** Claude Opus 4.6 (Plan subagent, independent context)
+**Date:** 2026-05-01
+**Scope:** Phase 3b checkpoint-gate amendment review
+**Findings:** Ten findings (3 P1, 5 P2, 2 P3). All P1s and P2s addressed in amendment:
+1. (P1) Does not belong in Phase 3 proper — restructured as Phase 3b with own acceptance tests
+2. (P1) Race condition if em-recall not invoked — added SessionStart hook for mechanical invocation
+3. (P1) Marker creation must be script-driven not AI-driven — em-recall.mjs touches marker automatically
+4. (P2) Hardcoded extensions miss .yml/.json — gate all write tools (like plan-gate)
+5. (P2) Empty marker allows shortcutting — require non-empty `.pre-checkpoint-done`
+6. (P2) Two hooks need distinct error messages — documented, distinct messages specified
+7. (P2) Cleanup timing unspecified — SessionEnd + push-triggered cleanup
+8. (P2) Deadlock risk — allowlist pattern from plan-gate.sh
+9. (P3) Not a new pattern bp-012 — added to bp-001 enforcement table instead
+10. (P3) Consider merging into single write-gate.sh — evaluate during implementation
+**AI-slop check:** clean
 **Decision:** proceed (after revision applied)
 
 ---

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -180,11 +180,26 @@ Add a violation-aware recall pass:
 Evidence from session 3: steps 8 (E2E) and 9 (bug logging) are skipped 100% of the time because they come **after the work feels done** — momentum carries the AI from "fix findings" straight to "commit and push." The checkpoint-gate catches the start of a task; the push-gate catches the end.
 
 - `checkpoint-gate.sh` also blocks `git push` and `gh pr create` Bash commands when `.claude/.post-checkpoint-required` exists AND `.claude/.post-checkpoint-done` does not exist (or is empty)
-- `.post-checkpoint-required` is touched by `checkpoint-gate.sh` when it allows through the first code edit (the pre-checkpoint passed → implementation started → post-checkpoint will be needed)
+- `.post-checkpoint-required` is touched by `checkpoint-gate.sh` on every allowed write (idempotent `touch`) — no "first edit" tracking needed. The marker's existence is what matters, not creation count.
 - `.post-checkpoint-done` must be **non-empty** — AI writes the Rule 18 post-implementation checkpoint into it
 - Allowlist: commands writing to `.post-checkpoint-done` pass through
 - Error message: "Post-implementation checkpoint required. Complete E2E testing and bug logging, then print the Rule 18 post-implementation checkpoint block to proceed."
+- Command matching for `git push` / `gh pr create`: match anywhere in the command string (not just start), since these are unlikely false positives in compound statements like `git push origin main && echo done`
 - This enforces bp-006 (push-after-verify) mechanically — no push until E2E + bug logging + post-checkpoint are done
+
+**Limitations:**
+- The push-gate only works within Claude Code sessions (PreToolUse hook). Pushing from a separate terminal, Git GUI, or outside the session bypasses it. If true enforcement is needed, escalate to a Git pre-push hook or CI check — consistent with bp-010 philosophy.
+- If `git push` fails after markers are cleaned (cleanup happens before push executes in PreToolUse), the gate is disarmed for the rest of the session. Accepted as pragmatic trade-off — push failure is rare and the alternative (PostToolUse cleanup) adds significant complexity for minimal benefit.
+
+**State machine (4 markers):**
+```
+idle → .checkpoint-required (em-recall detects violations)
+     → .pre-checkpoint-done (AI prints pre-checkpoint)
+       + .post-checkpoint-required (touched on every allowed write)
+     → .post-checkpoint-done (AI prints post-checkpoint)
+     → idle (push allowed, all markers cleaned)
+```
+Orphaned states (e.g., `.post-checkpoint-required` without `.checkpoint-required`) are cleaned by SessionEnd sweep.
 
 **Cleanup (two mechanisms):**
 - `SessionEnd` hook removes all markers (`.checkpoint-required`, `.pre-checkpoint-done`, `.post-checkpoint-required`, `.post-checkpoint-done`) as end-of-session sweep. Extends `em-session-end-prompt.mjs` from Phase 1 (single script, multiple responsibilities: violation prompt + marker cleanup).
@@ -299,6 +314,10 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] Write command to `.post-checkpoint-done` allowed through (no deadlock)
 - [ ] `git push` / `gh pr create` allowed through cleans up all 4 markers
 - [ ] Push-gate error message: mentions E2E, bug logging, and post-implementation checkpoint
+- [ ] `gh pr create` also blocked by push-gate (not just `git push`)
+- [ ] Push failure after marker cleanup does not re-engage gate (documented limitation)
+- [ ] Orphaned markers (e.g., `.post-checkpoint-required` alone) cleaned by SessionEnd
+- [ ] SessionStart hook produces `.checkpoint-required` before any user interaction (flow test)
 
 ### Sequencing
 

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -228,6 +228,56 @@ Orphaned states (e.g., `.post-checkpoint-required` without `.checkpoint-required
 
 **Depends on:** Phase 3 (violation-aware recall output)
 
+### Phase 4: Positive Reinforcement
+
+**Motivation:** RFC-002 Phases 1-3b only track failures. Session 3 proved that compliance also produces actionable data — the successful light-scope doc update revealed that correct classification + plan-gate = clean execution. A system that only surfaces violations is punitive; one that also surfaces what worked is constructive and helps the AI replicate success conditions.
+
+**New script: `scripts/em-pattern-success.mjs` (~60 lines)**
+
+Convenience wrapper (like `em-violation.mjs`) for storing successful pattern compliance with context about what conditions led to success.
+
+- Usage: `node em-pattern-success.mjs --pattern <pattern_id> --summary "<what went right>" --body "<success factors>" [--factors "<factor1,factor2>"]`
+- Validates pattern exists in `patterns/_index.json` (same as `em-violation.mjs`)
+- Auto-tags: `compliance`, `behavioral-pattern`, `complied:<pattern_id>`
+- Structured body with `## What went right` and `## Success factors` sections
+- Shells out to `em-store.mjs` with `--category compliance`
+- Output: `{ status, id, pattern, file }`
+
+**New category: `compliance`**
+- Added to `VALID_CATEGORIES` in `em-store.mjs`
+
+**Extend `em-pattern-health.mjs` (Phase 2):**
+- Add compliance tracking alongside violation tracking
+- For each pattern: count `complied:<pattern_id>` tags in the same rolling window
+- New fields in health report: `compliance_count`, `compliance_rate`, `streak` (consecutive successes), `success_factors` (most common factors from episode bodies)
+- New recommendation: `healthy-with-data` (pattern has both violations and compliances — the data shows what works)
+
+**Extend `em-recall.mjs` (Phase 3) pre-flight:**
+- Surface both violations AND successes in pre-flight warnings:
+  ```json
+  {
+    "preflight_warnings": [
+      {
+        "pattern_id": "bp-001-implementation-workflow",
+        "violations_last_30d": 3,
+        "compliances_last_30d": 2,
+        "message": "bp-001: 3 violations (full scope), 2 successes (light scope + plan-gate). Compliance correlates with correct classification."
+      }
+    ]
+  }
+  ```
+- Success context is actionable: "last time this worked, you classified as light and the plan-gate was active"
+
+**Files created:**
+- `scripts/em-pattern-success.mjs`
+
+**Files modified:**
+- `scripts/em-store.mjs` — add `compliance` to `VALID_CATEGORIES`
+- `scripts/em-pattern-health.mjs` (Phase 2) — add compliance tracking fields
+- `scripts/em-recall.mjs` (Phase 3) — add compliance data to pre-flight output
+
+**Depends on:** Phase 2 (health report) + Phase 3 (recall pre-flight output)
+
 ### Instruction file updates
 
 Update instruction files incrementally as each phase ships (do not batch to the end):
@@ -238,7 +288,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 
 ### Scope
 
-- **In scope:** violation category, structured violation storage, pattern health reports, violation-aware recall, pre-flight warnings, checkpoint enforcement gate (mechanical hook blocking code edits until checkpoint printed), SessionStart hook for recall invocation, session-end violation prompt via `SessionEnd` hook, bp-009 reconciliation
+- **In scope:** violation category, structured violation storage, pattern health reports, violation-aware recall, pre-flight warnings, checkpoint enforcement gate (mechanical hook blocking code edits until checkpoint printed), SessionStart hook for recall invocation, session-end violation prompt via `SessionEnd` hook, bp-009 reconciliation, positive reinforcement (compliance tracking, success factors, balanced pre-flight)
 - **Out of scope:** automatic violation detection (AI cannot reliably self-detect — see Problem section), punishment/penalty mechanisms, cross-user violation sharing, violation severity levels, automated pattern rewriting
 
 ---
@@ -320,37 +370,52 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] Orphaned markers (e.g., `.post-checkpoint-required` alone) cleaned by SessionEnd
 - [ ] SessionStart hook produces `.checkpoint-required` before any user interaction (flow test)
 
+**Phase 4:**
+- [ ] `compliance` category accepted by `em-store.mjs`
+- [ ] `em-pattern-success.mjs` stores compliance with `complied:<pattern_id>` tag
+- [ ] `em-pattern-success.mjs` validates pattern exists in `patterns/_index.json`
+- [ ] `em-pattern-success.mjs` auto-tags with `compliance`, `behavioral-pattern`, `complied:<pattern_id>`
+- [ ] `--factors` stored in structured body section
+- [ ] `em-pattern-health.mjs` reports `compliance_count` and `compliance_rate` per pattern
+- [ ] `em-recall.mjs` pre-flight surfaces both violation and compliance counts
+- [ ] Pre-flight message includes success factors when compliance data exists
+- [ ] No compliance data does not break health report or pre-flight (graceful absence)
+
 ### Sequencing
 
 ```mermaid
 graph TD
     RFC1P3[RFC-001 Phase 3: Proactive Recall<br/>SHIPPED]
-    P1[Phase 1: Violation Tracking]
+    P1[Phase 1: Violation Tracking<br/>SHIPPED]
     P2[Phase 2: Pattern Refinement]
     P3[Phase 3: Actionable Recall]
     P3b[Phase 3b: Checkpoint Enforcement Gate]
+    P4[Phase 4: Positive Reinforcement]
     INST[Instruction File Updates]
 
     P1 --> P2
     P1 --> P3
     RFC1P3 --> P3
     P3 --> P3b
-    P2 --> INST
+    P2 --> P4
+    P3 --> P4
     P3b --> INST
+    P4 --> INST
 
     classDef shipped fill:#c8e6c9
     classDef tier1 fill:#e1f5fe
     classDef tier2 fill:#fff9c4
     classDef tier3 fill:#e8f5e9
     classDef enforcement fill:#ffccbc
-    class RFC1P3 shipped
-    class P1 tier1
+    classDef positive fill:#e8f5e9,stroke:#4caf50
+    class RFC1P3,P1 shipped
     class P2,P3 tier2
     class P3b enforcement
+    class P4 positive
     class INST tier3
 ```
 
-> **Hard dependency:** Phase 3 extends `em-recall.mjs` (RFC-001 Phase 3, now shipped). Phase 3b depends on Phase 3's pre-flight output. Phases 1 and 2 have no external blockers.
+> **Dependencies:** Phase 3 extends `em-recall.mjs` (RFC-001 Phase 3, shipped). Phase 3b depends on Phase 3's pre-flight. Phase 4 depends on Phase 2 (health report) + Phase 3 (recall output). Phases 1 (shipped) and 2 have no external blockers.
 
 ---
 

--- a/patterns/_index.json
+++ b/patterns/_index.json
@@ -79,6 +79,14 @@
       "tags": ["behavioral-pattern", "workflow", "git", "review", "discipline"],
       "scope": "global",
       "version": "1.0.0"
+    },
+    {
+      "pattern_id": "bp-012-complete-session-wrap-up",
+      "file": "complete-session-wrap-up.md",
+      "name": "Complete session wrap-up — episodic memory, changes, handoff",
+      "tags": ["behavioral-pattern", "session-discipline", "episodic-memory", "completeness"],
+      "scope": "global",
+      "version": "1.0.0"
     }
   ]
 }

--- a/patterns/complete-session-wrap-up.md
+++ b/patterns/complete-session-wrap-up.md
@@ -1,0 +1,45 @@
+---
+pattern_id: bp-012-complete-session-wrap-up
+name: "Complete session wrap-up — episodic memory, changes, handoff"
+category: decision
+tags: [behavioral-pattern, bp-012-complete-session-wrap-up, session-discipline, episodic-memory, completeness]
+scope: global
+version: 1.0.0
+---
+
+# Complete Session Wrap-Up
+
+At session end, complete ALL three steps in order. Do not skip any. The session is not over until all three are done.
+
+## Steps (in order)
+
+1. **Store episodic memories** — review session for significant decisions, discoveries, milestones, lessons learned. Store 0-3 episodes via `em-store.mjs`. Check if any project-specific decisions are generalizable to global behavioral patterns.
+
+2. **Reconcile changes** — ensure all code changes are committed, pushed, and in a PR. Check `git status` and `git log origin/main...HEAD`. If changes exist that aren't in a PR, create one. Update any existing PRs with new commits.
+
+3. **Write session handoff** — write/overwrite `memory/session_handoff.md` (~300 words). Must reflect actual repo state (correct branch, correct PR numbers, correct merge status). Tell user to `/clear`.
+
+## Detection triggers
+
+- User says "wrap up", "session handoff", "let's stop", "what's next session"
+- About to write session_handoff.md — have episodes been stored?
+- About to tell user to `/clear` — have all changes been pushed?
+
+## Why this exists
+
+Across 3+ sessions, the AI consistently:
+- Forgot to store learnings in episodic memory before handoff
+- Left uncommitted changes on branches that had already been merged
+- Wrote session handoff with stale PR numbers or branch names
+- Had to be reminded by the user every time
+
+The session "feels done" after the handoff is written, but loose ends remain. This is the same "after work feels done" failure mode that causes bp-001 violations at task end.
+
+## Enforcement
+
+- **Current:** Documentation only (this pattern + MEMORY.md reminder)
+- **Future:** SessionEnd hook could run a checklist script that verifies: (a) recent em-store calls in session, (b) clean git status, (c) session_handoff.md freshness
+
+## Scope
+
+All projects, all AI tools. Applies at every session end.

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test-plan-gate.sh — Automated tests for the plan-gate PreToolUse hook.
+#
+# Usage: bash tests/test-plan-gate.sh
+#
+# Tests the hook by piping mock JSON and checking exit codes + output.
+
+set -uo pipefail
+
+HOOK="$HOME/.claude/hooks/plan-gate.sh"
+TEST_DIR=$(mktemp -d)
+MARKER="$TEST_DIR/.claude/.plan-approval-pending"
+passed=0
+failed=0
+
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+# Helper: build mock JSON
+mock_json() {
+  local tool_name="$1"
+  local command="${2:-}"
+  if [ -n "$command" ]; then
+    jq -n --arg tn "$tool_name" --arg cmd "$command" --arg cwd "$TEST_DIR" \
+      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd}'
+  else
+    jq -n --arg tn "$tool_name" --arg cwd "$TEST_DIR" \
+      '{tool_name: $tn, tool_input: {}, cwd: $cwd}'
+  fi
+}
+
+assert_allowed() {
+  local test_name="$1"
+  local json="$2"
+  local output
+  local exit_code=0
+  output=$(echo "$json" | bash "$HOOK" 2>/dev/null) || exit_code=$?
+  if [ $exit_code -eq 0 ] && [ -z "$output" ]; then
+    echo "  ✓ $test_name"
+    ((passed++))
+  else
+    echo "  ✗ $test_name (exit=$exit_code, output=$output)"
+    ((failed++))
+  fi
+}
+
+assert_blocked() {
+  local test_name="$1"
+  local json="$2"
+  local output
+  local exit_code=0
+  output=$(echo "$json" | bash "$HOOK" 2>/dev/null) || exit_code=$?
+  if echo "$output" | grep -q '"decision".*"block"'; then
+    echo "  ✓ $test_name"
+    ((passed++))
+  else
+    echo "  ✗ $test_name (expected block, got exit=$exit_code, output=$output)"
+    ((failed++))
+  fi
+}
+
+# ===========================================================================
+echo ""
+echo "--- With marker present ---"
+# ===========================================================================
+mkdir -p "$(dirname "$MARKER")"
+touch "$MARKER"
+
+assert_allowed "1. Read tool allowed with marker" \
+  "$(mock_json 'Read')"
+
+assert_allowed "1b. Glob tool allowed with marker" \
+  "$(mock_json 'Glob')"
+
+assert_allowed "1c. Agent tool allowed with marker" \
+  "$(mock_json 'Agent')"
+
+assert_blocked "2. Edit blocked with marker" \
+  "$(mock_json 'Edit')"
+
+assert_blocked "3. Bash with write command blocked with marker" \
+  "$(mock_json 'Bash' 'echo hello > file.txt')"
+
+assert_allowed "4. rm ...plan-approval-pending allowed through" \
+  "$(mock_json 'Bash' "rm $MARKER")"
+
+assert_allowed "5. Adversarial rm with marker name (documents current regex)" \
+  "$(mock_json 'Bash' "rm -rf /tmp/foo .plan-approval-pending")"
+
+assert_blocked "6. rm without marker name blocked" \
+  "$(mock_json 'Bash' 'rm somefile.txt')"
+
+assert_blocked "7. Write tool blocked with marker" \
+  "$(mock_json 'Write')"
+
+assert_blocked "7b. Bash read-only command also blocked with marker (hook blocks all Bash)" \
+  "$(mock_json 'Bash' 'ls -la')"
+
+# ===========================================================================
+echo ""
+echo "--- Without marker ---"
+# ===========================================================================
+rm "$MARKER"
+
+assert_allowed "8. Bash allowed without marker" \
+  "$(mock_json 'Bash' 'echo hello')"
+
+assert_allowed "9. Edit allowed without marker" \
+  "$(mock_json 'Edit')"
+
+assert_allowed "10. Write allowed without marker" \
+  "$(mock_json 'Write')"
+
+# ===========================================================================
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+
+exit $((failed > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

Post-merge changes from the RFC-002 Phase 1 branch that weren't in main:

- **Phase 3b: Checkpoint Enforcement Gate** added to RFC-002 — pre-checkpoint gate (blocks code edits) + push-gate (blocks git push until post-checkpoint done). 23 acceptance tests, 4-marker state machine, limitations documented.
- **Plan-gate.sh automated tests** — 13 test cases covering read-only allowed, writes blocked, rm passthrough, adversarial patterns, no-marker passthrough.
- **3 review cycles**: 2nd opinion (10 findings), code review (6 findings), push-gate 2nd opinion (9 findings) — all addressed.

## Test plan

- [ ] `bash tests/test-plan-gate.sh` — 13 tests pass
- [ ] RFC-002 Phase 3b section internally consistent (23 acceptance tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)