### PR TITLE
feat: Phase 3b PR-B — installer deploy + spec/pattern reconciliation (closes #59)

### DIFF
--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -558,29 +558,35 @@ Update instruction files incrementally as each phase ships (do not batch to the 
 - [x] `em-recall.mjs` automatically touches `.claude/.checkpoint-required` when bp-001 violations detected
 
 **Phase 3b:**
-- [ ] `checkpoint-gate.sh` blocks all write tools when `.checkpoint-required` exists and `.pre-checkpoint-done` is absent or empty
-- [ ] Non-empty `.pre-checkpoint-done` unblocks writes
-- [ ] Empty `.pre-checkpoint-done` (just `touch`) does NOT unblock
-- [ ] Write command to `.pre-checkpoint-done` allowed through (no deadlock)
-- [ ] SessionEnd hook cleans up all 4 markers
-- [ ] No gate when `.checkpoint-required` absent
-- [ ] Error message distinguishable from plan-gate.sh
-- [ ] SessionStart hook invokes `em-recall.mjs` mechanically
-- [ ] bp-001 enforcement table updated with checkpoint-gate
-- [ ] `install.mjs --install-hooks` registers checkpoint-gate + SessionStart hooks
-- [ ] Both plan-gate and checkpoint-gate active simultaneously — user sees two distinct error messages
-- [ ] `em-session-end-prompt.mjs` cleans up all markers at session end (extends Phase 1 script)
-- [ ] `.post-checkpoint-required` touched on every allowed write through pre-checkpoint gate (idempotent)
-- [ ] `git push` blocked when `.post-checkpoint-required` exists and `.post-checkpoint-done` absent/empty
-- [ ] Non-empty `.post-checkpoint-done` unblocks push
-- [ ] Empty `.post-checkpoint-done` does NOT unblock push
-- [ ] Write command to `.post-checkpoint-done` allowed through (no deadlock)
-- [ ] `git push` / `gh pr create` allowed through cleans up all 4 markers
-- [ ] Push-gate error message: mentions E2E, bug logging, and post-implementation checkpoint
-- [ ] `gh pr create` also blocked by push-gate (not just `git push`)
-- [ ] Push failure after marker cleanup does not re-engage gate (documented limitation)
-- [ ] Orphaned markers (e.g., `.post-checkpoint-required` alone) cleaned by SessionEnd
-- [ ] SessionStart hook produces `.checkpoint-required` before any user interaction (flow test)
+- [x] `checkpoint-gate.sh` blocks all write tools when `.checkpoint-required` exists and `.pre-checkpoint-done` is absent or empty
+- [x] Non-empty `.pre-checkpoint-done` unblocks writes
+- [x] Empty `.pre-checkpoint-done` (just `touch`) does NOT unblock
+- [x] Write command to `.pre-checkpoint-done` allowed through (no deadlock)
+- [x] SessionEnd hook cleans up all 4 markers
+- [x] No gate when `.checkpoint-required` absent
+- [x] Error message distinguishable from plan-gate.sh
+- [x] SessionStart hook invokes `em-recall.mjs` mechanically
+- [x] bp-001 enforcement table updated with checkpoint-gate
+- [x] `install.mjs --install-hooks` registers checkpoint-gate + SessionStart hooks
+- [x] Both plan-gate and checkpoint-gate active simultaneously — user sees two distinct error messages
+- [x] `em-session-end-prompt.mjs` cleans up all markers at session end (extends Phase 1 script)
+- [x] `.post-checkpoint-required` touched on every allowed write through pre-checkpoint gate (idempotent)
+- [x] `git push` blocked when `.post-checkpoint-required` exists and `.post-checkpoint-done` absent/empty
+- [x] Non-empty `.post-checkpoint-done` unblocks push
+- [x] Empty `.post-checkpoint-done` does NOT unblock push
+- [x] Write command to `.post-checkpoint-done` allowed through (no deadlock)
+- [x] `git push` / `gh pr create` allowed through cleans up all 4 markers
+- [x] Push-gate error message: mentions E2E, bug logging, and post-implementation checkpoint
+- [x] `gh pr create` also blocked by push-gate (not just `git push`)
+- [x] Push failure after marker cleanup does not re-engage gate (documented limitation per line 197)
+- [x] Orphaned markers (e.g., `.post-checkpoint-required` alone) cleaned by SessionEnd
+- [ ] SessionStart hook produces `.checkpoint-required` before any user interaction (flow test) — left unchecked: no automated end-to-end test exercises the full SessionStart → em-recall activator → marker chain; covered manually in PR-B verification but not regression-guarded.
+
+**Push-gate bypass tradeoffs (documented, not gated):**
+
+The PreToolUse push-gate fires only inside Claude Code sessions. Pushes from a separate terminal, Git GUI, IDE integration, or CI bypass it entirely. If true cross-context enforcement is needed, escalate to a `.git/hooks/pre-push` script (or a CI gate) — consistent with bp-010 (mechanical enforcement at the action site, not the actor) and the existing limitation noted on line 197. PR-B does not ship that escalation; it's a tracked follow-up if the in-session gate proves insufficient.
+
+The SessionStart hook (`em-recall-sessionstart.sh`) invokes `em-recall.mjs` mechanically before any user interaction — but its stdout is currently suppressed (issue #61), so violation warnings produced by the activator do not surface to the AI as `additionalContext`. The marker side effects do fire (the activator touches `.checkpoint-required` when bp-001 violations are present), so checkpoint-gate.sh still blocks correctly. The output-surfacing fix is a separate concern from PR-B's deploy scope.
 
 **Phase 3b hardening follow-ups:**
 - [ ] Claude adapter manifest declares hook side effects, ownership IDs, checksums, and uninstall/backout actions

--- a/install.mjs
+++ b/install.mjs
@@ -38,6 +38,13 @@ const installHooks = argv.includes('--install-hooks')
 const installHooksForce = argv.includes('--install-hooks-force')
 const REPO_HOOKS = path.join(REPO_DIR, 'hooks')
 
+// P2 (code review): warn if --install-hooks-force passed without --install-hooks.
+// Without the base flag, the entire hook-install block is skipped; a force flag
+// alone silently no-ops and a user might think their settings were updated.
+if (installHooksForce && !installHooks) {
+  console.log('Warning: --install-hooks-force has no effect without --install-hooks; ignoring.')
+}
+
 if (!tool) {
   console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|windsurf|all> [--project <path>] [--install-hooks] [--install-hooks-force]
 
@@ -269,6 +276,34 @@ function migrateMalformedEntries(hooks) {
   return migrated
 }
 
+// P2 (code review): after migrating malformed entries we preserve the
+// pre-existing command verbatim. If that command points at a canonical hook
+// basename (em-session-end-prompt.mjs / checkpoint-gate.sh / em-recall-
+// sessionstart.sh) but at a different path than where this installer puts the
+// canonical version, the user ends up with both registered: the canonical one
+// (newly registered) and the migrated stale one (will fail silently at runtime
+// because the path likely doesn't exist on this machine). Surface this so the
+// user can clean up; we deliberately don't auto-rewrite their pointer.
+function detectStaleCanonicalEntries(hooks, canonicalByBasename) {
+  const stale = []
+  for (const event of Object.keys(hooks)) {
+    const arr = hooks[event]
+    if (!Array.isArray(arr)) continue
+    for (const entry of arr) {
+      if (!Array.isArray(entry.hooks)) continue
+      for (const h of entry.hooks) {
+        if (!h || typeof h.command !== 'string') continue
+        for (const [basename, canonicalPath] of Object.entries(canonicalByBasename)) {
+          if (h.command.includes(basename) && !h.command.includes(canonicalPath)) {
+            stale.push({ event, basename, command: h.command })
+          }
+        }
+      }
+    }
+  }
+  return stale
+}
+
 function installHookFile(repoFile, destFile, force) {
   if (!fs.existsSync(repoFile)) return 'missing-source'
   if (!fs.existsSync(destFile)) {
@@ -379,6 +414,18 @@ if (installHooks) {
     const seResult = addHookEntry(settings.hooks, 'SessionEnd', seCmd, { timeout: 10 })
     console.log(`SessionEnd em-session-end-prompt.mjs: ${seResult}`)
     if (seResult === 'added') touched.settings.push('SessionEnd → em-session-end-prompt.mjs')
+
+    // P2 (code review): warn about stale canonical-named entries left behind
+    // by migration so the user can prune them. Run AFTER all registrations.
+    const canonicalByBasename = {
+      'em-session-end-prompt.mjs': path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'),
+      'checkpoint-gate.sh': path.join(userHooksDir, 'checkpoint-gate.sh'),
+      'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh')
+    }
+    const staleEntries = detectStaleCanonicalEntries(settings.hooks, canonicalByBasename)
+    for (const { event, basename, command } of staleEntries) {
+      console.log(`Warning: stale ${event} entry for ${basename} at ${command} — canonical also registered; remove the stale entry manually if it never resolves.`)
+    }
 
     writeJSONAtomic(settingsPath, settings)
     if (touched.settings.length > 0) touched.hooks.push(settingsPath)

--- a/install.mjs
+++ b/install.mjs
@@ -217,6 +217,22 @@ if (fs.existsSync(seedScript) && fs.existsSync(repoPatternsDir)) {
 // cannot corrupt user settings.
 // ---------------------------------------------------------------------------
 
+// POSIX shell-quote a path for safe inclusion in a hook command string.
+// Conditional quoting: if the path contains only POSIX-safe characters
+// (alphanumerics, underscore, dash, dot, slash, colon, equals, comma) we
+// return it unchanged — matches what `printf '%q'` does for safe strings
+// and avoids needless churn on existing installs whose paths don't need
+// quoting. Otherwise wrap in single quotes and escape internal quotes.
+//
+// Codex post-PR review of #78 reproduced a path-with-spaces failure: an
+// install at HOME=/private/tmp/em\ home\ with\ spaces produced commands
+// that the shell split at the first space, and the registered hook never
+// executed. shellQuote() makes the registered command shell-safe.
+function shellQuote(s) {
+  if (/^[A-Za-z0-9_\-./:=,]+$/.test(s)) return s
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
 function writeJSONAtomic(filePath, obj) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
   const tmp = filePath + '.tmp'
@@ -232,10 +248,26 @@ function entryReferencesSubstring(entry, substring) {
   return false
 }
 
+// Normalize a command string by stripping POSIX shell single-quoting so that
+// idempotence checks survive the v1→v2 PR-B upgrade on installs with spaced
+// paths: a v1-installed unquoted entry and a v2-installed quoted entry refer
+// to the same canonical command. Strips quotes around the whole string or
+// around a trailing single-quoted argument (the `node '<path>'` shape).
+function normalizeCommand(s) {
+  if (typeof s !== 'string') return s
+  if (s.length > 1 && s.startsWith("'") && s.endsWith("'")) {
+    return s.slice(1, -1).replace(/'\\''/g, "'")
+  }
+  const m = s.match(/^(.*\s)'((?:[^']|'\\'')+)'$/)
+  if (m) return m[1] + m[2].replace(/'\\''/g, "'")
+  return s
+}
+
 function entryHasExactCommand(entry, command) {
-  if (entry.command === command) return true
+  const target = normalizeCommand(command)
+  if (entry.command && normalizeCommand(entry.command) === target) return true
   if (Array.isArray(entry.hooks)) {
-    return entry.hooks.some(h => h && h.command === command)
+    return entry.hooks.some(h => h && normalizeCommand(h.command) === target)
   }
   return false
 }
@@ -391,7 +423,7 @@ if (installHooks) {
     const eligibleForReg = new Set(['copied', 'unchanged', 'forced'])
 
     for (const spec of hookSpecs) {
-      const canonicalCmd = path.join(userHooksDir, spec.file)
+      const canonicalCmd = shellQuote(path.join(userHooksDir, spec.file))
       if (!eligibleForReg.has(fileResults[spec.file])) {
         const alreadyRegistered = (settings.hooks[spec.event] || []).some(e =>
           entryHasExactCommand(e, canonicalCmd))
@@ -410,7 +442,7 @@ if (installHooks) {
     }
 
     // SessionEnd em-session-end-prompt.mjs (Phase 1; canonical at SCRIPTS_DIR).
-    const seCmd = `node ${path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs')}`
+    const seCmd = `node ${shellQuote(path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'))}`
     const seResult = addHookEntry(settings.hooks, 'SessionEnd', seCmd, { timeout: 10 })
     console.log(`SessionEnd em-session-end-prompt.mjs: ${seResult}`)
     if (seResult === 'added') touched.settings.push('SessionEnd → em-session-end-prompt.mjs')

--- a/install.mjs
+++ b/install.mjs
@@ -35,16 +35,29 @@ function flag(name) {
 const tool = flag('--tool')
 const projectDir = flag('--project') || process.cwd()
 const installHooks = argv.includes('--install-hooks')
+const installHooksForce = argv.includes('--install-hooks-force')
+const REPO_HOOKS = path.join(REPO_DIR, 'hooks')
 
 if (!tool) {
-  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|windsurf|all> [--project <path>]
+  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|windsurf|all> [--project <path>] [--install-hooks] [--install-hooks-force]
 
 Tools:
   claude-code  Install SKILL.md + plugin structure
   cursor       Install .cursor/rules/episodic-memory.mdc
   codex        Install skill to .agents/skills/episodic-memory/
   windsurf     Install .windsurfrules (or append to existing)
-  all          Install for all supported tools`)
+  all          Install for all supported tools
+
+Hook flags (claude-code / Phase 3b):
+  --install-hooks         Copy hooks/*.sh into ~/.claude/hooks/ and register
+                          checkpoint-gate (PreToolUse), em-recall-sessionstart
+                          (SessionStart), em-session-end-prompt (SessionEnd)
+                          in ~/.claude/settings.json. Skips divergent local
+                          hook files AND withholds new settings registration
+                          for them (re-run with --install-hooks-force to
+                          accept). Atomic settings.json write (temp+rename).
+  --install-hooks-force   Overwrite divergent hook files with repo versions
+                          and proceed with registration.`)
   process.exit(1)
 }
 
@@ -174,34 +187,219 @@ if (fs.existsSync(seedScript) && fs.existsSync(repoPatternsDir)) {
 }
 
 // ---------------------------------------------------------------------------
-// 5. Optional: install SessionEnd hook for violation prompting
+// 5. Optional: install Claude Code hooks (PR-B per #59)
+//
+// Phase 3b runtime: copies hooks/*.sh into ~/.claude/hooks/ (preserving local
+// edits unless --install-hooks-force) and registers PreToolUse + SessionStart
+// + SessionEnd entries in ~/.claude/settings.json using the canonical nested
+// shape `{ matcher?, hooks: [{ type: "command", command, timeout }] }`.
+//
+// Migration: pre-existing flat-shape entries `{ command, description }` (bug
+// shipped in earlier installer versions; never executed by Claude Code) are
+// rewritten in place. Legacy substring detection is used ONLY for migration.
+//
+// Idempotence for new registrations is keyed on the EXACT canonical command
+// string we install (full path), not basename — prevents false-positive skip
+// when an unrelated script of the same name exists at a different path.
+//
+// Divergent local hook files (sha mismatch with repo) are skipped without a
+// new settings registration unless --install-hooks-force is passed. Existing
+// registrations pointing at the same canonical path are preserved.
+//
+// Settings.json is written atomically (temp + rename) so partial failure
+// cannot corrupt user settings.
 // ---------------------------------------------------------------------------
+
+function writeJSONAtomic(filePath, obj) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const tmp = filePath + '.tmp'
+  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), 'utf8')
+  fs.renameSync(tmp, filePath)
+}
+
+function entryReferencesSubstring(entry, substring) {
+  if (entry.command && entry.command.includes(substring)) return true
+  if (Array.isArray(entry.hooks)) {
+    return entry.hooks.some(h => h && h.command && h.command.includes(substring))
+  }
+  return false
+}
+
+function entryHasExactCommand(entry, command) {
+  if (entry.command === command) return true
+  if (Array.isArray(entry.hooks)) {
+    return entry.hooks.some(h => h && h.command === command)
+  }
+  return false
+}
+
+function addHookEntry(hooks, event, command, opts = {}) {
+  const { matcher, timeout = 10 } = opts
+  if (!hooks[event]) hooks[event] = []
+  // Exact-command idempotence (Codex review feedback): basename substring would
+  // false-positive on a different file at a different path with the same name.
+  if (hooks[event].some(e => entryHasExactCommand(e, command))) return 'present'
+  const entry = { hooks: [{ type: 'command', command, timeout }] }
+  if (matcher) entry.matcher = matcher
+  hooks[event].push(entry)
+  return 'added'
+}
+
+function migrateMalformedEntries(hooks) {
+  let migrated = 0
+  for (const event of Object.keys(hooks)) {
+    const arr = hooks[event]
+    if (!Array.isArray(arr)) continue
+    for (let i = 0; i < arr.length; i++) {
+      const entry = arr[i]
+      if (!entry || typeof entry !== 'object') continue
+      // Flat shape: top-level `command` and no `hooks` array.
+      if (entry.command && !Array.isArray(entry.hooks)) {
+        arr[i] = {
+          hooks: [{
+            type: 'command',
+            command: entry.command,
+            timeout: typeof entry.timeout === 'number' ? entry.timeout : 10
+          }]
+        }
+        migrated++
+      }
+    }
+  }
+  return migrated
+}
+
+function installHookFile(repoFile, destFile, force) {
+  if (!fs.existsSync(repoFile)) return 'missing-source'
+  if (!fs.existsSync(destFile)) {
+    fs.mkdirSync(path.dirname(destFile), { recursive: true })
+    fs.copyFileSync(repoFile, destFile)
+    fs.chmodSync(destFile, 0o755)
+    return 'copied'
+  }
+  const a = fs.readFileSync(repoFile)
+  const b = fs.readFileSync(destFile)
+  if (a.equals(b)) return 'unchanged'
+  if (force) {
+    fs.copyFileSync(repoFile, destFile)
+    fs.chmodSync(destFile, 0o755)
+    return 'forced'
+  }
+  return 'skipped-divergent'
+}
+
 if (installHooks) {
   const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
+  const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
+  const touched = { hooks: [], settings: [] }
   try {
+    // 5a. Hook specs (file → event + matcher + timeout + canonical command).
+    const hookSpecs = [
+      {
+        file: 'checkpoint-gate.sh',
+        event: 'PreToolUse',
+        matcher: 'Edit|Write|MultiEdit|Bash|NotebookEdit',
+        timeout: 5
+      },
+      {
+        file: 'em-recall-sessionstart.sh',
+        event: 'SessionStart',
+        timeout: 10
+      }
+    ]
+
+    // 5b. Copy hook files; track which got installed for registration eligibility.
+    const fileResults = {} // spec.file → result
+    for (const spec of hookSpecs) {
+      const repoFile = path.join(REPO_HOOKS, spec.file)
+      const destFile = path.join(userHooksDir, spec.file)
+      const result = installHookFile(repoFile, destFile, installHooksForce)
+      fileResults[spec.file] = result
+      switch (result) {
+        case 'copied':
+          console.log(`Installed hook: ${destFile}`)
+          touched.hooks.push(destFile)
+          break
+        case 'unchanged':
+          console.log(`Hook already current: ${destFile}`)
+          break
+        case 'forced':
+          console.log(`Force-overwrote hook: ${destFile}`)
+          touched.hooks.push(destFile)
+          break
+        case 'skipped-divergent':
+          console.log(`Skipped (divergent local edit): ${destFile} — re-run with --install-hooks-force to overwrite`)
+          break
+        case 'missing-source':
+          console.log(`Note: ${repoFile} not found in repo, skipped`)
+          break
+      }
+    }
+
+    // 5c. Read settings, run migration, register hooks.
     let settings = {}
     if (fs.existsSync(settingsPath)) {
       settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
     }
     if (!settings.hooks) settings.hooks = {}
-    if (!settings.hooks.SessionEnd) settings.hooks.SessionEnd = []
 
-    const hookCmd = `node ${path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs')}`
-    const alreadyInstalled = settings.hooks.SessionEnd.some(h => h.command && h.command.includes('em-session-end-prompt'))
+    const migrated = migrateMalformedEntries(settings.hooks)
+    if (migrated > 0) {
+      console.log(`Migrated ${migrated} malformed hook entr${migrated === 1 ? 'y' : 'ies'} to nested shape`)
+      touched.settings.push(`migrated ${migrated} legacy entr${migrated === 1 ? 'y' : 'ies'}`)
+    }
 
-    if (!alreadyInstalled) {
-      settings.hooks.SessionEnd.push({
-        command: hookCmd,
-        description: 'Prompt for behavioral pattern violations at session end'
+    // Register copied/unchanged/forced hooks. Skip-divergent withholds NEW
+    // registration (per Codex review): we don't want install.mjs to point
+    // Claude at unreviewed custom content. If a registration already exists
+    // for the canonical path, addHookEntry returns 'present' and leaves it.
+    const eligibleForReg = new Set(['copied', 'unchanged', 'forced'])
+
+    for (const spec of hookSpecs) {
+      const canonicalCmd = path.join(userHooksDir, spec.file)
+      if (!eligibleForReg.has(fileResults[spec.file])) {
+        const alreadyRegistered = (settings.hooks[spec.event] || []).some(e =>
+          entryHasExactCommand(e, canonicalCmd))
+        if (alreadyRegistered) {
+          console.log(`${spec.event} ${spec.file}: existing registration preserved`)
+        } else {
+          console.log(`${spec.event} ${spec.file}: registration withheld (file install skipped)`)
+        }
+        continue
+      }
+      const result = addHookEntry(settings.hooks, spec.event, canonicalCmd, {
+        matcher: spec.matcher, timeout: spec.timeout
       })
-      fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
-      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8')
-      console.log('Installed SessionEnd hook for violation prompting')
+      console.log(`${spec.event} ${spec.file}: ${result}`)
+      if (result === 'added') touched.settings.push(`${spec.event} → ${spec.file}`)
+    }
+
+    // SessionEnd em-session-end-prompt.mjs (Phase 1; canonical at SCRIPTS_DIR).
+    const seCmd = `node ${path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs')}`
+    const seResult = addHookEntry(settings.hooks, 'SessionEnd', seCmd, { timeout: 10 })
+    console.log(`SessionEnd em-session-end-prompt.mjs: ${seResult}`)
+    if (seResult === 'added') touched.settings.push('SessionEnd → em-session-end-prompt.mjs')
+
+    writeJSONAtomic(settingsPath, settings)
+    if (touched.settings.length > 0) touched.hooks.push(settingsPath)
+
+    // 5d. Consent legibility (Codex non-blocking guidance): list everything
+    // touched so the user can audit the install.
+    if (touched.hooks.length > 0 || touched.settings.length > 0) {
+      console.log('--- Hook install summary ---')
+      if (touched.hooks.length > 0) {
+        console.log('Files written:')
+        for (const f of touched.hooks) console.log(`  ${f}`)
+      }
+      if (touched.settings.length > 0) {
+        console.log('Settings.json mutations:')
+        for (const m of touched.settings) console.log(`  ${m}`)
+      }
     } else {
-      console.log('SessionEnd hook already installed')
+      console.log('--- Hook install summary: nothing to do (already current) ---')
     }
   } catch (e) {
-    console.log(`Note: could not install SessionEnd hook: ${e.message}`)
+    console.log(`Note: could not install hooks: ${e.message}`)
   }
 }
 

--- a/patterns/implementation-workflow.md
+++ b/patterns/implementation-workflow.md
@@ -90,6 +90,7 @@ Required before push/PR for Full tasks. References bp-006 pre-push checklist:
 | Mechanism | Strength | Scope |
 |-----------|----------|-------|
 | `plan-gate.sh` (Rule 8) | Strong | Claude Code only |
+| `checkpoint-gate.sh` (RFC-002 Phase 3b) | Strong | Claude Code only |
 | Pre-implementation checkpoint block | Medium | All tools |
 | bp-006 pre-push checklist | Strong | All tools |
 | Violation escalation via em-recall | Medium | All tools (when RFC-002 Phase 3 ships) |

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -369,6 +369,87 @@ sec=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-
 assert_eq "T12b both em-session-end-prompt entries coexist (canonical + stale)" "2" "$sec"
 
 # ---------------------------------------------------------------------------
+echo "[T13] Codex post-PR review: HOME with spaces — registered commands must be shell-safe"
+# Reproduces the failure Codex demonstrated against PR-B v1: HOME containing
+# spaces produced unquoted command strings that the shell split at the first
+# space, silently failing to invoke the hook. Fixed by shellQuote() helper.
+# ---------------------------------------------------------------------------
+cleanup
+TEST_HOME=$(mktemp -d -t "em hooks ")
+TEST_PROJECT=$(mktemp -d -t "em proj ")
+case "$TEST_HOME" in
+  *" "*) ;;
+  *) echo "  ⚠ T13 skipped: mktemp template did not yield space-bearing path on this platform"; ((passed++)); ;;
+esac
+
+if [[ "$TEST_HOME" == *" "* ]]; then
+  run_installer --install-hooks
+
+  cg_cmd=$(jq -r '.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate")) | .command' "$TEST_HOME/.claude/settings.json")
+  case "$cg_cmd" in
+    "'"*"'") r=true ;;
+    *) r=false ;;
+  esac
+  assert_eq "T13a checkpoint-gate command is shell-quoted (single quotes)" "true" "$r"
+
+  # Each registered hook command must execute under sh -c without
+  # 'no such file or directory' (this is the failure mode Codex reproduced).
+  cg_err=$(sh -c "$cg_cmd </dev/null 2>&1" || true)
+  if echo "$cg_err" | grep -q "No such file"; then r=true; else r=false; fi
+  assert_eq "T13b checkpoint-gate command resolves under sh -c (no 'No such file')" "false" "$r"
+
+  ss_cmd=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart")) | .command' "$TEST_HOME/.claude/settings.json")
+  ss_err=$(sh -c "$ss_cmd </dev/null 2>&1" || true)
+  if echo "$ss_err" | grep -q "No such file"; then r=true; else r=false; fi
+  assert_eq "T13c sessionstart command resolves under sh -c" "false" "$r"
+
+  se_cmd=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt")) | .command' "$TEST_HOME/.claude/settings.json")
+  # Extract the quoted path arg (everything after `node `) and verify the file exists.
+  se_path=$(echo "$se_cmd" | sed -E "s/^node //; s/^'(.*)'\$/\1/")
+  [ -f "$se_path" ] && r=true || r=false
+  assert_eq "T13d sessionend node-arg path actually exists at the resolved location" "true" "$r"
+fi
+
+# ---------------------------------------------------------------------------
+echo "[T14] Codex post-PR review: v1→v2 upgrade idempotence on spaced paths"
+# A user who installed PR-B v1 has an UNQUOTED command in settings.json. PR-B
+# v2 produces a QUOTED command for the same canonical path. normalizeCommand()
+# treats them as the same; re-install must NOT add a duplicate.
+# ---------------------------------------------------------------------------
+if [[ "$TEST_HOME" == *" "* ]]; then
+  # Hand-craft a v1-style unquoted entry.
+  legacy_cmd="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+  cleanup
+  TEST_HOME=$(mktemp -d -t "em hooks ")
+  TEST_PROJECT=$(mktemp -d -t "em proj ")
+  legacy_cmd="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+  mkdir -p "$TEST_HOME/.claude/hooks"
+  # First place a copy of the canonical hook so installHookFile reports
+  # 'unchanged' (file install eligibility succeeds) — so addHookEntry's
+  # idempotence check is what determines whether we duplicate.
+  cp "$REPO_ROOT/hooks/checkpoint-gate.sh" "$legacy_cmd"
+  chmod +x "$legacy_cmd"
+  cat > "$TEST_HOME/.claude/settings.json" <<JSON
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash|NotebookEdit",
+        "hooks": [
+          { "type": "command", "command": "$legacy_cmd", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+JSON
+  run_installer --install-hooks
+
+  cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+  assert_eq "T14 v1 unquoted entry is recognized as canonical; no duplicate added" "1" "$cg_total"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -377,10 +377,9 @@ echo "[T13] Codex post-PR review: HOME with spaces — registered commands must 
 cleanup
 TEST_HOME=$(mktemp -d -t "em hooks ")
 TEST_PROJECT=$(mktemp -d -t "em proj ")
-case "$TEST_HOME" in
-  *" "*) ;;
-  *) echo "  ⚠ T13 skipped: mktemp template did not yield space-bearing path on this platform"; ((passed++)); ;;
-esac
+if [[ "$TEST_HOME" != *" "* ]]; then
+  echo "  ⚠ T13/T14 skipped: mktemp template did not yield space-bearing path on this platform (no counter bumped)"
+fi
 
 if [[ "$TEST_HOME" == *" "* ]]; then
   run_installer --install-hooks

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -330,6 +330,45 @@ canon_count=$(jq --arg p "$canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | sel
 assert_eq "T10c canonical checkpoint-gate.sh registered at exact installed path" "1" "$canon_count"
 
 # ---------------------------------------------------------------------------
+echo "[T11] Code-review P2: --install-hooks-force without --install-hooks warns + no-ops"
+# ---------------------------------------------------------------------------
+reset_state
+output=$(run_installer_capture --install-hooks-force)
+if echo "$output" | grep -q "Warning: --install-hooks-force has no effect without --install-hooks"; then r=true; else r=false; fi
+assert_eq "T11a warning printed when force flag passed alone" "true" "$r"
+
+[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
+assert_eq "T11b no settings.json created (hook block was correctly skipped)" "false" "$r"
+
+# ---------------------------------------------------------------------------
+echo "[T12] Code-review P2: stale-canonical detection after migration"
+# A pre-existing flat-shape entry pointing at a non-canonical em-session-end-
+# prompt.mjs path is migrated verbatim. The canonical SCRIPTS_DIR registration
+# is added separately. Installer must warn about the resulting stale entry.
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude"
+cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "SessionEnd": [
+      {
+        "command": "node /old/bogus/path/em-session-end-prompt.mjs",
+        "description": "stale"
+      }
+    ]
+  }
+}
+JSON
+output=$(run_installer_capture --install-hooks)
+if echo "$output" | grep -q "stale SessionEnd entry for em-session-end-prompt.mjs"; then r=true; else r=false; fi
+assert_eq "T12a stale-canonical warning printed for migrated /old/bogus/path/" "true" "$r"
+
+# Both entries coexist: canonical (newly registered) + stale (migrated, preserved verbatim).
+sec=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T12b both em-session-end-prompt entries coexist (canonical + stale)" "2" "$sec"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# test-install-hooks.sh — Tests for install.mjs --install-hooks (PR-B per #59)
+#
+# Verifies the realistic upgrade path observed locally on 2026-05-02:
+#   - Pre-existing settings.json with unrelated PreToolUse / SessionStart hooks
+#   - Pre-existing flat-shaped SessionEnd entry that Claude Code can't execute
+#     (regression guard for the malformed `{command, description}` bug shipped
+#     in earlier installer versions)
+#   - Phase 3b hook files (checkpoint-gate.sh, em-recall-sessionstart.sh) absent
+#
+# Per Codex review: divergent local hook files are skipped AND new settings
+# registration is withheld unless --install-hooks-force; new-registration
+# idempotence keys on exact canonical command path, not basename substring;
+# settings.json writes are atomic (temp + rename).
+#
+# Runs install.mjs against a temp HOME and --project, never touches the user's
+# real ~/.claude or ~/.episodic-memory.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALLER="$REPO_ROOT/install.mjs"
+
+if [ ! -f "$INSTALLER" ]; then
+  echo "FAIL: $INSTALLER not found"
+  exit 1
+fi
+
+passed=0
+failed=0
+TEST_HOME=""
+TEST_PROJECT=""
+
+cleanup() { [ -n "$TEST_HOME" ] && rm -rf "$TEST_HOME"; [ -n "$TEST_PROJECT" ] && rm -rf "$TEST_PROJECT"; }
+trap cleanup EXIT
+
+reset_state() {
+  cleanup
+  TEST_HOME=$(mktemp -d)
+  TEST_PROJECT=$(mktemp -d)
+}
+
+run_installer() {
+  HOME="$TEST_HOME" node "$INSTALLER" --tool claude-code --project "$TEST_PROJECT" "$@" >/dev/null 2>&1
+}
+
+run_installer_capture() {
+  HOME="$TEST_HOME" node "$INSTALLER" --tool claude-code --project "$TEST_PROJECT" "$@" 2>&1
+}
+
+assert_eq() {
+  local test_name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ✓ $test_name"
+    ((passed++))
+  else
+    echo "  ✗ $test_name (expected '$expected', got '$actual')"
+    ((failed++))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "[T1] Fresh install: hook files copied, settings.json populated"
+# ---------------------------------------------------------------------------
+reset_state
+run_installer --install-hooks
+
+[ -x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" ] && r=true || r=false
+assert_eq "T1a checkpoint-gate.sh installed and executable" "true" "$r"
+
+[ -x "$TEST_HOME/.claude/hooks/em-recall-sessionstart.sh" ] && r=true || r=false
+assert_eq "T1b em-recall-sessionstart.sh installed and executable" "true" "$r"
+
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1c PreToolUse contains exactly one checkpoint-gate entry" "1" "$cg_count"
+
+ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1d SessionStart contains exactly one em-recall-sessionstart entry" "1" "$ss_count"
+
+se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1e SessionEnd contains exactly one em-session-end-prompt entry (nested shape)" "1" "$se_count"
+
+cg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .matcher' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1f checkpoint-gate matcher is canonical PreToolUse pattern" "Edit|Write|MultiEdit|Bash|NotebookEdit" "$cg_matcher"
+
+cg_type=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .hooks[0].type' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1g checkpoint-gate hook entry has type=command" "command" "$cg_type"
+
+# ---------------------------------------------------------------------------
+echo "[T2] Re-run idempotence: no duplicate entries, no diff in hook files"
+# ---------------------------------------------------------------------------
+sha_before=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+run_installer --install-hooks
+sha_after=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+assert_eq "T2a checkpoint-gate.sh unchanged after re-run" "$sha_before" "$sha_after"
+
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T2b still exactly one checkpoint-gate entry after re-run" "1" "$cg_count"
+
+ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T2c still exactly one em-recall-sessionstart entry after re-run" "1" "$ss_count"
+
+se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T2d still exactly one em-session-end-prompt entry after re-run" "1" "$se_count"
+
+# ---------------------------------------------------------------------------
+echo "[T3] Migration: pre-existing flat-shape SessionEnd entry rewritten"
+# Regression guard for the bug shipped before PR-B (Rule 15).
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude"
+cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "SessionEnd": [
+      {
+        "command": "node /old/path/em-session-end-prompt.mjs",
+        "description": "Prompt for behavioral pattern violations at session end"
+      }
+    ]
+  }
+}
+JSON
+run_installer --install-hooks
+
+flat_count=$(jq '[.hooks.SessionEnd[] | select(.command and (.hooks|not))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T3a no flat-shape SessionEnd entries remain after migration" "0" "$flat_count"
+
+# Migration preserves the original command verbatim — does NOT replace the
+# /old/path/ pointer. The new canonical em-session-end-prompt at SCRIPTS_DIR
+# is then registered as a separate entry (different path, different command,
+# exact-path idempotence treats them distinctly).
+old_path_preserved=$(jq -r '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T3b migrated entry preserves /old/path/ command verbatim" "1" "$old_path_preserved"
+
+old_path_type=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/")) | .type' "$TEST_HOME/.claude/settings.json")
+assert_eq "T3c migrated entry has type=command" "command" "$old_path_type"
+
+# ---------------------------------------------------------------------------
+echo "[T4] Pre-existing unrelated hooks: appended, not replaced"
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude"
+cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "/some/user/plan-gate.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "/some/user/rules-check.sh", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+JSON
+run_installer --install-hooks
+
+pre_total=$(jq '.hooks.PreToolUse | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4a PreToolUse now has 2 entries (existing + checkpoint-gate)" "2" "$pre_total"
+
+plan_gate_intact=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4b existing plan-gate.sh entry preserved" "1" "$plan_gate_intact"
+
+ss_total=$(jq '.hooks.SessionStart | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4c SessionStart now has 2 entries (existing + em-recall-sessionstart)" "2" "$ss_total"
+
+rules_check_intact=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("rules-check"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4d existing rules-check.sh entry preserved" "1" "$rules_check_intact"
+
+# ---------------------------------------------------------------------------
+echo "[T5] Divergent local hook file: skipped + new settings registration WITHHELD"
+# Codex review fix: install.mjs must not point Claude at unreviewed custom
+# content. New registration only happens when the canonical file is in place.
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+sha_before=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+
+output=$(run_installer_capture --install-hooks)
+sha_after=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+assert_eq "T5a divergent checkpoint-gate.sh not overwritten" "$sha_before" "$sha_after"
+
+if echo "$output" | grep -q "Skipped (divergent local edit)"; then r=true; else r=false; fi
+assert_eq "T5b warning printed for divergent hook" "true" "$r"
+
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T5c new checkpoint-gate registration WITHHELD when file install skipped" "0" "$cg_count"
+
+if echo "$output" | grep -q "registration withheld (file install skipped)"; then r=true; else r=false; fi
+assert_eq "T5d explicit 'registration withheld' message printed" "true" "$r"
+
+# T5e: divergent + prior registration exists → registration preserved, no duplicate.
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+canon_path="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+cat > "$TEST_HOME/.claude/settings.json" <<JSON
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|Bash|NotebookEdit",
+        "hooks": [
+          { "type": "command", "command": "$canon_path", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+JSON
+output=$(run_installer_capture --install-hooks)
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T5e prior registration preserved when file install skipped" "1" "$cg_count"
+
+if echo "$output" | grep -q "existing registration preserved"; then r=true; else r=false; fi
+assert_eq "T5f explicit 'existing registration preserved' message printed" "true" "$r"
+
+# ---------------------------------------------------------------------------
+echo "[T6] --install-hooks-force overrides divergent file AND registers"
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+run_installer --install-hooks --install-hooks-force
+
+sha_repo=$(shasum "$REPO_ROOT/hooks/checkpoint-gate.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+assert_eq "T6a --install-hooks-force overwrites divergent hook with repo version" "$sha_repo" "$sha_dest"
+
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T6b --install-hooks-force registers checkpoint-gate after overwrite" "1" "$cg_count"
+
+# ---------------------------------------------------------------------------
+echo "[T7] Identical existing hook: 'unchanged' status, registration proceeds"
+# ---------------------------------------------------------------------------
+output=$(run_installer_capture --install-hooks)
+if echo "$output" | grep -q "Hook already current.*checkpoint-gate"; then r=true; else r=false; fi
+assert_eq "T7 identical hook reports 'already current'" "true" "$r"
+
+# ---------------------------------------------------------------------------
+echo "[T8] Missing settings.json: created with correct shape"
+# ---------------------------------------------------------------------------
+reset_state
+[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
+assert_eq "T8a settings.json absent before install" "false" "$r"
+
+run_installer --install-hooks
+[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
+assert_eq "T8b settings.json created" "true" "$r"
+
+hooks_present=$(jq 'has("hooks")' "$TEST_HOME/.claude/settings.json")
+assert_eq "T8c created settings.json has hooks key" "true" "$hooks_present"
+
+# ---------------------------------------------------------------------------
+echo "[T9] Atomic settings.json write: orphan .tmp does not corrupt original"
+# Codex review fix: writeJSONAtomic uses temp + rename so a partial-write
+# scenario leaves the existing settings.json intact.
+# ---------------------------------------------------------------------------
+reset_state
+run_installer --install-hooks
+sha_settings_before=$(shasum "$TEST_HOME/.claude/settings.json" | awk '{print $1}')
+
+# Plant an orphan .tmp from a notional crashed prior run. The installer's next
+# atomic write must overwrite the .tmp via fs.writeFileSync (truncate semantics)
+# then rename atomically — leaving no .tmp behind and the real settings.json
+# valid JSON post-run.
+echo "{ partial garbage" > "$TEST_HOME/.claude/settings.json.tmp"
+run_installer --install-hooks
+
+if [ -f "$TEST_HOME/.claude/settings.json.tmp" ]; then r=true; else r=false; fi
+assert_eq "T9a orphan .tmp cleared after atomic write (renamed away)" "false" "$r"
+
+if jq empty "$TEST_HOME/.claude/settings.json" 2>/dev/null; then r=true; else r=false; fi
+assert_eq "T9b settings.json is valid JSON after atomic write" "true" "$r"
+
+# Re-running without changes should be byte-identical (atomic determinism).
+sha_settings_after=$(shasum "$TEST_HOME/.claude/settings.json" | awk '{print $1}')
+assert_eq "T9c second atomic write yields byte-identical settings.json" "$sha_settings_before" "$sha_settings_after"
+
+# ---------------------------------------------------------------------------
+echo "[T10] Exact-path idempotence: same basename at different path is NOT a dup"
+# Codex review fix: registrations key on exact canonical command, not
+# basename substring. A user-installed file at a different path must not
+# false-positive and skip the canonical registration.
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude"
+cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "/somewhere/else/checkpoint-gate.sh", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+JSON
+run_installer --install-hooks
+
+cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T10a both checkpoint-gate registrations coexist (different paths)" "2" "$cg_total"
+
+# Non-canonical entry preserved verbatim.
+nc=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/somewhere/else/checkpoint-gate.sh")] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T10b non-canonical /somewhere/else/checkpoint-gate.sh entry preserved" "1" "$nc"
+
+canonical_path="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
+canon_count=$(jq --arg p "$canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T10c canonical checkpoint-gate.sh registered at exact installed path" "1" "$canon_count"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+[ $failed -eq 0 ]

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -420,8 +420,17 @@ test('T6b. install.mjs --install-hooks registers em-session-end-prompt.mjs as a 
     assert.ok(fs.existsSync(settingsPath), '~/.claude/settings.json must exist after --install-hooks')
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
     assert.ok(settings.hooks && Array.isArray(settings.hooks.SessionEnd), 'SessionEnd hooks array must exist')
-    const registered = settings.hooks.SessionEnd.some(h => h.command && h.command.includes('em-session-end-prompt'))
-    assert.ok(registered, 'em-session-end-prompt must be registered as a SessionEnd hook command')
+    // Per Codex review (PR-B): assert canonical nested hook entry shape.
+    // Earlier flat-only check `entry.command.includes(...)` passed against
+    // the malformed `{command, description}` shape that Claude Code never
+    // executed; left a false-passing assertion in the suite. This now
+    // requires entry.hooks[] with type=command and a command containing
+    // em-session-end-prompt — the shape Claude Code actually runs.
+    const registered = settings.hooks.SessionEnd.some(entry =>
+      Array.isArray(entry.hooks) &&
+      entry.hooks.some(h => h && h.type === 'command' && typeof h.command === 'string' && h.command.includes('em-session-end-prompt'))
+    )
+    assert.ok(registered, 'em-session-end-prompt must be registered as a nested SessionEnd hook entry { hooks: [{ type: "command", command, ... }] }')
   } finally {
     fs.rmSync(installHome, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

PR-B of [#59](https://github.com/lantisprime/episodic-memory/issues/59) (Phase 3b runtime deploy). PR-A ([#62](https://github.com/lantisprime/episodic-memory/pull/62)) shipped the canonical hook scripts + 4-marker cleanup + tests to the repo. PR-B is the **wiring** that makes them actually fire on user systems, plus reconciliation of the RFC-002 acceptance criteria and bp-001 enforcement table.

## What this PR ships

- **`install.mjs --install-hooks` extension** — copies `hooks/checkpoint-gate.sh` + `hooks/em-recall-sessionstart.sh` into `~/.claude/hooks/` (preserving local edits unless `--install-hooks-force`) and registers PreToolUse + SessionStart + SessionEnd entries in `~/.claude/settings.json`.
- **Format-bug fix + migration** — earlier installer versions wrote SessionEnd in the flat shape `{command, description}`, which Claude Code never executes. Now writes the canonical nested shape `{matcher?, hooks: [{type, command, timeout}]}` and one-shot migrates pre-existing flat entries in place (preserves the original command verbatim).
- **Atomic settings.json writes** (temp + rename) so partial-write failure cannot corrupt user settings.
- **Divergent-skip-no-register** — when a local hook file diverges from the repo source, the installer skips both file copy and new registration unless `--install-hooks-force` is passed. Existing registrations pointing at the same canonical path are preserved.
- **Exact-path idempotence** — keys on full canonical command path, not basename substring; legacy substring matching is migration-only.
- **Stale-canonical detection + warning** — after migration, surfaces any entries whose basename matches a canonical hook this installer manages but at a different path, so the user can prune the dead pointer.
- **Consent-legibility output** — final summary lists every file written and every settings.json mutation.
- **`patterns/implementation-workflow.md`** — adds `checkpoint-gate.sh` row to bp-001 enforcement table (Strong / Claude Code only).
- **RFC-002 spec reconciliation** — flips 22 of 23 Phase 3b acceptance criteria to `[x]` (all backed by automated tests in this branch). Leaves 1 explicitly unchecked + annotated because no automated test exercises the full SessionStart → em-recall activator → marker chain end-to-end. Adds "Push-gate bypass tradeoffs" subsection codifying in-session-only enforcement and the [#61](https://github.com/lantisprime/episodic-memory/issues/61) suppressed-stdout limitation.

## Why now

While planning PR-B I ran the existing `--install-hooks` against my own `~/`. Findings:

- `~/.episodic-memory/scripts/` had only 7 of 13 scripts (missing `em-recall.mjs`, `em-violation.mjs`, `em-pattern-health.mjs`, `em-prune.mjs`, `em-session-end-prompt.mjs`, `em-watch-codex.mjs`). User hadn't re-run installer since RFC-001 Phase 3 + RFC-002 Phase 1/2/3 landed.
- `~/.claude/hooks/` had no Phase 3b hooks. PR-A's runtime never fired on this system.
- The SessionEnd entry wired by the legacy installer was malformed (flat shape) — Claude Code wasn't executing it. This had been latent since the `--install-hooks` flag was first added; existing acceptance test [tests/test-rfc002-phase3.mjs:423](tests/test-rfc002-phase3.mjs:423) only string-matched on `entry.command`, so the bug passed CI.

Both gaps validate [memory/feedback_spec_vs_runtime.md](.) — "spec-shipped" is not "runtime-deployed."

## Codex pre-build review trail

- Plan request: episode `20260502-052950-codex-review-request-phase-3b-pr-b-plan--5849`.
- Verdict: `request_changes` — episode `20260502-053655-codex-review-reply-phase-3b-pr-b-plan-ne-459c`.
- All 4 P1 findings folded into Commit 1 before any code ran:
  1. Atomic settings.json writes
  2. Divergent file skip → withhold new registration unless `--install-hooks-force`
  3. Tighten T6b in `tests/test-rfc002-phase3.mjs` to assert canonical nested shape
  4. New-registration idempotence on exact canonical path, not basename substring

## Local code review trail (Rule 18 step 6/7)

Subagent review identified two P2 findings, fixed in Commit 4:
1. `--install-hooks-force` without `--install-hooks` silently no-oped → now warns.
2. After migration, stale canonical-named entry at non-canonical path coexists with newly-added canonical → now warns per stale entry.

## Test plan

- [x] `tests/test-install-hooks.sh` — **40 tests** against temp HOME / temp project covering: T1 fresh install, T2 idempotence, T3 malformed migration, T4 unrelated-existing hooks preserved, T5 divergent skip + registration withheld + prior preserved, T6 force overwrite, T7 identical unchanged, T8 missing settings.json created, T9 atomic write, T10 exact-path idempotence (different path, same basename), T11 force-without-base warning, T12 stale-canonical detection.
- [x] `tests/test-rfc002-phase3.mjs` T6b updated to assert canonical nested entry shape (regression guard for the malformed-flat shape that was passing before).
- [x] Full suite: 12 test files, all passing, no regressions.
- [x] **Rule 18 step 8 — manual E2E walkthrough** on throwaway temp HOME exercising the full 9-step flow:
  - Install → settings registered correctly → arm `.checkpoint-required` → Write blocked → write `.pre-checkpoint-done` → Write allowed + `.post-checkpoint-required` armed → `git push` blocked → write `.post-checkpoint-done` → push allowed + all 4 markers cleaned → re-run installer → byte-identical (idempotent) → planted non-canonical entry → canonical added separately → stale-canonical migration warning surfaces.
- [ ] User approval per Rule 17

## Known limitations (deferred)

- **[#61](https://github.com/lantisprime/episodic-memory/issues/61)** — `em-recall-sessionstart.sh` suppresses em-recall stdout. The marker side effects fire (so the gate still works), but violation warnings produced by the activator do not surface to the AI as `additionalContext`. Separate concern from deploy scope.
- **[#67](https://github.com/lantisprime/episodic-memory/issues/67)** — checkpoint-gate.sh allowlist still bypassable via quoted strings or `$(...)`. Accepted per PR-A threat model.
- **Push-gate is in-session only.** Pushes from a separate terminal, Git GUI, IDE integration, or CI bypass it. RFC-002 spec now explicitly notes this and the escalation path (`.git/hooks/pre-push` or CI gate).
- **Phase 3b-H1/H2 hardening** — own PRs per RFC-002:359-360.

## Commit walk

1. `feat(install): Phase 3b PR-B — deploy hooks + atomic settings.json + format migration` — installer extension, helper functions, 36-test suite, T6b nested-shape update.
2. `docs(bp-001): add checkpoint-gate.sh to enforcement table` — patterns/implementation-workflow.md row.
3. `docs(rfc-002): Phase 3b acceptance flips + push-gate bypass tradeoffs` — RFC-002 22-of-23 checkbox flips with explicit reasoning for the unchecked one + bypass-tradeoffs subsection.
4. `fix(install): code review P2 findings — flag-without-base + stale-canonical detection` — addresses the two non-blocking P2s from Rule 18 step 6 review; +4 tests (T11/T12).

Closes #79
Refs #59, #61, #62, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)