### PR TITLE
docs(rfc): flip RFC-003 status to accepted

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -10,7 +10,7 @@ RFCs document proposed changes to the episodic-memory system. Every non-trivial 
 |---|---|---|---|
 | RFC-001 | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, and Semantic Consolidation | accepted | Charlton Ho |
 | RFC-002 | Learning Loop: Violation Tracking, Pattern Refinement, and Actionable Recall | accepted | Charlton Ho |
-| RFC-003 | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | draft | Charlton Ho |
+| RFC-003 | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | accepted | Charlton Ho |
 
 ---
 

--- a/docs/rfcs/RFC-003-pluggable-tool-adapters.md
+++ b/docs/rfcs/RFC-003-pluggable-tool-adapters.md
@@ -2,7 +2,7 @@
 rfc_id: RFC-003
 slug: pluggable-tool-adapters
 title: "Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging"
-status: draft
+status: accepted
 champion: Charlton Ho
 created: 2026-05-02
 last_modified: 2026-05-02

--- a/docs/rfcs/pending-analysis.md
+++ b/docs/rfcs/pending-analysis.md
@@ -6,7 +6,7 @@ Raw input for future RFCs. Each entry is a problem + evidence + candidate direct
 
 ## MCP surface vs file-based install — convergent peer signal vs design differentiator
 
-**Status:** seed for potential RFC (numbered after RFC-003 if that lands)
+**Status:** seed for potential RFC (numbered after RFC-003, which is now accepted)
 **Date:** 2026-05-01
 **Triggering question:** Peer-system research synthesis (knowledge_base/) found all major neighbors expose memory via MCP server. This repo exposes via instruction files. Is this a gap to close, or the differentiator?
 


### PR DESCRIPTION
## Summary
- RFC-003 (Pluggable Tool Adapters) was merged via #74 but the frontmatter still read `status: draft` — fix the lifecycle drift.
- Update `docs/rfcs/README.md` table cell `draft` → `accepted`.
- Update `docs/rfcs/pending-analysis.md` MCP-surface seed note: "if that lands" → "now accepted".
- Second-opinion section (required before acceptance per Rule 10) already present at RFC-003 line 446.

## Test plan
- [ ] `grep -n "status:" docs/rfcs/RFC-003-pluggable-tool-adapters.md` shows `accepted`.
- [ ] `docs/rfcs/README.md` table row for RFC-003 reads `accepted`.
- [ ] `docs/rfcs/pending-analysis.md` no longer says "if that lands" for RFC-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)