### PR TITLE
fix(hooks): canonicalize plan-gate.sh + close tool-name allowlist gap (PR-A for #86)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -11,23 +11,29 @@ Phase 3b (RFC-002) introduces user-level hooks that need to be installed into `~
 - **One hook per file.** Each script handles a single hook event (PreToolUse, SessionStart, etc.).
 - **Hooks are bash + jq + grep.** Some hooks (e.g. `em-recall-sessionstart.sh`) delegate to Node scripts living elsewhere; the hook *script itself* stays bash so install + diagnosis don't depend on Node being available before any tool runs.
 - **`set -e` and JSON via stdin.** Claude Code passes hook input as JSON on stdin; emit a `{"decision": "block", "reason": "..."}` JSON to block.
-- **Test against the repo source.** Tests in `tests/test-*.sh` invoke `$REPO/hooks/<name>.sh` directly with a temp `cwd` and `HOME`, not the installed copy at `~/.claude/hooks/`. This means PR diffs verify the actual checked-in hook content, not whatever a maintainer happened to install locally. Exception: hook *composition* tests must reference an installed peer hook (e.g. `plan-gate.sh`), since that hook is currently user-maintained outside this repo. Such tests gracefully skip if the peer is absent.
+- **Test against the repo source.** Tests in `tests/test-*.sh` invoke `$REPO/hooks/<name>.sh` directly with a temp `cwd` and `HOME`, not the installed copy at `~/.claude/hooks/`. This means PR diffs verify the actual checked-in hook content, not whatever a maintainer happened to install locally.
 
 ## Files
 
 | Hook | Event | Purpose |
 |------|-------|---------|
 | `checkpoint-gate.sh` | PreToolUse | RFC-002 Phase 3b two-gate write/push enforcement |
+| `plan-gate.sh` | PreToolUse | Blocks write tools while `.claude/.plan-approval-pending` exists; allows read-only tools (canonical list lives in the `case` at `hooks/plan-gate.sh` — do not duplicate here). Issue #86 PR-A canonicalized this from a previously user-maintained file. |
 | `em-recall-sessionstart.sh` | SessionStart | Mechanically invokes em-recall so its activator can arm checkpoint-gate before any user interaction |
 
 ## Installation
 
-Until PR-B (per #59) lands its conservative installer, users must install hooks manually. The PR-B `install.mjs --install-hooks` will:
+`install.mjs --install-hooks` (PR-B per #59 + PR-A per #86):
 
-- Compare each repo file against the user-installed copy at `~/.claude/hooks/`
-- **Skip with a warning** when they differ (preserving local edits)
-- Only overwrite under explicit `--install-hooks-force`
-- Register hooks in `~/.claude/settings.json` and chmod them executable
+- Compares each repo file against the user-installed copy at `~/.claude/hooks/`
+- **Skips with a warning** when they differ (preserving local edits) AND withholds new settings registration unless a prior canonical registration exists
+- Only overwrites under explicit `--install-hooks-force`
+- Registers hooks in `~/.claude/settings.json` (atomic temp+rename) and chmods them executable
+- Surfaces stale-canonical-named entries (same basename, different path) as warnings without auto-removing them
+
+## Bash command-level allowlisting (deferred to PR-B per issue #86)
+
+`plan-gate.sh` currently blocks **all** Bash invocations while the marker is set, even read-only ones (`ls`, `grep`, `cat`, etc.). PR-A canonicalizes the hook + adds the missing read-only tool-name allowlist entries (`NotebookRead`, `ToolSearch`); strict per-command Bash allowlisting is the scope of a follow-up PR-B.
 
 ## Editing rules
 
@@ -37,3 +43,4 @@ Until PR-B (per #59) lands its conservative installer, users must install hooks 
 
 - RFC-002 Phase 3b spec: `docs/rfcs/RFC-002-learning-loop.md`
 - Tracking issue: #59
+- plan-gate canonicalization: #86 (PR-A: tool-name allowlist + canonicalize; PR-B: strict Bash command allowlist)

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+# plan-gate.sh — PreToolUse hook
+# Blocks write tools while .claude/.plan-approval-pending exists in the project.
+# Read-only tools are always allowed (needed for planning).
+
+INPUT="$(cat)"
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
+CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+MARKER="$CWD/.claude/.plan-approval-pending"
+
+# Read-only tools — always allowed.
+# NotebookRead and ToolSearch added per issue #86 (PR-A): both are read-only /
+# planning traffic and were empirically blocked while a plan-approval marker
+# was set. BashOutput / KillBash are intentionally NOT on this list pending a
+# follow-up evaluation — KillBash mutates process state.
+case "$TOOL_NAME" in
+  Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
+    exit 0
+    ;;
+esac
+
+# If no marker, allow everything
+[ ! -f "$MARKER" ] && exit 0
+
+# Allow the specific command that removes the marker (unblock after approval)
+if [ "$TOOL_NAME" = "Bash" ]; then
+  COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
+  if echo "$COMMAND" | grep -qE '^rm\s+.*\.plan-approval-pending'; then
+    exit 0
+  fi
+fi
+
+# Marker exists — block write tools
+echo '{"decision": "block", "reason": "Plan approval pending. Review the plan above and approve before implementation. To approve, say \"go\" or \"approved\". The .claude/.plan-approval-pending marker will be removed and implementation will proceed."}'

--- a/install.mjs
+++ b/install.mjs
@@ -57,9 +57,10 @@ Tools:
 
 Hook flags (claude-code / Phase 3b):
   --install-hooks         Copy hooks/*.sh into ~/.claude/hooks/ and register
-                          checkpoint-gate (PreToolUse), em-recall-sessionstart
-                          (SessionStart), em-session-end-prompt (SessionEnd)
-                          in ~/.claude/settings.json. Skips divergent local
+                          checkpoint-gate + plan-gate (PreToolUse),
+                          em-recall-sessionstart (SessionStart), and
+                          em-session-end-prompt (SessionEnd) in
+                          ~/.claude/settings.json. Skips divergent local
                           hook files AND withholds new settings registration
                           for them (re-run with --install-hooks-force to
                           accept). Atomic settings.json write (temp+rename).
@@ -368,6 +369,16 @@ if (installHooks) {
         matcher: 'Edit|Write|MultiEdit|Bash|NotebookEdit',
         timeout: 5
       },
+      // plan-gate.sh: no matcher — must run on every PreToolUse so the
+      // tool-name allowlist (read-only tools) is the sole filter for what
+      // bypasses the marker. Issue #86 (PR-A): canonicalized into the repo
+      // and registered by the installer; Bash command-level allowlisting
+      // is deferred to PR-B.
+      {
+        file: 'plan-gate.sh',
+        event: 'PreToolUse',
+        timeout: 5
+      },
       {
         file: 'em-recall-sessionstart.sh',
         event: 'SessionStart',
@@ -452,6 +463,7 @@ if (installHooks) {
     const canonicalByBasename = {
       'em-session-end-prompt.mjs': path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'),
       'checkpoint-gate.sh': path.join(userHooksDir, 'checkpoint-gate.sh'),
+      'plan-gate.sh': path.join(userHooksDir, 'plan-gate.sh'),
       'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh')
     }
     const staleEntries = detectStaleCanonicalEntries(settings.hooks, canonicalByBasename)

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -73,8 +73,20 @@ assert_eq "T1a checkpoint-gate.sh installed and executable" "true" "$r"
 [ -x "$TEST_HOME/.claude/hooks/em-recall-sessionstart.sh" ] && r=true || r=false
 assert_eq "T1b em-recall-sessionstart.sh installed and executable" "true" "$r"
 
+# Issue #86 PR-A: plan-gate.sh canonicalized into repo + deployed by installer.
+[ -x "$TEST_HOME/.claude/hooks/plan-gate.sh" ] && r=true || r=false
+assert_eq "T1b2 plan-gate.sh installed and executable (#86 PR-A)" "true" "$r"
+
 cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T1c PreToolUse contains exactly one checkpoint-gate entry" "1" "$cg_count"
+
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1c2 PreToolUse contains exactly one plan-gate entry (#86 PR-A)" "1" "$pg_count"
+
+# plan-gate.sh registers with NO matcher (per design — must run on every
+# PreToolUse so the tool-name allowlist is the sole filter).
+pg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("plan-gate")) | .matcher // "<none>"' "$TEST_HOME/.claude/settings.json")
+assert_eq "T1c3 plan-gate registered with no matcher (runs on every PreToolUse)" "<none>" "$pg_matcher"
 
 ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T1d SessionStart contains exactly one em-recall-sessionstart entry" "1" "$ss_count"
@@ -98,6 +110,9 @@ assert_eq "T2a checkpoint-gate.sh unchanged after re-run" "$sha_before" "$sha_af
 
 cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T2b still exactly one checkpoint-gate entry after re-run" "1" "$cg_count"
+
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T2b2 still exactly one plan-gate entry after re-run (#86 PR-A)" "1" "$pg_count"
 
 ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T2c still exactly one em-recall-sessionstart entry after re-run" "1" "$ss_count"
@@ -163,13 +178,24 @@ cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
   }
 }
 JSON
-run_installer --install-hooks
+output=$(run_installer_capture --install-hooks)
 
 pre_total=$(jq '.hooks.PreToolUse | length' "$TEST_HOME/.claude/settings.json")
-assert_eq "T4a PreToolUse now has 2 entries (existing + checkpoint-gate)" "2" "$pre_total"
+# Post #86 PR-A: existing /some/user/plan-gate.sh + canonical checkpoint-gate
+# + canonical plan-gate = 3 entries. The stale /some/user/plan-gate.sh is
+# preserved verbatim (T4b) and the canonical is registered separately (T4b3).
+assert_eq "T4a PreToolUse now has 3 entries (existing plan-gate + canonical checkpoint-gate + canonical plan-gate)" "3" "$pre_total"
 
-plan_gate_intact=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
-assert_eq "T4b existing plan-gate.sh entry preserved" "1" "$plan_gate_intact"
+plan_gate_existing=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/some/user/plan-gate.sh")] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4b existing /some/user/plan-gate.sh entry preserved verbatim" "1" "$plan_gate_existing"
+
+plan_gate_canonical_path="$TEST_HOME/.claude/hooks/plan-gate.sh"
+plan_gate_canonical=$(jq --arg p "$plan_gate_canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T4b2 canonical plan-gate.sh registered at exact installed path (#86 PR-A)" "1" "$plan_gate_canonical"
+
+# Stale-canonical warning surfaced by detectStaleCanonicalEntries.
+if echo "$output" | grep -q "stale PreToolUse entry for plan-gate.sh"; then r=true; else r=false; fi
+assert_eq "T4b3 stale-canonical warning printed for non-canonical /some/user/plan-gate.sh" "true" "$r"
 
 ss_total=$(jq '.hooks.SessionStart | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T4c SessionStart now has 2 entries (existing + em-recall-sessionstart)" "2" "$ss_total"
@@ -447,6 +473,77 @@ JSON
   cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
   assert_eq "T14 v1 unquoted entry is recognized as canonical; no duplicate added" "1" "$cg_total"
 fi
+
+# ---------------------------------------------------------------------------
+echo "[T15] Issue #86 PR-A: divergent local plan-gate.sh — skipped + reg withheld"
+# Mirrors T5/T5a-T5d for checkpoint-gate. plan-gate.sh canonicalized into the
+# repo per #86 PR-A; the same conservative install behavior applies — we must
+# not point Claude at unreviewed custom content.
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
+echo "# user-customized plan-gate" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
+sha_before=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+
+output=$(run_installer_capture --install-hooks)
+sha_after=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+assert_eq "T15a divergent plan-gate.sh not overwritten" "$sha_before" "$sha_after"
+
+if echo "$output" | grep -q "Skipped (divergent local edit).*plan-gate.sh"; then r=true; else r=false; fi
+assert_eq "T15b warning printed for divergent plan-gate" "true" "$r"
+
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T15c new plan-gate registration WITHHELD when file install skipped" "0" "$pg_count"
+
+# T15d: divergent plan-gate + prior canonical registration → preserved.
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
+echo "# user-customized" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
+canon_pg_path="$TEST_HOME/.claude/hooks/plan-gate.sh"
+cat > "$TEST_HOME/.claude/settings.json" <<JSON
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$canon_pg_path", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+JSON
+output=$(run_installer_capture --install-hooks)
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T15d prior plan-gate registration preserved when file install skipped" "1" "$pg_count"
+
+# P2 (code review): assert the user-visible "existing registration preserved"
+# message actually printed for plan-gate. Without this, a branch flip in
+# install.mjs:installHooks (eligibleForReg → preserved/withheld) could regress
+# silently while the count assertion still passes.
+if echo "$output" | grep -q "PreToolUse plan-gate.sh: existing registration preserved"; then r=true; else r=false; fi
+assert_eq "T15e explicit 'existing registration preserved' message printed for plan-gate" "true" "$r"
+
+# ---------------------------------------------------------------------------
+echo "[T16] Issue #86 PR-A: --install-hooks-force overwrites divergent plan-gate AND registers"
+# ---------------------------------------------------------------------------
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
+echo "# user-customized" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
+run_installer --install-hooks --install-hooks-force
+
+sha_repo=$(shasum "$REPO_ROOT/hooks/plan-gate.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+assert_eq "T16a --install-hooks-force overwrites divergent plan-gate with repo version" "$sha_repo" "$sha_dest"
+
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+assert_eq "T16b --install-hooks-force registers plan-gate after overwrite" "1" "$pg_count"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -3,11 +3,21 @@
 #
 # Usage: bash tests/test-plan-gate.sh
 #
-# Tests the hook by piping mock JSON and checking exit codes + output.
+# Tests the repo source at $REPO/hooks/plan-gate.sh (issue #86 PR-A:
+# canonicalized into the repo). Fails fast if absent — CI must verify the
+# checked-in hook content, not whatever a maintainer happened to install
+# locally.
 
 set -uo pipefail
 
-HOOK="$HOME/.claude/hooks/plan-gate.sh"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/plan-gate.sh"
+
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: $HOOK not found in repo. Issue #86 PR-A canonicalizes plan-gate.sh into hooks/."
+  exit 1
+fi
+
 TEST_DIR=$(mktemp -d)
 MARKER="$TEST_DIR/.claude/.plan-approval-pending"
 passed=0
@@ -75,6 +85,22 @@ assert_allowed "1b. Glob tool allowed with marker" \
 assert_allowed "1c. Agent tool allowed with marker" \
   "$(mock_json 'Agent')"
 
+# Issue #86 PR-A: NotebookRead and ToolSearch added to read-only allowlist.
+assert_allowed "1d. NotebookRead allowed with marker (#86 PR-A)" \
+  "$(mock_json 'NotebookRead')"
+
+assert_allowed "1e. ToolSearch allowed with marker (#86 PR-A)" \
+  "$(mock_json 'ToolSearch')"
+
+assert_allowed "1f. Skill allowed with marker" \
+  "$(mock_json 'Skill')"
+
+assert_allowed "1g. WebFetch allowed with marker" \
+  "$(mock_json 'WebFetch')"
+
+assert_allowed "1h. mcp__ prefix allowed with marker" \
+  "$(mock_json 'mcp__some_server__some_tool')"
+
 assert_blocked "2. Edit blocked with marker" \
   "$(mock_json 'Edit')"
 
@@ -93,8 +119,20 @@ assert_blocked "6. rm without marker name blocked" \
 assert_blocked "7. Write tool blocked with marker" \
   "$(mock_json 'Write')"
 
-assert_blocked "7b. Bash read-only command also blocked with marker (hook blocks all Bash)" \
+# Issue #86 PR-B (deferred): plan-gate still blocks all read-only Bash. PR-A
+# does NOT introduce a Bash command-level allowlist. This guard ensures PR-B's
+# scope stays scoped — if PR-A inadvertently lets ls through, the test fails.
+assert_blocked "7b. Bash read-only command also blocked with marker (PR-B owns this)" \
   "$(mock_json 'Bash' 'ls -la')"
+
+# Issue #86 PR-A regression guard: BashOutput / KillBash deliberately NOT on
+# the allowlist (Codex review feedback — KillBash mutates process state; both
+# pending follow-up evaluation).
+assert_blocked "7c. BashOutput blocked with marker (deferred per Codex review)" \
+  "$(mock_json 'BashOutput')"
+
+assert_blocked "7d. KillBash blocked with marker (mutates process state)" \
+  "$(mock_json 'KillBash')"
 
 # ===========================================================================
 echo ""


### PR DESCRIPTION
## Summary
- Canonicalize `plan-gate.sh` into the repo (was user-maintained outside) and register it via `install.mjs --install-hooks` with no matcher (must run on every PreToolUse).
- Add `NotebookRead` and `ToolSearch` to the read-only tool-name allowlist — these were empirically blocked while a plan-approval marker was set.
- Deliberately do NOT add `BashOutput` or `KillBash` (per Codex review — KillBash mutates process state; both pending follow-up evaluation).

This is PR-A of Codex's recommended split for issue #86. PR-B (strict per-command Bash allowlisting) is deferred.

## Test plan
- [x] `bash tests/test-plan-gate.sh` — 20/20 pass (rewritten to source repo's `hooks/plan-gate.sh`; fail-fast if absent per Rule 13). New cases: NotebookRead/ToolSearch newly allowed; BashOutput/KillBash/read-only-Bash still blocked (PR-B scope guards).
- [x] `bash tests/test-install-hooks.sh` — 58/58 pass. New: T1b2/T1c2/T1c3 (fresh install), T2b2 (rerun idempotence), T4b2/T4b3 (pre-existing entries preserved + stale-warned), T15a-e (divergent local skipped + reg-withheld + prior-canonical preserved with explicit message assert), T16a-b (`--install-hooks-force` overwrites + registers). Covers all 5 install-hook scenarios from Codex's plan review.
- [x] Full test suite (`tests/test-*`): 344+ green.
- [x] E2E: manual `install.mjs --install-hooks` against fresh `TMPHOME` deploys all 3 hooks + writes settings.json with canonical nested-shape entries.
- [x] Subagent code review (Rule 18 step 6): P2-1 (README allowlist drift) + P2-2 (T15d missing message assert) fixed in-commit.

## Out of scope
- PR-B strict Bash command allowlist (separate PR).
- BashOutput allowlist evaluation (follow-up issue).
- checkpoint-gate.sh read-only Bash gap (related but distinct gate; follow-up issue).
- Issue #81 installer migrate-then-dedup gap (independent).

## Codex plan review
Approved with refinements at episode `20260502-080753-...-2427`. All recommendations applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)