### PR TITLE
feat: em-watch-codex — poll local memory for new Codex replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,26 @@ node ~/.episodic-memory/scripts/em-pattern-health.mjs --has-enforcement bp-006-p
 
 Searches `~/.claude/hooks/`, `<project>/.claude/hooks/`, `<project>/.git/hooks/`, and `<project>/.github/workflows/` for `pattern_id` references to detect mechanical enforcement. Patterns flagged `needs-enforcement` are violated repeatedly with no hook to stop them; `needs-attention` means an enforcement file exists but violations still occur (escalate to a human).
 
+### Codex Watcher
+```bash
+# Poll project-local memory for new Codex replies (default scope: local)
+node ~/.episodic-memory/scripts/em-watch-codex.mjs
+
+# Both stores with independent cursors
+node ~/.episodic-memory/scripts/em-watch-codex.mjs --scope all
+
+# Preview without advancing the cursor
+node ~/.episodic-memory/scripts/em-watch-codex.mjs --no-update
+
+# Replay from a specific episode id
+node ~/.episodic-memory/scripts/em-watch-codex.mjs --since 20260501-073215-codex-review-of-em-watch-codex-mjs-plan-5420
+
+# Override the project root (otherwise walks up from cwd to nearest .episodic-memory/index.jsonl)
+node ~/.episodic-memory/scripts/em-watch-codex.mjs --project-root /path/to/repo
+```
+
+Returns Codex-authored episodes (tag `codex`, `codex-review`, or `codex-reply`) newer than the last seen id. Cursor lives at `<store>/state/codex-watcher.json` with independent per-scope keys. Episode ids are total-ordered (`YYYYMMDD-HHMMSS-<slug>-<hash>`), so the cursor is immune to clock skew across tools. Cursor advances only to the max id of *returned* episodes — partial-line writes during concurrent `em-store` appends are skipped and re-read on the next invocation.
+
 ### Session End Prompt
 ```bash
 node ~/.episodic-memory/scripts/em-session-end-prompt.mjs

--- a/scripts/em-watch-codex.mjs
+++ b/scripts/em-watch-codex.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * em-watch-codex.mjs — Poll project-local episodic memory for new Codex replies.
+ *
+ * Usage:
+ *   node em-watch-codex.mjs [--scope local|global|all] [--since <id>]
+ *                           [--no-update] [--project-root <path>] [--limit <n>]
+ *
+ * Outputs JSON: { status, count, episodes, scopes_queried,
+ *                 cursor_updated, previous: {local, global},
+ *                 new: {local, global}, [warning] }
+ *
+ * Scope semantics: scopes are independent. --scope all reads both with
+ * separate cursors; no implicit fallback. Default is local (directed-watcher
+ * semantics — diverges from em-list.mjs default of "all" deliberately).
+ *
+ * Cursor: <store>/state/codex-watcher.json with shape {local: <id>, global: <id>}.
+ * Episode IDs are total-ordered (`YYYYMMDD-HHMMSS-<slug>-<hash>`), used directly
+ * as a high-water mark — no wall-clock timestamp comparison.
+ *
+ * Cursor invariant: advance only to max-id of returned episodes, never to
+ * max-id of scanned episodes. Partial-line reads of index.jsonl skip via
+ * try/catch and never advance the cursor past them.
+ *
+ * Tag match: tag in {codex, codex-review, codex-reply}. No summary-prefix
+ * fallback (foot-gun: real episodes carry both `claude` and `codex` tags).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+const TAG_ALIASES = ['codex', 'codex-review', 'codex-reply']
+const VALID_SCOPES = ['local', 'global', 'all']
+
+const argv = process.argv.slice(2)
+
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1) return undefined
+  const v = argv[i + 1]
+  if (i + 1 >= argv.length || (typeof v === 'string' && v.startsWith('--'))) {
+    fail(`Flag ${name} requires a value.`)
+  }
+  return v
+}
+
+function fail(message, code = 2) {
+  console.log(JSON.stringify({ status: 'error', message }))
+  process.exit(code)
+}
+
+const scope = flag('--scope') || 'local'
+if (!VALID_SCOPES.includes(scope)) {
+  fail(`Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}`)
+}
+
+const since = flag('--since')
+// Episode id grammar: YYYYMMDD-HHMMSS-<slug>-<4hex>
+const ID_REGEX = /^\d{8}-\d{6}-[a-z0-9-]+-[a-f0-9]{4}$/
+if (since !== undefined && !ID_REGEX.test(since)) {
+  fail(`Invalid --since "${since}". Must be an episode id (YYYYMMDD-HHMMSS-<slug>-<hash>).`)
+}
+
+const noUpdate = argv.includes('--no-update')
+const projectRootFlag = flag('--project-root')
+const limit = parseInt(flag('--limit') || '50', 10)
+
+// ---------------------------------------------------------------------------
+// Walk up to find the canonical project-local store. Stop before HOME — the
+// global store at `~/.episodic-memory/` would otherwise be mistaken for a
+// local project root if cwd is anywhere under HOME.
+//
+// Uses fs.realpathSync to canonicalize paths because on macOS /tmp is
+// symlinked to /private/tmp, so process.cwd() and os.homedir() can differ
+// by prefix even when they reference the same physical directory.
+// ---------------------------------------------------------------------------
+function canonical(p) {
+  try { return fs.realpathSync(p) } catch { return path.resolve(p) }
+}
+
+function findLocalStore(startDir) {
+  const home = canonical(os.homedir())
+  let dir = canonical(startDir)
+  while (true) {
+    if (dir === home) return null
+    const candidate = path.join(dir, '.episodic-memory', 'index.jsonl')
+    if (fs.existsSync(candidate)) return path.join(dir, '.episodic-memory')
+    const parent = path.dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+const resolvedLocal = projectRootFlag
+  ? path.join(path.resolve(projectRootFlag), '.episodic-memory')
+  : findLocalStore(process.cwd())
+const LOCAL_DIR = resolvedLocal || path.join(process.cwd(), '.episodic-memory')
+// Track whether LOCAL_DIR was actually discovered. When false, we refuse to
+// write the cursor file — otherwise --scope global from outside any project
+// would silently materialize <cwd>/.episodic-memory/state/.
+const HAS_LOCAL_STORE = projectRootFlag !== undefined
+  || findLocalStore(process.cwd()) !== null
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+
+const SCOPES_QUERIED =
+  scope === 'all' ? ['local', 'global'] :
+  scope === 'local' ? ['local'] : ['global']
+
+const dirForScope = (s) => (s === 'local' ? LOCAL_DIR : GLOBAL_DIR)
+
+// ---------------------------------------------------------------------------
+// Cursor: <local-store>/state/codex-watcher.json
+//   { local: <id>|null, global: <id>|null }
+// Cursor file lives in the LOCAL store regardless of which scope is queried.
+// Local store doubles as the project's stateful surface; global is intentionally
+// kept stateless from this script's perspective.
+// ---------------------------------------------------------------------------
+const CURSOR_FILE = path.join(LOCAL_DIR, 'state', 'codex-watcher.json')
+
+function loadCursor() {
+  try {
+    const raw = fs.readFileSync(CURSOR_FILE, 'utf8')
+    const parsed = JSON.parse(raw)
+    return {
+      local: typeof parsed.local === 'string' ? parsed.local : null,
+      global: typeof parsed.global === 'string' ? parsed.global : null,
+    }
+  } catch {
+    return { local: null, global: null }
+  }
+}
+
+function saveCursor(cursor) {
+  const dir = path.dirname(CURSOR_FILE)
+  fs.mkdirSync(dir, { recursive: true })
+  // Unique tmp filename per call so concurrent writers don't race on rename:
+  // without per-process suffix, A's renameSync moves the shared tmp away,
+  // then B's renameSync ENOENTs.
+  const tmp = `${CURSOR_FILE}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`
+  fs.writeFileSync(tmp, JSON.stringify(cursor, null, 2), 'utf8')
+  fs.renameSync(tmp, CURSOR_FILE)
+}
+
+// ---------------------------------------------------------------------------
+// Index loading: parse each line, skip parse failures (handles partial writes
+// during concurrent em-store appends).
+// ---------------------------------------------------------------------------
+function loadIndex(dataDir) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  const out = []
+  const raw = fs.readFileSync(indexFile, 'utf8')
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      out.push(JSON.parse(line))
+    } catch {
+      // partial write or corruption — skip; cursor will not advance past it
+    }
+  }
+  return out
+}
+
+function loadTagsIndex(dataDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dataDir, 'tags.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Match: tag-only filter, aliases supported.
+// Use tags.json inverted index when available; fall back to linear scan.
+// Mirrors em-pattern-health.mjs:140-191 for convention consistency.
+// ---------------------------------------------------------------------------
+function matchedIdsViaTagsIndex(tagsIdx) {
+  if (!tagsIdx) return null
+  const ids = new Set()
+  for (const alias of TAG_ALIASES) {
+    const list = tagsIdx[alias.toLowerCase()]
+    if (Array.isArray(list)) for (const id of list) ids.add(id)
+  }
+  return ids
+}
+
+function tagAliasMatched(tags) {
+  if (!Array.isArray(tags)) return null
+  // Iterate the episode's tags in order so callers can route on the tag the
+  // author wrote first (e.g., `[codex-reply, codex]` reports `codex-reply`),
+  // rather than always returning TAG_ALIASES[0].
+  const aliasSet = new Set(TAG_ALIASES)
+  for (const t of tags) {
+    const norm = String(t).toLowerCase().trim()
+    if (aliasSet.has(norm)) return norm
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Per-scope query
+// ---------------------------------------------------------------------------
+function queryScope(scopeName, sinceCursor) {
+  const dir = dirForScope(scopeName)
+  const tagsIdx = loadTagsIndex(dir)
+  const entries = loadIndex(dir)
+  const candidateIds = matchedIdsViaTagsIndex(tagsIdx)
+  const usedFallback = candidateIds === null
+
+  const matches = []
+  for (const e of entries) {
+    if (!e || typeof e.id !== 'string') continue
+    if (e.status === 'superseded') continue
+    if (sinceCursor && e.id <= sinceCursor) continue
+
+    let alias
+    if (candidateIds) {
+      if (!candidateIds.has(e.id)) continue
+      alias = tagAliasMatched(e.tags) || 'codex'
+    } else {
+      alias = tagAliasMatched(e.tags)
+      if (!alias) continue
+    }
+
+    matches.push({
+      id: e.id,
+      date: e.date,
+      time: e.time,
+      project: e.project,
+      category: e.category,
+      tags: e.tags,
+      summary: e.summary,
+      source: scopeName,
+      match_reason: `tag:${alias}`,
+    })
+  }
+
+  // Sort by id ascending — id is total-ordered.
+  matches.sort((a, b) => a.id.localeCompare(b.id))
+
+  return { matches, usedFallback, hasIndexFile: fs.existsSync(path.join(dir, 'index.jsonl')) }
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+const cursorBefore = loadCursor()
+const previous = { local: cursorBefore.local, global: cursorBefore.global }
+const newCursor = { local: cursorBefore.local, global: cursorBefore.global }
+
+const allMatches = []
+let warning = null
+
+for (const s of SCOPES_QUERIED) {
+  const sinceForScope = since !== undefined ? since : cursorBefore[s]
+  const { matches, usedFallback, hasIndexFile } = queryScope(s, sinceForScope)
+  if (usedFallback && hasIndexFile) {
+    warning = `tags.json missing for ${s}; used linear scan. Run em-rebuild-index.mjs to regenerate.`
+  }
+  for (const m of matches) allMatches.push(m)
+
+  // Advance cursor only to max id of *returned* episodes for this scope.
+  // Zero-result → no-advance (preserves cursor against partial writes / races).
+  if (matches.length > 0) {
+    const maxId = matches[matches.length - 1].id
+    newCursor[s] = maxId
+  }
+}
+
+// Dedup across scopes by id (in case of cross-scope copies — local takes priority,
+// matching em-list.mjs:48-54 dedupe convention).
+const seen = new Set()
+const deduped = []
+for (const m of allMatches) {
+  if (seen.has(m.id)) continue
+  seen.add(m.id)
+  deduped.push(m)
+}
+deduped.sort((a, b) => a.id.localeCompare(b.id))
+const limited = deduped.slice(0, limit)
+
+const cursorChanged =
+  newCursor.local !== cursorBefore.local || newCursor.global !== cursorBefore.global
+
+let cursorUpdated = false
+if (!noUpdate && cursorChanged && since === undefined && HAS_LOCAL_STORE) {
+  // Only persist when:
+  //   - --no-update wasn't passed
+  //   - the cursor actually moved
+  //   - --since wasn't an explicit override (one-off lookup)
+  //   - we found (or were given) a real local store; otherwise refuse to
+  //     materialize a phantom .episodic-memory/state/ in cwd
+  saveCursor(newCursor)
+  cursorUpdated = true
+}
+
+const out = {
+  status: 'ok',
+  count: limited.length,
+  episodes: limited,
+  scopes_queried: SCOPES_QUERIED,
+  cursor_updated: cursorUpdated,
+  previous,
+  // Always echo the would-be cursor so --no-update callers can preview the
+  // advance without persisting it. cursor_updated is the persistence signal.
+  new: newCursor,
+}
+if (warning) out.warning = warning
+console.log(JSON.stringify(out))

--- a/tests/test-em-watch-codex.mjs
+++ b/tests/test-em-watch-codex.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+/**
+ * test-em-watch-codex.mjs — Tests for em-watch-codex.mjs
+ *
+ * Usage: node tests/test-em-watch-codex.mjs
+ *
+ * Covers tag-alias filtering, id-based cursor, scope independence, walk-up
+ * project-root resolution, partial-line resilience, and CLI arg validation.
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync, spawnSync, spawn } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const WATCH = path.join(SCRIPTS, 'em-watch-codex.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+const pending = []
+
+function test(name, fn) {
+  let result
+  try {
+    result = fn()
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+    return
+  }
+  if (result && typeof result.then === 'function') {
+    pending.push(result.then(
+      () => { passed++; console.log(`  ✓ ${name}`) },
+      (e) => { failed++; failures.push({ name, error: e.message }); console.log(`  ✗ ${name}: ${e.message}`) },
+    ))
+    return
+  }
+  passed++
+  console.log(`  ✓ ${name}`)
+}
+
+function watchAsync(args, cwd, env) {
+  return new Promise((resolve) => {
+    const p = spawn('node', [WATCH, ...args.split(' ').filter(Boolean)], { cwd, env })
+    let stdout = '', stderr = ''
+    p.stdout.on('data', d => { stdout += d })
+    p.stderr.on('data', d => { stderr += d })
+    p.on('close', (code) => resolve({ code, stdout, stderr, json: safeParse(stdout.trim()) }))
+  })
+}
+
+function safeParse(s) { try { return JSON.parse(s) } catch { return null } }
+
+function watch(args, cwd, env) {
+  const r = spawnSync('node', [WATCH, ...args.split(' ').filter(Boolean)], {
+    encoding: 'utf8', cwd, env,
+  })
+  return {
+    code: r.status,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    json: safeParse((r.stdout || '').trim()),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: build a temp project + global store
+// ---------------------------------------------------------------------------
+function makeFixture() {
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-watch-codex-'))
+  const tmpProject = path.join(tmpHome, 'project')
+  fs.mkdirSync(tmpProject, { recursive: true })
+  const localStore = path.join(tmpProject, '.episodic-memory')
+  const globalStore = path.join(tmpHome, '.episodic-memory')
+  fs.mkdirSync(path.join(localStore, 'episodes'), { recursive: true })
+  fs.mkdirSync(path.join(globalStore, 'episodes'), { recursive: true })
+  // Initialize empty index files so findLocalStore walk-up works.
+  fs.writeFileSync(path.join(localStore, 'index.jsonl'), '', 'utf8')
+  fs.writeFileSync(path.join(globalStore, 'index.jsonl'), '', 'utf8')
+  return {
+    tmpHome,
+    tmpProject,
+    localStore,
+    globalStore,
+    env: { ...process.env, HOME: tmpHome },
+  }
+}
+
+function appendEntry(store, entry) {
+  fs.appendFileSync(path.join(store, 'index.jsonl'), JSON.stringify(entry) + '\n', 'utf8')
+}
+
+function writeTagsIndex(store, obj) {
+  fs.writeFileSync(path.join(store, 'tags.json'), JSON.stringify(obj), 'utf8')
+}
+
+function makeEntry({ id, tags = ['codex'], summary = 'Codex something', project = 'p', category = 'context', status = 'active' }) {
+  // Date/time derived from id prefix so they stay consistent.
+  const date = `${id.slice(0, 4)}-${id.slice(4, 6)}-${id.slice(6, 8)}`
+  const time = `${id.slice(9, 11)}:${id.slice(11, 13)}`
+  return { id, date, time, project, category, status, supersedes: null, tags, summary }
+}
+
+console.log('Running em-watch-codex tests...')
+
+// T1: empty store → count 0, cursor not advanced
+test('T1 empty store returns count 0 and does not write cursor', () => {
+  const f = makeFixture()
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.code, 0)
+  assert.strictEqual(r.json.status, 'ok')
+  assert.strictEqual(r.json.count, 0)
+  assert.strictEqual(r.json.cursor_updated, false)
+  assert.ok(!fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+})
+
+// T2: 1 new codex-tagged → returned, cursor advanced
+test('T2 single codex-tagged episode returned and cursor advanced', () => {
+  const f = makeFixture()
+  const id = '20260501-080000-codex-reply-aaaa'
+  appendEntry(f.localStore, makeEntry({ id }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, id)
+  assert.strictEqual(r.json.cursor_updated, true)
+  assert.deepStrictEqual(r.json.previous, { local: null, global: null })
+  assert.strictEqual(r.json.new.local, id)
+  const cursor = JSON.parse(fs.readFileSync(path.join(f.localStore, 'state', 'codex-watcher.json'), 'utf8'))
+  assert.strictEqual(cursor.local, id)
+})
+
+// T3: codex + non-codex → only codex returned
+test('T3 non-codex tagged episodes excluded', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-reply-aaaa', tags: ['codex'] }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-claude-only-bbbb', tags: ['claude'] }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080002-untagged-cccc', tags: [] }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080000-codex-reply-aaaa')
+})
+
+// T4: both `claude` and `codex` tags → returned once
+test('T4 episode with both claude and codex tags returned exactly once', () => {
+  const f = makeFixture()
+  const id = '20260501-080000-mixed-tags-aaaa'
+  appendEntry(f.localStore, makeEntry({ id, tags: ['claude', 'codex'] }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, id)
+  assert.strictEqual(r.json.episodes[0].match_reason, 'tag:codex')
+})
+
+// T5: malformed cursor file → treated as no cursor, return all
+test('T5 malformed cursor file ignored, all codex episodes returned', () => {
+  const f = makeFixture()
+  fs.mkdirSync(path.join(f.localStore, 'state'), { recursive: true })
+  fs.writeFileSync(path.join(f.localStore, 'state', 'codex-watcher.json'), '{not json', 'utf8')
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-codex-bbbb' }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 2)
+})
+
+// T6: --no-update → cursor not advanced
+test('T6 --no-update returns episodes but does not persist cursor', () => {
+  const f = makeFixture()
+  const id = '20260501-080000-codex-reply-aaaa'
+  appendEntry(f.localStore, makeEntry({ id }))
+  const r = watch('--no-update', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.cursor_updated, false)
+  assert.ok(!fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+})
+
+// T7: --since override respected (and does not write cursor)
+test('T7 --since override respected and does not advance cursor', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-codex-bbbb' }))
+  const r = watch('--since 20260501-080000-codex-aaaa', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080001-codex-bbbb')
+  assert.strictEqual(r.json.cursor_updated, false)
+  assert.ok(!fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+})
+
+// T8: scope semantics
+test('T8a --scope local reads local only', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-local-codex-aaaa' }))
+  appendEntry(f.globalStore, makeEntry({ id: '20260501-080001-global-codex-bbbb' }))
+  const r = watch('--scope local', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080000-local-codex-aaaa')
+  assert.deepStrictEqual(r.json.scopes_queried, ['local'])
+})
+
+test('T8b --scope global reads global only', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-local-codex-aaaa' }))
+  appendEntry(f.globalStore, makeEntry({ id: '20260501-080001-global-codex-bbbb' }))
+  const r = watch('--scope global', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080001-global-codex-bbbb')
+  assert.deepStrictEqual(r.json.scopes_queried, ['global'])
+})
+
+test('T8c --scope all reads both with independent cursors', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-local-codex-aaaa' }))
+  appendEntry(f.globalStore, makeEntry({ id: '20260501-080001-global-codex-bbbb' }))
+  const r = watch('--scope all', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 2)
+  assert.deepStrictEqual(r.json.scopes_queried, ['local', 'global'])
+  assert.strictEqual(r.json.new.local, '20260501-080000-local-codex-aaaa')
+  assert.strictEqual(r.json.new.global, '20260501-080001-global-codex-bbbb')
+  const sources = r.json.episodes.map(e => e.source).sort()
+  assert.deepStrictEqual(sources, ['global', 'local'])
+})
+
+// T9: stale-local + new-global with --scope all returns global new (no cross-scope masking)
+test('T9 stale-local + new-global: --scope all returns global new without masking', () => {
+  const f = makeFixture()
+  // Pre-populate cursor as if local was already seen.
+  fs.mkdirSync(path.join(f.localStore, 'state'), { recursive: true })
+  fs.writeFileSync(
+    path.join(f.localStore, 'state', 'codex-watcher.json'),
+    JSON.stringify({ local: '20260501-079999-old-codex-zzzz', global: null }),
+    'utf8',
+  )
+  appendEntry(f.localStore, makeEntry({ id: '20260501-070000-stale-codex-aaaa' })) // older than cursor
+  appendEntry(f.globalStore, makeEntry({ id: '20260501-080000-new-codex-bbbb' }))
+  const r = watch('--scope all', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080000-new-codex-bbbb')
+  assert.strictEqual(r.json.episodes[0].source, 'global')
+})
+
+// T10: cursor advance is atomic (temp+rename) — verify no .tmp file remains
+test('T10 cursor write is atomic (no .tmp residue)', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  watch('', f.tmpProject, f.env)
+  const stateDir = path.join(f.localStore, 'state')
+  const files = fs.readdirSync(stateDir)
+  assert.deepStrictEqual(files.sort(), ['codex-watcher.json'])
+})
+
+// T11: worktree run walks up to main-repo store (no worktree-local store exists)
+test('T11 worktree run walks up to main repo store when worktree has no local store', () => {
+  const f = makeFixture()
+  const worktreeDir = path.join(f.tmpProject, '.claude', 'worktrees', 'fake-tree')
+  fs.mkdirSync(worktreeDir, { recursive: true })
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  const r = watch('', worktreeDir, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080000-codex-aaaa')
+  assert.ok(fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+  assert.ok(!fs.existsSync(path.join(worktreeDir, '.episodic-memory', 'state', 'codex-watcher.json')))
+})
+
+// T11b: worktree-local store wins over parent's store (first ancestor with index.jsonl)
+test('T11b worktree-local store takes precedence over parent main repo', () => {
+  const f = makeFixture()
+  const worktreeDir = path.join(f.tmpProject, '.claude', 'worktrees', 'fake-tree')
+  const worktreeStore = path.join(worktreeDir, '.episodic-memory')
+  fs.mkdirSync(path.join(worktreeStore, 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(worktreeStore, 'index.jsonl'), '', 'utf8')
+  // Distinct episodes per store. Walk-up should pick the worktree's first.
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-parent-codex-aaaa' }))
+  appendEntry(worktreeStore, makeEntry({ id: '20260501-080001-worktree-codex-bbbb' }))
+  const r = watch('', worktreeDir, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].id, '20260501-080001-worktree-codex-bbbb')
+  assert.ok(fs.existsSync(path.join(worktreeStore, 'state', 'codex-watcher.json')))
+  assert.ok(!fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+})
+
+// T12: partial last line in index.jsonl skipped; cursor advances only to last parsed id
+test('T12 partial last line skipped, cursor advances only to last parsed id', () => {
+  const f = makeFixture()
+  // Write two valid entries, then append a partial JSON line.
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-codex-bbbb' }))
+  // Simulate partial write — broken JSON, no closing brace, no newline at start.
+  fs.appendFileSync(path.join(f.localStore, 'index.jsonl'), '{"id":"20260501-080002-codex-cccc","tags":["cod', 'utf8')
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 2)
+  assert.strictEqual(r.json.new.local, '20260501-080001-codex-bbbb')
+  // On a subsequent run, after the partial line gets completed, the third entry
+  // should be picked up (cursor was NOT advanced past it).
+  // Rewrite index with the third line completed.
+  const completedThird = JSON.stringify(makeEntry({ id: '20260501-080002-codex-cccc' }))
+  fs.writeFileSync(
+    path.join(f.localStore, 'index.jsonl'),
+    [
+      JSON.stringify(makeEntry({ id: '20260501-080000-codex-aaaa' })),
+      JSON.stringify(makeEntry({ id: '20260501-080001-codex-bbbb' })),
+      completedThird,
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  const r2 = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r2.json.count, 1)
+  assert.strictEqual(r2.json.episodes[0].id, '20260501-080002-codex-cccc')
+})
+
+// T13: tag aliases codex-review and codex-reply matched
+test('T13 codex-review and codex-reply tag aliases matched', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-rev-aaaa', tags: ['codex-review'] }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-rep-bbbb', tags: ['codex-reply'] }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080002-other-cccc', tags: ['random'] }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 2)
+  const reasons = r.json.episodes.map(e => e.match_reason).sort()
+  assert.deepStrictEqual(reasons, ['tag:codex-reply', 'tag:codex-review'])
+})
+
+// T14: same-second ids tie-break by full id string
+test('T14 same-second ids ordered by full id string', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-zzzz' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-mmmm' }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.deepStrictEqual(
+    r.json.episodes.map(e => e.id),
+    ['20260501-080000-codex-aaaa', '20260501-080000-codex-mmmm', '20260501-080000-codex-zzzz'],
+  )
+  assert.strictEqual(r.json.new.local, '20260501-080000-codex-zzzz')
+})
+
+// T15: invalid --scope → exit 2 with error JSON
+test('T15 invalid --scope rejected with exit 2 and error JSON', () => {
+  const f = makeFixture()
+  const r = watch('--scope foo', f.tmpProject, f.env)
+  assert.strictEqual(r.code, 2)
+  assert.strictEqual(r.json.status, 'error')
+  assert.ok(/Invalid --scope/.test(r.json.message))
+})
+
+// T16: invalid --since → exit 2
+test('T16 invalid --since (non-id format) rejected with exit 2', () => {
+  const f = makeFixture()
+  const r = watch('--since 2026-05-01T07:00:00Z', f.tmpProject, f.env)
+  assert.strictEqual(r.code, 2)
+  assert.strictEqual(r.json.status, 'error')
+  assert.ok(/Invalid --since/.test(r.json.message))
+})
+
+// T18: tags.json missing → linear-fallback warning emitted
+test('T18 tags.json missing emits linear-scan warning', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  // No tags.json written → loadTagsIndex returns null → fallback path.
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.ok(r.json.warning && /tags\.json missing/.test(r.json.warning),
+    `expected tags.json warning, got: ${JSON.stringify(r.json.warning)}`)
+})
+
+// T19: --since with --prefixed value → exit 2 (catches typo "--since --scope local")
+test('T19 flag with --prefixed value is rejected', () => {
+  const f = makeFixture()
+  const r = watch('--since --scope local', f.tmpProject, f.env)
+  assert.strictEqual(r.code, 2)
+  assert.strictEqual(r.json.status, 'error')
+  assert.ok(/--since requires a value/.test(r.json.message))
+})
+
+// T20: --scope global from outside any project does not materialize phantom local store
+test('T20 --scope global without project root does not create phantom .episodic-memory', () => {
+  const f = makeFixture()
+  const orphanDir = path.join(f.tmpHome, 'orphan')
+  fs.mkdirSync(orphanDir, { recursive: true })
+  appendEntry(f.globalStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  const r = watch('--scope global', orphanDir, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.cursor_updated, false)
+  // No .episodic-memory created in the orphan cwd.
+  assert.ok(!fs.existsSync(path.join(orphanDir, '.episodic-memory')))
+})
+
+// T21: --no-update preview shows would-be cursor advance
+test('T21 --no-update echoes would-be cursor in new field', () => {
+  const f = makeFixture()
+  const id = '20260501-080000-codex-aaaa'
+  appendEntry(f.localStore, makeEntry({ id }))
+  const r = watch('--no-update', f.tmpProject, f.env)
+  assert.strictEqual(r.json.cursor_updated, false)
+  assert.strictEqual(r.json.previous.local, null)
+  assert.strictEqual(r.json.new.local, id)
+  assert.ok(!fs.existsSync(path.join(f.localStore, 'state', 'codex-watcher.json')))
+})
+
+// T22: tag iteration order — match_reason reflects episode's first matching tag
+test('T22 match_reason reflects episode tag order, not alias precedence', () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa', tags: ['codex-reply', 'codex'] }))
+  const r = watch('', f.tmpProject, f.env)
+  assert.strictEqual(r.json.count, 1)
+  assert.strictEqual(r.json.episodes[0].match_reason, 'tag:codex-reply')
+})
+
+// T17: concurrent watcher invocations don't double-skip
+//   With cursor advance happening only to max-id of returned episodes, the
+//   worst case is one run "loses" its cursor write to the other's overwrite
+//   — but the run that "lost" still saw the episodes. The cursor file ends
+//   up at the max-id from whichever run won the rename race. Across both
+//   runs, every matching episode is observed at least once.
+test('T17 two concurrent watcher invocations both see all episodes (no double-skip)', async () => {
+  const f = makeFixture()
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080000-codex-aaaa' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080001-codex-bbbb' }))
+  appendEntry(f.localStore, makeEntry({ id: '20260501-080002-codex-cccc' }))
+  // Fire two watcher processes truly concurrently. Each reads the index +
+  // cursor before either has written, so both should observe all 3 episodes.
+  const [r1, r2] = await Promise.all([
+    watchAsync('', f.tmpProject, f.env),
+    watchAsync('', f.tmpProject, f.env),
+  ])
+  for (const r of [r1, r2]) {
+    assert.strictEqual(r.json.status, 'ok')
+    assert.strictEqual(r.json.count, 3)
+  }
+  const cursor = JSON.parse(fs.readFileSync(path.join(f.localStore, 'state', 'codex-watcher.json'), 'utf8'))
+  assert.strictEqual(cursor.local, '20260501-080002-codex-cccc')
+})
+
+// ---------------------------------------------------------------------------
+// Summary (waits for any async tests to settle)
+// ---------------------------------------------------------------------------
+await Promise.all(pending)
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.log(`  ✗ ${f.name}: ${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- New on-demand watcher script that mirrors what Codex does in reverse: scan project-local episodic memory for new Codex-authored episodes (tag `codex`, `codex-review`, or `codex-reply`)
- 25 tests covering tag filtering, id-based cursor, scope independence, walk-up project resolution, partial-line resilience, and concurrent invocation safety
- Three real bugs caught + fixed during the review cycle (#39, #40, #41), each with a regression test in this commit

## Design highlights

| Concern | Approach |
|---|---|
| Clock skew across tools | id-based cursor (`YYYYMMDD-HHMMSS-<slug>-<hash>` is total-ordered) |
| Worktree vs main repo | Walk up to ancestor with `.episodic-memory/index.jsonl`; stop before HOME via realpath comparison; `--project-root` override |
| Scope semantics | Independent per-scope cursors in `state/codex-watcher.json`; no implicit fallback |
| Tag matching | `codex`, `codex-review`, `codex-reply` aliases; no summary-prefix fallback |
| Partial-line race | Parse-fail lines skipped; cursor advance only to max id of *returned* episodes |
| Concurrent invocations | Per-process unique tmp filename for atomic temp+rename |

## Reviews completed

1. **In-house Plan subagent** — verdict revise; 2 BLOCKERs + 4 MAJORs + 3 MINORs, all dispositioned in v3.1 plan
2. **Codex consensus** — verdict approve-with-revisions; agreement on cursor design, scope independence, walk-up resolution; disagreement on default scope settled in Codex's favor (explicit scopes, no implicit union)
3. **Code review subagent** — verdict ship-with-fixes; 2 MAJORs + 4 MINORs, all addressed in this commit

## Test plan
- [x] `node tests/test-em-watch-codex.mjs` — 25 passing
- [x] E2E from main repo — returns codex-tagged episodes
- [x] E2E from worktree — correctly returns worktree-local store contents (worktree-local wins per design; use `--project-root` or `cd` to monitor main repo)
- [x] Concurrency stress (T17) — two simultaneous invocations both observe full episode set; cursor ends at max id

## Bugs filed (Rule 18 step 9)
- [#39](https://github.com/lantisprime/episodic-memory/issues/39) — concurrent saveCursor rename race
- [#40](https://github.com/lantisprime/episodic-memory/issues/40) — phantom .episodic-memory materialized with --scope global from non-project cwd
- [#41](https://github.com/lantisprime/episodic-memory/issues/41) — macOS /tmp symlink defeated walk-up HOME-stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)