### PR TITLE
feat(hooks): shared command classifier — closes #86 PR-B / #89 / #101 (Session 1)

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -182,8 +182,15 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
     _block_post
   fi
-  # Allowed push — clear all four markers (task complete).
-  rm -f "$PRE_REQ" "$PRE_DONE" "$POST_REQ" "$POST_DONE" 2>/dev/null || true
+  # Audit P1: marker cleanup is gated on plan-gate not pending. PreToolUse
+  # hooks run independently; if plan-gate or another PreToolUse hook ALSO
+  # blocks this call, we must not have already removed the markers (the
+  # tool will not actually run). Cleanup only when plan-gate is clear —
+  # in that case, push_or_pr_create has reached the user's intended
+  # task-complete moment.
+  if [ ! -f "$PLAN_PENDING" ]; then
+    rm -f "$PRE_REQ" "$PRE_DONE" "$POST_REQ" "$POST_DONE" 2>/dev/null || true
+  fi
   exit 0
 fi
 

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -1,147 +1,195 @@
 #!/usr/bin/env bash
 set -e
 
-# checkpoint-gate.sh — RFC-002 Phase 3b PreToolUse hook
+# checkpoint-gate.sh — RFC-002 Phase 3b PreToolUse hook.
 #
-# Dependencies: bash, jq, grep. Same as plan-gate.sh — if any are missing
-# the hook will fail under set -e; behavior in that case is whatever Claude
-# Code does with a hook exit code != 0 (not redocumented here).
+# Session 1 rewrite (#86 PR-B / #89 / #101): replaces the regex-based
+# marker-write allowlist (lines ~46-117 in the prior version) and the
+# git-push / gh-pr-create regex (lines ~125-141) with the shared classifier
+# from hooks/lib/command-classifier.sh.
 #
-# Two gates with shared marker state in $CWD/.claude/:
+# Two gates with shared marker state in <repo-root>/.claude/:
 #
 #   pre-checkpoint:
-#     Blocks Edit/Write/MultiEdit/Bash/NotebookEdit when
-#     .checkpoint-required exists AND .pre-checkpoint-done is missing/empty.
-#     Activator: em-recall.mjs touches .checkpoint-required when bp-001
-#     violations surface in pre-flight (Phase 3, em-recall.mjs:347-369).
+#     Blocks Edit/Write/MultiEdit/Bash/NotebookEdit when .checkpoint-required
+#     exists AND .pre-checkpoint-done is missing/empty. Activator:
+#     em-recall.mjs touches .checkpoint-required when bp-001 violations
+#     surface in pre-flight (Phase 3, em-recall.mjs:347-369).
 #
 #   push-gate:
-#     Blocks Bash containing `git push` or `gh pr create` when
-#     .post-checkpoint-required exists AND .post-checkpoint-done missing/empty.
-#     Allowed pushes clean all 4 markers (task complete).
+#     Blocks Bash classified as push_or_pr_create OR shared_write that mutates
+#     external GitHub state when .post-checkpoint-required exists AND
+#     .post-checkpoint-done is missing/empty. Allowed pushes clean all 4
+#     markers (task complete).
 #
 # .post-checkpoint-required is armed on every allowed write that passed the
-# pre-gate (idempotent touch). Allowlist: Bash commands referencing
-# .pre-checkpoint-done or .post-checkpoint-done pass through (deadlock
-# prevention — same pattern as plan-gate.sh's rm allowlist).
+# pre-gate (idempotent touch).
+#
+# Marker-write allowlist (deadlock prevention) is now classifier-driven:
+# Bash classified as marker_write whose TARGET is one of the repo-root
+# checkpoint markers passes the pre-gate iff:
+#   - .pre-checkpoint-done write: requires .checkpoint-required exists AND
+#     .pre-checkpoint-done is missing/empty (writing into the gate's expected
+#     state, not bypassing it).
+#   - .post-checkpoint-done write: requires .post-checkpoint-required exists
+#     AND .post-checkpoint-done is missing/empty.
+# Cross-gate invariant (Codex ...3503 P1): checkpoint marker writes are
+# blocked while the repo-root .plan-approval-pending marker exists. Both
+# gates independently enforce the invariant; do not rely on Claude hook
+# order.
 
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-MARKER_DIR="$CWD/.claude"
+# Source classifier + repo-root resolver. Use BASH_SOURCE for symlink safety.
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+LIB_DIR="$HOOK_DIR/lib"
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ]; then
+  echo '{"decision": "block", "reason": "checkpoint-gate.sh: hooks/lib/ not found alongside hook. Re-run install.mjs --install-hooks."}'
+  exit 0
+fi
+# shellcheck disable=SC1091
+source "$LIB_DIR/repo-root.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/command-classifier.sh"
+
+REPO_ROOT="$(resolve_repo_root "$CWD")"
+MARKER_DIR="$REPO_ROOT/.claude"
 PRE_REQ="$MARKER_DIR/.checkpoint-required"
 PRE_DONE="$MARKER_DIR/.pre-checkpoint-done"
 POST_REQ="$MARKER_DIR/.post-checkpoint-required"
 POST_DONE="$MARKER_DIR/.post-checkpoint-done"
+PLAN_PENDING="$MARKER_DIR/.plan-approval-pending"
 
 # Read-only tools — always allowed
 case "$TOOL_NAME" in
-  Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|mcp__*)
+  Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
     exit 0
     ;;
 esac
 
-# Allowlist: Bash redirecting (>, >>, or tee) into a checkpoint-done marker.
-# Three-step tightening history:
-#   #65: require redirect operator before marker name (no longer just a
-#        substring match) — blocked `cat /etc/passwd; echo .pre-checkpoint-done`.
-#   #66: only check the part of the command BEFORE the first `<<` (heredoc /
-#        here-string introducer). Heredoc bodies are text, not commands; a
-#        redirect mentioned inside a heredoc body must not bypass the gate.
-#        Example bypass that this addresses:
-#          cat > readme.md <<EOF
-#          echo > .pre-checkpoint-done
-#          EOF
-#        Pre-<< portion is `cat > readme.md `; no marker redirect → blocks.
-#   #68: anchor the pattern to end-of-COMMAND_HEAD ([[:space:]]*$) so a
-#        chained command after the marker write doesn't ride through the
-#        allowlist. Pre-fix: `echo X > .pre-checkpoint-done; rm -rf /tmp`
-#        passed the allowlist and the rm ran. Post-fix: trailing `;` (or
-#        `&&`/`||`/`|`/`&`) after the marker filename means no match —
-#        falls through to the gates' normal block path.
-#
-# Legitimate single-statement marker-writes still pass:
-#   echo "..." > .pre-checkpoint-done
-#   cat > .pre-checkpoint-done <<EOF\n...\nEOF
-#   tee .post-checkpoint-done <<<"text"
-#   printf "..." > .pre-checkpoint-done
-#
-# Known residuals (accepted): quoted strings and command substitution can
-# still embed the redirect-to-marker pattern as text (#67); heredoc body
-# followed by a chained command after EOF still bypasses (because the `<<`
-# truncation drops everything from the heredoc onward).
+# Helper: emit a block decision
+_block_pre() {
+  echo '{"decision": "block", "reason": "Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to .claude/.pre-checkpoint-done (must be non-empty) before write tools are unblocked. Hook: checkpoint-gate.sh."}'
+  exit 0
+}
+_block_post() {
+  echo '{"decision": "block", "reason": "Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty) before pushing. Hook: checkpoint-gate.sh."}'
+  exit 0
+}
+_block_plan_pending() {
+  echo '{"decision": "block", "reason": "Plan approval pending. Checkpoint marker writes are blocked while .claude/.plan-approval-pending exists. Approve the plan first. Hook: checkpoint-gate.sh."}'
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Bash classification — compute label up front for downstream gates.
+# ---------------------------------------------------------------------------
+LABEL=""
+TARGET=""
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
-  COMMAND_HEAD="${COMMAND%%<<*}"
-  # Flatten newlines to spaces (#72): grep -E evaluates line-by-line and `$`
-  # matches end-of-line, so without flattening, `echo > marker\n; rm` would
-  # match line 1 and bypass the allowlist. Flattening makes the whole
-  # COMMAND_HEAD a single line so `$` matches end-of-string.
-  COMMAND_HEAD_FLAT="${COMMAND_HEAD//$'\n'/ }"
+  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT")"
+  LABEL="${RESULT%%	*}"
+  REST="${RESULT#*	}"
+  TARGET="${REST%%	*}"
 
-  # #73 / #75: detect post-heredoc-EOF chained commands. If COMMAND has
-  # `<<TERM`, find the terminator line and check for non-whitespace content
-  # after it. If found, the allowlist must NOT match — heredoc body
-  # legitimately writes the marker, but a chained command after EOF runs
-  # unchecked.
-  POST_HEREDOC_HAS_CONTENT=0
-  if [ "$COMMAND_HEAD" != "$COMMAND" ]; then
-    # Extract terminator from first <<. Handles bash heredoc forms:
-    #   <<EOF, <<-EOF, <<'EOF', <<"EOF" (#73 initial coverage)
-    #   <<\EOF (backslash-escaped, #75)
-    #   <<123, <<==EOF==, etc. (any non-whitespace non-special term, #75)
-    # Terminator class: non-whitespace, non-redirect, non-pipe-special,
-    # non-quote chars. Optional leading `\` per bash quote-removal rules.
-    TERM=$(printf '%s' "$COMMAND" | sed -nE "s/^[^<]*<<-?[[:space:]]*['\"]?\\\\?([^[:space:]<>|&;'\"]+).*/\1/p" | head -1)
-    if [ -n "$TERM" ]; then
-      # Find lines AFTER the first occurrence of the terminator-only line.
-      # `<<-` form allows leading tabs on the terminator; awk strips them
-      # before comparing.
-      POST=$(printf '%s' "$COMMAND" | awk -v t="$TERM" '
-        f { print; next }
-        { line=$0; sub(/^\t+/, "", line); if (line==t) f=1 }
-      ')
-      if printf '%s' "$POST" | grep -qE '[^[:space:]]'; then
-        POST_HEREDOC_HAS_CONTENT=1
-      fi
-    fi
+  # Read-only Bash → allow immediately (closes #89).
+  if [ "$LABEL" = "read_only" ]; then
+    exit 0
   fi
 
-  if [ "$POST_HEREDOC_HAS_CONTENT" = "0" ]; then
-    if echo "$COMMAND_HEAD_FLAT" | grep -qE '(>|>>|tee[[:space:]]+)[^|&;<>]*\.(pre|post)-checkpoint-done[[:space:]]*$'; then
-      exit 0
+  # marker_write deadlock-prevention allowlist. Only allow when the gate's
+  # state expects that specific marker write. All other marker_write Bash
+  # falls through to the pre-gate as a normal write.
+  if [ "$LABEL" = "marker_write" ]; then
+    # Cross-gate invariant: checkpoint marker writes are blocked while
+    # .plan-approval-pending exists (Codex ...3503 P1).
+    if [ -f "$PLAN_PENDING" ]; then
+      if [ "$TARGET" = "$PLAN_PENDING" ]; then
+        # Allow plan-marker removal — plan-gate.sh is what cares about this.
+        exit 0
+      fi
+      _block_plan_pending
     fi
+    case "$TARGET" in
+      "$PRE_DONE")
+        if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
+          exit 0
+        fi
+        ;;
+      "$POST_DONE")
+        if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+          exit 0
+        fi
+        ;;
+      "$PLAN_PENDING")
+        exit 0
+        ;;
+    esac
+    # Did not satisfy a prerequisite — fall through to pre-gate as a normal
+    # write. Pre-gate will block if PRE_REQ armed and PRE_DONE empty.
   fi
 fi
 
+# ---------------------------------------------------------------------------
 # Pre-checkpoint gate
+# ---------------------------------------------------------------------------
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    # classify_path for Write/Edit/MultiEdit/NotebookEdit
+    FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    if [ -n "$FILE_PATH" ]; then
+      RESULT="$(classify_path "$FILE_PATH" "$REPO_ROOT")"
+      LABEL="${RESULT%%	*}"
+      REST="${RESULT#*	}"
+      TARGET="${REST%%	*}"
+      if [ "$LABEL" = "marker_write" ]; then
+        # Cross-gate invariant
+        if [ -f "$PLAN_PENDING" ] && [ "$TARGET" != "$PLAN_PENDING" ]; then
+          _block_plan_pending
+        fi
+        case "$TARGET" in
+          "$PRE_DONE")
+            if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
+              exit 0
+            fi
+            ;;
+          "$POST_DONE")
+            if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+              exit 0
+            fi
+            ;;
+          "$PLAN_PENDING")
+            exit 0
+            ;;
+        esac
+      fi
+    fi
+    ;;
+esac
+
 if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
-  echo '{"decision": "block", "reason": "Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to .claude/.pre-checkpoint-done (must be non-empty) before write tools are unblocked. Hook: checkpoint-gate.sh."}'
+  _block_pre
+fi
+
+# ---------------------------------------------------------------------------
+# Push-gate: only fires for Bash classified as push_or_pr_create.
+# ---------------------------------------------------------------------------
+if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
+  if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+    _block_post
+  fi
+  # Allowed push — clear all four markers (task complete).
+  rm -f "$PRE_REQ" "$PRE_DONE" "$POST_REQ" "$POST_DONE" 2>/dev/null || true
   exit 0
 fi
 
-# Push gate
-# Match `git push` (with optional global flags between git and push) or
-# `gh pr create`. Tightened from `git[[:space:]]+([^&;|]*[[:space:]])?push`
-# per #69 — that allowed arbitrary tokens (including non-push subcommands
-# like `commit -m push` or `branch push`) to ride between `git` and `push`,
-# producing false positives that blocked legitimate non-push git commands.
-# New form only allows global flag tokens: `-X`, `--long-flag`, `-X arg`.
-if [ "$TOOL_NAME" = "Bash" ]; then
-  COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
-  if echo "$COMMAND" | grep -qE '(^|[[:space:]&;|()])(git[[:space:]]+(-[^[:space:]]+[[:space:]]+([^-][^[:space:]]*[[:space:]]+)?)*push|gh[[:space:]]+pr[[:space:]]+create)([[:space:]&;|()]|$)'; then
-    if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
-      echo '{"decision": "block", "reason": "Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty) before pushing. Hook: checkpoint-gate.sh."}'
-      exit 0
-    fi
-    rm -f "$PRE_REQ" "$PRE_DONE" "$POST_REQ" "$POST_DONE" 2>/dev/null || true
-    exit 0
-  fi
-fi
-
+# ---------------------------------------------------------------------------
 # Allowed write — arm post-tracking if pre-checkpoint was satisfied
+# ---------------------------------------------------------------------------
 case "$TOOL_NAME" in
   Edit|Write|MultiEdit|Bash|NotebookEdit)
     if [ -f "$PRE_REQ" ] && [ -s "$PRE_DONE" ]; then

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -474,18 +474,25 @@ _classify_segment() {
   done
 
   # ---- Check redirects for marker writes ----
+  # If any output redirect targets a marker → marker_write.
+  # If any output redirect targets a non-marker → has_nonmarker_redirect, which
+  # forces shared_write later (overrides read-only command classification —
+  # `echo hello > file.txt` is a write even though `echo` is read-only).
   local r
+  local has_nonmarker_redirect=0
   for r in ${REDIRS[@]+"${REDIRS[@]}"}; do
     local rop="${r%%	*}"
     local rtarget="${r#*	}"
     local rbase="$(basename "$rtarget")"
     case "$rbase" in
       .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
-        # Resolve target path to absolute under target_root
         local abs_target
         abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
         return 0
+        ;;
+      *)
+        has_nonmarker_redirect=1
         ;;
     esac
   done
@@ -606,11 +613,19 @@ _classify_segment() {
     ls|cat|head|tail|grep|egrep|fgrep|rg|find|wc|awk|sed|tr|cut|sort|uniq|file|stat|du|df|pwd|whoami|hostname|date|env|printenv|which|type|command|tree|less|more|jq|yq|cmp|diff|column)
       # tee deliberately NOT here — it always writes (to stdout or file).
       # Bare tee in a pipeline is rare; we err safe and classify as shared_write.
+      if [ "$has_nonmarker_redirect" = "1" ]; then
+        printf '%s\t\t%s\n' "shared_write" "readonly_cmd_redirected"
+        return 0
+      fi
       printf '%s\t\t%s\n' "read_only" "readonly_cmd"
       return 0
       ;;
     echo|printf|true|false)
-      # echo/printf without redirect: no side effect
+      # echo/printf with output redirect → shared_write; without → read_only.
+      if [ "$has_nonmarker_redirect" = "1" ]; then
+        printf '%s\t\t%s\n' "shared_write" "echo_redirected"
+        return 0
+      fi
       printf '%s\t\t%s\n' "read_only" "echo_or_printf"
       return 0
       ;;

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -736,14 +736,64 @@ _classify_git() {
       printf '%s\t\t%s\n' "push_or_pr_create" "git_push"
       return 0
       ;;
-    status|log|diff|show|rev-parse|rev-list|reflog|blame|grep|describe|ls-files|ls-tree|ls-remote|fetch|cat-file|config|remote|branch|tag|worktree|var|help|version|shortlog|whatchanged|name-rev|check-ignore|check-mailmap|check-attr|annotate|count-objects)
-      # These are mostly read-only when used without write subcommands.
-      # branch/tag/remote/worktree/config CAN write — but by default invocation
-      # they list. We err on the side of read_only for these and let the
-      # specific write forms (push, commit, etc) catch the actual writes.
-      # Note: `git fetch` is technically a network op but produces no remote
-      # mutation; classify as read_only for our purposes.
+    status|log|diff|show|rev-parse|rev-list|reflog|blame|grep|describe|ls-files|ls-tree|ls-remote|fetch|cat-file|var|help|version|shortlog|whatchanged|name-rev|check-ignore|check-mailmap|check-attr|annotate|count-objects)
+      # Pure reads. fetch is a network op with no remote mutation.
       printf '%s\t\t%s\n' "read_only" "git_read_subcommand"
+      return 0
+      ;;
+    branch|tag|remote|worktree|config)
+      # Codex PR #113 review finding 1 [P1]: these subcommands EITHER list OR
+      # write depending on args. `git branch foo` creates a branch,
+      # `git remote add`, `git worktree add`, `git config user.name x` all
+      # write — and previously classified as read_only, bypassing plan-gate.
+      # Rule: if any positional (non-flag) arg follows the subcommand OR a
+      # write-only flag is present → shared_write. Bare list forms remain
+      # read_only.
+      local _gj=$((i+1))
+      local _has_positional=0 _has_write_flag=0 _np=0
+      while [ $_gj -lt ${#T[@]} ]; do
+        local _gt="${T[$_gj]}"
+        case "$_gt" in
+          -D|-d|-M|-m|-c|-C|--delete|--rename|--copy|--unset|--unset-all|--add|--replace-all|--edit|--set-upstream|--track|--no-track|--set-upstream-to|--force|-f)
+            _has_write_flag=1
+            ;;
+          -*) ;; # other flags treated as read-flags (verbose, list, etc.)
+          *)
+            _has_positional=1
+            _np=$((_np+1))
+            ;;
+        esac
+        _gj=$((_gj+1))
+      done
+      if [ "$sub" = "config" ]; then
+        # `git config <key>` (1 positional) reads; 2+ writes.
+        if [ $_np -le 1 ] && [ $_has_write_flag -eq 0 ]; then
+          printf '%s\t\t%s\n' "read_only" "git_config_read"
+          return 0
+        fi
+        printf '%s\t\t%s\n' "shared_write" "git_config_write"
+        return 0
+      fi
+      if [ "$sub" = "worktree" ]; then
+        local _wt_idx=$((i+2))
+        local _wt_sub=""
+        if [ $_wt_idx -lt ${#T[@]} ]; then _wt_sub="${T[$_wt_idx]}"; fi
+        case "$_wt_sub" in
+          ""|list)
+            printf '%s\t\t%s\n' "read_only" "git_worktree_list"
+            return 0
+            ;;
+          add|remove|move|repair|prune|lock|unlock)
+            printf '%s\t\t%s\n' "shared_write" "git_worktree_${_wt_sub}"
+            return 0
+            ;;
+        esac
+      fi
+      if [ $_has_positional -eq 1 ] || [ $_has_write_flag -eq 1 ]; then
+        printf '%s\t\t%s\n' "shared_write" "git_${sub}_write"
+        return 0
+      fi
+      printf '%s\t\t%s\n' "read_only" "git_${sub}_list"
       return 0
       ;;
     commit|add|rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|fetch|clone|init|gc|prune|notes|submodule|apply|am|format-patch|bisect|update-index|update-ref|symbolic-ref|hash-object|mktree|read-tree|write-tree|commit-tree|fsck|repack|pack-refs|pack-objects|unpack-objects|prune-packed|rerere|filter-branch|replay|sparse-checkout|maintenance)
@@ -795,18 +845,12 @@ _classify_gh() {
           return 0
           ;;
         review)
-          # gh pr review --approve mutates; --comment is informational.
-          local j=$((i+2))
-          while [ $j -lt $n ]; do
-            case "${T[$j]}" in
-              --approve|--request-changes)
-                printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_review_approve"
-                return 0
-                ;;
-            esac
-            j=$((j+1))
-          done
-          printf '%s\t\t%s\n' "shared_write" "gh_pr_review_comment"
+          # Codex PR #113 review finding 2 [P1]: gh pr review --comment was
+          # shared_write, but checkpoint-gate push-gate only blocks
+          # push_or_pr_create — bypass. ALL gh pr review forms write a review
+          # state to the PR (the --comment flag still posts a review record,
+          # not a side-comment). Treat all as push_or_pr_create.
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_review"
           return 0
           ;;
         list|view|status|diff|checks|checkout|lock|unlock)

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -907,9 +907,11 @@ _classify_gh() {
       ;;
     pr)
       case "$sub" in
-        create|merge|close|reopen|edit|comment|ready|update-branch)
+        create|merge|close|reopen|edit|comment|ready|update-branch|revert)
           # update-branch added during commit 8 subagent review (same F2
           # pathology: a write verb that updates the PR head on the remote).
+          # revert added during commit 9 per Codex `...9fc4` (creates a
+          # revert PR — same shared-mutation class as create).
           printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_${sub}"
           return 0
           ;;

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -741,62 +741,129 @@ _classify_git() {
       printf '%s\t\t%s\n' "read_only" "git_read_subcommand"
       return 0
       ;;
-    branch|tag|remote|worktree|config)
-      # Codex PR #113 review finding 1 [P1]: these subcommands EITHER list OR
-      # write depending on args. `git branch foo` creates a branch,
-      # `git remote add`, `git worktree add`, `git config user.name x` all
-      # write — and previously classified as read_only, bypassing plan-gate.
-      # Rule: if any positional (non-flag) arg follows the subcommand OR a
-      # write-only flag is present → shared_write. Bare list forms remain
-      # read_only.
+    branch|tag)
+      # Issue #116 [P1]: read forms with positionals were misclassified.
+      # Inverted default per Plan-agent recommendation: detect write flags
+      # explicitly; read flags + free positionals = read; bare positional
+      # (no flags) = create (write).
       local _gj=$((i+1))
-      local _has_positional=0 _has_write_flag=0 _np=0
+      local _has_write_flag=0 _has_read_flag=0 _free_positional=0
       while [ $_gj -lt ${#T[@]} ]; do
         local _gt="${T[$_gj]}"
         case "$_gt" in
-          -D|-d|-M|-m|-c|-C|--delete|--rename|--copy|--unset|--unset-all|--add|--replace-all|--edit|--set-upstream|--track|--no-track|--set-upstream-to|--force|-f)
-            _has_write_flag=1
-            ;;
-          -*) ;; # other flags treated as read-flags (verbose, list, etc.)
-          *)
-            _has_positional=1
-            _np=$((_np+1))
-            ;;
+          # Write flags (delete / rename / copy / move / track / sign / edit)
+          -d|-D|-m|-M|-c|-C|--delete|--rename|--copy|--move|-u|--track|--no-track|--unset-upstream|-f|--force|-s|--sign|--edit-description|--set-upstream-to|--cleanup)
+            _has_write_flag=1 ;;
+          --edit-description=*|--set-upstream-to=*|--cleanup=*)
+            _has_write_flag=1 ;;
+          # Read flags (list / filter / sort / format / verbose)
+          --list|-l|--contains|--no-contains|--merged|--no-merged|--points-at|--sort|--format|--column|-a|-r|-v|-vv|--all|--remotes|--show-current|-q|--quiet|--no-color|--ignore-case|-i)
+            _has_read_flag=1 ;;
+          --list=*|--contains=*|--no-contains=*|--merged=*|--no-merged=*|--points-at=*|--sort=*|--format=*|--column=*)
+            _has_read_flag=1 ;;
+          -n*) _has_read_flag=1 ;;  # tag -n[N]
+          --*=*) ;;                  # unknown equals-form
+          -*) ;;                     # unknown flag — neutral
+          *)  _free_positional=1 ;;
         esac
         _gj=$((_gj+1))
       done
-      if [ "$sub" = "config" ]; then
-        # `git config <key>` (1 positional) reads; 2+ writes.
-        if [ $_np -le 1 ] && [ $_has_write_flag -eq 0 ]; then
-          printf '%s\t\t%s\n' "read_only" "git_config_read"
-          return 0
-        fi
-        printf '%s\t\t%s\n' "shared_write" "git_config_write"
+      if [ $_has_write_flag -eq 1 ]; then
+        printf '%s\t\t%s\n' "shared_write" "git_${sub}_write_flag"
         return 0
       fi
-      if [ "$sub" = "worktree" ]; then
-        local _wt_idx=$((i+2))
-        local _wt_sub=""
-        if [ $_wt_idx -lt ${#T[@]} ]; then _wt_sub="${T[$_wt_idx]}"; fi
-        case "$_wt_sub" in
-          ""|list)
-            printf '%s\t\t%s\n' "read_only" "git_worktree_list"
-            return 0
-            ;;
-          add|remove|move|repair|prune|lock|unlock)
-            printf '%s\t\t%s\n' "shared_write" "git_worktree_${_wt_sub}"
-            return 0
-            ;;
-        esac
-      fi
-      if [ $_has_positional -eq 1 ] || [ $_has_write_flag -eq 1 ]; then
-        printf '%s\t\t%s\n' "shared_write" "git_${sub}_write"
+      if [ $_free_positional -eq 1 ] && [ $_has_read_flag -eq 0 ]; then
+        # Bare `git branch new-name` or `git tag v1.0` creates.
+        printf '%s\t\t%s\n' "shared_write" "git_${sub}_create"
         return 0
       fi
-      printf '%s\t\t%s\n' "read_only" "git_${sub}_list"
+      printf '%s\t\t%s\n' "read_only" "git_${sub}_read"
       return 0
       ;;
-    commit|add|rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|fetch|clone|init|gc|prune|notes|submodule|apply|am|format-patch|bisect|update-index|update-ref|symbolic-ref|hash-object|mktree|read-tree|write-tree|commit-tree|fsck|repack|pack-refs|pack-objects|unpack-objects|prune-packed|rerere|filter-branch|replay|sparse-checkout|maintenance)
+    remote)
+      # Inverted default: known write subcommands explicitly listed.
+      # Anything else (incl. get-url, show, show-url, get-all, -v, -vv) → read.
+      local _gj=$((i+1))
+      while [ $_gj -lt ${#T[@]} ]; do
+        case "${T[$_gj]}" in
+          -*) _gj=$((_gj+1));;
+          *)  break ;;
+        esac
+      done
+      if [ $_gj -lt ${#T[@]} ]; then
+        case "${T[$_gj]}" in
+          add|remove|rm|rename|set-url|set-head|set-branches|prune|update)
+            printf '%s\t\t%s\n' "shared_write" "git_remote_${T[$_gj]}"
+            return 0 ;;
+        esac
+      fi
+      printf '%s\t\t%s\n' "read_only" "git_remote_read"
+      return 0
+      ;;
+    worktree)
+      local _gj=$((i+1))
+      while [ $_gj -lt ${#T[@]} ]; do
+        case "${T[$_gj]}" in
+          -*) _gj=$((_gj+1));;
+          *)  break ;;
+        esac
+      done
+      if [ $_gj -lt ${#T[@]} ]; then
+        # Subagent code review: lock/unlock/prune mutate state too (locks
+        # touch metadata; prune removes stale entries). Previous version had
+        # them as writes; the inverted-default revision dropped them. Restore.
+        case "${T[$_gj]}" in
+          add|remove|move|repair|lock|unlock|prune)
+            printf '%s\t\t%s\n' "shared_write" "git_worktree_${T[$_gj]}"
+            return 0 ;;
+        esac
+      fi
+      printf '%s\t\t%s\n' "read_only" "git_worktree_read"
+      return 0
+      ;;
+    config)
+      # Write detection: explicit write flag OR (2+ free positionals AND no
+      # explicit read flag). Scope flags (--global/--system/--local/
+      # --worktree) and value-taking option flags (--file/--blob/-f/--type/
+      # --default) consumed without counting as positionals.
+      #
+      # Subagent code review fixes:
+      # - --remove-section / --rename-section are writes (was missed).
+      # - --get / --get-all / --get-regexp / --get-urlmatch / --get-color /
+      #   --get-colorbool / --list / -l are explicit READ flags. They take
+      #   one or more positional args but those args are NOT a key/value
+      #   set-form pair. Suppress the _np>=2 rule when any read flag is
+      #   present (e.g. `git config --get-color color.diff red` is read).
+      local _gj=$((i+1))
+      local _has_write_flag=0 _has_read_flag=0 _np=0
+      while [ $_gj -lt ${#T[@]} ]; do
+        local _gt="${T[$_gj]}"
+        case "$_gt" in
+          --unset|--unset-all|--add|--replace-all|--edit|-e|--remove-section|--rename-section)
+            _has_write_flag=1 ;;
+          --get|--get-all|--get-regexp|--get-urlmatch|--get-color|--get-colorbool|--list|-l|--show-scope|--show-origin|--name-only|--includes|--no-includes|-z|--null)
+            _has_read_flag=1 ;;
+          --file|--blob|-f|--type|--default)
+            _gj=$((_gj+1)) ;;
+          --file=*|--blob=*|--type=*|--default=*) ;;
+          --*=*) ;;
+          -*) ;;
+          *) _np=$((_np+1)) ;;
+        esac
+        _gj=$((_gj+1))
+      done
+      if [ $_has_write_flag -eq 1 ]; then
+        printf '%s\t\t%s\n' "shared_write" "git_config_write_flag"
+        return 0
+      fi
+      if [ $_np -ge 2 ] && [ $_has_read_flag -eq 0 ]; then
+        printf '%s\t\t%s\n' "shared_write" "git_config_set"
+        return 0
+      fi
+      printf '%s\t\t%s\n' "read_only" "git_config_read"
+      return 0
+      ;;
+    commit|add|rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|clone|init|gc|prune|notes|submodule|apply|am|format-patch|bisect|update-index|update-ref|symbolic-ref|hash-object|mktree|read-tree|write-tree|commit-tree|fsck|repack|pack-refs|pack-objects|unpack-objects|prune-packed|rerere|filter-branch|replay|sparse-checkout|maintenance)
       printf '%s\t\t%s\n' "shared_write" "git_local_write"
       return 0
       ;;

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -530,7 +530,33 @@ _classify_segment() {
       ;;
   esac
 
-  # ---- Unsafe shell forms ----
+  # ---- Unsafe shell forms (Audit P1: control-flow + wrappers) ----
+  # Any control-flow keyword or shell-group token AT ANY POSITION in the
+  # segment makes structural classification unreliable: `while true; do
+  # git push; done` and `( git push )` would otherwise classify by their
+  # first token (`while`, `(`) and never reach _classify_git. Conservative
+  # block-by-default — these are rare in normal Bash tool calls.
+  local _ti
+  for _ti in "${TOKS[@]+${TOKS[@]}}"; do
+    case "$_ti" in
+      "if"|"then"|"else"|"elif"|"fi"|"for"|"while"|"until"|"do"|"done"|"case"|"esac"|"select"|"function"|"{"|"}"|"("|")"|"[["|"]]")
+        printf '%s\t\t%s\n' "unsafe_complex" "shell_keyword_or_group"
+        return 0
+        ;;
+    esac
+  done
+
+  # Wrapper utilities that execute their argument (env, command, sudo,
+  # nohup, nice, ionice, time, timeout, xargs, watch). Treat as
+  # unsafe_complex so the structural escape `env GIT_DIR=… git push`
+  # cannot bypass push detection by classifying as read_only.
+  case "$first" in
+    env|command|sudo|nohup|nice|ionice|time|timeout|xargs|watch|stdbuf|chronic)
+      printf '%s\t\t%s\n' "unsafe_complex" "wrapper_utility_${first}"
+      return 0
+      ;;
+  esac
+
   case "$first" in
     bash|sh|zsh|dash|ksh)
       # Is there a -c flag?
@@ -616,9 +642,13 @@ _classify_segment() {
 
   # ---- Read-only command allowlist ----
   case "$first" in
-    ls|cat|head|tail|grep|egrep|fgrep|rg|find|wc|awk|sed|tr|cut|sort|uniq|file|stat|du|df|pwd|whoami|hostname|date|env|printenv|which|type|command|tree|less|more|jq|yq|cmp|diff|column)
-      # tee deliberately NOT here — it always writes (to stdout or file).
-      # Bare tee in a pipeline is rare; we err safe and classify as shared_write.
+    ls|cat|head|tail|grep|egrep|fgrep|rg|find|wc|awk|sed|tr|cut|sort|uniq|file|stat|du|df|pwd|whoami|hostname|date|printenv|which|tree|less|more|jq|yq|cmp|diff|column)
+      # Audit P1: env / command / type / sudo / xargs / nohup / nice / ionice
+      # / time / timeout deliberately NOT here. They are wrapper utilities
+      # that execute the next argument — `env GIT_DIR=… git push` would
+      # bypass push detection if env classified as read_only. tee likewise:
+      # always writes. Err safe and let those fall through to default
+      # shared_write or, where structural risk warrants, unsafe_complex below.
       if [ "$has_nonmarker_redirect" = "1" ]; then
         printf '%s\t\t%s\n' "shared_write" "readonly_cmd_redirected"
         return 0

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -907,7 +907,9 @@ _classify_gh() {
       ;;
     pr)
       case "$sub" in
-        create|merge|close|reopen|edit|comment|ready)
+        create|merge|close|reopen|edit|comment|ready|update-branch)
+          # update-branch added during commit 8 subagent review (same F2
+          # pathology: a write verb that updates the PR head on the remote).
           printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_${sub}"
           return 0
           ;;
@@ -920,11 +922,35 @@ _classify_gh() {
           printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_review"
           return 0
           ;;
-        list|view|status|diff|checks|checkout|lock|unlock)
+        list|view|status|diff|checks)
           printf '%s\t\t%s\n' "read_only" "gh_pr_${sub}"
           return 0
           ;;
+        checkout)
+          # Codex PR #113 F2 [P1] (`...9796`/`...9cdd`): gh pr checkout
+          # mutates the local working tree (fetches the PR ref, switches/
+          # creates a branch, may stomp uncommitted changes). It is not a
+          # read of GitHub state. Classify shared_write so plan-gate and
+          # checkpoint pre-gate block it; not push_or_pr_create because
+          # nothing is published to the remote.
+          printf '%s\t\t%s\n' "shared_write" "gh_pr_checkout"
+          return 0
+          ;;
+        lock|unlock)
+          # Codex PR #113 F2 [P1] (`...9796`/`...9cdd`): gh pr lock|unlock
+          # mutate shared GitHub state (PR comment-locking is observable to
+          # everyone with repo access). Mirror gh issue lock|unlock which
+          # was already correctly classified. push_or_pr_create routes
+          # through the checkpoint post-gate (visible-to-others bucket).
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_${sub}"
+          return 0
+          ;;
         *)
+          # All known `gh pr` write verbs are enumerated above. Default
+          # is shared_write so unknown future subcommands fail safe (block
+          # plan-gate / pre-gate) without bypassing the push-gate's
+          # narrower bucket. If a new shared/remote-mutating verb lands,
+          # add it explicitly above.
           printf '%s\t\t%s\n' "shared_write" "gh_pr_unknown"
           return 0
           ;;

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -393,6 +393,12 @@ _tokenize() {
               printf 'E heredoc_unterminated\n'
               return 0
             fi
+            # After heredoc body ends, force a segment break. Anything after
+            # the heredoc terminator is a NEW command; without this break,
+            # `cat > .pre-checkpoint-done <<EOF\n...\nEOF\nrm -rf /` would
+            # pass through as a single segment and the classifier would only
+            # see the marker_write, missing the chained rm.
+            printf 'O NL\n'
           fi
         elif [ "${cmd:$((i+1)):1}" = "(" ]; then
           printf 'E process_substitution\n'

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1,0 +1,1005 @@
+#!/usr/bin/env bash
+# command-classifier.sh — Quote/heredoc-aware Bash command classifier.
+#
+# Closes #86 PR-B + #89 + #101 via a shared helper. Replaces ad-hoc regex
+# command detection in plan-gate.sh and checkpoint-gate.sh.
+#
+# Source this file and call:
+#   classify_command "$cmd"  → echoes "LABEL\tTARGET\tREASON"
+#   classify_path    "$path" → echoes "LABEL\tTARGET\tREASON" (for Write/Edit)
+#
+# Six labels (per Codex review `...cad2`/`...3503`):
+#   read_only           pure observation (ls, cat, git status, gh pr view, …)
+#   shared_write        local side-effect (git commit, npm install, mkdir, …)
+#   push_or_pr_create   publishes/mutates shared state
+#                         (git push, gh pr create/merge/close/…, gh issue …,
+#                          gh release, gh api -X POST/PUT/PATCH/DELETE, …)
+#   marker_write        gate-control deadlock-prevention (writes/removes a
+#                         repo-root .claude/.* marker). TARGET = absolute path.
+#   unsafe_complex      can't safely tokenize (bash -c, eval, $(...), backticks,
+#                         unbalanced quotes, ambiguous heredoc, …)
+#   unknown             parsed cleanly but doesn't match a known shape
+#
+# Tokenization strategy (Codex `...3503` P1):
+#   Quote/heredoc-aware lexical scan FIRST, then split on UNQUOTED control
+#   operators only. Never raw-split text on `&&`/`||`/`;`/`|`/newline before
+#   tokenization — that recreates the false-positive class #101/#89 are
+#   meant to eliminate.
+#
+# Output format (forward-compat for #80 H1 lifecycle records):
+#   LABEL<TAB>TARGET<TAB>REASON
+#   TARGET is empty for non-marker labels.
+#   REASON is a short identifier of the rule that fired.
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+# _tokenize "$cmd" emits records to stdout, one per line:
+#   T <text>      a token (word or quoted string concatenation)
+#   O <op>        unquoted control operator: && || ; | & NL
+#   R <text>      a redirection operator + filename pair: e.g. ">file"
+#                 (recognized only at unquoted segment boundaries)
+#   E <reason>    irrecoverable: unbalanced quote, command substitution, etc.
+#                 callers MUST treat any E as unsafe_complex.
+#
+# Recognized constructs:
+#   - single quotes: literal, no escapes
+#   - double quotes: \" \\ \$ \` recognized; everything else literal
+#   - $'…' ANSI-C: treated as token but NOT scanned for command substitution
+#                  (still safe — it's a string literal)
+#   - $"…" gettext: treated as a double-quoted string
+#   - backslash escape outside quotes
+#   - heredoc: <<TERM, <<-TERM, <<'TERM', <<"TERM", <<\TERM — body skipped
+#              everything AFTER the heredoc terminator continues normal scan
+#   - command substitution $(…) and `…` → emit E (unsafe_complex)
+#   - process substitution <(…) >(…) → emit E (unsafe_complex)
+#   - control operators: && || ; | & newline (only when unquoted)
+#   - comments: # to end-of-line (only when at token boundary, unquoted)
+#   - redirects: > >> < << <<< 2> 2>> &> >& with filename token
+
+_tokenize() {
+  local cmd="$1"
+  local i=0 n=${#cmd}
+  local c
+  local cur=""        # current token being assembled
+  local has_token=0   # 1 if cur represents a real token (vs empty)
+
+  _flush() {
+    if [ "$has_token" = "1" ]; then
+      printf 'T %s\n' "$cur"
+      cur=""
+      has_token=0
+    fi
+  }
+
+  while [ $i -lt $n ]; do
+    c="${cmd:$i:1}"
+
+    case "$c" in
+      "'")
+        # Single-quoted: literal until next '
+        i=$((i+1))
+        local sq=""
+        while [ $i -lt $n ]; do
+          local sc="${cmd:$i:1}"
+          if [ "$sc" = "'" ]; then
+            i=$((i+1))
+            break
+          fi
+          sq="$sq$sc"
+          i=$((i+1))
+        done
+        if [ $i -gt $n ]; then
+          printf 'E unbalanced_single_quote\n'
+          return 0
+        fi
+        # Was the closing quote actually consumed?
+        # If we reached end without finding ', i==n and last char was not '.
+        if [ $i -eq $n ] && [ "${cmd:$((n-1)):1}" != "'" ]; then
+          printf 'E unbalanced_single_quote\n'
+          return 0
+        fi
+        cur="$cur$sq"
+        has_token=1
+        ;;
+      '"')
+        # Double-quoted: \" \\ \$ \` honored; everything else literal.
+        # $(…) and `…` inside double quotes still expand → unsafe.
+        i=$((i+1))
+        local dq=""
+        local closed=0
+        while [ $i -lt $n ]; do
+          local dc="${cmd:$i:1}"
+          if [ "$dc" = '"' ]; then
+            i=$((i+1))
+            closed=1
+            break
+          fi
+          if [ "$dc" = '\' ] && [ $((i+1)) -lt $n ]; then
+            local nx="${cmd:$((i+1)):1}"
+            case "$nx" in
+              '"'|'\'|'$'|'`'|'\n')
+                dq="$dq$nx"
+                i=$((i+2))
+                continue
+                ;;
+            esac
+            dq="$dq$dc"
+            i=$((i+1))
+            continue
+          fi
+          if [ "$dc" = '$' ] && [ $((i+1)) -lt $n ] && [ "${cmd:$((i+1)):1}" = '(' ]; then
+            printf 'E command_substitution_in_double_quote\n'
+            return 0
+          fi
+          if [ "$dc" = '`' ]; then
+            printf 'E backtick_in_double_quote\n'
+            return 0
+          fi
+          dq="$dq$dc"
+          i=$((i+1))
+        done
+        if [ $closed -eq 0 ]; then
+          printf 'E unbalanced_double_quote\n'
+          return 0
+        fi
+        cur="$cur$dq"
+        has_token=1
+        ;;
+      '$')
+        # $'…' ANSI-C string, $"…" gettext, $(…) cmd-sub, ${…} param expansion
+        local nx="${cmd:$((i+1)):1}"
+        if [ "$nx" = "'" ]; then
+          # ANSI-C: literal until next ' (with backslash escapes — for safety
+          # treat content as literal text but consume escapes)
+          i=$((i+2))
+          local ac=""
+          local aclosed=0
+          while [ $i -lt $n ]; do
+            local ach="${cmd:$i:1}"
+            if [ "$ach" = "'" ]; then
+              i=$((i+1))
+              aclosed=1
+              break
+            fi
+            if [ "$ach" = '\' ] && [ $((i+1)) -lt $n ]; then
+              ac="$ac${cmd:$((i+1)):1}"
+              i=$((i+2))
+              continue
+            fi
+            ac="$ac$ach"
+            i=$((i+1))
+          done
+          if [ $aclosed -eq 0 ]; then
+            printf 'E unbalanced_ansic_quote\n'
+            return 0
+          fi
+          cur="$cur$ac"
+          has_token=1
+        elif [ "$nx" = '"' ]; then
+          # $"…" — treat as double-quoted (re-enter loop with dquote handler).
+          # Easier: leave cur as-is, increment past $, fall through to next
+          # iteration which will see " and handle it.
+          i=$((i+1))
+        elif [ "$nx" = '(' ]; then
+          printf 'E command_substitution\n'
+          return 0
+        elif [ "$nx" = '{' ]; then
+          # ${var} — accept as token char; we don't track variable values.
+          cur="$cur\$"
+          has_token=1
+          i=$((i+1))
+        else
+          cur="$cur\$"
+          has_token=1
+          i=$((i+1))
+        fi
+        ;;
+      '`')
+        printf 'E backtick_substitution\n'
+        return 0
+        ;;
+      '\')
+        # Backslash escape outside quotes
+        if [ $((i+1)) -lt $n ]; then
+          local en="${cmd:$((i+1)):1}"
+          if [ "$en" = $'\n' ]; then
+            # Line continuation — skip both
+            i=$((i+2))
+            continue
+          fi
+          cur="$cur$en"
+          has_token=1
+          i=$((i+2))
+        else
+          # Trailing backslash
+          i=$((i+1))
+        fi
+        ;;
+      '#')
+        # Comment only at token boundary
+        if [ "$has_token" = "0" ]; then
+          # Skip to end-of-line
+          while [ $i -lt $n ] && [ "${cmd:$i:1}" != $'\n' ]; do
+            i=$((i+1))
+          done
+        else
+          cur="$cur$c"
+          has_token=1
+          i=$((i+1))
+        fi
+        ;;
+      ' '|$'\t')
+        _flush
+        i=$((i+1))
+        ;;
+      $'\n')
+        _flush
+        printf 'O NL\n'
+        i=$((i+1))
+        ;;
+      ';')
+        _flush
+        # ;; and ;& and ;;& are case-statement terminators; treat all as ;
+        if [ "${cmd:$((i+1)):1}" = ";" ]; then
+          printf 'O ;;\n'
+          i=$((i+2))
+        else
+          printf 'O ;\n'
+          i=$((i+1))
+        fi
+        ;;
+      '&')
+        _flush
+        if [ "${cmd:$((i+1)):1}" = "&" ]; then
+          printf 'O &&\n'
+          i=$((i+2))
+        elif [ "${cmd:$((i+1)):1}" = ">" ]; then
+          # &> redirect — emit as redirect op
+          printf 'O &>\n'
+          i=$((i+2))
+        else
+          printf 'O &\n'
+          i=$((i+1))
+        fi
+        ;;
+      '|')
+        _flush
+        if [ "${cmd:$((i+1)):1}" = "|" ]; then
+          printf 'O ||\n'
+          i=$((i+2))
+        else
+          printf 'O |\n'
+          i=$((i+1))
+        fi
+        ;;
+      '>')
+        _flush
+        if [ "${cmd:$((i+1)):1}" = ">" ]; then
+          printf 'O >>\n'
+          i=$((i+2))
+        elif [ "${cmd:$((i+1)):1}" = "(" ]; then
+          printf 'E process_substitution\n'
+          return 0
+        else
+          printf 'O >\n'
+          i=$((i+1))
+        fi
+        ;;
+      '<')
+        # Heredoc / here-string / redirect / process-sub
+        if [ "${cmd:$((i+1)):1}" = "<" ]; then
+          # << or <<< or <<-
+          if [ "${cmd:$((i+2)):1}" = "<" ]; then
+            # <<< here-string — skip, then continue. Body is the next token.
+            _flush
+            printf 'O <<<\n'
+            i=$((i+3))
+          else
+            # Heredoc <<TERM or <<-TERM (with optional ' " \ around TERM)
+            _flush
+            i=$((i+2))
+            local strip_tabs=0
+            if [ "${cmd:$i:1}" = "-" ]; then
+              strip_tabs=1
+              i=$((i+1))
+            fi
+            # Skip whitespace before TERM
+            while [ $i -lt $n ]; do
+              local hc="${cmd:$i:1}"
+              if [ "$hc" = " " ] || [ "$hc" = $'\t' ]; then
+                i=$((i+1))
+              else
+                break
+              fi
+            done
+            # Read TERM (can be quoted)
+            local term=""
+            local first="${cmd:$i:1}"
+            case "$first" in
+              "'")
+                i=$((i+1))
+                while [ $i -lt $n ] && [ "${cmd:$i:1}" != "'" ]; do
+                  term="$term${cmd:$i:1}"
+                  i=$((i+1))
+                done
+                [ $i -lt $n ] && i=$((i+1))
+                ;;
+              '"')
+                i=$((i+1))
+                while [ $i -lt $n ] && [ "${cmd:$i:1}" != '"' ]; do
+                  term="$term${cmd:$i:1}"
+                  i=$((i+1))
+                done
+                [ $i -lt $n ] && i=$((i+1))
+                ;;
+              '\')
+                i=$((i+1))
+                while [ $i -lt $n ]; do
+                  local tc="${cmd:$i:1}"
+                  case "$tc" in
+                    [[:space:]\<\>\|\&\;\'\"]) break ;;
+                  esac
+                  term="$term$tc"
+                  i=$((i+1))
+                done
+                ;;
+              *)
+                while [ $i -lt $n ]; do
+                  local tc="${cmd:$i:1}"
+                  case "$tc" in
+                    [[:space:]\<\>\|\&\;\'\"]) break ;;
+                  esac
+                  term="$term$tc"
+                  i=$((i+1))
+                done
+                ;;
+            esac
+            if [ -z "$term" ]; then
+              printf 'E heredoc_no_terminator\n'
+              return 0
+            fi
+            printf 'O HEREDOC\n'
+            printf 'T %s\n' "$term"
+            # Skip to end of current line
+            while [ $i -lt $n ] && [ "${cmd:$i:1}" != $'\n' ]; do
+              i=$((i+1))
+            done
+            [ $i -lt $n ] && i=$((i+1))
+            # Skip heredoc body until line that equals TERM (with optional
+            # leading tabs if strip_tabs)
+            local found_terminator=0
+            while [ $i -lt $n ]; do
+              # Read one line
+              local line=""
+              while [ $i -lt $n ] && [ "${cmd:$i:1}" != $'\n' ]; do
+                line="$line${cmd:$i:1}"
+                i=$((i+1))
+              done
+              [ $i -lt $n ] && i=$((i+1))
+              local ckline="$line"
+              if [ "$strip_tabs" = "1" ]; then
+                # Strip leading tabs
+                while [ "${ckline:0:1}" = $'\t' ]; do
+                  ckline="${ckline:1}"
+                done
+              fi
+              if [ "$ckline" = "$term" ]; then
+                found_terminator=1
+                break
+              fi
+            done
+            if [ $found_terminator -eq 0 ]; then
+              printf 'E heredoc_unterminated\n'
+              return 0
+            fi
+          fi
+        elif [ "${cmd:$((i+1)):1}" = "(" ]; then
+          printf 'E process_substitution\n'
+          return 0
+        else
+          _flush
+          printf 'O <\n'
+          i=$((i+1))
+        fi
+        ;;
+      *)
+        cur="$cur$c"
+        has_token=1
+        i=$((i+1))
+        ;;
+    esac
+  done
+
+  _flush
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Per-segment classifier
+# ---------------------------------------------------------------------------
+# Reads tokens (T-records and redirect O-records) from stdin for ONE segment,
+# echoes "LABEL\tTARGET\tREASON".
+#
+# Algorithm:
+#   1. Strip leading env-assignment tokens (VAR=value).
+#   2. If no tokens left → unknown / empty.
+#   3. Detect `bash -c`, `sh -c`, `eval`, `source <file>` → unsafe_complex.
+#   4. Detect redirect-into-marker (any token > or >> or &> followed by a
+#      target token whose basename is .pre-checkpoint-done /
+#      .post-checkpoint-done / .plan-approval-pending) → marker_write.
+#   5. Detect rm-of-marker: `rm [flags] <path-with-marker-basename>`.
+#   6. Detect tee/cat-redirect into marker.
+#   7. First non-flag token is `git` → classify by subcommand.
+#   8. First non-flag token is `gh` → classify by subcommand.
+#   9. First non-flag token is in read-only allowlist → read_only.
+#  10. Otherwise → shared_write (default for write-side commands we don't
+#      explicitly recognize).
+
+_classify_segment() {
+  local target_root="$1"  # repo root for marker resolution
+  shift
+
+  # Read all token + redirect records into arrays
+  local -a TOKS=()
+  local -a REDIRS=()  # each: "OP\tTARGET" pair for redirection
+  local pending_redir=""
+  while IFS= read -r line; do
+    case "$line" in
+      "T "*)
+        local txt="${line:2}"
+        if [ -n "$pending_redir" ]; then
+          REDIRS+=("$pending_redir"$'\t'"$txt")
+          pending_redir=""
+        else
+          TOKS+=("$txt")
+        fi
+        ;;
+      "O >")
+        pending_redir=">"
+        ;;
+      "O >>")
+        pending_redir=">>"
+        ;;
+      "O &>")
+        pending_redir="&>"
+        ;;
+      "O <"|"O <<<"|"O HEREDOC")
+        # Inputs / heredocs don't matter for write classification
+        ;;
+      *)
+        # Other operators shouldn't appear (segments are pre-split)
+        ;;
+    esac
+  done
+
+  # ---- Check redirects for marker writes ----
+  local r
+  for r in ${REDIRS[@]+"${REDIRS[@]}"}; do
+    local rop="${r%%	*}"
+    local rtarget="${r#*	}"
+    local rbase="$(basename "$rtarget")"
+    case "$rbase" in
+      .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
+        # Resolve target path to absolute under target_root
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
+    esac
+  done
+
+  # ---- Strip leading env-assignment tokens (VAR=value) ----
+  local idx=0
+  while [ $idx -lt ${#TOKS[@]} ]; do
+    case "${TOKS[$idx]}" in
+      [A-Za-z_]*=*)
+        idx=$((idx+1))
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ $idx -ge ${#TOKS[@]} ]; then
+    printf '%s\t\t%s\n' "read_only" "empty_or_env_only"
+    return 0
+  fi
+
+  local first="${TOKS[$idx]}"
+
+  # ---- Empty / no-op shells ----
+  case "$first" in
+    :|true|false)
+      printf '%s\t\t%s\n' "read_only" "no_op_builtin"
+      return 0
+      ;;
+  esac
+
+  # ---- Unsafe shell forms ----
+  case "$first" in
+    bash|sh|zsh|dash|ksh)
+      # Is there a -c flag?
+      local j=$((idx+1))
+      while [ $j -lt ${#TOKS[@]} ]; do
+        if [ "${TOKS[$j]}" = "-c" ]; then
+          printf '%s\t\t%s\n' "unsafe_complex" "shell_dash_c"
+          return 0
+        fi
+        j=$((j+1))
+      done
+      ;;
+    eval)
+      printf '%s\t\t%s\n' "unsafe_complex" "eval"
+      return 0
+      ;;
+    source|.)
+      printf '%s\t\t%s\n' "unsafe_complex" "source_or_dot"
+      return 0
+      ;;
+    exec)
+      printf '%s\t\t%s\n' "unsafe_complex" "exec"
+      return 0
+      ;;
+  esac
+
+  # ---- rm-of-marker ----
+  if [ "$first" = "rm" ]; then
+    local j=$((idx+1))
+    while [ $j -lt ${#TOKS[@]} ]; do
+      local t="${TOKS[$j]}"
+      case "$t" in
+        -*) j=$((j+1)); continue ;;
+      esac
+      local tbase="$(basename "$t")"
+      case "$tbase" in
+        .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
+      esac
+      j=$((j+1))
+    done
+    # Plain rm of non-marker → shared_write
+    printf '%s\t\t%s\n' "shared_write" "rm_non_marker"
+    return 0
+  fi
+
+  # ---- tee with marker ----
+  if [ "$first" = "tee" ]; then
+    local j=$((idx+1))
+    while [ $j -lt ${#TOKS[@]} ]; do
+      local t="${TOKS[$j]}"
+      case "$t" in
+        -*) j=$((j+1)); continue ;;
+      esac
+      local tbase="$(basename "$t")"
+      case "$tbase" in
+        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
+      esac
+      break
+    done
+  fi
+
+  # ---- git ----
+  if [ "$first" = "git" ]; then
+    _classify_git "$idx" "${TOKS[@]}"
+    return 0
+  fi
+
+  # ---- gh ----
+  if [ "$first" = "gh" ]; then
+    _classify_gh "$idx" "${TOKS[@]}"
+    return 0
+  fi
+
+  # ---- Read-only command allowlist ----
+  case "$first" in
+    ls|cat|head|tail|grep|egrep|fgrep|rg|find|wc|awk|sed|tr|cut|sort|uniq|file|stat|du|df|pwd|whoami|hostname|date|env|printenv|which|type|command|tree|less|more|jq|yq|cmp|diff|column)
+      # tee deliberately NOT here — it always writes (to stdout or file).
+      # Bare tee in a pipeline is rare; we err safe and classify as shared_write.
+      printf '%s\t\t%s\n' "read_only" "readonly_cmd"
+      return 0
+      ;;
+    echo|printf|true|false)
+      # echo/printf without redirect: no side effect
+      printf '%s\t\t%s\n' "read_only" "echo_or_printf"
+      return 0
+      ;;
+    node|python|python3|ruby|perl)
+      # Interpreters: classify by script name if it's a known em-* read script
+      local script="${TOKS[$((idx+1))]:-}"
+      case "$(basename "$script" 2>/dev/null)" in
+        em-search.mjs|em-list.mjs|em-watch-codex.mjs|em-pattern-health.mjs|em-check-stale.mjs|em-rebuild-index.mjs)
+          # em-rebuild-index touches index.jsonl — treat as shared_write
+          if [ "$(basename "$script")" = "em-rebuild-index.mjs" ]; then
+            printf '%s\t\t%s\n' "shared_write" "interpreter_em_rebuild"
+            return 0
+          fi
+          printf '%s\t\t%s\n' "read_only" "interpreter_em_read"
+          return 0
+          ;;
+        em-store.mjs|em-revise.mjs|em-prune.mjs|em-violation.mjs|em-recall.mjs|em-workflow-validate.mjs)
+          printf '%s\t\t%s\n' "shared_write" "interpreter_em_write"
+          return 0
+          ;;
+      esac
+      printf '%s\t\t%s\n' "shared_write" "interpreter_other"
+      return 0
+      ;;
+  esac
+
+  # ---- Default ----
+  printf '%s\t\t%s\n' "shared_write" "default_write"
+  return 0
+}
+
+# git subcommand classifier
+_classify_git() {
+  local start=$1
+  shift
+  local -a T=("$@")
+  local n=${#T[@]}
+
+  # Skip global flags after `git`. Per current checkpoint-gate.sh push regex:
+  # only allow flag tokens between git and subcommand. Long --opt[=val] and
+  # -X arg pairs both possible.
+  local i=$((start+1))
+  local sub=""
+  while [ $i -lt $n ]; do
+    local t="${T[$i]}"
+    case "$t" in
+      --*=*) i=$((i+1)); continue ;;
+      --no-pager|--bare|--paginate|--git-dir|--work-tree|--namespace|--exec-path|--literal-pathspecs|--glob-pathspecs|--noglob-pathspecs|--icase-pathspecs|--super-prefix|--config-env|-C|-c)
+        # -C and -c take an argument
+        case "$t" in
+          -C|-c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix|--config-env)
+            i=$((i+2))
+            ;;
+          *)
+            i=$((i+1))
+            ;;
+        esac
+        continue
+        ;;
+      -*) i=$((i+1)); continue ;;
+      *) sub="$t"; break ;;
+    esac
+  done
+
+  if [ -z "$sub" ]; then
+    printf '%s\t\t%s\n' "shared_write" "git_no_subcommand"
+    return 0
+  fi
+
+  case "$sub" in
+    push)
+      printf '%s\t\t%s\n' "push_or_pr_create" "git_push"
+      return 0
+      ;;
+    status|log|diff|show|rev-parse|rev-list|reflog|blame|grep|describe|ls-files|ls-tree|ls-remote|fetch|cat-file|config|remote|branch|tag|worktree|var|help|version|shortlog|whatchanged|name-rev|check-ignore|check-mailmap|check-attr|annotate|count-objects)
+      # These are mostly read-only when used without write subcommands.
+      # branch/tag/remote/worktree/config CAN write — but by default invocation
+      # they list. We err on the side of read_only for these and let the
+      # specific write forms (push, commit, etc) catch the actual writes.
+      # Note: `git fetch` is technically a network op but produces no remote
+      # mutation; classify as read_only for our purposes.
+      printf '%s\t\t%s\n' "read_only" "git_read_subcommand"
+      return 0
+      ;;
+    commit|add|rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|fetch|clone|init|gc|prune|notes|submodule|apply|am|format-patch|bisect|update-index|update-ref|symbolic-ref|hash-object|mktree|read-tree|write-tree|commit-tree|fsck|repack|pack-refs|pack-objects|unpack-objects|prune-packed|rerere|filter-branch|replay|sparse-checkout|maintenance)
+      printf '%s\t\t%s\n' "shared_write" "git_local_write"
+      return 0
+      ;;
+    *)
+      printf '%s\t\t%s\n' "shared_write" "git_unknown_subcommand"
+      return 0
+      ;;
+  esac
+}
+
+# gh subcommand classifier
+_classify_gh() {
+  local start=$1
+  shift
+  local -a T=("$@")
+  local n=${#T[@]}
+
+  local i=$((start+1))
+  # Skip gh global flags
+  while [ $i -lt $n ]; do
+    case "${T[$i]}" in
+      --help|-h|--version|--repo|-R)
+        if [ "${T[$i]}" = "--repo" ] || [ "${T[$i]}" = "-R" ]; then
+          i=$((i+2))
+        else
+          i=$((i+1))
+        fi
+        ;;
+      -*) i=$((i+1)) ;;
+      *) break ;;
+    esac
+  done
+
+  local cmd="${T[$i]:-}"
+  local sub="${T[$((i+1))]:-}"
+
+  case "$cmd" in
+    "")
+      printf '%s\t\t%s\n' "read_only" "gh_no_command"
+      return 0
+      ;;
+    pr)
+      case "$sub" in
+        create|merge|close|reopen|edit|comment|ready)
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_${sub}"
+          return 0
+          ;;
+        review)
+          # gh pr review --approve mutates; --comment is informational.
+          local j=$((i+2))
+          while [ $j -lt $n ]; do
+            case "${T[$j]}" in
+              --approve|--request-changes)
+                printf '%s\t\t%s\n' "push_or_pr_create" "gh_pr_review_approve"
+                return 0
+                ;;
+            esac
+            j=$((j+1))
+          done
+          printf '%s\t\t%s\n' "shared_write" "gh_pr_review_comment"
+          return 0
+          ;;
+        list|view|status|diff|checks|checkout|lock|unlock)
+          printf '%s\t\t%s\n' "read_only" "gh_pr_${sub}"
+          return 0
+          ;;
+        *)
+          printf '%s\t\t%s\n' "shared_write" "gh_pr_unknown"
+          return 0
+          ;;
+      esac
+      ;;
+    issue)
+      case "$sub" in
+        create|close|reopen|edit|comment|delete|develop|lock|unlock|pin|unpin|transfer)
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_issue_${sub}"
+          return 0
+          ;;
+        list|view|status)
+          printf '%s\t\t%s\n' "read_only" "gh_issue_${sub}"
+          return 0
+          ;;
+        *)
+          printf '%s\t\t%s\n' "shared_write" "gh_issue_unknown"
+          return 0
+          ;;
+      esac
+      ;;
+    release|repo|gist|label|workflow|run|secret|variable|ssh-key|gpg-key)
+      case "$sub" in
+        list|view|status|download)
+          printf '%s\t\t%s\n' "read_only" "gh_${cmd}_${sub}"
+          return 0
+          ;;
+        "")
+          printf '%s\t\t%s\n' "read_only" "gh_${cmd}_no_sub"
+          return 0
+          ;;
+        *)
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_${cmd}_${sub}"
+          return 0
+          ;;
+      esac
+      ;;
+    api)
+      # gh api: detect method.
+      # Default GET → read_only.
+      # -X / -XPOST / -X=POST / --method POST/PUT/PATCH/DELETE → push_or_pr_create.
+      # gh api graphql → unsafe_complex (mutation detection in body too brittle).
+      local j=$((i+1))
+      local saw_graphql=0
+      local method="GET"
+      while [ $j -lt $n ]; do
+        local t="${T[$j]}"
+        case "$t" in
+          graphql) saw_graphql=1; j=$((j+1)) ;;
+          -X|--method)
+            method="${T[$((j+1))]:-GET}"
+            j=$((j+2))
+            ;;
+          -X=*|--method=*)
+            method="${t#*=}"
+            j=$((j+1))
+            ;;
+          -X*)
+            # -XPOST glued
+            method="${t:2}"
+            j=$((j+1))
+            ;;
+          *)
+            j=$((j+1))
+            ;;
+        esac
+      done
+      if [ $saw_graphql -eq 1 ]; then
+        printf '%s\t\t%s\n' "unsafe_complex" "gh_api_graphql"
+        return 0
+      fi
+      # Normalize method
+      method="$(printf '%s' "$method" | tr '[:lower:]' '[:upper:]')"
+      case "$method" in
+        POST|PUT|PATCH|DELETE)
+          printf '%s\t\t%s\n' "push_or_pr_create" "gh_api_${method}"
+          return 0
+          ;;
+        GET|HEAD|"")
+          printf '%s\t\t%s\n' "read_only" "gh_api_${method}"
+          return 0
+          ;;
+        *)
+          printf '%s\t\t%s\n' "shared_write" "gh_api_${method}"
+          return 0
+          ;;
+      esac
+      ;;
+    auth|status|alias|completion|config|extension|browse|search)
+      printf '%s\t\t%s\n' "read_only" "gh_${cmd}"
+      return 0
+      ;;
+    *)
+      printf '%s\t\t%s\n' "shared_write" "gh_unknown_command"
+      return 0
+      ;;
+  esac
+}
+
+# Resolve a marker path to absolute form under target_root.
+# Strips relative components but does NOT resolve symlinks (we want to
+# detect symlink shenanigans by basename mismatch — caller checks).
+_resolve_marker_path() {
+  local p="$1"
+  local root="$2"
+  case "$p" in
+    /*) printf '%s' "$p" ;;
+    *)  printf '%s/%s' "$root" "$p" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# classify_command — public entry point
+# ---------------------------------------------------------------------------
+# Args:
+#   $1  command string
+#   $2  repo root (for marker resolution); optional, defaults to cwd
+#
+# Output: LABEL\tTARGET\tREASON
+classify_command() {
+  local cmd="$1"
+  local repo_root="${2:-$(pwd)}"
+
+  # Run tokenizer
+  local stream
+  stream="$(_tokenize "$cmd")"
+
+  # Check for E records (unsafe)
+  if printf '%s\n' "$stream" | grep -q '^E '; then
+    local reason
+    reason="$(printf '%s\n' "$stream" | grep '^E ' | head -1 | cut -c3-)"
+    printf '%s\t\t%s\n' "unsafe_complex" "$reason"
+    return 0
+  fi
+
+  # Split into segments by control operator
+  # Each segment classified, final label = MOST RESTRICTIVE.
+  # Restrictiveness order (most → least):
+  #   unsafe_complex > push_or_pr_create > shared_write > marker_write > read_only > unknown
+  # marker_write is intentionally NOT most-restrictive: a segment chained
+  # AFTER a marker write doesn't downgrade the marker write, but a marker
+  # write chained AFTER a push_or_pr_create still upgrades to push.
+
+  local seg_buf=""
+  local final_label=""
+  local final_target=""
+  local final_reason=""
+
+  _consider() {
+    local lbl="$1" tgt="$2" rsn="$3"
+    local lp=$(_priority "$lbl")
+    local fp=$(_priority "$final_label")
+    if [ -z "$final_label" ] || [ "$lp" -gt "$fp" ]; then
+      final_label="$lbl"
+      final_target="$tgt"
+      final_reason="$rsn"
+    fi
+  }
+
+  local line
+  local seg_lines=""
+  while IFS= read -r line; do
+    case "$line" in
+      "O &&"|"O ||"|"O ;"|"O ;;"|"O |"|"O &"|"O NL")
+        # End segment, classify
+        if [ -n "$seg_lines" ]; then
+          local result
+          result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root")"
+          local lbl="${result%%	*}"
+          local rest="${result#*	}"
+          local tgt="${rest%%	*}"
+          local rsn="${rest#*	}"
+          _consider "$lbl" "$tgt" "$rsn"
+          seg_lines=""
+        fi
+        ;;
+      *)
+        if [ -n "$seg_lines" ]; then
+          seg_lines="$seg_lines"$'\n'"$line"
+        else
+          seg_lines="$line"
+        fi
+        ;;
+    esac
+  done <<< "$stream"
+
+  # Final segment
+  if [ -n "$seg_lines" ]; then
+    local result
+    result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root")"
+    local lbl="${result%%	*}"
+    local rest="${result#*	}"
+    local tgt="${rest%%	*}"
+    local rsn="${rest#*	}"
+    _consider "$lbl" "$tgt" "$rsn"
+  fi
+
+  if [ -z "$final_label" ]; then
+    final_label="read_only"
+    final_reason="empty_command"
+  fi
+
+  printf '%s\t%s\t%s\n' "$final_label" "$final_target" "$final_reason"
+}
+
+# Priority for "most restrictive wins" reduction.
+_priority() {
+  case "$1" in
+    unsafe_complex)     printf '6' ;;
+    push_or_pr_create)  printf '5' ;;
+    shared_write)       printf '4' ;;
+    marker_write)       printf '3' ;;
+    unknown)            printf '2' ;;
+    read_only)          printf '1' ;;
+    *)                  printf '0' ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# classify_path — for Write/Edit/MultiEdit/NotebookEdit tool_input.file_path
+# ---------------------------------------------------------------------------
+# Args:
+#   $1  file path
+#   $2  repo root
+classify_path() {
+  local p="$1"
+  local repo_root="${2:-$(pwd)}"
+  local base
+  base="$(basename "$p")"
+  case "$base" in
+    .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done)
+      local abs
+      abs="$(_resolve_marker_path "$p" "$repo_root")"
+      printf '%s\t%s\t%s\n' "marker_write" "$abs" "path_marker"
+      return 0
+      ;;
+  esac
+  printf '%s\t\t%s\n' "shared_write" "path_default"
+  return 0
+}

--- a/hooks/lib/repo-root.sh
+++ b/hooks/lib/repo-root.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# repo-root.sh — Resolve the canonical repo root for marker-path resolution.
+#
+# Mirrors scripts/lib/local-dir.mjs (PR #105 / #85 algorithm). Source from a
+# hook and call resolve_repo_root [cwd]. Echoes the resolved repo-root path
+# (no trailing newline). Falls back to cwd when resolution fails.
+#
+# Algorithm (see local-dir.mjs comments for full rationale):
+#   1. git -C <cwd> rev-parse --git-common-dir → if basename is .git, use parent.
+#   2. Otherwise (submodule, --separate-git-dir, GIT_DIR=…) fall back to
+#      git rev-parse --show-toplevel (returns this git context's working tree).
+#   3. Otherwise (non-git, bare repo, git unavailable) fall back to cwd.
+#
+# Decoupled from local-dir.mjs: shell hooks must not depend on Node.js runtime.
+
+resolve_repo_root() {
+  local cwd="${1:-$(pwd)}"
+  local common_dir abs base top
+
+  if common_dir="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)"; then
+    case "$common_dir" in
+      /*) abs="$common_dir" ;;
+      *)  abs="$cwd/$common_dir" ;;
+    esac
+    # Normalize. cd -P resolves symlinks; if it fails (path missing) keep raw.
+    if abs="$(cd -P "$abs" 2>/dev/null && pwd)"; then :; else abs="${abs%/}"; fi
+    base="$(basename "$abs")"
+    if [ "$base" = ".git" ]; then
+      printf '%s' "$(dirname "$abs")"
+      return 0
+    fi
+    if top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"; then
+      if [ -n "$top" ]; then
+        printf '%s' "$top"
+        return 0
+      fi
+    fi
+  fi
+  printf '%s' "$cwd"
+}

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -2,21 +2,51 @@
 set -e
 
 # plan-gate.sh — PreToolUse hook
-# Blocks write tools while .claude/.plan-approval-pending exists in the project.
-# Read-only tools are always allowed (needed for planning).
+#
+# Blocks write tools while .claude/.plan-approval-pending exists in the
+# repo root. Read-only tools are always allowed (planning needs them).
+#
+# Bash classification uses hooks/lib/command-classifier.sh (Session 1,
+# closes #86 PR-B). Replaces the prior regex-based marker-rm allowlist
+# with a quote/heredoc-aware classifier so quoted body text containing
+# `gh pr create` or `.plan-approval-pending` does not false-positive
+# (the `...a1e0` shape).
+#
+# Allowlist:
+#   - Read-only tools (always)
+#   - Bash with classifier label `read_only` (#89: ls, cat, git status, etc.)
+#   - Bash that classifies as `marker_write` whose TARGET is exactly
+#     repo-root .claude/.plan-approval-pending (deadlock prevention).
+#     Codex review ...3503: plan marker REMOVAL is the only plan-gate marker
+#     action allowed; checkpoint pre/post writes are NOT allowed by plan-gate.
+#
+# All other tool calls block while the marker exists.
 
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-MARKER="$CWD/.claude/.plan-approval-pending"
+# Source classifier + repo-root resolver. Use BASH_SOURCE so symlinked hook
+# invocations resolve correctly (Codex ...3503: $(dirname "$0") breaks under
+# macOS without coreutils readlink -f).
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+LIB_DIR="$HOOK_DIR/lib"
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ]; then
+  # Lib missing — fail loud rather than silently allowing
+  echo '{"decision": "block", "reason": "plan-gate.sh: hooks/lib/ not found alongside hook. Re-run install.mjs --install-hooks."}'
+  exit 0
+fi
+# shellcheck disable=SC1091
+source "$LIB_DIR/repo-root.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/command-classifier.sh"
+
+REPO_ROOT="$(resolve_repo_root "$CWD")"
+MARKER="$REPO_ROOT/.claude/.plan-approval-pending"
+EXPECTED_MARKER_ABS="$MARKER"
 
 # Read-only tools — always allowed.
-# NotebookRead and ToolSearch added per issue #86 (PR-A): both are read-only /
-# planning traffic and were empirically blocked while a plan-approval marker
-# was set. BashOutput / KillBash are intentionally NOT on this list pending a
-# follow-up evaluation — KillBash mutates process state.
 case "$TOOL_NAME" in
   Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
     exit 0
@@ -26,13 +56,30 @@ esac
 # If no marker, allow everything
 [ ! -f "$MARKER" ] && exit 0
 
-# Allow the specific command that removes the marker (unblock after approval)
+# Classifier-driven Bash gating
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
-  if echo "$COMMAND" | grep -qE '^rm\s+.*\.plan-approval-pending'; then
-    exit 0
-  fi
+  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT")"
+  LABEL="${RESULT%%	*}"
+  REST="${RESULT#*	}"
+  TARGET="${REST%%	*}"
+
+  case "$LABEL" in
+    read_only)
+      # #89 fix: read-only Bash should not be blocked while planning.
+      exit 0
+      ;;
+    marker_write)
+      # Only allow exact removal of the plan-approval marker.
+      # Codex ...3503 P1: target must equal repo-root .plan-approval-pending,
+      # not any other marker. Path traversal / symlink / cwd≠repo blocked
+      # by the equality check against the resolved repo-root path.
+      if [ "$TARGET" = "$EXPECTED_MARKER_ABS" ]; then
+        exit 0
+      fi
+      ;;
+  esac
 fi
 
-# Marker exists — block write tools
+# Marker exists — block
 echo '{"decision": "block", "reason": "Plan approval pending. Review the plan above and approve before implementation. To approve, say \"go\" or \"approved\". The .claude/.plan-approval-pending marker will be removed and implementation will proceed."}'

--- a/install.mjs
+++ b/install.mjs
@@ -490,11 +490,42 @@ if (installHooks) {
     // Codex PR #113 finding 3 [P2]: hooks that source hooks/lib/ files are
     // dependent on lib install success. If any required lib was skipped-
     // divergent, withhold NEW registration of dependent hooks. Existing
-    // registration is preserved (don't yank a working setup). This applies
-    // to plan-gate.sh and checkpoint-gate.sh which source command-classifier
-    // and repo-root.
+    // registration is preserved (don't yank a working setup).
+    //
+    // Issue #116 [P2] / Plan-agent v2 review: derive libDependentHooks at
+    // runtime by grepping each hook's REPO source for `source.*hooks/lib/`
+    // (not the deployed copy — Plan-agent confirmed direction to avoid
+    // bootstrap circularity). A future hook (e.g. push-gate.sh in PR-E)
+    // that sources hooks/lib/ is automatically included; a stateless hook
+    // is automatically excluded.
     const eligibleForReg = new Set(['copied', 'unchanged', 'forced'])
-    const libDependentHooks = new Set(['plan-gate.sh', 'checkpoint-gate.sh'])
+    const libDependentHooks = new Set()
+    // Build the set of expected lib basenames (so a hook need not literally
+    // contain "hooks/lib/" — variable-built paths via $LIB_DIR/ also match).
+    let libBasenames = []
+    if (fs.existsSync(REPO_HOOKS_LIB)) {
+      libBasenames = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh'))
+    }
+    for (const spec of hookSpecs) {
+      const repoFile = path.join(REPO_HOOKS, spec.file)
+      if (!fs.existsSync(repoFile)) continue
+      const src = fs.readFileSync(repoFile, 'utf8')
+      // Match if the hook (a) literally references hooks/lib/, or (b) uses
+      // a `source` / `.` statement naming any known lib basename. The latter
+      // catches variable-built paths like `source "$LIB_DIR/foo.sh"`.
+      // Codex audit: previous regex only matched (a), missing both real
+      // dependent hooks because they use $LIB_DIR variable form. Silent
+      // protection bypass.
+      const literalLibPath = /(^|\s)(source|\.)\s+[^\n]*hooks\/lib\//.test(src)
+      const sourcesKnownLib = libBasenames.some(b => {
+        // Match `source ... <basename>` or `. ... <basename>` on the same line.
+        const re = new RegExp(`(^|\\n|\\s)(source|\\.)\\s+[^\\n]*${b.replace(/\./g, '\\.')}`)
+        return re.test(src)
+      })
+      if (literalLibPath || sourcesKnownLib) {
+        libDependentHooks.add(spec.file)
+      }
+    }
 
     for (const spec of hookSpecs) {
       const canonicalCmd = shellQuote(path.join(userHooksDir, spec.file))

--- a/install.mjs
+++ b/install.mjs
@@ -378,6 +378,13 @@ if (installHooks) {
     // Per Codex review ...8c92: install must keep the lib in sync with the
     // hooks; same per-file hash + --install-hooks-force semantics. Per
     // ...3503 Q3: source-of-truth is current repo files at install time.
+    // libResults[file] tracks per-lib install outcome. Codex PR #113 review
+    // finding 3 [P2]: dependent hooks must NOT be registered if any required
+    // lib was skipped-divergent — registered hook would source stale/missing
+    // lib at runtime and fail loud (or worse, silently behave wrong if user's
+    // divergent lib is incomplete).
+    const libResults = {}
+    let anyLibSkippedDivergent = false
     if (fs.existsSync(REPO_HOOKS_LIB)) {
       fs.mkdirSync(userHooksLibDir, { recursive: true })
       const libFiles = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh'))
@@ -385,6 +392,7 @@ if (installHooks) {
         const src = path.join(REPO_HOOKS_LIB, file)
         const dst = path.join(userHooksLibDir, file)
         const result = installHookFile(src, dst, installHooksForce)
+        libResults[file] = result
         switch (result) {
           case 'copied':
             console.log(`Installed hook lib: ${dst}`)
@@ -399,6 +407,7 @@ if (installHooks) {
             break
           case 'skipped-divergent':
             console.log(`Skipped hook lib (divergent local edit): ${dst} — re-run with --install-hooks-force to overwrite`)
+            anyLibSkippedDivergent = true
             break
           case 'missing-source':
             console.log(`Note: ${src} not found in repo, skipped`)
@@ -477,15 +486,27 @@ if (installHooks) {
     // registration (per Codex review): we don't want install.mjs to point
     // Claude at unreviewed custom content. If a registration already exists
     // for the canonical path, addHookEntry returns 'present' and leaves it.
+    //
+    // Codex PR #113 finding 3 [P2]: hooks that source hooks/lib/ files are
+    // dependent on lib install success. If any required lib was skipped-
+    // divergent, withhold NEW registration of dependent hooks. Existing
+    // registration is preserved (don't yank a working setup). This applies
+    // to plan-gate.sh and checkpoint-gate.sh which source command-classifier
+    // and repo-root.
     const eligibleForReg = new Set(['copied', 'unchanged', 'forced'])
+    const libDependentHooks = new Set(['plan-gate.sh', 'checkpoint-gate.sh'])
 
     for (const spec of hookSpecs) {
       const canonicalCmd = shellQuote(path.join(userHooksDir, spec.file))
-      if (!eligibleForReg.has(fileResults[spec.file])) {
+      const fileEligible = eligibleForReg.has(fileResults[spec.file])
+      const libBlocksReg = libDependentHooks.has(spec.file) && anyLibSkippedDivergent
+      if (!fileEligible || libBlocksReg) {
         const alreadyRegistered = (settings.hooks[spec.event] || []).some(e =>
           entryHasExactCommand(e, canonicalCmd))
         if (alreadyRegistered) {
           console.log(`${spec.event} ${spec.file}: existing registration preserved`)
+        } else if (libBlocksReg) {
+          console.log(`${spec.event} ${spec.file}: registration withheld (required hooks/lib was skipped-divergent — re-run with --install-hooks-force)`)
         } else {
           console.log(`${spec.event} ${spec.file}: registration withheld (file install skipped)`)
         }

--- a/install.mjs
+++ b/install.mjs
@@ -368,8 +368,45 @@ function installHookFile(repoFile, destFile, force) {
 if (installHooks) {
   const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
   const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
-  const touched = { hooks: [], settings: [] }
+  const userHooksLibDir = path.join(userHooksDir, 'lib')
+  const REPO_HOOKS_LIB = path.join(REPO_HOOKS, 'lib')
+  const touched = { hooks: [], settings: [], hookLib: [] }
   try {
+    // 5_lib. Deploy hooks/lib/ alongside hooks/. Session 1 (#86 PR-B / #89 /
+    // #101) introduces hooks/lib/command-classifier.sh and hooks/lib/repo-root.sh
+    // sourced by plan-gate.sh and checkpoint-gate.sh via $BASH_SOURCE/cd -P.
+    // Per Codex review ...8c92: install must keep the lib in sync with the
+    // hooks; same per-file hash + --install-hooks-force semantics. Per
+    // ...3503 Q3: source-of-truth is current repo files at install time.
+    if (fs.existsSync(REPO_HOOKS_LIB)) {
+      fs.mkdirSync(userHooksLibDir, { recursive: true })
+      const libFiles = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh'))
+      for (const file of libFiles) {
+        const src = path.join(REPO_HOOKS_LIB, file)
+        const dst = path.join(userHooksLibDir, file)
+        const result = installHookFile(src, dst, installHooksForce)
+        switch (result) {
+          case 'copied':
+            console.log(`Installed hook lib: ${dst}`)
+            touched.hookLib.push(dst)
+            break
+          case 'unchanged':
+            console.log(`Hook lib already current: ${dst}`)
+            break
+          case 'forced':
+            console.log(`Force-overwrote hook lib: ${dst}`)
+            touched.hookLib.push(dst)
+            break
+          case 'skipped-divergent':
+            console.log(`Skipped hook lib (divergent local edit): ${dst} — re-run with --install-hooks-force to overwrite`)
+            break
+          case 'missing-source':
+            console.log(`Note: ${src} not found in repo, skipped`)
+            break
+        }
+      }
+    }
+
     // 5a. Hook specs (file → event + matcher + timeout + canonical command).
     const hookSpecs = [
       {

--- a/install.mjs
+++ b/install.mjs
@@ -88,6 +88,15 @@ for (const file of scriptFiles) {
   fs.copyFileSync(src, dst)
   fs.chmodSync(dst, 0o755)
 }
+// scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-* scripts.
+const REPO_SCRIPTS_LIB = path.join(REPO_SCRIPTS, 'lib')
+if (fs.existsSync(REPO_SCRIPTS_LIB)) {
+  const libDst = path.join(SCRIPTS_DIR, 'lib')
+  fs.mkdirSync(libDst, { recursive: true })
+  for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs'))) {
+    fs.copyFileSync(path.join(REPO_SCRIPTS_LIB, file), path.join(libDst, file))
+  }
+}
 console.log(`Installed ${scriptFiles.length} scripts to ${SCRIPTS_DIR}`)
 
 // 1b. Copy patterns/_index.json for global pattern validation

--- a/scripts/em-check-stale.mjs
+++ b/scripts/em-check-stale.mjs
@@ -14,9 +14,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 

--- a/scripts/em-list.mjs
+++ b/scripts/em-list.mjs
@@ -12,9 +12,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -19,11 +19,12 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const HOME = os.homedir()
 const CWD = process.cwd()
 const GLOBAL_DIR = path.join(HOME, '.episodic-memory')
-const LOCAL_DIR = path.join(CWD, '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir(CWD)
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -24,9 +24,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 function flag(name) {

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -13,9 +13,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 function flag(name) {

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -19,9 +19,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -15,9 +15,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -18,9 +18,10 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -14,9 +14,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -30,9 +30,10 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
-const LOCAL_DIR = path.join(process.cwd(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
 
 // ---------------------------------------------------------------------------
 // CLI args

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -9,11 +9,20 @@
  * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
  *
  * Edge-case handling:
- *   - Linked worktree:  common-dir basename is `.git`     -> parent.
- *   - Submodule:        common-dir is `<repo>/.git/modules/<name>`     -> strip from `/.git/`.
- *   - Worktree-of-sub:  common-dir is `<repo>/.git/modules/<name>/worktrees/<wt>` -> strip from `/.git/`.
- *   - --separate-git-dir / GIT_DIR: no `/.git/` segment in common-dir   -> cwd fallback.
- *   - Bare repo / non-git cwd:                                          -> cwd fallback.
+ *   - Linked worktree of main:  common-dir basename is `.git` -> parent. (This
+ *     is the case #85 is about: the linked worktree's common-dir is the SHARED
+ *     main `.git`, so we resolve to the main repo root.)
+ *   - Submodule:                common-dir is `<super>/.git/modules/<name>`,
+ *     basename ≠ `.git` -> use `git rev-parse --show-toplevel`, which returns
+ *     the SUBMODULE's working tree (its own local memory, not the superproject's).
+ *   - --separate-git-dir / GIT_DIR=...: common-dir is the gitdir target,
+ *     basename ≠ `.git` -> --show-toplevel returns the linked work tree.
+ *   - Bare repo:                --show-toplevel errors -> cwd fallback.
+ *   - Non-git cwd:              first git call throws -> cwd fallback.
+ *
+ * NOTE: A worktree of a submodule degrades to the submodule's worktree root via
+ *       --show-toplevel (consistent with how a worktree of main is handled, just
+ *       one level deeper). Out of scope for #85 — file an issue if it bites.
  */
 
 import path from 'path'
@@ -26,22 +35,21 @@ export function resolveLocalDir(cwd = process.cwd()) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).toString().trim()
     const absCommon = path.resolve(cwd, commonDir)
-    // Canonical worktree: <repo>/.git
+    // Canonical case (linked worktree of main, or main itself): <repo>/.git.
     if (path.basename(absCommon) === '.git') {
       return path.join(path.dirname(absCommon), '.episodic-memory')
     }
-    // Submodule / worktree-of-submodule: strip from `/.git/...`. Last occurrence
-    // handles nested cases (worktree of a submodule).
-    const sep = path.sep
-    const marker = `${sep}.git${sep}`
-    const idx = absCommon.lastIndexOf(marker)
-    if (idx !== -1) {
-      return path.join(absCommon.slice(0, idx), '.episodic-memory')
-    }
-    // No `.git` segment (--separate-git-dir / GIT_DIR / bare): no reliable
-    // way to recover the main worktree. Fall through to cwd.
+    // Submodule, --separate-git-dir, GIT_DIR=..., etc. The common-dir parent is
+    // NOT the working tree (e.g. for a submodule it's the superproject's
+    // .git/modules/, not the submodule's checkout). Use --show-toplevel to get
+    // the actual working tree of THIS git context.
+    const top = execSync('git rev-parse --show-toplevel', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+    if (top) return path.join(top, '.episodic-memory')
   } catch {
-    // not a git repo, or git unavailable
+    // not a git repo, bare repo, or git unavailable
   }
   return path.join(cwd, '.episodic-memory')
 }

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -1,0 +1,47 @@
+/**
+ * local-dir.mjs — resolve the canonical .episodic-memory/ directory for --scope local.
+ *
+ * Walks to the main repository root via `git rev-parse --git-common-dir` so that
+ * invocations from a linked worktree write to the SAME store as the main checkout.
+ * Closes #85.
+ *
+ * Resolution captured at module-load time by callers (e.g. `const LOCAL_DIR =
+ * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
+ *
+ * Edge-case handling:
+ *   - Linked worktree:  common-dir basename is `.git`     -> parent.
+ *   - Submodule:        common-dir is `<repo>/.git/modules/<name>`     -> strip from `/.git/`.
+ *   - Worktree-of-sub:  common-dir is `<repo>/.git/modules/<name>/worktrees/<wt>` -> strip from `/.git/`.
+ *   - --separate-git-dir / GIT_DIR: no `/.git/` segment in common-dir   -> cwd fallback.
+ *   - Bare repo / non-git cwd:                                          -> cwd fallback.
+ */
+
+import path from 'path'
+import { execSync } from 'child_process'
+
+export function resolveLocalDir(cwd = process.cwd()) {
+  try {
+    const commonDir = execSync('git rev-parse --git-common-dir', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+    const absCommon = path.resolve(cwd, commonDir)
+    // Canonical worktree: <repo>/.git
+    if (path.basename(absCommon) === '.git') {
+      return path.join(path.dirname(absCommon), '.episodic-memory')
+    }
+    // Submodule / worktree-of-submodule: strip from `/.git/...`. Last occurrence
+    // handles nested cases (worktree of a submodule).
+    const sep = path.sep
+    const marker = `${sep}.git${sep}`
+    const idx = absCommon.lastIndexOf(marker)
+    if (idx !== -1) {
+      return path.join(absCommon.slice(0, idx), '.episodic-memory')
+    }
+    // No `.git` segment (--separate-git-dir / GIT_DIR / bare): no reliable
+    // way to recover the main worktree. Fall through to cwd.
+  } catch {
+    // not a git repo, or git unavailable
+  }
+  return path.join(cwd, '.episodic-memory')
+}

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -227,6 +227,9 @@ assert_blocked "28c. gh pr unlock blocked by push-gate (F2 push_or_pr_create)" \
 # Subagent review on commit 8: gh pr update-branch is push_or_pr_create.
 assert_blocked "28d. gh pr update-branch blocked by push-gate" \
   "$(mock_json 'Bash' 'gh pr update-branch 113')" "Post-implementation checkpoint required"
+# Codex review on commit 8 (`...9fc4`): gh pr revert is push_or_pr_create.
+assert_blocked "28e. gh pr revert blocked by push-gate" \
+  "$(mock_json 'Bash' 'gh pr revert 113')" "Post-implementation checkpoint required"
 
 # Empty post-done does NOT unblock
 touch "$POST_DONE"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -152,6 +152,13 @@ assert_blocked "14. Bash write command blocked by pre-gate" \
   "$(mock_json 'Bash' 'echo hello > /tmp/somefile')" "Checkpoint required"
 assert_allowed "14b. Bash read-only echo allowed (#89)" \
   "$(mock_json 'Bash' 'echo hello')"
+# Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr checkout mutates local
+# working tree (shared_write), so pre-gate must block it.
+assert_blocked "14c. gh pr checkout blocked by pre-gate (F2 shared_write)" \
+  "$(mock_json 'Bash' 'gh pr checkout 113')" "Checkpoint required"
+# Negative: read-only PR commands must still pass during pre-gate.
+assert_allowed "14d. gh pr view allowed by pre-gate (read_only)" \
+  "$(mock_json 'Bash' 'gh pr view 113')"
 assert_blocked "15. NotebookEdit blocked by pre-gate" "$(mock_json 'NotebookEdit')" "Checkpoint required"
 
 # Marker-write allowlist (deadlock prevention)
@@ -210,6 +217,16 @@ assert_blocked "27. cd && git push blocked by push-gate" \
   "$(mock_json 'Bash' 'cd /tmp && git push')" "Post-implementation checkpoint required"
 assert_blocked "28. git push -f blocked by push-gate" \
   "$(mock_json 'Bash' 'git push -f origin main')" "Post-implementation checkpoint required"
+
+# Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr lock/unlock are shared
+# GitHub mutations (push_or_pr_create) and must be blocked by the push-gate.
+assert_blocked "28b. gh pr lock blocked by push-gate (F2 push_or_pr_create)" \
+  "$(mock_json 'Bash' 'gh pr lock 113')" "Post-implementation checkpoint required"
+assert_blocked "28c. gh pr unlock blocked by push-gate (F2 push_or_pr_create)" \
+  "$(mock_json 'Bash' 'gh pr unlock 113')" "Post-implementation checkpoint required"
+# Subagent review on commit 8: gh pr update-branch is push_or_pr_create.
+assert_blocked "28d. gh pr update-branch blocked by push-gate" \
+  "$(mock_json 'Bash' 'gh pr update-branch 113')" "Post-implementation checkpoint required"
 
 # Empty post-done does NOT unblock
 touch "$POST_DONE"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -18,6 +18,13 @@ fi
 
 TEST_DIR=$(mktemp -d)
 TEST_HOME=$(mktemp -d)
+# macOS /var → /private/var symlink: classifier resolves with cd -P, so the
+# test must use the resolved path for marker-target equality checks.
+TEST_DIR="$(cd -P "$TEST_DIR" && pwd)"
+TEST_HOME="$(cd -P "$TEST_HOME" && pwd)"
+# Session 1 (#86 PR-B): checkpoint-gate sources hooks/lib/command-classifier.sh
+# and resolves repo-root via git-common-dir. Initialize TEST_DIR as a git repo.
+git -C "$TEST_DIR" init -q 2>/dev/null
 MARKER_DIR="$TEST_DIR/.claude"
 PRE_REQ="$MARKER_DIR/.checkpoint-required"
 PRE_DONE="$MARKER_DIR/.pre-checkpoint-done"
@@ -138,16 +145,24 @@ assert_allowed "10. Grep allowed (always)" "$(mock_json 'Grep')"
 assert_blocked "11. Edit blocked by pre-gate" "$(mock_json 'Edit')" "Checkpoint required"
 assert_blocked "12. Write blocked by pre-gate" "$(mock_json 'Write')" "Checkpoint required"
 assert_blocked "13. MultiEdit blocked by pre-gate" "$(mock_json 'MultiEdit')" "Checkpoint required"
-assert_blocked "14. Bash blocked by pre-gate" "$(mock_json 'Bash' 'echo hello')" "Checkpoint required"
+# #89 (Session 1): read-only Bash is now allowed during pre-gate. The shape
+# of test 14 changes from "echo hello" (now read_only / allowed) to a real
+# write that should block.
+assert_blocked "14. Bash write command blocked by pre-gate" \
+  "$(mock_json 'Bash' 'echo hello > /tmp/somefile')" "Checkpoint required"
+assert_allowed "14b. Bash read-only echo allowed (#89)" \
+  "$(mock_json 'Bash' 'echo hello')"
 assert_blocked "15. NotebookEdit blocked by pre-gate" "$(mock_json 'NotebookEdit')" "Checkpoint required"
 
 # Marker-write allowlist (deadlock prevention)
 assert_allowed "16. Bash writing pre-checkpoint-done allowed (no deadlock)" \
   "$(mock_json 'Bash' "echo 'checkpoint text' > $PRE_DONE")"
-assert_allowed "17. Bash writing post-checkpoint-done allowed" \
-  "$(mock_json 'Bash' "echo 'post text' > $POST_DONE")"
+# Session 1 (Codex ...3503 P1): per-marker prerequisites. Writing POST_DONE
+# requires .post-checkpoint-required; with only PRE_REQ armed, this blocks.
+assert_blocked "17. Bash writing post-checkpoint-done BLOCKED (POST_REQ not armed)" \
+  "$(mock_json 'Bash' "echo 'post text' > $POST_DONE")" "Checkpoint required"
 assert_allowed "18. Bash heredoc to pre-checkpoint-done allowed" \
-  "$(mock_json 'Bash' "cat > $PRE_DONE <<EOF\ncheckpoint\nEOF")"
+  "$(mock_json 'Bash' "$(printf 'cat > %s <<EOF\ncheckpoint\nEOF' "$PRE_DONE")")"
 
 # ============================================================================
 echo ""
@@ -273,20 +288,27 @@ touch "$PRE_REQ"
 
 # Pathological cases: command mentions marker name but doesn't write to it.
 # Pre-tightening these would have bypassed the gate; post-tightening they block.
-assert_blocked "45. Bash 'cat etc; echo .pre-checkpoint-done' blocked (no redirect)" \
-  "$(mock_json 'Bash' "cat /etc/passwd; echo .pre-checkpoint-done")" "Checkpoint required"
-assert_blocked "46. Bash echo of marker name without redirect blocked" \
-  "$(mock_json 'Bash' "echo .post-checkpoint-done")" "Checkpoint required"
-assert_blocked "47. Bash heredoc body containing marker name blocked when no redirect to it" \
-  "$(mock_json 'Bash' "cat <<EOF\n.pre-checkpoint-done\nEOF")" "Checkpoint required"
+# #89 (Session 1): read-only commands that merely MENTION marker names
+# (without writing to them) are now allowed. The classifier distinguishes
+# string-content from actual redirects.
+assert_allowed "45. Bash 'cat etc; echo .pre-checkpoint-done' allowed (no write)" \
+  "$(mock_json 'Bash' "cat /etc/passwd; echo .pre-checkpoint-done")"
+assert_allowed "46. Bash echo of marker name without redirect allowed (#89)" \
+  "$(mock_json 'Bash' "echo .post-checkpoint-done")"
+# Heredoc body without redirect still blocks (it's a write — `cat <<EOF` writes
+# to stdout but classifier sees `cat` as read_only when no redirect target).
+# Actually under #89: cat without redirect is read_only. Allow.
+assert_allowed "47. Bash 'cat <<EOF' (heredoc as input, no redirect) allowed" \
+  "$(mock_json 'Bash' "$(printf 'cat <<EOF\n.pre-checkpoint-done\nEOF')")"
 
 # Legitimate writes still pass the tightened allowlist
 assert_allowed "48. Bash '> .pre-checkpoint-done' allowed (redirect)" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE")"
-assert_allowed "49. Bash '>> .post-checkpoint-done' allowed (append)" \
-  "$(mock_json 'Bash' "echo content >> $POST_DONE")"
-assert_allowed "50. Bash 'tee .post-checkpoint-done' allowed" \
-  "$(mock_json 'Bash' "echo content | tee $POST_DONE")"
+# Session 1 (Codex ...3503 P1): writing POST_DONE without POST_REQ armed blocks.
+assert_blocked "49. Bash '>> .post-checkpoint-done' BLOCKED (POST_REQ not armed)" \
+  "$(mock_json 'Bash' "echo content >> $POST_DONE")" "Checkpoint required"
+assert_blocked "50. Bash 'tee .post-checkpoint-done' BLOCKED (POST_REQ not armed)" \
+  "$(mock_json 'Bash' "echo content | tee $POST_DONE")" "Checkpoint required"
 
 # ============================================================================
 echo ""
@@ -311,10 +333,11 @@ EOF'
 assert_allowed "55. Heredoc TO marker still allowed (redirect in pre-<< portion)" \
   "$(mock_json 'Bash' "$heredoc_legit")"
 
-# Here-string to marker still allowed
+# Here-string to POST_DONE: per-marker prereq requires POST_REQ which isn't
+# set in this test section (only PRE_REQ active) → blocks (Session 1 tightening).
 herestring_legit='tee '"$POST_DONE"' <<<"checkpoint text"'
-assert_allowed "56. Here-string TO marker still allowed" \
-  "$(mock_json 'Bash' "$herestring_legit")"
+assert_blocked "56. Here-string to POST_DONE BLOCKED (POST_REQ not armed)" \
+  "$(mock_json 'Bash' "$herestring_legit")" "Checkpoint required"
 
 # Bypass attempt with here-string: < but no redirect to marker in pre-<<<
 herestring_bypass='cat > readme.md <<<"echo > .pre-checkpoint-done"'
@@ -381,7 +404,7 @@ touch "$PRE_REQ"
 assert_allowed "69. Pure echo > marker still allowed (regression)" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE")"
 assert_allowed "70. Pure cat > marker <<EOF still allowed (regression)" \
-  "$(mock_json 'Bash' "cat > $PRE_DONE <<EOF\nRule 18\nEOF")"
+  "$(mock_json 'Bash' "$(printf 'cat > %s <<EOF\nRule 18\nEOF' "$PRE_DONE")")"
 assert_allowed "71. Pure tee marker <<<text still allowed (regression)" \
   "$(mock_json 'Bash' "tee $PRE_DONE <<<\"checkpoint\"")"
 # Trailing whitespace after marker should still pass (legitimate noise)
@@ -448,17 +471,34 @@ assert_blocked "82. heredoc + post-EOF && chain — blocks" \
   "$(mock_json 'Bash' "$heredoc_chain2")" "Checkpoint required"
 
 # <<- form (leading tabs allowed on terminator) with post content
+# Session 1: classifier distinguishes chained-command intent. A chained
+# read_only `echo leak` after a marker write is no longer treated as a
+# bypass attempt — read_only chains cannot escalate the marker write to
+# something dangerous. Adversarial chains that ARE writes (rm, git push,
+# etc.) still escalate to shared_write/push_or_pr_create which block.
+# These tests now assert the read-only-chain case allows.
 heredoc_dash=$(printf 'cat > %s <<-EOF\n\tcontent\n\tEOF\necho leak' "$PRE_DONE")
-assert_blocked "83. <<-EOF form with post-EOF content — blocks" \
-  "$(mock_json 'Bash' "$heredoc_dash")" "Checkpoint required"
+assert_allowed "83. <<-EOF + read-only echo chain — allowed (read_only chain)" \
+  "$(mock_json 'Bash' "$heredoc_dash")"
 
-# Quoted terminator <<'EOF'
+# Adversarial dash-EOF with rm chain still blocks (rm is shared_write).
+heredoc_dash_evil=$(printf 'cat > %s <<-EOF\n\tcontent\n\tEOF\nrm -rf /tmp/IMPORTANT' "$PRE_DONE")
+assert_blocked "83b. <<-EOF + rm chain — blocks (shared_write chain)" \
+  "$(mock_json 'Bash' "$heredoc_dash_evil")" "Checkpoint required"
+
 heredoc_quoted="cat > $PRE_DONE <<'EOF'
 literal text
 EOF
 echo leak"
-assert_blocked "84. <<'EOF' quoted-terminator form with post content — blocks" \
-  "$(mock_json 'Bash' "$heredoc_quoted")" "Checkpoint required"
+assert_allowed "84. <<'EOF' + read-only echo chain — allowed (read_only chain)" \
+  "$(mock_json 'Bash' "$heredoc_quoted")"
+
+heredoc_quoted_evil="cat > $PRE_DONE <<'EOF'
+literal text
+EOF
+rm -rf /tmp/IMPORTANT"
+assert_blocked "84b. <<'EOF' + rm chain — blocks (shared_write chain)" \
+  "$(mock_json 'Bash' "$heredoc_quoted_evil")" "Checkpoint required"
 
 # Pure heredoc (regression): no post-EOF content → still allowed
 pure_heredoc="cat > $PRE_DONE <<EOF

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -169,6 +169,32 @@ assert_label "T100 nohup gh pr create" "nohup gh pr create --title x" "unsafe_co
 assert_label "T101 timeout gh api" "timeout 30 gh api -X POST /foo" "unsafe_complex"
 
 echo ""
+echo "--- Codex PR-113 review finding 1: git management subcommands ---"
+# branch/tag/remote/worktree/config: list forms read_only, write forms shared_write.
+assert_label "T110 git branch (list)" "git branch" "read_only"
+assert_label "T111 git branch -a (list)" "git branch -a" "read_only"
+assert_label "T112 git branch foo (create)" "git branch new-topic" "shared_write"
+assert_label "T113 git branch -D foo (delete)" "git branch -D old-topic" "shared_write"
+assert_label "T114 git tag (list)" "git tag" "read_only"
+assert_label "T115 git tag v1 (create)" "git tag v1.0" "shared_write"
+assert_label "T116 git remote (list)" "git remote" "read_only"
+assert_label "T117 git remote -v (list)" "git remote -v" "read_only"
+assert_label "T118 git remote add (write)" "git remote add origin https://x" "shared_write"
+assert_label "T119 git worktree list" "git worktree list" "read_only"
+assert_label "T120 git worktree add (write)" "git worktree add /tmp/wt foo" "shared_write"
+assert_label "T121 git config user.name (read)" "git config user.name" "read_only"
+assert_label "T122 git config user.name x (write)" "git config user.name foo" "shared_write"
+assert_label "T123 git config --unset (write)" "git config --unset user.name" "shared_write"
+
+echo ""
+echo "--- Codex PR-113 review finding 2: gh pr review ---"
+# All gh pr review forms write a review state — even --comment posts a review.
+assert_label "T130 gh pr review --approve" "gh pr review 5 --approve" "push_or_pr_create"
+assert_label "T131 gh pr review --comment" "gh pr review 5 --comment --body x" "push_or_pr_create"
+assert_label "T132 gh pr review --request-changes" "gh pr review 5 --request-changes" "push_or_pr_create"
+assert_label "T133 gh pr review (no flags)" "gh pr review 5" "push_or_pr_create"
+
+echo ""
 echo "--- classify_path ---"
 assert_path() {
   local desc="$1"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -147,6 +147,28 @@ assert_label "T82 mkdir" "mkdir -p foo" "shared_write"
 assert_label "T83 node em-store" "node scripts/em-store.mjs --project x" "shared_write"
 
 echo ""
+echo "--- Audit P1 (subagent finding 1): shell-keyword / group bypass ---"
+# Without these, ( git push ), { git push; }, while/for/if-bodies all
+# classified as shared_write because the first token wasn't 'git'/'gh'.
+assert_label "T90 ( git push )" "( git push )" "unsafe_complex"
+assert_label "T91 { git push; }" "{ git push; }" "unsafe_complex"
+assert_label "T92 if then git push fi" "if true; then git push; fi" "unsafe_complex"
+assert_label "T93 while do git push done" "while true; do git push; done" "unsafe_complex"
+assert_label "T94 for do git push done" "for x in a b; do git push; done" "unsafe_complex"
+
+echo ""
+echo "--- Audit P1 (subagent finding 2): wrapper-utility bypass ---"
+# env / command / sudo / xargs / nohup / time / timeout all execute the
+# next argument. Pre-fix these were on the read_only allowlist (env,
+# command, type) and let trailing git push slip through.
+assert_label "T96 env git push" "env GIT_DIR=/tmp git push" "unsafe_complex"
+assert_label "T97 command git push" "command git push" "unsafe_complex"
+assert_label "T98 sudo git push" "sudo git push" "unsafe_complex"
+assert_label "T99 xargs git push" "echo origin | xargs git push" "unsafe_complex"
+assert_label "T100 nohup gh pr create" "nohup gh pr create --title x" "unsafe_complex"
+assert_label "T101 timeout gh api" "timeout 30 gh api -X POST /foo" "unsafe_complex"
+
+echo ""
 echo "--- classify_path ---"
 assert_path() {
   local desc="$1"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -268,6 +268,23 @@ assert_label "T196 git worktree lock" "git worktree lock /tmp/wt" "shared_write"
 assert_label "T197 git worktree unlock" "git worktree unlock /tmp/wt" "shared_write"
 assert_label "T198 git worktree prune" "git worktree prune" "shared_write"
 
+# Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr checkout/lock/unlock were
+# wrongly bucketed read_only. checkout mutates local working tree;
+# lock/unlock mutate shared GitHub PR state.
+assert_label "T199 gh pr checkout" "gh pr checkout 113" "shared_write"
+assert_label "T200 gh pr lock" "gh pr lock 113" "push_or_pr_create"
+assert_label "T201 gh pr unlock" "gh pr unlock 113" "push_or_pr_create"
+# Negative coverage — read-only PR commands must remain read_only after the
+# above split, otherwise the fix would over-block legitimate inspection.
+assert_label "T202 gh pr view (still read_only)" "gh pr view 113" "read_only"
+assert_label "T203 gh pr list (still read_only)" "gh pr list" "read_only"
+assert_label "T204 gh pr status (still read_only)" "gh pr status" "read_only"
+assert_label "T205 gh pr diff (still read_only)" "gh pr diff 113" "read_only"
+assert_label "T206 gh pr checks (still read_only)" "gh pr checks 113" "read_only"
+# Subagent review on commit 8: same F2 pathology — gh pr update-branch
+# updates the PR head on the remote, must be push_or_pr_create.
+assert_label "T207 gh pr update-branch" "gh pr update-branch 113" "push_or_pr_create"
+
 echo ""
 echo "--- classify_path ---"
 assert_path() {

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -195,6 +195,80 @@ assert_label "T132 gh pr review --request-changes" "gh pr review 5 --request-cha
 assert_label "T133 gh pr review (no flags)" "gh pr review 5" "push_or_pr_create"
 
 echo ""
+echo "--- Commit 7 (#116): inverted-default git mgmt classifier ---"
+# Read forms with positionals — previously misclassified shared_write.
+assert_label "T140 git remote get-url" "git remote get-url origin" "read_only"
+assert_label "T141 git remote show" "git remote show origin" "read_only"
+assert_label "T142 git remote -v" "git remote -v" "read_only"
+assert_label "T143 git tag -l pattern" "git tag -l 'v*'" "read_only"
+assert_label "T144 git tag --list" "git tag --list" "read_only"
+assert_label "T145 git tag --contains" "git tag --contains HEAD" "read_only"
+assert_label "T146 git tag --merged" "git tag --merged main" "read_only"
+assert_label "T147 git tag --sort= equals form" "git tag --sort=-version:refname" "read_only"
+assert_label "T148 git tag -n5 glued count" "git tag -n5" "read_only"
+assert_label "T149 git branch -a" "git branch -a" "read_only"
+assert_label "T150 git branch -r" "git branch -r" "read_only"
+assert_label "T151 git branch --contains" "git branch --contains HEAD" "read_only"
+assert_label "T152 git branch --merged" "git branch --merged main" "read_only"
+assert_label "T153 git branch --no-merged" "git branch --no-merged" "read_only"
+assert_label "T154 git branch --points-at" "git branch --points-at HEAD" "read_only"
+assert_label "T155 git branch --list pattern" "git branch --list 'feat/*'" "read_only"
+assert_label "T156 git branch -l pattern" "git branch -l 'feat/*'" "read_only"
+assert_label "T157 git branch --show-current" "git branch --show-current" "read_only"
+assert_label "T158 git branch --column" "git branch --column" "read_only"
+assert_label "T159 git branch --sort=" "git branch --sort=committerdate" "read_only"
+assert_label "T160 git branch --format=" "git branch --format='%(refname)'" "read_only"
+assert_label "T161 git config --list" "git config --list" "read_only"
+assert_label "T162 git config --get-regexp" "git config --get-regexp '^user'" "read_only"
+assert_label "T163 git config --global user.name read" "git config --global user.name" "read_only"
+assert_label "T164 git config --file path key" "git config --file /tmp/c user.name" "read_only"
+assert_label "T165 git worktree list" "git worktree list" "read_only"
+assert_label "T166 git worktree --help" "git worktree --help" "read_only"
+
+# Write forms still detected (regression).
+assert_label "T170 git branch new-name (create)" "git branch new-topic" "shared_write"
+assert_label "T171 git branch -D delete" "git branch -D old" "shared_write"
+assert_label "T172 git branch --edit-description" "git branch --edit-description" "shared_write"
+assert_label "T173 git branch --edit-description=foo" "git branch --edit-description=foo" "shared_write"
+assert_label "T174 git branch --set-upstream-to=" "git branch --set-upstream-to=origin/main" "shared_write"
+assert_label "T175 git branch --track" "git branch --track main origin" "shared_write"
+assert_label "T176 git tag v1" "git tag v1.0" "shared_write"
+assert_label "T177 git tag -d" "git tag -d v1.0" "shared_write"
+assert_label "T178 git tag -f" "git tag -f v1.0" "shared_write"
+assert_label "T179 git tag -s" "git tag -s v1.0" "shared_write"
+assert_label "T180 git remote add" "git remote add origin https://x" "shared_write"
+assert_label "T181 git remote rename" "git remote rename old new" "shared_write"
+assert_label "T182 git remote set-url" "git remote set-url origin https://y" "shared_write"
+assert_label "T183 git remote prune" "git remote prune origin" "shared_write"
+assert_label "T184 git config user.name foo" "git config user.name foo" "shared_write"
+assert_label "T185 git config --global user.name foo" "git config --global user.name foo" "shared_write"
+assert_label "T186 git config --unset" "git config --unset user.name" "shared_write"
+assert_label "T187 git config --add" "git config --add user.name foo" "shared_write"
+assert_label "T188 git worktree add" "git worktree add /tmp/wt foo" "shared_write"
+assert_label "T189 git worktree remove" "git worktree remove /tmp/wt" "shared_write"
+
+# Reverse-flag-order (Plan-agent [P3] fuzz)
+assert_label "T190 reversed: pattern then --list" "git branch 'feat/*' --list" "read_only"
+
+# Subagent code review fixes for commit 7
+# git config read-flags suppress positional-count rule
+assert_label "T191 git config --get-color (3 positionals, read flag)" \
+  "git config --get-color color.diff red" "read_only"
+assert_label "T192 git config --get-colorbool" \
+  "git config --get-colorbool color.ui true" "read_only"
+assert_label "T193 git config --get-urlmatch" \
+  "git config --get-urlmatch http http://example.com" "read_only"
+# git config write-only flags previously missed
+assert_label "T194 git config --remove-section" \
+  "git config --remove-section section.name" "shared_write"
+assert_label "T195 git config --rename-section" \
+  "git config --rename-section old new" "shared_write"
+# git worktree lock/unlock/prune restored as writes
+assert_label "T196 git worktree lock" "git worktree lock /tmp/wt" "shared_write"
+assert_label "T197 git worktree unlock" "git worktree unlock /tmp/wt" "shared_write"
+assert_label "T198 git worktree prune" "git worktree prune" "shared_write"
+
+echo ""
 echo "--- classify_path ---"
 assert_path() {
   local desc="$1"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -284,6 +284,9 @@ assert_label "T206 gh pr checks (still read_only)" "gh pr checks 113" "read_only
 # Subagent review on commit 8: same F2 pathology — gh pr update-branch
 # updates the PR head on the remote, must be push_or_pr_create.
 assert_label "T207 gh pr update-branch" "gh pr update-branch 113" "push_or_pr_create"
+# Codex review on commit 8 (`...9fc4`): gh pr revert creates a revert PR —
+# same shared-mutation class as gh pr create.
+assert_label "T208 gh pr revert" "gh pr revert 113" "push_or_pr_create"
 
 echo ""
 echo "--- classify_path ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# test-command-classifier.sh — Tests for hooks/lib/command-classifier.sh
+#
+# Usage: bash tests/test-command-classifier.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/hooks/lib/command-classifier.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: $LIB not found"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+passed=0
+failed=0
+
+# Mock repo root for marker resolution
+TEST_ROOT="/tmp/test-classifier-root"
+
+assert_label() {
+  local desc="$1"
+  local cmd="$2"
+  local expected_label="$3"
+  local expected_target="${4:-}"
+
+  local result label target reason
+  result="$(classify_command "$cmd" "$TEST_ROOT")"
+  label="${result%%	*}"
+  local rest="${result#*	}"
+  target="${rest%%	*}"
+  reason="${rest#*	}"
+
+  local ok=1
+  if [ "$label" != "$expected_label" ]; then ok=0; fi
+  if [ -n "$expected_target" ] && [ "$target" != "$expected_target" ]; then ok=0; fi
+
+  if [ $ok -eq 1 ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc"
+    echo "    cmd:      $cmd"
+    echo "    expected: $expected_label" "${expected_target:+(target=$expected_target)}"
+    echo "    got:      $label (target=$target, reason=$reason)"
+    failed=$((failed+1))
+  fi
+}
+
+echo ""
+echo "--- Read-only ---"
+assert_label "T01 ls" "ls -la" "read_only"
+assert_label "T02 cat" "cat /etc/hosts" "read_only"
+assert_label "T03 grep" "grep -r foo ." "read_only"
+assert_label "T04 git status" "git status" "read_only"
+assert_label "T05 git log" "git log --oneline" "read_only"
+assert_label "T06 git -C path log" "git -C /tmp log" "read_only"
+assert_label "T07 git --no-pager show" "git --no-pager show HEAD" "read_only"
+assert_label "T08 gh pr view" "gh pr view 123" "read_only"
+assert_label "T09 gh pr list" "gh pr list" "read_only"
+assert_label "T10 gh issue list" "gh issue list" "read_only"
+assert_label "T11 gh api default GET" "gh api /repos/foo/bar" "read_only"
+assert_label "T12 echo with no redirect" "echo hello" "read_only"
+assert_label "T13 empty" "" "read_only"
+assert_label "T14 colon noop" ":" "read_only"
+assert_label "T15 true" "true" "read_only"
+assert_label "T16 node em-search" "node scripts/em-search.mjs --project x" "read_only"
+assert_label "T17 wc -l" "wc -l file.txt" "read_only"
+
+echo ""
+echo "--- Push or PR-create ---"
+assert_label "T20 git push" "git push origin main" "push_or_pr_create"
+assert_label "T21 git -C path push" "git -C /tmp push" "push_or_pr_create"
+assert_label "T22 git --no-pager push" "git --no-pager push" "push_or_pr_create"
+assert_label "T23 gh pr create" "gh pr create --title foo --body bar" "push_or_pr_create"
+assert_label "T24 gh pr merge" "gh pr merge 123" "push_or_pr_create"
+assert_label "T25 gh issue create" "gh issue create --title foo" "push_or_pr_create"
+assert_label "T26 gh issue close" "gh issue close 5" "push_or_pr_create"
+assert_label "T27 gh release create" "gh release create v1.0" "push_or_pr_create"
+assert_label "T28 gh api -X POST" "gh api -X POST /repos/foo/bar/merges" "push_or_pr_create"
+assert_label "T29 gh api -XPOST" "gh api -XPOST /repos/foo/bar/issues" "push_or_pr_create"
+assert_label "T30 gh api --method POST" "gh api --method POST /repos/foo/bar/comments" "push_or_pr_create"
+assert_label "T31 gh api method-after-path" "gh api /repos/foo/bar/labels -X POST" "push_or_pr_create"
+assert_label "T32 gh api lowercase" "gh api -X post /repos/foo/bar/issues" "push_or_pr_create"
+assert_label "T33 env before git push" "GIT_SSH=foo git push" "push_or_pr_create"
+assert_label "T34 gh pr review --approve" "gh pr review 5 --approve" "push_or_pr_create"
+
+echo ""
+echo "--- False-positive guards (push detection should NOT fire) ---"
+assert_label "T40 git stash push" "git stash push -m wip" "shared_write"
+assert_label "T41 git commit -m push" "git commit -m push" "shared_write"
+assert_label "T42 quoted gh pr create in echo" "echo 'gh pr create'" "read_only"
+assert_label "T43 quoted git push in echo" "echo \"git push origin\"" "read_only"
+assert_label "T44 git branch (read shape)" "git branch" "read_only"
+
+echo ""
+echo "--- Marker write detection ---"
+assert_label "T50 echo redirect to .pre-checkpoint-done" \
+  "echo hello > .pre-checkpoint-done" "marker_write" "$TEST_ROOT/.pre-checkpoint-done"
+assert_label "T51 echo redirect to .post-checkpoint-done" \
+  "echo done > .post-checkpoint-done" "marker_write" "$TEST_ROOT/.post-checkpoint-done"
+assert_label "T52 cat heredoc to marker" \
+  "cat > .pre-checkpoint-done <<EOF
+body
+EOF" "marker_write" "$TEST_ROOT/.pre-checkpoint-done"
+assert_label "T53 rm plan-approval-pending" \
+  "rm .claude/.plan-approval-pending" "marker_write" "$TEST_ROOT/.claude/.plan-approval-pending"
+assert_label "T54 rm -f marker" \
+  "rm -f .pre-checkpoint-done" "marker_write" "$TEST_ROOT/.pre-checkpoint-done"
+assert_label "T55 quoted body containing marker name" \
+  "echo 'this is .pre-checkpoint-done text'" "read_only"
+
+echo ""
+echo "--- Unsafe complex ---"
+assert_label "T60 bash -c" "bash -c 'rm -rf /'" "unsafe_complex"
+assert_label "T61 sh -c" "sh -c 'echo'" "unsafe_complex"
+assert_label "T62 eval" "eval echo foo" "unsafe_complex"
+assert_label "T63 source file" "source ./script.sh" "unsafe_complex"
+assert_label "T64 command substitution" 'echo $(date)' "unsafe_complex"
+assert_label "T65 backtick" 'echo `date`' "unsafe_complex"
+assert_label "T66 unbalanced single quote" "echo 'oops" "unsafe_complex"
+assert_label "T67 unbalanced double quote" 'echo "oops' "unsafe_complex"
+assert_label "T68 process substitution" "diff <(ls) <(ls -la)" "unsafe_complex"
+assert_label "T69 gh api graphql" "gh api graphql -f query='mutation { x }'" "unsafe_complex"
+
+echo ""
+echo "--- Control-operator chain reduction ---"
+# Most-restrictive wins. unsafe > push > shared > marker > read_only.
+assert_label "T70 marker rm then push" "rm .plan-approval-pending && git push" "push_or_pr_create"
+assert_label "T71 ls then rm marker" "ls && rm .plan-approval-pending" "marker_write"
+assert_label "T72 ls then commit" "ls && git commit -m foo" "shared_write"
+assert_label "T73 ls then bash -c" "ls && bash -c 'foo'" "unsafe_complex"
+assert_label "T74 chained pipe" "ls | grep foo" "read_only"
+assert_label "T75 chained pipe with write" "ls | tee output.txt" "shared_write"
+assert_label "T76 quoted control op" "echo 'a && b'" "read_only"
+assert_label "T77 quoted semicolon" "echo 'foo;bar'" "read_only"
+
+echo ""
+echo "--- shared_write defaults ---"
+assert_label "T80 git commit" "git commit -m wip" "shared_write"
+assert_label "T81 npm install" "npm install" "shared_write"
+assert_label "T82 mkdir" "mkdir -p foo" "shared_write"
+assert_label "T83 node em-store" "node scripts/em-store.mjs --project x" "shared_write"
+
+echo ""
+echo "--- classify_path ---"
+assert_path() {
+  local desc="$1"
+  local path="$2"
+  local expected="$3"
+  local result label
+  result="$(classify_path "$path" "$TEST_ROOT")"
+  label="${result%%	*}"
+  if [ "$label" = "$expected" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc — got $label, expected $expected"
+    failed=$((failed+1))
+  fi
+}
+assert_path "P01 marker path" ".pre-checkpoint-done" "marker_write"
+assert_path "P02 plan-approval-pending" ".claude/.plan-approval-pending" "marker_write"
+assert_path "P03 ordinary file" "src/foo.mjs" "shared_write"
+assert_path "P04 absolute marker" "$TEST_ROOT/.claude/.post-checkpoint-done" "marker_write"
+
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+
+exit $((failed > 0 ? 1 : 0))

--- a/tests/test-em-local-dir-worktree.mjs
+++ b/tests/test-em-local-dir-worktree.mjs
@@ -122,6 +122,51 @@ test('non-git cwd falls back to <cwd>/.episodic-memory/', () => {
   )
 })
 
+// Regression for the v1 bug Codex caught on PR #105: --git-common-dir for a
+// submodule returns <super>/.git/modules/<name>; an over-eager `/.git/` strip
+// would resolve the submodule's local memory to the SUPERPROJECT root, cross-
+// contaminating two separate stores. Correct behavior: --show-toplevel returns
+// the submodule's own working tree.
+test('submodule writes to the SUBMODULE working tree, not the superproject', () => {
+  const superRepo = path.join(tmpRoot, 'super')
+  const subSrc = path.join(tmpRoot, 'subsrc')
+  fs.mkdirSync(superRepo, { recursive: true })
+  fs.mkdirSync(subSrc, { recursive: true })
+
+  // Create a "remote" repo for the submodule
+  git(subSrc, 'init -q -b main')
+  git(subSrc, 'config user.email test@example.com')
+  git(subSrc, 'config user.name test')
+  fs.writeFileSync(path.join(subSrc, 'README.md'), '# sub\n')
+  git(subSrc, 'add README.md')
+  git(subSrc, 'commit -q -m sub-init')
+
+  // Create the superproject and add the submodule. file:// + protocol.file.allow
+  // is required by modern git for local submodule sources.
+  git(superRepo, 'init -q -b main')
+  git(superRepo, 'config user.email test@example.com')
+  git(superRepo, 'config user.name test')
+  fs.writeFileSync(path.join(superRepo, 'README.md'), '# super\n')
+  git(superRepo, 'add README.md')
+  git(superRepo, 'commit -q -m super-init')
+  git(superRepo, `-c protocol.file.allow=always submodule add -q file://${fs.realpathSync(subSrc)} sub`)
+
+  const subCheckout = path.join(superRepo, 'sub')
+  const superStore = path.join(fs.realpathSync(superRepo), '.episodic-memory')
+  const subStore = path.join(fs.realpathSync(subCheckout), '.episodic-memory')
+
+  const res = storeFrom(subCheckout, 'from-submodule')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(subStore + path.sep),
+    `expected file under submodule store ${subStore}, got ${res.file}`,
+  )
+  assert.ok(
+    !res.file.startsWith(superStore + path.sep),
+    `submodule episode leaked into superproject store: ${res.file}`,
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Summary (cleanup runs via process.on('exit') registered above)
 // ---------------------------------------------------------------------------

--- a/tests/test-em-local-dir-worktree.mjs
+++ b/tests/test-em-local-dir-worktree.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * test-em-local-dir-worktree.mjs — Tests for #85 LOCAL_DIR worktree resolution.
+ *
+ * Verifies that em-store --scope local writes to the MAIN repo's
+ * .episodic-memory/ regardless of whether invoked from main checkout, a linked
+ * worktree, a nested cwd inside the worktree, or a non-git directory.
+ *
+ * Usage: node tests/test-em-local-dir-worktree.mjs
+ * Zero dependencies — uses Node.js assert + fs + child_process.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+function storeFrom(cwd, summary) {
+  const out = execSync(
+    `node ${STORE} --scope local --project test --category context --summary "${summary}" --body "body"`,
+    { cwd, stdio: ['ignore', 'pipe', 'pipe'] },
+  ).toString()
+  const res = JSON.parse(out)
+  // Realpath res.file too, so macOS /var → /private/var symlinks don't
+  // break startsWith() comparisons against realpathed expected stores.
+  if (res.file) res.file = fs.realpathSync(res.file)
+  return res
+}
+
+// ---------------------------------------------------------------------------
+// Setup: temp main repo + linked worktree + nested dir + non-git dir
+// ---------------------------------------------------------------------------
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-localdir-'))
+// Register cleanup early so setup failures don't leak temp dirs.
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+const mainRepo = path.join(tmpRoot, 'main')
+const worktreeRoot = path.join(tmpRoot, 'wt')
+const nestedDir = path.join(worktreeRoot, 'a', 'b', 'c')
+const nonGitDir = path.join(tmpRoot, 'plain')
+
+fs.mkdirSync(mainRepo, { recursive: true })
+fs.mkdirSync(nonGitDir, { recursive: true })
+
+git(mainRepo, 'init -q -b main')
+git(mainRepo, 'config user.email test@example.com')
+git(mainRepo, 'config user.name test')
+fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
+git(mainRepo, 'add README.md')
+git(mainRepo, 'commit -q -m init')
+git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
+fs.mkdirSync(nestedDir, { recursive: true })
+
+// Resolve realpath upfront so assertions handle macOS /var → /private/var.
+const mainStore = path.join(fs.realpathSync(mainRepo), '.episodic-memory')
+const worktreeStore = path.join(fs.realpathSync(worktreeRoot), '.episodic-memory')
+const nonGitStore = path.join(fs.realpathSync(nonGitDir), '.episodic-memory')
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('main checkout writes episode to main repo .episodic-memory/', () => {
+  const res = storeFrom(mainRepo, 'from-main')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(res.file.startsWith(mainStore + path.sep), `expected file under ${mainStore}, got ${res.file}`)
+  assert.ok(fs.existsSync(res.file))
+})
+
+test('linked worktree writes episode to MAIN repo .episodic-memory/, not worktree', () => {
+  const res = storeFrom(worktreeRoot, 'from-worktree')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(mainStore + path.sep),
+    `expected file under ${mainStore}, got ${res.file}`,
+  )
+  assert.ok(
+    !res.file.startsWith(worktreeStore + path.sep),
+    `episode leaked into worktree store: ${res.file}`,
+  )
+  assert.ok(!fs.existsSync(worktreeStore), `worktree .episodic-memory/ should not exist, found at ${worktreeStore}`)
+})
+
+test('nested cwd inside worktree still writes to MAIN repo .episodic-memory/', () => {
+  const res = storeFrom(nestedDir, 'from-nested')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(mainStore + path.sep),
+    `expected file under ${mainStore}, got ${res.file}`,
+  )
+})
+
+test('non-git cwd falls back to <cwd>/.episodic-memory/', () => {
+  const res = storeFrom(nonGitDir, 'from-non-git')
+  assert.strictEqual(res.status, 'ok')
+  assert.ok(
+    res.file.startsWith(nonGitStore + path.sep),
+    `expected fallback under ${nonGitStore}, got ${res.file}`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Summary (cleanup runs via process.on('exit') registered above)
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.error('\nFailures:')
+  for (const f of failures) console.error(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -77,6 +77,15 @@ assert_eq "T1b em-recall-sessionstart.sh installed and executable" "true" "$r"
 [ -x "$TEST_HOME/.claude/hooks/plan-gate.sh" ] && r=true || r=false
 assert_eq "T1b2 plan-gate.sh installed and executable (#86 PR-A)" "true" "$r"
 
+# Session 1 (#86 PR-B / #89 / #101): hooks/lib/ deployed alongside hooks/.
+[ -f "$TEST_HOME/.claude/hooks/lib/command-classifier.sh" ] && r=true || r=false
+assert_eq "T1b3 hooks/lib/command-classifier.sh installed (Session 1)" "true" "$r"
+[ -f "$TEST_HOME/.claude/hooks/lib/repo-root.sh" ] && r=true || r=false
+assert_eq "T1b4 hooks/lib/repo-root.sh installed (Session 1)" "true" "$r"
+# Hooks should be able to source the lib (smoke test).
+HOME="$TEST_HOME" bash -c "source $TEST_HOME/.claude/hooks/lib/command-classifier.sh && type classify_command >/dev/null 2>&1" && r=true || r=false
+assert_eq "T1b5 installed lib sources successfully and exports classify_command" "true" "$r"
+
 cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T1c PreToolUse contains exactly one checkpoint-gate entry" "1" "$cg_count"
 

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -151,6 +151,21 @@ assert_blocked "7b6. gh api -X POST blocked with marker" \
 assert_blocked "7b7. git push blocked with marker" \
   "$(mock_json 'Bash' 'git push origin main')"
 
+# Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr checkout mutates local
+# working tree (shared_write). Plan-gate must block writes while marker
+# armed. lock/unlock are push_or_pr_create — also blocked here.
+assert_blocked "7b10. gh pr checkout blocked with marker (F2 shared_write)" \
+  "$(mock_json 'Bash' 'gh pr checkout 113')"
+assert_blocked "7b11. gh pr lock blocked with marker (F2 push_or_pr_create)" \
+  "$(mock_json 'Bash' 'gh pr lock 113')"
+assert_blocked "7b12. gh pr unlock blocked with marker (F2 push_or_pr_create)" \
+  "$(mock_json 'Bash' 'gh pr unlock 113')"
+# Negative: read-only PR commands must still be allowed under marker.
+assert_allowed "7b13. gh pr list still allowed with marker (read_only)" \
+  "$(mock_json 'Bash' 'gh pr list')"
+assert_allowed "7b14. gh pr diff still allowed with marker (read_only)" \
+  "$(mock_json 'Bash' 'gh pr diff 113')"
+
 # #86 ...a1e0: quoted body containing 'gh pr create' must NOT bypass.
 # Plan-gate blocks because echo with quoted body classifies as read_only,
 # which is allowed — but the marker was being incorrectly removed by the

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -160,6 +160,9 @@ assert_blocked "7b11. gh pr lock blocked with marker (F2 push_or_pr_create)" \
   "$(mock_json 'Bash' 'gh pr lock 113')"
 assert_blocked "7b12. gh pr unlock blocked with marker (F2 push_or_pr_create)" \
   "$(mock_json 'Bash' 'gh pr unlock 113')"
+# Codex review on commit 8 (`...9fc4`): gh pr revert is push_or_pr_create.
+assert_blocked "7b12b. gh pr revert blocked with marker" \
+  "$(mock_json 'Bash' 'gh pr revert 113')"
 # Negative: read-only PR commands must still be allowed under marker.
 assert_allowed "7b13. gh pr list still allowed with marker (read_only)" \
   "$(mock_json 'Bash' 'gh pr list')"

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -19,6 +19,14 @@ if [ ! -f "$HOOK" ]; then
 fi
 
 TEST_DIR=$(mktemp -d)
+# macOS: /var is a symlink to /private/var. plan-gate's resolve_repo_root uses
+# `cd -P` which resolves symlinks; the test's MARKER path must use the same
+# resolved form so target-equality checks succeed.
+TEST_DIR="$(cd -P "$TEST_DIR" && pwd)"
+# Session 1 (#86 PR-B): plan-gate sources hooks/lib/command-classifier.sh and
+# resolves repo-root via git-common-dir (PR #105 algorithm). Initialize
+# TEST_DIR as a git repo so resolve_repo_root returns TEST_DIR.
+git -C "$TEST_DIR" init -q 2>/dev/null
 MARKER="$TEST_DIR/.claude/.plan-approval-pending"
 passed=0
 failed=0
@@ -110,8 +118,14 @@ assert_blocked "3. Bash with write command blocked with marker" \
 assert_allowed "4. rm ...plan-approval-pending allowed through" \
   "$(mock_json 'Bash' "rm $MARKER")"
 
-assert_allowed "5. Adversarial rm with marker name (documents current regex)" \
-  "$(mock_json 'Bash' "rm -rf /tmp/foo .plan-approval-pending")"
+# Issue #86 PR-B: classifier-driven detection. The old regex matched any rm
+# whose token list mentioned `.plan-approval-pending`; the new classifier
+# returns marker_write only for the exact resolved marker path. A multi-arg
+# rm targeting a different .plan-approval-pending elsewhere in the FS is
+# still classified as marker_write but the TARGET won't equal repo-root, so
+# plan-gate now blocks it.
+assert_blocked "5. Adversarial rm with /tmp marker name BLOCKED (PR-B classifier)" \
+  "$(mock_json 'Bash' "rm -rf /tmp/foo /tmp/.plan-approval-pending")"
 
 assert_blocked "6. rm without marker name blocked" \
   "$(mock_json 'Bash' 'rm somefile.txt')"
@@ -119,11 +133,39 @@ assert_blocked "6. rm without marker name blocked" \
 assert_blocked "7. Write tool blocked with marker" \
   "$(mock_json 'Write')"
 
-# Issue #86 PR-B (deferred): plan-gate still blocks all read-only Bash. PR-A
-# does NOT introduce a Bash command-level allowlist. This guard ensures PR-B's
-# scope stays scoped — if PR-A inadvertently lets ls through, the test fails.
-assert_blocked "7b. Bash read-only command also blocked with marker (PR-B owns this)" \
+# Issue #86 PR-B + #89: plan-gate now allows read-only Bash via classifier.
+assert_allowed "7b. Bash read-only ls allowed with marker (#86 PR-B + #89)" \
   "$(mock_json 'Bash' 'ls -la')"
+assert_allowed "7b2. Bash git status allowed with marker" \
+  "$(mock_json 'Bash' 'git status')"
+assert_allowed "7b3. Bash gh pr view allowed with marker" \
+  "$(mock_json 'Bash' 'gh pr view 123')"
+assert_allowed "7b4. Bash node em-search allowed with marker" \
+  "$(mock_json 'Bash' 'node scripts/em-search.mjs --project x')"
+
+# #101: gh write methods must remain blocked while plan-gate is armed.
+assert_blocked "7b5. gh pr create blocked with marker (write)" \
+  "$(mock_json 'Bash' 'gh pr create --title foo')"
+assert_blocked "7b6. gh api -X POST blocked with marker" \
+  "$(mock_json 'Bash' 'gh api -X POST /repos/foo/bar/issues')"
+assert_blocked "7b7. git push blocked with marker" \
+  "$(mock_json 'Bash' 'git push origin main')"
+
+# #86 ...a1e0: quoted body containing 'gh pr create' must NOT bypass.
+# Plan-gate blocks because echo with quoted body classifies as read_only,
+# which is allowed — but the marker was being incorrectly removed by the
+# old regex if the body matched `^rm.*\.plan-approval-pending`. New
+# classifier doesn't have that bypass.
+assert_allowed "7b8. echo with quoted 'gh pr create' allowed (read_only)" \
+  "$(mock_json 'Bash' "echo 'gh pr create'")"
+
+# #86 ...a1e0 specifically: an rm whose body string mentions
+# .plan-approval-pending but doesn't actually target the real path must block.
+# The old regex `^rm\s+.*\.plan-approval-pending` matched any rm with the
+# substring; the new classifier resolves the target path and refuses if it
+# doesn't equal the repo-root marker.
+assert_blocked "7b9. rm of unrelated file with marker-name in body BLOCKS (PR-B)" \
+  "$(mock_json 'Bash' "rm /tmp/some-file-mentioning-.plan-approval-pending-in-name")"
 
 # Issue #86 PR-A regression guard: BashOutput / KillBash deliberately NOT on
 # the allowlist (Codex review feedback — KillBash mutates process state; both

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -493,6 +493,14 @@ test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (P
       fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(sessionScripts, f))
     }
   }
+  const SCRIPTS_LIB = path.join(SCRIPTS_DIR, 'lib')
+  if (fs.existsSync(SCRIPTS_LIB)) {
+    const sessionLib = path.join(sessionScripts, 'lib')
+    fs.mkdirSync(sessionLib, { recursive: true })
+    for (const f of fs.readdirSync(SCRIPTS_LIB)) {
+      if (f.endsWith('.mjs')) fs.copyFileSync(path.join(SCRIPTS_LIB, f), path.join(sessionLib, f))
+    }
+  }
 
   // Seed a recent bp-001 violation in the project's local store using
   // the same env/HOME the hook will run under.


### PR DESCRIPTION
## Summary
Shared command classifier closing #86 PR-B / #89 / #101. Replaces ad-hoc regex command detection in plan-gate.sh and checkpoint-gate.sh with a quote/heredoc-aware classifier under `hooks/lib/`.

- 6 labels: `read_only`, `shared_write`, `push_or_pr_create`, `marker_write` (+ target), `unsafe_complex`, `unknown`
- Per-marker prerequisite tables for marker writes (Codex `...3503` P1)
- Cross-gate invariant: checkpoint marker writes blocked while `.plan-approval-pending` exists
- `gh api -X POST/PUT/PATCH/DELETE/--method` and method-after-path covered (#101)
- Read-only Bash now passes during pre-checkpoint (#89)
- Quoted body containing literal "gh pr create" / ".plan-approval-pending" no longer false-positives (#86 the `...a1e0` shape)
- Wrapper utilities (`env`, `command`, `sudo`, `xargs`, `nohup`, `time`, `timeout`, …) → `unsafe_complex`
- Shell-keyword / group bypasses (`( git push )`, `{ }`, `if/while/for/case`) → `unsafe_complex`

## Issues fixed
- Closes #86 (PR-B portion: classifier-driven plan-gate, no more `^rm.*\.plan-approval-pending` regex)
- Closes #89 (read-only Bash bypass; checkpoint-gate no longer blocks `ls`/`cat`/`node em-search`/`Write` to its own marker)
- Closes #101 (gh write methods + git push variants beyond literal forms)

## Out of scope
- #85 worktree LOCAL_DIR (separate PR per Codex `...6436`)
- PR-D / PR-E (Sessions 2/3 / #80 H1)
- BashOutput classification (deferred until hook-payload fixture proves read-only)
- Bash-tokenizer edge cases tracked as P2/P3 in #112

## Commits
1. `b173407` feat(hooks): shared command classifier + repo-root resolver (1/4)
2. `89f22a0` feat(plan-gate): wire shared command classifier (2/4)
3. `fe050f7` feat(checkpoint-gate): wire shared command classifier (3/4)
4. `90a66cf` feat(install): deploy hooks/lib/ alongside hooks/ (4/4)
5. `a293f04` fix(classifier): P1 audit fixes — wrapper / control-flow / cleanup race (5/5)

## Tests
**481 / 481 pass** across 15 files. New / extended:
- `tests/test-command-classifier.sh` — 80 cases (NEW)
- `tests/test-plan-gate.sh` — 28 (was 19, +9)
- `tests/test-checkpoint-gate.sh` — 94 (was 91, +3)
- `tests/test-install-hooks.sh` — 61 (was 58, +3)

Test output:
```
PASS test-checkpoint-gate.sh -- Passed: 94 Failed: 0
PASS test-command-classifier.sh -- Results: 80 passed, 0 failed
PASS test-em-recall-sessionstart.sh -- Passed: 9 Failed: 0
PASS test-install-hooks.sh -- Passed: 61 Failed: 0
PASS test-plan-gate.sh -- Results: 28 passed, 0 failed
PASS test-em-local-dir-worktree.mjs -- 5 passed, 0 failed
PASS test-em-watch-codex.mjs -- 25 passed, 0 failed
PASS test-p3-fixes.mjs -- Results: 7 passed, 0 failed
PASS test-phase2.mjs -- Results: 24 passed, 0 failed
PASS test-phase3.mjs -- Results: 20 passed, 0 failed
PASS test-rfc002-phase1.mjs -- Results: 17 passed, 0 failed
PASS test-rfc002-phase2.mjs -- Results: 31 passed, 0 failed
PASS test-rfc002-phase3.mjs -- Results: 28 passed, 0 failed
PASS test-seed-patterns.mjs -- 15 passed, 0 failed
PASS test-workflow-validate.mjs -- 37 passed, 0 failed
```

## Behavior changes (intentional)
1. Read-only Bash no longer blocked during pre-checkpoint flow (#89).
2. POST_DONE writes blocked when only PRE_REQ is armed (per-marker prereq, Codex `...3503`).
3. Echo of marker name without redirect now passes (it's a read).
4. Read-only chains after marker writes now allowed (most-restrictive-wins reduction; adversarial chains like `rm` / `git push` still escalate).
5. Marker cleanup in push-gate now gated on plan-pending absent (audit P1 #3 — race condition between independent PreToolUse hooks).

## Bugs found + fixed during PR
- 4 commit-internal (filed #110)
- 3 audit P1s (filed #111)
- 8 P2/P3 deferred (filed #112)

## Codex review history
- Plan v3 review: `20260503-015007-codex-review-session-1-plan-v3-approve-w-3503`
- Implementation checklist: `20260503-015220-...-6b34`
- Prior-PR-lessons addendum: `20260503-015327-...-ea40`
- Code-review request: `20260503-022303-...-2984`
- Codex reply (no code findings; enforcement work folded into #80 via comment): `20260503-022745-...-9fee`

## Test plan
- [x] `bash tests/test-command-classifier.sh` — 80/80
- [x] `bash tests/test-plan-gate.sh` — 28/28
- [x] `bash tests/test-checkpoint-gate.sh` — 94/94
- [x] `bash tests/test-install-hooks.sh` — 61/61
- [x] All `.mjs` test files pass
- [x] E2E: gates drove this very session live; classifier, plan-gate, checkpoint-gate, install all exercised against real Bash invocations
- [ ] Post-merge: 3-layer verify (origin/main / local main / installed runtime) per PR #105 lesson
- [ ] Post-merge: `node install.mjs --install-hooks` to deploy lib + updated hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
