### PR TITLE
docs(claude.md): point project agents at docs/rfc and PRINCIPLES.md; ban mental tracing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 - `.claude-plugin/plugin.json` — Claude Code plugin manifest
 - `skills/episodic-memory/` — Claude Code skill (symlinks to instructions/ and scripts/)
 
+
 ## Data locations
 - Global: `~/.episodic-memory/` (scripts, episodes, index)
 - Per-project: `.episodic-memory/` (local episodes + index)
+- `docs/rfc/` - contains the RFC to be used in implementation when the statis is ACCEPTED
+- PRINCIPLES.MD - when planning, designing and implementing requirements, Claude Code ust read this and follow
 
 ## Development conventions
 - Scripts are `.mjs` (ESM) with zero external dependencies
@@ -19,6 +22,8 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 - Scripts handle missing data directories gracefully (create on first use)
 - Episode IDs are immutable; decisions are corrected via revision chains, not edits
 - Use atomic write (temp + rename) for index rebuilds
+- You must not do mental tracing always use the actual files or data
+- You must do code review and use the actual files
 
 ## Testing
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 ## Data locations
 - Global: `~/.episodic-memory/` (scripts, episodes, index)
 - Per-project: `.episodic-memory/` (local episodes + index)
-- `docs/rfc/` - contains the RFC to be used in implementation when the statis is ACCEPTED
-- PRINCIPLES.MD - when planning, designing and implementing requirements, Claude Code ust read this and follow
+- `docs/rfc/` — contains the RFC to be used in implementation when the status is ACCEPTED
+- `PRINCIPLES.md` — when planning, designing, and implementing requirements, Claude Code must read this and follow
 
 ## Development conventions
 - Scripts are `.mjs` (ESM) with zero external dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 ## Data locations
 - Global: `~/.episodic-memory/` (scripts, episodes, index)
 - Per-project: `.episodic-memory/` (local episodes + index)
-- `docs/rfc/` — contains the RFC to be used in implementation when the status is ACCEPTED
+- `docs/rfcs/` — contains the RFC to be used in implementation when the status is ACCEPTED
 - `PRINCIPLES.md` — when planning, designing, and implementing requirements, Claude Code must read this and follow
 
 ## Development conventions


### PR DESCRIPTION
## Summary

Adds doctrine bullets to CLAUDE.md that have been load-bearing in recent project sessions but weren't codified in the file:

- **Data locations** section: tells project agents that `docs/rfc/` is where accepted RFCs live and `PRINCIPLES.md` is required reading for planning / design / implementation.
- **Development conventions** section: bans mental tracing — agents must read the actual files or data, and code review must reference the actual files (not the reviewer's recall of them).

The "no mental tracing" rule especially earned its place this session: every bp-001 violation in the Phase 3b PR-B session ([5 logged](.episodic-memory/episodes/)) traced to declaring a step done without producing the artifact — exactly the failure mode this rule names.

## Notes for reviewer

The text is preserved verbatim from the user's local edit so authorship intent is unchanged. There are minor typos that could be fixed in a follow-up if desired:

- "the statis is ACCEPTED" → likely "the status is ACCEPTED"
- "PRINCIPLES.MD" → file is actually `PRINCIPLES.md` on disk
- "Claude Code ust read this and follow" → "must read"
- The "no mental tracing" bullet is one long line; could be split for readability

Happy to open a follow-up grammar PR if you want, or fold edits into this one before merge.

## Test plan

- [x] Documentation only — no code, no tests
- [ ] User approval per Rule 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)