### PR TITLE
fix(em-recall): armCheckpointMarker writes to repo-root, not cwd (#106)

### DIFF
--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -19,10 +19,11 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
-import { resolveLocalDir } from './lib/local-dir.mjs'
+import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
+const REPO_ROOT = resolveRepoRoot()
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -261,9 +262,9 @@ function shouldArmBp001Checkpoint(activeEntries, now) {
 // Idempotent marker arming. Best-effort — failures are swallowed so a
 // non-writable .claude dir doesn't take down the whole recall.
 // ---------------------------------------------------------------------------
-function armCheckpointMarker(cwd) {
+function armCheckpointMarker(repoRoot) {
   try {
-    const claudeDir = path.join(cwd, '.claude')
+    const claudeDir = path.join(repoRoot, '.claude')
     fs.mkdirSync(claudeDir, { recursive: true })
     const markerPath = path.join(claudeDir, '.checkpoint-required')
     if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
@@ -380,7 +381,7 @@ const preflight_warnings = []
 // blocks write tools, so the false-positive surface is bounded.
 // ---------------------------------------------------------------------------
 if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
-  armCheckpointMarker(process.cwd())
+  armCheckpointMarker(REPO_ROOT)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -15,6 +15,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveRepoRoot } from './lib/local-dir.mjs'
 
 // ---------------------------------------------------------------------------
 // Load known patterns from _index.json
@@ -38,7 +39,12 @@ function loadPatternsIndex() {
 // Cleans orphaned states too (e.g. .post-checkpoint-required without
 // .checkpoint-required, per RFC-002 line 207). Failure is silent — markers
 // may not exist or .claude/ may be missing in some workflows.
-const claudeDir = path.join(process.cwd(), '.claude')
+//
+// resolveRepoRoot ensures we clean the SAME .claude/ that armCheckpointMarker
+// (em-recall) and the hooks (hooks/lib/repo-root.sh) target — a worktree-cwd
+// would otherwise sweep an empty worktree-local .claude/ while leaving the
+// real markers stranded at the main repo root. Closes #106.
+const claudeDir = path.join(resolveRepoRoot(), '.claude')
 for (const marker of [
   '.checkpoint-required',
   '.pre-checkpoint-done',

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -1,17 +1,29 @@
 /**
- * local-dir.mjs — resolve the canonical .episodic-memory/ directory for --scope local.
+ * local-dir.mjs — resolve canonical project paths for the episodic-memory store
+ * AND for `.claude/` marker files.
  *
- * Walks to the main repository root via `git rev-parse --git-common-dir` so that
- * invocations from a linked worktree write to the SAME store as the main checkout.
- * Closes #85.
+ * Two exports:
+ *   - resolveRepoRoot(cwd)  — the primitive. Returns the main repo's working tree.
+ *   - resolveLocalDir(cwd)  — `<repo-root>/.episodic-memory/` (PR #105 / #85).
+ *
+ * resolveLocalDir is `path.join(resolveRepoRoot(cwd), '.episodic-memory')` —
+ * a one-line postfix on the primitive. Single source of truth for the
+ * git-resolution heuristic; do not duplicate it.
+ *
+ * Walks to the main repository root via `git rev-parse --git-common-dir` so
+ * invocations from a linked worktree converge on the SAME root as the main
+ * checkout. resolveRepoRoot is also used by armCheckpointMarker (em-recall)
+ * and the SessionEnd cleanup loop (em-session-end-prompt) so bp-001 marker
+ * writes land where the hook readers (hooks/lib/repo-root.sh) look for them.
+ * Closes #106 (sibling to #85).
  *
  * Resolution captured at module-load time by callers (e.g. `const LOCAL_DIR =
  * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
  *
  * Edge-case handling:
  *   - Linked worktree of main:  common-dir basename is `.git` -> parent. (This
- *     is the case #85 is about: the linked worktree's common-dir is the SHARED
- *     main `.git`, so we resolve to the main repo root.)
+ *     is the case #85/#106 are about: the linked worktree's common-dir is the
+ *     SHARED main `.git`, so we resolve to the main repo root.)
  *   - Submodule:                common-dir is `<super>/.git/modules/<name>`,
  *     basename ≠ `.git` -> use `git rev-parse --show-toplevel`, which returns
  *     the SUBMODULE's working tree (its own local memory, not the superproject's).
@@ -28,7 +40,7 @@
 import path from 'path'
 import { execSync } from 'child_process'
 
-export function resolveLocalDir(cwd = process.cwd()) {
+export function resolveRepoRoot(cwd = process.cwd()) {
   try {
     const commonDir = execSync('git rev-parse --git-common-dir', {
       cwd,
@@ -37,7 +49,7 @@ export function resolveLocalDir(cwd = process.cwd()) {
     const absCommon = path.resolve(cwd, commonDir)
     // Canonical case (linked worktree of main, or main itself): <repo>/.git.
     if (path.basename(absCommon) === '.git') {
-      return path.join(path.dirname(absCommon), '.episodic-memory')
+      return path.dirname(absCommon)
     }
     // Submodule, --separate-git-dir, GIT_DIR=..., etc. The common-dir parent is
     // NOT the working tree (e.g. for a submodule it's the superproject's
@@ -47,9 +59,13 @@ export function resolveLocalDir(cwd = process.cwd()) {
       cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
     }).toString().trim()
-    if (top) return path.join(top, '.episodic-memory')
+    if (top) return top
   } catch {
     // not a git repo, bare repo, or git unavailable
   }
-  return path.join(cwd, '.episodic-memory')
+  return cwd
+}
+
+export function resolveLocalDir(cwd = process.cwd()) {
+  return path.join(resolveRepoRoot(cwd), '.episodic-memory')
 }

--- a/tests/test-em-repo-root-worktree.mjs
+++ b/tests/test-em-repo-root-worktree.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * test-em-repo-root-worktree.mjs — Tests for #106 armCheckpointMarker
+ * worktree-orphan + scripts/lib/local-dir.mjs:resolveRepoRoot extraction.
+ *
+ * Two layers of verification:
+ *   1. Resolver unit tests — resolveRepoRoot returns the main repo working
+ *      tree from main / linked worktree / nested cwd / non-git / submodule.
+ *   2. Integration regression tests — em-recall.mjs invoked from a linked
+ *      worktree writes .checkpoint-required at <main>/.claude/, not
+ *      <worktree>/.claude/. em-session-end-prompt.mjs invoked from a worktree
+ *      cleans markers at <main>/.claude/, not <worktree>/.claude/.
+ *
+ * Defensive ordering (per feedback_test_resource_existence_check.md):
+ * each integration assertion checks BOTH "marker exists at main" AND
+ * "marker does not exist at worktree" — the negative assertion is the
+ * load-bearing one. Otherwise a misconfigured test that races cleanup
+ * against the assertion would silently pass.
+ *
+ * Usage: node tests/test-em-repo-root-worktree.mjs
+ * Zero dependencies.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+import { resolveRepoRoot } from '../scripts/lib/local-dir.mjs'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+// ---------------------------------------------------------------------------
+// Setup: temp main repo + linked worktree + nested dir + non-git dir
+// ---------------------------------------------------------------------------
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-reporoot-'))
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+
+const mainRepo = path.join(tmpRoot, 'main')
+const worktreeRoot = path.join(tmpRoot, 'wt')
+const nestedDir = path.join(worktreeRoot, 'a', 'b', 'c')
+const nonGitDir = path.join(tmpRoot, 'plain')
+
+fs.mkdirSync(mainRepo, { recursive: true })
+fs.mkdirSync(nonGitDir, { recursive: true })
+
+git(mainRepo, 'init -q -b main')
+git(mainRepo, 'config user.email test@example.com')
+git(mainRepo, 'config user.name test')
+fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
+git(mainRepo, 'add README.md')
+git(mainRepo, 'commit -q -m init')
+git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
+fs.mkdirSync(nestedDir, { recursive: true })
+
+const mainRepoReal = fs.realpathSync(mainRepo)
+const worktreeRootReal = fs.realpathSync(worktreeRoot)
+const nonGitDirReal = fs.realpathSync(nonGitDir)
+
+// Seed a recent bp-001 violation in mainRepo's local store so em-recall
+// will arm the checkpoint marker. Use em-store --scope local — post-PR #105
+// resolveLocalDir routes to mainRepo regardless of cwd.
+execSync(
+  `node ${STORE} --scope local --project test ` +
+  `--category violation ` +
+  `--tags "violated:bp-001-implementation-workflow,test-fixture" ` +
+  `--summary "test fixture violation" ` +
+  `--body "Seeded by test-em-repo-root-worktree.mjs to trigger marker arming."`,
+  { cwd: mainRepo, stdio: ['ignore', 'pipe', 'pipe'] },
+)
+
+// ---------------------------------------------------------------------------
+// Layer 1 — resolveRepoRoot unit tests
+// ---------------------------------------------------------------------------
+
+test('resolveRepoRoot: main checkout returns main repo working tree', () => {
+  const got = fs.realpathSync(resolveRepoRoot(mainRepo))
+  assert.strictEqual(got, mainRepoReal)
+})
+
+test('resolveRepoRoot: linked worktree returns MAIN repo working tree (not worktree)', () => {
+  const got = fs.realpathSync(resolveRepoRoot(worktreeRoot))
+  assert.strictEqual(got, mainRepoReal, `expected ${mainRepoReal}, got ${got}`)
+  assert.notStrictEqual(got, worktreeRootReal, `resolver returned worktree path: ${got}`)
+})
+
+test('resolveRepoRoot: nested cwd inside worktree resolves to MAIN repo', () => {
+  const got = fs.realpathSync(resolveRepoRoot(nestedDir))
+  assert.strictEqual(got, mainRepoReal)
+})
+
+test('resolveRepoRoot: non-git cwd falls back to cwd', () => {
+  const got = fs.realpathSync(resolveRepoRoot(nonGitDir))
+  assert.strictEqual(got, nonGitDirReal)
+})
+
+// Regression for the v1 bug Codex caught on PR #105: an over-eager `/.git/`
+// segment-strip would resolve a submodule's local memory to the SUPERPROJECT
+// root, cross-contaminating two stores. Correct behavior: --show-toplevel
+// returns the submodule's own working tree.
+test('resolveRepoRoot: submodule resolves to SUBMODULE working tree, not superproject', () => {
+  const superRepo = path.join(tmpRoot, 'super')
+  const subSrc = path.join(tmpRoot, 'subsrc')
+  fs.mkdirSync(superRepo, { recursive: true })
+  fs.mkdirSync(subSrc, { recursive: true })
+
+  git(subSrc, 'init -q -b main')
+  git(subSrc, 'config user.email test@example.com')
+  git(subSrc, 'config user.name test')
+  fs.writeFileSync(path.join(subSrc, 'README.md'), '# sub\n')
+  git(subSrc, 'add README.md')
+  git(subSrc, 'commit -q -m sub-init')
+
+  git(superRepo, 'init -q -b main')
+  git(superRepo, 'config user.email test@example.com')
+  git(superRepo, 'config user.name test')
+  fs.writeFileSync(path.join(superRepo, 'README.md'), '# super\n')
+  git(superRepo, 'add README.md')
+  git(superRepo, 'commit -q -m super-init')
+  git(superRepo, `-c protocol.file.allow=always submodule add -q file://${fs.realpathSync(subSrc)} sub`)
+
+  const subCheckout = path.join(superRepo, 'sub')
+  const subCheckoutReal = fs.realpathSync(subCheckout)
+  const superRepoReal = fs.realpathSync(superRepo)
+
+  const got = fs.realpathSync(resolveRepoRoot(subCheckout))
+  assert.strictEqual(got, subCheckoutReal, `expected submodule root ${subCheckoutReal}, got ${got}`)
+  assert.notStrictEqual(got, superRepoReal, `submodule resolved to superproject: ${got}`)
+})
+
+// ---------------------------------------------------------------------------
+// Layer 2 — Integration regression tests for #106
+// ---------------------------------------------------------------------------
+
+const mainClaudeDir = path.join(mainRepoReal, '.claude')
+const worktreeClaudeDir = path.join(worktreeRootReal, '.claude')
+const mainMarker = path.join(mainClaudeDir, '.checkpoint-required')
+const worktreeMarker = path.join(worktreeClaudeDir, '.checkpoint-required')
+
+function clearMarkers() {
+  for (const dir of [mainClaudeDir, worktreeClaudeDir]) {
+    for (const m of [
+      '.checkpoint-required',
+      '.pre-checkpoint-done',
+      '.post-checkpoint-required',
+      '.post-checkpoint-done',
+    ]) {
+      try { fs.unlinkSync(path.join(dir, m)) } catch {}
+    }
+  }
+}
+
+test('em-recall from main writes .checkpoint-required at <main>/.claude/', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: mainRepo, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  // Defensive: assert main marker AND verify worktree did not get one too.
+  assert.ok(fs.existsSync(mainMarker), `expected ${mainMarker} after em-recall from main`)
+  assert.ok(!fs.existsSync(worktreeMarker), `unexpected ${worktreeMarker} after em-recall from main`)
+})
+
+test('em-recall from linked worktree writes .checkpoint-required at <main>/.claude/, NOT worktree', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  // Positive: marker landed at main repo root.
+  assert.ok(
+    fs.existsSync(mainMarker),
+    `expected ${mainMarker} after em-recall from worktree (regressed #106)`,
+  )
+  // Negative: marker did NOT land at worktree (the bug-shape assertion).
+  // Defensive ordering: this assertion is the load-bearing one for #106.
+  assert.ok(
+    !fs.existsSync(worktreeMarker),
+    `marker leaked into worktree: ${worktreeMarker} (this is the #106 bug)`,
+  )
+  // Defensive existence check: verify the worktree dir itself wasn't deleted
+  // out from under us before the assertion, which would make the negative
+  // check vacuously pass.
+  assert.ok(
+    fs.existsSync(worktreeRootReal),
+    `worktree root went missing during test — negative assertion was vacuous`,
+  )
+})
+
+test('em-recall from nested cwd inside worktree still writes marker at <main>/.claude/', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: nestedDir, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  assert.ok(fs.existsSync(mainMarker))
+  assert.ok(!fs.existsSync(worktreeMarker), `marker leaked into worktree from nested cwd`)
+})
+
+test('em-session-end-prompt from worktree cleans markers at <main>/.claude/, not worktree', () => {
+  clearMarkers()
+  // Seed both stores with the full marker set so we can prove which one
+  // gets swept.
+  fs.mkdirSync(mainClaudeDir, { recursive: true })
+  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
+  for (const m of [
+    '.checkpoint-required',
+    '.pre-checkpoint-done',
+    '.post-checkpoint-required',
+    '.post-checkpoint-done',
+  ]) {
+    fs.writeFileSync(path.join(mainClaudeDir, m), 'seed')
+    fs.writeFileSync(path.join(worktreeClaudeDir, m), 'worktree-seed')
+  }
+
+  // Confirm setup is real (defensive — guards against a refactor that
+  // accidentally clears the seed before the cleanup runs).
+  assert.ok(fs.existsSync(mainMarker), 'pre-condition: main marker seeded')
+  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: worktree marker seeded')
+
+  execSync(`node ${SESSION_END}`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  // Positive: main markers swept.
+  assert.ok(!fs.existsSync(mainMarker), `expected ${mainMarker} cleaned after SessionEnd from worktree`)
+  // Negative: worktree markers untouched (proves the sweep targeted main).
+  // After #106, em-session-end-prompt should NOT touch worktree-local markers
+  // unless the worktree is a non-git cwd (which it isn't here).
+  assert.ok(
+    fs.existsSync(worktreeMarker),
+    `worktree marker swept unexpectedly — em-session-end-prompt resolved to worktree, not main (regressed #106)`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Layer 3 — Negative-scenario tests (verify-by-artifact Skill 2)
+//
+// Set up failure / edge states explicitly and observe behavior, rather than
+// just testing the happy path with negative assertions.
+// ---------------------------------------------------------------------------
+
+test('NEG: stale worktree-local marker (pre-fix legacy state) is preserved, not migrated', () => {
+  clearMarkers()
+  // Simulate a user who ran em-recall from this worktree BEFORE PR #106 landed.
+  // The pre-fix bug left a marker in <worktree>/.claude/. After the fix:
+  //   - new arming writes to <main>/.claude/ (correct)
+  //   - the legacy worktree-local marker is OUT OF BAND — we do not auto-migrate
+  //   - em-session-end-prompt now sweeps main-only, so the worktree marker
+  //     persists forever (acceptable: hooks read from main, so it's inert)
+  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
+  fs.writeFileSync(worktreeMarker, 'legacy-from-pre-106')
+  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: legacy worktree marker seeded')
+
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  // New behavior: marker now lives at main.
+  assert.ok(fs.existsSync(mainMarker), 'new arming should land at main')
+  // Legacy marker preserved verbatim — we don't read or modify worktree state.
+  assert.ok(fs.existsSync(worktreeMarker), 'legacy worktree marker should be untouched')
+  assert.strictEqual(
+    fs.readFileSync(worktreeMarker, 'utf8'),
+    'legacy-from-pre-106',
+    'legacy marker contents should not be rewritten',
+  )
+})
+
+test('NEG: em-recall from non-git cwd degrades gracefully (no crash, no cross-store leak)', () => {
+  clearMarkers()
+  // From a non-git cwd:
+  //   - resolveRepoRoot returns cwd (no main repo to converge on)
+  //   - LOCAL_DIR = <cwd>/.episodic-memory (does not exist; loadIndex returns [])
+  //   - global store has no bp-001 violation either (test seed lives in mainRepo)
+  //   - shouldArmBp001Checkpoint returns false → armCheckpointMarker never runs
+  //   - em-recall exits 0 with empty episodes
+  // Assertion shape: no crash, no marker anywhere, no .claude/ dir spuriously created.
+  let exitOk = true
+  try {
+    execSync(`node ${RECALL} --scope local --no-track`, {
+      cwd: nonGitDir, stdio: ['ignore', 'ignore', 'ignore'],
+    })
+  } catch {
+    exitOk = false
+  }
+
+  assert.ok(exitOk, 'em-recall should exit 0 from non-git cwd')
+  // No marker created at cwd, main, or worktree.
+  assert.ok(
+    !fs.existsSync(path.join(nonGitDirReal, '.claude')),
+    `.claude/ created at non-git cwd — activator armed spuriously`,
+  )
+  assert.ok(!fs.existsSync(mainMarker), 'non-git cwd should not write to main repo')
+  assert.ok(!fs.existsSync(worktreeMarker), 'non-git cwd should not write to worktree')
+})
+
+test('NEG: em-recall with no recent bp-001 violation does NOT arm marker (activator no-op)', () => {
+  clearMarkers()
+  // Use a fresh ephemeral repo with NO seeded violation. shouldArmBp001Checkpoint
+  // returns false → armCheckpointMarker is never called → no marker written.
+  // Verifies the activator does not spuriously create marker files.
+  const cleanRepo = path.join(tmpRoot, 'clean')
+  fs.mkdirSync(cleanRepo, { recursive: true })
+  git(cleanRepo, 'init -q -b main')
+  git(cleanRepo, 'config user.email test@example.com')
+  git(cleanRepo, 'config user.name test')
+  fs.writeFileSync(path.join(cleanRepo, 'README.md'), '# clean\n')
+  git(cleanRepo, 'add README.md')
+  git(cleanRepo, 'commit -q -m init')
+
+  const cleanRepoReal = fs.realpathSync(cleanRepo)
+  const cleanMarker = path.join(cleanRepoReal, '.claude', '.checkpoint-required')
+
+  // No --project test → don't pick up the seeded violation in mainRepo.
+  execSync(`node ${RECALL} --scope local --no-track`, {
+    cwd: cleanRepo, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  assert.ok(
+    !fs.existsSync(cleanMarker),
+    `unexpected marker at ${cleanMarker} — activator armed without violation evidence`,
+  )
+  // Defensive: prove the dir would have existed if marker WERE written
+  // (the parent .claude/ dir would have been mkdir'd by armCheckpointMarker).
+  // We assert .claude/ doesn't exist either — proves armCheckpointMarker
+  // never ran, not just that the marker file was missing.
+  assert.ok(
+    !fs.existsSync(path.join(cleanRepoReal, '.claude')),
+    `.claude/ dir created without arming — armCheckpointMarker ran spuriously`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.error('\nFailures:')
+  for (const f of failures) console.error(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Invariant

After invoking \`armCheckpointMarker\` from any cwd within a repo (main checkout, linked worktree of main, nested cwd inside a worktree, submodule), \`.checkpoint-required\` lands at \`<main-repo-root>/.claude/\` — never at \`<cwd>/.claude/\`. Same invariant applies to \`em-session-end-prompt.mjs\`'s SessionEnd marker cleanup loop. Closes #106.

## Why this matters

Pre-fix, the writers and readers of bp-001 enforcement markers diverged. Hook readers ([hooks/lib/repo-root.sh](https://github.com/lantisprime/episodic-memory/blob/main/hooks/lib/repo-root.sh)) already resolve to main repo root via \`git rev-parse --git-common-dir\`. JS-side writers used bare \`process.cwd()\`. From a linked worktree, \`armCheckpointMarker\` armed at the worktree's local \`.claude/\`, where no hook would ever read it. Phase 3b enforcement state was effectively per-worktree and inconsistent across worktrees of the same repo.

Sibling bug to #85 (closed by [PR #105](https://github.com/lantisprime/episodic-memory/pull/105)). Same shape, different artifact — #85 was about \`.episodic-memory/\` episode store; #106 is about \`.claude/\` marker files.

## Surface inventory (writers / cleanup sites)

| File:line | Pre-fix | Post-fix |
|---|---|---|
| [scripts/em-recall.mjs:265](https://github.com/lantisprime/episodic-memory/blob/main/scripts/em-recall.mjs#L265) | \`armCheckpointMarker(cwd)\` writes \`<cwd>/.claude/.checkpoint-required\` | \`armCheckpointMarker(repoRoot)\` writes \`<repo-root>/.claude/.checkpoint-required\` |
| [scripts/em-recall.mjs:384](https://github.com/lantisprime/episodic-memory/blob/main/scripts/em-recall.mjs#L384) | \`armCheckpointMarker(process.cwd())\` | \`armCheckpointMarker(REPO_ROOT)\` (module-load resolved) |
| [scripts/em-session-end-prompt.mjs:47](https://github.com/lantisprime/episodic-memory/blob/main/scripts/em-session-end-prompt.mjs#L47) | \`path.join(process.cwd(), '.claude')\` | \`path.join(resolveRepoRoot(), '.claude')\` |

Out of scope (intentional, documented):
- [scripts/em-pattern-health.mjs:260](https://github.com/lantisprime/episodic-memory/blob/main/scripts/em-pattern-health.mjs#L260) — \`<cwd>/.claude/hooks\` for project-local hook discovery, distinct concept from marker files. Confirmed via #139 acceptance criteria.

## Architectural chokepoint refactor

\`scripts/lib/local-dir.mjs\` now exposes two primitives:

\`\`\`js
export function resolveRepoRoot(cwd = process.cwd()) { ... }
export function resolveLocalDir(cwd = process.cwd()) {
  return path.join(resolveRepoRoot(cwd), '.episodic-memory')
}
\`\`\`

Single source of truth for the git-resolution heuristic. Identical behavior to prior \`resolveLocalDir\` (verified by 5/5 regression tests in [tests/test-em-local-dir-worktree.mjs](https://github.com/lantisprime/episodic-memory/blob/main/tests/test-em-local-dir-worktree.mjs)).

## Grep artifact (post-fix verification)

\`\`\`
$ grep -rn \"process\\.cwd().*\\.claude\\|path\\.join.*cwd.*\\.claude\" scripts/ --include=\"*.mjs\"
scripts/em-pattern-health.mjs:260:  { dir: path.join(CWD, '.claude', 'hooks'), include: f => /\\.sh\\$/.test(f) },
\`\`\`

Zero unintended matches. The remaining em-pattern-health.mjs entry is the documented exception per [comment at em-pattern-health.mjs:250](https://github.com/lantisprime/episodic-memory/blob/main/scripts/em-pattern-health.mjs#L250) (\"project-local Claude Code hooks\").

\`\`\`
$ grep -rn \"armCheckpointMarker\" scripts/ --include=\"*.mjs\"
scripts/em-recall.mjs:265:function armCheckpointMarker(repoRoot) {
scripts/em-recall.mjs:384:  armCheckpointMarker(REPO_ROOT)
\`\`\`

Definition + single call site. Signature change is purely internal.

## Test results

\`\`\`
$ node tests/test-em-repo-root-worktree.mjs
12 passed, 0 failed

$ node tests/test-em-local-dir-worktree.mjs
5 passed, 0 failed   (no regression to PR #105)

$ bash tests/test-em-recall-sessionstart.sh
Passed: 9, Failed: 0

$ bash tests/test-checkpoint-gate.sh
Passed: 100, Failed: 0

$ bash tests/test-plan-gate.sh
Results: 34 passed, 0 failed

$ node tests/test-rfc002-phase3.mjs
Results: 28 passed, 0 failed   (incl. T7j SessionStart marker arming E2E)
\`\`\`

The new test file ([tests/test-em-repo-root-worktree.mjs](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/tests/test-em-repo-root-worktree.mjs)) has three layers:

- **Layer 1 (5 tests):** \`resolveRepoRoot\` unit — main / linked worktree / nested cwd / non-git / submodule
- **Layer 2 (4 tests):** integration regression for #106 — em-recall + em-session-end-prompt invoked from worktree paths, with **defensive negative assertions** per \`feedback_test_resource_existence_check.md\` (asserts worktree marker does NOT exist; existence-check on the worktree dir itself to guard against vacuous assertions)
- **Layer 3 (3 tests):** explicit failure scenarios per \`feedback_verify_by_artifact.md\` Skill 2 — stale pre-fix worktree marker is preserved (no auto-migration); non-git cwd degrades gracefully (no crash, no cross-store leak); no-violation case (activator correctly no-ops, no spurious arming)

Layer 3 caught my own wrong assumption during implementation (originally tested the non-git fallback expecting marker arming to fire; activator correctly no-ops because no violation evidence reaches the cwd-scoped store) — exactly the value of negative-scenario testing per the lesson.

## Bp-001 named refs

- \`plan_ref\`: documented across this conversation; final plan locked before \`start\`
- \`approval_ref\`: user said \`start\` after second-opinion review + global-lessons cross-check
- \`prior_review_ref\`: Plan-agent verdict ACCEPT WITH MOD (in-conversation); applied 8 of 10 modifications, deferred 2 documented as known follow-ups
- \`fix_landing_ref\`: commit \`389fe87\`
- \`test_log_ref\`: see Test results section above
- \`bug_log_ref\`: #139 (architectural follow-up filed BEFORE implementation per single-output-boundary lesson)
- \`code_review_ref\`: subagent verdict ACCEPT (this PR's iteration)

## Specific scrutiny asks (anti round-robin)

1. **Resolver edge cases.** Run \`git worktree add /tmp/wt && cd /tmp/wt && node ~/.episodic-memory/scripts/em-recall.mjs --no-track\` and observe where \`.claude/.checkpoint-required\` lands. Compare to pre-fix behavior. (Repro for the bug-shape.)
2. **Stale-state migration.** The fix does not auto-migrate worktree-local markers from before #106 landed. Layer 3 test covers this as documented behavior, not a bug. Confirm or push back.
3. **Module-load semantics.** \`em-recall.mjs:25-26\` runs \`resolveLocalDir()\` and \`resolveRepoRoot()\` on import — two \`git rev-parse\` calls. Same pattern as pre-PR code (already paid for \`LOCAL_DIR\`); negligible cost. OK?

## Known follow-ups (deferred, documented)

- Resolver test gaps: bare-repo path + \`--separate-git-dir\` / \`GIT_DIR=...\` not explicitly exercised. Bare-repo is transitively covered by the non-git fallback path; \`--separate-git-dir\` is exotic. Defer.
- Submodule comment phrasing in \`local-dir.mjs:6\` (subagent finding 7) — minor doc nit. Defer.
- Architectural cleanup of \`em-watch-codex.mjs\`'s competing \`findLocalStore\` walk-up resolver, plus the patterns/_index.json + project-name inference sites — captured in #139.

## Test plan

- [x] Layer 1 resolver unit tests (5/5)
- [x] Layer 2 integration tests with defensive negative assertions (4/4)
- [x] Layer 3 negative-scenario tests (3/3)
- [x] Pre-existing test-em-local-dir-worktree.mjs regression baseline (5/5)
- [x] Adjacent suites: sessionstart hook, checkpoint-gate, plan-gate, rfc002-phase3 (171/171 collectively)
- [x] Grep artifact: zero unintended \`process.cwd().*\\.claude\` matches
- [ ] Post-merge: \`node install.mjs --tool claude-code --install-hooks\` to deploy the new resolver to \`~/.episodic-memory/scripts/\`; smoke-test arming from a worktree (per \`feedback_validate_pr_applied_locally.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)