### PR TITLE
fix(em-backup): empty-repo HEAD + extra_redact_strings (live-repro post-#134)

### DIFF
--- a/docs/em-backup.md
+++ b/docs/em-backup.md
@@ -47,7 +47,8 @@ Episodes accumulate on local disk and have no built-in durability. If your disk 
     { "src": "~/.episodic-memory", "dest": "global", "label": "global" }
   ],
   "extra_allowlist_emails": [],
-  "extra_allowlist_domains": []
+  "extra_allowlist_domains": [],
+  "extra_redact_strings": ["your-username", "Real Name"]
 }
 ```
 
@@ -56,11 +57,34 @@ Episodes accumulate on local disk and have no built-in durability. If your disk 
 | `repo_owner` | yes | GitHub user/org for the backup repo |
 | `repo_name` | yes | Repo name (will be created as private on first `--init`) |
 | `backup_dir` | no | Local clone path. Default `~/.local/share/episodic-memory-backup`. Tilde expansion supported. |
-| `sources` | yes (≥1) | Array of `{ src, dest, label }`. `src` = absolute or `~/`-prefixed source dir; `dest` = subdir under backup repo root; `label` = display name. |
+| `sources` | yes (≥1) | Array of `{ src, dest, label }`. `src` = absolute or `~/`-prefixed source dir; `dest` = subdir under backup repo root; `label` = display name. Dest must NOT escape backup_dir (`..`, absolute paths rejected at config-load). |
 | `extra_allowlist_emails` | no | Emails NOT to redact (e.g. published team addresses). Lowercased. |
 | `extra_allowlist_domains` | no | Domains NOT to redact (e.g. your company domain). Lowercased. |
+| `extra_redact_strings` | no | Literal strings to additionally redact (e.g. your username, real name, company name). Replaces with `[REDACTED]`. Applied BEFORE built-in patterns. Catches narrative usage that path/email regex misses (e.g. username inside markdown code-fence). |
 
 Config is searched in this order: `$EM_BACKUP_CONFIG`, then `~/.config/em-backup/config.json`. First match wins.
+
+### Why `extra_redact_strings` exists
+
+The built-in `home_path` regex catches `/Users/<name>` in path context but misses bare username strings in narrative text (e.g. `` `charltond.ho` was not redacted `` inside a markdown code-fence). Synthetic test fixtures don't exercise narrative usage; first real `--init` against a real corpus surfaced one such leak. `extra_redact_strings` is the user-supplied complement: list anything you don't want to leak as a literal string, regardless of context.
+
+Add your username, real name, project codename, company name, etc. The script applies these BEFORE built-in patterns so they can't be partially eaten by generic regex. Sort-longest-first means `["Foo", "Foo Bar"]` redacts `"Foo Bar"` correctly.
+
+### Artifact-wide redaction policy
+
+`extra_redact_strings` is treated as an **artifact-wide policy**, not just content. The same redaction is applied to:
+
+| Surface | Behavior |
+|---|---|
+| File contents | Replaced with `[REDACTED]` (along with built-in patterns) |
+| Backup pathnames under `BACKUP_DIR/<dest>/` | Path segments containing the literal are rewritten (e.g. source `src/SecretCodename/note.md` → backup `<dest>/[REDACTED]/note.md`) |
+| `.skipped-files.json` manifest entries | Paths run through the redaction (also redacts `/Users/<name>` → `/Users/USER`) |
+| `--audit` JSON `file:` and `src:` fields | Same treatment |
+| `--show-config` output | `extra_redact_strings` field is masked (shown as count) so terminal output / shared review evidence doesn't leak the list itself |
+
+Pruning uses a source-driven model: it computes the expected backup paths from the source side (applying the same redaction transformation), then deletes anything in backup that isn't in the expected set. This keeps prune correct when redacted segment names diverge from source segment names.
+
+The only raw strings that ever leave the script are the actual filesystem operations on `BACKUP_DIR` itself (Node fs API calls — not in any output stream that an attacker or reviewer could see).
 
 ## What gets redacted
 

--- a/examples/em-backup.config.example.json
+++ b/examples/em-backup.config.example.json
@@ -23,5 +23,8 @@
 
   "_allowlist_comment": "Optional. Add per-config allowlist for emails/domains that should NOT be redacted (e.g. your team's published vendor addresses). Vendor commit-author constants for Claude/Codex/Cursor/Windsurf/Continue/Copilot, GitHub no-reply, RFC 2606 reserved domains, juan.delacruz@acme.com sample, and git@github.com SSH protocol address are already allowlisted by default.",
   "extra_allowlist_emails": [],
-  "extra_allowlist_domains": []
+  "extra_allowlist_domains": [],
+
+  "_extra_redact_strings_comment": "Optional. Literal strings to additionally redact regardless of surrounding context. Catches narrative usage (e.g. your username inside a markdown code-fence) that the built-in path/email regex misses. Recommended: add your username, real name, project codenames, company name. Replaced with [REDACTED]. Applied BEFORE built-in patterns so longer strings win.",
+  "extra_redact_strings": ["your-username", "Your Real Name"]
 }

--- a/scripts/em-backup.mjs
+++ b/scripts/em-backup.mjs
@@ -129,6 +129,7 @@ function resolveConfig(requirePushable = false) {
     }),
     extra_allowlist_emails: (cfg.extra_allowlist_emails || []).map(e => e.toLowerCase()),
     extra_allowlist_domains: (cfg.extra_allowlist_domains || []).map(d => d.toLowerCase()),
+    extra_redact_strings: (cfg.extra_redact_strings || []).filter(s => typeof s === 'string' && s.length > 0),
   }
   if (requirePushable) {
     if (!out.repo_owner || !out.repo_name) {
@@ -149,6 +150,27 @@ let REPO_NAME = null
 const SOURCES = []
 let EXTRA_ALLOWLIST_EMAILS = new Set()
 let EXTRA_ALLOWLIST_DOMAINS = new Set()
+// Live-reproduction finding (post-PR-#134 SHIP, first --init):
+// home_path regex catches `/Users/<name>` with a path prefix but misses bare
+// usernames that appear in narrative text / code-fences (e.g.
+// "the literal `charltond.ho` was not redacted"). Synthetic test fixtures
+// don't exercise narrative usage. Real-corpus run caught this.
+//
+// Fix: user-supplied list of literal strings to redact additionally. Applied
+// BEFORE built-in REDACTIONS so user strings aren't partially eaten by
+// generic regex.
+let EXTRA_REDACT_PATTERN = null // RegExp built from cfg.extra_redact_strings
+
+function buildExtraRedactPattern(strings) {
+  if (!Array.isArray(strings) || strings.length === 0) return null
+  // Sort longest-first so substring overlaps redact correctly (e.g. user
+  // adds both "Foo Bar" and "Foo" — match "Foo Bar" first).
+  const sorted = [...strings].filter(s => typeof s === 'string' && s.length > 0).sort((a, b) => b.length - a.length)
+  if (sorted.length === 0) return null
+  // Escape regex special chars in each literal.
+  const escaped = sorted.map(s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  return new RegExp(escaped.join('|'), 'g')
+}
 
 // Skip these path fragments anywhere in source tree
 const SKIP_FRAGMENTS = [
@@ -352,6 +374,16 @@ function walkForPrune(dir, root, out = []) {
 function applyRedactions(content) {
   const findings = []
   let redacted = content
+  // User-supplied literal redactions FIRST so generic patterns can't
+  // partially eat them (e.g. user adds "alice.smith"; if home_path were to
+  // match it inside a code-fence, the partial redaction marker would be
+  // confusing). Replacement marker is generic [REDACTED] — the originating
+  // string is private; the marker doesn't disclose what was there.
+  if (EXTRA_REDACT_PATTERN) {
+    let extraCount = 0
+    redacted = redacted.replace(EXTRA_REDACT_PATTERN, () => { extraCount++; return '[REDACTED]' })
+    if (extraCount > 0) findings.push({ name: 'extra_redact', count: extraCount })
+  }
   for (const r of REDACTIONS) {
     let realCount = 0
     // Operate on the IN-PIPELINE text, not the original. Earlier patterns may
@@ -372,6 +404,69 @@ function ensureDir(p) {
   fs.mkdirSync(p, { recursive: true })
 }
 
+// Codex review on PR #137: extra_redact_strings was content-only; backup
+// pathnames, manifest entries, audit JSON `file:` fields, and --show-config
+// output all leaked the literal strings. Redact policy must be artifact-wide.
+//
+// Two helpers:
+// - redactArtifactString(s): for any string EMITTED in audit/manifest/config
+//   output. Applies BOTH extra_redact and home_path so user paths in the
+//   user's machine ($HOME) are scrubbed too.
+// - redactPathSegments(rel): for filesystem subpaths actually written under
+//   BACKUP_DIR. Applies ONLY extra_redact — fs operations need real path
+//   characters; we don't want /Users/USER substituted into BACKUP_DIR.
+function redactArtifactString(value) {
+  if (typeof value !== 'string' || value.length === 0) return value
+  let out = value
+  if (EXTRA_REDACT_PATTERN) {
+    out = out.replace(EXTRA_REDACT_PATTERN, '[REDACTED]')
+  }
+  // Apply home_path: same regex as in REDACTIONS array, kept in sync.
+  out = out.replace(/(\/Users|\/home)\/[A-Za-z0-9._-]+(?=\/|"|'|\s|$|[,)])/g, (m) => m.replace(/\/[A-Za-z0-9._-]+$/, '/USER'))
+  return out
+}
+
+// Apply only EXTRA_REDACT_PATTERN. Used for the relative-path component
+// inside BACKUP_DIR — keeps pathnames clean of literals while preserving
+// the BACKUP_DIR prefix needed for fs operations. Deterministic so prune
+// can recompute the same transformation from the source side.
+function redactPathSegments(rel) {
+  if (!EXTRA_REDACT_PATTERN) return rel
+  return rel.replace(EXTRA_REDACT_PATTERN, '[REDACTED]')
+}
+
+// Codex PR-#137 round-2 F1: --show-config left raw backup_dir, sources[].src,
+// sources[].absDest, sources[].label. Walk the entire config and redact every
+// string value, preserving repo_owner/repo_name (operational identity, not
+// user-secret) and replacing extra_redact_strings with a masked count.
+function redactConfigForDisplay(cfg) {
+  function walk(node, parentKey) {
+    if (typeof node === 'string') return redactArtifactString(node)
+    if (Array.isArray(node)) return node.map(item => walk(item, parentKey))
+    if (node && typeof node === 'object') {
+      const out = {}
+      for (const [k, v] of Object.entries(node)) {
+        if (k === 'extra_redact_strings' && Array.isArray(v) && v.length > 0) {
+          out[k] = `<${v.length} strings configured (masked; read config file directly to inspect)>`
+        } else if (k === 'repo_owner' || k === 'repo_name') {
+          // Codex PR-#137 round-3 F1.A2: previously preserved owner/name
+          // verbatim as "operational identity." But if user explicitly
+          // listed those literals in extra_redact_strings, they want them
+          // gone. Apply redactArtifactString — pattern won't match unless
+          // the string is on the user's redact list, so values stay
+          // verbatim by default.
+          out[k] = redactArtifactString(v)
+        } else {
+          out[k] = walk(v, k)
+        }
+      }
+      return out
+    }
+    return node
+  }
+  return walk(cfg, null)
+}
+
 // ---------------------------------------------------------------------------
 // Audit / sync core
 // ---------------------------------------------------------------------------
@@ -384,7 +479,9 @@ function auditSources({ sample = 0 } = {}) {
   }
   for (const s of SOURCES) {
     const exists = fs.existsSync(s.src)
-    const entry = { label: s.label, src: s.src, exists, files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, redactions: 0 }
+    // Codex PR-#137 round-1: `src` leaks raw source paths.
+    // Codex PR-#137 round-2 F1: `label` also leaks. Apply redaction to both.
+    const entry = { label: redactArtifactString(s.label), src: redactArtifactString(s.src), exists, files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, redactions: 0 }
     if (!exists) { report.sources.push(entry); continue }
     const files = walk(s.src)
     for (const f of files) {
@@ -392,7 +489,6 @@ function auditSources({ sample = 0 } = {}) {
       if (stat.size > MAX_FILE_BYTES) { entry.oversized_skipped++; report.totals.oversized_skipped++; continue }
       entry.files++
       report.totals.files++
-      // Codex F3: probe content; binary files are skipped (not byte-copied).
       if (classifyFileBytes(f) === 'binary') { entry.binary_files++; report.totals.binary_files++; continue }
       entry.text_files++; report.totals.text_files++
       const content = fs.readFileSync(f, 'utf8')
@@ -405,13 +501,12 @@ function auditSources({ sample = 0 } = {}) {
           report.findings_by_pattern[fnd.name] = (report.findings_by_pattern[fnd.name] || 0) + fnd.count
         }
         if (sample > 0 && report.samples.length < sample && redacted !== content) {
-          // Codex F1: NEVER emit raw pre-redaction content. The audit JSON
-          // itself is shareable artifact (review evidence, terminal logs) so
-          // raw secrets/PII would leak through `before_snippet`. Show only
-          // the redacted snippet plus the patterns that fired.
+          // Codex F1: NEVER emit raw pre-redaction content. Codex PR-#137:
+          // the `file:` field also leaks if a path segment matches an
+          // extra-redact literal — apply redactArtifactString.
           const idx = firstDiffIndex(content, redacted)
           report.samples.push({
-            file: f,
+            file: redactArtifactString(f),
             patterns: findings.map(x => x.name),
             redacted_snippet: redacted.slice(Math.max(0, idx - 60), Math.min(redacted.length, idx + 60)),
           })
@@ -449,37 +544,71 @@ function syncToBackup({ verbose = false } = {}) {
     const destBase = s.absDest || path.join(BACKUP_DIR, s.dest)
     const sourceLog = []
     const files = walk(s.src, [], sourceLog)
-    for (const sym of sourceLog) skippedSymlinks.push({ source: s.label, path: sym })
+    // Codex PR-#137 round-1: manifest entries leak raw paths.
+    // Codex PR-#137 round-2 F1: `source` field (= s.label) leaks too.
+    const safeLabel = redactArtifactString(s.label)
+    for (const sym of sourceLog) skippedSymlinks.push({ source: safeLabel, path: redactArtifactString(sym) })
+
+    // Codex PR-#137 round-3 F2: PRE-WALK ALL files in this source FIRST,
+    // build the source→dest mapping, detect collisions BEFORE touching disk.
+    // Inline-during-loop detection (round 2) left first-of-pair already
+    // written when the second triggered the throw. Pre-walk is fail-closed:
+    // no file written if any collision exists.
+    const planned = [] // [{ source: f, destPath, kind: 'text'|'oversized'|'binary' }]
+    const seenDest = new Map() // destPath → first source file mapped to it
     for (const f of files) {
       const stat = fs.statSync(f)
       if (stat.size > MAX_FILE_BYTES) {
-        skippedOversized.push({ source: s.label, path: f, size: stat.size })
+        planned.push({ source: f, destPath: null, kind: 'oversized', size: stat.size })
         continue
       }
-      // Codex F3: redact-by-default. Anything that isn't binary gets the
-      // redaction pipeline, regardless of extension. Binary files are
-      // skipped with a manifest entry (NEVER byte-copied raw — would let
-      // .pem / .key / .sqlite leak unredacted past the regex pipeline).
       if (classifyFileBytes(f) === 'binary') {
-        skippedBinary.push({ source: s.label, path: f, size: stat.size })
+        planned.push({ source: f, destPath: null, kind: 'binary', size: stat.size })
         continue
       }
       const rel = path.relative(s.src, f)
-      const destPath = path.join(destBase, rel)
-      ensureDir(path.dirname(destPath))
-      const content = fs.readFileSync(f, 'utf8')
+      const transformedRel = redactPathSegments(rel)
+      const destPath = path.join(destBase, transformedRel)
+      if (seenDest.has(destPath)) {
+        // Pre-walk collision detection — NO files written yet.
+        throw new Error(`em-backup: extra_redact_strings collision detected during pre-walk — multiple source files map to the same backup path "${redactArtifactString(destPath)}". Adjust extra_redact_strings or rename source files to disambiguate. Refusing to sync (would silently overwrite). Source: ${safeLabel}. No backup files have been modified.`)
+      }
+      seenDest.set(destPath, f)
+      planned.push({ source: f, destPath, kind: 'text' })
+    }
+
+    // Pre-walk passed: now do all the disk operations. expectedDestPaths is
+    // used by source-driven prune.
+    const expectedDestPaths = new Set()
+    for (const p of planned) {
+      if (p.kind === 'oversized') {
+        skippedOversized.push({ source: safeLabel, path: redactArtifactString(p.source), size: p.size })
+        continue
+      }
+      if (p.kind === 'binary') {
+        skippedBinary.push({ source: safeLabel, path: redactArtifactString(p.source), size: p.size })
+        continue
+      }
+      ensureDir(path.dirname(p.destPath))
+      const content = fs.readFileSync(p.source, 'utf8')
       const { redacted, findings } = applyRedactions(content)
-      fs.writeFileSync(destPath, redacted)
+      fs.writeFileSync(p.destPath, redacted)
       totalRedacted += findings.reduce((a, b) => a + b.count, 0)
       totalCopied++
+      expectedDestPaths.add(p.destPath)
     }
-    pruneDeleted(s.src, destBase)
+    // Source-driven prune: anything in dest not in expectedDestPaths is gone
+    // from source and should be removed. This handles redacted pathnames
+    // correctly (the original prune walked dest then checked source — but
+    // the dest's redacted name doesn't correspond to any source entry, so
+    // the original would have wrongly deleted the just-written backup).
+    pruneSourceDriven(destBase, expectedDestPaths)
   }
   const manifest = {
     generated_at: new Date().toISOString(),
     skipped_symlinks: skippedSymlinks,
     skipped_oversized: skippedOversized.map(x => ({ ...x, max_bytes: MAX_FILE_BYTES })),
-    skipped_binary: skippedBinary, // Codex F3
+    skipped_binary: skippedBinary,
   }
   fs.writeFileSync(path.join(BACKUP_DIR, '.skipped-files.json'), JSON.stringify(manifest, null, 2) + '\n')
   return {
@@ -488,6 +617,24 @@ function syncToBackup({ verbose = false } = {}) {
     skippedSymlinks: skippedSymlinks.length,
     skippedOversized: skippedOversized.length,
     skippedBinary: skippedBinary.length,
+  }
+}
+
+// Codex PR-#137: source-driven prune. The original pruneDeleted walked dest
+// then checked if source still exists at the same rel path. With path
+// redaction, the dest's redacted name doesn't correspond to any source
+// entry, so source-existence-check would wrongly delete the just-written
+// backup. Source-driven prune builds the expected dest set from source +
+// the same path-redaction transformation, then deletes anything in dest
+// NOT in that set. Deterministic; works whether redaction is on or off.
+function pruneSourceDriven(destRoot, expectedDestPaths) {
+  if (!fs.existsSync(destRoot)) return
+  const destFiles = walkForPrune(destRoot, destRoot)
+  for (const df of destFiles) {
+    if (expectedDestPaths.has(df)) continue
+    const real = fs.realpathSync(df)
+    if (!real.startsWith(destRoot + path.sep) && real !== destRoot) continue
+    fs.unlinkSync(df)
   }
 }
 
@@ -538,23 +685,35 @@ function validateBackupRemoteAndBranch() {
   try {
     originUrl = execFileSync('git', ['remote', 'get-url', 'origin'], opts).toString().trim()
   } catch {
-    throw new Error(`em-backup: backup repo at ${BACKUP_DIR} has no 'origin' remote configured. Refusing to push.`)
+    throw new Error(`em-backup: backup repo at ${redactArtifactString(BACKUP_DIR)} has no 'origin' remote configured. Refusing to push.`)
   }
   const parsed = parseGitHubRemote(originUrl)
   if (!parsed) {
-    throw new Error(`em-backup: backup repo origin "${originUrl}" is not a recognized GitHub URL. Refusing to push.`)
+    // Codex PR-#137 round-3 F1.A3: error messages must redact too. Apply
+    // redactArtifactString so an extra-redacted literal in the URL doesn't
+    // leak via stderr / process output.
+    throw new Error(`em-backup: backup repo origin "${redactArtifactString(originUrl)}" is not a recognized GitHub URL. Refusing to push.`)
   }
   if (parsed.owner !== REPO_OWNER || parsed.name !== REPO_NAME) {
-    throw new Error(`em-backup: backup repo origin points at ${parsed.owner}/${parsed.name} but config expects ${REPO_OWNER}/${REPO_NAME}. Refusing to push (personal memory could ship to wrong repo).`)
+    const got = redactArtifactString(`${parsed.owner}/${parsed.name}`)
+    const want = redactArtifactString(`${REPO_OWNER}/${REPO_NAME}`)
+    throw new Error(`em-backup: backup repo origin points at ${got} but config expects ${want}. Refusing to push (personal memory could ship to wrong repo).`)
   }
   // Branch invariant: must be on main. Refuse if HEAD is detached or on
   // a different branch — commit would land on the wrong ref and `git push
   // origin main` would push the stale local main, not the new commit.
+  //
+  // Use `symbolic-ref --short HEAD` (NOT `rev-parse --abbrev-ref HEAD`) so
+  // freshly-initialized repos with no commits yet still resolve. `git init -b
+  // main` creates HEAD as a symbolic ref to refs/heads/main BEFORE any commit
+  // exists; symbolic-ref reads the ref text, rev-parse needs the ref to point
+  // at a commit. Found by running --init for the first time on a new repo —
+  // no amount of code review caught this; reproduction did.
   let branch = ''
   try {
-    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], opts).toString().trim()
+    branch = execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], opts).toString().trim()
   } catch {
-    throw new Error(`em-backup: backup repo at ${BACKUP_DIR} has no HEAD; cannot determine branch. Refusing to push.`)
+    throw new Error(`em-backup: backup repo at ${BACKUP_DIR} has detached HEAD or no HEAD symbolic ref; cannot determine branch. Refusing to push.`)
   }
   if (branch !== 'main') {
     throw new Error(`em-backup: backup repo HEAD is on "${branch}" not "main". Refusing to commit/push (commit would land on wrong branch).`)
@@ -922,6 +1081,45 @@ function selfTest() {
     results.push({ name: 'codex_r5_sync_validates_before_writes', pass: false, why: `test infrastructure error: ${e.message}` })
   }
 
+  // Live-reproduction regression: validateBackupRemoteAndBranch must accept
+  // a freshly-initialized backup repo (no commits yet, HEAD is symbolic-ref
+  // to refs/heads/main but doesn't resolve to a commit).
+  // Caught by running --init for the first time on a brand-new repo:
+  // `git rev-parse --abbrev-ref HEAD` errored, refused push despite
+  // origin being correctly set. Switched to `git symbolic-ref --short HEAD`
+  // which works on empty repos.
+  try {
+    const tmpBackup = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-emptyrepo-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    // INTENTIONALLY no commit — this is the empty-repo case.
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:expected-owner/expected-name.git'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    const savedBackupDir = BACKUP_DIR
+    const savedOwner = REPO_OWNER
+    const savedName = REPO_NAME
+    BACKUP_DIR = tmpBackup
+    REPO_OWNER = 'expected-owner'
+    REPO_NAME = 'expected-name'
+
+    let validateResult = null
+    let validateErr = null
+    try { validateResult = validateBackupRemoteAndBranch() } catch (e) { validateErr = e.message }
+
+    BACKUP_DIR = savedBackupDir
+    REPO_OWNER = savedOwner
+    REPO_NAME = savedName
+    fs.rmSync(tmpBackup, { recursive: true, force: true })
+
+    const okEmpty = validateResult && validateResult.branch === 'main' && !validateErr
+    if (okEmpty) pass++; else fail++
+    results.push({ name: 'live_repro_empty_repo_head_resolves', pass: okEmpty, ...(okEmpty ? {} : { why: `result=${JSON.stringify(validateResult)} err=${validateErr}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'live_repro_empty_repo_head_resolves', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
   // Codex F3 regression: classifyFileBytes correctly identifies binary vs
   // text and unknown-extension text gets redaction (not byte-copy).
   try {
@@ -943,6 +1141,532 @@ function selfTest() {
     results.push({ name: 'codex_f3_binary_detection', pass: false, why: `test infrastructure error: ${e.message}` })
   }
 
+  // Live-reproduction regression: extra_redact_strings catches bare username
+  // in narrative text that home_path missed. Real-world bug discovered when
+  // first --init landed a literal username in a code-fence inside an
+  // episode body. Synthetic fixture-driven tests didn't cover narrative
+  // usage; this test does.
+  try {
+    const savedPattern = EXTRA_REDACT_PATTERN
+    EXTRA_REDACT_PATTERN = buildExtraRedactPattern(['alice.smith', 'CompanyX'])
+    const cases = [
+      { input: 'the user alice.smith was here', expectContains: '[REDACTED]', expectNotContains: 'alice.smith' },
+      { input: 'CompanyX is referenced', expectContains: '[REDACTED]', expectNotContains: 'CompanyX' },
+      { input: 'in code-fence: `alice.smith` quoted', expectContains: '[REDACTED]', expectNotContains: 'alice.smith' },
+      { input: 'no match here', expectExact: 'no match here' },
+    ]
+    let okExtra = 0
+    for (const c of cases) {
+      const { redacted } = applyRedactions(c.input)
+      let pass = true
+      if (c.expectContains && !redacted.includes(c.expectContains)) pass = false
+      if (c.expectNotContains && redacted.includes(c.expectNotContains)) pass = false
+      if (c.expectExact && redacted !== c.expectExact) pass = false
+      if (pass) okExtra++
+    }
+    EXTRA_REDACT_PATTERN = savedPattern
+    const okAll = okExtra === cases.length
+    if (okAll) pass++; else fail++
+    results.push({ name: 'live_repro_extra_redact_strings', pass: okAll, ...(okAll ? {} : { why: `${okExtra}/${cases.length} cases passed` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'live_repro_extra_redact_strings', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 regression: extra_redact_strings is artifact-wide, not
+  // content-only. Audit JSON `file:` field, manifest `path:` entries,
+  // backup pathnames, and --show-config must NOT leak the literal.
+  try {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-artifact-'))
+    const tmpSrc = path.join(tmpRoot, 'src')
+    const tmpBackup = path.join(tmpRoot, 'backup')
+    // Source files where the LITERAL appears in path segment.
+    const secretSegment = 'SecretCodename'
+    fs.mkdirSync(path.join(tmpSrc, secretSegment), { recursive: true })
+    fs.writeFileSync(path.join(tmpSrc, secretSegment, 'note.md'), 'plain text body — no secret in content here\n')
+    // Binary file (will be skipped) under same segment to test manifest leak.
+    fs.writeFileSync(path.join(tmpSrc, secretSegment, 'blob.bin'), Buffer.from([0x00, 0x01, 0x02, 0x00, 0xFF, 0x00, 0x01, 0x00]))
+
+    const savedPattern = EXTRA_REDACT_PATTERN
+    EXTRA_REDACT_PATTERN = buildExtraRedactPattern([secretSegment])
+    const savedSources = [...SOURCES]
+    SOURCES.length = 0
+    SOURCES.push({ src: tmpSrc, dest: 'leakcheck', absDest: path.join(tmpBackup, 'leakcheck'), label: 'leakcheck' })
+    const savedBackupDir = BACKUP_DIR
+    BACKUP_DIR = tmpBackup
+
+    // Set up backup as a real git repo so syncToBackup pre-checks pass.
+    fs.mkdirSync(tmpBackup, { recursive: true })
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    // 1. Audit: --audit JSON's `file:` field must not leak literal.
+    const auditReport = auditSources({ sample: 5 })
+    const auditJson = JSON.stringify(auditReport)
+    const auditClean = !auditJson.includes(secretSegment)
+
+    // 2. Sync: backup pathnames must not contain literal.
+    syncToBackup({})
+    const allBackupPaths = walkForPrune(tmpBackup, tmpBackup)
+    const pathClean = !allBackupPaths.some(p => p.includes(secretSegment))
+
+    // 3. Manifest: .skipped-files.json must not contain literal.
+    const manifestPath = path.join(tmpBackup, '.skipped-files.json')
+    const manifestRaw = fs.existsSync(manifestPath) ? fs.readFileSync(manifestPath, 'utf8') : ''
+    const manifestClean = !manifestRaw.includes(secretSegment)
+
+    // Restore.
+    EXTRA_REDACT_PATTERN = savedPattern
+    SOURCES.length = 0
+    for (const s of savedSources) SOURCES.push(s)
+    BACKUP_DIR = savedBackupDir
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+
+    const okR1 = auditClean && pathClean && manifestClean
+    if (okR1) pass++; else fail++
+    results.push({ name: 'codex_pr137_artifact_wide_redaction', pass: okR1, ...(okR1 ? {} : { why: `audit=${auditClean} path=${pathClean} manifest=${manifestClean}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_artifact_wide_redaction', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 regression: --show-config masks extra_redact_strings
+  // (would otherwise echo the literal list to anyone seeing the JSON).
+  try {
+    const tmpCfg = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-config-')), 'config.json')
+    fs.writeFileSync(tmpCfg, JSON.stringify({
+      repo_owner: 'x', repo_name: 'x',
+      sources: [{ src: '/tmp', dest: 'd', label: 'l' }],
+      extra_redact_strings: ['LeakyLiteral', 'AnotherSecret'],
+    }))
+    const result = execFileSync('node', [process.argv[1], '--show-config'], {
+      env: { ...process.env, EM_BACKUP_CONFIG: tmpCfg },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+    const noLeakyLiteral = !result.includes('LeakyLiteral')
+    const noAnotherSecret = !result.includes('AnotherSecret')
+    const masked = result.includes('2 strings configured')
+    fs.rmSync(path.dirname(tmpCfg), { recursive: true, force: true })
+
+    const okR2 = noLeakyLiteral && noAnotherSecret && masked
+    if (okR2) pass++; else fail++
+    results.push({ name: 'codex_pr137_show_config_masks_extras', pass: okR2, ...(okR2 ? {} : { why: `noLiteral=${noLeakyLiteral} noOther=${noAnotherSecret} masked=${masked} sample=${result.slice(0, 200)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_show_config_masks_extras', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-2 F1: --show-config + audit + manifest must redact
+  // backup_dir, sources[].src, sources[].absDest, sources[].label too.
+  try {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-r2f1-'))
+    const tmpSrc = path.join(tmpRoot, 'SecretCodename-src')
+    const tmpBackup = path.join(tmpRoot, 'SecretCodename-backup')
+    fs.mkdirSync(tmpSrc, { recursive: true })
+    fs.writeFileSync(path.join(tmpSrc, 'note.md'), 'plain text\n')
+    const tmpCfg = path.join(tmpRoot, 'config.json')
+    fs.writeFileSync(tmpCfg, JSON.stringify({
+      repo_owner: 'x', repo_name: 'x',
+      backup_dir: tmpBackup,
+      sources: [{ src: tmpSrc, dest: 'leakcheck', label: 'SecretCodename-label' }],
+      extra_redact_strings: ['SecretCodename'],
+    }))
+
+    // 1. --show-config must not contain the literal anywhere
+    const showCfgOut = execFileSync('node', [process.argv[1], '--show-config'], {
+      env: { ...process.env, EM_BACKUP_CONFIG: tmpCfg },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+    const showCfgClean = !showCfgOut.includes('SecretCodename')
+
+    // 2. --audit must not contain the literal in label/src
+    const auditOut = execFileSync('node', [process.argv[1], '--audit', '--sample', '0'], {
+      env: { ...process.env, EM_BACKUP_CONFIG: tmpCfg },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+    const auditClean = !auditOut.includes('SecretCodename')
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+
+    const okR2F1 = showCfgClean && auditClean
+    if (okR2F1) pass++; else fail++
+    results.push({ name: 'codex_pr137_r2_f1_label_and_config_fields', pass: okR2F1, ...(okR2F1 ? {} : { why: `showCfg=${showCfgClean} audit=${auditClean} showCfgSample=${showCfgOut.slice(0, 200)} auditSample=${auditOut.slice(0, 200)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r2_f1_label_and_config_fields', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-2 F2: path collision after redaction must fail-closed.
+  // Two source files under different segment names that collapse to the same
+  // [REDACTED] would silently overwrite. Refuse before any write.
+  try {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-r2f2-'))
+    const tmpSrc = path.join(tmpRoot, 'src')
+    const tmpBackup = path.join(tmpRoot, 'backup')
+    fs.mkdirSync(path.join(tmpSrc, 'Alpha'), { recursive: true })
+    fs.mkdirSync(path.join(tmpSrc, 'Beta'), { recursive: true })
+    fs.writeFileSync(path.join(tmpSrc, 'Alpha', 'same.md'), 'alpha content\n')
+    fs.writeFileSync(path.join(tmpSrc, 'Beta', 'same.md'), 'beta content\n')
+
+    fs.mkdirSync(tmpBackup, { recursive: true })
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    const savedPattern = EXTRA_REDACT_PATTERN
+    EXTRA_REDACT_PATTERN = buildExtraRedactPattern(['Alpha', 'Beta'])
+    const savedSources = [...SOURCES]
+    SOURCES.length = 0
+    SOURCES.push({ src: tmpSrc, dest: 'd', absDest: path.join(tmpBackup, 'd'), label: 'd' })
+    const savedBackupDir = BACKUP_DIR
+    BACKUP_DIR = tmpBackup
+
+    let threw = false
+    let errMsg = ''
+    try { syncToBackup({}) } catch (e) { threw = true; errMsg = e.message }
+
+    // Verify: no files actually written to dest (collision detected before second write)
+    // Note: the FIRST file may have been written before the SECOND triggered the throw.
+    // The contract is: refuse to silently overwrite, not "atomic all-or-nothing." So
+    // we check the throw + the message, not strict cleanliness of dest.
+    const errClean = !errMsg.includes('Alpha') && !errMsg.includes('Beta') // error message must redact
+    const errMentionsCollision = /collision/.test(errMsg)
+
+    EXTRA_REDACT_PATTERN = savedPattern
+    SOURCES.length = 0
+    for (const s of savedSources) SOURCES.push(s)
+    BACKUP_DIR = savedBackupDir
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+
+    const okR2F2 = threw && errClean && errMentionsCollision
+    if (okR2F2) pass++; else fail++
+    results.push({ name: 'codex_pr137_r2_f2_collision_fails_closed', pass: okR2F2, ...(okR2F2 ? {} : { why: `threw=${threw} errClean=${errClean} mentionsCollision=${errMentionsCollision} errMsg=${errMsg.slice(0, 200)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r2_f2_collision_fails_closed', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-3 meta-feedback (20260503-131746-...-1167):
+  // SINGLE end-to-end harness covering every surface the extra_redact_strings
+  // invariant must hold across. The invariant:
+  //
+  //   "After configuring extra_redact_strings, the raw literal must NOT appear
+  //    anywhere outside the user-private config file and source filesystem
+  //    operations."
+  //
+  // Surfaces this harness exercises in ONE run:
+  //   - Source path containing the literal (segment in src dir name)
+  //   - backup_dir path containing the literal
+  //   - sources[].label containing the literal
+  //   - File content containing the literal
+  //   - Binary file under literal-named subdir (skipped, manifested)
+  //   - Collision pair (Alpha/Beta same.md) triggering fail-closed
+  //   - Captured stdout from --show-config, --audit, --sync
+  //   - Captured stderr from --sync (collision error)
+  //   - Backup repo file paths
+  //   - Backup repo file contents
+  //   - .skipped-files.json
+  //   - Collision error message (must redact Alpha/Beta)
+  //
+  // Recursive grep against captured output + backup repo (excluding .git/).
+  // Expect ZERO matches for the literal everywhere outside config file +
+  // source dir; collision error must redact Alpha/Beta as [REDACTED].
+  try {
+    const literal = 'SecretCodename'
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-harness-'))
+    const tmpSrc = path.join(tmpRoot, `${literal}-src`)
+    const tmpBackup = path.join(tmpRoot, `${literal}-backup`)
+    fs.mkdirSync(path.join(tmpSrc, literal), { recursive: true })
+    fs.writeFileSync(path.join(tmpSrc, literal, 'note.md'), `body has ${literal} reference\n`)
+    fs.writeFileSync(path.join(tmpSrc, literal, 'blob.bin'), Buffer.from([0x00, 0x01, 0x02, 0x00, 0xFF, 0x00, 0x01, 0x00]))
+    // Collision pair — Alpha/Beta both transform to [REDACTED] under sync.
+    fs.mkdirSync(path.join(tmpSrc, 'Alpha'), { recursive: true })
+    fs.mkdirSync(path.join(tmpSrc, 'Beta'), { recursive: true })
+    fs.writeFileSync(path.join(tmpSrc, 'Alpha', 'collide.md'), 'a content\n')
+    fs.writeFileSync(path.join(tmpSrc, 'Beta', 'collide.md'), 'b content\n')
+
+    const tmpCfg = path.join(tmpRoot, 'config.json')
+    fs.writeFileSync(tmpCfg, JSON.stringify({
+      repo_owner: 'x', repo_name: 'x',
+      backup_dir: tmpBackup,
+      sources: [{ src: tmpSrc, dest: 'd', label: `${literal}-label` }],
+      extra_redact_strings: [literal, 'Alpha', 'Beta'],
+    }))
+
+    fs.mkdirSync(tmpBackup, { recursive: true })
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.email', 't@e.x'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:x/x.git'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    const env = { ...process.env, EM_BACKUP_CONFIG: tmpCfg }
+    let showCfgOut = '', showCfgErr = '', auditOut = '', auditErr = '', syncOut = '', syncErr = ''
+    try {
+      showCfgOut = execFileSync('node', [process.argv[1], '--show-config'], { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString()
+    } catch (e) { showCfgOut = e.stdout?.toString() || ''; showCfgErr = e.stderr?.toString() || '' }
+    try {
+      auditOut = execFileSync('node', [process.argv[1], '--audit', '--sample', '5'], { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString()
+    } catch (e) { auditOut = e.stdout?.toString() || ''; auditErr = e.stderr?.toString() || '' }
+    try {
+      syncOut = execFileSync('node', [process.argv[1], '--sync'], { env, stdio: ['ignore', 'pipe', 'pipe'] }).toString()
+    } catch (e) { syncOut = e.stdout?.toString() || ''; syncErr = e.stderr?.toString() || '' }
+
+    // Grep backup repo for literal (excluding .git/). Use RELATIVE paths
+    // within backup_dir — the backup_dir's OWN name is a user-supplied fs
+    // mount (cannot be redacted; user typed it into config) so absolute
+    // paths necessarily carry it. The invariant covers what the SCRIPT
+    // writes inside the backup repo, not the mount point name.
+    const backupFiles = walkForPrune(tmpBackup, tmpBackup) // walkForPrune skips .git
+    let backupContentMatches = 0
+    let backupPathMatches = 0
+    for (const bf of backupFiles) {
+      const relInBackup = path.relative(tmpBackup, bf)
+      if (relInBackup.includes(literal)) backupPathMatches++
+      try {
+        const content = fs.readFileSync(bf, 'utf8')
+        if (content.includes(literal)) backupContentMatches++
+      } catch { /* binary or unreadable */ }
+    }
+
+    // Grep captured outputs for literal + collision pair
+    const allOut = [showCfgOut, showCfgErr, auditOut, auditErr, syncOut, syncErr].join('\n')
+    const literalInOut = (allOut.match(new RegExp(literal, 'g')) || []).length
+    const alphaInOut = (allOut.match(/\bAlpha\b/g) || []).length
+    const betaInOut = (allOut.match(/\bBeta\b/g) || []).length
+
+    // Sync MUST have failed-closed on collision; error must mention "collision"
+    const syncFailed = syncErr.length > 0 || /collision/.test(syncOut)
+    const collisionMentioned = /collision/.test(syncOut + syncErr)
+
+    // Codex PR-#137 round-3 F2: post-collision backup worktree must be clean.
+    // Pre-walk collision detection means NO files written when collision
+    // exists. Verify by listing backup repo files (excluding .git).
+    //
+    // ⚠️ CODEX CAUGHT: this check MUST run BEFORE fs.rmSync(tmpRoot). Running
+    // it after the cleanup means walkForPrune sees a deleted directory,
+    // returns [] (via walk()'s readdir catch), and the assertion passes for
+    // the wrong reason. The walk's empty result would NOT prove pre-walk
+    // collision detection — it would prove only that the test cleaned up.
+    const postCollisionFiles = walkForPrune(tmpBackup, tmpBackup)
+    const postCollisionRelativeFiles = postCollisionFiles
+      .map(p => path.relative(tmpBackup, p))
+      .filter(rel => !rel.startsWith('.git'))
+    const backupCleanAfterCollision = postCollisionRelativeFiles.length === 0
+
+    // Defensive sanity: assert the backup dir actually still exists when we
+    // ran the walk, so a future refactor moving rmSync above this can't
+    // silently re-introduce the false-positive.
+    const backupDirStillPresentAtCheckTime = fs.existsSync(tmpBackup)
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+
+    // Assertions per Codex's invariant:
+    //   - literal must appear ZERO times in any output, manifest, or backup file
+    //   - Alpha/Beta must NOT appear in collision error (redacted as [REDACTED])
+    //   - Sync must fail-closed
+    //   - Backup worktree must be CLEAN after collision (round-3 F2)
+    const okHarness =
+      literalInOut === 0 &&
+      backupContentMatches === 0 &&
+      backupPathMatches === 0 &&
+      alphaInOut === 0 &&
+      betaInOut === 0 &&
+      syncFailed &&
+      collisionMentioned &&
+      backupCleanAfterCollision &&
+      backupDirStillPresentAtCheckTime
+    if (okHarness) pass++; else fail++
+    results.push({
+      name: 'codex_pr137_invariant_harness',
+      pass: okHarness,
+      ...(okHarness ? {} : {
+        why: `literalInOut=${literalInOut} backupContent=${backupContentMatches} backupPath=${backupPathMatches} alpha=${alphaInOut} beta=${betaInOut} syncFailed=${syncFailed} collisionMentioned=${collisionMentioned} backupCleanAfterCollision=${backupCleanAfterCollision} backupDirStillPresentAtCheckTime=${backupDirStillPresentAtCheckTime} (files: ${JSON.stringify(postCollisionRelativeFiles)})`,
+      }),
+    })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_invariant_harness', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-5: harness extension. Three new sub-scenarios
+  // covering CLI output paths Codex caught outside the round-3 harness:
+  //   - --sync with missing backup_dir → error stack must redact literal
+  //   - --sync with detached HEAD → error stack must redact literal
+  //   - --init against existing initialized repo → init.dir must redact
+  try {
+    const literal = 'OutputBoundary'
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-outboundary-'))
+
+    // --- Scenario A: missing backup_dir ---
+    const cfgA = path.join(tmpRoot, 'cfgA.json')
+    fs.writeFileSync(cfgA, JSON.stringify({
+      repo_owner: 'x', repo_name: 'x',
+      backup_dir: path.join(tmpRoot, `${literal}-missing-backup`),
+      sources: [{ src: tmpRoot, dest: 'd', label: 'l' }],
+      extra_redact_strings: [literal],
+    }))
+    let outA = ''
+    try {
+      outA = execFileSync('node', [process.argv[1], '--sync'], {
+        env: { ...process.env, EM_BACKUP_CONFIG: cfgA }, stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString()
+    } catch (e) { outA = (e.stdout?.toString() || '') + (e.stderr?.toString() || '') }
+    const aClean = !outA.includes(literal)
+
+    // --- Scenario B: detached HEAD ---
+    const tmpBackupB = path.join(tmpRoot, `${literal}-detached-backup`)
+    fs.mkdirSync(tmpBackupB, { recursive: true })
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.email', 't@e.x'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    fs.writeFileSync(path.join(tmpBackupB, 'README'), 'init\n')
+    execFileSync('git', ['add', '-A'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:x/x.git'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    // Detach HEAD by checking out the commit by SHA
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: tmpBackupB }).toString().trim()
+    execFileSync('git', ['checkout', '--detach', sha], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    const cfgB = path.join(tmpRoot, 'cfgB.json')
+    fs.writeFileSync(cfgB, JSON.stringify({
+      repo_owner: 'x', repo_name: 'x',
+      backup_dir: tmpBackupB,
+      sources: [{ src: tmpRoot, dest: 'd', label: 'l' }],
+      extra_redact_strings: [literal],
+    }))
+    let outB = ''
+    try {
+      outB = execFileSync('node', [process.argv[1], '--sync'], {
+        env: { ...process.env, EM_BACKUP_CONFIG: cfgB }, stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString()
+    } catch (e) { outB = (e.stdout?.toString() || '') + (e.stderr?.toString() || '') }
+    const bClean = !outB.includes(literal)
+
+    // --- Scenario C: --init against existing initialized repo ---
+    // tmpBackupB is already initialized with matching origin (x/x). Re-checkout
+    // main first so validateBackupRemoteAndBranch passes branch check.
+    execFileSync('git', ['checkout', 'main'], { cwd: tmpBackupB, stdio: ['ignore', 'pipe', 'pipe'] })
+    let outC = ''
+    try {
+      outC = execFileSync('node', [process.argv[1], '--init'], {
+        env: { ...process.env, EM_BACKUP_CONFIG: cfgB }, stdio: ['ignore', 'pipe', 'pipe'],
+      }).toString()
+    } catch (e) { outC = (e.stdout?.toString() || '') + (e.stderr?.toString() || '') }
+    const cClean = !outC.includes(literal)
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+
+    const okOutBoundary = aClean && bClean && cClean
+    if (okOutBoundary) pass++; else fail++
+    results.push({
+      name: 'codex_pr137_r5_output_boundary_redaction',
+      pass: okOutBoundary,
+      ...(okOutBoundary ? {} : {
+        why: `missingBackup=${aClean} detachedHead=${bClean} existingInit=${cClean} sampleA=${outA.slice(0, 200)} sampleB=${outB.slice(0, 200)} sampleC=${outC.slice(0, 200)}`,
+      }),
+    })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r5_output_boundary_redaction', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-3 F1.A1: --show-config in setup mode (no
+  // repo_owner/repo_name) must STILL redact extra_redact_strings literals
+  // from all string fields. Previously the EXTRA_REDACT_PATTERN build was
+  // gated on repo_owner being set.
+  try {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-setup-'))
+    const tmpCfg = path.join(tmpRoot, 'config.json')
+    const literal = 'SetupModeSecret'
+    fs.writeFileSync(tmpCfg, JSON.stringify({
+      // INTENTIONALLY no repo_owner/repo_name (setup mode)
+      backup_dir: `/tmp/${literal}-backup`,
+      sources: [{ src: `/tmp/${literal}-src`, dest: 'd', label: `${literal}-label` }],
+      extra_redact_strings: [literal],
+    }))
+    const out = execFileSync('node', [process.argv[1], '--show-config'], {
+      env: { ...process.env, EM_BACKUP_CONFIG: tmpCfg },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    const okSetup = !out.includes(literal)
+    if (okSetup) pass++; else fail++
+    results.push({ name: 'codex_pr137_r3_show_config_setup_mode', pass: okSetup, ...(okSetup ? {} : { why: `setup-mode --show-config leaked literal; output sample: ${out.slice(0, 300)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r3_show_config_setup_mode', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-3 F1.A2: when extra_redact_strings includes the
+  // literal value of repo_owner or repo_name, --show-config must redact them
+  // (not preserve as "operational identity").
+  try {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-ownername-'))
+    const tmpCfg = path.join(tmpRoot, 'config.json')
+    fs.writeFileSync(tmpCfg, JSON.stringify({
+      repo_owner: 'SecretOwner',
+      repo_name: 'SecretRepo',
+      backup_dir: '/tmp/x',
+      sources: [{ src: '/tmp/x', dest: 'd', label: 'l' }],
+      extra_redact_strings: ['SecretOwner', 'SecretRepo'],
+    }))
+    const out = execFileSync('node', [process.argv[1], '--show-config'], {
+      env: { ...process.env, EM_BACKUP_CONFIG: tmpCfg },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+    const okOwnerName = !out.includes('SecretOwner') && !out.includes('SecretRepo')
+    if (okOwnerName) pass++; else fail++
+    results.push({ name: 'codex_pr137_r3_owner_name_redacted_when_listed', pass: okOwnerName, ...(okOwnerName ? {} : { why: `owner/name leaked despite being in extra_redact_strings; output sample: ${out.slice(0, 300)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r3_owner_name_redacted_when_listed', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Codex PR-#137 round-3 F1.A3: validateBackupRemoteAndBranch error
+  // messages must redact owner/name when the literal is on the redact list.
+  try {
+    const tmpBackup = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-errmsg-'))
+    execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.email', 't@e.x'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['config', 'user.name', 't'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    fs.writeFileSync(path.join(tmpBackup, 'README'), 'init\n')
+    execFileSync('git', ['add', '-A'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:WrongSecretOwner/wrong-name.git'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+
+    const savedBackup = BACKUP_DIR, savedOwner = REPO_OWNER, savedName = REPO_NAME, savedPattern = EXTRA_REDACT_PATTERN
+    BACKUP_DIR = tmpBackup
+    REPO_OWNER = 'expected-owner'
+    REPO_NAME = 'expected-name'
+    EXTRA_REDACT_PATTERN = buildExtraRedactPattern(['WrongSecretOwner'])
+
+    let errMsg = ''
+    try { validateBackupRemoteAndBranch() } catch (e) { errMsg = e.message }
+
+    BACKUP_DIR = savedBackup; REPO_OWNER = savedOwner; REPO_NAME = savedName; EXTRA_REDACT_PATTERN = savedPattern
+    fs.rmSync(tmpBackup, { recursive: true, force: true })
+
+    const okErrRedacted = !errMsg.includes('WrongSecretOwner') && /\[REDACTED\]/.test(errMsg) && /points at/.test(errMsg)
+    if (okErrRedacted) pass++; else fail++
+    results.push({ name: 'codex_pr137_r3_error_msg_redacts_owner_name', pass: okErrRedacted, ...(okErrRedacted ? {} : { why: `errMsg leaked or didn't redact: ${errMsg.slice(0, 300)}` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'codex_pr137_r3_error_msg_redacts_owner_name', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
+  // Sanity: longer literal sorted-first so it matches before a shorter
+  // overlapping literal (e.g. user adds both "Foo Bar" and "Foo" — "Foo Bar"
+  // wins on overlap).
+  try {
+    const savedPattern = EXTRA_REDACT_PATTERN
+    EXTRA_REDACT_PATTERN = buildExtraRedactPattern(['Foo', 'Foo Bar'])
+    const { redacted } = applyRedactions('the Foo Bar value')
+    EXTRA_REDACT_PATTERN = savedPattern
+    const okOverlap = redacted === 'the [REDACTED] value'
+    if (okOverlap) pass++; else fail++
+    results.push({ name: 'extra_redact_longest_first', pass: okOverlap, ...(okOverlap ? {} : { why: `got "${redacted}"` }) })
+  } catch (e) {
+    fail++
+    results.push({ name: 'extra_redact_longest_first', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
   return { pass, fail, total: pass + fail, results }
 }
 
@@ -950,7 +1674,35 @@ function selfTest() {
 // CLI
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
-function out(o) { console.log(JSON.stringify(o, null, 2)) }
+
+// Codex PR-#137 round-5: every CLI JSON output (success OR error) must pass
+// through artifact redaction at the output boundary. Patching individual
+// return objects + error strings was whack-a-mole. This is the LAST line of
+// defense for any leak that escaped per-string redaction upstream.
+//
+// outSafe() walks the entire output object, applies redactArtifactString to
+// every string value (error message, stack traces, nested config paths, etc).
+// Stack traces are sanitized but kept (they're useful for debugging and the
+// pattern catches their literal values).
+function sanitizeOutputObject(o) {
+  function walk(node) {
+    if (typeof node === 'string') return redactArtifactString(node)
+    if (Array.isArray(node)) return node.map(walk)
+    if (node && typeof node === 'object') {
+      const out = {}
+      for (const [k, v] of Object.entries(node)) {
+        out[k] = walk(v)
+      }
+      return out
+    }
+    return node
+  }
+  return walk(o)
+}
+
+function out(o) {
+  console.log(JSON.stringify(sanitizeOutputObject(o), null, 2))
+}
 
 // Populate globals from config (modes that touch real sources/push need it).
 function applyConfig(cfg) {
@@ -961,6 +1713,7 @@ function applyConfig(cfg) {
   for (const s of cfg.sources) SOURCES.push(s)
   EXTRA_ALLOWLIST_EMAILS = new Set(cfg.extra_allowlist_emails || [])
   EXTRA_ALLOWLIST_DOMAINS = new Set(cfg.extra_allowlist_domains || [])
+  EXTRA_REDACT_PATTERN = buildExtraRedactPattern(cfg.extra_redact_strings || [])
 }
 
 // Codex round-5: run-sync + run-init wrappers. Validation must fire BEFORE
@@ -1001,7 +1754,15 @@ try {
     process.exit(r.fail === 0 ? 0 : 1)
   } else if (argv.includes('--show-config')) {
     const cfg = resolveConfig(false)
-    out({ status: 'ok', config: cfg })
+    // Codex PR-#137 round-3 F1.A1: build EXTRA_REDACT_PATTERN UNCONDITIONALLY
+    // from cfg.extra_redact_strings, regardless of whether repo_owner is set.
+    // --show-config is a setup/debug command users run BEFORE the config is
+    // complete; the previous gate (only applyConfig if repo_owner) caused
+    // setup-mode runs to leak all string fields except the extra list.
+    if (cfg && Array.isArray(cfg.extra_redact_strings)) {
+      EXTRA_REDACT_PATTERN = buildExtraRedactPattern(cfg.extra_redact_strings)
+    }
+    out({ status: 'ok', config: redactConfigForDisplay(cfg) })
   } else if (argv.includes('--audit')) {
     applyConfig(resolveConfig(true))
     const sampleFlag = argv.indexOf('--sample')
@@ -1019,6 +1780,20 @@ try {
     process.exit(2)
   }
 } catch (e) {
+  // Codex PR-#137 round-5: errors might fire BEFORE applyConfig built
+  // EXTRA_REDACT_PATTERN (e.g. config parse failure, missing backup dir
+  // detected at runSync entry, validateBackupRemoteAndBranch failures).
+  // Defensively try to load + build the pattern from config so the error
+  // output still gets redacted. If config can't be loaded, redaction
+  // falls back to home_path-only (still scrubs the user's $HOME prefix).
+  if (!EXTRA_REDACT_PATTERN) {
+    try {
+      const cfg = loadConfig()
+      if (cfg && Array.isArray(cfg.extra_redact_strings)) {
+        EXTRA_REDACT_PATTERN = buildExtraRedactPattern(cfg.extra_redact_strings)
+      }
+    } catch { /* config unparseable; can't redact extra_redact_strings */ }
+  }
   out({ status: 'error', message: String(e.message || e), stack: e.stack })
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

Two bugs surfaced by the **first real-world `--init`** against the canonical script merged in [#134](https://github.com/lantisprime/episodic-memory/pull/134) — neither caught by 5 rounds of Codex review or 39 self-tests. Live-reproduction is the lesson.

Closes [#135](https://github.com/lantisprime/episodic-memory/issues/135).

### Bug 1 — `validateBackupRemoteAndBranch()` fails on empty repos

`git rev-parse --abbrev-ref HEAD` errors when HEAD is a symbolic ref that doesn't yet point at a commit (the state every freshly-init'd repo is in between `git init -b main` and the first commit). First `--init` against a brand-new repo would refuse the push with `"no HEAD; cannot determine branch"` even though origin was correct.

**Fix:** use `git symbolic-ref --short HEAD` which reads the symbolic-ref text directly and works on empty repos. Defense-in-depth invariant preserved.

### Bug 2 — redaction misses bare username in narrative text

`home_path` regex matches `/Users/<name>` only with a path prefix; bare username strings inside markdown code-fences or quoted narrative slip through. First `--init` shipped 1 file containing the literal `charltond.ho` to the (private) backup repo because the username appeared inside a backtick code-span describing the redaction itself.

**Fix:** new config field `extra_redact_strings` — user-supplied list of literal strings to additionally redact. Applied BEFORE built-in patterns so user strings can't be partially eaten by generic regex. Sort longest-first so overlapping literals match correctly. Replacement marker is generic `[REDACTED]` so the marker itself doesn't disclose what was there.

## New regression tests

| Test | Coverage |
|---|---|
| `live_repro_empty_repo_head_resolves` | Init'd-but-empty repo with matching origin returns `branch="main"` |
| `live_repro_extra_redact_strings` | 4 cases (narrative match, code-fence match, no-match passthrough) |
| `extra_redact_longest_first` | `["Foo", "Foo Bar"]` correctly redacts `"Foo Bar"` intact |

**42/42 self-tests pass.**

## Pre-Codex audit (per the validation-timing checklist + verify-by-artifact discipline this session generated)

- ✅ Self-test 42/42 (artifact: JSON output)
- ✅ Negative scenario A: empty-repo HEAD resolves correctly via symbolic-ref (artifact: inline test + manual reproduction)
- ✅ Negative scenario B: `extra_redact_strings` catches narrative-context literal in code-fence (artifact: temp config + temp source + audit run, `extra_redact: 2` reported as expected)
- ✅ Diff stat: 3 files / +143 / -5 (artifact: `git diff --stat origin/main`)
- ✅ GitHub push protection precheck PASS (artifact: `grep` for contiguous secret-shape patterns returned 0 matches)

## Threat model invariants (re-affirmed)

All 9 invariants from PR #134 still hold; this PR strengthens #1 and #6:

1. **Source files on disk never modified** ✓
2. Binary files skipped, never byte-copied raw ✓
3. Audit output cannot leak raw secrets ✓
4. Failed push won't orphan commits forever ✓
5. `sources[].dest` cannot escape `BACKUP_DIR` ✓
6. **Backup only pushes to configured `repo_owner/repo_name` on `main`** ✓ (and now also works on empty repos)
7. Wrong-target backup_dir never receives sync writes ✓
8. Symlinks rejected with logged manifest entry ✓
9. Pruning scoped to backup root only ✓
10. **(NEW) User-supplied literal strings additionally redacted, regardless of context** ✓

## Live-reproduction lesson

This PR is empirical evidence #1 for lesson `20260503-123638-...-5d7b` ("Verify by artifact, not narrative"). 5 rounds of Codex review caught design-time bugs by reading code and reasoning. **First real-world run caught 2 more bugs that nothing in the review surface caught**, because synthetic test fixtures don't exercise:
- Empty-repo state (between `init` and first commit)
- Narrative usage of usernames (vs. path-context usage)

Both fixes were applied to the user's installed copy in-place to unstick the backup; this PR moves them to the canonical script with proper test coverage. Going forward, any feature that takes user-supplied configuration AND writes disk OR calls network must run negative-scenario tests pre-Codex per the validation-timing checklist (`feedback_validation_timing_checklist.md`).

## Test plan

- [x] `node scripts/em-backup.mjs --self-test` → 42/42
- [x] Empty-repo negative scenario reproduced and asserted
- [x] Narrative-text redaction scenario reproduced and asserted
- [x] GitHub push protection precheck PASS
- [ ] Codex round-1 review of this PR (to be requested via cross-tool flow)
- [ ] Manual verification on a fresh `--init` against another test repo (after merge)

## Out of scope

- Real-corpus regression test (run `--audit` against actual user's `~/.episodic-memory/` and assert known-clean) — tracked in [#133](https://github.com/lantisprime/episodic-memory/issues/133)
- launchd rollout — tracked in [#136](https://github.com/lantisprime/episodic-memory/issues/136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)