### PR TITLE
fix(scripts): resolve LOCAL_DIR via git-common-dir for worktree correctness (#85)

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -88,6 +88,15 @@ for (const file of scriptFiles) {
   fs.copyFileSync(src, dst)
   fs.chmodSync(dst, 0o755)
 }
+// scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-* scripts.
+const REPO_SCRIPTS_LIB = path.join(REPO_SCRIPTS, 'lib')
+if (fs.existsSync(REPO_SCRIPTS_LIB)) {
+  const libDst = path.join(SCRIPTS_DIR, 'lib')
+  fs.mkdirSync(libDst, { recursive: true })
+  for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs'))) {
+    fs.copyFileSync(path.join(REPO_SCRIPTS_LIB, file), path.join(libDst, file))
+  }
+}
 console.log(`Installed ${scriptFiles.length} scripts to ${SCRIPTS_DIR}`)
 
 // 1b. Copy patterns/_index.json for global pattern validation

--- a/scripts/em-check-stale.mjs
+++ b/scripts/em-check-stale.mjs
@@ -14,9 +14,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 

--- a/scripts/em-list.mjs
+++ b/scripts/em-list.mjs
@@ -12,9 +12,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -19,11 +19,12 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const HOME = os.homedir()
 const CWD = process.cwd()
 const GLOBAL_DIR = path.join(HOME, '.episodic-memory')
-const LOCAL_DIR = path.join(CWD, '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir(CWD)
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -24,9 +24,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 function flag(name) {

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -13,9 +13,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 function flag(name) {

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -19,9 +19,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -15,9 +15,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -18,9 +18,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -14,9 +14,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -30,9 +30,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -9,11 +9,20 @@
  * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
  *
  * Edge-case handling:
- *   - Linked worktree:  common-dir basename is `.git`     -> parent.
- *   - Submodule:        common-dir is `<repo>/.git/modules/<name>`     -> strip from `/.git/`.
- *   - Worktree-of-sub:  common-dir is `<repo>/.git/modules/<name>/worktrees/<wt>` -> strip from `/.git/`.
- *   - --separate-git-dir / GIT_DIR: no `/.git/` segment in common-dir   -> cwd fallback.
- *   - Bare repo / non-git cwd:                                          -> cwd fallback.
+ *   - Linked worktree of main:  common-dir basename is `.git` -> parent. (This
+ *     is the case #85 is about: the linked worktree's common-dir is the SHARED
+ *     main `.git`, so we resolve to the main repo root.)
+ *   - Submodule:                common-dir is `<super>/.git/modules/<name>`,
+ *     basename ≠ `.git` -> use `git rev-parse --show-toplevel`, which returns
+ *     the SUBMODULE's working tree (its own local memory, not the superproject's).
+ *   - --separate-git-dir / GIT_DIR=...: common-dir is the gitdir target,
+ *     basename ≠ `.git` -> --show-toplevel returns the linked work tree.
+ *   - Bare repo:                --show-toplevel errors -> cwd fallback.
+ *   - Non-git cwd:              first git call throws -> cwd fallback.
+ *
+ * NOTE: A worktree of a submodule degrades to the submodule's worktree root via
+ *       --show-toplevel (consistent with how a worktree of main is handled, just
+ *       one level deeper). Out of scope for #85 — file an issue if it bites.
  */
 
 import path from 'path'
@@ -26,22 +35,21 @@ export function resolveLocalDir(cwd = process.cwd()) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).toString().trim()
     const absCommon = path.resolve(cwd, commonDir)
-    // Canonical worktree: <repo>/.git
+    // Canonical case (linked worktree of main, or main itself): <repo>/.git.
     if (path.basename(absCommon) === '.git') {
       return path.join(path.dirname(absCommon), '.episodic-memory')
     }
-    // Submodule / worktree-of-submodule: strip from `/.git/...`. Last occurrence
-    // handles nested cases (worktree of a submodule).
-    const sep = path.sep
-    const marker = `${sep}.git${sep}`
-    const idx = absCommon.lastIndexOf(marker)
-    if (idx !== -1) {
-      return path.join(absCommon.slice(0, idx), '.episodic-memory')
-    }
-    // No `.git` segment (--separate-git-dir / GIT_DIR / bare): no reliable
-    // way to recover the main worktree. Fall through to cwd.
+    // Submodule, --separate-git-dir, GIT_DIR=..., etc. The common-dir parent is
+    // NOT the working tree (e.g. for a submodule it's the superproject's
+    // .git/modules/, not the submodule's checkout). Use --show-toplevel to get
+    // the actual working tree of THIS git context.
+    const top = execSync('git rev-parse --show-toplevel', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+    if (top) return path.join(top, '.episodic-memory')
   } catch {
-    // not a git repo, or git unavailable
+    // not a git repo, bare repo, or git unavailable
   }
   return path.join(cwd, '.episodic-memory')
 }

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -1,0 +1,47 @@
+/**
+ * local-dir.mjs — resolve the canonical .episodic-memory/ directory for --scope local.
+ *
+ * Walks to the main repository root via `git rev-parse --git-common-dir` so that
+ * invocations from a linked worktree write to the SAME store as the main checkout.
+ * Closes #85.
+ *
+ * Resolution captured at module-load time by callers (e.g. `const LOCAL_DIR =
+ * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
+ *
+ * Edge-case handling:
+ *   - Linked worktree:  common-dir basename is `.git`     -> parent.
+ *   - Submodule:        common-dir is `<repo>/.git/modules/<name>`     -> strip from `/.git/`.
+ *   - Worktree-of-sub:  common-dir is `<repo>/.git/modules/<name>/worktrees/<wt>` -> strip from `/.git/`.
+ *   - --separate-git-dir / GIT_DIR: no `/.git/` segment in common-dir   -> cwd fallback.
+ *   - Bare repo / non-git cwd:                                          -> cwd fallback.
+ */
+
+import path from 'path'
+import { execSync } from 'child_process'
+
+export function resolveLocalDir(cwd = process.cwd()) {
+  try {
+    const commonDir = execSync('git rev-parse --git-common-dir', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+    const absCommon = path.resolve(cwd, commonDir)
+    // Canonical worktree: <repo>/.git
+    if (path.basename(absCommon) === '.git') {
+      return path.join(path.dirname(absCommon), '.episodic-memory')
+    }
+    // Submodule / worktree-of-submodule: strip from `/.git/...`. Last occurrence
+    // handles nested cases (worktree of a submodule).
+    const sep = path.sep
+    const marker = `${sep}.git${sep}`
+    const idx = absCommon.lastIndexOf(marker)
+    if (idx !== -1) {
+      return path.join(absCommon.slice(0, idx), '.episodic-memory')
+    }
+    // No `.git` segment (--separate-git-dir / GIT_DIR / bare): no reliable
+    // way to recover the main worktree. Fall through to cwd.
+  } catch {
+    // not a git repo, or git unavailable
+  }
+  return path.join(cwd, '.episodic-memory')
+}

--- a/tests/test-em-local-dir-worktree.mjs
+++ b/tests/test-em-local-dir-worktree.mjs
@@ -122,6 +122,51 @@ test('non-git cwd falls back to <cwd>/.episodic-memory/', () => {
   )
 })
 
+// Regression for the v1 bug Codex caught on PR #105: --git-common-dir for a
+// submodule returns <super>/.git/modules/<name>; an over-eager `/.git/` strip
+// would resolve the submodule's local memory to the SUPERPROJECT root, cross-
+// contaminating two separate stores. Correct behavior: --show-toplevel returns
+// the submodule's own working tree.
+test('submodule writes to the SUBMODULE working tree, not the superproject', () => {
+  const superRepo = path.join(tmpRoot, 'super')
+  const subSrc = path.join(tmpRoot, 'subsrc')
+  fs.mkdirSync(superRepo, { recursive: true })
+  fs.mkdirSync(subSrc, { recursive: true })
+
+  // Create a "remote" repo for the submodule
+  git(subSrc, 'init -q -b main')
+  git(subSrc, 'config user.email test@example.com')
+  git(subSrc, 'config user.name test')
+  fs.writeFileSync(path.join(subSrc, 'README.md'), '# sub\n')
+  git(subSrc, 'add README.md')
+  git(subSrc, 'commit -q -m sub-init')
+
+  // Create the superproject and add the submodule. file:// + protocol.file.allow
+  // is required by modern git for local submodule sources.
+  git(superRepo, 'init -q -b main')
+  git(superRepo, 'config user.email test@example.com')
+  git(superRepo, 'config user.name test')
+  fs.writeFileSync(path.join(superRepo, 'README.md'), '# super\n')
+  git(superRepo, 'add README.md')
+  git(superRepo, 'commit -q -m super-init')
+  git(superRepo, `-c protocol.file.allow=always submodule add -q file://${fs.realpathSync(subSrc)} sub`)
+
+  const subCheckout = path.join(superRepo, 'sub')
+  const superStore = path.join(fs.realpathSync(superRepo), '.episodic-memory')
+  const subStore = path.join(fs.realpathSync(subCheckout), '.episodic-memory')
+
+  const res = storeFrom(subCheckout, 'from-submodule')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(subStore + path.sep),
+    `expected file under submodule store ${subStore}, got ${res.file}`,
+  )
+  assert.ok(
+    !res.file.startsWith(superStore + path.sep),
+    `submodule episode leaked into superproject store: ${res.file}`,
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Summary (cleanup runs via process.on('exit') registered above)
 // ---------------------------------------------------------------------------

--- a/tests/test-em-local-dir-worktree.mjs
+++ b/tests/test-em-local-dir-worktree.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * test-em-local-dir-worktree.mjs — Tests for #85 LOCAL_DIR worktree resolution.
+ *
+ * Verifies that em-store --scope local writes to the MAIN repo's
+ * .episodic-memory/ regardless of whether invoked from main checkout, a linked
+ * worktree, a nested cwd inside the worktree, or a non-git directory.
+ *
+ * Usage: node tests/test-em-local-dir-worktree.mjs
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+function storeFrom(cwd, summary) {
+  const out = execSync(
+    `node ${STORE} --scope local --project test --category context --summary "${summary}" --body "body"`,
+    { cwd, stdio: ['ignore', 'pipe', 'pipe'] },
+  ).toString()
+  const res = JSON.parse(out)
+  // Realpath res.file too, so macOS /var → /private/var symlinks don't
+  // break startsWith() comparisons against realpathed expected stores.
+  if (res.file) res.file = fs.realpathSync(res.file)
+  return res
+}
+
+// ---------------------------------------------------------------------------
+// Setup: temp main repo + linked worktree + nested dir + non-git dir
+// ---------------------------------------------------------------------------
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-localdir-'))
+// Register cleanup early so setup failures don't leak temp dirs.
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+const mainRepo = path.join(tmpRoot, 'main')
+const worktreeRoot = path.join(tmpRoot, 'wt')
+const nestedDir = path.join(worktreeRoot, 'a', 'b', 'c')
+const nonGitDir = path.join(tmpRoot, 'plain')
+
+fs.mkdirSync(mainRepo, { recursive: true })
+fs.mkdirSync(nonGitDir, { recursive: true })
+
+git(mainRepo, 'init -q -b main')
+git(mainRepo, 'config user.email test@example.com')
+git(mainRepo, 'config user.name test')
+fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
+git(mainRepo, 'add README.md')
+git(mainRepo, 'commit -q -m init')
+git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
+fs.mkdirSync(nestedDir, { recursive: true })
+
+// Resolve realpath upfront so assertions handle macOS /var → /private/var.
+const mainStore = path.join(fs.realpathSync(mainRepo), '.episodic-memory')
+const worktreeStore = path.join(fs.realpathSync(worktreeRoot), '.episodic-memory')
+const nonGitStore = path.join(fs.realpathSync(nonGitDir), '.episodic-memory')
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('main checkout writes episode to main repo .episodic-memory/', () => {
+  const res = storeFrom(mainRepo, 'from-main')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(res.file.startsWith(mainStore + path.sep), `expected file under ${mainStore}, got ${res.file}`)
+  assert.ok(fs.existsSync(res.file))
+})
+
+test('linked worktree writes episode to MAIN repo .episodic-memory/, not worktree', () => {
+  const res = storeFrom(worktreeRoot, 'from-worktree')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(mainStore + path.sep),
+    `expected file under ${mainStore}, got ${res.file}`,
+  )
+  assert.ok(
+    !res.file.startsWith(worktreeStore + path.sep),
+    `episode leaked into worktree store: ${res.file}`,
+  )
+  assert.ok(!fs.existsSync(worktreeStore), `worktree .episodic-memory/ should not exist, found at ${worktreeStore}`)
+})
+
+test('nested cwd inside worktree still writes to MAIN repo .episodic-memory/', () => {
+  const res = storeFrom(nestedDir, 'from-nested')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(mainStore + path.sep),
+    `expected file under ${mainStore}, got ${res.file}`,
+  )
+})
+
+test('non-git cwd falls back to <cwd>/.episodic-memory/', () => {
+  const res = storeFrom(nonGitDir, 'from-non-git')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(nonGitStore + path.sep),
+    `expected fallback under ${nonGitStore}, got ${res.file}`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Summary (cleanup runs via process.on('exit') registered above)
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.error('\nFailures:')
+  for (const f of failures) console.error(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -493,6 +493,14 @@ test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (P
       fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(sessionScripts, f))
     }
   }
+  const SCRIPTS_LIB = path.join(SCRIPTS_DIR, 'lib')
+  if (fs.existsSync(SCRIPTS_LIB)) {
+    const sessionLib = path.join(sessionScripts, 'lib')
+    fs.mkdirSync(sessionLib, { recursive: true })
+    for (const f of fs.readdirSync(SCRIPTS_LIB)) {
+      if (f.endsWith('.mjs')) fs.copyFileSync(path.join(SCRIPTS_LIB, f), path.join(sessionLib, f))
+    }
+  }
 
   // Seed a recent bp-001 violation in the project's local store using
   // the same env/HOME the hook will run under.


### PR DESCRIPTION
## Summary
- **Closes #85.** 10 em-* scripts defaulted `--scope local` to `process.cwd()/.episodic-memory/`, so invocations from a linked git worktree wrote episodes to the worktree's orphan store instead of the main repo's shared store.
- New [`scripts/lib/local-dir.mjs`](scripts/lib/local-dir.mjs) exports `resolveLocalDir()`. Resolution policy:
  - **Linked worktree of main / main itself:** `git rev-parse --git-common-dir` returns `<repo>/.git`; basename is `.git` → take parent. (This is the case #85 is about.)
  - **Submodule, --separate-git-dir, GIT_DIR=...:** common-dir basename ≠ `.git` → use `git rev-parse --show-toplevel`, which returns the correct working tree of THIS git context (the submodule's checkout, not the superproject's).
  - **Bare repo / non-git cwd:** falls through to cwd-relative.
- Wired into 10 scripts (em-store, em-list, em-search, em-recall, em-revise, em-prune, em-check-stale, em-rebuild-index, em-workflow-validate, em-pattern-health) + `install.mjs` deploys the new `scripts/lib/` directory + `tests/test-rfc002-phase3.mjs:T7j` updated to mirror the install layout.

## Review process
Per Rule 18 / bp-001:
1. Plan presented (chat).
2. Codex review (request `20260503-004922-...460e`, reply `20260503-005126-...6436`) — flagged 6 additional files I had missed (em-workflow-validate especially — validator-backed gates would otherwise read a worktree-orphan store) and recommended the defensive git-walk. Folded.
3. Plan-agent code review (general-purpose subagent) — flagged P0/P1 fixes; folded into commit `64b59e8`.
4. **Codex re-review on commit `64b59e8` caught a P1:** the original `/.git/` segment-stripping fallback wrongly resolved a submodule's local memory to the **superproject's** root (cross-contamination). Repro: `cwd=<super>/sub` → v1 returned `<super>/.episodic-memory`; correct answer is `<super>/sub/.episodic-memory`.
5. Fix in commit `2f24a96`: replaced segment-strip with `git rev-parse --show-toplevel` for non-`.git`-basename common dirs. Plan-agent's earlier concern about `--show-toplevel` only applied to *linked worktrees of main*, which hit the canonical `.git`-basename branch first and never reach the fallback — I conflated the cases on round 1.
6. **Codex re-review on commit `2f24a96` signs off** (episode `20260503-011651-...226e`). All tests pass; manual submodule repro now resolves correctly.

## Test plan
- [x] `node tests/test-em-local-dir-worktree.mjs` — **5/5** (main, linked worktree, nested cwd, non-git fallback, **submodule regression**)
- [x] `node tests/test-rfc002-phase3.mjs` — 28/28 incl. T7j (E2E SessionStart hook), updated to copy `scripts/lib/`
- [x] `node tests/test-p3-fixes.mjs` — 7/7
- [x] `node tests/test-phase2.mjs` — 24/24
- [x] `node tests/test-phase3.mjs` — 20/20
- [x] `node tests/test-rfc002-phase1.mjs` — 17/17
- [x] `node tests/test-rfc002-phase2.mjs` — 31/31
- [x] `node tests/test-em-watch-codex.mjs` — 25/25
- [x] `bash tests/test-checkpoint-gate.sh` — 91/91
- [x] `bash tests/test-plan-gate.sh` — 20/20
- [x] `bash tests/test-install-hooks.sh` — 58/58
- [x] **Codex manual install repro:** `~/.episodic-memory/scripts/lib/local-dir.mjs` deploys correctly via `--install-hooks`

## Follow-ups (filed)
- [#106](https://github.com/lantisprime/episodic-memory/issues/106) — `armCheckpointMarker(process.cwd())` worktree-orphan (high priority, affects bp-001 enforcement)
- [#107](https://github.com/lantisprime/episodic-memory/issues/107) — `loadPatternsIndex` cwd-relative
- [#108](https://github.com/lantisprime/episodic-memory/issues/108) — em-watch-codex.findLocalStore consolidation
- (Will file): worktree-of-submodule policy — currently degrades to that worktree's own `.episodic-memory/`; might want to walk to submodule's primary checkout instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)