### PR TITLE
fix: activate Phase 3b checkpoint gate by decoupling marker arming from task_type

### DIFF
--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -3,15 +3,17 @@ set -e
 
 # em-recall-sessionstart.sh — RFC-002 Phase 3b SessionStart hook
 #
-# Mechanically invokes em-recall at session start. The only effective side
-# effect today is the marker activation: if bp-001 surfaces in pre-flight,
-# em-recall.mjs:347-369 touches $CWD/.claude/.checkpoint-required, which
-# arms checkpoint-gate.sh.
+# Mechanically invokes em-recall at session start. The effective side effect
+# is the marker activation: em-recall.mjs's shouldArmBp001Checkpoint
+# predicate runs unconditionally on session start (decoupled from
+# --task-type), and arms $CWD/.claude/.checkpoint-required whenever a recent
+# bp-001-implementation-workflow violation exists, which in turn arms
+# checkpoint-gate.sh.
 #
-# Known limitation (#65, #61): em-recall stdout is redirected to /dev/null,
-# so violation warnings do NOT surface to the AI yet. Spec line 220 calls
-# for surfacing via SessionStart additionalContext JSON; the protocol work
-# was deferred so the runtime gate could land first.
+# Known limitation (#61): em-recall stdout is redirected to /dev/null, so
+# violation warnings do NOT surface to the AI yet. Spec line 220 calls for
+# surfacing via SessionStart additionalContext JSON; the protocol work is
+# tracked under #61.
 #
 # Per Codex review: parse cwd from stdin, cd to it, then run em-recall with
 # no project arg so cwd/git inference owns project resolution. This keeps

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -234,6 +234,45 @@ function runViolationPreflight(activeEntries, taskType, patterns) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 3b activation predicate: returns true iff there exists at least one
+// active (non-superseded) episode within the 30-day cutoff that is a
+// bp-001-implementation-workflow violation. Decoupled from task_type so the
+// SessionStart hook can arm the checkpoint marker even when branch/task-type
+// inference returns null. Pure function — testable in isolation and stable
+// for #80's later validator-backed gate to swap.
+// ---------------------------------------------------------------------------
+function shouldArmBp001Checkpoint(activeEntries, now) {
+  const cutoff = new Date(now)
+  cutoff.setDate(cutoff.getDate() - 30)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+  const tag = 'violated:bp-001-implementation-workflow'
+  return activeEntries.some(e =>
+    e &&
+    e.category === 'violation' &&
+    Array.isArray(e.tags) &&
+    e.tags.includes(tag) &&
+    typeof e.date === 'string' &&
+    e.date >= cutoffStr
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Idempotent marker arming. Best-effort — failures are swallowed so a
+// non-writable .claude dir doesn't take down the whole recall.
+// ---------------------------------------------------------------------------
+function armCheckpointMarker(cwd) {
+  try {
+    const claudeDir = path.join(cwd, '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    const markerPath = path.join(claudeDir, '.checkpoint-required')
+    if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
+  } catch {
+    // Best-effort: marker creation failure leaves Phase 3b gate inactive
+    // for this session.
+  }
+}
+
+// ---------------------------------------------------------------------------
 // SYNC: em-search.mjs:loadIndex — update both on change
 // ---------------------------------------------------------------------------
 function loadIndex(dataDir, source) {
@@ -330,42 +369,34 @@ const context = inferContext()
 const preflight_warnings = []
 
 // ---------------------------------------------------------------------------
+// Phase 3b activation (RFC-002 Phase 3 / T7): arm the checkpoint marker
+// whenever a recent bp-001-implementation-workflow violation exists,
+// regardless of task_type. The SessionStart hook
+// (hooks/em-recall-sessionstart.sh) does not pass --task-type, so a
+// task-type-conditional arming path was inert in real sessions despite
+// Phase 3b being deployed. bp-001 is workflow discipline that applies to
+// any session that ends up writing files; checkpoint-gate itself only
+// blocks write tools, so the false-positive surface is bounded.
+// ---------------------------------------------------------------------------
+if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
+  armCheckpointMarker(process.cwd())
+}
+
+// ---------------------------------------------------------------------------
 // Task type: explicit flag wins; otherwise infer from branch tokens.
-// `null` means task type is unclear → no violation pre-flight runs (T3).
+// `null` means task type is unclear → no task-type-scoped pre-flight runs
+// (T3). Marker arming above is independent.
 // ---------------------------------------------------------------------------
 const taskType = taskTypeFlag || inferTaskType(context.branch_tokens)
 
 // ---------------------------------------------------------------------------
-// Violation pre-flight (RFC-002 Phase 3 / T1-T5)
+// Violation pre-flight (RFC-002 Phase 3 / T1-T5) — task-type-scoped
+// warnings for ranking and user-facing messaging.
 // ---------------------------------------------------------------------------
 if (taskType) {
   const patterns = loadPatternsIndex()
   const violationWarnings = runViolationPreflight(activeEntries, taskType, patterns)
   preflight_warnings.push(...violationWarnings)
-}
-
-// ---------------------------------------------------------------------------
-// Phase 3b activation hook (RFC-002 Phase 3 / T7): when a bp-001 violation
-// surfaces, touch .claude/.checkpoint-required in cwd. Phase 3b's
-// checkpoint-gate.sh reads this marker to gate write tools. Best-effort
-// atomic create — no locking, failure is non-fatal. Phase 3b's full SessionEnd
-// sweep will own the four-marker lifecycle; until then,
-// em-session-end-prompt.mjs sweeps this marker so it doesn't persist between
-// sessions when the gate isn't active.
-// ---------------------------------------------------------------------------
-const bp001Surfaced = preflight_warnings.some(w =>
-  w && w.type === 'violation' && w.pattern_id === 'bp-001-implementation-workflow'
-)
-if (bp001Surfaced) {
-  try {
-    const claudeDir = path.join(process.cwd(), '.claude')
-    fs.mkdirSync(claudeDir, { recursive: true })
-    const markerPath = path.join(claudeDir, '.checkpoint-required')
-    if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
-  } catch {
-    // Best-effort: marker creation failure leaves Phase 3b gate inactive
-    // for this session. Surfacing the warning to the user is what matters.
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -21,7 +21,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 import assert from 'assert'
 
 const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
@@ -313,14 +313,40 @@ test('T7b. No marker when only non-bp-001 violations surface', () => {
   assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist when bp-001 is not surfaced')
 })
 
-test('T7c. No marker when task type is unclear (no pre-flight runs)', () => {
+test('T7c. Marker arms when bp-001 violations exist even if task type is unclear', () => {
+  // Phase 3b activation fix: the SessionStart hook does not pass --task-type,
+  // and branch inference can return null. Marker arming is now decoupled from
+  // task_type — bp-001 violations alone are sufficient. Without this, the
+  // gate was inert in real sessions despite being deployed.
   clearStore()
   clearMarker()
   for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
   rebuild()
-  setBranch('main') // no keyword match
+  setBranch('main') // no keyword match → inferTaskType returns null
   recall('--no-track')
-  assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist when task type unknown')
+  assert.ok(fs.existsSync(markerPath), '.checkpoint-required must exist when bp-001 violations recent, regardless of task_type')
+})
+
+test('T7c2. No marker when there are no recent bp-001 violations (regardless of task type)', () => {
+  clearStore()
+  clearMarker()
+  // Seed only non-bp-001 violations
+  for (let d = 1; d <= 3; d++) seedViolation('bp-006-push-after-verify', d)
+  rebuild()
+  setBranch('main')
+  recall('--no-track')
+  assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist without bp-001 violations')
+})
+
+test('T7c3. No marker when bp-001 violations are older than 30-day cutoff', () => {
+  clearStore()
+  clearMarker()
+  // Seed bp-001 violations 31 and 60 days ago — outside cutoff
+  seedViolation('bp-001-implementation-workflow', 31)
+  seedViolation('bp-001-implementation-workflow', 60)
+  rebuild()
+  recall('--no-track')
+  assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist for stale (>30d) violations')
 })
 
 test('T7d. Marker creation is idempotent (re-recall does not error)', () => {
@@ -434,6 +460,66 @@ test('T6b. install.mjs --install-hooks registers em-session-end-prompt.mjs as a 
   } finally {
     fs.rmSync(installHome, { recursive: true, force: true })
   }
+})
+
+test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (Phase 3b activation E2E)', () => {
+  // Closes the 23rd unchecked RFC-002 Phase 3b acceptance criterion: no E2E
+  // test had previously exercised the SessionStart -> em-recall -> marker
+  // chain with the real hook script and a real em-recall. This is the bug
+  // class that left Phase 3b inert in production despite all unit tests
+  // passing — the hook does not pass --task-type, but the unit tests did.
+  const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p3-sshook-'))
+  const sessionProject = path.join(sessionHome, 'project')
+  fs.mkdirSync(sessionProject, { recursive: true })
+  execSync('git init -q', { cwd: sessionProject })
+  execSync('git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init', { cwd: sessionProject })
+  // Branch with no task-type keywords so inferTaskType returns null —
+  // exercises the activation path that ignores task_type.
+  execSync('git checkout -q -B main', { cwd: sessionProject })
+
+  // Install patterns + real em-recall under the test HOME, mirroring how
+  // install.mjs lays out scripts.
+  const sessionPatterns = path.join(sessionProject, 'patterns')
+  fs.mkdirSync(sessionPatterns, { recursive: true })
+  fs.copyFileSync(srcIndex, path.join(sessionPatterns, '_index.json'))
+
+  const sessionScripts = path.join(sessionHome, '.episodic-memory', 'scripts')
+  fs.mkdirSync(sessionScripts, { recursive: true })
+  // Copy every script the recall path may execSync into (em-track-recall.mjs
+  // is invoked unless --no-track is passed; the hook runs without --no-track).
+  const SCRIPTS_DIR = path.join(REPO_ROOT, 'scripts')
+  for (const f of fs.readdirSync(SCRIPTS_DIR)) {
+    if (f.endsWith('.mjs')) {
+      fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(sessionScripts, f))
+    }
+  }
+
+  // Seed a recent bp-001 violation in the project's local store using
+  // the same env/HOME the hook will run under.
+  const sessionEnv = { ...process.env, HOME: sessionHome }
+  execSync(`node "${VIOLATION}" --pattern bp-001-implementation-workflow --summary "seeded e2e" --body "test" --scope local`, {
+    cwd: sessionProject, env: sessionEnv, encoding: 'utf8'
+  })
+  // Backdate to today (already today) and rebuild index just in case.
+  execSync(`node "${REBUILD}" --scope all`, { cwd: sessionProject, env: sessionEnv })
+
+  const hookPath = path.join(REPO_ROOT, 'hooks', 'em-recall-sessionstart.sh')
+  const markerOut = path.join(sessionProject, '.claude', '.checkpoint-required')
+  assert.ok(!fs.existsSync(markerOut), 'precondition: marker should not exist')
+
+  const stdin = JSON.stringify({ cwd: sessionProject })
+  // Run the hook EXACTLY the way Claude Code would: stdin JSON, HOME pointing
+  // at the user's installed em-recall, no --task-type passed. Use spawnSync
+  // with input rather than echo+pipe so tmpdir paths containing quotes
+  // can't corrupt the JSON.
+  spawnSync('bash', [hookPath], {
+    input: stdin, env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+  })
+
+  assert.ok(fs.existsSync(markerOut),
+    '.checkpoint-required must be armed by the real SessionStart hook with no --task-type — Phase 3b activation E2E')
+
+  fs.rmSync(sessionHome, { recursive: true, force: true })
 })
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Phase 3b's runtime checkpoint gate (PR-A #62, PR-B #78) was merged + globally installed but **never armed in real sessions**. The SessionStart hook invokes em-recall without `--task-type`; em-recall's marker-arming logic was gated on task_type, so with task_type=null nothing armed. Six bp-001 violations accumulated in one session before this was discovered.

Codex (cross-tool peer review, ep `...e8b5`) verified empirically: no `--task-type` → no preflight warnings → no marker. With `--task-type implementation` → 14 bp-001 warnings → marker armed.

## Fix

`scripts/em-recall.mjs`:
- New pure predicate `shouldArmBp001Checkpoint(activeEntries, now)` — returns true if any active episode is a bp-001-implementation-workflow violation within the 30-day cutoff. Decoupled from task_type. Stable interface for [#80](https://github.com/lantisprime/episodic-memory/issues/80)'s later validator-backed gate to swap.
- New helper `armCheckpointMarker(cwd)` — idempotent marker write.
- New unconditional arming path runs before task_type computation. Existing task-type-scoped `runViolationPreflight()` preserved for ranking/messaging.

`hooks/em-recall-sessionstart.sh`: comment block updated (line numbers + bp-001 surface description were stale).

## Tests

- **T7c flipped** — bp-001 violations arm the marker even when task type is unclear. This is the bug fix.
- **T7c2** — no marker when only non-bp-001 violations exist.
- **T7c3** — no marker when bp-001 violations are >30 days old.
- **T7j (E2E)** — runs the real `hooks/em-recall-sessionstart.sh` with JSON stdin against a real em-recall under isolated HOME, asserts marker armed with no `--task-type`. Uses `spawnSync` rather than `echo | bash` per code review (defends against tmpdir paths with quotes). **Closes the missing 23rd RFC-002 Phase 3b acceptance criterion.**

All test suites green: phase-3 (28), checkpoint-gate (91), sessionstart (9), plan-gate (13), phase2 (24), phase3 (20), rfc002-phase1 (17), rfc002-phase2 (31), p3-fixes (7), seed-patterns (15), em-watch-codex (25).

## Out of scope (separate issues)
- [#61](https://github.com/lantisprime/episodic-memory/issues/61) — em-recall SessionStart `additionalContext` / stdout. Codex confirmed not the activation blocker; visibility fix.
- Worktree `LOCAL_DIR` footgun (em-recall reads `process.cwd()/.episodic-memory`, invisible to main-repo store from a worktree). Will file new issue.
- [#80](https://github.com/lantisprime/episodic-memory/issues/80) / Phase 3b-H1 — unchanged priority; lands on top of working baseline.

## Test plan
- [x] `node tests/test-rfc002-phase3.mjs` — 28/28
- [x] All other test suites — green
- [x] Manual E2E in this real session — em-recall (no `--task-type`) arms `.claude/.checkpoint-required` given existing bp-001 violations in local memory
- [ ] After merge: pull global install + verify Phase 3b gate fires in next session start (the actual production verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)