### PR TITLE
feat(workflow): add em-workflow-validate.mjs (RFC-002 PR-C, #80)

### DIFF
--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -96,6 +96,7 @@ At least one of `reply_ref` or `evidence_ref` is required (external witness).
 
 ```json
 {
+  "pre_checkpoint_ref": "episode:<pre-checkpoint episode id>",
   "evidence": {
     "tests": [
       { "command": "node tests/test-x.mjs", "status": "passed", "log_ref": "episode:<id>" }
@@ -116,6 +117,11 @@ At least one of `reply_ref` or `evidence_ref` is required (external witness).
 }
 ```
 
+`pre_checkpoint_ref` is **required** (schema_version 1). It binds the
+post-checkpoint back to the pre-checkpoint that authorized the work; without
+it an attacker could splice a same-task post-checkpoint from an unrelated
+attempt onto the chain.
+
 - `evidence.tests` MUST be a non-empty array.
 - `code_review.reply_ref` required when `status === "done"`.
 - `e2e.log_ref` required when `status === "passed"`.
@@ -134,6 +140,43 @@ At least one of `reply_ref` or `evidence_ref` is required (external witness).
 ```
 
 Validator rejects `push-allowed` whose `post_checkpoint_ref` does not resolve to a `post-checkpoint` episode for the same task.
+
+## Per-gate head & branch rules
+
+The validator enforces context (`worktree`, `branch`, `head`) consistency
+across the chain. Rules differ for terminal vs non-terminal links:
+
+- **Worktree** equality enforced on every chain link (compared via realpath).
+- **Branch** equality enforced on every chain link AND against `--branch`
+  (when passed). Branch-switch mid-chain is rejected — it's the primary
+  forgery vector.
+- **Head**:
+  - Terminal link (the gated event itself): `ctx.head === --head` exact.
+    Rationale: the terminal episode asserts the chain is current.
+  - Non-terminal links: `ctx.head` may be older than `--head`, but when git
+    is available it must be an ancestor of `--head` (`git merge-base
+    --is-ancestor`). When git is available but the recorded `ctx.head` is
+    not a known commit (status 128), the link is rejected — referencing a
+    fictional commit is a chain failure. When git is unavailable (no repo),
+    the ancestor check is skipped silently so the validator remains usable
+    outside a repo.
+
+Special case for `push-allowed` gate: the referenced `post-checkpoint`
+episode's `context.head` MUST also equal `--head` exactly. Ancestor-only
+would be too weak — it would allow new commits between the post-checkpoint
+evidence and the push, defeating the purpose. Re-run the post-checkpoint at
+current HEAD if commits have landed. To make this check meaningful,
+**`--head` is required when `--gate push-allowed`** — the validator exits
+with a usage error if it is omitted.
+
+## Schema versioning
+
+Validator-backed gates (PR-D Plan Gate v2, PR-E checkpoint-gate) accept
+only `schema_version: 1` workflow.lifecycle chains. Pre-PR-C lifecycle
+episodes (if any) without `pre_checkpoint_ref` will not satisfy the gates;
+since PR-C is not yet hook-wired, no migration is required — chains are
+authored fresh under the new schema. Older non-lifecycle episodes are
+unaffected.
 
 ## Episode reference resolution (RFC-002:327)
 

--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -120,6 +120,10 @@ At least one of `reply_ref` or `evidence_ref` is required (external witness).
 - `code_review.reply_ref` required when `status === "done"`.
 - `e2e.log_ref` required when `status === "passed"`.
 - `bug_logging.issues` MUST be an array when `status === "done"` (empty array means "checked, no bugs").
+- `bug_logging.issues[]` element shape: each non-empty entry MUST be either a
+  GitHub issue URL `https://github.com/<owner>/<repo>/issues/<n>` or the
+  short form `gh:<owner>/<repo>#<n>`. Free-form strings are rejected. Live
+  existence of the issue is **not** checked by this validator (deferred).
 
 ### `push-allowed`
 
@@ -130,6 +134,29 @@ At least one of `reply_ref` or `evidence_ref` is required (external witness).
 ```
 
 Validator rejects `push-allowed` whose `post_checkpoint_ref` does not resolve to a `post-checkpoint` episode for the same task.
+
+## Episode reference resolution (RFC-002:327)
+
+Every value of shape `episode:<id>` in any of the fields below must resolve
+against the local + global episode index (regardless of `--scope`). The
+validator rejects:
+
+- references to non-existent ids
+- references to superseded or non-active episodes
+- self-witness (a ref pointing to its own episode id)
+- references whose timestamp is **after** the citing episode (chain links must
+  be temporally ordered)
+- chain-link refs (`approval_ref`, `post_checkpoint_ref`) whose target
+  category is not `workflow.lifecycle`
+
+Fields resolved: `pre-checkpoint.approval_ref`, `pre-checkpoint.plan_ref`
+(when episode-shaped), `pre-checkpoint.second_opinion.reply_ref`,
+`review-done.reply_ref`, `review-done.evidence_ref`,
+`evidence.tests[].log_ref`, `evidence.code_review.reply_ref`,
+`evidence.e2e.log_ref`, `push-allowed.post_checkpoint_ref`.
+
+Non-episode-shaped values (file paths, URLs, GitHub issue refs) pass through
+unchanged.
 
 ## Placeholder rejection (RFC-002:327)
 

--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -171,12 +171,16 @@ with a usage error if it is omitted.
 
 ## Schema versioning
 
-Validator-backed gates (PR-D Plan Gate v2, PR-E checkpoint-gate) accept
-only `schema_version: 1` workflow.lifecycle chains. Pre-PR-C lifecycle
-episodes (if any) without `pre_checkpoint_ref` will not satisfy the gates;
-since PR-C is not yet hook-wired, no migration is required — chains are
-authored fresh under the new schema. Older non-lifecycle episodes are
-unaffected.
+Payloads do not carry an explicit `schema_version` field today. The shape
+defined by this document is informally **schema v1**; validator-backed gates
+(PR-D Plan Gate v2, PR-E checkpoint-gate) accept only this shape. Pre-PR-C
+lifecycle episodes (if any) without `pre_checkpoint_ref` on `post-checkpoint`
+will not satisfy the gates; since PR-C is not yet hook-wired, no migration is
+required — chains are authored fresh under the new shape. Older non-lifecycle
+episodes are unaffected.
+
+A future PR may add a literal `schema_version` field (and start rejecting
+payloads with unknown versions) once we have a second shape to switch on.
 
 ## Episode reference resolution (RFC-002:327)
 

--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -1,0 +1,190 @@
+# workflow.lifecycle Episode Schema
+
+**Status:** draft (RFC-002 Phase 3b-H1 PR-C)
+**Source of truth:** [RFC-002:259-327](../rfcs/RFC-002-learning-loop.md)
+**Validator:** [`scripts/em-workflow-validate.mjs`](../../scripts/em-workflow-validate.mjs)
+
+## Purpose
+
+Replace non-empty marker semantics (`[ -s "$MARKER" ]`) in checkpoint-gate.sh
+with append-only workflow lifecycle episodes. Each Rule 18 transition is
+recorded as a `workflow.lifecycle` episode whose payload references prior
+artifacts (plans, approvals, reviews, tests, issues). The validator parses the
+chain and answers: "may this gate clear?"
+
+## Storage
+
+- Episode category: `workflow.lifecycle`
+- Stored via `em-store.mjs --category workflow.lifecycle ...`
+- Episode body MUST contain exactly one ` ```json ` fenced code block; that
+  block is the lifecycle payload. Anything else in the body is informational.
+
+## Events (RFC-002:262)
+
+Ordered chain. Each event is one episode.
+
+| Event | When |
+|---|---|
+| `classified` | Task classification done (light vs full, scope sketched) |
+| `plan-approved` | User approved the implementation plan |
+| `pre-checkpoint` | Pre-implementation checkpoint armed (was: `.pre-checkpoint-done` marker) |
+| `review-done` | Second-opinion or code-review complete with reply reference |
+| `post-checkpoint` | Post-implementation checkpoint with full evidence (was: `.post-checkpoint-done` marker) |
+| `scope-change` | Approved scope expansion (Phase 3b-H2) |
+| `push-allowed` | Push/PR-create cleared by validator |
+
+## Required fields (all events)
+
+```json
+{
+  "event": "<one of the events above>",
+  "pattern_id": "bp-001-implementation-workflow",
+  "task": "<stable task identifier — used to chain episodes>",
+  "context": {
+    "worktree": "<absolute path>",
+    "branch": "<git branch>",
+    "head": "<git sha at time of episode>"
+  }
+}
+```
+
+`task` is the chaining key. Pick a concise stable string (e.g. `"PR-C: workflow validator"`) and reuse it across every event for the same Rule 18 cycle.
+
+## Per-event additions
+
+### `plan-approved`
+
+```json
+{
+  "plan_ref": "<file path or doc URL of the plan>",
+  "classification": "light|full"
+}
+```
+
+`plan-approved` is itself the approval record. `pre-checkpoint` references this episode's id via `approval_ref`. `episode:self` is rejected as a placeholder — references must point to real distinct artifacts.
+
+### `pre-checkpoint`
+
+```json
+{
+  "plan_ref": "<file path or doc URL>",
+  "approval_ref": "episode:<plan-approved episode id>",
+  "second_opinion": {
+    "status": "skipped|pending|done",
+    "recipient": "codex|subagent|...",
+    "reply_ref": "episode:<id>"
+  }
+}
+```
+
+`second_opinion.reply_ref` is **required** when `status === "done"`. If skipped, omit the object or set status accordingly.
+
+`approval_ref` MUST resolve to a `plan-approved` episode for the same `task`. The validator rejects orphaned references.
+
+### `review-done`
+
+```json
+{
+  "reply_ref": "episode:<review episode id>",
+  "evidence_ref": "<file path or other concrete reference>"
+}
+```
+
+At least one of `reply_ref` or `evidence_ref` is required (external witness).
+
+### `post-checkpoint`
+
+```json
+{
+  "evidence": {
+    "tests": [
+      { "command": "node tests/test-x.mjs", "status": "passed", "log_ref": "episode:<id>" }
+    ],
+    "code_review": {
+      "status": "done",
+      "reply_ref": "episode:<subagent review id>"
+    },
+    "e2e": {
+      "status": "passed",
+      "log_ref": "episode:<id>"
+    },
+    "bug_logging": {
+      "status": "done",
+      "issues": ["<issue url or number>", "..."]
+    }
+  }
+}
+```
+
+- `evidence.tests` MUST be a non-empty array.
+- `code_review.reply_ref` required when `status === "done"`.
+- `e2e.log_ref` required when `status === "passed"`.
+- `bug_logging.issues` MUST be an array when `status === "done"` (empty array means "checked, no bugs").
+
+### `push-allowed`
+
+```json
+{
+  "post_checkpoint_ref": "episode:<post-checkpoint episode id>"
+}
+```
+
+Validator rejects `push-allowed` whose `post_checkpoint_ref` does not resolve to a `post-checkpoint` episode for the same task.
+
+## Placeholder rejection (RFC-002:327)
+
+Any required string field whose value is one of:
+
+- empty string, `"TBD"`, `"TODO"`, `"placeholder"`, `"..."`, `"xxx"`, `"n/a"`, `"na"`
+- a bare ref prefix with no payload (e.g. `"episode:"`)
+
+is rejected with an error. References must carry an actual id/path/URL.
+
+## Validator usage
+
+```bash
+node scripts/em-workflow-validate.mjs \
+  --task "PR-C: workflow validator" \
+  --gate pre-checkpoint \
+  --branch claude/keen-euler-b48a7b \
+  --head $(git rev-parse HEAD)
+```
+
+Exit codes:
+- `0` — gate passes
+- `1` — gate fails (missing events, schema errors, broken chain)
+- `2` — usage error
+
+Output (always JSON to stdout):
+
+```json
+{
+  "status": "ok",
+  "valid": true,
+  "gate": "pre-checkpoint",
+  "task": "PR-C: workflow validator",
+  "pattern_id": "bp-001-implementation-workflow",
+  "required": ["plan-approved", "pre-checkpoint"],
+  "missing": [],
+  "errors": [],
+  "warnings": [],
+  "episodes": [{ "id": "...", "event": "plan-approved", "date": "2026-05-02", "time": "17:30", "branch": "...", "head": "..." }]
+}
+```
+
+## Gate requirements
+
+| Gate | Required events |
+|---|---|
+| `pre-checkpoint` | `plan-approved`, `pre-checkpoint` |
+| `post-checkpoint` | `plan-approved`, `pre-checkpoint`, `post-checkpoint` |
+| `push-allowed` | `plan-approved`, `pre-checkpoint`, `post-checkpoint`, `push-allowed` |
+
+`classified`, `review-done`, and `scope-change` are not required for any gate by default. Future PRs (Plan Gate v2 / Phase 3b-H2) may tighten this.
+
+## Out of scope (this PR)
+
+- Hook integration (`checkpoint-gate.sh` still uses marker semantics — see PR-E).
+- Adapter cache layer (`.claude/em-gates/*` referencing episode IDs — see PR-D/PR-E).
+- Step-instrumentation skills/wrappers that emit lifecycle episodes as Rule 18 side effects.
+- Plan-content hashing for stronger task-identity binding (proposed hardening, not in RFC).

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -37,7 +37,7 @@ const body = flag('--body')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
 
-const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation']
+const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']
 
 if (!project || !category || !summary || !body) {
   console.log(JSON.stringify({

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -144,7 +144,20 @@ function isPlaceholder(v) {
   return false
 }
 
-function validatePayload(payload, entry, errors, warnings) {
+// Resolve every `episode:<id>`-shaped value in a list of (label, value) pairs.
+// Non-episode-shaped values (file paths, URLs, etc.) pass through unchanged.
+// Errors are pushed into the shared array.
+function checkEpisodeRefs(pairs, entry, indexById, errors, opts = {}) {
+  for (const [label, value] of pairs) {
+    if (typeof value !== 'string') continue
+    if (!value.startsWith('episode:')) continue
+    if (isPlaceholder(value)) continue // already errored upstream
+    const r = resolveEpisodeRef(value, indexById, entry, opts)
+    if (r.error) errors.push(`episode:${entry.id}: ${label} ${r.error}`)
+  }
+}
+
+function validatePayload(payload, entry, errors, warnings, indexById) {
   const fp = `episode:${entry.id}`
   if (payload.event && !EVENT_ORDER.includes(payload.event)) {
     errors.push(`${fp}: unknown event "${payload.event}". Must be one of: ${EVENT_ORDER.join(', ')}`)
@@ -190,16 +203,32 @@ function validatePayload(payload, entry, errors, warnings) {
     case 'pre-checkpoint':
       if (isPlaceholder(payload.plan_ref)) errors.push(`${fp}: pre-checkpoint.plan_ref missing or placeholder`)
       if (isPlaceholder(payload.approval_ref)) errors.push(`${fp}: pre-checkpoint.approval_ref missing or placeholder`)
+      // approval_ref must resolve to a workflow.lifecycle plan-approved episode.
+      // The category check is done here; the event check happens in validateChain
+      // since events[] has already extracted payloads.
+      checkEpisodeRefs(
+        [['approval_ref', payload.approval_ref]],
+        entry, indexById, errors,
+        { expectedCategory: 'workflow.lifecycle' }
+      )
+      // plan_ref MAY be an episode ref (e.g. an inline RFC excerpt episode)
+      // or a file path / URL. If episode-shaped, resolve it.
+      checkEpisodeRefs([['plan_ref', payload.plan_ref]], entry, indexById, errors)
       if (payload.second_opinion) {
         const so = payload.second_opinion
         if (!so.status || isPlaceholder(so.status)) errors.push(`${fp}: pre-checkpoint.second_opinion.status missing`)
         if (so.status === 'done' && isPlaceholder(so.reply_ref)) errors.push(`${fp}: pre-checkpoint.second_opinion.reply_ref required when status=done`)
+        if (so.reply_ref) checkEpisodeRefs([['second_opinion.reply_ref', so.reply_ref]], entry, indexById, errors)
       }
       break
     case 'review-done':
       if (isPlaceholder(payload.reply_ref) && isPlaceholder(payload.evidence_ref)) {
         errors.push(`${fp}: review-done requires reply_ref or evidence_ref (external witness)`)
       }
+      checkEpisodeRefs(
+        [['reply_ref', payload.reply_ref], ['evidence_ref', payload.evidence_ref]],
+        entry, indexById, errors
+      )
       break
     case 'post-checkpoint':
       const ev = payload.evidence
@@ -230,26 +259,81 @@ function validatePayload(payload, entry, errors, warnings) {
       if (ev.bug_logging && ev.bug_logging.status === 'done' && !Array.isArray(ev.bug_logging.issues)) {
         errors.push(`${fp}: evidence.bug_logging.issues must be an array when status=done`)
       }
+      // Resolve all episode-shaped evidence refs (#98 finding 2).
+      if (Array.isArray(ev.tests)) {
+        ev.tests.forEach((t, i) => {
+          if (t) checkEpisodeRefs([[`evidence.tests[${i}].log_ref`, t.log_ref]], entry, indexById, errors)
+        })
+      }
+      if (ev.code_review) checkEpisodeRefs([['evidence.code_review.reply_ref', ev.code_review.reply_ref]], entry, indexById, errors)
+      if (ev.e2e) checkEpisodeRefs([['evidence.e2e.log_ref', ev.e2e.log_ref]], entry, indexById, errors)
+      // bug_logging.issues[] shape: empty array OR strings of shape
+      // https://github.com/<owner>/<repo>/issues/<n> | gh:<owner>/<repo>#<n>.
+      // Free-form strings rejected (was previously unvalidated — #98 finding 2).
+      if (ev.bug_logging && Array.isArray(ev.bug_logging.issues)) {
+        ev.bug_logging.issues.forEach((iss, i) => {
+          if (typeof iss !== 'string' || !ISSUE_REF_RE.test(iss)) {
+            errors.push(`${fp}: evidence.bug_logging.issues[${i}] must be GitHub issue URL (https://github.com/owner/repo/issues/N) or gh:owner/repo#N, got "${iss}"`)
+          }
+        })
+      }
       break
     case 'push-allowed':
       if (isPlaceholder(payload.post_checkpoint_ref)) {
         errors.push(`${fp}: push-allowed requires post_checkpoint_ref pointing to the post-checkpoint episode`)
       }
+      checkEpisodeRefs(
+        [['post_checkpoint_ref', payload.post_checkpoint_ref]],
+        entry, indexById, errors,
+        { expectedCategory: 'workflow.lifecycle' }
+      )
       break
   }
 }
 
 // ---------------------------------------------------------------------------
-// Approval-ref / post-checkpoint-ref continuity: pre-checkpoint must reference
-// a plan-approved episode for the same task; push-allowed must reference a
-// post-checkpoint episode for the same task. This is the chain integrity
-// check that prevents replay of unrelated episodes.
+// Episode reference resolution. RFC-002:327 requires references to point to
+// real artifacts. Resolution checks (a) the id exists in the index, (b) the
+// episode is active (not superseded), (c) the ref is not self-witness, and
+// (d) the referenced episode's timestamp is <= the citing episode's. Optional
+// `expectedCategory` enforces kind for chain-link refs (e.g. approval_ref
+// must point to a workflow.lifecycle episode).
 // ---------------------------------------------------------------------------
 function refTarget(ref) {
   if (typeof ref !== 'string') return null
   const m = ref.match(/^episode:(.+)$/)
   return m ? m[1].trim() : null
 }
+
+function resolveEpisodeRef(ref, indexById, currentEpisode, opts = {}) {
+  const id = refTarget(ref)
+  if (!id) return { error: `not an episode reference (expected episode:<id>): "${ref}"` }
+  if (id === currentEpisode.id) {
+    return { error: `episode:${id} self-witness: ref points to its own episode id` }
+  }
+  const entry = indexById.get(id)
+  if (!entry) return { error: `episode:${id} not found (checked local + global)` }
+  if (entry.status === 'superseded') return { error: `episode:${id} is superseded` }
+  if (entry.status && entry.status !== 'active') {
+    return { error: `episode:${id} is not active (status=${entry.status})` }
+  }
+  const refTime = `${entry.date} ${entry.time}`
+  const curTime = `${currentEpisode.date} ${currentEpisode.time}`
+  if (refTime > curTime) {
+    return { error: `episode:${id} timestamp ${refTime} is after citing episode ${curTime} (chain must be temporally ordered)` }
+  }
+  if (opts.expectedCategory && entry.category !== opts.expectedCategory) {
+    return { error: `episode:${id} category "${entry.category}" != expected "${opts.expectedCategory}"` }
+  }
+  return { entry, source: entry._source }
+}
+
+// `bug_logging.issues[]` element shape per workflow-lifecycle.md:
+// empty array (checked, no bugs), or strings of shape
+//   https://github.com/<owner>/<repo>/issues/<n>
+//   gh:<owner>/<repo>#<n>
+// Free-form strings are rejected (was previously unvalidated — #98 finding 2).
+const ISSUE_REF_RE = /^(https:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+|gh:[^\/\s]+\/[^\/\s#]+#\d+)$/
 
 function validateChain(events, errors) {
   const byEvent = {}
@@ -266,7 +350,7 @@ function validateChain(events, errors) {
     }
     const matching = (byEvent['plan-approved'] || []).find(e => e.entry.id === targetId)
     if (!matching) {
-      errors.push(`episode:${pre.entry.id}: approval_ref episode:${targetId} not found among plan-approved episodes for task`)
+      errors.push(`episode:${pre.entry.id}: approval_ref episode:${targetId} not a plan-approved episode for this task (chain link must be same-task plan-approved, not arbitrary episode)`)
     }
   }
   // push-allowed.post_checkpoint_ref must point to a post-checkpoint episode
@@ -278,7 +362,7 @@ function validateChain(events, errors) {
     }
     const matching = (byEvent['post-checkpoint'] || []).find(e => e.entry.id === targetId)
     if (!matching) {
-      errors.push(`episode:${pa.entry.id}: post_checkpoint_ref episode:${targetId} not found among post-checkpoint episodes for task`)
+      errors.push(`episode:${pa.entry.id}: post_checkpoint_ref episode:${targetId} not a post-checkpoint episode for this task (chain link must be same-task post-checkpoint, not arbitrary episode)`)
     }
   }
 }
@@ -297,6 +381,13 @@ allEntries = allEntries.filter(e => {
   seen.add(e.id)
   return true
 })
+
+// Index by id for episode ref resolution. Includes ALL episodes (any category,
+// any status) — the resolver handles status/timestamp/category checks itself.
+// resolveEpisodeRef ignores caller's --scope: a lifecycle chain may legitimately
+// cite a global witness, and vice versa (#98 finding 2 / Codex MINOR 7).
+const indexById = new Map()
+for (const e of allEntries) indexById.set(e.id, e)
 
 // Filter to active workflow.lifecycle episodes
 const workflowEntries = allEntries.filter(e =>
@@ -322,7 +413,7 @@ for (const entry of workflowEntries) {
   }
   // Pre-filter: must be the same task + pattern
   if (payload.task !== task || payload.pattern_id !== patternId) continue
-  validatePayload(payload, entry, errors, warnings)
+  validatePayload(payload, entry, errors, warnings, indexById)
   events.push({ entry, payload })
 }
 

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -477,24 +477,32 @@ function validateChain(events, errors, gateArg, headArg) {
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
-let allEntries = []
-if (scope === 'local' || scope === 'all') allEntries.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') allEntries.push(...loadIndex(GLOBAL_DIR, 'global'))
+// Caller --scope governs which scopes are searched for the lifecycle chain
+// itself (the workflowEntries below). Episode reference resolution is a
+// separate concern: a lifecycle chain may legitimately cite a global witness
+// even when --scope=local (and vice versa). So we build indexById from BOTH
+// local and global unconditionally, while workflowEntries respects --scope.
+// Without this split, a local chain that cites a global log would fail with
+// "not found (checked local + global)" — the exact behavior Codex reproduced
+// in the PR #98 re-review (#98 finding 2 follow-up).
+const localEntries = loadIndex(LOCAL_DIR, 'local')
+const globalEntries = loadIndex(GLOBAL_DIR, 'global')
 
-// Dedupe (local takes priority, same as em-recall)
+// Resolver index: every id from both scopes, local takes priority on collision.
+const indexById = new Map()
+for (const e of globalEntries) indexById.set(e.id, e)
+for (const e of localEntries) indexById.set(e.id, e) // local wins
+
+// Lifecycle chain entries respect --scope.
+let allEntries = []
+if (scope === 'local' || scope === 'all') allEntries.push(...localEntries)
+if (scope === 'global' || scope === 'all') allEntries.push(...globalEntries)
 const seen = new Set()
 allEntries = allEntries.filter(e => {
   if (seen.has(e.id)) return false
   seen.add(e.id)
   return true
 })
-
-// Index by id for episode ref resolution. Includes ALL episodes (any category,
-// any status) — the resolver handles status/timestamp/category checks itself.
-// resolveEpisodeRef ignores caller's --scope: a lifecycle chain may legitimately
-// cite a global witness, and vice versa (#98 finding 2 / Codex MINOR 7).
-const indexById = new Map()
-for (const e of allEntries) indexById.set(e.id, e)
 
 // Filter to active workflow.lifecycle episodes
 const workflowEntries = allEntries.filter(e =>

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -29,6 +29,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { execFileSync } from 'child_process'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
@@ -67,6 +68,19 @@ const REQUIRED_FOR_GATE = {
   'push-allowed': ['plan-approved', 'pre-checkpoint', 'post-checkpoint', 'push-allowed']
 }
 
+// Terminal event for each gate. Per-gate head rules (#98 finding 1):
+// only the terminal link must have ctx.head == --head; non-terminal chain
+// links may sit at older heads (their authoring time, not current HEAD).
+// Branch must match across ALL chain links — branch-switch is the forgery
+// vector. push-allowed adds an additional exact-equality check on the
+// referenced post-checkpoint's head, since that's what asserts "code at
+// this SHA passed evidence" (see validateChain for that special case).
+const TERMINAL_FOR_GATE = {
+  'pre-checkpoint': 'pre-checkpoint',
+  'post-checkpoint': 'post-checkpoint',
+  'push-allowed': 'push-allowed'
+}
+
 function fail(msg, code = 2) {
   console.log(JSON.stringify({ status: 'error', message: msg }))
   process.exit(code)
@@ -76,6 +90,10 @@ if (!task) fail('Missing --task')
 if (!gate) fail(`Missing --gate. Must be one of: ${VALID_GATES.join(', ')}`)
 if (!VALID_GATES.includes(gate)) fail(`Invalid --gate "${gate}". Must be one of: ${VALID_GATES.join(', ')}`)
 if (!VALID_SCOPES.includes(scope)) fail(`Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}`)
+// push-allowed gate requires --head: without it the post-checkpoint exact-
+// equality head check is silently skipped, which would let stale evidence
+// satisfy a push (#98 finding 1 / Codex BLOCKER 2).
+if (gate === 'push-allowed' && !head) fail('--head is required for --gate push-allowed (post-checkpoint head must be asserted against current HEAD)')
 
 // ---------------------------------------------------------------------------
 // Index loading — mirrors em-search.mjs:loadIndex / em-recall.mjs:loadIndex.
@@ -131,6 +149,46 @@ function realpathOrPath(p) {
   try { return fs.realpathSync(p) } catch { return p }
 }
 
+// Probe git availability once. If we're inside a work tree, git is "available"
+// — and a subsequent status-128 from is-ancestor must mean "unknown sha"
+// (which we treat as failure, not skip). If git is unavailable / not a repo,
+// ancestor checks are skipped silently — the validator must work outside a
+// repo (e.g. running over a pure index dump in CI).
+let GIT_AVAILABLE = null
+function gitAvailable() {
+  if (GIT_AVAILABLE !== null) return GIT_AVAILABLE
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      stdio: 'ignore', cwd: process.cwd()
+    })
+    GIT_AVAILABLE = true
+  } catch {
+    GIT_AVAILABLE = false
+  }
+  return GIT_AVAILABLE
+}
+
+// `git merge-base --is-ancestor <a> <b>` exits 0 if a is an ancestor of b,
+// 1 if not, 128 if not a repo / unknown sha.
+// Returns true / false / null (null = git unavailable, skip the check).
+// When git IS available but a sha is unknown (status 128), returns false —
+// referencing a fictional commit is a chain failure.
+function isAncestor(ancestor, descendant) {
+  if (!ancestor || !descendant) return null
+  if (ancestor === descendant) return true
+  if (!gitAvailable()) return null
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+      stdio: 'ignore', cwd: process.cwd()
+    })
+    return true
+  } catch (e) {
+    // status 1 = not an ancestor; status 128 = unknown sha (now that git is
+    // available, this is a hard failure, not "skip silently").
+    return false
+  }
+}
+
 function isPlaceholder(v) {
   if (v == null) return true
   if (typeof v !== 'string') return false
@@ -184,14 +242,29 @@ function validatePayload(payload, entry, errors, warnings, indexById) {
       errors.push(`${fp}: context.worktree "${ctx.worktree}" != expected "${expectedWorktree}"`)
     }
   }
-  // Branch / head mismatch is an error when a flag is explicitly passed
-  // (a hook caller asserts a specific value). Stale-head warnings without
-  // an explicit flag would be too strict for ad-hoc validator runs.
+  // Branch must match across ALL chain links (#98 finding 1 — branch-switch
+  // is the forgery vector). Enforced whenever --branch is passed.
   if (branch && ctx.branch && ctx.branch !== branch) {
-    errors.push(`${fp}: context.branch "${ctx.branch}" != requested "${branch}"`)
+    errors.push(`${fp}: context.branch "${ctx.branch}" != requested "${branch}" (chain links must share branch)`)
   }
-  if (head && ctx.head && ctx.head !== head) {
-    errors.push(`${fp}: context.head "${ctx.head}" != requested "${head}" (stale episode?)`)
+  // Head check is per-gate: terminal link MUST equal --head; non-terminal
+  // links may sit at an older head, but if git is available that head must
+  // be an ancestor of --head (same git history). Skip ancestor check if
+  // git is unavailable (validator must work outside a repo too).
+  if (head && ctx.head) {
+    const terminalEvent = TERMINAL_FOR_GATE[gate]
+    const isTerminal = payload.event === terminalEvent
+    if (isTerminal) {
+      if (ctx.head !== head) {
+        errors.push(`${fp}: context.head "${ctx.head}" != requested "${head}" (terminal ${payload.event} must be at current HEAD; new commits since evidence?)`)
+      }
+    } else if (ctx.head !== head) {
+      const anc = isAncestor(ctx.head, head)
+      if (anc === false) {
+        errors.push(`${fp}: context.head "${ctx.head}" is not an ancestor of current HEAD "${head}" (chain link must be in same git history — branch switch or unrelated chain?)`)
+      }
+      // anc === null: git unavailable; skip silently.
+    }
   }
 
   switch (payload.event) {
@@ -231,6 +304,17 @@ function validatePayload(payload, entry, errors, warnings, indexById) {
       )
       break
     case 'post-checkpoint':
+      // pre_checkpoint_ref is required — it's the splice-resistance link
+      // back to the pre-checkpoint episode in the same chain (#98 finding 1).
+      if (isPlaceholder(payload.pre_checkpoint_ref)) {
+        errors.push(`${fp}: post-checkpoint.pre_checkpoint_ref missing or placeholder (required to bind chain back to pre-checkpoint)`)
+      } else {
+        checkEpisodeRefs(
+          [['pre_checkpoint_ref', payload.pre_checkpoint_ref]],
+          entry, indexById, errors,
+          { expectedCategory: 'workflow.lifecycle' }
+        )
+      }
       const ev = payload.evidence
       if (!ev || typeof ev !== 'object') {
         errors.push(`${fp}: post-checkpoint.evidence missing`)
@@ -335,7 +419,7 @@ function resolveEpisodeRef(ref, indexById, currentEpisode, opts = {}) {
 // Free-form strings are rejected (was previously unvalidated — #98 finding 2).
 const ISSUE_REF_RE = /^(https:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+|gh:[^\/\s]+\/[^\/\s#]+#\d+)$/
 
-function validateChain(events, errors) {
+function validateChain(events, errors, gateArg, headArg) {
   const byEvent = {}
   for (const e of events) {
     if (!byEvent[e.payload.event]) byEvent[e.payload.event] = []
@@ -353,7 +437,21 @@ function validateChain(events, errors) {
       errors.push(`episode:${pre.entry.id}: approval_ref episode:${targetId} not a plan-approved episode for this task (chain link must be same-task plan-approved, not arbitrary episode)`)
     }
   }
-  // push-allowed.post_checkpoint_ref must point to a post-checkpoint episode
+  // post-checkpoint.pre_checkpoint_ref must point to a pre-checkpoint episode
+  // for same task (#98 finding 1 splice-resistance).
+  for (const post of (byEvent['post-checkpoint'] || [])) {
+    if (!post.payload.pre_checkpoint_ref) continue // already errored upstream
+    const targetId = refTarget(post.payload.pre_checkpoint_ref)
+    if (!targetId) continue
+    const matching = (byEvent['pre-checkpoint'] || []).find(e => e.entry.id === targetId)
+    if (!matching) {
+      errors.push(`episode:${post.entry.id}: pre_checkpoint_ref episode:${targetId} not a pre-checkpoint episode for this task (chain splicing rejected)`)
+    }
+  }
+  // push-allowed.post_checkpoint_ref must point to a post-checkpoint episode.
+  // Additionally for push-allowed gate: the referenced post-checkpoint's head
+  // MUST equal --head (Codex correction on #98 finding 1: ancestor-only is too
+  // weak — it would let commits land after the evidence SHA).
   for (const pa of (byEvent['push-allowed'] || [])) {
     const targetId = refTarget(pa.payload.post_checkpoint_ref)
     if (!targetId) {
@@ -363,6 +461,15 @@ function validateChain(events, errors) {
     const matching = (byEvent['post-checkpoint'] || []).find(e => e.entry.id === targetId)
     if (!matching) {
       errors.push(`episode:${pa.entry.id}: post_checkpoint_ref episode:${targetId} not a post-checkpoint episode for this task (chain link must be same-task post-checkpoint, not arbitrary episode)`)
+      continue
+    }
+    if (gateArg === 'push-allowed' && headArg) {
+      const pcHead = matching.payload.context && matching.payload.context.head
+      if (!pcHead) {
+        errors.push(`episode:${pa.entry.id}: referenced post-checkpoint episode:${targetId} has no context.head — cannot verify against current HEAD`)
+      } else if (pcHead !== headArg) {
+        errors.push(`episode:${pa.entry.id}: referenced post-checkpoint episode:${targetId} has head "${pcHead}" != current --head "${headArg}". Code may have changed since evidence was recorded — re-run post-checkpoint at current HEAD.`)
+      }
     }
   }
 }
@@ -417,7 +524,7 @@ for (const entry of workflowEntries) {
   events.push({ entry, payload })
 }
 
-validateChain(events, errors)
+validateChain(events, errors, gate, head)
 
 const presentEvents = new Set(events.map(e => e.payload.event))
 const required = REQUIRED_FOR_GATE[gate] || []

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * em-workflow-validate.mjs — Validate workflow.lifecycle episode chain for a task.
+ *
+ * RFC-002 Phase 3b-H1 PR-C. Replaces non-empty-marker semantics (`[ -s "$MARKER" ]`)
+ * with append-only workflow lifecycle episodes referenced by the gate.
+ *
+ * Usage:
+ *   node em-workflow-validate.mjs --task <task>
+ *                                 --gate <pre-checkpoint|post-checkpoint|push-allowed>
+ *                                 [--pattern-id <id>]      # default: bp-001-implementation-workflow
+ *                                 [--worktree <abs path>]  # context match (error on mismatch)
+ *                                 [--branch <branch>]      # context match (error on mismatch when passed)
+ *                                 [--head <sha>]           # context match (error on mismatch when passed)
+ *                                 [--scope local|global|all]  # default: all
+ *                                 [--strict]               # treat warnings as errors
+ *
+ * Exits 0 on validation pass, 1 on validation fail, 2 on usage/IO error.
+ * Always emits JSON to stdout: { status, valid, gate, task, missing[], errors[], warnings[], episodes[] }
+ *
+ * Episode body convention: workflow.lifecycle episodes MUST contain exactly one
+ * ```json fenced code block whose content conforms to the schema in
+ * docs/specs/workflow-lifecycle.md (mirrored from RFC-002:267-327).
+ *
+ * This script does NOT modify episodes, write markers, or call hooks. It is a
+ * pure validator. Hooks shell out to it and act on the JSON result.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const task = flag('--task')
+const gate = flag('--gate')
+const patternId = flag('--pattern-id') || 'bp-001-implementation-workflow'
+const worktreeFlag = flag('--worktree')
+const branch = flag('--branch')
+const head = flag('--head')
+const scope = flag('--scope') || 'all'
+const strict = argv.includes('--strict')
+
+const VALID_GATES = ['pre-checkpoint', 'post-checkpoint', 'push-allowed']
+const VALID_SCOPES = ['local', 'global', 'all']
+
+// Lifecycle event order per RFC-002:262.
+// classified and scope-change are not required for any gate by default.
+const EVENT_ORDER = ['classified', 'plan-approved', 'pre-checkpoint', 'review-done', 'post-checkpoint', 'scope-change', 'push-allowed']
+
+// Required predecessor chain by gate. The gate passes iff all required events
+// are present, in order, with valid payloads and consistent task identity.
+const REQUIRED_FOR_GATE = {
+  'pre-checkpoint': ['plan-approved', 'pre-checkpoint'],
+  'post-checkpoint': ['plan-approved', 'pre-checkpoint', 'post-checkpoint'],
+  'push-allowed': ['plan-approved', 'pre-checkpoint', 'post-checkpoint', 'push-allowed']
+}
+
+function fail(msg, code = 2) {
+  console.log(JSON.stringify({ status: 'error', message: msg }))
+  process.exit(code)
+}
+
+if (!task) fail('Missing --task')
+if (!gate) fail(`Missing --gate. Must be one of: ${VALID_GATES.join(', ')}`)
+if (!VALID_GATES.includes(gate)) fail(`Invalid --gate "${gate}". Must be one of: ${VALID_GATES.join(', ')}`)
+if (!VALID_SCOPES.includes(scope)) fail(`Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}`)
+
+// ---------------------------------------------------------------------------
+// Index loading — mirrors em-search.mjs:loadIndex / em-recall.mjs:loadIndex.
+// SYNC: keep aligned with those two if the index format changes.
+// ---------------------------------------------------------------------------
+function loadIndex(dataDir, source) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+    try {
+      const entry = JSON.parse(line)
+      entry._source = source
+      entry._dataDir = dataDir
+      return entry
+    } catch { return null }
+  }).filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// Payload extraction. Episodes are .md files; the lifecycle payload is the
+// first ```json fenced code block in the body. Returns parsed JSON or throws.
+// ---------------------------------------------------------------------------
+function extractPayload(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8')
+  const m = text.match(/```json\s*\n([\s\S]*?)\n```/)
+  if (!m) throw new Error(`No \`\`\`json fenced block found in ${filePath}`)
+  return JSON.parse(m[1])
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation per RFC-002:267-327.
+//
+// Required fields per event:
+//   all:               event, pattern_id, task, context.{worktree,branch,head}
+//   plan-approved:     plan_ref, approval_ref
+//   pre-checkpoint:    plan_ref, approval_ref, second_opinion?{status,recipient,reply_ref?}
+//   review-done:       reply_ref or evidence reference (witness)
+//   post-checkpoint:   evidence.{tests[],code_review,e2e,bug_logging}
+//   push-allowed:      references post-checkpoint episode by id
+//
+// Placeholder rejection: any required reference field whose value is the
+// literal "TBD", "TODO", "placeholder", "...", "" or whose ref-shaped values
+// (episode:..., issue:..., file:..., command:..., log:...) lack a payload
+// after the prefix is treated as placeholder and rejected. `episode:self` is
+// also rejected as a placeholder — self-witnessing approval is not evidence
+// (RFC-002:327: references must point to real artifacts).
+// ---------------------------------------------------------------------------
+const PLACEHOLDER_VALUES = new Set(['', 'tbd', 'todo', 'placeholder', '...', 'xxx', 'n/a', 'na'])
+const REF_PREFIXES = ['episode:', 'issue:', 'file:', 'command:', 'log:', 'sha:']
+const SELF_REFS = new Set(['episode:self', 'self'])
+
+function realpathOrPath(p) {
+  try { return fs.realpathSync(p) } catch { return p }
+}
+
+function isPlaceholder(v) {
+  if (v == null) return true
+  if (typeof v !== 'string') return false
+  const lower = v.trim().toLowerCase()
+  if (PLACEHOLDER_VALUES.has(lower)) return true
+  if (SELF_REFS.has(lower)) return true
+  for (const p of REF_PREFIXES) {
+    if (lower === p || lower === p.slice(0, -1)) return true
+    if (lower.startsWith(p) && lower.slice(p.length).trim() === '') return true
+  }
+  return false
+}
+
+function validatePayload(payload, entry, errors, warnings) {
+  const fp = `episode:${entry.id}`
+  if (payload.event && !EVENT_ORDER.includes(payload.event)) {
+    errors.push(`${fp}: unknown event "${payload.event}". Must be one of: ${EVENT_ORDER.join(', ')}`)
+  }
+  if (payload.pattern_id !== patternId) {
+    errors.push(`${fp}: pattern_id "${payload.pattern_id}" != requested "${patternId}"`)
+  }
+  if (payload.task !== task) {
+    errors.push(`${fp}: task "${payload.task}" != requested "${task}"`)
+  }
+  const ctx = payload.context || {}
+  for (const f of ['worktree', 'branch', 'head']) {
+    if (!ctx[f] || isPlaceholder(ctx[f])) errors.push(`${fp}: context.${f} missing or placeholder`)
+  }
+  // Worktree mismatch is an error per RFC-002:327. Either the explicit flag
+  // or the validator's CWD is the source of truth — explicit flag wins.
+  // Compare resolved real paths so symlink-affected matches (e.g. macOS
+  // /var → /private/var) don't false-positive.
+  const expectedWorktree = worktreeFlag || process.cwd()
+  if (ctx.worktree) {
+    const actualReal = realpathOrPath(ctx.worktree)
+    const expectedReal = realpathOrPath(expectedWorktree)
+    if (actualReal !== expectedReal) {
+      errors.push(`${fp}: context.worktree "${ctx.worktree}" != expected "${expectedWorktree}"`)
+    }
+  }
+  // Branch / head mismatch is an error when a flag is explicitly passed
+  // (a hook caller asserts a specific value). Stale-head warnings without
+  // an explicit flag would be too strict for ad-hoc validator runs.
+  if (branch && ctx.branch && ctx.branch !== branch) {
+    errors.push(`${fp}: context.branch "${ctx.branch}" != requested "${branch}"`)
+  }
+  if (head && ctx.head && ctx.head !== head) {
+    errors.push(`${fp}: context.head "${ctx.head}" != requested "${head}" (stale episode?)`)
+  }
+
+  switch (payload.event) {
+    case 'plan-approved':
+      // plan-approved IS the approval record — it doesn't need approval_ref
+      // pointing elsewhere. pre-checkpoint references plan-approved by id.
+      if (isPlaceholder(payload.plan_ref)) errors.push(`${fp}: plan-approved.plan_ref missing or placeholder`)
+      break
+    case 'pre-checkpoint':
+      if (isPlaceholder(payload.plan_ref)) errors.push(`${fp}: pre-checkpoint.plan_ref missing or placeholder`)
+      if (isPlaceholder(payload.approval_ref)) errors.push(`${fp}: pre-checkpoint.approval_ref missing or placeholder`)
+      if (payload.second_opinion) {
+        const so = payload.second_opinion
+        if (!so.status || isPlaceholder(so.status)) errors.push(`${fp}: pre-checkpoint.second_opinion.status missing`)
+        if (so.status === 'done' && isPlaceholder(so.reply_ref)) errors.push(`${fp}: pre-checkpoint.second_opinion.reply_ref required when status=done`)
+      }
+      break
+    case 'review-done':
+      if (isPlaceholder(payload.reply_ref) && isPlaceholder(payload.evidence_ref)) {
+        errors.push(`${fp}: review-done requires reply_ref or evidence_ref (external witness)`)
+      }
+      break
+    case 'post-checkpoint':
+      const ev = payload.evidence
+      if (!ev || typeof ev !== 'object') {
+        errors.push(`${fp}: post-checkpoint.evidence missing`)
+        break
+      }
+      if (!Array.isArray(ev.tests) || ev.tests.length === 0) {
+        errors.push(`${fp}: post-checkpoint.evidence.tests must be a non-empty array`)
+      } else {
+        ev.tests.forEach((t, i) => {
+          if (!t || isPlaceholder(t.command)) errors.push(`${fp}: evidence.tests[${i}].command missing/placeholder`)
+          if (!t || isPlaceholder(t.status)) errors.push(`${fp}: evidence.tests[${i}].status missing/placeholder`)
+          if (!t || isPlaceholder(t.log_ref)) errors.push(`${fp}: evidence.tests[${i}].log_ref missing/placeholder`)
+        })
+      }
+      for (const k of ['code_review', 'e2e', 'bug_logging']) {
+        const sub = ev[k]
+        if (!sub || typeof sub !== 'object') errors.push(`${fp}: post-checkpoint.evidence.${k} missing`)
+        else if (isPlaceholder(sub.status)) errors.push(`${fp}: evidence.${k}.status missing/placeholder`)
+      }
+      if (ev.code_review && ev.code_review.status === 'done' && isPlaceholder(ev.code_review.reply_ref)) {
+        errors.push(`${fp}: evidence.code_review.reply_ref required when status=done`)
+      }
+      if (ev.e2e && ev.e2e.status === 'passed' && isPlaceholder(ev.e2e.log_ref)) {
+        errors.push(`${fp}: evidence.e2e.log_ref required when status=passed`)
+      }
+      if (ev.bug_logging && ev.bug_logging.status === 'done' && !Array.isArray(ev.bug_logging.issues)) {
+        errors.push(`${fp}: evidence.bug_logging.issues must be an array when status=done`)
+      }
+      break
+    case 'push-allowed':
+      if (isPlaceholder(payload.post_checkpoint_ref)) {
+        errors.push(`${fp}: push-allowed requires post_checkpoint_ref pointing to the post-checkpoint episode`)
+      }
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Approval-ref / post-checkpoint-ref continuity: pre-checkpoint must reference
+// a plan-approved episode for the same task; push-allowed must reference a
+// post-checkpoint episode for the same task. This is the chain integrity
+// check that prevents replay of unrelated episodes.
+// ---------------------------------------------------------------------------
+function refTarget(ref) {
+  if (typeof ref !== 'string') return null
+  const m = ref.match(/^episode:(.+)$/)
+  return m ? m[1].trim() : null
+}
+
+function validateChain(events, errors) {
+  const byEvent = {}
+  for (const e of events) {
+    if (!byEvent[e.payload.event]) byEvent[e.payload.event] = []
+    byEvent[e.payload.event].push(e)
+  }
+  // pre-checkpoint.approval_ref must point to a plan-approved episode for same task
+  for (const pre of (byEvent['pre-checkpoint'] || [])) {
+    const targetId = refTarget(pre.payload.approval_ref)
+    if (!targetId) {
+      errors.push(`episode:${pre.entry.id}: approval_ref "${pre.payload.approval_ref}" is not an episode reference (expected episode:<id>)`)
+      continue
+    }
+    const matching = (byEvent['plan-approved'] || []).find(e => e.entry.id === targetId)
+    if (!matching) {
+      errors.push(`episode:${pre.entry.id}: approval_ref episode:${targetId} not found among plan-approved episodes for task`)
+    }
+  }
+  // push-allowed.post_checkpoint_ref must point to a post-checkpoint episode
+  for (const pa of (byEvent['push-allowed'] || [])) {
+    const targetId = refTarget(pa.payload.post_checkpoint_ref)
+    if (!targetId) {
+      errors.push(`episode:${pa.entry.id}: post_checkpoint_ref not an episode reference`)
+      continue
+    }
+    const matching = (byEvent['post-checkpoint'] || []).find(e => e.entry.id === targetId)
+    if (!matching) {
+      errors.push(`episode:${pa.entry.id}: post_checkpoint_ref episode:${targetId} not found among post-checkpoint episodes for task`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+let allEntries = []
+if (scope === 'local' || scope === 'all') allEntries.push(...loadIndex(LOCAL_DIR, 'local'))
+if (scope === 'global' || scope === 'all') allEntries.push(...loadIndex(GLOBAL_DIR, 'global'))
+
+// Dedupe (local takes priority, same as em-recall)
+const seen = new Set()
+allEntries = allEntries.filter(e => {
+  if (seen.has(e.id)) return false
+  seen.add(e.id)
+  return true
+})
+
+// Filter to active workflow.lifecycle episodes
+const workflowEntries = allEntries.filter(e =>
+  e.status !== 'superseded' && e.category === 'workflow.lifecycle'
+)
+
+const errors = []
+const warnings = []
+const events = [] // {entry, payload}
+
+for (const entry of workflowEntries) {
+  const filePath = path.join(entry._dataDir, 'episodes', `${entry.id}.md`)
+  if (!fs.existsSync(filePath)) {
+    warnings.push(`episode:${entry.id}: file ${filePath} not found (orphaned index entry)`)
+    continue
+  }
+  let payload
+  try {
+    payload = extractPayload(filePath)
+  } catch (e) {
+    errors.push(`episode:${entry.id}: ${e.message}`)
+    continue
+  }
+  // Pre-filter: must be the same task + pattern
+  if (payload.task !== task || payload.pattern_id !== patternId) continue
+  validatePayload(payload, entry, errors, warnings)
+  events.push({ entry, payload })
+}
+
+validateChain(events, errors)
+
+const presentEvents = new Set(events.map(e => e.payload.event))
+const required = REQUIRED_FOR_GATE[gate] || []
+const missing = required.filter(e => !presentEvents.has(e))
+
+const valid = errors.length === 0 && missing.length === 0 && (!strict || warnings.length === 0)
+
+const output = {
+  status: 'ok',
+  valid,
+  gate,
+  task,
+  pattern_id: patternId,
+  required,
+  missing,
+  errors,
+  warnings,
+  episodes: events.map(e => ({
+    id: e.entry.id,
+    event: e.payload.event,
+    date: e.entry.date,
+    time: e.entry.time,
+    branch: e.payload.context && e.payload.context.branch,
+    head: e.payload.context && e.payload.context.head
+  }))
+}
+
+console.log(JSON.stringify(output))
+process.exit(valid ? 0 : 1)

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -83,6 +83,35 @@ function mkEpisode({ event, task = 'TEST', patternId = 'bp-001-implementation-wo
   return id
 }
 
+// Seed a non-lifecycle witness episode (e.g. test log, code review reply).
+// Used for evidence refs (log_ref, reply_ref) that must resolve against the
+// index per #98 finding 2. Date/time are 11:00 so they precede the 12:00
+// lifecycle fixtures (resolver requires ref timestamp <= citing timestamp).
+function mkWitness({ category = 'discovery', summary = 'witness', status = 'active', date = '2026-05-02', time = '11:00' } = {}) {
+  counter++
+  const id = `20260502-1100${String(counter).padStart(2, '0')}-witness-${counter.toString(16).padStart(4, '0')}`
+  const fm = [
+    '---',
+    `id: ${id}`,
+    `date: ${date}`,
+    `time: "${time}"`,
+    'project: test',
+    `category: ${category}`,
+    `status: ${status}`,
+    'tags: []',
+    `summary: ${summary}`,
+    '---',
+    ''
+  ].join('\n')
+  const body = `# witness\n\nplain witness episode for evidence refs.\n`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), fm + '\n' + body)
+  fs.appendFileSync(indexFile, JSON.stringify({
+    id, date, time, project: 'test', category, status,
+    supersedes: null, tags: [], summary
+  }) + '\n')
+  return id
+}
+
 function runValidate(args) {
   try {
     const out = execFileSync('node', [VALIDATE, ...args], {
@@ -173,16 +202,19 @@ test('T7 task isolation: different task is filtered out', () => {
   assert.deepStrictEqual(r.json.missing, ['plan-approved', 'pre-checkpoint'])
 })
 
-test('T8 happy: post-checkpoint gate with full evidence', () => {
+test('T8 happy: post-checkpoint gate with full evidence (real witness episodes)', () => {
+  const logId = mkWitness({ summary: 'test log' })
+  const reviewId = mkWitness({ summary: 'code review' })
+  const e2eId = mkWitness({ summary: 'e2e log' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
   mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
       evidence: {
-        tests: [{ command: 'node tests/test-x.mjs', status: 'passed', log_ref: 'episode:test-log-id' }],
-        code_review: { status: 'done', reply_ref: 'episode:review-id' },
-        e2e: { status: 'passed', log_ref: 'episode:e2e-id' },
+        tests: [{ command: 'node tests/test-x.mjs', status: 'passed', log_ref: `episode:${logId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${reviewId}` },
+        e2e: { status: 'passed', log_ref: `episode:${e2eId}` },
         bug_logging: { status: 'done', issues: [] }
       }
     }
@@ -192,6 +224,8 @@ test('T8 happy: post-checkpoint gate with full evidence', () => {
 })
 
 test('T9 evidence: empty tests array is rejected', () => {
+  const r2 = mkWitness({ summary: 'review' })
+  const e2 = mkWitness({ summary: 'e2e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
   mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
@@ -199,8 +233,8 @@ test('T9 evidence: empty tests array is rejected', () => {
     extra: {
       evidence: {
         tests: [],
-        code_review: { status: 'done', reply_ref: 'episode:review-id' },
-        e2e: { status: 'passed', log_ref: 'episode:e2e-id' },
+        code_review: { status: 'done', reply_ref: `episode:${r2}` },
+        e2e: { status: 'passed', log_ref: `episode:${e2}` },
         bug_logging: { status: 'done', issues: [] }
       }
     }
@@ -211,15 +245,17 @@ test('T9 evidence: empty tests array is rejected', () => {
 })
 
 test('T10 evidence: code_review.status=done without reply_ref is rejected', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const eId = mkWitness({ summary: 'e2e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
   mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
       evidence: {
-        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
         code_review: { status: 'done', reply_ref: '' },
-        e2e: { status: 'passed', log_ref: 'episode:e' },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
         bug_logging: { status: 'done', issues: [] }
       }
     }
@@ -230,15 +266,18 @@ test('T10 evidence: code_review.status=done without reply_ref is rejected', () =
 })
 
 test('T11 push-allowed: requires post_checkpoint_ref pointing to actual episode', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'review' })
+  const eId = mkWitness({ summary: 'e2e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
   mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   const postId = mkEpisode({
     event: 'post-checkpoint',
     extra: {
       evidence: {
-        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
-        code_review: { status: 'done', reply_ref: 'episode:r' },
-        e2e: { status: 'passed', log_ref: 'episode:e' },
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
         bug_logging: { status: 'done', issues: [] }
       }
     }
@@ -249,15 +288,18 @@ test('T11 push-allowed: requires post_checkpoint_ref pointing to actual episode'
 })
 
 test('T12 push-allowed: orphaned post_checkpoint_ref is rejected', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'review' })
+  const eId = mkWitness({ summary: 'e2e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
   mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
       evidence: {
-        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
-        code_review: { status: 'done', reply_ref: 'episode:r' },
-        e2e: { status: 'passed', log_ref: 'episode:e' },
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
         bug_logging: { status: 'done', issues: [] }
       }
     }
@@ -341,6 +383,195 @@ test('T19 head mismatch with --head flag is an error', () => {
   const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'newsha2'])
   assert.strictEqual(r.json.valid, false)
   assert.ok(r.json.errors.some(e => e.includes('context.head')))
+})
+
+// ---------------------------------------------------------------------------
+// #98 finding 2 — episode reference resolution & forge-resistance.
+// ---------------------------------------------------------------------------
+
+test('T20 evidence ref must resolve: bogus log_ref id is rejected', () => {
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:does-not-exist-9999' }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('evidence.tests[0].log_ref') && e.includes('not found')),
+    `expected log_ref not-found error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T21 evidence ref to superseded episode is rejected', () => {
+  const supersededId = mkWitness({ summary: 'old log', status: 'superseded' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${supersededId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('superseded')),
+    `expected superseded error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T22 evidence ref to future-dated episode is rejected (chain temporal order)', () => {
+  // citing episode is at 12:00; a witness at 13:00 is "after" the chain.
+  const futureId = mkWitness({ summary: 'future log', time: '13:00' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${futureId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('temporally ordered') || e.includes('after citing')),
+    `expected timestamp ordering error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T23 chain-link ref to non-lifecycle category is rejected', () => {
+  // approval_ref pointing to a discovery episode (not workflow.lifecycle)
+  // should fail the expectedCategory check.
+  const fakePlanId = mkWitness({ summary: 'fake plan', category: 'discovery' })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${fakePlanId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref') && (e.includes('category') || e.includes('not a plan-approved'))),
+    `expected category mismatch, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T24 bug_logging.issues[]: free-form string rejected', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: ['fix this thing later'] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('bug_logging.issues[0]')),
+    `expected issue shape error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T25 bug_logging.issues[]: gh:owner/repo#n short form accepted', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: ['gh:lantisprime/episodic-memory#42'] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T26 bug_logging.issues[]: GitHub URL accepted', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: ['https://github.com/lantisprime/episodic-memory/issues/98'] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T27 self-witness: real id pointing to citing episode is rejected', () => {
+  // Build a post-checkpoint whose log_ref points to itself. To do this we
+  // need to know the next id mkEpisode will assign. Counter is shared, so we
+  // peek ahead by computing it.
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  // Predict the next id format used by mkEpisode (counter+1 suffix and event=post-checkpoint)
+  // Easier: pass log_ref to a known prior id (lId is fine for non-self) — we test
+  // self-witness by having post-checkpoint cite its OWN id. Since mkEpisode uses
+  // a deterministic counter, we just resolve via filesystem after creation.
+  // Workaround: write the post-checkpoint via direct fixture so we control the id.
+  const selfId = `20260502-120099-self-witness-test-9999`
+  const payload = {
+    event: 'post-checkpoint',
+    pattern_id: 'bp-001-implementation-workflow',
+    task: 'TEST',
+    context: { worktree: tmpCwd, branch: 'main', head: 'abc1234' },
+    evidence: {
+      tests: [{ command: 'x', status: 'passed', log_ref: `episode:${selfId}` }],
+      code_review: { status: 'done', reply_ref: `episode:${rId}` },
+      e2e: { status: 'passed', log_ref: `episode:${eId}` },
+      bug_logging: { status: 'done', issues: [] }
+    }
+  }
+  const fm = `---\nid: ${selfId}\ndate: 2026-05-02\ntime: "12:00"\nproject: test\ncategory: workflow.lifecycle\nstatus: active\ntags: []\nsummary: post-checkpoint\n---\n`
+  const body = `# x\n\n\`\`\`json\n${JSON.stringify(payload)}\n\`\`\`\n`
+  fs.writeFileSync(path.join(episodesDir, `${selfId}.md`), fm + '\n' + body)
+  fs.appendFileSync(indexFile, JSON.stringify({
+    id: selfId, date: '2026-05-02', time: '12:00', project: 'test',
+    category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: 'self'
+  }) + '\n')
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('self-witness')),
+    `expected self-witness error, got: ${JSON.stringify(r.json.errors)}`)
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+/**
+ * test-workflow-validate.mjs — Tests for em-workflow-validate.mjs
+ *
+ * RFC-002 Phase 3b-H1 PR-C. Validates the workflow.lifecycle episode chain
+ * validator. Uses an isolated $HOME so episodes don't leak into the real
+ * memory store.
+ *
+ * Usage: node tests/test-workflow-validate.mjs
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execFileSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const VALIDATE = path.join(SCRIPTS, 'em-workflow-validate.mjs')
+
+// Isolated HOME for the test session
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-validate-test-'))
+const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'em-validate-cwd-'))
+const dataDir = path.join(tmpHome, '.episodic-memory')
+const episodesDir = path.join(dataDir, 'episodes')
+const indexFile = path.join(dataDir, 'index.jsonl')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    // Reset between tests
+    fs.rmSync(dataDir, { recursive: true, force: true })
+    fs.mkdirSync(episodesDir, { recursive: true })
+    fs.writeFileSync(indexFile, '')
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (e) {
+    console.log(`  ✗ ${name}`)
+    console.log(`    ${e.message}`)
+    failures.push({ name, error: e.message, stack: e.stack })
+    failed++
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — write episode .md + index entry directly. Avoids the
+// em-store dependency so tests are independent and faster.
+// ---------------------------------------------------------------------------
+let counter = 0
+function mkEpisode({ event, task = 'TEST', patternId = 'bp-001-implementation-workflow', branch = 'main', head = 'abc1234', extra = {} }) {
+  counter++
+  const id = `20260502-1200${String(counter).padStart(2, '0')}-${event}-${counter.toString(16).padStart(4, '0')}`
+  const payload = {
+    event,
+    pattern_id: patternId,
+    task,
+    context: { worktree: tmpCwd, branch, head },
+    ...extra
+  }
+  const body = `# ${event}\n\nTest fixture.\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\`\n`
+  const fm = [
+    '---',
+    `id: ${id}`,
+    'date: 2026-05-02',
+    'time: "12:00"',
+    'project: test',
+    'category: workflow.lifecycle',
+    'status: active',
+    'tags: []',
+    `summary: ${event}`,
+    '---',
+    ''
+  ].join('\n')
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), fm + '\n' + body)
+  fs.appendFileSync(indexFile, JSON.stringify({
+    id, date: '2026-05-02', time: '12:00', project: 'test',
+    category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: event
+  }) + '\n')
+  return id
+}
+
+function runValidate(args) {
+  try {
+    const out = execFileSync('node', [VALIDATE, ...args], {
+      env: { ...process.env, HOME: tmpHome },
+      cwd: tmpCwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    return { exit: 0, json: JSON.parse(out) }
+  } catch (e) {
+    if (e.stdout) {
+      try { return { exit: e.status, json: JSON.parse(e.stdout) } } catch {}
+    }
+    throw e
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+console.log('em-workflow-validate.mjs tests')
+console.log('================================')
+
+test('T1 happy: pre-checkpoint gate passes with plan-approved + pre-checkpoint', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'docs/plan.md', classification: 'full' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.exit, 0, `expected exit 0, got ${r.exit}: ${JSON.stringify(r.json)}`)
+  assert.strictEqual(r.json.valid, true)
+  assert.strictEqual(r.json.missing.length, 0)
+  assert.strictEqual(r.json.errors.length, 0)
+})
+
+test('T2 missing: pre-checkpoint gate fails when no episodes exist', () => {
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.exit, 1)
+  assert.strictEqual(r.json.valid, false)
+  assert.deepStrictEqual(r.json.missing, ['plan-approved', 'pre-checkpoint'])
+})
+
+test('T3 partial: pre-checkpoint missing plan-approved fails', () => {
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: 'episode:nonexistent-id' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.missing.includes('plan-approved'))
+  // Also: the orphaned approval_ref should produce an error
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref episode:nonexistent-id not found')))
+})
+
+test('T4 placeholder: empty plan_ref is rejected', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: '' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('plan-approved.plan_ref')))
+})
+
+test('T5 placeholder: TBD literal is rejected', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'TBD' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('plan_ref')))
+})
+
+test('T6 placeholder: bare "episode:" prefix in pre-checkpoint approval_ref rejected', () => {
+  mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'docs/plan.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: 'episode:' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref')))
+})
+
+test('T6b placeholder: episode:self in pre-checkpoint approval_ref rejected (self-witness)', () => {
+  mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'docs/plan.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: 'episode:self' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref')))
+})
+
+test('T7 task isolation: different task is filtered out', () => {
+  const planA = mkEpisode({ event: 'plan-approved', task: 'TASK-A', extra: { plan_ref: 'a.md' } })
+  mkEpisode({ event: 'pre-checkpoint', task: 'TASK-A', extra: { plan_ref: 'a.md', approval_ref: `episode:${planA}` } })
+  // Validator queried for TASK-B should see no matching events
+  const r = runValidate(['--task', 'TASK-B', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.deepStrictEqual(r.json.missing, ['plan-approved', 'pre-checkpoint'])
+})
+
+test('T8 happy: post-checkpoint gate with full evidence', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'node tests/test-x.mjs', status: 'passed', log_ref: 'episode:test-log-id' }],
+        code_review: { status: 'done', reply_ref: 'episode:review-id' },
+        e2e: { status: 'passed', log_ref: 'episode:e2e-id' },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)} missing: ${JSON.stringify(r.json.missing)}`)
+})
+
+test('T9 evidence: empty tests array is rejected', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [],
+        code_review: { status: 'done', reply_ref: 'episode:review-id' },
+        e2e: { status: 'passed', log_ref: 'episode:e2e-id' },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('evidence.tests must be a non-empty array')))
+})
+
+test('T10 evidence: code_review.status=done without reply_ref is rejected', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
+        code_review: { status: 'done', reply_ref: '' },
+        e2e: { status: 'passed', log_ref: 'episode:e' },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('code_review.reply_ref')))
+})
+
+test('T11 push-allowed: requires post_checkpoint_ref pointing to actual episode', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const postId = mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
+        code_review: { status: 'done', reply_ref: 'episode:r' },
+        e2e: { status: 'passed', log_ref: 'episode:e' },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T12 push-allowed: orphaned post_checkpoint_ref is rejected', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: 'episode:l' }],
+        code_review: { status: 'done', reply_ref: 'episode:r' },
+        e2e: { status: 'passed', log_ref: 'episode:e' },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: 'episode:bogus-id-12345' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('post_checkpoint_ref')))
+})
+
+test('T13 schema: missing context.head rejected', () => {
+  const id = `20260502-malformed-${Date.now()}`
+  const payload = {
+    event: 'plan-approved',
+    pattern_id: 'bp-001-implementation-workflow',
+    task: 'TEST',
+    context: { worktree: tmpCwd, branch: 'main' }, // no head
+    plan_ref: 'p.md'
+  }
+  const fm = `---\nid: ${id}\ndate: 2026-05-02\ntime: "12:00"\nproject: test\ncategory: workflow.lifecycle\nstatus: active\ntags: []\nsummary: malformed\n---\n`
+  const body = `# x\n\n\`\`\`json\n${JSON.stringify(payload)}\n\`\`\`\n`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), fm + '\n' + body)
+  fs.appendFileSync(indexFile, JSON.stringify({ id, date: '2026-05-02', time: '12:00', project: 'test', category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: 'x' }) + '\n')
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('context.head')))
+})
+
+test('T14 missing fenced block produces parse error', () => {
+  const id = `20260502-noblock-${Date.now()}`
+  const fm = `---\nid: ${id}\ndate: 2026-05-02\ntime: "12:00"\nproject: test\ncategory: workflow.lifecycle\nstatus: active\ntags: []\nsummary: x\n---\n`
+  const body = `# no json block here\n\nplain text only.\n`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), fm + '\n' + body)
+  fs.appendFileSync(indexFile, JSON.stringify({ id, date: '2026-05-02', time: '12:00', project: 'test', category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: 'x' }) + '\n')
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('No `\`\`\`json` fenced block') || e.includes('json fenced block')))
+})
+
+test('T15 superseded episodes are skipped', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  // Mark plan-approved as superseded by editing the index
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').map(l => {
+    const e = JSON.parse(l)
+    if (e.id === planId) e.status = 'superseded'
+    return JSON.stringify(e)
+  })
+  fs.writeFileSync(indexFile, lines.join('\n') + '\n')
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.missing.includes('plan-approved'))
+})
+
+test('T16 invalid gate rejected with exit 2', () => {
+  const r = runValidate(['--task', 'TEST', '--gate', 'bogus'])
+  assert.strictEqual(r.exit, 2, `expected exit 2, got ${r.exit}`)
+  assert.strictEqual(r.json.status, 'error')
+})
+
+test('T17 branch mismatch with --branch flag is an error', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', branch: 'old-branch', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--branch', 'main'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('context.branch')))
+})
+
+test('T18 worktree mismatch is an error (RFC-002:327)', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  // Pass a different worktree than tmpCwd (which is what fixtures use)
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--worktree', '/some/other/path'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('context.worktree')))
+})
+
+test('T19 head mismatch with --head flag is an error', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', head: 'oldsha1', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'newsha2'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('context.head')))
+})
+
+// ---------------------------------------------------------------------------
+console.log('================================')
+console.log(`${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('\nFailures:')
+  failures.forEach(f => console.log(`  ✗ ${f.name}: ${f.error}`))
+}
+
+// Cleanup
+fs.rmSync(tmpHome, { recursive: true, force: true })
+fs.rmSync(tmpCwd, { recursive: true, force: true })
+
+process.exit(failed === 0 ? 0 : 1)

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -207,10 +207,11 @@ test('T8 happy: post-checkpoint gate with full evidence (real witness episodes)'
   const reviewId = mkWitness({ summary: 'code review' })
   const e2eId = mkWitness({ summary: 'e2e log' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
-  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
       evidence: {
         tests: [{ command: 'node tests/test-x.mjs', status: 'passed', log_ref: `episode:${logId}` }],
         code_review: { status: 'done', reply_ref: `episode:${reviewId}` },
@@ -270,10 +271,11 @@ test('T11 push-allowed: requires post_checkpoint_ref pointing to actual episode'
   const rId = mkWitness({ summary: 'review' })
   const eId = mkWitness({ summary: 'e2e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
-  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   const postId = mkEpisode({
     event: 'post-checkpoint',
     extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
       evidence: {
         tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
         code_review: { status: 'done', reply_ref: `episode:${rId}` },
@@ -283,7 +285,7 @@ test('T11 push-allowed: requires post_checkpoint_ref pointing to actual episode'
     }
   })
   mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${postId}` } })
-  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed'])
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
   assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
 })
 
@@ -305,7 +307,7 @@ test('T12 push-allowed: orphaned post_checkpoint_ref is rejected', () => {
     }
   })
   mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: 'episode:bogus-id-12345' } })
-  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed'])
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
   assert.strictEqual(r.json.valid, false)
   assert.ok(r.json.errors.some(e => e.includes('post_checkpoint_ref')))
 })
@@ -497,10 +499,11 @@ test('T25 bug_logging.issues[]: gh:owner/repo#n short form accepted', () => {
   const rId = mkWitness({ summary: 'r' })
   const eId = mkWitness({ summary: 'e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
-  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
       evidence: {
         tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
         code_review: { status: 'done', reply_ref: `episode:${rId}` },
@@ -518,10 +521,11 @@ test('T26 bug_logging.issues[]: GitHub URL accepted', () => {
   const rId = mkWitness({ summary: 'r' })
   const eId = mkWitness({ summary: 'e' })
   const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
-  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
   mkEpisode({
     event: 'post-checkpoint',
     extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
       evidence: {
         tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
         code_review: { status: 'done', reply_ref: `episode:${rId}` },
@@ -532,6 +536,181 @@ test('T26 bug_logging.issues[]: GitHub URL accepted', () => {
   })
   const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
   assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+// ---------------------------------------------------------------------------
+// #98 finding 1 — per-gate head/branch rules + chain selection via refs.
+// ---------------------------------------------------------------------------
+
+test('T28 per-gate head: non-terminal link with old head passes when git unavailable (no ancestor check)', () => {
+  // pre-checkpoint at old head, validating post-checkpoint gate at new head.
+  // pre-checkpoint is non-terminal here, so its old head is acceptable.
+  // git is unavailable in the test env (tmpCwd is not a repo) so the
+  // ancestor check is skipped silently.
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', head: 'oldsha111', extra: { plan_ref: 'p.md' } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', head: 'oldsha111', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    head: 'newsha222',
+    extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint', '--head', 'newsha222'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T29 per-gate head: terminal link with mismatched head fails', () => {
+  // pre-checkpoint at oldsha; --head is newsha; pre-checkpoint IS terminal
+  // for pre-checkpoint gate, so it must equal --head.
+  const planId = mkEpisode({ event: 'plan-approved', head: 'oldsha111', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', head: 'oldsha111', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'newsha222'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('terminal pre-checkpoint must be at current HEAD')),
+    `expected terminal head error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T30 branch switch between plan-approved and post-checkpoint fails', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', branch: 'feature-a', extra: { plan_ref: 'p.md' } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', branch: 'feature-a', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    branch: 'feature-b', // switched mid-chain
+    extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint', '--branch', 'feature-b'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('chain links must share branch')),
+    `expected branch-switch error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T31 push-allowed: post-checkpoint at older head than --head fails (extra commits)', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', head: 'sha1', extra: { plan_ref: 'p.md' } })
+  const preId = mkEpisode({ event: 'pre-checkpoint', head: 'sha1', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const postId = mkEpisode({
+    event: 'post-checkpoint',
+    head: 'sha2', // evidence recorded at sha2
+    extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  // push-allowed at sha3 — but post-checkpoint was at sha2. Extra commits
+  // landed since evidence; must re-run post-checkpoint.
+  mkEpisode({ event: 'push-allowed', head: 'sha3', extra: { post_checkpoint_ref: `episode:${postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'sha3'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('Code may have changed since evidence')),
+    `expected post-checkpoint head exact-equal error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T32 pre_checkpoint_ref missing in post-checkpoint is rejected', () => {
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      // pre_checkpoint_ref intentionally omitted
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('pre_checkpoint_ref missing')),
+    `expected pre_checkpoint_ref missing error, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T33 pre_checkpoint_ref splicing: refs different chain pre-checkpoint fails', () => {
+  // Two parallel chains for same task — task-A pre-checkpoint and task-B
+  // pre-checkpoint (different tasks). post-checkpoint for TASK-A but
+  // pre_checkpoint_ref points to TASK-B's pre-checkpoint. Validator queries
+  // for TASK-A: TASK-B episodes are filtered out, so the pre_checkpoint_ref
+  // resolves to a workflow.lifecycle episode (passes category check) but
+  // is not in the loaded events[] for TASK-A — the chain-link check rejects.
+  const lId = mkWitness({ summary: 'log' })
+  const rId = mkWitness({ summary: 'r' })
+  const eId = mkWitness({ summary: 'e' })
+  const planA = mkEpisode({ event: 'plan-approved', task: 'TASK-A', extra: { plan_ref: 'a.md' } })
+  mkEpisode({ event: 'pre-checkpoint', task: 'TASK-A', extra: { plan_ref: 'a.md', approval_ref: `episode:${planA}` } })
+  // TASK-B's pre-checkpoint — splice target
+  const planB = mkEpisode({ event: 'plan-approved', task: 'TASK-B', extra: { plan_ref: 'b.md' } })
+  const preB = mkEpisode({ event: 'pre-checkpoint', task: 'TASK-B', extra: { plan_ref: 'b.md', approval_ref: `episode:${planB}` } })
+  mkEpisode({
+    event: 'post-checkpoint',
+    task: 'TASK-A',
+    extra: {
+      pre_checkpoint_ref: `episode:${preB}`, // splice from TASK-B
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] }
+      }
+    }
+  })
+  const r = runValidate(['--task', 'TASK-A', '--gate', 'post-checkpoint'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('chain splicing rejected') || e.includes('pre_checkpoint_ref')),
+    `expected splicing rejection, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T34 push-allowed gate without --head is rejected as usage error', () => {
+  // BLOCKER 2: post-checkpoint head check is silently skipped without --head.
+  // Validator now refuses push-allowed gate when --head is absent.
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed'])
+  assert.strictEqual(r.exit, 2, `expected exit 2, got ${r.exit}`)
+  assert.strictEqual(r.json.status, 'error')
+  assert.ok(r.json.message.includes('--head is required'),
+    `expected --head required error, got: ${r.json.message}`)
+})
+
+test('T35 branch switch on plan-approved (vs pre-checkpoint) is also caught', () => {
+  // MAJOR 4: confirm branch enforcement covers plan-approved, not just
+  // post-checkpoint. plan-approved at feature-a, pre-checkpoint at feature-b.
+  const planId = mkEpisode({ event: 'plan-approved', branch: 'feature-a', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', branch: 'feature-b', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--branch', 'feature-b'])
+  assert.strictEqual(r.json.valid, false)
+  // plan-approved is on feature-a, --branch is feature-b → mismatch
+  assert.ok(r.json.errors.some(e => e.includes('chain links must share branch')),
+    `expected branch-switch error on plan-approved, got: ${JSON.stringify(r.json.errors)}`)
 })
 
 test('T27 self-witness: real id pointing to citing episode is rejected', () => {

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -21,9 +21,15 @@ const VALIDATE = path.join(SCRIPTS, 'em-workflow-validate.mjs')
 // Isolated HOME for the test session
 const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-validate-test-'))
 const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'em-validate-cwd-'))
-const dataDir = path.join(tmpHome, '.episodic-memory')
+const dataDir = path.join(tmpHome, '.episodic-memory')           // global ($HOME)
 const episodesDir = path.join(dataDir, 'episodes')
 const indexFile = path.join(dataDir, 'index.jsonl')
+// Local store under tmpCwd for tests that need to verify the scope/resolver
+// split — a local lifecycle chain citing a global witness must resolve
+// regardless of --scope.
+const localDataDir = path.join(tmpCwd, '.episodic-memory')
+const localEpisodesDir = path.join(localDataDir, 'episodes')
+const localIndexFile = path.join(localDataDir, 'index.jsonl')
 
 let passed = 0
 let failed = 0
@@ -33,8 +39,11 @@ function test(name, fn) {
   try {
     // Reset between tests
     fs.rmSync(dataDir, { recursive: true, force: true })
+    fs.rmSync(localDataDir, { recursive: true, force: true })
     fs.mkdirSync(episodesDir, { recursive: true })
     fs.writeFileSync(indexFile, '')
+    fs.mkdirSync(localEpisodesDir, { recursive: true })
+    fs.writeFileSync(localIndexFile, '')
     fn()
     console.log(`  ✓ ${name}`)
     passed++
@@ -689,6 +698,54 @@ test('T33 pre_checkpoint_ref splicing: refs different chain pre-checkpoint fails
   assert.strictEqual(r.json.valid, false)
   assert.ok(r.json.errors.some(e => e.includes('chain splicing rejected') || e.includes('pre_checkpoint_ref')),
     `expected splicing rejection, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T36 cross-scope resolution: local chain citing global witness resolves under --scope local', () => {
+  // Codex re-review P2: indexById was built from --scope-filtered entries,
+  // so a local chain citing a global witness failed with "not found (checked
+  // local + global)" — contradicting docs/comments. Fix: build resolver index
+  // from BOTH scopes regardless of --scope.
+  // Witness lives in global ($HOME .episodic-memory).
+  counter++
+  const witnessId = `20260502-1100${String(counter).padStart(2, '0')}-global-witness-${counter.toString(16).padStart(4, '0')}`
+  const witnessFm = `---\nid: ${witnessId}\ndate: 2026-05-02\ntime: "11:00"\nproject: test\ncategory: discovery\nstatus: active\ntags: []\nsummary: global witness\n---\n`
+  fs.writeFileSync(path.join(episodesDir, `${witnessId}.md`), witnessFm + '\n# global witness\n')
+  fs.appendFileSync(indexFile, JSON.stringify({
+    id: witnessId, date: '2026-05-02', time: '11:00', project: 'test',
+    category: 'discovery', status: 'active', supersedes: null, tags: [], summary: 'global witness'
+  }) + '\n')
+  // Lifecycle chain lives in local (tmpCwd .episodic-memory).
+  const writeLocalLifecycle = (event, extra) => {
+    counter++
+    const id = `20260502-1200${String(counter).padStart(2, '0')}-${event}-${counter.toString(16).padStart(4, '0')}`
+    const payload = {
+      event, pattern_id: 'bp-001-implementation-workflow', task: 'TEST',
+      context: { worktree: tmpCwd, branch: 'main', head: 'abc1234' },
+      ...extra
+    }
+    const fm = `---\nid: ${id}\ndate: 2026-05-02\ntime: "12:00"\nproject: test\ncategory: workflow.lifecycle\nstatus: active\ntags: []\nsummary: ${event}\n---\n`
+    const body = `# ${event}\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\`\n`
+    fs.writeFileSync(path.join(localEpisodesDir, `${id}.md`), fm + '\n' + body)
+    fs.appendFileSync(localIndexFile, JSON.stringify({
+      id, date: '2026-05-02', time: '12:00', project: 'test',
+      category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: event
+    }) + '\n')
+    return id
+  }
+  const planId = writeLocalLifecycle('plan-approved', { plan_ref: 'p.md' })
+  const preId = writeLocalLifecycle('pre-checkpoint', { plan_ref: 'p.md', approval_ref: `episode:${planId}` })
+  writeLocalLifecycle('post-checkpoint', {
+    pre_checkpoint_ref: `episode:${preId}`,
+    evidence: {
+      tests: [{ command: 'x', status: 'passed', log_ref: `episode:${witnessId}` }],
+      code_review: { status: 'done', reply_ref: `episode:${witnessId}` },
+      e2e: { status: 'passed', log_ref: `episode:${witnessId}` },
+      bug_logging: { status: 'done', issues: [] }
+    }
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint', '--scope', 'local'])
+  assert.strictEqual(r.json.valid, true,
+    `expected valid with cross-scope resolution; errors: ${JSON.stringify(r.json.errors)}`)
 })
 
 test('T34 push-allowed gate without --head is rejected as usage error', () => {


### PR DESCRIPTION
## Summary

- Implements RFC-002 Phase 3b-H1 **PR-C** (the first of three PRs for [#80](https://github.com/lantisprime/episodic-memory/issues/80)): a pure validator for `workflow.lifecycle` episode chains per [RFC-002:259-327](docs/rfcs/RFC-002-learning-loop.md).
- No hook changes, no cache layer, no behavior change to existing gates. The validator is callable but not wired in — PR-D (Plan Gate v2) and PR-E (validator-backed checkpoint-gate) follow.
- Replaces the non-empty-marker semantics (`[ -s "$MARKER" ]`) with append-only lifecycle episodes that reference real artifacts (plans, approvals, reviews, tests, issues). Empirical motivation: 7 bp-001 violations in one session on 2026-05-02, 6 of them after the existing gate cleared via marker-write-as-procedural-step.

## What's in this PR

- **`scripts/em-workflow-validate.mjs`** (new, 280 lines) — validates `plan-approved`, `pre-checkpoint`, `review-done`, `post-checkpoint`, `push-allowed` events. JSON to stdout, exits 0 (pass) / 1 (fail) / 2 (usage). Pure validator — no episode mutation, no marker writes.
- **`docs/specs/workflow-lifecycle.md`** (new) — schema reference mirroring RFC-002, episode body convention (one ` ```json ` fenced block per lifecycle episode), validator usage and gate-requirement matrix.
- **`tests/test-workflow-validate.mjs`** (new, **20 tests, all passing**) — fixtures + happy paths for all three gates + every RFC-002:327 rejection class.
- **`scripts/em-store.mjs`** (1 line) — `'workflow.lifecycle'` added to `VALID_CATEGORIES`.

## Code review (Rule 18 step 6)

Subagent code review identified 8 findings. Addressed inline:
- **P1.1** `episode:self` rejected as placeholder; `plan-approved` no longer requires `approval_ref` (it IS the approval record).
- **P1.2** Worktree mismatch is now an **error** (per RFC-002:327), not a warning. Realpath-aware so macOS `/var` → `/private/var` symlinks don't false-positive.
- **P1.3** Branch/head mismatch are **errors** when flags are explicitly passed (was warnings).
- **P2.3** Test T16 (invalid-gate exit-2 assertion) no longer silently passes on exception.

Deferred to follow-up issues so they land in PR-D/E queue rather than bloating PR-C:
- [#92](https://github.com/lantisprime/episodic-memory/issues/92) chain temporal ordering
- [#93](https://github.com/lantisprime/episodic-memory/issues/93) frontmatter status double-check
- [#94](https://github.com/lantisprime/episodic-memory/issues/94) loadIndex SYNC drift test
- [#95](https://github.com/lantisprime/episodic-memory/issues/95) multiple-fenced-block hardening
- [#96](https://github.com/lantisprime/episodic-memory/issues/96) evidence_ref shape requirement
- [#97](https://github.com/lantisprime/episodic-memory/issues/97) push-allowed transitive validity test

## Test plan

- [x] `node tests/test-workflow-validate.mjs` — 20/20 pass
- [x] Regression suite (8 existing test files) — 167/167 pass, no regressions
- [x] em-store category change covered by existing test-rfc002-phase1 (17/17)
- [ ] (Reviewer) Verify schema doc matches RFC-002:259-327 wording
- [ ] (Reviewer) Sanity check that validator JSON output is hook-friendly (single line, parseable, exit codes correct)

## What this PR explicitly does NOT do

- No hook integration (`checkpoint-gate.sh` still uses marker semantics — PR-E)
- No `.claude/em-gates/*` cache layer (PR-D/E)
- No step-instrumentation skills/wrappers (separate work, follow-up)
- No plan-content hashing for stronger task-identity binding (proposed hardening, not in RFC)
- Does not close [#80](https://github.com/lantisprime/episodic-memory/issues/80) — only PR-E does, after PR-D lands

## Sequencing context

Per RFC-002:354-360 the broader Phase 3b-H1 work is:
- **PR-C (this PR):** lifecycle schema + validator
- **PR-D:** Plan Gate v2 / review lifecycle requirement before plan-gate clears
- **PR-E:** validator-backed pre-write + pre-push gates using lifecycle episodes + adapter cache

Issue [#89](https://github.com/lantisprime/episodic-memory/issues/89) (checkpoint-gate read-only Bash gap) is a separate prerequisite for usability while #80's gate is armed; will be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)