### PR TITLE
feat(hooks): stop-gate.sh — close docs-only summarize-as-done bp-001 hole (#128)

### DIFF
--- a/docs/rfcs/RFC-003-pluggable-tool-adapters.md
+++ b/docs/rfcs/RFC-003-pluggable-tool-adapters.md
@@ -494,3 +494,27 @@ Other findings addressed:
 | OQ-5 | Cursor/Windsurf manual `/em-check` — implemented as a slash command (Claude Code style) or a documented shell alias? Different tools have different surfaces. | Charlton Ho | open |
 | OQ-6 | Issue [#64](https://github.com/lantisprime/episodic-memory/issues/64) `em-store --scope local` cwd-resolution policy — three options (walk-to-`.git`, explicit `--project-root`, warn-on-worktree). | Charlton Ho | **open — to be decided in Phase 1** (moved earlier than original plan because typed requests inherit the bug if deferred) |
 | OQ-7 | Issue [#118](https://github.com/lantisprime/episodic-memory/issues/118) (`em-review-request` + `review-request` schema in `em-workflow-validate`) is the first concrete consumer of `em-request review.code`. Three alignment items to settle before #118 builds — and one honest migration-cost note. **(a) BP-001 evidence refs:** the plan ref / approval ref / pre-checkpoint ref / tests ref / code-review ref / bug-log ref / command-inventory ref are not declared in [Message envelope](#message-envelope). Lean: add a generic optional `evidence: {}` map to the envelope, with required keys declared per-type in `requests/<type>.json` (consistent with the existing `required_fields` precedent under [Request taxonomy registry](#request-taxonomy-registry); keeps BP-001-specific vocabulary out of the type schema, per P2). **(b) Validation reuse:** PR [#98](https://github.com/lantisprime/episodic-memory/pull/98)'s `resolveEpisodeRef` (exact-id, active-status, not-self, timestamp ordering, category check, local+global priority) is a strict superset of P1 envelope validation. Lean: lift into core verbatim (per P9). **(c) Field naming:** Lean: #118 adopts RFC-003 names (`target` not `--task`; split `branch` and `worktree`) and adds `requester` / `recipient` from day one. **Migration-cost note:** `em-workflow-validate.mjs` today is gate-/event-name-keyed (`REQUIRED_FOR_GATE`, `EVENT_ORDER`) with **flat-keyed** payloads (`payload.plan_ref`, `payload.pre_checkpoint_ref`, `payload.evidence.tests[]`) and chain-semantic checks (splice-resistance, per-gate head rules) that have no analog on a typed `em-request`. The resolver lifts cleanly; the payload schema does not. Open: write both shapes during transition vs write envelope shape from day one and teach the validator to read it — not a clean "rename + extract." Field-mapping table and detailed reconciliation: see [#118](https://github.com/lantisprime/episodic-memory/issues/118). | Charlton Ho | **open — alignment proposal pending** |
+
+---
+
+## Considerations — #128 stop-gate alignment
+
+Issue [#128](https://github.com/lantisprime/episodic-memory/issues/128) ships `hooks/stop-gate.sh` as a Phase 3b primitive that closes the docs-only-summarize-as-done hole (canonical violation episode `20260503-093636-...-a25d`; reinforced by `20260504-113846-...-d6e5`). To stay alignable with this RFC's adapter architecture, #128's implementation makes three commitments — annotation only; does not amend the accepted Proposal/Implementation plan.
+
+### Commitments
+
+1. **Decision logic in core, hook is a thin wrapper.** The block-or-allow decision lives in `scripts/em-recall.mjs` as `--gate stop`. The shell hook reads stdin, honors the `stop_hook_active` infinite-loop guard (per cached docs `claude-code-hooks-guide.md:421-431`), invokes the core script, and passes JSON through (with a fail-loud envelope on script absence/error). [Phase 2:404](#phase-2-claude-code-reference-adapter) will relocate the shell wrapper into `adapters/claude-code/capabilities/enforcement.mjs`; the core `--gate` flag remains in core unchanged (P9 — core never imports adapters).
+
+2. **`--gate <event>` keys on Claude Code event names.** First implementation: `--gate stop`. Future events that may follow if Phase 1 ratifies the dispatch contract: `presubmit` (UserPromptSubmit), `prewrite` (PreToolUse with write tools), `prepush` (PreToolUse with push), `pretool` (broad PreToolUse). This locks the dispatch convention to **event-name keying** so Phase 1's typed-request work and Phase 2's enforcement.mjs share one taxonomy. If Phase 1 later chooses gate-class keying over event-name keying, this section becomes the migration record.
+
+3. **Marker file paths via `resolveRepoRoot()` (PR #105 / PR #140 primitive).** The core `--gate stop` reads `.claude/` markers from the main repo root, not from the hook's stdin `cwd` field. This converges hook writers and readers per #106's worktree-orphan fix (PR #140). Reusing the post-#140 module-load `REPO_ROOT` constant in `em-recall.mjs` makes the gate worktree-safe by construction.
+
+### Out of scope for #128
+
+- Full BP-1 step-by-step state machine ("design C" from prior conversation) — belongs in `scripts/em-workflow-validate.mjs` as core, when RFC-003 Phase 1 starts. #128 closes only the wrap-up gate.
+- `--gate presubmit` / `--gate prewrite` / `--gate prepush` — extensible by design but not implemented in #128.
+- Migration to `adapters/claude-code/capabilities/enforcement.mjs` — Phase 2 work; #128 stays as a runtime hook.
+
+### Phase 3b spec link
+
+The Phase 3b *spec* (issue [#25](https://github.com/lantisprime/episodic-memory/issues/25)) and tracking issue [#80](https://github.com/lantisprime/episodic-memory/issues/80) remain valid. #128 is a tactical hole-closer for the docs-only-summarize-as-done shape; the architectural cleanup remains [Phase 2:404](#phase-2-claude-code-reference-adapter) territory.

--- a/hooks/stop-gate.sh
+++ b/hooks/stop-gate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+# stop-gate.sh — Stop / SubagentStop hook for bp-001 wrap-up enforcement.
+#
+# Closes shape-4 docs-only-summarize-as-done hole (issue #128). When the
+# bp-001 checkpoint marker is armed AND the post-implementation checkpoint
+# block has not been written, blocks Claude's turn-end so the user must
+# complete step 8/9 before the cycle is "done."
+#
+# Architecture (RFC-003 Phase 3b primitive; Phase 2 will subsume into
+# adapters/claude-code/capabilities/enforcement.mjs — see RFC-003
+# §Considerations — #128 stop-gate alignment):
+#   - Decision logic lives in core: `node em-recall.mjs --gate stop`.
+#   - This shell script is a thin runtime adapter:
+#     1. Reads stdin (Claude Code hook input JSON).
+#     2. Honors `stop_hook_active` early-exit (mandatory infinite-loop
+#        guard per knowledge_base/claude-code-hooks-guide.md:421-431).
+#     3. Invokes core decision script.
+#     4. Passes core's JSON through, or emits fail-loud envelope on script
+#        absence / non-zero exit.
+#
+# Registered on both Stop AND SubagentStop events (see install.mjs hookSpecs).
+# SubagentStop is the conversion of Stop for subagent contexts per
+# claude-code-hooks-reference.md:409.
+#
+# Note: multiple Stop hooks with `decision: block` are OR-combined (any
+# blocker wins) — no ordering dependency vs other registered Stop hooks.
+
+INPUT="$(cat)"
+
+# stop_hook_active short-circuit (BEFORE any node spawn — keeps the recursive
+# Stop fire-and-exit path cheap, no node startup cost).
+#
+# Fail-soft on malformed JSON: if jq can't parse INPUT, treat stop_hook_active
+# as false and let the gate proceed. set -e would otherwise propagate jq's
+# non-zero exit code and crash the hook on garbage input (Layer 3 negative
+# scenario).
+STOP_HOOK_ACTIVE="$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)"
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# Resolve em-recall.mjs at canonical global install path. The hook does not
+# attempt to use the in-repo script — production hooks invoke globally
+# installed copies, which is what install.mjs --install-hooks deploys.
+EM_RECALL="$HOME/.episodic-memory/scripts/em-recall.mjs"
+if [ ! -f "$EM_RECALL" ]; then
+  echo '{"decision": "block", "reason": "stop-gate.sh: em-recall.mjs not found at canonical global path. Re-run install.mjs."}'
+  exit 0
+fi
+
+# Invoke core decision logic. Capture stdout; fail-loud envelope on error.
+# Repo-root resolution lives in em-recall.mjs (post-#140 resolveRepoRoot at
+# module load); we intentionally do NOT pass cwd info via stdin.
+DECISION="$(node "$EM_RECALL" --gate stop 2>/dev/null)" || {
+  echo '{"decision": "block", "reason": "stop-gate.sh: em-recall --gate stop exited non-zero. Re-run install.mjs --install-hooks."}'
+  exit 0
+}
+
+# Pass core's JSON through verbatim. Empty stdout = no decision = allow.
+if [ -n "$DECISION" ]; then
+  echo "$DECISION"
+fi
+exit 0

--- a/hooks/stop-gate.sh
+++ b/hooks/stop-gate.sh
@@ -41,6 +41,17 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
+# Parse .cwd from hook input. The hook PROCESS cwd is whatever Claude Code
+# launched the hook from — NOT necessarily the project. Codex round-1 caught
+# this bypass: without honoring input .cwd, em-recall's resolveRepoRoot at
+# module load resolves from /private/tmp (or wherever) instead of the
+# project, silently allowing Stop on an armed project.
+#
+# Same pattern as em-recall-sessionstart.sh:27-28 + checkpoint-gate.sh:43-44 +
+# plan-gate.sh:27-28: parse .cwd, fall back to pwd if missing.
+CWD="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")"
+[ -z "$CWD" ] && CWD="$(pwd)"
+
 # Resolve em-recall.mjs at canonical global install path. The hook does not
 # attempt to use the in-repo script — production hooks invoke globally
 # installed copies, which is what install.mjs --install-hooks deploys.
@@ -50,9 +61,19 @@ if [ ! -f "$EM_RECALL" ]; then
   exit 0
 fi
 
+# Invalid .cwd guard: if CWD doesn't exist or isn't readable, fail-soft (no
+# decision). Mirrors em-recall-sessionstart.sh:43-45 + #70 wrong-project
+# class (don't run em-recall in whatever cwd the hook process inherited).
+# Fail-soft because Stop's "no decision" = allow, which is the conservative
+# default when we can't be sure which project's marker to read.
+if ! cd "$CWD" 2>/dev/null; then
+  exit 0
+fi
+
 # Invoke core decision logic. Capture stdout; fail-loud envelope on error.
-# Repo-root resolution lives in em-recall.mjs (post-#140 resolveRepoRoot at
-# module load); we intentionally do NOT pass cwd info via stdin.
+# Repo-root resolution in em-recall.mjs (resolveRepoRoot module-load) now
+# resolves from the cwd we just cd'd to — i.e., the project the hook input
+# named, not the hook process's inherited cwd.
 DECISION="$(node "$EM_RECALL" --gate stop 2>/dev/null)" || {
   echo '{"decision": "block", "reason": "stop-gate.sh: em-recall --gate stop exited non-zero. Re-run install.mjs --install-hooks."}'
   exit 0

--- a/install.mjs
+++ b/install.mjs
@@ -438,6 +438,23 @@ if (installHooks) {
         file: 'em-recall-sessionstart.sh',
         event: 'SessionStart',
         timeout: 10
+      },
+      // stop-gate.sh: registered on both Stop AND SubagentStop. SubagentStop
+      // is the conversion of Stop for subagent contexts per
+      // claude-code-hooks-reference.md:409 — without explicit SubagentStop
+      // registration, subagent shape-4 (docs-only-summarize-as-done from
+      // inside a Skill / Plan / Explore agent) is uncovered. Issue #128.
+      // Phase 3b primitive; future RFC-003 Phase 2 subsumes into
+      // adapters/claude-code/capabilities/enforcement.mjs.
+      {
+        file: 'stop-gate.sh',
+        event: 'Stop',
+        timeout: 5
+      },
+      {
+        file: 'stop-gate.sh',
+        event: 'SubagentStop',
+        timeout: 5
       }
     ]
 
@@ -562,7 +579,8 @@ if (installHooks) {
       'em-session-end-prompt.mjs': path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'),
       'checkpoint-gate.sh': path.join(userHooksDir, 'checkpoint-gate.sh'),
       'plan-gate.sh': path.join(userHooksDir, 'plan-gate.sh'),
-      'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh')
+      'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh'),
+      'stop-gate.sh': path.join(userHooksDir, 'stop-gate.sh')
     }
     const staleEntries = detectStaleCanonicalEntries(settings.hooks, canonicalByBasename)
     for (const { event, basename, command } of staleEntries) {

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -44,6 +44,7 @@ const noTrack = argv.includes('--no-track')
 const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
 const warnCount = parseInt(flag('--warn-count') || '500', 10)
 const taskTypeFlag = flag('--task-type')
+const gateFlag = flag('--gate')
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
@@ -55,6 +56,43 @@ const VALID_TASK_TYPES = ['implementation', 'push', 'rule', 'general']
 if (taskTypeFlag !== undefined && !VALID_TASK_TYPES.includes(taskTypeFlag)) {
   console.log(JSON.stringify({ status: 'error', message: `Invalid --task-type "${taskTypeFlag}". Must be one of: ${VALID_TASK_TYPES.join(', ')}` }))
   process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Gate dispatch (RFC-003 Phase 3b primitive; future Phase 2 will subsume the
+// shell wrapper into adapters/claude-code/capabilities/enforcement.mjs while
+// keeping this dispatch in core per P9. See RFC-003 §Considerations — #128
+// stop-gate alignment for the event-name-keying commitment.)
+//
+// `--gate <event>` returns a hook-decision JSON to stdout for adapter
+// consumption. Empty stdout = allow (Claude proceeds normally on Stop).
+// `{decision: "block", reason: "..."}` = block.
+//
+// Currently implemented: stop. The dispatch contract may extend to other
+// Claude Code events (presubmit/prewrite/prepush) as Phase 1 ratifies.
+// ---------------------------------------------------------------------------
+const VALID_GATES = ['stop']
+if (gateFlag !== undefined && !VALID_GATES.includes(gateFlag)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --gate "${gateFlag}". Must be one of: ${VALID_GATES.join(', ')}` }))
+  process.exit(1)
+}
+
+if (gateFlag === 'stop') {
+  // REPO_ROOT was resolved at module load (line ~26) via resolveRepoRoot()
+  // from scripts/lib/local-dir.mjs. This converges with the hook readers in
+  // hooks/checkpoint-gate.sh + hooks/plan-gate.sh that use repo-root.sh.
+  // Closes #106's worktree-orphan class for this gate.
+  const claudeDir = path.join(REPO_ROOT, '.claude')
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  const postDone = path.join(claudeDir, '.post-checkpoint-done')
+  let postDoneSize = 0
+  try { postDoneSize = fs.statSync(postDone).size } catch {}
+  if (fs.existsSync(preReq) && postDoneSize === 0) {
+    const reason = 'Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty), then end your turn again. Hook: stop-gate.sh.'
+    console.log(JSON.stringify({ decision: 'block', reason }))
+  }
+  // Otherwise: emit nothing. Empty stdout on Stop = allow Claude to stop.
+  process.exit(0)
 }
 
 const recallStart = Date.now()

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -19,10 +19,11 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
-import { resolveLocalDir } from './lib/local-dir.mjs'
+import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
+const REPO_ROOT = resolveRepoRoot()
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -261,9 +262,9 @@ function shouldArmBp001Checkpoint(activeEntries, now) {
 // Idempotent marker arming. Best-effort — failures are swallowed so a
 // non-writable .claude dir doesn't take down the whole recall.
 // ---------------------------------------------------------------------------
-function armCheckpointMarker(cwd) {
+function armCheckpointMarker(repoRoot) {
   try {
-    const claudeDir = path.join(cwd, '.claude')
+    const claudeDir = path.join(repoRoot, '.claude')
     fs.mkdirSync(claudeDir, { recursive: true })
     const markerPath = path.join(claudeDir, '.checkpoint-required')
     if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
@@ -380,7 +381,7 @@ const preflight_warnings = []
 // blocks write tools, so the false-positive surface is bounded.
 // ---------------------------------------------------------------------------
 if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
-  armCheckpointMarker(process.cwd())
+  armCheckpointMarker(REPO_ROOT)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -15,6 +15,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { resolveRepoRoot } from './lib/local-dir.mjs'
 
 // ---------------------------------------------------------------------------
 // Load known patterns from _index.json
@@ -38,7 +39,12 @@ function loadPatternsIndex() {
 // Cleans orphaned states too (e.g. .post-checkpoint-required without
 // .checkpoint-required, per RFC-002 line 207). Failure is silent — markers
 // may not exist or .claude/ may be missing in some workflows.
-const claudeDir = path.join(process.cwd(), '.claude')
+//
+// resolveRepoRoot ensures we clean the SAME .claude/ that armCheckpointMarker
+// (em-recall) and the hooks (hooks/lib/repo-root.sh) target — a worktree-cwd
+// would otherwise sweep an empty worktree-local .claude/ while leaving the
+// real markers stranded at the main repo root. Closes #106.
+const claudeDir = path.join(resolveRepoRoot(), '.claude')
 for (const marker of [
   '.checkpoint-required',
   '.pre-checkpoint-done',

--- a/scripts/lib/local-dir.mjs
+++ b/scripts/lib/local-dir.mjs
@@ -1,17 +1,29 @@
 /**
- * local-dir.mjs — resolve the canonical .episodic-memory/ directory for --scope local.
+ * local-dir.mjs — resolve canonical project paths for the episodic-memory store
+ * AND for `.claude/` marker files.
  *
- * Walks to the main repository root via `git rev-parse --git-common-dir` so that
- * invocations from a linked worktree write to the SAME store as the main checkout.
- * Closes #85.
+ * Two exports:
+ *   - resolveRepoRoot(cwd)  — the primitive. Returns the main repo's working tree.
+ *   - resolveLocalDir(cwd)  — `<repo-root>/.episodic-memory/` (PR #105 / #85).
+ *
+ * resolveLocalDir is `path.join(resolveRepoRoot(cwd), '.episodic-memory')` —
+ * a one-line postfix on the primitive. Single source of truth for the
+ * git-resolution heuristic; do not duplicate it.
+ *
+ * Walks to the main repository root via `git rev-parse --git-common-dir` so
+ * invocations from a linked worktree converge on the SAME root as the main
+ * checkout. resolveRepoRoot is also used by armCheckpointMarker (em-recall)
+ * and the SessionEnd cleanup loop (em-session-end-prompt) so bp-001 marker
+ * writes land where the hook readers (hooks/lib/repo-root.sh) look for them.
+ * Closes #106 (sibling to #85).
  *
  * Resolution captured at module-load time by callers (e.g. `const LOCAL_DIR =
  * resolveLocalDir()` at the top of em-*.mjs). Do not chdir before importing.
  *
  * Edge-case handling:
  *   - Linked worktree of main:  common-dir basename is `.git` -> parent. (This
- *     is the case #85 is about: the linked worktree's common-dir is the SHARED
- *     main `.git`, so we resolve to the main repo root.)
+ *     is the case #85/#106 are about: the linked worktree's common-dir is the
+ *     SHARED main `.git`, so we resolve to the main repo root.)
  *   - Submodule:                common-dir is `<super>/.git/modules/<name>`,
  *     basename ≠ `.git` -> use `git rev-parse --show-toplevel`, which returns
  *     the SUBMODULE's working tree (its own local memory, not the superproject's).
@@ -28,7 +40,7 @@
 import path from 'path'
 import { execSync } from 'child_process'
 
-export function resolveLocalDir(cwd = process.cwd()) {
+export function resolveRepoRoot(cwd = process.cwd()) {
   try {
     const commonDir = execSync('git rev-parse --git-common-dir', {
       cwd,
@@ -37,7 +49,7 @@ export function resolveLocalDir(cwd = process.cwd()) {
     const absCommon = path.resolve(cwd, commonDir)
     // Canonical case (linked worktree of main, or main itself): <repo>/.git.
     if (path.basename(absCommon) === '.git') {
-      return path.join(path.dirname(absCommon), '.episodic-memory')
+      return path.dirname(absCommon)
     }
     // Submodule, --separate-git-dir, GIT_DIR=..., etc. The common-dir parent is
     // NOT the working tree (e.g. for a submodule it's the superproject's
@@ -47,9 +59,13 @@ export function resolveLocalDir(cwd = process.cwd()) {
       cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
     }).toString().trim()
-    if (top) return path.join(top, '.episodic-memory')
+    if (top) return top
   } catch {
     // not a git repo, bare repo, or git unavailable
   }
-  return path.join(cwd, '.episodic-memory')
+  return cwd
+}
+
+export function resolveLocalDir(cwd = process.cwd()) {
+  return path.join(resolveRepoRoot(cwd), '.episodic-memory')
 }

--- a/tests/test-em-repo-root-worktree.mjs
+++ b/tests/test-em-repo-root-worktree.mjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * test-em-repo-root-worktree.mjs — Tests for #106 armCheckpointMarker
+ * worktree-orphan + scripts/lib/local-dir.mjs:resolveRepoRoot extraction.
+ *
+ * Two layers of verification:
+ *   1. Resolver unit tests — resolveRepoRoot returns the main repo working
+ *      tree from main / linked worktree / nested cwd / non-git / submodule.
+ *   2. Integration regression tests — em-recall.mjs invoked from a linked
+ *      worktree writes .checkpoint-required at <main>/.claude/, not
+ *      <worktree>/.claude/. em-session-end-prompt.mjs invoked from a worktree
+ *      cleans markers at <main>/.claude/, not <worktree>/.claude/.
+ *
+ * Defensive ordering (per feedback_test_resource_existence_check.md):
+ * each integration assertion checks BOTH "marker exists at main" AND
+ * "marker does not exist at worktree" — the negative assertion is the
+ * load-bearing one. Otherwise a misconfigured test that races cleanup
+ * against the assertion would silently pass.
+ *
+ * Usage: node tests/test-em-repo-root-worktree.mjs
+ * Zero dependencies.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+import { resolveRepoRoot } from '../scripts/lib/local-dir.mjs'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
+const STORE = path.join(SCRIPTS, 'em-store.mjs')
+const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+// ---------------------------------------------------------------------------
+// Setup: temp main repo + linked worktree + nested dir + non-git dir
+// ---------------------------------------------------------------------------
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-reporoot-'))
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+
+const mainRepo = path.join(tmpRoot, 'main')
+const worktreeRoot = path.join(tmpRoot, 'wt')
+const nestedDir = path.join(worktreeRoot, 'a', 'b', 'c')
+const nonGitDir = path.join(tmpRoot, 'plain')
+
+fs.mkdirSync(mainRepo, { recursive: true })
+fs.mkdirSync(nonGitDir, { recursive: true })
+
+git(mainRepo, 'init -q -b main')
+git(mainRepo, 'config user.email test@example.com')
+git(mainRepo, 'config user.name test')
+fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
+git(mainRepo, 'add README.md')
+git(mainRepo, 'commit -q -m init')
+git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
+fs.mkdirSync(nestedDir, { recursive: true })
+
+const mainRepoReal = fs.realpathSync(mainRepo)
+const worktreeRootReal = fs.realpathSync(worktreeRoot)
+const nonGitDirReal = fs.realpathSync(nonGitDir)
+
+// Seed a recent bp-001 violation in mainRepo's local store so em-recall
+// will arm the checkpoint marker. Use em-store --scope local — post-PR #105
+// resolveLocalDir routes to mainRepo regardless of cwd.
+execSync(
+  `node ${STORE} --scope local --project test ` +
+  `--category violation ` +
+  `--tags "violated:bp-001-implementation-workflow,test-fixture" ` +
+  `--summary "test fixture violation" ` +
+  `--body "Seeded by test-em-repo-root-worktree.mjs to trigger marker arming."`,
+  { cwd: mainRepo, stdio: ['ignore', 'pipe', 'pipe'] },
+)
+
+// ---------------------------------------------------------------------------
+// Layer 1 — resolveRepoRoot unit tests
+// ---------------------------------------------------------------------------
+
+test('resolveRepoRoot: main checkout returns main repo working tree', () => {
+  const got = fs.realpathSync(resolveRepoRoot(mainRepo))
+  assert.strictEqual(got, mainRepoReal)
+})
+
+test('resolveRepoRoot: linked worktree returns MAIN repo working tree (not worktree)', () => {
+  const got = fs.realpathSync(resolveRepoRoot(worktreeRoot))
+  assert.strictEqual(got, mainRepoReal, `expected ${mainRepoReal}, got ${got}`)
+  assert.notStrictEqual(got, worktreeRootReal, `resolver returned worktree path: ${got}`)
+})
+
+test('resolveRepoRoot: nested cwd inside worktree resolves to MAIN repo', () => {
+  const got = fs.realpathSync(resolveRepoRoot(nestedDir))
+  assert.strictEqual(got, mainRepoReal)
+})
+
+test('resolveRepoRoot: non-git cwd falls back to cwd', () => {
+  const got = fs.realpathSync(resolveRepoRoot(nonGitDir))
+  assert.strictEqual(got, nonGitDirReal)
+})
+
+// Regression for the v1 bug Codex caught on PR #105: an over-eager `/.git/`
+// segment-strip would resolve a submodule's local memory to the SUPERPROJECT
+// root, cross-contaminating two stores. Correct behavior: --show-toplevel
+// returns the submodule's own working tree.
+test('resolveRepoRoot: submodule resolves to SUBMODULE working tree, not superproject', () => {
+  const superRepo = path.join(tmpRoot, 'super')
+  const subSrc = path.join(tmpRoot, 'subsrc')
+  fs.mkdirSync(superRepo, { recursive: true })
+  fs.mkdirSync(subSrc, { recursive: true })
+
+  git(subSrc, 'init -q -b main')
+  git(subSrc, 'config user.email test@example.com')
+  git(subSrc, 'config user.name test')
+  fs.writeFileSync(path.join(subSrc, 'README.md'), '# sub\n')
+  git(subSrc, 'add README.md')
+  git(subSrc, 'commit -q -m sub-init')
+
+  git(superRepo, 'init -q -b main')
+  git(superRepo, 'config user.email test@example.com')
+  git(superRepo, 'config user.name test')
+  fs.writeFileSync(path.join(superRepo, 'README.md'), '# super\n')
+  git(superRepo, 'add README.md')
+  git(superRepo, 'commit -q -m super-init')
+  git(superRepo, `-c protocol.file.allow=always submodule add -q file://${fs.realpathSync(subSrc)} sub`)
+
+  const subCheckout = path.join(superRepo, 'sub')
+  const subCheckoutReal = fs.realpathSync(subCheckout)
+  const superRepoReal = fs.realpathSync(superRepo)
+
+  const got = fs.realpathSync(resolveRepoRoot(subCheckout))
+  assert.strictEqual(got, subCheckoutReal, `expected submodule root ${subCheckoutReal}, got ${got}`)
+  assert.notStrictEqual(got, superRepoReal, `submodule resolved to superproject: ${got}`)
+})
+
+// ---------------------------------------------------------------------------
+// Layer 2 — Integration regression tests for #106
+// ---------------------------------------------------------------------------
+
+const mainClaudeDir = path.join(mainRepoReal, '.claude')
+const worktreeClaudeDir = path.join(worktreeRootReal, '.claude')
+const mainMarker = path.join(mainClaudeDir, '.checkpoint-required')
+const worktreeMarker = path.join(worktreeClaudeDir, '.checkpoint-required')
+
+function clearMarkers() {
+  for (const dir of [mainClaudeDir, worktreeClaudeDir]) {
+    for (const m of [
+      '.checkpoint-required',
+      '.pre-checkpoint-done',
+      '.post-checkpoint-required',
+      '.post-checkpoint-done',
+    ]) {
+      try { fs.unlinkSync(path.join(dir, m)) } catch {}
+    }
+  }
+}
+
+test('em-recall from main writes .checkpoint-required at <main>/.claude/', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: mainRepo, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  // Defensive: assert main marker AND verify worktree did not get one too.
+  assert.ok(fs.existsSync(mainMarker), `expected ${mainMarker} after em-recall from main`)
+  assert.ok(!fs.existsSync(worktreeMarker), `unexpected ${worktreeMarker} after em-recall from main`)
+})
+
+test('em-recall from linked worktree writes .checkpoint-required at <main>/.claude/, NOT worktree', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  // Positive: marker landed at main repo root.
+  assert.ok(
+    fs.existsSync(mainMarker),
+    `expected ${mainMarker} after em-recall from worktree (regressed #106)`,
+  )
+  // Negative: marker did NOT land at worktree (the bug-shape assertion).
+  // Defensive ordering: this assertion is the load-bearing one for #106.
+  assert.ok(
+    !fs.existsSync(worktreeMarker),
+    `marker leaked into worktree: ${worktreeMarker} (this is the #106 bug)`,
+  )
+  // Defensive existence check: verify the worktree dir itself wasn't deleted
+  // out from under us before the assertion, which would make the negative
+  // check vacuously pass.
+  assert.ok(
+    fs.existsSync(worktreeRootReal),
+    `worktree root went missing during test — negative assertion was vacuous`,
+  )
+})
+
+test('em-recall from nested cwd inside worktree still writes marker at <main>/.claude/', () => {
+  clearMarkers()
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: nestedDir, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+  assert.ok(fs.existsSync(mainMarker))
+  assert.ok(!fs.existsSync(worktreeMarker), `marker leaked into worktree from nested cwd`)
+})
+
+test('em-session-end-prompt from worktree cleans markers at <main>/.claude/, not worktree', () => {
+  clearMarkers()
+  // Seed both stores with the full marker set so we can prove which one
+  // gets swept.
+  fs.mkdirSync(mainClaudeDir, { recursive: true })
+  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
+  for (const m of [
+    '.checkpoint-required',
+    '.pre-checkpoint-done',
+    '.post-checkpoint-required',
+    '.post-checkpoint-done',
+  ]) {
+    fs.writeFileSync(path.join(mainClaudeDir, m), 'seed')
+    fs.writeFileSync(path.join(worktreeClaudeDir, m), 'worktree-seed')
+  }
+
+  // Confirm setup is real (defensive — guards against a refactor that
+  // accidentally clears the seed before the cleanup runs).
+  assert.ok(fs.existsSync(mainMarker), 'pre-condition: main marker seeded')
+  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: worktree marker seeded')
+
+  execSync(`node ${SESSION_END}`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  // Positive: main markers swept.
+  assert.ok(!fs.existsSync(mainMarker), `expected ${mainMarker} cleaned after SessionEnd from worktree`)
+  // Negative: worktree markers untouched (proves the sweep targeted main).
+  // After #106, em-session-end-prompt should NOT touch worktree-local markers
+  // unless the worktree is a non-git cwd (which it isn't here).
+  assert.ok(
+    fs.existsSync(worktreeMarker),
+    `worktree marker swept unexpectedly — em-session-end-prompt resolved to worktree, not main (regressed #106)`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Layer 3 — Negative-scenario tests (verify-by-artifact Skill 2)
+//
+// Set up failure / edge states explicitly and observe behavior, rather than
+// just testing the happy path with negative assertions.
+// ---------------------------------------------------------------------------
+
+test('NEG: stale worktree-local marker (pre-fix legacy state) is preserved, not migrated', () => {
+  clearMarkers()
+  // Simulate a user who ran em-recall from this worktree BEFORE PR #106 landed.
+  // The pre-fix bug left a marker in <worktree>/.claude/. After the fix:
+  //   - new arming writes to <main>/.claude/ (correct)
+  //   - the legacy worktree-local marker is OUT OF BAND — we do not auto-migrate
+  //   - em-session-end-prompt now sweeps main-only, so the worktree marker
+  //     persists forever (acceptable: hooks read from main, so it's inert)
+  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
+  fs.writeFileSync(worktreeMarker, 'legacy-from-pre-106')
+  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: legacy worktree marker seeded')
+
+  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+    cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  // New behavior: marker now lives at main.
+  assert.ok(fs.existsSync(mainMarker), 'new arming should land at main')
+  // Legacy marker preserved verbatim — we don't read or modify worktree state.
+  assert.ok(fs.existsSync(worktreeMarker), 'legacy worktree marker should be untouched')
+  assert.strictEqual(
+    fs.readFileSync(worktreeMarker, 'utf8'),
+    'legacy-from-pre-106',
+    'legacy marker contents should not be rewritten',
+  )
+})
+
+test('NEG: em-recall from non-git cwd degrades gracefully (no crash, no cross-store leak)', () => {
+  clearMarkers()
+  // From a non-git cwd:
+  //   - resolveRepoRoot returns cwd (no main repo to converge on)
+  //   - LOCAL_DIR = <cwd>/.episodic-memory (does not exist; loadIndex returns [])
+  //   - global store has no bp-001 violation either (test seed lives in mainRepo)
+  //   - shouldArmBp001Checkpoint returns false → armCheckpointMarker never runs
+  //   - em-recall exits 0 with empty episodes
+  // Assertion shape: no crash, no marker anywhere, no .claude/ dir spuriously created.
+  let exitOk = true
+  try {
+    execSync(`node ${RECALL} --scope local --no-track`, {
+      cwd: nonGitDir, stdio: ['ignore', 'ignore', 'ignore'],
+    })
+  } catch {
+    exitOk = false
+  }
+
+  assert.ok(exitOk, 'em-recall should exit 0 from non-git cwd')
+  // No marker created at cwd, main, or worktree.
+  assert.ok(
+    !fs.existsSync(path.join(nonGitDirReal, '.claude')),
+    `.claude/ created at non-git cwd — activator armed spuriously`,
+  )
+  assert.ok(!fs.existsSync(mainMarker), 'non-git cwd should not write to main repo')
+  assert.ok(!fs.existsSync(worktreeMarker), 'non-git cwd should not write to worktree')
+})
+
+test('NEG: em-recall with no recent bp-001 violation does NOT arm marker (activator no-op)', () => {
+  clearMarkers()
+  // Use a fresh ephemeral repo with NO seeded violation. shouldArmBp001Checkpoint
+  // returns false → armCheckpointMarker is never called → no marker written.
+  // Verifies the activator does not spuriously create marker files.
+  const cleanRepo = path.join(tmpRoot, 'clean')
+  fs.mkdirSync(cleanRepo, { recursive: true })
+  git(cleanRepo, 'init -q -b main')
+  git(cleanRepo, 'config user.email test@example.com')
+  git(cleanRepo, 'config user.name test')
+  fs.writeFileSync(path.join(cleanRepo, 'README.md'), '# clean\n')
+  git(cleanRepo, 'add README.md')
+  git(cleanRepo, 'commit -q -m init')
+
+  const cleanRepoReal = fs.realpathSync(cleanRepo)
+  const cleanMarker = path.join(cleanRepoReal, '.claude', '.checkpoint-required')
+
+  // No --project test → don't pick up the seeded violation in mainRepo.
+  execSync(`node ${RECALL} --scope local --no-track`, {
+    cwd: cleanRepo, stdio: ['ignore', 'ignore', 'ignore'],
+  })
+
+  assert.ok(
+    !fs.existsSync(cleanMarker),
+    `unexpected marker at ${cleanMarker} — activator armed without violation evidence`,
+  )
+  // Defensive: prove the dir would have existed if marker WERE written
+  // (the parent .claude/ dir would have been mkdir'd by armCheckpointMarker).
+  // We assert .claude/ doesn't exist either — proves armCheckpointMarker
+  // never ran, not just that the marker file was missing.
+  assert.ok(
+    !fs.existsSync(path.join(cleanRepoReal, '.claude')),
+    `.claude/ dir created without arming — armCheckpointMarker ran spuriously`,
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.error('\nFailures:')
+  for (const f of failures) console.error(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -530,6 +530,130 @@ test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (P
   fs.rmSync(sessionHome, { recursive: true, force: true })
 })
 
+test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next SessionStart re-arms (#128 SessionEnd race tie-breaker)', () => {
+  // Verifies the SessionEnd-race tie-breaker verdict from #128 plan review:
+  // even though SessionEnd unconditionally sweeps all 4 markers, the next
+  // SessionStart re-arms the gate because shouldArmBp001Checkpoint reads
+  // from the EPISODE STORE (persistent), not the marker file. The marker
+  // is just runtime state for the current arming cycle. This test pins the
+  // idempotent-re-arm contract — any future regression that points the
+  // predicate at the marker would silently disarm the gate; this test
+  // catches that.
+  //
+  // Round-trip:
+  //   1. Setup: temp project + seeded bp-001 violation in episode store
+  //   2. SessionStart hook arms .checkpoint-required
+  //   3. Simulate Stop firing (em-recall --gate stop) → returns block JSON
+  //   4. em-session-end-prompt.mjs sweeps all 4 markers
+  //   5. SessionStart hook runs again → .checkpoint-required re-armed
+  //   6. Verify the violation episode still exists (source of truth survived)
+  const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p3-roundtrip-'))
+  const sessionProject = path.join(sessionHome, 'project')
+  fs.mkdirSync(sessionProject, { recursive: true })
+  execSync('git init -q', { cwd: sessionProject })
+  execSync('git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init', { cwd: sessionProject })
+  execSync('git checkout -q -B main', { cwd: sessionProject })
+
+  const sessionPatterns = path.join(sessionProject, 'patterns')
+  fs.mkdirSync(sessionPatterns, { recursive: true })
+  fs.copyFileSync(srcIndex, path.join(sessionPatterns, '_index.json'))
+
+  const sessionScripts = path.join(sessionHome, '.episodic-memory', 'scripts')
+  fs.mkdirSync(sessionScripts, { recursive: true })
+  const SCRIPTS_DIR = path.join(REPO_ROOT, 'scripts')
+  for (const f of fs.readdirSync(SCRIPTS_DIR)) {
+    if (f.endsWith('.mjs')) {
+      fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(sessionScripts, f))
+    }
+  }
+  const SCRIPTS_LIB = path.join(SCRIPTS_DIR, 'lib')
+  if (fs.existsSync(SCRIPTS_LIB)) {
+    const sessionLib = path.join(sessionScripts, 'lib')
+    fs.mkdirSync(sessionLib, { recursive: true })
+    for (const f of fs.readdirSync(SCRIPTS_LIB)) {
+      if (f.endsWith('.mjs')) fs.copyFileSync(path.join(SCRIPTS_LIB, f), path.join(sessionLib, f))
+    }
+  }
+
+  const sessionEnv = { ...process.env, HOME: sessionHome }
+  // Seed violation in episode store. This is the persistent source of truth
+  // that survives SessionEnd sweep.
+  execSync(`node "${VIOLATION}" --pattern bp-001-implementation-workflow --summary "round-trip seed" --body "test" --scope local`, {
+    cwd: sessionProject, env: sessionEnv, encoding: 'utf8'
+  })
+  execSync(`node "${REBUILD}" --scope all`, { cwd: sessionProject, env: sessionEnv })
+
+  const hookPath = path.join(REPO_ROOT, 'hooks', 'em-recall-sessionstart.sh')
+  const claudeDir = path.join(sessionProject, '.claude')
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  const postReq = path.join(claudeDir, '.post-checkpoint-required')
+  const preDone = path.join(claudeDir, '.pre-checkpoint-done')
+  const postDone = path.join(claudeDir, '.post-checkpoint-done')
+
+  // ----- Step 1: First SessionStart arms marker -----
+  spawnSync('bash', [hookPath], {
+    input: JSON.stringify({ cwd: sessionProject }),
+    env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+  })
+  assert.ok(fs.existsSync(preReq), 'step 1: SessionStart should arm .checkpoint-required')
+
+  // ----- Step 2: Stop fires; em-recall --gate stop returns block -----
+  const stopOut = execSync(`node "${path.join(sessionScripts, 'em-recall.mjs')}" --gate stop`, {
+    cwd: sessionProject, env: sessionEnv, encoding: 'utf8'
+  })
+  const stopJson = JSON.parse(stopOut)
+  assert.strictEqual(stopJson.decision, 'block',
+    'step 2: --gate stop must block when armed and post-done empty')
+
+  // Defensive: marker still present at the moment we asserted block decision.
+  // Guards against vacuous-pass if cleanup raced ahead of the assertion.
+  assert.ok(fs.existsSync(preReq),
+    'step 2 (defensive): marker still present at decision time (non-vacuous)')
+
+  // ----- Step 3: SessionEnd sweeps all 4 markers -----
+  // Pre-condition: arm all 4 to verify the sweep covers them all
+  fs.writeFileSync(preDone, 'pre-content')
+  fs.writeFileSync(postReq, '')
+  fs.writeFileSync(postDone, 'post-content')
+  // Defensive: confirm setup is real before SessionEnd touches it
+  assert.ok(fs.existsSync(preReq) && fs.existsSync(preDone) &&
+            fs.existsSync(postReq) && fs.existsSync(postDone),
+    'step 3 setup: all 4 markers seeded')
+
+  execSync(`node "${path.join(sessionScripts, 'em-session-end-prompt.mjs')}"`, {
+    cwd: sessionProject, env: sessionEnv, encoding: 'utf8'
+  })
+
+  assert.ok(!fs.existsSync(preReq), 'step 3: SessionEnd should sweep .checkpoint-required')
+  assert.ok(!fs.existsSync(preDone), 'step 3: SessionEnd should sweep .pre-checkpoint-done')
+  assert.ok(!fs.existsSync(postReq), 'step 3: SessionEnd should sweep .post-checkpoint-required')
+  assert.ok(!fs.existsSync(postDone), 'step 3: SessionEnd should sweep .post-checkpoint-done')
+
+  // ----- Step 4: Next SessionStart re-arms marker (idempotent contract) -----
+  spawnSync('bash', [hookPath], {
+    input: JSON.stringify({ cwd: sessionProject }),
+    env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+  })
+  assert.ok(fs.existsSync(preReq),
+    'step 4: SECOND SessionStart should re-arm marker — proves shouldArmBp001Checkpoint reads episode store, not marker')
+
+  // ----- Step 5: Violation episode still in the store (source of truth survived) -----
+  const indexPath = path.join(sessionProject, '.episodic-memory', 'index.jsonl')
+  assert.ok(fs.existsSync(indexPath), 'step 5: episode index still exists post-roundtrip')
+  const indexLines = fs.readFileSync(indexPath, 'utf8').split('\n').filter(Boolean)
+  const hasViolation = indexLines.some(line => {
+    try {
+      const e = JSON.parse(line)
+      return e.category === 'violation' && Array.isArray(e.tags) &&
+             e.tags.includes('violated:bp-001-implementation-workflow')
+    } catch { return false }
+  })
+  assert.ok(hasViolation,
+    'step 5: bp-001 violation episode survived the round-trip (the actual source of truth for re-arming)')
+
+  fs.rmSync(sessionHome, { recursive: true, force: true })
+})
+
 // ===========================================================================
 // Summary
 // ===========================================================================

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# test-stop-gate.sh — Tests for #128 hooks/stop-gate.sh + em-recall --gate stop
+#
+# Three layers per feedback_bp1_step9_filing_trigger.md sister lesson
+# `20260504-113349-...-3ef1` (Layer-3 explicit failure-scenario tests):
+#   Layer 1 — em-recall --gate stop unit cases (subprocess; controlled fixtures)
+#   Layer 2 — stop-gate.sh integration (simulated hook input piped through shell)
+#   Layer 3 — explicit failure scenarios (corrupt marker, missing .claude,
+#             worktree-cwd resolution, SubagentStop conversion, hook-script
+#             missing, stop_hook_active short-circuit, malformed JSON input)
+#
+# Defensive ordering per feedback_test_resource_existence_check.md: every
+# state assertion is paired with an existence check on the artifact at
+# check time, so a misordered cleanup doesn't make the test pass for the
+# wrong reason.
+
+set -e
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/stop-gate.sh"
+EM_RECALL="$REPO_ROOT/scripts/em-recall.mjs"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ✓ $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1: $2")
+  echo "  ✗ $1: $2"
+}
+
+# Build a pristine temp git repo for each test that needs one.
+mk_repo() {
+  local d="$1"
+  rm -rf "$d"
+  mkdir -p "$d"
+  ( cd "$d" && \
+    git init -q -b main && \
+    git config user.email test@example.com && \
+    git config user.name test && \
+    echo x > README.md && \
+    git add . && \
+    git commit -q -m init )
+}
+
+# Run em-recall --gate stop with REPO_ROOT-pinned cwd; returns stdout.
+gate_stop() {
+  local cwd="$1"
+  ( cd "$cwd" && node "$EM_RECALL" --gate stop 2>/dev/null )
+}
+
+# Pipe a synthetic hook input JSON through the hook script. Mocks
+# HOME so the hook resolves the canonical em-recall to our repo's copy.
+run_hook() {
+  local input_json="$1"
+  local fake_home="$2"
+  echo "$input_json" | HOME="$fake_home" bash "$HOOK" 2>/dev/null
+}
+
+# Build a fake HOME with em-recall.mjs at the canonical install path so
+# the hook's lookup at "$HOME/.episodic-memory/scripts/em-recall.mjs"
+# resolves correctly. The fake HOME also gets a copy of the resolver lib
+# so em-recall.mjs's import works.
+mk_fake_home() {
+  local fake_home="$1"
+  rm -rf "$fake_home"
+  mkdir -p "$fake_home/.episodic-memory/scripts/lib"
+  cp "$REPO_ROOT/scripts/em-recall.mjs" "$fake_home/.episodic-memory/scripts/em-recall.mjs"
+  cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$fake_home/.episodic-memory/scripts/lib/local-dir.mjs"
+}
+
+TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# ============================================================================
+# Layer 1 — em-recall --gate stop unit cases
+# ============================================================================
+echo ""
+echo "=== Layer 1: em-recall --gate stop unit cases ==="
+
+L1_REPO="$TMP_ROOT/L1"
+mk_repo "$L1_REPO"
+mkdir -p "$L1_REPO/.claude"
+
+# 1.1 No marker → empty stdout → allow
+out="$(gate_stop "$L1_REPO")"
+if [ -z "$out" ]; then pass "L1.1: no marker → empty stdout (allow)"
+else fail "L1.1: no marker → empty stdout" "got: $out"
+fi
+
+# 1.2 Marker armed, post-done empty → block JSON
+touch "$L1_REPO/.claude/.checkpoint-required"
+out="$(gate_stop "$L1_REPO")"
+if echo "$out" | grep -q '"decision":"block"'; then pass "L1.2: armed + post-empty → block"
+else fail "L1.2: armed + post-empty → block" "got: $out"
+fi
+
+# Defensive existence check: the marker we set still exists at this point.
+if [ -f "$L1_REPO/.claude/.checkpoint-required" ]; then pass "L1.2 (defensive): marker still present at check time"
+else fail "L1.2 defensive existence" "marker disappeared between setup and assertion"
+fi
+
+# 1.3 Marker armed, post-done non-empty → empty stdout (allow)
+echo "post-checkpoint content" > "$L1_REPO/.claude/.post-checkpoint-done"
+out="$(gate_stop "$L1_REPO")"
+if [ -z "$out" ]; then pass "L1.3: armed + post-non-empty → empty stdout (allow)"
+else fail "L1.3: armed + post-non-empty" "got: $out"
+fi
+
+# 1.4 Marker armed, post-done exists but EMPTY (size 0) → block (size matters, not presence)
+rm "$L1_REPO/.claude/.post-checkpoint-done"
+touch "$L1_REPO/.claude/.post-checkpoint-done"
+out="$(gate_stop "$L1_REPO")"
+if echo "$out" | grep -q '"decision":"block"'; then pass "L1.4: armed + post-zero-bytes → block"
+else fail "L1.4: armed + post-zero-bytes → block" "got: $out"
+fi
+
+# 1.5 Invalid --gate value → error JSON, exit 1
+set +e
+out="$(node "$EM_RECALL" --gate prewrite 2>&1)"
+rc=$?
+set -e
+if [ "$rc" = "1" ] && echo "$out" | grep -q "Invalid --gate"; then pass "L1.5: invalid --gate → error + exit 1"
+else fail "L1.5: invalid --gate" "rc=$rc out=$out"
+fi
+
+# ============================================================================
+# Layer 2 — stop-gate.sh integration via piped JSON
+# ============================================================================
+echo ""
+echo "=== Layer 2: stop-gate.sh integration ==="
+
+L2_REPO="$TMP_ROOT/L2"
+mk_repo "$L2_REPO"
+mkdir -p "$L2_REPO/.claude"
+L2_HOME="$TMP_ROOT/L2_home"
+mk_fake_home "$L2_HOME"
+
+# 2.1 No marker, hook input minimal → empty/no decision → allow
+input='{"session_id":"test","stop_hook_active":false}'
+out="$(cd "$L2_REPO" && run_hook "$input" "$L2_HOME")"
+if [ -z "$out" ]; then pass "L2.1: no marker → hook emits nothing (allow)"
+else fail "L2.1: no marker → empty" "got: $out"
+fi
+
+# 2.2 Marker armed, post-done empty → hook emits block JSON
+touch "$L2_REPO/.claude/.checkpoint-required"
+out="$(cd "$L2_REPO" && run_hook "$input" "$L2_HOME")"
+if echo "$out" | grep -q '"decision":"block"'; then pass "L2.2: armed + post-empty → hook block"
+else fail "L2.2: armed + post-empty → hook block" "got: $out"
+fi
+# Defensive: marker still present
+if [ -f "$L2_REPO/.claude/.checkpoint-required" ]; then pass "L2.2 (defensive): marker still present"
+else fail "L2.2 defensive" "marker missing at check time"
+fi
+
+# 2.3 Marker armed, post-done non-empty → hook emits nothing
+echo "post block" > "$L2_REPO/.claude/.post-checkpoint-done"
+out="$(cd "$L2_REPO" && run_hook "$input" "$L2_HOME")"
+if [ -z "$out" ]; then pass "L2.3: armed + post-non-empty → hook allow"
+else fail "L2.3: armed + post-non-empty → hook allow" "got: $out"
+fi
+rm "$L2_REPO/.claude/.post-checkpoint-done"
+
+# 2.4 stop_hook_active=true → hook short-circuits BEFORE invoking node
+# (verify by removing em-recall from the fake home; if the hook still
+# exits 0 with no output, we know it never tried to call it)
+rm "$L2_HOME/.episodic-memory/scripts/em-recall.mjs"
+input_active='{"session_id":"test","stop_hook_active":true}'
+out="$(cd "$L2_REPO" && run_hook "$input_active" "$L2_HOME")"
+if [ -z "$out" ]; then pass "L2.4: stop_hook_active=true → short-circuit (no node call)"
+else fail "L2.4: stop_hook_active short-circuit" "got: $out (expected empty; em-recall was deliberately removed)"
+fi
+# Restore em-recall for subsequent tests
+mk_fake_home "$L2_HOME"
+
+# ============================================================================
+# Layer 3 — explicit failure-scenario tests
+# ============================================================================
+echo ""
+echo "=== Layer 3: explicit failure scenarios ==="
+
+# 3.1 Worktree-cwd resolution: hook fires from a linked worktree, marker
+# is at MAIN repo .claude/, hook must resolve and read MAIN's marker
+# (post-#106 invariant). NOT the worktree's empty .claude/.
+L3_MAIN="$TMP_ROOT/L3_main"
+L3_WT="$TMP_ROOT/L3_wt"
+mk_repo "$L3_MAIN"
+( cd "$L3_MAIN" && git worktree add -q -b wt-branch "$L3_WT" )
+
+mkdir -p "$L3_MAIN/.claude"
+touch "$L3_MAIN/.claude/.checkpoint-required"
+# Worktree's .claude/ does NOT exist — would falsely allow if resolver
+# walked to wrong root.
+
+L3_HOME="$TMP_ROOT/L3_home"
+mk_fake_home "$L3_HOME"
+
+input_min='{"session_id":"test"}'
+# Run from the worktree cwd
+out="$(cd "$L3_WT" && run_hook "$input_min" "$L3_HOME")"
+if echo "$out" | grep -q '"decision":"block"'; then pass "L3.1: hook from worktree resolves to MAIN .claude/ + blocks"
+else fail "L3.1: worktree resolution" "got: $out (expected block; main has armed marker)"
+fi
+# Defensive: confirm marker still at main, NOT at worktree
+if [ -f "$L3_MAIN/.claude/.checkpoint-required" ] && [ ! -f "$L3_WT/.claude/.checkpoint-required" ]; then
+  pass "L3.1 (defensive): marker at main, NOT worktree at check time"
+else
+  fail "L3.1 defensive" "marker location wrong at check time"
+fi
+
+# 3.2 .claude/ dir entirely missing → no marker → allow (graceful)
+L3_NO_CLAUDE="$TMP_ROOT/L3_noclaude"
+mk_repo "$L3_NO_CLAUDE"
+# Deliberately do NOT create .claude/
+out="$(cd "$L3_NO_CLAUDE" && run_hook "$input_min" "$L3_HOME")"
+if [ -z "$out" ]; then pass "L3.2: missing .claude dir → graceful allow"
+else fail "L3.2: missing .claude" "got: $out"
+fi
+
+# 3.3 Marker armed, .post-checkpoint-done is a directory not a file (corrupt state)
+# fs.statSync will succeed with non-zero blksize but our code uses .size
+# (which is 0 for directories on most platforms but undefined in spec).
+# Intent: even a weird state should not crash; hook should still emit
+# something parseable.
+L3_CORRUPT="$TMP_ROOT/L3_corrupt"
+mk_repo "$L3_CORRUPT"
+mkdir -p "$L3_CORRUPT/.claude/.post-checkpoint-done"  # dir, not file
+touch "$L3_CORRUPT/.claude/.checkpoint-required"
+set +e
+out="$(cd "$L3_CORRUPT" && run_hook "$input_min" "$L3_HOME")"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then pass "L3.3: corrupt state → hook exits 0 (no crash)"
+else fail "L3.3: corrupt state crash" "rc=$rc out=$out"
+fi
+
+# 3.4 em-recall.mjs missing entirely → fail-loud block envelope
+L3_NOSCRIPT_HOME="$TMP_ROOT/L3_noscript_home"
+mkdir -p "$L3_NOSCRIPT_HOME/.episodic-memory/scripts"
+# Deliberately do NOT copy em-recall.mjs
+out="$(cd "$L3_MAIN" && echo "$input_min" | HOME="$L3_NOSCRIPT_HOME" bash "$HOOK" 2>/dev/null)"
+# JSON style varies between em-recall (no spaces) and shell echo (with spaces);
+# match either via the field name regex.
+if echo "$out" | grep -qE '"decision":[[:space:]]*"block"' && echo "$out" | grep -q "em-recall.mjs not found"; then
+  pass "L3.4: missing em-recall.mjs → fail-loud block envelope"
+else
+  fail "L3.4: missing em-recall fail-loud" "got: $out"
+fi
+
+# 3.5 SubagentStop variant — same shell, same JSON shape, same behavior
+# (the hook is content-agnostic about which event registered it).
+input_subagent='{"session_id":"test","stop_hook_active":false}'
+mkdir -p "$L3_MAIN/.claude"
+touch "$L3_MAIN/.claude/.checkpoint-required"
+rm -f "$L3_MAIN/.claude/.post-checkpoint-done"
+out="$(cd "$L3_MAIN" && run_hook "$input_subagent" "$L3_HOME")"
+if echo "$out" | grep -q '"decision":"block"'; then pass "L3.5: SubagentStop event input → same block decision"
+else fail "L3.5: SubagentStop" "got: $out"
+fi
+
+# 3.6 Malformed JSON input (jq receives garbage) → hook should not crash
+# stop_hook_active extraction returns "false" on jq failure; gate runs.
+input_bad='not valid json'
+set +e
+out="$(cd "$L3_MAIN" && echo "$input_bad" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+rc=$?
+set -e
+if [ "$rc" = "0" ]; then pass "L3.6: malformed input JSON → hook exits 0 (no crash)"
+else fail "L3.6: malformed JSON" "rc=$rc out=$out"
+fi
+
+# 3.7 stop_hook_active=true takes precedence over armed marker
+# (proves the short-circuit fires before marker check)
+input_active='{"session_id":"test","stop_hook_active":true}'
+out="$(cd "$L3_MAIN" && run_hook "$input_active" "$L3_HOME")"
+if [ -z "$out" ]; then pass "L3.7: stop_hook_active=true overrides armed marker (short-circuits)"
+else fail "L3.7: stop_hook_active precedence" "got: $out (expected empty; armed marker should be ignored when active)"
+fi
+# Defensive: prove the marker is still armed (i.e., we DIDN'T disarm it
+# accidentally; the short-circuit just bypassed the check)
+if [ -f "$L3_MAIN/.claude/.checkpoint-required" ]; then pass "L3.7 (defensive): marker still present (short-circuit didn't mutate state)"
+else fail "L3.7 defensive" "marker disappeared during short-circuit"
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=================================================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=================================================="
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do echo "  $f"; done
+  exit 1
+fi
+exit 0

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -289,6 +289,53 @@ if [ -f "$L3_MAIN/.claude/.checkpoint-required" ]; then pass "L3.7 (defensive): 
 else fail "L3.7 defensive" "marker disappeared during short-circuit"
 fi
 
+# 3.8 BYPASS REGRESSION (Codex round-1 finding 1, P1):
+# Hook PROCESS cwd is /private/tmp (outside any project) but hook INPUT JSON
+# has cwd pointing at the armed repo. Pre-fix: stop-gate.sh ignored input
+# cwd → em-recall resolveRepoRoot resolved from /private/tmp → silently
+# allowed Stop on the armed project. Post-fix: hook parses input cwd,
+# cd's to it, em-recall reads main repo's .claude/ correctly → blocks.
+mkdir -p "$L3_MAIN/.claude"
+touch "$L3_MAIN/.claude/.checkpoint-required"
+rm -f "$L3_MAIN/.claude/.post-checkpoint-done"
+input_with_cwd="$(printf '{"cwd":"%s","stop_hook_active":false}' "$L3_MAIN")"
+out="$(cd /private/tmp 2>/dev/null && echo "$input_with_cwd" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+if echo "$out" | grep -qE '"decision":[[:space:]]*"block"'; then
+  pass "L3.8: hook from /private/tmp + input cwd→armed repo → blocks (Codex finding 1 regression)"
+else
+  fail "L3.8: bypass regression (Codex P1 finding)" "got: $out (expected block; armed marker at $L3_MAIN/.claude/.checkpoint-required)"
+fi
+# Defensive: confirm the marker we set still exists at this point
+if [ -f "$L3_MAIN/.claude/.checkpoint-required" ]; then pass "L3.8 (defensive): marker still present at check time"
+else fail "L3.8 defensive existence" "marker disappeared between setup and assertion"
+fi
+
+# 3.9 INVALID .cwd graceful-fail: input cwd points at non-existent dir.
+# Per #70 wrong-project class, we must NOT run em-recall in whatever cwd
+# the hook process inherited. Hook should fail-soft (empty stdout = allow).
+input_bad_cwd='{"cwd":"/nonexistent-path-for-test","stop_hook_active":false}'
+out="$(cd "$L3_MAIN" && echo "$input_bad_cwd" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+# Note: even though we cd'd to L3_MAIN (which has armed marker), the bad
+# input .cwd takes precedence. The hook tries to cd to the bad path, fails,
+# and exits 0 with no decision (graceful — don't run em-recall in
+# inherited cwd to avoid #70 wrong-project bug).
+if [ -z "$out" ]; then
+  pass "L3.9: invalid input .cwd → fail-soft, no decision (#70 wrong-project guard)"
+else
+  fail "L3.9: invalid cwd graceful-fail" "got: $out (expected empty; should not run em-recall in inherited cwd)"
+fi
+
+# 3.10 Empty .cwd in input falls back to pwd (canonical pattern).
+# When .cwd is "" or missing, hook uses pwd. Process cwd here is L3_MAIN
+# (armed); should block.
+input_no_cwd='{"stop_hook_active":false}'
+out="$(cd "$L3_MAIN" && echo "$input_no_cwd" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+if echo "$out" | grep -qE '"decision":[[:space:]]*"block"'; then
+  pass "L3.10: missing input .cwd → falls back to pwd → blocks correctly"
+else
+  fail "L3.10: cwd fallback to pwd" "got: $out"
+fi
+
 # ============================================================================
 # Summary
 # ============================================================================


### PR DESCRIPTION
## Invariant

After this PR, `Stop` and `SubagentStop` hook events from any cwd within a repo (main checkout, linked worktree of main, nested cwd, submodule) **block Claude's turn-end** when `<main-repo-root>/.claude/.checkpoint-required` is non-empty AND `<main-repo-root>/.claude/.post-checkpoint-done` is empty. Decision logic lives in core (\`em-recall.mjs --gate stop\`) for RFC-003 Phase 2 adapter migration; the shell hook is a thin runtime wrapper with mandatory \`stop_hook_active\` short-circuit. Closes #128.

## Why this matters

Empirical evidence: 5+ recurrences of the docs-only-summarize-as-done shape across recent sessions, including \`20260503-093636-...-a25d\` (canonical violation, RFC-003 OQ-7 doc edit) and \`20260504-113846-...-d6e5\` (PR #140's own cycle — documentation-tier rule loaded, failed under task-end momentum). Per MEMORY.md "CRITICAL: Rule 18 / bp-001 — Only Hooks Work":

> 8 violations in session 3 despite full awareness. Documentation-based enforcement fails 100%.
> Enforcement hierarchy: STRONG: PreToolUse hooks. WEAK: CLAUDE.md, bp-001, MEMORY.md, session handoffs.

Stop is the missing PreToolUse-equivalent for turn-end. Pre-#128, a docs-only PR could be summarized as "done" without ever touching a tool, leaving the existing PreToolUse gates inert.

## Architectural alignment with RFC-003

Decision logic lives in core (\`scripts/em-recall.mjs --gate stop\`) per RFC-003 P9 (*Core never imports adapters*). Phase 2 will subsume the shell wrapper into \`adapters/claude-code/capabilities/enforcement.mjs\`; the core \`--gate\` flag remains in core unchanged. RFC-003 §Considerations — #128 stop-gate alignment (added in this PR, after OQ-7) commits to **event-name keying** for the dispatch contract. See [docs/rfcs/RFC-003-pluggable-tool-adapters.md](docs/rfcs/RFC-003-pluggable-tool-adapters.md).

## Surface inventory

| Surface | File:line | What it does |
|---|---|---|
| Core dispatch | [scripts/em-recall.mjs:46-95](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/scripts/em-recall.mjs#L46-L95) | New \`--gate <event>\` flag; first event \`stop\`; reads \`<REPO_ROOT>/.claude/\` markers via post-#140 module-load constant |
| Hook wrapper | [hooks/stop-gate.sh](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/hooks/stop-gate.sh) (NEW, 60 lines) | Thin shell adapter: stdin parse + \`stop_hook_active\` short-circuit + node call + fail-loud envelope |
| Stop registration | [install.mjs:447-458](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/install.mjs#L447-L458) | Two hookSpecs entries (\`Stop\` AND \`SubagentStop\`) with \`timeout: 5\` |
| canonicalByBasename | [install.mjs:583](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/install.mjs#L583) | Stale-entry detection includes stop-gate.sh |
| RFC-003 considerations | [docs/rfcs/RFC-003-pluggable-tool-adapters.md](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/docs/rfcs/RFC-003-pluggable-tool-adapters.md) (after OQ-7) | Architectural lock-in for event-name keying + Phase 2 migration target |
| Layer 1 + 2 + 3 tests | [tests/test-stop-gate.sh](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/tests/test-stop-gate.sh) (NEW, 20 cases) | Unit / integration / explicit failure scenarios |
| Round-trip test | [tests/test-rfc002-phase3.mjs](https://github.com/lantisprime/episodic-memory/blob/claude/nostalgic-shtern-bff65e/tests/test-rfc002-phase3.mjs) T7k | SessionEnd-race round-trip per Plan-agent Finding 6 tie-breaker |

## Grep artifact (post-fix verification)

\`\`\`
$ grep -n \"gateFlag\\|VALID_GATES\\|--gate\" scripts/em-recall.mjs
47:const gateFlag = flag('--gate')
67:// \`--gate <event>\` returns a hook-decision JSON to stdout for adapter
74:const VALID_GATES = ['stop']
75:if (gateFlag !== undefined && !VALID_GATES.includes(gateFlag)) {
76:  console.log(JSON.stringify({ status: 'error', message: \`Invalid --gate \"\${gateFlag}\"...\` }))
80:if (gateFlag === 'stop') {

$ grep -rn \"stop_hook_active\" hooks/ scripts/
hooks/stop-gate.sh:39:STOP_HOOK_ACTIVE=\"\$(echo \"\$INPUT\" | jq -r '.stop_hook_active // false' 2>/dev/null || echo false)\"
(comment lines + test fixtures elided; production source-of-truth is single line in shell)

$ grep -n \"stop-gate\" install.mjs
450:        file: 'stop-gate.sh',
451:        event: 'Stop',
455:        file: 'stop-gate.sh',
456:        event: 'SubagentStop',
583:      'stop-gate.sh': path.join(userHooksDir, 'stop-gate.sh')
\`\`\`

Single-source-of-truth on \`stop_hook_active\` in shell (per RFC-003 P9 — hook-runtime concerns stay in adapter). Two distinct hookSpecs entries (Stop + SubagentStop) per agent Finding 7 / hooks-reference.md:409.

## Test results (290 tests across 9 suites)

\`\`\`
$ bash tests/test-stop-gate.sh
Results: 20 passed, 0 failed

$ node tests/test-rfc002-phase3.mjs
Results: 29 passed, 0 failed   (incl. T7k SessionEnd-race round-trip)

$ node tests/test-em-repo-root-worktree.mjs
12 passed, 0 failed   (no regression vs PR #140)

$ node tests/test-em-local-dir-worktree.mjs
5 passed, 0 failed   (no regression vs PR #105)

$ bash tests/test-em-recall-sessionstart.sh
Passed: 9, Failed: 0

$ bash tests/test-checkpoint-gate.sh
Passed: 100, Failed: 0

$ bash tests/test-plan-gate.sh
Results: 34 passed, 0 failed

$ bash tests/test-install-hooks.sh
Passed: 61, Failed: 0

$ node tests/test-phase3.mjs
Results: 20 passed, 0 failed
\`\`\`

T7k empirically validates the SessionEnd-race tie-breaker verdict: arm via SessionStart → block via Stop → sweep via SessionEnd → re-arm via next SessionStart. Round-trip is idempotent because \`shouldArmBp001Checkpoint\` reads from the episode store (persistent), not the marker file.

Layer 3 caught two real bugs during implementation:
- **Malformed JSON input:** \`set -e\` + bare \`jq\` crashed the hook with rc=5 → fixed with \`|| echo false\` fail-soft
- **JSON output style asymmetry:** em-recall outputs compact JSON; shell echoes use spaces → tests handle both via \`[[:space:]]*\` regex

## Bp-001 named refs

- **plan_ref:** documented across this conversation; locked after Plan-agent two-round review (initial + tie-breaker on SessionEnd race)
- **approval_ref:** user said \`go\` after second-opinion consensus
- **prior_review_ref:** Plan-agent verdicts ACCEPT WITH MOD applied (11 findings); REJECT-with-evidence on Finding 6 (tie-breaker confirmed); DEFER on Finding 11 (filed as #142)
- **fix_landing_ref:** commit \`e5e6760\`
- **test_log_ref:** see Test results section above
- **bug_log_ref:** [#142](https://github.com/lantisprime/episodic-memory/issues/142) chokepoint audit + [#143](https://github.com/lantisprime/episodic-memory/issues/143) edge-case tightening (per BP-1 step 9 / \`feedback_bp1_step9_filing_trigger.md\`)
- **code_review_ref:** subagent verdict ACCEPT (this PR's iteration)

## Specific scrutiny asks (anti round-robin per \`...a33c\`)

1. **\`em-recall --gate stop\` API design.** This PR de facto specifies Phase 1's \`em-recall --gate\` interface for the \`stop\` event. RFC-003 §Considerations locks event-name keying. Is the dispatch shape (single positional arg, JSON stdout, exit 0 on allow / non-zero on error) consistent with what Phase 1 will need for other events?

2. **\`stop_hook_active\` short-circuit.** Verify it fires BEFORE node spawn. L2.4 deletes em-recall.mjs and confirms the hook still exits 0 — proving the short-circuit short-circuits.

3. **SessionEnd race.** T7k pins the round-trip contract. Without this PR's \`--gate stop\` implementation, was there ever a real failure mode? Or is the gate-state-resets-by-design behavior pre-existing?

4. **install.mjs dual-event registration.** \`addHookEntry\` is per-event-keyed; \`detectStaleCanonicalEntries\` walks all events. Does the dedup logic handle two distinct event entries pointing at the same script correctly?

## Known follow-ups (deferred, filed as issues)

- [#142](https://github.com/lantisprime/episodic-memory/issues/142) bp-001 enforcement chokepoint audit (UserPromptSubmit/TaskCompleted/SubagentStop coverage)
- [#143](https://github.com/lantisprime/episodic-memory/issues/143) stop-gate edge-case tightening (non-git cwd graceful-allow, \`.size\` on directory marker)
- Both LOW priority; same class as #67/#106 accepted residuals

## Test plan

- [x] Layer 1 unit tests for \`em-recall --gate stop\` (5/5)
- [x] Layer 2 integration tests via shell hook (5/5)
- [x] Layer 3 explicit failure scenarios (10/10)
- [x] T7k SessionEnd-race round-trip (1/1)
- [x] Adjacent suite regression: 8 suites, 270/270
- [x] Grep artifact verified
- [ ] Post-merge: \`node install.mjs --tool claude-code --install-hooks\` to deploy the new hook + register Stop/SubagentStop entries; smoke-test gate from a worktree per \`feedback_validate_pr_applied_locally.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)