### PR TITLE
docs(claude.md): pin workplan-discovery instruction for new sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 - You must not do mental tracing always use the actual files or data
 - You must do code review and use the actual files
 
+## Discovering active priorities (read on session start)
+Before recommending or starting work, fetch the latest workplan:
+```bash
+node scripts/em-search.mjs --tags workplan --limit 1 --scope all
+# then read the body of the top result
+```
+Workplans are stored as `category: decision` with tag `workplan`. The terminal revision in the supersedes chain is the current one. The active queue table holds priority/status/session/tokens/depends-on per item. (Tier-2 of MEMORY.md "Current workplan" pointer; tool-agnostic for Cursor/Codex/Windsurf.)
+
 ## Testing
 ```bash
 node scripts/em-store.mjs --project test --category decision --summary "test" --body "test body"


### PR DESCRIPTION
## Summary
- Adds a `## Discovering active priorities` section to project CLAUDE.md instructing the agent to fetch the latest workplan via `em-search --tags workplan --limit 1 --scope all` on session start.
- Companion to a parallel MEMORY.md `## Current workplan` pointer (tier-1, Claude Code auto-memory only); this CLAUDE.md change is tier-2 and tool-agnostic so Cursor/Codex/Windsurf users benefit equally.
- Defers the long-term fix (a `em-search --view workplan` view module) to deferred note `20260503-070829-...-58d1`.

## Why now
Caught this session when a fresh Claude window couldn't find workplan v5 (`20260503-070410-...-f16a`) — it lives in episodic memory but no session-start surface exposed its ID. Five workplan revisions in one session made the discovery problem load-bearing.

## Scope
- `CLAUDE.md` only. **Not** `instructions/*.md` — those are framework templates that `install.mjs` deploys into consuming repos; workplan-discovery is a project-internal convention for this repo, not a downstream feature (P9 — core stays portable).

## Principle alignment ([PRINCIPLES.md](PRINCIPLES.md))
- P4 (cognitive load > lightweight): documenting the discovery command beats requiring every fresh session to remember it.
- P9 (core never imports adapters): scoped to this repo's CLAUDE.md, not to installed consumer repos.

## Test plan
- [ ] Manual: open a fresh Claude session, observe that the "Discovering active priorities" section appears in the CLAUDE.md auto-load and that `em-search --tags workplan --limit 1 --scope all` returns workplan v5 as the top result.
- [ ] No code paths changed; no automated test required.

## References
- Workplan v5: episodic memory id `20260503-070410-workplan-2026-05-03-v5-adds-121-em-revis-f16a` (global scope per #121).
- Deferred RFC note: `20260503-070829-...-58d1`.
- Related issues: #121 (em-revise scope-lock — keeps revisions in global, motivates the explicit pointer).