### PR TITLE
docs: refresh README + USER_MANUAL for shipped Phase 3b, RFC-003, hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A **shared memory layer for AI coding agents**. Different agentic AI platforms �
 
 Works with: **Claude Code**, **Cursor**, **Codex (OpenAI)**, **Windsurf / Continue**
 
+The design principles guiding the system are documented in [PRINCIPLES.md](PRINCIPLES.md).
+
 ## Capabilities
 
 - **Cross-tool memory sharing** — A decision Claude Code made yesterday surfaces when Cursor or Codex starts working on the same project today. All four agents read/write the same episode files; no tool is siloed.
@@ -175,7 +177,7 @@ Behavioral patterns are documentation — they tell AI assistants **what** to fo
 - **Violation tracking** (`em-violation.mjs`) — structured storage with pattern linkage, searchable by `--category violation` and `--tag violated:<pattern_id>`
 - **Session-end prompt** (`em-session-end-prompt.mjs`) — SessionEnd hook that asks about violations
 - **Proactive recall** (`em-recall.mjs`) — surfaces past violations at session start as pre-flight warnings
-- **Checkpoint enforcement gate** (RFC-002 Phase 3b, coming) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done
+- **Checkpoint enforcement gate** (RFC-002 Phase 3b, shipped + activated 2026-05-02 via [#78](https://github.com/lantisprime/episodic-memory/pull/78) and [#84](https://github.com/lantisprime/episodic-memory/pull/84)) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done. Opt-in via `node install.mjs --tool claude-code --install-hooks --project <path>`; registers SessionStart + PreToolUse + SessionEnd hooks in `~/.claude/settings.json`.
 
 **External ([user-preferences](https://github.com/lantisprime/user-preferences)):**
 - **Pre-tool hooks** (e.g., `plan-gate.sh`) that block writes during the planning phase
@@ -189,7 +191,8 @@ Episodic-memory and user-preferences are fully independent — install either or
 | RFC | Title | Status |
 |-----|-------|--------|
 | [RFC-001](docs/rfcs/RFC-001-memory-improvements.md) | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, Semantic Consolidation | Accepted (Phases 1-3 shipped) |
-| [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Accepted (Phases 1-2 shipped) |
+| [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Accepted (Phases 1-3 + 3b shipped + runtime-deployed) |
+| [RFC-003](docs/rfcs/RFC-003-pluggable-tool-adapters.md) | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | Accepted (Phase 1 not yet started) |
 
 ## Scripts Reference
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -18,6 +18,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
+- [Scenario 12: The Checkpoint Gate Stopped the AI](#scenario-12-the-checkpoint-gate-stopped-the-ai)
 - [What Gets Stored and What Doesn't](#what-gets-stored-and-what-doesnt)
 - [Browsing Your Memories](#browsing-your-memories)
 - [Troubleshooting](#troubleshooting)
@@ -34,6 +35,9 @@ node ~/episodic-memory/install.mjs --tool cursor --project /path/to/my-project
 
 # For Claude Code
 node ~/episodic-memory/install.mjs --tool claude-code --project /path/to/my-project
+
+# For Claude Code with checkpoint enforcement hooks (opt-in, recommended)
+node ~/episodic-memory/install.mjs --tool claude-code --install-hooks --project /path/to/my-project
 
 # For Codex
 node ~/episodic-memory/install.mjs --tool codex --project /path/to/my-project
@@ -270,6 +274,8 @@ AI:   I see from a previous session that you chose Tailwind CSS
 
 **How it works:** Both tools read from and write to `~/.episodic-memory/`. The instruction files are different per tool, but the data is shared.
 
+**Cross-tool messaging via Codex watcher.** When Codex writes review feedback as episodes (tagged `codex`, `codex-review`, or `codex-reply`), Claude Code or Cursor can poll for new replies with `em-watch-codex.mjs` — episodes act as a lightweight message bus between tools, with per-scope cursors so nothing is read twice.
+
 ---
 
 ## Scenario 9: Explicitly Asking to Remember
@@ -360,6 +366,38 @@ AI:   ⚠️ Pre-flight warning: bp-001 (implementation workflow) was
 ```
 
 **What happened:** Violations are stored with the pattern ID, the wrong sequence, and the correct sequence. The system aggregates them and surfaces warnings when you start similar work. Over time, this drives enforcement improvements — if a rule is violated repeatedly, it gets a mechanical gate (hook) instead of relying on documentation.
+
+---
+
+## Scenario 12: The Checkpoint Gate Stopped the AI
+
+**What happens:** You installed Claude Code with `--install-hooks`. The AI tries to edit a file or run a command and is blocked with a message about a "checkpoint required."
+
+```
+AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
+
+      "Checkpoint required. Write the Rule 18 pre-implementation
+      checkpoint block to .claude/.pre-checkpoint-done before write
+      tools are unblocked."
+
+      I'll print my implementation plan, get your approval, then
+      write the checkpoint marker before continuing.
+```
+
+**Why this exists:** The checkpoint enforcement gate (RFC-002 Phase 3b) is a PreToolUse hook that prevents the AI from skipping the plan → review → approval steps of the implementation workflow (bp-001). It's the mechanical version of the rules described in Scenario 11 — instead of relying on the AI to remember, the hook physically blocks edits until a checkpoint is recorded.
+
+**Two gates:**
+- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until `.claude/.pre-checkpoint-done` exists with the plan summary.
+- **Push-gate** — blocks `git push` until E2E testing and bug-logging steps are complete.
+
+**To clear the gate (intentionally):**
+
+```bash
+# After the AI has shown its plan and you've approved it:
+echo "ok" > .claude/.pre-checkpoint-done
+```
+
+**To opt out entirely:** Don't pass `--install-hooks` during install, or remove the hook entries from `~/.claude/settings.json`.
 
 ---
 
@@ -539,6 +577,16 @@ node ~/.episodic-memory/scripts/em-pattern-health.mjs --check
 A pattern flagged `needs-enforcement` is being violated repeatedly *and* the script found no mechanical hook (in `~/.claude/hooks/`, `<project>/.claude/hooks/`, `<project>/.git/hooks/`, or `<project>/.github/workflows/`) referencing the pattern. That's a signal to write or install a hook. `needs-attention` means a hook exists but violations are still happening — escalate to a human.
 
 If detection misses a hook (e.g., enforcement lives in an unusual file), pass `--has-enforcement <pattern_id>` to override; repeat the flag for multiple patterns.
+
+### "I want to archive old memories"
+
+`em-prune.mjs` archives episodes that score below a relevance threshold. Use `--dry-run` first to preview, and `--check` as a CI gate that exits 1 when prunable episodes exist:
+
+```bash
+node ~/.episodic-memory/scripts/em-prune.mjs --dry-run
+node ~/.episodic-memory/scripts/em-prune.mjs --scope global --threshold 0.15
+node ~/.episodic-memory/scripts/em-prune.mjs --check
+```
 
 ### "I want to start fresh"
 


### PR DESCRIPTION
## Summary

Documentation lagged the runtime. This PR brings [README.md](../blob/claude/intelligent-black-fd1530/README.md) and [docs/USER_MANUAL.md](../blob/claude/intelligent-black-fd1530/docs/USER_MANUAL.md) in line with what's actually shipped as of 2026-05-02.

### README.md
- Reference [PRINCIPLES.md](../blob/claude/intelligent-black-fd1530/PRINCIPLES.md) near the intro (added by #74).
- Enforcement section: checkpoint gate (RFC-002 Phase 3b) is **shipped + activated** via #78 and #84 — not "coming". Document the `--install-hooks` opt-in flow.
- RFC table:
  - RFC-002 → "Phases 1-3 + 3b shipped + runtime-deployed".
  - **New row: RFC-003** (Pluggable Tool Adapters), Accepted (merged via #74; status flipped via #83).

### docs/USER_MANUAL.md
- **Getting Started**: show `--install-hooks` variant for Claude Code so users discover opt-in enforcement.
- **Scenario 8 (Switching Between Tools)**: add a callout for `em-watch-codex.mjs` as the cross-tool message bus.
- **New Scenario 12 (The Checkpoint Gate Stopped the AI)**: explains what the gate is, why it exists, how to clear it (`echo "ok" > .claude/.pre-checkpoint-done`), and how to opt out. Without this, users hitting the gate had no documentation pointer.
- **Troubleshooting**: add `em-prune` entry for archiving old memories.

## Why now

- Phase 3b activation (#84) merged 2026-05-02 — gate now fires in real Claude Code sessions. README still said "coming".
- RFC-003 was merged (#74) and accepted (#83) but never appeared in the README RFC table.
- `em-prune` and `em-watch-codex` are documented in the README scripts reference but invisible from the user-facing manual.

## Test plan

- [ ] Visual review of rendered README on GitHub (RFC table, links, PR refs resolve).
- [ ] Visual review of rendered USER_MANUAL on GitHub (TOC entry for Scenario 12 anchors correctly, code blocks render, troubleshooting list ordering).
- [ ] Confirm PR refs (#74, #78, #82, #83, #84) all resolve.
- [ ] Confirm relative links (PRINCIPLES.md, docs/rfcs/RFC-003-pluggable-tool-adapters.md) resolve from rendered README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)