### PR TITLE
feat: RFC-002 Phase 3 — Actionable Recall + Phase 3c spec

### DIFF
--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -429,7 +429,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [x] `--task-type` flag for explicit task context
 - [x] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
 - [ ] SessionEnd hook prompts user for violation flagging (not instruction-only); AI may prepare draft candidates in Phase 3c (clerk model — see OQ-6)
-- [ ] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
+- [x] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
 
 **Phase 3b:**
 - [ ] `checkpoint-gate.sh` blocks all write tools when `.checkpoint-required` exists and `.pre-checkpoint-done` is absent or empty

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -428,7 +428,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [x] No pre-flight when no violations exist or task type unclear (clean output)
 - [x] `--task-type` flag for explicit task context
 - [x] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
-- [ ] SessionEnd hook prompts user for violation flagging (not instruction-only); AI may prepare draft candidates in Phase 3c (clerk model — see OQ-6)
+- [x] SessionEnd hook prompts user for violation flagging (not instruction-only); AI may prepare draft candidates in Phase 3c (clerk model — see OQ-6)
 - [x] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
 
 **Phase 3b:**

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -233,6 +233,63 @@ Orphaned states (e.g., `.post-checkpoint-required` without `.checkpoint-required
 
 **Depends on:** Phase 3 (violation-aware recall output)
 
+### Phase 3c: Hybrid Violation Reporting (clerk model)
+
+**Motivation:** Phase 3's user-flagged-only SessionEnd prompt places high cognitive load on the user — they must remember every behavioral pattern (currently bp-001 through bp-012) and recall every micro-violation across multi-hour sessions. Empirical evidence (session 5, 2026-05-01: bp-010 P4 self-caught at rule-18 step 6, violation episode `20260501-105506`) shows AI self-flagging already works at code-review checkpoints. But self-reporting bias is real enough that AI-detected violations cannot become authoritative without human adjudication. Codex review of OQ-6 (reply `20260501-112318`) recommends a clerk model: **AI drafts candidate violations for human adjudication; only confirmed items are stored.** Do not call this auto-detection — AI is clerk, not judge.
+
+**Candidate proposal schema (NOT a change to `em-violation.mjs` storage; only the SessionEnd flow):**
+
+Each candidate has:
+- `pattern_id` — which BP was potentially violated
+- `confidence` — band: `high` / `medium` / `low` (not numeric, prevents false precision)
+- `evidence_ref` — link or reference to the specific tool calls / messages that show the violation
+- `sequence` — what AI did (draft for `em-violation --sequence`)
+- `correct_sequence` — what AI should have done (draft for `em-violation --correct`)
+- `why_it_might_be_wrong` — explicit uncertainty / counter-evidence the AI considered (epistemic humility built into the schema; mitigates self-reporting bias)
+
+**SessionEnd flow (Phase 3c):**
+
+1. AI scans session transcript → builds candidate list against `patterns/_index.json`
+2. SessionEnd hook prompts: "AI has drafted N candidate violations. Review?"
+3. For each candidate, user can: **confirm** (store as-is via `em-violation.mjs`), **edit** (modify any field, then store), **reject** (discard)
+4. **Backstop prompt** after candidate review: "Any I missed?" — user can flag violations AI didn't propose (preserves user as authoritative source)
+5. Only confirmed/edited candidates flow to `em-violation.mjs --pattern ... --sequence ... --correct ...`
+6. If candidate list is empty: backstop prompt still fires (Phase 3 baseline)
+
+**Optional: rejected-proposal telemetry**
+
+If user opts in (via flag or config), rejected candidates are stored in a separate non-violation telemetry stream (e.g., `.episodic-memory/rejected-proposals.jsonl`) for future calibration analysis — useful for measuring AI false-positive rate over time. Default: rejected candidates are discarded.
+
+**Out of scope for Phase 3c (deferred):**
+
+- **In-session detection at every rule-18 checkpoint.** Invasive, requires hooks at multiple points; defer to a future Phase 3d if SessionEnd-only proves insufficient.
+- **Auto-storage without user confirmation.** Explicitly rejected by Codex; clerk model is the contract.
+- **Numeric confidence scores.** Bands (high/medium/low) only — false precision risk.
+
+**Files created:**
+
+- `scripts/em-violation-candidates.mjs` (~80 lines) — scans session transcript for likely violations against `patterns/_index.json`, outputs candidate JSON
+
+**Files modified:**
+
+- `scripts/em-session-end-prompt.mjs` — extend with candidate-proposal flow (review → confirm/edit/reject → backstop → store confirmed via `em-violation.mjs`)
+
+**Acceptance tests:**
+
+- [ ] AI proposes candidates with all 6 schema fields populated (`pattern_id`, `confidence`, `evidence_ref`, `sequence`, `correct_sequence`, `why_it_might_be_wrong`)
+- [ ] Confirm flow stores candidate via `em-violation.mjs` unchanged
+- [ ] Edit flow lets user modify any field before storage
+- [ ] Reject flow discards candidate by default (no storage)
+- [ ] Backstop prompt fires after candidate review (every session, even with empty candidate list)
+- [ ] Confidence bands restricted to `high`/`medium`/`low` (no numeric scores)
+- [ ] User-added violations from backstop prompt also flow through `em-violation.mjs`
+- [ ] Optional telemetry opt-in writes to separate stream, never to main violation index
+- [ ] Rejected-with-telemetry flow does not create violation episode (preserves index integrity)
+
+**Depends on:** Phase 3 (user-flagged baseline must exist; Phase 3c is an upgrade, not a replacement). Independent of Phase 3b — can ship before or after the checkpoint-gate.
+
+**Sequencing:** Ship Phase 3 with user-flagged baseline first. Phase 3c is post-Phase-3. Could ship before or after Phase 4.
+
 ### Phase 4: Positive Reinforcement
 
 **Motivation:** RFC-002 Phases 1-3b only track failures. Session 3 proved that compliance also produces actionable data — the successful light-scope doc update revealed that correct classification + plan-gate = clean execution. A system that only surfaces violations is punitive; one that also surfaces what worked is constructive and helps the AI replicate success conditions.
@@ -371,7 +428,7 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [ ] No pre-flight when no violations exist or task type unclear (clean output)
 - [ ] `--task-type` flag for explicit task context
 - [ ] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
-- [ ] SessionEnd hook prompts user for violation flagging (not instruction-only)
+- [ ] SessionEnd hook prompts user for violation flagging (not instruction-only); AI may prepare draft candidates in Phase 3c (clerk model — see OQ-6)
 - [ ] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
 
 **Phase 3b:**
@@ -536,6 +593,7 @@ P3s deferred to implementation (stored in episodic memory): F-9 (error UX), F-10
 | OQ-3 | How should `violated_pattern` be stored? Tags vs frontmatter field. | — | resolved — tag-based (e.g., `violated:bp-006-push-after-verify`); queryable via existing `tags.json`, no schema extension needed; structured fields like `violation_sequence` stored as markdown sections in episode body |
 | OQ-4 | Should pre-flight warnings be suppressible? Deferred to after Phase 3 ships — implement without `--no-preflight` first, gather user feedback, add flag in a follow-up if needed. | — | open (deferred) |
 | OQ-5 | Should the `SessionEnd` hook for violation prompting be part of the episodic-memory installer, or part of the user-preferences installer? | — | resolved — episodic-memory installer; the hook calls `em-violation.mjs` which is an episodic-memory script; aligns with bp-005 (enforcement lives in consuming repos) |
+| OQ-6 | Should violation reporting be user-flagged (current Phase 3 spec) or hybrid AI-flagged + user-confirmed? Cognitive load on user is high; AI self-flagging already works in practice (session 5, 2026-05-01: bp-010 P4 self-caught at rule-18 step 6 without user prompting). Proposed hybrid: AI scans session → presents structured list with confidence/reasoning → user confirms/edits/rejects → backstop prompt for AI-missed violations. Mechanics (em-violation.mjs, marker activation, acceptance tests) unchanged; only the SessionEnd prompt flow changes. | — | resolved with amendment — Codex verdict (reply `20260501-112318-codex-review-rfc-002-oq-6-hybrid-violati-a940`): cognitive-load concern is real; self-reporting bias is also real. Adopt **clerk model** (AI drafts candidates with `pattern_id`/`confidence`/`evidence_ref`/`sequence`/`correct_sequence`/`why_it_might_be_wrong`; user confirms/edits/rejects; backstop prompt for missed items). Ship Phase 3 with user-flagged baseline; clerk model in Phase 3c (specced below). Don't call it "auto-detection" — AI is clerk, not judge. |
 
 ---
 

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -423,11 +423,11 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [x] "needs-enforcement" vs "needs-attention" distinction correct (attention + no enforcement = needs-enforcement)
 
 **Phase 3:**
-- [ ] Recall includes `preflight_warnings` when violations exist for task-relevant patterns
-- [ ] Pre-flight surfaces violation count and last violation date
-- [ ] No pre-flight when no violations exist or task type unclear (clean output)
-- [ ] `--task-type` flag for explicit task context
-- [ ] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
+- [x] Recall includes `preflight_warnings` when violations exist for task-relevant patterns
+- [x] Pre-flight surfaces violation count and last violation date
+- [x] No pre-flight when no violations exist or task type unclear (clean output)
+- [x] `--task-type` flag for explicit task context
+- [x] Keyword inference from git branch name as fallback (not "current file context" — CLI has no IDE context)
 - [ ] SessionEnd hook prompts user for violation flagging (not instruction-only); AI may prepare draft candidates in Phase 3c (clerk model — see OQ-6)
 - [ ] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
 

--- a/install.mjs
+++ b/install.mjs
@@ -194,6 +194,7 @@ if (installHooks) {
         command: hookCmd,
         description: 'Prompt for behavioral pattern violations at session end'
       })
+      fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8')
       console.log('Installed SessionEnd hook for violation prompting')
     } else {

--- a/instructions/AGENTS.md
+++ b/instructions/AGENTS.md
@@ -16,8 +16,8 @@ You have access to a persistent episodic memory system for storing and recalling
 - User says "remember this"
 
 **Recall** episodes when:
-- Starting work — proactively search for this project's episodes (limit 5)
-- User asks "what did we decide about X"
+- Starting work — proactively `em-recall.mjs` with `--task-type` for the upcoming work (surfaces episodes + violation pre-flight; RFC-002 Phase 3)
+- User asks "what did we decide about X" — `em-search.mjs`
 - Before making a decision that might contradict a past one
 
 **Revise** when a prior decision proves wrong — don't delete, create a revision chain.
@@ -34,7 +34,13 @@ Revise (self-correction):
 node ~/.episodic-memory/scripts/em-revise.mjs --original <episode-id> --summary "<text>" --body "<text>" --tags "<t1,t2>"
 ```
 
-Search:
+Recall (session-start, proactive — surfaces episodes + violation pre-flight):
+```bash
+node ~/.episodic-memory/scripts/em-recall.mjs --project <name> [--task-type <implementation|push|rule|general>] [--limit 5]
+```
+Use `--task-type implementation` before code work to surface recent bp-001/bp-006 violations from the last 30 days. Pass `general` (or omit) for ad-hoc recall without violation pre-flight.
+
+Search (ad-hoc):
 ```bash
 node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] [--category <cat>] [--full]
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full

--- a/instructions/SKILL.md
+++ b/instructions/SKILL.md
@@ -8,7 +8,7 @@ description: >
   when starting work on a project to proactively recall relevant past episodes.
   Even if the user doesn't explicitly ask, store episodes for important
   decisions, discoveries, or context valuable in future sessions.
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Episodic Memory
@@ -34,11 +34,12 @@ When researching from the web: first check `em-search.mjs --category research --
 
 ## Recall
 
-- Session start: proactively `em-search.mjs --project <name> --limit 5`
+- Session start: proactively `em-recall.mjs --project <name> [--task-type <implementation|push|rule|general>] [--limit 5]` — surfaces relevant episodes + violation pre-flight for behavioral patterns related to the task type (RFC-002 Phase 3). Use `--task-type implementation` before code work to surface recent bp-001/bp-006 violations.
 - User asks about past decisions: `em-search.mjs --query "<topic>" [--full]`
 - Before contradicting a past decision: search first
 
 ```bash
+node ~/.episodic-memory/scripts/em-recall.mjs [--project <name>] [--task-type <implementation|push|rule|general>] [--scope local|global|all] [--limit <n>] [--days <n>]
 node ~/.episodic-memory/scripts/em-search.mjs [--project <name>] [--query <text>] [--tag <t>] [--category <c>] [--since <date>] [--limit <n>] [--full] [--scope local|global|all] [--include-superseded] [--history <id>]
 node ~/.episodic-memory/scripts/em-list.mjs [--project <name>] [--limit <n>]
 ```

--- a/instructions/codex-skill.md
+++ b/instructions/codex-skill.md
@@ -21,11 +21,12 @@ When researching from the web: first check `em-search.mjs --category research --
 
 ## Recall
 
-- Session start: proactively `em-search.mjs --project <name> --limit 5`
+- Session start: proactively `em-recall.mjs --project <name> [--task-type <implementation|push|rule|general>] [--limit 5]` — surfaces relevant episodes + violation pre-flight for behavioral patterns related to the task type (RFC-002 Phase 3). Use `--task-type implementation` before code work to surface recent bp-001/bp-006 violations.
 - User asks about past decisions: `em-search.mjs --query "<topic>" [--full]`
 - Before contradicting a past decision: search first
 
 ```bash
+node ~/.episodic-memory/scripts/em-recall.mjs [--project <name>] [--task-type <implementation|push|rule|general>] [--scope local|global|all] [--limit <n>] [--days <n>]
 node ~/.episodic-memory/scripts/em-search.mjs [--project <name>] [--query <text>] [--tag <t>] [--category <c>] [--since <date>] [--limit <n>] [--full] [--scope local|global|all] [--include-superseded] [--history <id>]
 node ~/.episodic-memory/scripts/em-list.mjs [--project <name>] [--limit <n>]
 ```

--- a/instructions/cursor.mdc
+++ b/instructions/cursor.mdc
@@ -22,8 +22,8 @@ You have access to a persistent episodic memory system. Use it to store and reca
 - User says "remember this"
 
 **Recall** when:
-- Starting work on this project — proactively search for episodes (limit 5)
-- User asks "what did we decide about X"
+- Starting work on this project — proactively `em-recall.mjs` with `--task-type` for the upcoming work (surfaces episodes + violation pre-flight; RFC-002 Phase 3)
+- User asks "what did we decide about X" — `em-search.mjs`
 - Before making a decision that might contradict a past one
 
 **Revise** when a prior decision proves wrong — don't delete, create a revision chain.
@@ -50,7 +50,13 @@ node ~/.episodic-memory/scripts/em-revise.mjs \
   --tags "<tags>"
 ```
 
-### Search
+### Recall (session-start, proactive — surfaces episodes + violation pre-flight)
+```bash
+node ~/.episodic-memory/scripts/em-recall.mjs --project <name> [--task-type <implementation|push|rule|general>] [--limit 5]
+```
+Use `--task-type implementation` before code work to surface recent bp-001/bp-006 violations from the last 30 days. Pass `general` (or omit) for ad-hoc recall without violation pre-flight.
+
+### Search (ad-hoc)
 ```bash
 node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] [--full]
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full

--- a/instructions/windsurf.md
+++ b/instructions/windsurf.md
@@ -16,8 +16,8 @@ You have access to a persistent episodic memory system for storing and recalling
 - User says "remember this"
 
 **Recall** episodes when:
-- Starting work — proactively search for this project's episodes (limit 5)
-- User asks "what did we decide about X"
+- Starting work — proactively `em-recall.mjs` with `--task-type` for the upcoming work (surfaces episodes + violation pre-flight; RFC-002 Phase 3)
+- User asks "what did we decide about X" — `em-search.mjs`
 - Before making a decision that might contradict a past one
 
 **Revise** when a prior decision proves wrong — don't delete, create a revision chain.
@@ -34,7 +34,13 @@ Revise (self-correction):
 node ~/.episodic-memory/scripts/em-revise.mjs --original <episode-id> --summary "<text>" --body "<text>" --tags "<t1,t2>"
 ```
 
-Search:
+Recall (session-start, proactive — surfaces episodes + violation pre-flight):
+```bash
+node ~/.episodic-memory/scripts/em-recall.mjs --project <name> [--task-type <implementation|push|rule|general>] [--limit 5]
+```
+Use `--task-type implementation` before code work to surface recent bp-001/bp-006 violations from the last 30 days. Pass `general` (or omit) for ad-hoc recall without violation pre-flight.
+
+Search (ad-hoc):
 ```bash
 node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] [--category <cat>] [--full]
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -41,10 +41,17 @@ const days = parseInt(flag('--days') || '7', 10)
 const noTrack = argv.includes('--no-track')
 const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
 const warnCount = parseInt(flag('--warn-count') || '500', 10)
+const taskTypeFlag = flag('--task-type')
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
   console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(1)
+}
+
+const VALID_TASK_TYPES = ['implementation', 'push', 'rule', 'general']
+if (taskTypeFlag !== undefined && !VALID_TASK_TYPES.includes(taskTypeFlag)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --task-type "${taskTypeFlag}". Must be one of: ${VALID_TASK_TYPES.join(', ')}` }))
   process.exit(1)
 }
 
@@ -134,6 +141,96 @@ function writeBackAccessTracking(results) {
       // Access tracking is best-effort — skip silently on failure
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Task-type → relevant pattern_ids (RFC-002 Phase 3)
+// Pre-flight surfaces violations of these patterns when task type is known.
+// Empty list means no violation pre-flight runs (e.g. task-type=general).
+// ---------------------------------------------------------------------------
+const TASK_TYPE_PATTERNS = {
+  implementation: ['bp-001-implementation-workflow', 'bp-006-push-after-verify'],
+  push: ['bp-006-push-after-verify'],
+  rule: ['bp-010-habits-override-knowledge'],
+  general: []
+}
+
+// ---------------------------------------------------------------------------
+// Branch token → task type keyword inference. First match wins. No match
+// means task type stays unknown and no pre-flight runs.
+// ---------------------------------------------------------------------------
+const BRANCH_TYPE_KEYWORDS = {
+  implementation: ['implement', 'build', 'feature', 'phase', 'feat'],
+  push: ['push', 'merge', 'pr', 'release'],
+  rule: ['rule', 'enforce', 'pattern']
+}
+
+function inferTaskType(branchTokens) {
+  if (!branchTokens || branchTokens.length === 0) return null
+  for (const type of ['implementation', 'push', 'rule']) {
+    const keywords = BRANCH_TYPE_KEYWORDS[type]
+    if (branchTokens.some(t => keywords.includes(t))) return type
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Load patterns/_index.json (project-local first, then global install).
+// Mirrors em-violation.mjs:loadPatternsIndex.
+// ---------------------------------------------------------------------------
+function loadPatternsIndex() {
+  const candidates = [
+    path.join(process.cwd(), 'patterns', '_index.json'),
+    path.join(os.homedir(), '.episodic-memory', 'patterns', '_index.json')
+  ]
+  for (const p of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+      if (data.patterns && Array.isArray(data.patterns)) return data.patterns
+    } catch {}
+  }
+  return []
+}
+
+// ---------------------------------------------------------------------------
+// Violation pre-flight: scan activeEntries for violations of patterns
+// relevant to the task type within the last 30 days. Returns warning objects.
+// ---------------------------------------------------------------------------
+function runViolationPreflight(activeEntries, taskType, patterns) {
+  if (!taskType) return []
+  const relevantIds = TASK_TYPE_PATTERNS[taskType] || []
+  if (relevantIds.length === 0) return []
+
+  const validIds = new Set(patterns.map(p => p.pattern_id))
+  const filterIds = relevantIds.filter(id => validIds.has(id))
+  if (filterIds.length === 0) return []
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - 30)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  const warnings = []
+  for (const patternId of filterIds) {
+    const violationTag = `violated:${patternId}`
+    const matching = activeEntries.filter(e =>
+      e.category === 'violation' &&
+      Array.isArray(e.tags) &&
+      e.tags.includes(violationTag) &&
+      typeof e.date === 'string' &&
+      e.date >= cutoffStr
+    )
+    if (matching.length === 0) continue
+    matching.sort((a, b) => b.date.localeCompare(a.date))
+    const last = matching[0].date
+    warnings.push({
+      type: 'violation',
+      pattern_id: patternId,
+      violations_last_30d: matching.length,
+      last_violation: last,
+      message: `${patternId} violated ${matching.length} time${matching.length === 1 ? '' : 's'} in last 30 days (last: ${last}). Remember to follow this pattern before proceeding.`
+    })
+  }
+  return warnings
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +330,21 @@ const context = inferContext()
 const preflight_warnings = []
 
 // ---------------------------------------------------------------------------
+// Task type: explicit flag wins; otherwise infer from branch tokens.
+// `null` means task type is unclear → no violation pre-flight runs (T3).
+// ---------------------------------------------------------------------------
+const taskType = taskTypeFlag || inferTaskType(context.branch_tokens)
+
+// ---------------------------------------------------------------------------
+// Violation pre-flight (RFC-002 Phase 3 / T1-T5)
+// ---------------------------------------------------------------------------
+if (taskType) {
+  const patterns = loadPatternsIndex()
+  const violationWarnings = runViolationPreflight(activeEntries, taskType, patterns)
+  preflight_warnings.push(...violationWarnings)
+}
+
+// ---------------------------------------------------------------------------
 // Pass 1: Project match
 // ---------------------------------------------------------------------------
 const pass1 = new Map()
@@ -275,7 +387,7 @@ if (context.effective_tokens.length > 0) {
 
   if (tagsIndexMissing) {
     // Fallback: linear scan
-    preflight_warnings.push('tags.json missing or corrupt in one or more stores. Run em-rebuild-index.mjs to regenerate.')
+    preflight_warnings.push({ type: 'system', message: 'tags.json missing or corrupt in one or more stores. Run em-rebuild-index.mjs to regenerate.' })
     for (const e of activeEntries) {
       if (e.tags) {
         const eTags = e.tags.map(t => t.toLowerCase().trim())
@@ -362,7 +474,8 @@ const result = {
   context: {
     project: context.project,
     branch_tokens: context.branch_tokens,
-    effective_tokens: context.effective_tokens
+    effective_tokens: context.effective_tokens,
+    task_type: taskType
   },
   count: episodes.length,
   episodes,
@@ -373,10 +486,10 @@ const result = {
 // Performance health check
 const elapsed = Date.now() - recallStart
 if (elapsed > warnTimeMs) {
-  preflight_warnings.push(`Recall took ${elapsed}ms across ${totalEpisodeCount} episodes. Consider running em-prune.mjs to archive stale episodes.`)
+  preflight_warnings.push({ type: 'system', message: `Recall took ${elapsed}ms across ${totalEpisodeCount} episodes. Consider running em-prune.mjs to archive stale episodes.` })
 }
 if (totalEpisodeCount > warnCount) {
-  preflight_warnings.push(`${totalEpisodeCount} episodes in index. Performance may degrade. Run em-prune.mjs --dry-run to check for prunable episodes.`)
+  preflight_warnings.push({ type: 'system', message: `${totalEpisodeCount} episodes in index. Performance may degrade. Run em-prune.mjs --dry-run to check for prunable episodes.` })
 }
 
 console.log(JSON.stringify(result))

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -345,6 +345,30 @@ if (taskType) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 3b activation hook (RFC-002 Phase 3 / T7): when a bp-001 violation
+// surfaces, touch .claude/.checkpoint-required in cwd. Phase 3b's
+// checkpoint-gate.sh reads this marker to gate write tools. Best-effort
+// atomic create — no locking, failure is non-fatal. Phase 3b's full SessionEnd
+// sweep will own the four-marker lifecycle; until then,
+// em-session-end-prompt.mjs sweeps this marker so it doesn't persist between
+// sessions when the gate isn't active.
+// ---------------------------------------------------------------------------
+const bp001Surfaced = preflight_warnings.some(w =>
+  w && w.type === 'violation' && w.pattern_id === 'bp-001-implementation-workflow'
+)
+if (bp001Surfaced) {
+  try {
+    const claudeDir = path.join(process.cwd(), '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    const markerPath = path.join(claudeDir, '.checkpoint-required')
+    if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
+  } catch {
+    // Best-effort: marker creation failure leaves Phase 3b gate inactive
+    // for this session. Surfacing the warning to the user is what matters.
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Pass 1: Project match
 // ---------------------------------------------------------------------------
 const pass1 = new Map()

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -33,6 +33,15 @@ function loadPatternsIndex() {
   return []
 }
 
+// Best-effort cleanup of Phase 3b activation marker created by em-recall.mjs.
+// Phase 3b will own the full four-marker SessionEnd sweep; until then this
+// stops .checkpoint-required from persisting across sessions when the gate
+// isn't active. Failure is silent — marker may not exist or .claude/ may be
+// missing in some workflows.
+try {
+  fs.unlinkSync(path.join(process.cwd(), '.claude', '.checkpoint-required'))
+} catch {}
+
 const patterns = loadPatternsIndex()
 
 const knownPatterns = patterns.map(p => ({

--- a/tests/test-phase3.mjs
+++ b/tests/test-phase3.mjs
@@ -221,7 +221,8 @@ test('10. Prune suggestion for low-score episodes', () => {
 
 test('11. Performance warnings with low thresholds', () => {
   const r = recall('--project project --no-track --warn-count 1')
-  const hasCountWarning = r.preflight_warnings.some(w => w.includes('episodes in index'))
+  // RFC-002 Phase 3: preflight_warnings entries are objects { type, message, ... }
+  const hasCountWarning = r.preflight_warnings.some(w => w && w.type === 'system' && w.message && w.message.includes('episodes in index'))
   assert.ok(hasCountWarning, 'Should warn about episode count')
 })
 

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * test-rfc002-phase3.mjs — Tests for RFC-002 Phase 3: Actionable Recall
+ *
+ * Usage: node tests/test-rfc002-phase3.mjs
+ *
+ * Covers acceptance tests T1-T5 for Phase 3 (commit 1):
+ *   T1: Recall includes preflight_warnings when violations exist for task-relevant patterns
+ *   T2: Pre-flight surfaces violation count and last violation date
+ *   T3: No pre-flight when no violations exist or task type unclear (clean output)
+ *   T4: --task-type flag for explicit task context
+ *   T5: Keyword inference from git branch name as fallback
+ *
+ * T6 (SessionEnd hook prompt) is covered by Phase 1's shipped infrastructure
+ * (em-session-end-prompt.mjs + install.mjs --install-hooks).
+ * T7 (.checkpoint-required marker) ships in commit 2.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
+const VIOLATION = path.join(SCRIPTS, 'em-violation.mjs')
+const REBUILD = path.join(SCRIPTS, 'em-rebuild-index.mjs')
+const REPO_ROOT = path.join(path.dirname(new URL(import.meta.url).pathname), '..')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup: isolated temp project with patterns/_index.json + a fresh HOME.
+// Mirrors test-rfc002-phase2.mjs convention.
+// ---------------------------------------------------------------------------
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p3-'))
+const tmpProject = path.join(tmpHome, 'project')
+fs.mkdirSync(tmpProject, { recursive: true })
+
+// Initialize as a git repo so context inference doesn't fail
+execSync('git init -q', { cwd: tmpProject })
+execSync('git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init', { cwd: tmpProject })
+
+const patternsDir = path.join(tmpProject, 'patterns')
+fs.mkdirSync(patternsDir, { recursive: true })
+const srcIndex = path.join(REPO_ROOT, 'patterns', '_index.json')
+fs.copyFileSync(srcIndex, path.join(patternsDir, '_index.json'))
+
+const env = { ...process.env, HOME: tmpHome }
+
+function recall(args = '', cwd = tmpProject) {
+  const result = execSync(`node "${RECALL}" ${args}`, { encoding: 'utf8', cwd, env })
+  return JSON.parse(result.trim())
+}
+
+function recallExit(args = '', cwd = tmpProject) {
+  try {
+    const stdout = execSync(`node "${RECALL}" ${args}`, { encoding: 'utf8', cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
+    return { code: 0, stdout, json: safeParse(stdout.trim()) }
+  } catch (e) {
+    return { code: e.status, stdout: e.stdout || '', json: safeParse((e.stdout || '').trim()) }
+  }
+}
+
+function safeParse(s) {
+  try { return JSON.parse(s) } catch { return null }
+}
+
+function violation(args, cwd = tmpProject) {
+  const result = execSync(`node "${VIOLATION}" ${args}`, { encoding: 'utf8', cwd, env })
+  return JSON.parse(result.trim())
+}
+
+function rebuild(cwd = tmpProject) {
+  return execSync(`node "${REBUILD}" --scope all`, { encoding: 'utf8', cwd, env })
+}
+
+function seedViolation(patternId, daysAgo, scope = 'global') {
+  const r = violation(`--pattern ${patternId} --summary "seeded ${patternId} ${daysAgo}d" --body "test" --scope ${scope}`)
+  assert.strictEqual(r.status, 'ok', `seedViolation failed: ${JSON.stringify(r)}`)
+  const dataDir = scope === 'global' ? path.join(tmpHome, '.episodic-memory') : path.join(tmpProject, '.episodic-memory')
+  const fakeDate = new Date(Date.now() - daysAgo * 86400000).toISOString().slice(0, 10)
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const lines = fs.readFileSync(indexFile, 'utf8').split('\n').filter(Boolean)
+  const updated = lines.map(line => {
+    const e = JSON.parse(line)
+    if (e.id === r.id) e.date = fakeDate
+    return JSON.stringify(e)
+  })
+  fs.writeFileSync(indexFile, updated.join('\n') + '\n', 'utf8')
+  const epFile = r.file
+  const content = fs.readFileSync(epFile, 'utf8').replace(/^date: .+$/m, `date: ${fakeDate}`)
+  fs.writeFileSync(epFile, content, 'utf8')
+  return r.id
+}
+
+function clearStore() {
+  for (const dir of [path.join(tmpHome, '.episodic-memory'), path.join(tmpProject, '.episodic-memory')]) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function setBranch(name) {
+  execSync(`git checkout -q -B ${name}`, { cwd: tmpProject })
+}
+
+// ===========================================================================
+console.log('\n--- RFC-002 Phase 3 Acceptance Tests ---')
+// ===========================================================================
+
+test('T1. preflight_warnings populated when violations exist for task-relevant patterns', () => {
+  clearStore()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  const r = recall('--task-type implementation --no-track')
+  assert.strictEqual(r.status, 'ok')
+  const violations = r.preflight_warnings.filter(w => w && w.type === 'violation')
+  assert.strictEqual(violations.length, 1, `expected 1 violation warning, got ${violations.length}`)
+  assert.strictEqual(violations[0].pattern_id, 'bp-001-implementation-workflow')
+})
+
+test('T2. Pre-flight surfaces violation count and last violation date', () => {
+  clearStore()
+  for (let d = 1; d <= 5; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  const r = recall('--task-type implementation --no-track')
+  const w = r.preflight_warnings.find(w => w.type === 'violation' && w.pattern_id === 'bp-001-implementation-workflow')
+  assert.ok(w, 'violation warning missing')
+  assert.strictEqual(w.violations_last_30d, 5)
+  // Most recent is 1 day ago
+  const expectedLast = new Date(Date.now() - 1 * 86400000).toISOString().slice(0, 10)
+  assert.strictEqual(w.last_violation, expectedLast)
+  assert.ok(w.message && w.message.includes('bp-001'))
+  assert.ok(w.message.includes(expectedLast))
+})
+
+test('T3a. No violation pre-flight when task type unclear (no flag, no inference)', () => {
+  clearStore()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  setBranch('main')
+  const r = recall('--no-track')
+  assert.strictEqual(r.context.task_type, null, `expected task_type null, got ${r.context.task_type}`)
+  const violations = r.preflight_warnings.filter(w => w && w.type === 'violation')
+  assert.strictEqual(violations.length, 0, 'no violation warnings when task type unknown')
+})
+
+test('T3b. No violation pre-flight when no violations exist (clean output)', () => {
+  clearStore()
+  rebuild()
+  const r = recall('--task-type implementation --no-track')
+  const violations = r.preflight_warnings.filter(w => w && w.type === 'violation')
+  assert.strictEqual(violations.length, 0)
+})
+
+test('T3c. Violations older than 30 days are excluded', () => {
+  clearStore()
+  seedViolation('bp-001-implementation-workflow', 5) // in window
+  seedViolation('bp-001-implementation-workflow', 60) // outside window
+  rebuild()
+  const r = recall('--task-type implementation --no-track')
+  const w = r.preflight_warnings.find(w => w.type === 'violation' && w.pattern_id === 'bp-001-implementation-workflow')
+  assert.ok(w)
+  assert.strictEqual(w.violations_last_30d, 1, '60d-old violation must be excluded')
+})
+
+test('T4a. --task-type implementation surfaces bp-001 + bp-006', () => {
+  clearStore()
+  seedViolation('bp-001-implementation-workflow', 2)
+  seedViolation('bp-006-push-after-verify', 3)
+  rebuild()
+  const r = recall('--task-type implementation --no-track')
+  const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id).sort()
+  assert.deepStrictEqual(ids, ['bp-001-implementation-workflow', 'bp-006-push-after-verify'])
+})
+
+test('T4b. --task-type push surfaces only bp-006 (not bp-001)', () => {
+  clearStore()
+  seedViolation('bp-001-implementation-workflow', 2)
+  seedViolation('bp-006-push-after-verify', 3)
+  rebuild()
+  const r = recall('--task-type push --no-track')
+  const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id)
+  assert.deepStrictEqual(ids, ['bp-006-push-after-verify'])
+})
+
+test('T4c. --task-type rule surfaces only bp-010', () => {
+  clearStore()
+  seedViolation('bp-001-implementation-workflow', 2)
+  seedViolation('bp-010-habits-override-knowledge', 3)
+  rebuild()
+  const r = recall('--task-type rule --no-track')
+  const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id)
+  assert.deepStrictEqual(ids, ['bp-010-habits-override-knowledge'])
+})
+
+test('T4d. --task-type general surfaces nothing', () => {
+  clearStore()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  const r = recall('--task-type general --no-track')
+  const violations = r.preflight_warnings.filter(w => w.type === 'violation')
+  assert.strictEqual(violations.length, 0)
+})
+
+test('T4e. Invalid --task-type rejected', () => {
+  const r = recallExit('--task-type bogus --no-track')
+  assert.strictEqual(r.code, 1)
+  assert.ok(r.json && r.json.status === 'error' && r.json.message.includes('Invalid --task-type'))
+})
+
+test('T5a. Branch keyword inference: feature/foo-implement-bar → implementation', () => {
+  clearStore()
+  seedViolation('bp-001-implementation-workflow', 2)
+  rebuild()
+  setBranch('feature/foo-implement-bar')
+  const r = recall('--no-track')
+  assert.strictEqual(r.context.task_type, 'implementation')
+  const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id)
+  assert.ok(ids.includes('bp-001-implementation-workflow'))
+})
+
+test('T5b. Branch keyword inference: release/v1-push → push', () => {
+  clearStore()
+  seedViolation('bp-006-push-after-verify', 2)
+  rebuild()
+  setBranch('release/v1-push')
+  const r = recall('--no-track')
+  assert.strictEqual(r.context.task_type, 'push')
+})
+
+test('T5c. Branch with no recognizable keyword → null task_type, no warnings', () => {
+  clearStore()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  setBranch('main')
+  const r = recall('--no-track')
+  assert.strictEqual(r.context.task_type, null)
+})
+
+test('T5d. Explicit --task-type overrides branch inference', () => {
+  clearStore()
+  seedViolation('bp-006-push-after-verify', 2)
+  rebuild()
+  setBranch('feature/foo-implement-bar') // would infer implementation
+  const r = recall('--task-type push --no-track')
+  assert.strictEqual(r.context.task_type, 'push')
+  const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id)
+  assert.deepStrictEqual(ids, ['bp-006-push-after-verify'])
+})
+
+// ===========================================================================
+// Summary
+// ===========================================================================
+console.log('\n' + '='.repeat(50))
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) {
+    console.log(`  - ${f.name}: ${f.error}`)
+  }
+}
+console.log('='.repeat(50))
+
+fs.rmSync(tmpHome, { recursive: true, force: true })
+
+process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -4,18 +4,18 @@
  *
  * Usage: node tests/test-rfc002-phase3.mjs
  *
- * Covers acceptance tests T1-T5 + T7 for Phase 3:
+ * Covers acceptance tests T1-T7 for Phase 3:
  *   T1: Recall includes preflight_warnings when violations exist for task-relevant patterns
  *   T2: Pre-flight surfaces violation count and last violation date
  *   T3: No pre-flight when no violations exist or task type unclear (clean output)
  *   T4: --task-type flag for explicit task context
  *   T5: Keyword inference from git branch name as fallback
+ *   T6: SessionEnd hook prompts user for violation flagging — verifies both the
+ *       script prompt content and that install.mjs --install-hooks registers
+ *       the script as a SessionEnd hook (not instruction-only)
  *   T7: em-recall.mjs touches .claude/.checkpoint-required when bp-001 violations
  *       are surfaced via task-type-driven pre-flight; em-session-end-prompt.mjs
  *       sweeps the marker at session end (best-effort pre-Phase-3b cleanup).
- *
- * T6 (SessionEnd hook prompt) is covered by Phase 1's shipped infrastructure
- * (em-session-end-prompt.mjs + install.mjs --install-hooks).
  */
 
 import fs from 'fs'
@@ -29,6 +29,7 @@ const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
 const VIOLATION = path.join(SCRIPTS, 'em-violation.mjs')
 const REBUILD = path.join(SCRIPTS, 'em-rebuild-index.mjs')
 const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
+const INSTALL = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'install.mjs')
 const REPO_ROOT = path.join(path.dirname(new URL(import.meta.url).pathname), '..')
 
 let passed = 0
@@ -335,6 +336,38 @@ test('T7f. SessionEnd cleanup is silent when marker does not exist', () => {
   // Should not throw even with no marker present
   sessionEnd()
   assert.ok(!fs.existsSync(markerPath))
+})
+
+test('T6a. em-session-end-prompt.mjs outputs a violation-flagging prompt with known patterns', () => {
+  const out = sessionEnd()
+  const data = JSON.parse(out)
+  assert.ok(data.prompt && /violated|behavioral pattern/i.test(data.prompt), `prompt should ask about violations; got: ${data.prompt}`)
+  assert.ok(Array.isArray(data.known_patterns), 'known_patterns must be present')
+  assert.ok(data.known_patterns.length > 0, 'known_patterns must be populated from patterns/_index.json')
+  assert.ok(data.known_patterns.every(p => p.pattern_id && p.name), 'each pattern must have pattern_id + name')
+  assert.ok(data.store_command && data.store_command.includes('em-violation.mjs'), 'store_command must reference em-violation.mjs')
+})
+
+test('T6b. install.mjs --install-hooks registers em-session-end-prompt.mjs as a SessionEnd hook (not instruction-only)', () => {
+  // Isolated HOME so we don't touch the real user settings
+  const installHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p3-install-'))
+  const installEnv = { ...process.env, HOME: installHome }
+  const installProject = path.join(installHome, 'target')
+  fs.mkdirSync(installProject, { recursive: true })
+
+  try {
+    execSync(`node "${INSTALL}" --tool claude-code --project "${installProject}" --install-hooks`, {
+      encoding: 'utf8', env: installEnv, stdio: ['pipe', 'pipe', 'pipe']
+    })
+    const settingsPath = path.join(installHome, '.claude', 'settings.json')
+    assert.ok(fs.existsSync(settingsPath), '~/.claude/settings.json must exist after --install-hooks')
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
+    assert.ok(settings.hooks && Array.isArray(settings.hooks.SessionEnd), 'SessionEnd hooks array must exist')
+    const registered = settings.hooks.SessionEnd.some(h => h.command && h.command.includes('em-session-end-prompt'))
+    assert.ok(registered, 'em-session-end-prompt must be registered as a SessionEnd hook command')
+  } finally {
+    fs.rmSync(installHome, { recursive: true, force: true })
+  }
 })
 
 // ===========================================================================

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -4,16 +4,18 @@
  *
  * Usage: node tests/test-rfc002-phase3.mjs
  *
- * Covers acceptance tests T1-T5 for Phase 3 (commit 1):
+ * Covers acceptance tests T1-T5 + T7 for Phase 3:
  *   T1: Recall includes preflight_warnings when violations exist for task-relevant patterns
  *   T2: Pre-flight surfaces violation count and last violation date
  *   T3: No pre-flight when no violations exist or task type unclear (clean output)
  *   T4: --task-type flag for explicit task context
  *   T5: Keyword inference from git branch name as fallback
+ *   T7: em-recall.mjs touches .claude/.checkpoint-required when bp-001 violations
+ *       are surfaced via task-type-driven pre-flight; em-session-end-prompt.mjs
+ *       sweeps the marker at session end (best-effort pre-Phase-3b cleanup).
  *
  * T6 (SessionEnd hook prompt) is covered by Phase 1's shipped infrastructure
  * (em-session-end-prompt.mjs + install.mjs --install-hooks).
- * T7 (.checkpoint-required marker) ships in commit 2.
  */
 
 import fs from 'fs'
@@ -26,6 +28,7 @@ const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..',
 const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
 const VIOLATION = path.join(SCRIPTS, 'em-violation.mjs')
 const REBUILD = path.join(SCRIPTS, 'em-rebuild-index.mjs')
+const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
 const REPO_ROOT = path.join(path.dirname(new URL(import.meta.url).pathname), '..')
 
 let passed = 0
@@ -117,6 +120,16 @@ function clearStore() {
 
 function setBranch(name) {
   execSync(`git checkout -q -B ${name}`, { cwd: tmpProject })
+}
+
+const markerPath = path.join(tmpProject, '.claude', '.checkpoint-required')
+
+function clearMarker() {
+  try { fs.unlinkSync(markerPath) } catch {}
+}
+
+function sessionEnd() {
+  return execSync(`node "${SESSION_END}"`, { encoding: 'utf8', cwd: tmpProject, env })
 }
 
 // ===========================================================================
@@ -262,6 +275,66 @@ test('T5d. Explicit --task-type overrides branch inference', () => {
   assert.strictEqual(r.context.task_type, 'push')
   const ids = r.preflight_warnings.filter(w => w.type === 'violation').map(w => w.pattern_id)
   assert.deepStrictEqual(ids, ['bp-006-push-after-verify'])
+})
+
+test('T7a. Recall touches .claude/.checkpoint-required when bp-001 violation surfaces', () => {
+  clearStore()
+  clearMarker()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  recall('--task-type implementation --no-track')
+  assert.ok(fs.existsSync(markerPath), '.checkpoint-required should exist after bp-001 surfaces')
+})
+
+test('T7b. No marker when only non-bp-001 violations surface', () => {
+  clearStore()
+  clearMarker()
+  // Only bp-006 violations; --task-type push only surfaces bp-006, not bp-001
+  for (let d = 1; d <= 3; d++) seedViolation('bp-006-push-after-verify', d)
+  rebuild()
+  recall('--task-type push --no-track')
+  assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist when bp-001 is not surfaced')
+})
+
+test('T7c. No marker when task type is unclear (no pre-flight runs)', () => {
+  clearStore()
+  clearMarker()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  setBranch('main') // no keyword match
+  recall('--no-track')
+  assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist when task type unknown')
+})
+
+test('T7d. Marker creation is idempotent (re-recall does not error)', () => {
+  clearStore()
+  clearMarker()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  recall('--task-type implementation --no-track')
+  assert.ok(fs.existsSync(markerPath))
+  // Second recall should not throw
+  recall('--task-type implementation --no-track')
+  assert.ok(fs.existsSync(markerPath))
+})
+
+test('T7e. em-session-end-prompt.mjs sweeps the marker at session end', () => {
+  clearStore()
+  clearMarker()
+  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
+  rebuild()
+  recall('--task-type implementation --no-track')
+  assert.ok(fs.existsSync(markerPath), 'precondition: marker should exist')
+  sessionEnd()
+  assert.ok(!fs.existsSync(markerPath), 'marker should be removed by session-end script')
+})
+
+test('T7f. SessionEnd cleanup is silent when marker does not exist', () => {
+  clearStore()
+  clearMarker()
+  // Should not throw even with no marker present
+  sessionEnd()
+  assert.ok(!fs.existsSync(markerPath))
 })
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Ships **RFC-002 Phase 3 (Actionable Recall)** in full — em-recall.mjs now surfaces violation pre-flight warnings for behavioral patterns relevant to the inferred or specified task type, and touches `.claude/.checkpoint-required` to arm Phase 3b's checkpoint-gate when bp-001 violations surface.

Also lands the **Phase 3c spec** (clerk-model violation reporting, post-OQ-6 review with Codex), and a **side-bug fix** in install.mjs uncovered during T6 testing.

Closes the 7 acceptance tests in [docs/rfcs/RFC-002-learning-loop.md:368-376](https://github.com/lantisprime/episodic-memory/blob/claude/serene-chaplygin-8903d8/docs/rfcs/RFC-002-learning-loop.md) — all marked `[x]`.

## Commits (6)

| | Commit | What |
|---|---|---|
| 1 | `6ac06d4` | docs: Phase 3c spec — hybrid violation reporting (clerk model) |
| 2 | `53c5219` | feat: Phase 3 commit 1 — violation pre-flight (T1-T5) |
| 3 | `2e97b66` | feat: Phase 3 commit 2 — `.checkpoint-required` activation hook (T7) |
| 4 | `c570007` | fix(install): mkdir -p ~/.claude before writing settings.json (#52) |
| 5 | `d54acef` | test: Phase 3 commit 3 — T6 SessionEnd hook verification |
| 6 | `2bba691` | docs: Phase 3 commit 4 — instruction updates (5 files) |

## What's new in em-recall.mjs

- New flag: `--task-type <implementation|push|rule|general>`
- Branch keyword inference: `implement/build/feature/phase/feat → implementation`; `push/merge/pr/release → push`; `rule/enforce/pattern → rule`
- Task-type → patterns mapping per RFC line 150-153
- New `runViolationPreflight()` filters violations of relevant patterns within last 30 days
- Schema migrated from string warnings to objects with `type` discriminator (`{type: 'violation', pattern_id, violations_last_30d, last_violation, message}` for violation entries; `{type: 'system', message}` for perf/tags-missing warnings)
- `context.task_type` added to output for transparency
- `.claude/.checkpoint-required` touched when bp-001 violation surfaces — best-effort atomic create, no locking. Phase 3b's checkpoint-gate.sh will read this marker.

## Phase 3c (specced, not implemented here)

After Codex's OQ-6 review, the spec adopts a **clerk-model** for hybrid violation reporting:
- AI drafts candidate violations with `pattern_id`, `confidence` (band: high/medium/low), `evidence_ref`, `sequence`, `correct_sequence`, `why_it_might_be_wrong`
- User confirms / edits / rejects each
- Backstop prompt for AI-missed violations
- Only confirmed/edited candidates get stored via em-violation.mjs

Phase 3c ships post-Phase-3 (post-this-PR). 9 acceptance tests sketched.

## Side bug fix

`install.mjs --install-hooks` wrote `~/.claude/settings.json` without ensuring the parent directory existed. ENOENT was silently swallowed. Filed as #52, fixed inline in commit `c570007`. Regression covered by T6b.

## Tests

- New: `tests/test-rfc002-phase3.mjs` (22 acceptance tests covering T1-T7 + edge cases)
- Updated: `tests/test-phase3.mjs:224` (schema migration: preflight_warnings entries are now objects)
- **Total: 115/115 across all suites** (17 P1 + 31 P2 + 22 P3 + 20 RFC-001 P3 + 25 em-watch-codex)

## E2E verification against real data

Per-violation pipeline trace: all **13 active bp-001 violations** in the store individually pass every Phase 3 filter step. Pre-flight count matches the trace count exactly.

```
=== Per-violation Phase 3 pipeline trace (13 bp-001 violations) ===
[ 1/13] ✓ ... (all pass)
[13/13] ✓ ...

trace count:       13
em-recall count:   13
match? ✓ yes
```

Marker activation + cleanup cycle verified end-to-end. Pre-flight per task-type matches audit counts:

| Task type | Patterns | Audit | Pre-flight |
|---|---|---|---|
| implementation | bp-001, bp-006 | 13 | 13 ✓ |
| push | bp-006 | 0 | 0 ✓ |
| rule | bp-010 | 2 | 2 ✓ |
| general | (none) | — | 0 ✓ |

## Data hygiene cleanup (in episodic memory store, not git)

During E2E, found a test fixture entry (`20260501-060336-test-fixture-superseded-e2e-test-violati-c8b7`) carrying the production `violated:bp-001-implementation-workflow` tag, polluting pre-flight counts (14 reported, 13 real). Cleaned up the fixture's tags in main repo's `.episodic-memory/` (gitignored, not part of this PR).

## Out of scope (filed as separate work)

- **bp-012 task-type mapping gap** — bp-012 (complete-session-wrap-up) has 1 violation but no task type maps to it, so it never surfaces in pre-flight. Filing as enhancement.
- **Phase 3b implementation** (checkpoint-gate.sh + push-gate). This PR only sets the marker; the gate that reads it is Phase 3b.
- **Phase 3c implementation** (clerk-model SessionEnd flow). Spec only in this PR.

## Test plan

- [ ] Reviewer: read each commit's diff per rule 17
- [ ] CI: 115 tests pass
- [ ] Manual: clone, install, run `node ~/.episodic-memory/scripts/em-recall.mjs --task-type implementation` against a project with bp-001 violations → see warning surface
- [ ] Manual: verify `.claude/.checkpoint-required` is created when bp-001 surfaces
- [ ] Manual: run `node ~/.episodic-memory/scripts/em-session-end-prompt.mjs` → marker removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)