### PR TITLE
docs(research): peer-system synthesis + MCP pending-analysis

### DIFF
--- a/docs/research/peer-system-decisions.md
+++ b/docs/research/peer-system-decisions.md
@@ -1,0 +1,86 @@
+# Peer-system synthesis decisions
+
+**Date:** 2026-05-01
+**Sources:** 5 cached notes (`memory/knowledge_base/`) + 3 WebSearch passes covering 16+ candidates.
+**Method:** Problem-fit gate (one question per candidate: "is there an observed bp violation, recurring user friction, or known gap in this repo that this would close?"). No scoring matrix. A-Mem scored last; prestige flag armed (none triggered).
+**Token budget:** <30k. Actual: well under.
+
+## Observed problems (input to gate)
+
+From 11 violations + 12 active patterns + this conversation:
+
+1. Workflow discipline under momentum — addressed by Phase 3b checkpoint-gate (shipped #25).
+2. Staleness detection — one observed instance: MEMORY.md said "Phase 3b designed" when shipped.
+3. No retrieval-quality measure — em-recall has no benchmark.
+4. MCP surface gap (open) — see [pending-analysis.md](../rfcs/pending-analysis.md#mcp-surface-vs-file-based-install--convergent-peer-signal-vs-design-differentiator).
+
+## Rejected (no observed problem in this repo)
+
+One-liner each. All survived no further review.
+
+- **secret scrubbing** — never raised in violations or memory. *Caveat:* becomes mandatory if auto-capture / raw transcript / tool-output storage is added (Codex 2026-05-01 review). *Today's action* (Codex follow-up): redact `BODY="$(...)"`-style em-store calls when the body contains literal tool output, unreviewed logs, env dumps, HTTP headers, or stack traces with tokens. Distilled/intentional text is fine.
+- **BM25 / vector search** — text matching adequate at current volume.
+- **async / background persistence** — index rebuild is fast.
+- **vault / consolidation promotion** — bp-003 pattern-promotion already covers project→global lift.
+- **structured summary schema** — freeform summary works. *Flip signals* (Codex follow-up): scripts start grep/parsing summaries for status or next-steps; session wrap-up misses because state is buried in prose; retrieval benchmark needs labels not present in metadata. *Cheap instrumentation now:* lint counting episodes with missing useful frontmatter fields or overly long/ambiguous summaries — record cases where an agent had to read full body because summary/frontmatter was insufficient.
+- **pitfall / pattern categories** (memento) — `violation` category + bp-009 already structure this.
+- **archive / status (vs discard)** — supersedes covers archival.
+- **explicit project-binding config** — `--project` flag already exists.
+- **workspace config sync** — out of repo scope.
+- **watermark handoffs** — out of repo scope.
+- **topic-level summarize op** — not requested.
+- **graph backends** (Cognee, MemMachine, Graphiti, Zep) — different paradigm; no graph-shaped problem observed.
+- **mem0 / generic agent memory** — different domain.
+- **tool-specific** (Hindsight, RooCode, REM/Aider) — narrower than this repo's cross-tool target.
+- **related_ids / topic links** — lightweight value, no observed need. **Weakest rejection** (Codex follow-up: closest to flipping). *Flip trigger:* one concrete miss where semantically related episodes share no lexical / project / tag overlap. *Order:* retrieval benchmark first; topic links only as a candidate intervention if the benchmark surfaces link-shaped misses, otherwise it's unmeasured schema decoration.
+- **A-Mem 5-op tool surface** — current 5 em-* scripts already map to these ops.
+
+## Survivors
+
+### 1. Retrieval-quality benchmark — adopt-now (tracking, deferred implementation)
+
+**Source:** Letta Code (Dec 2025) reports 74.0% on LoCoMo by storing conversation histories in files; the benchmark approach is the takeaway, not Letta itself.
+**Observed problem:** em-recall has no measure of retrieval quality. Could be excellent, could be poor — unknown.
+**Updated rationale (Codex 2026-05-01 review):** Don't wait passively until Phase 4 — Phase 4 changes retrieval/consolidation, and without a smoke baseline beforehand, regressions land silently. Land a tiny fixed corpus + precision@k smoke baseline *before* Phase 4 touches the recall surface; expand the benchmark after Phase 4 stabilizes.
+**Acceptance shape (sketch):**
+- Smoke baseline (before Phase 4): ~10-20 synthetic episodes + queries with ground-truth relevance, precision@k for em-recall, "do not regress" CI step.
+- Full benchmark (after Phase 4): expanded corpus, recall@k, regression CI gate.
+**GH issue:** Filed as tracking issue — implementation deferred but baseline must land before Phase 4.
+
+### 2. Staleness detection — adopt-later
+
+**Source:** Codex's expanded inventory.
+**Observed problem:** MEMORY.md said "Phase 3b designed (23 acceptance tests)" when Phase 3b had merged via PR #25. Caught in this conversation by user, not by the system.
+**Why later, not now:** N=1 remains weak. Codex (2026-05-01) noted session_handoff/MEMORY drift is *likely* recurring but stops short of generalizing from one instance.
+**Acceptance shape (sketch):** lightweight check that compares MEMORY.md / session_handoff.md status claims against `git log --grep='Phase'` or RFC checklist state; flag mismatches at session start.
+**File a GH issue?** Not yet — log one more concrete stale-status incident before issue.
+
+### 3. MCP surface — adopt-now (instrument-first tracking issue), see pending-analysis
+
+**Source:** MemPalace, agentmemory, Supermemory, doobidoo, memento-mcp, memorix all converge on MCP.
+**Status:** Real residual gap, not vibes (Codex 2026-05-01 sharpened the framing). Phase 3b's SessionStart only closes start-of-session recall for *Claude-hooked* installs — it does NOT close (i) mid-conversation recall, (ii) Codex/Cursor/Windsurf first-class tool discovery, (iii) cross-tool handoff friction. See [pending-analysis.md](../rfcs/pending-analysis.md#mcp-surface-vs-file-based-install--convergent-peer-signal-vs-design-differentiator) for the full discussion.
+**Direction:** Keep full MCP rewrite deferred (high cost, weak observed need at that scale). File instrument-first issue NOW: telemetry on em-recall invocations to detect "would-have-helped" misses, plus thin-MCP-wrapper exploration around existing em-* scripts. Codex's identity take: a thin wrapper preserves the enforcement-loop differentiation; a full rewrite would blur it.
+**GH issue:** Filed as tracking issue (instrument + spike thin wrapper).
+
+## GH issues filed
+
+**Two**, both tracking with deferred implementation (Codex 2026-05-01 outside-objection: "zero GH issues makes adopt-later easy to forget — file lightweight tracking even if implementation deferred"):
+
+1. Retrieval-quality smoke baseline before Phase 4 — corpus, precision@k harness, "do not regress" CI step.
+2. MCP surface instrument-first + thin-wrapper exploration — em-recall invocation telemetry; spike thin stdio MCP wrapper around em-recall/em-store/em-violation; decide after data.
+
+Issue numbers added once filed.
+
+## Cheap instrumentations (Codex follow-up, 2026-05-01)
+
+These are pre-emptive observations, not new survivors. Cost is low; they sharpen the rejection list's flip triggers if/when more evidence appears. Not filed as separate GH issues — fold into Phase 4 work or related issues opportunistically.
+
+- **Summary/frontmatter lint** — count episodes with missing useful frontmatter fields or overly long/ambiguous summaries. Record cases where an agent had to read full body because summary/frontmatter was insufficient. Trigger to convert to schema work: counts climb consistently, or retrieval benchmark needs labels.
+- **Secret-shape warning in em-store** — lightweight check before storing bodies that match env-var / JWT-API-key / Authorization-header / huge-raw-dump shapes. Stderr warning; not blocking. Trigger to convert to full scrubber: auto-capture / raw transcript / tool-result storage ships.
+- **Topic-link miss capture** — when the retrieval benchmark records misses, flag any case where the missed episode has no lexical / project / tag overlap with the query. One such case = flip related_ids / topic links from rejected to defer.
+
+## Bias check
+
+- A-Mem scored last (cached note read after others) — A-Mem did not survive the gate. No prestige flag triggered.
+- No candidate's verdict appears prestige-driven. Letta's appeal was the LoCoMo benchmark approach (concrete), not the brand.
+- Path-dependency check: none of the rejected items would be materially harder to adopt in 6 months than today; rejection is not premature lock-in.

--- a/docs/research/peer-system-decisions.md
+++ b/docs/research/peer-system-decisions.md
@@ -45,7 +45,7 @@ One-liner each. All survived no further review.
 **Acceptance shape (sketch):**
 - Smoke baseline (before Phase 4): ~10-20 synthetic episodes + queries with ground-truth relevance, precision@k for em-recall, "do not regress" CI step.
 - Full benchmark (after Phase 4): expanded corpus, recall@k, regression CI gate.
-**GH issue:** Filed as tracking issue — implementation deferred but baseline must land before Phase 4.
+**GH issue:** [#55](https://github.com/lantisprime/episodic-memory/issues/55) — implementation deferred but baseline must land before Phase 4.
 
 ### 2. Staleness detection — adopt-later
 
@@ -60,16 +60,16 @@ One-liner each. All survived no further review.
 **Source:** MemPalace, agentmemory, Supermemory, doobidoo, memento-mcp, memorix all converge on MCP.
 **Status:** Real residual gap, not vibes (Codex 2026-05-01 sharpened the framing). Phase 3b's SessionStart only closes start-of-session recall for *Claude-hooked* installs — it does NOT close (i) mid-conversation recall, (ii) Codex/Cursor/Windsurf first-class tool discovery, (iii) cross-tool handoff friction. See [pending-analysis.md](../rfcs/pending-analysis.md#mcp-surface-vs-file-based-install--convergent-peer-signal-vs-design-differentiator) for the full discussion.
 **Direction:** Keep full MCP rewrite deferred (high cost, weak observed need at that scale). File instrument-first issue NOW: telemetry on em-recall invocations to detect "would-have-helped" misses, plus thin-MCP-wrapper exploration around existing em-* scripts. Codex's identity take: a thin wrapper preserves the enforcement-loop differentiation; a full rewrite would blur it.
-**GH issue:** Filed as tracking issue (instrument + spike thin wrapper).
+**GH issue:** [#56](https://github.com/lantisprime/episodic-memory/issues/56) — instrument + spike thin wrapper.
 
 ## GH issues filed
 
 **Two**, both tracking with deferred implementation (Codex 2026-05-01 outside-objection: "zero GH issues makes adopt-later easy to forget — file lightweight tracking even if implementation deferred"):
 
-1. Retrieval-quality smoke baseline before Phase 4 — corpus, precision@k harness, "do not regress" CI step.
-2. MCP surface instrument-first + thin-wrapper exploration — em-recall invocation telemetry; spike thin stdio MCP wrapper around em-recall/em-store/em-violation; decide after data.
+1. [#55](https://github.com/lantisprime/episodic-memory/issues/55) — Retrieval-quality smoke baseline before Phase 4 (corpus, precision@k harness, "do not regress" CI step).
+2. [#56](https://github.com/lantisprime/episodic-memory/issues/56) — MCP surface instrument-first + thin-wrapper exploration (em-recall invocation telemetry; spike thin stdio MCP wrapper around em-recall/em-store/em-violation; decide after data).
 
-Issue numbers added once filed.
+Plus separately filed during this work: [#57](https://github.com/lantisprime/episodic-memory/issues/57) — em-* scripts silently target wrong `.episodic-memory/` from worktree cwd (caught as bp-010 violation mid-synthesis).
 
 ## Cheap instrumentations (Codex follow-up, 2026-05-01)
 

--- a/docs/rfcs/pending-analysis.md
+++ b/docs/rfcs/pending-analysis.md
@@ -1,0 +1,63 @@
+# Pending analysis
+
+Raw input for future RFCs. Each entry is a problem + evidence + candidate directions, not a spec. Promote to a numbered RFC when ready.
+
+---
+
+## MCP surface vs file-based install — convergent peer signal vs design differentiator
+
+**Status:** seed for potential RFC (numbered after RFC-003 if that lands)
+**Date:** 2026-05-01
+**Triggering question:** Peer-system research synthesis (knowledge_base/) found all major neighbors expose memory via MCP server. This repo exposes via instruction files. Is this a gap to close, or the differentiator?
+
+### Evidence — peer-system convergence on MCP
+
+| System | Surface | Cross-tool reach |
+|---|---|---|
+| MemPalace (Apr 2026, 43k★ in 1 week) | MCP server | Claude Code, Codex CLI, Cursor, Claude Desktop |
+| agentmemory (Cognition) | Zero-config npm → MCP | Claude Code, Cursor, Gemini CLI, OpenCode |
+| Supermemory | MCP server + plugins | Claude Code, OpenCode (purpose-built for coding agents) |
+| doobidoo/mcp-memory-service | REST API + MCP + autonomous consolidation | Claude + LangGraph/CrewAI/AutoGen |
+| memento-mcp (cached) | MCP server, SQLite + FTS5 | MCP-compatible clients |
+| memorix (cached) | MCP server, SQLite + Orama | Broadest cross-tool target list |
+| **This repo** | **Shell scripts + per-tool instruction files** | Claude Code, Cursor, Codex, Windsurf via SKILL.md / cursor.mdc / AGENTS.md / windsurf.md |
+
+### Framing — gap is real, but only for the residual surface
+
+**(a) Real gap.** Instruction files don't surface memory as a live tool the agent discovers automatically. Phase 3b's SessionStart hook closes *only one* sub-gap: start-of-session recall for Claude Code installs that opted into hooks. It does not close:
+1. **Mid-conversation recall.** Once the session is running, the agent has to remember to invoke shell scripts. No first-class `recall(query)` available mid-flow.
+2. **Codex / Cursor / Windsurf tool discovery.** SessionStart hook is Claude-Code-specific. Agents on other tools have no auto-recall surface — only instruction-file prompting, which depends on the agent reading and acting on it.
+3. **Cross-tool handoff friction.** Memory passed between tools requires manual install + instruction files per tool; an MCP server registered once would be tool-discoverable.
+
+(Codex 2026-05-01 sharpened this framing — the original draft presented two symmetric framings, which under-stated the gap.)
+
+**(b) Intentional differentiation — partial.** "Tool-agnostic, zero deps, Node.js stdlib only" (CLAUDE.md project conventions) is real and worth preserving. The differentiator is **the enforcement loop** (bp violations, checkpoint gates, local flat-file auditability), not file-based-vs-MCP per se. A *thin* MCP wrapper around existing em-* scripts preserves zero-deps in the storage layer and preserves the enforcement loop; a *full* MCP rewrite (new server, new storage, new install path) would blur identity.
+
+### Pattern
+
+All five cached peer systems and all four newly-surfaced ones converge on MCP. The lone holdouts are file-based systems (AGENTS.md / CLAUDE.md / Hermes) — and even those have open feature requests to expose them via MCP (`hermes-agent#10835`).
+
+### Open questions before RFC
+
+1. **Observed friction.** Are there instances of "agent forgot to recall" or "agent couldn't recall mid-conversation" in this repo's violation log? Current scan: 11 violations, all bp-001/bp-012 workflow-discipline. No retrieval-surface friction observed.
+2. **Phase 3b coverage.** SessionStart hook auto-invokes em-recall and writes `.checkpoint-required` on bp-001 hits. Does this already close gap-(a)? Mid-conversation recall (vs session-start recall) is the residual.
+3. **Cost of MCP adoption.** Adding an MCP server breaks "zero deps." Does adoption come bundled with the @modelcontextprotocol/sdk dependency, or is a thin stdio wrapper feasible in stdlib only?
+4. **Coexistence.** Can MCP and file-based scripts ship side-by-side without dual-sourcing the storage layer? (Likely yes if MCP is a thin tool wrapper around existing em-* scripts.)
+5. **Identity / positioning.** If we add MCP, does this repo become "another mcp-memory-service" with weak differentiation? Or does the bp-001/bp-012 enforcement-loop angle remain unique regardless of surface?
+
+### Candidate directions
+
+1. **Reject.** Stay file-based. Add positioning to README: "zero-infra cross-tool memory — no server, no daemon." Differentiation by absence.
+2. **Thin MCP wrapper.** Wrap existing em-* scripts as MCP tools (`recall`, `store`, `violation`) without changing storage. <500 LOC, optional `--install-mcp` flag like `--install-hooks`. Coexists with shell access.
+3. **Full MCP rewrite.** New RFC. New server. New install path. High cost, weak observed need.
+4. **Defer + instrument.** Add em-recall invocation telemetry to detect "would-have-helped" misses (e.g., violations stored within N turns of an em-recall that should have surfaced the relevant pattern). Decide after data.
+
+### Recommendation
+
+**Adopt levers 2 + 4 as a single tracking issue, now.** File a GH issue covering: (i) em-recall invocation telemetry to detect "would-have-helped" misses; (ii) spike a thin stdio MCP wrapper around existing em-recall / em-store / em-violation scripts (no new storage, no new dependency in storage layer; MCP SDK lives only in the optional wrapper). Defer the **decision** on full adoption pending instrumentation data, but don't defer the issue itself — Codex's outside objection is that adopt-later items without tracking get forgotten.
+
+Reject lever 3 (full MCP rewrite) — high cost, weak observed need at that scale, blurs identity.
+
+Reject lever 1 (stay file-based, position by absence) — peer convergence is too strong to dismiss; the residual gaps (mid-conversation recall, cross-tool tool discovery, cross-tool handoff) are real for any user not on Claude Code with hooks installed.
+
+Promote to numbered RFC if telemetry shows ≥3 "would-have-helped" misses across two sessions OR if a user-experienced friction is reported on Codex/Cursor/Windsurf.


### PR DESCRIPTION
## Summary

- Distilled 5 cached peer-system notes + 6 newly-surfaced neighbors (MemPalace, agentmemory, Supermemory, MemNexus, Letta Code, Agent Context System) into a decisions doc — rejected list with flip triggers, 3 survivors, cheap-instrumentation observations.
- Created [`docs/rfcs/pending-analysis.md`](docs/rfcs/pending-analysis.md) with a single entry on the **MCP surface vs file-based install** fork. Phase 3b's SessionStart hook closes only one of three sub-gaps (start-of-session recall for Claude Code installs); mid-conversation recall, cross-tool tool discovery, and cross-tool handoff remain open. Recommended thin-MCP-wrapper exploration.
- Three rounds of Codex review incorporated (initial plan review → synthesis output review → rejection-list follow-up).

## Survivors

| # | Item | Verdict | Issue |
|---|---|---|---|
| 1 | Retrieval-quality smoke baseline | adopt-now (tracking, deferred impl) | #55 |
| 2 | Staleness detection | adopt-later (N=1, log one more incident) | — |
| 3 | MCP surface (instrument-first + thin wrapper) | adopt-now (tracking, deferred impl) | #56 |

Codex's outside objection — "zero GH issues makes adopt-later easy to forget" — drove the decision to file tracking issues even where implementation is deferred.

## Test plan

- [ ] Decisions doc readable, links to pending-analysis resolve
- [ ] Pending-analysis MCP entry framing not symmetric (gap-(a) is a real residual)
- [ ] Issues #55 and #56 cross-referenced from the docs
- [ ] No code changes; doc-only PR

## Related

- Issue #57: separate fix for em-* scripts targeting wrong `.episodic-memory/` from worktree cwd (filed during this work after a violation)
- Codex review episodes: `20260501-104404-...`, `20260501-124551-...`, `20260501-125738-...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)