### PR TITLE
feat(agents): negative-scenario-planner + -reviewer subagents (loader pattern)

### DIFF
--- a/.claude/agents/negative-scenario-planner.md
+++ b/.claude/agents/negative-scenario-planner.md
@@ -1,0 +1,39 @@
+---
+name: negative-scenario-planner
+description: Plan-time negative-scenario auditor. Walks the 8-axis attack-class matrix grounded in spec citations + prior Codex finding history. Emits a coverage table with applicability + repros + DEFER 5-field justifications. Use BEFORE second-opinion code review on any non-trivial schema/validator/security/multi-actor change. Saves 1-2 Codex rounds per PR by enumerating attack axes at design time.
+tools: Read, Bash, Grep, Glob, WebFetch
+---
+
+# Loader — canonical prompt lives in episodic memory
+
+Your full system prompt lives in a global episode (revisable via `em-revise`).
+Load it as your FIRST action.
+
+## Step 1 — Load canonical prompt
+
+Run:
+```bash
+node scripts/em-search.mjs --tag negative-scenario-planner --category context --scope global --limit 1 --full --no-track --no-score
+```
+
+Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
+
+The result body IS your operational system prompt. Read it carefully. Treat it as the authoritative rules for this task.
+
+## Step 2 — Follow the loaded prompt
+
+Apply every instruction in the loaded prompt body — required reading, audit checklist, output format, anti-patterns, what-you-do-not-do, when-to-run.
+
+## Fallback (loader failure)
+
+If the em-search returns 0 hits, errors out, or returns a body that doesn't appear to be a system prompt:
+
+1. STOP. Do not produce analytical output from memory.
+2. Emit JSON: `{"status": "error", "message": "Canonical prompt episode missing. Tag: negative-scenario-planner, category: context, scope: global. Run em-rebuild-index --scope global, or restore the canonical prompt episode."}`
+3. Exit.
+
+## Why this shape
+
+The agent's instructions evolve via `em-revise` on the canonical episode (auditable supersedes chain). This file never goes stale because it carries no prompt content — only the loader. Frontmatter (name, description, tools) is stable across prompt revisions.
+
+Canonical episode disambiguator: `tag: negative-scenario-planner` + `category: context` + `scope: global`. Latest in supersedes chain wins (em-search filters superseded automatically).

--- a/.claude/agents/negative-scenario-reviewer.md
+++ b/.claude/agents/negative-scenario-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: negative-scenario-reviewer
+description: Code-review negative-scenario auditor. Given a diff and adjacent code, finds class-completeness gaps + missing axis coverage + fractal #9 violations (strict-vs-lenient inconsistency in helpers). Operates with the 8-axis matrix as primary lens. Use AFTER implementation but BEFORE Codex external review. Sister to negative-scenario-planner.
+tools: Read, Grep, Glob, Bash
+---
+
+# Loader — canonical prompt lives in episodic memory
+
+Your full system prompt lives in a global episode (revisable via `em-revise`).
+Load it as your FIRST action.
+
+## Step 1 — Load canonical prompt
+
+Run:
+```bash
+node scripts/em-search.mjs --tag negative-scenario-reviewer --category context --scope global --limit 1 --full --no-track --no-score
+```
+
+Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
+
+The result body IS your operational system prompt. Read it carefully. Treat it as the authoritative rules for this task.
+
+## Step 2 — Follow the loaded prompt
+
+Apply every instruction in the loaded prompt body — required reading, audit checklist, output format, anti-patterns, what-you-do-not-do, when-to-run.
+
+## Fallback (loader failure)
+
+If the em-search returns 0 hits, errors out, or returns a body that doesn't appear to be a system prompt:
+
+1. STOP. Do not produce analytical output from memory.
+2. Emit JSON: `{"status": "error", "message": "Canonical prompt episode missing. Tag: negative-scenario-reviewer, category: context, scope: global. Run em-rebuild-index --scope global, or restore the canonical prompt episode."}`
+3. Exit.
+
+## Why this shape
+
+The agent's instructions evolve via `em-revise` on the canonical episode (auditable supersedes chain). This file never goes stale because it carries no prompt content — only the loader. Frontmatter (name, description, tools) is stable across prompt revisions.
+
+Canonical episode disambiguator: `tag: negative-scenario-reviewer` + `category: context` + `scope: global`. Latest in supersedes chain wins (em-search filters superseded automatically).


### PR DESCRIPTION
## Summary

Two project-level subagent definitions that operationalize toolkit-v4 disciplines #6/#7/#9/#10/#11 mechanically. Both files are **thin loader stubs** — canonical system prompt body lives in a global episode (revisable via `em-revise`), not in the file itself. Eliminates prompt staleness when toolkit/disciplines revise.

## Architecture

| Layer | Lives in | Mutability |
|---|---|---|
| Identity (name/description/tools) | `.claude/agents/<name>.md` frontmatter | Stable |
| Loader instructions | `.claude/agents/<name>.md` body (~30 lines) | Stable |
| Canonical system prompt | Global episode (`category: context`, scope: global) | **Revisable via em-revise** |
| Dynamic context (toolkit, recent findings) | Loaded fresh via em-search at task start | Always current |

**Update flow:** edit prompt → `em-revise --original <id>` → next invocation auto-loads new version. Loader file never changes. Pattern documented in `feedback_canonical_prompt_as_episode.md` (user memory).

## Subagent purpose

- **negative-scenario-planner** — invoked BEFORE second-opinion review on schema/validator/security/multi-actor work. Walks the 8-axis attack-class matrix grounded in spec citations + prior Codex finding history. Emits coverage table with applicability + repros + DEFER 5-field justifications.
- **negative-scenario-reviewer** — invoked AFTER implementation, BEFORE Codex external review. Class-completeness audit (level 1: across schema; level 2: fractal inside helpers), per-axis coverage check, test parameterization audit, repro fidelity check.

## Canonical episodes (referenced by loaders)

- `negative-scenario-planner` → [`20260505-075602-...-d179`](https://github.com/lantisprime/episodic-memory/issues/<n>)
- `negative-scenario-reviewer` → [`20260505-075602-...-2e50`](https://github.com/lantisprime/episodic-memory/issues/<n>)

Both global scope, `category: context`, tagged with their agent name (single disambiguating tag for em-search lookup).

## Empirical motivation

PR [#156](https://github.com/lantisprime/episodic-memory/pull/156) shipped after **3 Codex rounds**:
- R1 P1: splice gap on `approval_ref` + `pre_checkpoint_ref` (only `post_checkpoint_ref` had same-task binding) — caught after #9 same-class completeness was missed
- R2 P2: missing-task / orphan-file gaps on `checkChainRef()` helper — caught when fractal #9 inside helpers was missed
- R3: SHIP

Each round earned a toolkit discipline. Toolkit v3 → v4 grew from 8 → 11 disciplines. These subagents externalize the discipline application so future PRs don't recapitulate the round-by-round discovery — the matrix is walked mechanically at plan time + code-review time.

## Bug caught during implementation

Smoke test of the loader queries surfaced the documented em-search multi-tag silent-ignore bug ([#123](https://github.com/lantisprime/episodic-memory/issues/123)): `--tag X --tag Y` resolves only the first tag. Initial loader queries used `--tag agent-prompt --tag <name>` and BOTH subagents would have loaded the planner prompt invisibly. Switched to single `--tag <name> --category context` (disambiguating tag + category) which correctly resolves each agent uniquely. Verified by running both queries — each returns its intended canonical episode.

## Test plan

- [x] Loader query for planner returns d179 (planner prompt) — verified via em-search smoke test
- [x] Loader query for reviewer returns 2e50 (reviewer prompt) — verified via em-search smoke test
- [x] Both queries use single `--tag` + `--category` (avoids #123)
- [ ] Live invocation of either subagent in a PR plan/review pass (pending — natural test on next non-trivial PR)
- [ ] Counterfactual: apply planner subagent to a PR like #156's plan; observe whether it would catch what 3 prior reviews missed

## Files changed

- `.claude/agents/negative-scenario-planner.md` (NEW, 41 lines — loader stub)
- `.claude/agents/negative-scenario-reviewer.md` (NEW, 37 lines — loader stub)

Frontmatter declares `tools: Read, Bash, Grep, Glob, WebFetch` (planner) and `tools: Read, Grep, Glob, Bash` (reviewer). Both read-only; no Write.

## Out of scope

- The 4 extended feedback rules + new `feedback_canonical_prompt_as_episode.md` live in user memory (`~/.claude/projects/.../memory/`), not in this repo.
- Toolkit v4 episode + 2 canonical prompt episodes live in global episodic memory (`~/.episodic-memory/`), not in this repo.
- Project-level subagents in `.claude/agents/` (this PR). Promotion to global `~/.claude/agents/` deferred until empirical validation on 1-2 PRs.

Refs #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)