### PR TITLE
fix(claude.md): correct workplan-discovery command flags (post-#122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,11 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 ## Discovering active priorities (read on session start)
 Before recommending or starting work, fetch the latest workplan:
 ```bash
-node scripts/em-search.mjs --tags workplan --limit 1 --scope all
-# then read the body of the top result
+node scripts/em-search.mjs --tag workplan --category decision --limit 1 --scope all --full --no-score --no-track
 ```
 Workplans are stored as `category: decision` with tag `workplan`. The terminal revision in the supersedes chain is the current one. The active queue table holds priority/status/session/tokens/depends-on per item. (Tier-2 of MEMORY.md "Current workplan" pointer; tool-agnostic for Cursor/Codex/Windsurf.)
+
+Notes on the flags: `--tag` (singular — em-search silently ignores `--tags` per #123), `--category decision` (filters out evidence/lesson siblings that share the `workplan` tag), `--no-score` (recency sort; remove when #123 ships `--sort recency`), `--full` (returns body so the table renders), `--no-track` (avoids access-counter pollution from session-start polling).
 
 ## Testing
 ```bash


### PR DESCRIPTION
## Summary

PR #122 shipped a workplan-discovery instruction that **silently returned the wrong episode**, then in a fresh session forced a manual file-read fallback that lost the table format. This PR corrects the command flags. Codex reviewed the plan: episode \`20260503-073236-codex-plan-review-discovery-surface-fix--c19c\` (ACCEPT WITH MODIFICATION).

## Why the original was broken

\`em-search.mjs\` parses flags via a strict whitelist. Unknown flags are silently ignored — they don't error, don't warn, just no-op. Two such bugs in PR #122:

### Bug 1: \`--tags\` (plural) is not a real flag

```bash
$ node scripts/em-search.mjs --tags workplan --limit 5 --scope all
# returns 5 unfiltered episodes, NONE of which need a workplan tag:
#   20260501-045223-...-770e (tags: violation, behavioral-pattern, ...)
#   20260501-045608-...-6808 (tags: violation, behavioral-pattern, ...)
#   20260501-050944-...-4cb5 (tags: violation, behavioral-pattern, ...)
```

The supported flag is \`--tag\` (singular).

### Bug 2: even with \`--tag\`, default ranking buries date-newest

\`computeScore\` mixes recency, access count, and text-match. Older episodes with high access count outrank workplan v5. \`--no-score\` switches to date-only sort. (Tracked at #123; \`--sort recency\` proposed.)

### Bug 3: bare \`--tag workplan\` matches sibling-tagged episodes

This session's evidence/lesson episodes also carry tag \`workplan\` for traceability. \`--category decision\` narrows to actual workplan revisions.

### Bug 4: default output omits body

\`--full\` required to render the table.

## Verified fix

```bash
$ node scripts/em-search.mjs --tag workplan --category decision --limit 1 --scope all --full --no-score --no-track
# returns:
#   id: 20260503-070410-workplan-2026-05-03-v5-adds-121-em-revis-f16a
#   summary: Workplan 2026-05-03 v5 — adds #121 em-revise scope bug to Quick Wins
#   body length: 6566 chars
#   table marker present ("|"): True
```

## What changed

\`CLAUDE.md\` discovery section: 1 command line replaced + 1 explanatory paragraph added documenting why each flag is needed (so a future edit doesn't regress to the broken form).

## Out of scope

- MEMORY.md pointer fix (user-private, not repo-tracked) — applied separately as a side-effect artifact per Codex's reframe.
- \`em-search --view workplan\` view module (deferred to note \`20260503-070829-...-58d1\`) — long-term fix that would render the table without flag gymnastics.
- \`instructions/*.md\` framework templates — downstream/installer concern, not project-internal (P9).
- Reverting PR #122 — this PR is the targeted fix; PR #122's structural addition (the discovery section itself) is still net-positive.

## Test plan
- [x] \`em-search\` with corrected flags returns workplan v5 (\`...f16a\`) with full body. Output above.
- [x] Old broken commands (\`--id\`, \`--tags\`) reproduced as silently returning wrong episodes. Output above.
- [ ] Manual: open a fresh Claude session, observe that the corrected command actually surfaces the table on first read (no fallback to manual file Read needed).

## References
- PR #122 (the broken predecessor): https://github.com/lantisprime/episodic-memory/pull/122
- Codex plan review: episode \`20260503-073236-codex-plan-review-discovery-surface-fix--c19c\`
- em-search UX bug tracker: #123 (will be updated to add \`--id\` and \`--tags\` silent-ignore findings as part of this task chain)
- Deferred RFC for view module: episode \`20260503-070829-note-workplan-helper-feature-idea-princi-58d1\`