### PR TITLE
fix(#146): session-start gate deadlock

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -70,17 +70,24 @@ case "$TOOL_NAME" in
     ;;
 esac
 
-# Helper: emit a block decision
+# Helper: emit a block decision.
+# Reason strings include the ABSOLUTE marker path (#146 B1). Worktree-cwd
+# sessions resolve relative paths against the worktree, but markers live at
+# the main-repo .claude/. Without the absolute path the agent guesses wrong
+# and deadlocks (issue #146 live reproducer comment 4378971459).
 _block_pre() {
-  echo '{"decision": "block", "reason": "Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to .claude/.pre-checkpoint-done (must be non-empty) before write tools are unblocked. Hook: checkpoint-gate.sh."}'
+  jq -nc --arg path "$PRE_DONE" \
+    '{decision: "block", reason: ("Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to " + $path + " (must be non-empty) before write tools are unblocked. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
 _block_post() {
-  echo '{"decision": "block", "reason": "Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty) before pushing. Hook: checkpoint-gate.sh."}'
+  jq -nc --arg path "$POST_DONE" \
+    '{decision: "block", reason: ("Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to " + $path + " (must be non-empty) before pushing. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
 _block_plan_pending() {
-  echo '{"decision": "block", "reason": "Plan approval pending. Checkpoint marker writes are blocked while .claude/.plan-approval-pending exists. Approve the plan first. Hook: checkpoint-gate.sh."}'
+  jq -nc --arg path "$PLAN_PENDING" \
+    '{decision: "block", reason: ("Plan approval pending. Checkpoint marker writes are blocked while " + $path + " exists. Approve the plan first. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
 

--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -22,6 +22,14 @@ set -e
 # Idempotent: em-recall.mjs:364 only writes the marker if it doesn't already
 # exist, so re-runs (multiple SessionStart firings, --resume, etc.) won't
 # clobber state.
+#
+# --session-start (#146 A2): em-recall writes/touches .session-baseline on
+# every invocation with this flag. The mtime of .session-baseline is the
+# stop-gate's reference point: any task-signal marker (.checkpoint-required,
+# .post-checkpoint-required, .plan-approval-pending) with mtime > baseline
+# was created mid-session and prevents the no-task-signal carve-out. Stale
+# .plan-approval-pending whose mtime predates the prior baseline is also
+# cleared here (orphan from a crashed prior session).
 
 INPUT="$(cat)"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
@@ -43,6 +51,6 @@ fi
 if ! cd "$CWD" 2>/dev/null; then
   exit 0
 fi
-node "$EM_RECALL" --limit 5 >/dev/null 2>&1 || true
+node "$EM_RECALL" --limit 5 --session-start >/dev/null 2>&1 || true
 
 exit 0

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -122,10 +122,13 @@ const TASK_SIGNAL_MARKERS = [
 // as the parent's no-task-signal turn, which is the desired behavior.
 //
 // Symlink defense (P2-2): uses lstatSync so a symlink to an old file cannot
-// trick the carve-out into firing. A symlinked baseline returns lstat mtime
-// of the symlink itself (created by writeFileSync via this code); a markers
-// symlink is treated as the file at its own path (the symlink), not its
-// target. Threat model is honest-agent self-discipline, not adversarial.
+// trick the carve-out into firing. ANY symlink — baseline or marker —
+// causes the carve-out to FAIL CLOSED (return false / deny). Same-class
+// symmetry per feedback_same_class_completeness.md: a symlinked marker
+// could represent an active mid-session signal masked behind the symlink,
+// so treating it as absent (skip) is unsafe. Codex round-1 P2 finding
+// (episode 20260505-124511-...-845f) reproduced the asymmetry. Threat
+// model is honest-agent self-discipline, not adversarial.
 // ---------------------------------------------------------------------------
 function stopGateCarveOutApplies(claudeDir) {
   const baseline = path.join(claudeDir, '.session-baseline')
@@ -142,7 +145,10 @@ function stopGateCarveOutApplies(claudeDir) {
     let mt
     try {
       const st = fs.lstatSync(p)
-      if (st.isSymbolicLink()) continue
+      // Symmetric with baseline: any marker symlink fails carve-out closed.
+      // SessionStart cleanup still skips symlinks (won't unlink them), but
+      // gate evaluation must not treat them as absent.
+      if (st.isSymbolicLink()) return false
       mt = st.mtimeMs
     } catch { continue }
     if (mt > baselineMtime) return false

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -45,6 +45,7 @@ const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
 const warnCount = parseInt(flag('--warn-count') || '500', 10)
 const taskTypeFlag = flag('--task-type')
 const gateFlag = flag('--gate')
+const sessionStartFlag = argv.includes('--session-start')
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
@@ -77,6 +78,78 @@ if (gateFlag !== undefined && !VALID_GATES.includes(gateFlag)) {
   process.exit(1)
 }
 
+// #146 P2-5: --session-start is a SessionStart-hook side-effect mode; it
+// must not be combined with --gate (which is a different hook event-key).
+// Combining them would cause --gate's early exit to silently skip the
+// baseline write, which is the worst failure mode (carve-out inactive
+// without a clear signal).
+if (sessionStartFlag && gateFlag !== undefined) {
+  console.log(JSON.stringify({ status: 'error', message: '--session-start cannot be combined with --gate' }))
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Task-signal markers (#146 P3-3): the closed set of files whose mtime
+// distinguishes "fresh task work this session" from "stale from prior".
+// Extended class members (e.g. a future .review-pending) MUST be added here
+// to keep stopGateCarveOutApplies and the SessionStart orphan-clear in sync.
+// ---------------------------------------------------------------------------
+const TASK_SIGNAL_MARKERS = [
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.plan-approval-pending'
+]
+
+// ---------------------------------------------------------------------------
+// Stop-gate carve-out (#146 A2). Pure function — testable in isolation.
+//
+// Returns true iff the stop-gate should treat the current turn as having no
+// real task signal (e.g. session-start handoff y/n + workplan display) and
+// allow stop despite an armed .checkpoint-required.
+//
+// Invariant: every TASK_SIGNAL_MARKERS member must be either absent or
+// have mtime <= .session-baseline mtime. A signal mtime > baseline means it
+// was created/touched mid-session, which is the case the gate must catch.
+//
+// .session-baseline is written/touched by em-recall --session-start (called
+// from hooks/em-recall-sessionstart.sh). If it's missing, the carve-out does
+// not apply (conservative — pre-existing sessions before this fix shipped).
+//
+// SubagentStop semantics (P1-1): the same predicate runs for SubagentStop.
+// A subagent that wrote files would have caused checkpoint-gate to arm
+// .post-checkpoint-required (mtime > baseline), denying the carve-out. A
+// subagent that did read-only work satisfies the carve-out — same semantics
+// as the parent's no-task-signal turn, which is the desired behavior.
+//
+// Symlink defense (P2-2): uses lstatSync so a symlink to an old file cannot
+// trick the carve-out into firing. A symlinked baseline returns lstat mtime
+// of the symlink itself (created by writeFileSync via this code); a markers
+// symlink is treated as the file at its own path (the symlink), not its
+// target. Threat model is honest-agent self-discipline, not adversarial.
+// ---------------------------------------------------------------------------
+function stopGateCarveOutApplies(claudeDir) {
+  const baseline = path.join(claudeDir, '.session-baseline')
+  let baselineMtime
+  try {
+    const st = fs.lstatSync(baseline)
+    if (st.isSymbolicLink()) return false
+    baselineMtime = st.mtimeMs
+  } catch {
+    return false
+  }
+  for (const name of TASK_SIGNAL_MARKERS) {
+    const p = path.join(claudeDir, name)
+    let mt
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) continue
+      mt = st.mtimeMs
+    } catch { continue }
+    if (mt > baselineMtime) return false
+  }
+  return true
+}
+
 if (gateFlag === 'stop') {
   // REPO_ROOT was resolved at module load (line ~26) via resolveRepoRoot()
   // from scripts/lib/local-dir.mjs. This converges with the hook readers in
@@ -88,8 +161,11 @@ if (gateFlag === 'stop') {
   let postDoneSize = 0
   try { postDoneSize = fs.statSync(postDone).size } catch {}
   if (fs.existsSync(preReq) && postDoneSize === 0) {
-    const reason = 'Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty), then end your turn again. Hook: stop-gate.sh.'
-    console.log(JSON.stringify({ decision: 'block', reason }))
+    if (!stopGateCarveOutApplies(claudeDir)) {
+      const reason = 'Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty), then end your turn again. Hook: stop-gate.sh.'
+      console.log(JSON.stringify({ decision: 'block', reason }))
+    }
+    // else: carve-out applies — emit nothing (allow stop).
   }
   // Otherwise: emit nothing. Empty stdout on Stop = allow Claude to stop.
   process.exit(0)
@@ -409,6 +485,43 @@ const context = inferContext()
 const preflight_warnings = []
 
 // ---------------------------------------------------------------------------
+// SessionStart orphan-clear (#146 P1-2 + P1-3). MUST run BEFORE arming so
+// a freshly armed .checkpoint-required isn't a cleanup candidate.
+//
+// For every TASK_SIGNAL_MARKERS member that exists with mtime <= prior
+// baseline: rm. Skipped entirely if no prior baseline (first session ever).
+// Symlinks ignored (lstat-based; threat-model: honest-agent only).
+// ---------------------------------------------------------------------------
+let priorBaselineMtime = null
+if (sessionStartFlag) {
+  try {
+    const claudeDir = path.join(REPO_ROOT, '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    const baseline = path.join(claudeDir, '.session-baseline')
+    try {
+      const st = fs.lstatSync(baseline)
+      if (!st.isSymbolicLink()) priorBaselineMtime = st.mtimeMs
+    } catch {}
+
+    if (priorBaselineMtime !== null) {
+      for (const name of TASK_SIGNAL_MARKERS) {
+        const p = path.join(claudeDir, name)
+        try {
+          const st = fs.lstatSync(p)
+          if (st.isSymbolicLink()) continue
+          if (st.mtimeMs <= priorBaselineMtime) {
+            fs.rmSync(p, { force: true })
+          }
+        } catch {}
+      }
+    }
+  } catch {
+    // Best-effort: a failure here leaves carve-out inactive (fall back to
+    // original blocking behavior).
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Phase 3b activation (RFC-002 Phase 3 / T7): arm the checkpoint marker
 // whenever a recent bp-001-implementation-workflow violation exists,
 // regardless of task_type. The SessionStart hook
@@ -420,6 +533,32 @@ const preflight_warnings = []
 // ---------------------------------------------------------------------------
 if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
   armCheckpointMarker(REPO_ROOT)
+}
+
+// ---------------------------------------------------------------------------
+// SessionStart baseline write (#146 A2). Runs AFTER the arming block above
+// so a fresh `.checkpoint-required` armed for this session has mtime <=
+// baseline mtime (carve-out treats it as "armed at session start").
+//
+// fs.utimesSync forces baseline mtime to Date.now() — guarantees ordering
+// against the arm above regardless of filesystem mtime resolution (P2-1).
+// The orphan-clear for stale TASK_SIGNAL_MARKERS members ran earlier
+// (before arming) using the *prior* baseline mtime as the staleness
+// threshold.
+// ---------------------------------------------------------------------------
+if (sessionStartFlag) {
+  try {
+    const claudeDir = path.join(REPO_ROOT, '.claude')
+    fs.mkdirSync(claudeDir, { recursive: true })
+    const baseline = path.join(claudeDir, '.session-baseline')
+    fs.writeFileSync(baseline, '')
+    const now = Date.now() / 1000
+    fs.utimesSync(baseline, now, now)
+  } catch {
+    // Best-effort: baseline write failure leaves carve-out inactive for
+    // this session (gate falls back to original behavior — original
+    // bp-001 enforcement still works without the carve-out).
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -663,6 +663,57 @@ fi
 
 # ============================================================================
 echo ""
+echo "--- #146 B1: block-reason includes ABSOLUTE marker path ---"
+# ============================================================================
+# Pre-fix (issue #146 live reproducer): block reason said
+# ".claude/.pre-checkpoint-done" (relative). Agent in worktree cwd resolved
+# the relative path against the worktree, which mismatched the gate's
+# main-repo expectation, deadlocking. Fix: emit absolute marker path so
+# the agent writes to the correct location regardless of cwd.
+reset_state
+touch "$PRE_REQ"
+b1_out=$(echo "$(mock_json 'Edit')" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null || true)
+B1_EXPECTED="$TEST_DIR/.claude/.pre-checkpoint-done"
+if echo "$b1_out" | grep -qF "$B1_EXPECTED"; then
+  echo "  ✓ B1.pre. _block_pre reason embeds absolute pre-checkpoint path"
+  ((passed++))
+else
+  echo "  ✗ B1.pre. expected absolute path '$B1_EXPECTED' in: $b1_out"
+  ((failed++))
+fi
+# Defensive: the trigger marker .checkpoint-required still exists AND the
+# asserted path string equals the gate's resolved $PRE_DONE constant.
+if [ -f "$PRE_REQ" ] && [ "$PRE_DONE" = "$B1_EXPECTED" ]; then
+  echo "  ✓ B1.pre (defensive): trigger marker present + path string matches \$PRE_DONE"
+  ((passed++))
+else
+  echo "  ✗ B1.pre defensive: trigger=$([ -f "$PRE_REQ" ] && echo Y || echo N) PRE_DONE=$PRE_DONE expected=$B1_EXPECTED"
+  ((failed++))
+fi
+# Plan-pending block reason also gets absolute path
+reset_state
+touch "$PRE_REQ"
+PLAN_MARKER="$TEST_DIR/.claude/.plan-approval-pending"
+touch "$PLAN_MARKER"
+# A Bash command targeting the pre-checkpoint marker fires the
+# plan-pending block (cross-gate invariant). Reason should embed
+# absolute plan-pending path.
+plan_block_json=$(jq -nc \
+  --arg cmd "echo block > $TEST_DIR/.claude/.pre-checkpoint-done" \
+  --arg cwd "$TEST_DIR" \
+  '{tool_name: "Bash", cwd: $cwd, tool_input: {command: $cmd}}')
+plan_out=$(echo "$plan_block_json" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null || true)
+if echo "$plan_out" | grep -qF "$PLAN_MARKER"; then
+  echo "  ✓ B1.plan. _block_plan_pending reason embeds absolute plan-pending path"
+  ((passed++))
+else
+  echo "  ✗ B1.plan. expected absolute path '$PLAN_MARKER' in: $plan_out"
+  ((failed++))
+fi
+rm -f "$PLAN_MARKER"
+
+# ============================================================================
+echo ""
 echo "--- A8: hook does not pollute REPO_ROOT outside TEST_DIR ---"
 # ============================================================================
 # Regression guard mirroring test-em-recall-sessionstart.sh test 7. Snapshot

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -42,7 +42,14 @@ function bad(name, detail) {
 }
 
 function mkRepo(label) {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), `em-146-${label}-`))
+  // realpathSync canonicalizes through symlinks (e.g. macOS /var → /private/var).
+  // Without this, paths derived from mkdtempSync mismatch the gate's
+  // resolve_repo_root output (which uses `cd -P`), and the marker_write
+  // allowlist's literal `==` compare fails. Real-session agents use the
+  // B1 absolute path emitted by the gate (already canonical), so this is
+  // a test-isolation concern; production path is unaffected.
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), `em-146-${label}-`))
+  const d = fs.realpathSync(raw)
   execSync(`git init -q -b main "${d}"`)
   execSync(`git -C "${d}" config user.email t@t`)
   execSync(`git -C "${d}" config user.name t`)
@@ -385,6 +392,189 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
     ok('3.5: stop-gate block reason names .post-checkpoint-done marker')
   } else {
     bad('3.5: stop-gate reason', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+// ============================================================================
+console.log('\n=== L4 — Runtime-integration E2E (hook chain via real shell) ===')
+// ============================================================================
+// Exercises the actual hook scripts (em-recall-sessionstart.sh, stop-gate.sh,
+// checkpoint-gate.sh) the way Claude Code invokes them — piping JSON
+// through bash. This is the "real flow" that subprocess unit tests don't
+// cover. Sandbox: fake HOME with em-recall + lib copied in, fake project
+// with empty .episodic-memory/. Closes the BP-1 step 8 gap flagged in
+// violation episode 20260505-123354-...-0088.
+
+const HOOK_DIR = path.join(REPO_ROOT, 'hooks')
+const SESSIONSTART_HOOK = path.join(HOOK_DIR, 'em-recall-sessionstart.sh')
+const STOP_HOOK = path.join(HOOK_DIR, 'stop-gate.sh')
+const CHECKPOINT_HOOK = path.join(HOOK_DIR, 'checkpoint-gate.sh')
+
+function mkE2EHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'em-146-e2e-home-'))
+  cleanupDirs.push(home)
+  // Fake canonical install path expected by stop-gate.sh:58
+  const scripts = path.join(home, '.episodic-memory', 'scripts')
+  fs.mkdirSync(path.join(scripts, 'lib'), { recursive: true })
+  fs.copyFileSync(EM_RECALL, path.join(scripts, 'em-recall.mjs'))
+  // em-recall imports scripts/lib/local-dir.mjs at module load
+  const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', 'local-dir.mjs')
+  fs.copyFileSync(libSrc, path.join(scripts, 'lib', 'local-dir.mjs'))
+  // Empty episodes dir so shouldArmBp001Checkpoint returns false
+  fs.mkdirSync(path.join(home, '.episodic-memory', 'episodes'), { recursive: true })
+  return home
+}
+
+function runHook(hookPath, inputJson, cwd, home) {
+  const r = spawnSync('bash', [hookPath], {
+    input: inputJson,
+    cwd,
+    env: { ...process.env, HOME: home },
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status }
+}
+
+// 4.1 Full deadlock-scenario roundtrip — closes BP-1 step 8 gap.
+//
+// Reproduces the original #146 deadlock chain via real hook invocations
+// and verifies the fix:
+//   (a) SessionStart hook runs → .session-baseline written
+//   (b) Rule-9-only turn ends → Stop hook fires → carve-out allows stop
+//   (c) Mid-session arm of post-required → Stop hook blocks
+//   (d) Next SessionStart → stale markers cleared, baseline advanced
+{
+  const d = mkRepo('4-1'); cleanupDirs.push(d)
+  const home = mkE2EHome()
+  const claudeDir = path.join(d, '.claude')
+  const baseline = path.join(claudeDir, '.session-baseline')
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  const postReq = path.join(claudeDir, '.post-checkpoint-required')
+
+  // Plant a stale .checkpoint-required from a "prior session" — this is
+  // exactly the state that caused the original deadlock.
+  fs.writeFileSync(preReq, '')
+  setMtime(preReq, Date.now() - 60_000)
+
+  // (a) SessionStart hook
+  const startInput = JSON.stringify({ cwd: d, session_id: 'e2e-4-1' })
+  const startR = runHook(SESSIONSTART_HOOK, startInput, d, home)
+  if (startR.status === 0 && fs.existsSync(baseline)) {
+    ok('4.1a: SessionStart hook → .session-baseline written')
+  } else {
+    bad('4.1a: SessionStart hook', `status=${startR.status} stderr=${startR.stderr} baseline_exists=${fs.existsSync(baseline)}`)
+  }
+  // Defensive: stale preReq still exists (we planted it) — proves we're
+  // testing the carve-out path, not a vacuous no-marker path.
+  if (fs.existsSync(preReq)) ok('4.1a (defensive): stale preReq still present after SessionStart')
+  else bad('4.1a defensive', 'preReq disappeared (would make next assertions vacuous)')
+
+  // (b) Stop hook for Rule-9-only turn — should ALLOW (carve-out fires)
+  const stopInput = JSON.stringify({ cwd: d, session_id: 'e2e-4-1', stop_hook_active: false })
+  const stopR1 = runHook(STOP_HOOK, stopInput, d, home)
+  if (stopR1.status === 0 && !stopR1.stdout) {
+    ok('4.1b: Stop hook on no-task-signal turn → empty stdout (carve-out allows stop)')
+  } else {
+    bad('4.1b: carve-out should allow stop', `status=${stopR1.status} stdout=${stopR1.stdout}`)
+  }
+
+  // (c) Simulate a real mid-session task signal — touch postReq with
+  // mtime > baseline, then re-fire Stop hook → should BLOCK
+  fs.writeFileSync(postReq, '')
+  setMtime(postReq, Date.now() + 5_000)
+  const stopR2 = runHook(STOP_HOOK, stopInput, d, home)
+  if (stopR2.status === 0 && isBlock(stopR2)) {
+    ok('4.1c: Stop hook with mid-session signal → block (carve-out denied)')
+  } else {
+    bad('4.1c: real-task signal should block', `status=${stopR2.status} stdout=${stopR2.stdout}`)
+  }
+  // Defensive: postReq still present at decision time
+  if (fs.existsSync(postReq)) ok('4.1c (defensive): postReq still present at decision time')
+  else bad('4.1c defensive', 'postReq disappeared')
+
+  // (d) Next SessionStart — roll baseline back FIRST, then set postReq
+  // mtime even further back. Cleanup-loop reads PRIOR baseline (= rolled-
+  // back value) and rms postReq if its mtime <= prior baseline. Order
+  // matters: setMtime(postReq) must use a value strictly less than the
+  // ROLLED baseline, not the original baseline.
+  const rolledBaseline = Date.now() - 60_000
+  setMtime(baseline, rolledBaseline)
+  const rolledBaselineM = fs.statSync(baseline).mtimeMs
+  setMtime(postReq, rolledBaselineM - 5_000) // strictly older than rolled baseline
+  const startR2 = runHook(SESSIONSTART_HOOK, startInput, d, home)
+  if (startR2.status === 0 && !fs.existsSync(postReq)) {
+    ok('4.1d: next SessionStart clears stale postReq')
+  } else {
+    bad('4.1d: stale postReq not cleared', `status=${startR2.status} postReq_exists=${fs.existsSync(postReq)}`)
+  }
+  const newBaselineM = fs.statSync(baseline).mtimeMs
+  if (newBaselineM > rolledBaselineM) ok('4.1d (defensive): baseline mtime strictly advanced')
+  else bad('4.1d defensive', `baseline did not advance: rolled=${rolledBaselineM} new=${newBaselineM}`)
+}
+
+// 4.2 Checkpoint-gate B1 absolute-path emission via real hook.
+//
+// Pipes a synthetic Edit tool_input through checkpoint-gate.sh and asserts
+// the block reason embeds the absolute marker path (B1 fix). Pre-#146 the
+// reason had a relative path and the agent in worktree-cwd resolved it
+// against the wrong root, causing the deadlock.
+{
+  const d = mkRepo('4-2'); cleanupDirs.push(d)
+  const home = mkE2EHome()
+  const preReq = path.join(d, '.claude', '.checkpoint-required')
+  const preDone = path.join(d, '.claude', '.pre-checkpoint-done')
+  fs.writeFileSync(preReq, '') // armed
+  // pre-done absent (empty) → gate must block
+  const editInput = JSON.stringify({
+    tool_name: 'Edit',
+    cwd: d,
+    tool_input: {
+      file_path: path.join(d, 'README.md'),
+      old_string: 'x',
+      new_string: 'y'
+    }
+  })
+  const r = runHook(CHECKPOINT_HOOK, editInput, d, home)
+  if (r.status === 0 && isBlock(r) && r.stdout.includes(preDone)) {
+    ok('4.2: checkpoint-gate Edit → block reason embeds absolute pre-done path (B1)')
+  } else {
+    bad('4.2: B1 absolute path via real hook',
+      `status=${r.status} stdout=${r.stdout} expected_path=${preDone}`)
+  }
+  // Defensive: trigger marker still present at check time
+  if (fs.existsSync(preReq)) ok('4.2 (defensive): trigger marker still present at check time')
+  else bad('4.2 defensive', 'preReq disappeared')
+}
+
+// 4.3 marker_write deadlock-prevention path via real hook.
+//
+// Pipes a Write to .pre-checkpoint-done (the marker itself) through
+// checkpoint-gate.sh — when preReq is armed and preDone empty, the
+// classifier should label it marker_write and the gate should ALLOW.
+// Without this allowlist the agent can't satisfy the gate's precondition
+// (chicken-and-egg).
+{
+  const d = mkRepo('4-3'); cleanupDirs.push(d)
+  const home = mkE2EHome()
+  const preReq = path.join(d, '.claude', '.checkpoint-required')
+  const preDone = path.join(d, '.claude', '.pre-checkpoint-done')
+  fs.writeFileSync(preReq, '')
+  // preDone absent → gate's marker_write allowlist condition met
+  const writeInput = JSON.stringify({
+    tool_name: 'Write',
+    cwd: d,
+    tool_input: {
+      file_path: preDone,
+      content: 'pre-checkpoint block'
+    }
+  })
+  const r = runHook(CHECKPOINT_HOOK, writeInput, d, home)
+  if (r.status === 0 && !r.stdout) {
+    ok('4.3: Write to .pre-checkpoint-done allowed (marker_write allowlist)')
+  } else {
+    bad('4.3: marker_write should be allowed',
+      `status=${r.status} stdout=${r.stdout}`)
   }
 }
 

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -366,6 +366,57 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
   else bad('3.3: symlink should defeat carve-out', `got: ${JSON.stringify(r)}`)
 }
 
+// 3.3b Same-class symlink defense for MARKERS (Codex round-1 P2 fix,
+// episode ...845f). Pre-fix: marker symlinks were `continue`d (treated
+// as absent), so a symlinked .post-checkpoint-required newer than baseline
+// would let the carve-out fire incorrectly. Post-fix: any marker symlink
+// fails the carve-out closed, symmetric with baseline.
+{
+  const d = mkRepo('3-3b-post'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // Create a real "newer" file then symlink .post-checkpoint-required to it
+  const realPost = path.join(claudeDir, 'real-post-marker')
+  fs.writeFileSync(realPost, '')
+  setMtime(realPost, Date.now() + 5_000) // newer than baseline
+  fs.symlinkSync(realPost, path.join(claudeDir, '.post-checkpoint-required'))
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('3.3b-post: symlinked .post-checkpoint-required rejects carve-out (same-class)')
+  else bad('3.3b-post: marker symlink should defeat carve-out', `got: ${JSON.stringify(r)}`)
+}
+{
+  const d = mkRepo('3-3b-checkpoint'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // Symlinked .checkpoint-required newer than baseline. The gate-stop
+  // path requires preReq to exist (real or symlink) before evaluating
+  // carve-out — a symlinked preReq passes existsSync but should fail
+  // the carve-out closed.
+  const realCp = path.join(claudeDir, 'real-cp-marker')
+  fs.writeFileSync(realCp, '')
+  setMtime(realCp, Date.now() + 5_000)
+  fs.symlinkSync(realCp, path.join(claudeDir, '.checkpoint-required'))
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('3.3b-cp: symlinked .checkpoint-required rejects carve-out (same-class)')
+  else bad('3.3b-cp: marker symlink should defeat carve-out', `got: ${JSON.stringify(r)}`)
+}
+{
+  const d = mkRepo('3-3b-plan'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  const realPlan = path.join(claudeDir, 'real-plan-marker')
+  fs.writeFileSync(realPlan, '')
+  setMtime(realPlan, Date.now() + 5_000)
+  fs.symlinkSync(realPlan, path.join(claudeDir, '.plan-approval-pending'))
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('3.3b-plan: symlinked .plan-approval-pending rejects carve-out (same-class)')
+  else bad('3.3b-plan: plan-pending symlink should defeat carve-out', `got: ${JSON.stringify(r)}`)
+}
+
 // 3.4 --session-start + --gate stop combo rejected at CLI parse (P2-5).
 // Prevents the silent failure mode where --gate stop's early exit skips
 // the SessionStart-only baseline write.

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+// test-issue-146.mjs — Tests for #146 session-start deadlock fix.
+//
+// Coverage:
+//   L1 — em-recall --gate stop carve-out behavior (subprocess + temp repo)
+//        - 1.1 baseline absent → block (back-compat)
+//        - 1.2 baseline + all-stale → allow (carve-out fires)
+//        - 1.3 baseline + plan-pending newer → block (active plan in flight)
+//        - 1.4 baseline + .checkpoint-required newer → block (re-armed mid-session)
+//        - 1.5 baseline + .post-checkpoint-required newer → block
+//        - 1.6 baseline + plan-pending older (orphan) → allow
+//   L2 — em-recall --session-start side effects
+//        - 2.1 first run creates .session-baseline
+//        - 2.2 second run touches baseline mtime forward
+//        - 2.3 stale .plan-approval-pending cleared on second run
+//        - 2.4 in-flight plan-pending (mtime > prior baseline) preserved
+//        - 2.5 first-ever run leaves plan-pending alone (no prior baseline)
+//   L3 — checkpoint-gate.sh block-reason absolute-path (#146 B1)
+//        - dispatched via test-checkpoint-gate.sh extension; here we just
+//          assert the embedded jq path interpolation works for both pre/post
+//
+// Defensive ordering per feedback_test_resource_existence_check.md: every
+// state assertion is paired with an existence check on the artifact at
+// check time. A misordered cleanup must not pass for the wrong reason.
+
+import { execSync, spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const REPO_ROOT = path.resolve(new URL('..', import.meta.url).pathname)
+const EM_RECALL = path.join(REPO_ROOT, 'scripts', 'em-recall.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) {
+  fail++; failures.push(`${name}: ${detail}`)
+  console.log(`  ✗ ${name}: ${detail}`)
+}
+
+function mkRepo(label) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), `em-146-${label}-`))
+  execSync(`git init -q -b main "${d}"`)
+  execSync(`git -C "${d}" config user.email t@t`)
+  execSync(`git -C "${d}" config user.name t`)
+  fs.writeFileSync(path.join(d, 'README.md'), 'x\n')
+  execSync(`git -C "${d}" add . && git -C "${d}" commit -q -m init`)
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  return d
+}
+
+// Isolated HOME directory for the whole test run. Pinning HOME ensures
+// em-recall reads only the test's local episode store (none seeded), so
+// shouldArmBp001Checkpoint() returns false and the arming block doesn't
+// re-create .checkpoint-required after our cleanup.
+const TEST_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'em-146-home-'))
+fs.mkdirSync(path.join(TEST_HOME, '.episodic-memory', 'episodes'), { recursive: true })
+
+function runGateStop(cwd) {
+  const r = spawnSync('node', [EM_RECALL, '--gate', 'stop'], {
+    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: TEST_HOME }
+  })
+  // Return both stdout and exit status so tests can disambiguate
+  // "carve-out fired" (status 0, empty stdout) from "crashed" (non-0).
+  return { stdout: r.stdout || '', status: r.status }
+}
+
+function runSessionStart(cwd) {
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--limit', '1'], {
+    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: TEST_HOME }
+  })
+  return { stdout: r.stdout || '', status: r.status }
+}
+
+function setMtime(p, ms) {
+  const t = ms / 1000
+  fs.utimesSync(p, t, t)
+}
+
+function isBlock(r) {
+  const out = typeof r === 'string' ? r : r.stdout
+  if (!out) return false
+  try {
+    const j = JSON.parse(out)
+    return j.decision === 'block'
+  } catch { return false }
+}
+
+function isCarveOutAllow(r) {
+  // Strict pass: status 0 AND empty stdout. Distinguishes from a crash
+  // (non-zero status) that also produces empty stdout (P2-4 vacuous fix).
+  return r.status === 0 && !r.stdout
+}
+
+const cleanupDirs = []
+process.on('exit', () => {
+  for (const d of cleanupDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+  try { fs.rmSync(TEST_HOME, { recursive: true, force: true }) } catch {}
+})
+
+// ============================================================================
+console.log('\n=== L1 — stop-gate carve-out behavior ===')
+// ============================================================================
+
+// 1.1 baseline absent → block (back-compat: carve-out only fires when
+// SessionStart hook has shipped on this machine).
+{
+  const d = mkRepo('1-1'); cleanupDirs.push(d)
+  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('1.1: armed + no baseline → block (back-compat)')
+  else bad('1.1: armed + no baseline → block', `got: ${JSON.stringify(r)}`)
+
+  // Defensive: marker still present after gate runs
+  if (fs.existsSync(path.join(d, '.claude', '.checkpoint-required')))
+    ok('1.1 (defensive): marker still present at check time')
+  else bad('1.1 defensive', 'marker disappeared')
+}
+
+// 1.2 baseline + all-stale → allow (carve-out fires)
+{
+  const d = mkRepo('1-2'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  // Make checkpoint-required older
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // baseline now > checkpoint-required
+  const r = runGateStop(d)
+  if (isCarveOutAllow(r)) ok('1.2: baseline + all-stale → allow (carve-out fires)')
+  else bad('1.2: carve-out should fire', `got: ${JSON.stringify(r)}`)
+}
+
+// 1.3 baseline + plan-pending newer than baseline → block
+{
+  const d = mkRepo('1-3'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // sleep effect: plan-pending will be NEWER than baseline
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() + 5_000) // explicitly future to defeat fs resolution
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('1.3: plan-pending newer than baseline → block')
+  else bad('1.3: plan-pending → block', `got: ${JSON.stringify(r)}`)
+  if (fs.existsSync(planP)) ok('1.3 (defensive): plan-pending preserved')
+  else bad('1.3 defensive', 'plan-pending disappeared')
+}
+
+// 1.4 .checkpoint-required re-armed mid-session (newer than baseline) → block
+{
+  const d = mkRepo('1-4'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  fs.writeFileSync(preReq, '')
+  setMtime(preReq, Date.now() + 5_000) // mid-session re-arm
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('1.4: checkpoint-required re-armed mid-session → block')
+  else bad('1.4: re-arm should block', `got: ${JSON.stringify(r)}`)
+}
+
+// 1.5 .post-checkpoint-required newer than baseline → block
+{
+  const d = mkRepo('1-5'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  const postReq = path.join(claudeDir, '.post-checkpoint-required')
+  fs.writeFileSync(postReq, '')
+  setMtime(postReq, Date.now() + 5_000)
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('1.5: post-checkpoint-required mid-session → block')
+  else bad('1.5: post-required should block', `got: ${JSON.stringify(r)}`)
+}
+
+// 1.6 plan-pending OLDER than baseline (orphan) → allow
+{
+  const d = mkRepo('1-6'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.claude')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  const r = runGateStop(d)
+  if (isCarveOutAllow(r)) ok('1.6: orphan plan-pending (older than baseline) → allow')
+  else bad('1.6: orphan should not block', `got: ${JSON.stringify(r)}`)
+}
+
+// ============================================================================
+console.log('\n=== L2 — em-recall --session-start side effects ===')
+// ============================================================================
+
+// 2.1 first run creates .session-baseline
+{
+  const d = mkRepo('2-1'); cleanupDirs.push(d)
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  if (fs.existsSync(baseline)) bad('2.1 setup', 'baseline pre-existed')
+  const r = runSessionStart(d)
+  if (r.status === 0 && fs.existsSync(baseline)) ok('2.1: --session-start creates .session-baseline')
+  else bad('2.1: baseline create', `status=${r.status} exists=${fs.existsSync(baseline)}`)
+}
+
+// 2.2 second run advances baseline mtime
+{
+  const d = mkRepo('2-2'); cleanupDirs.push(d)
+  runSessionStart(d)
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  const m1 = fs.statSync(baseline).mtimeMs
+  // Force temporal separation
+  setMtime(baseline, m1 - 60_000)
+  const m1adj = fs.statSync(baseline).mtimeMs
+  runSessionStart(d)
+  const m2 = fs.statSync(baseline).mtimeMs
+  if (m2 > m1adj) ok('2.2: re-run advances baseline mtime')
+  else bad('2.2: baseline mtime', `before=${m1adj} after=${m2}`)
+}
+
+// 2.3 stale plan-pending cleared on subsequent run (P2-3 stricter)
+{
+  const d = mkRepo('2-3'); cleanupDirs.push(d)
+  runSessionStart(d) // creates baseline
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  // Force temporal separation: roll back baseline by 60s so we have
+  // unambiguous past/future zones to test against.
+  setMtime(baseline, Date.now() - 60_000)
+  const baselineM = fs.statSync(baseline).mtimeMs
+  // simulate prior session's plan-pending: mtime <= prior baseline
+  fs.writeFileSync(planP, '')
+  setMtime(planP, baselineM - 5_000) // unambiguously older than baseline
+  // second SessionStart: should clear stale plan-pending
+  runSessionStart(d)
+  if (!fs.existsSync(planP)) ok('2.3: stale plan-pending cleared on next SessionStart')
+  else bad('2.3: stale plan-pending NOT cleared', `still exists at ${planP}`)
+  // Defensive: baseline was UNAMBIGUOUSLY advanced past prior mtime
+  // (P2-3 vacuous-pass fix: must be strictly greater than the rolled-back
+  // baselineM, not >= which would pass even if write was skipped).
+  const newBaselineM = fs.statSync(baseline).mtimeMs
+  if (newBaselineM > baselineM) ok('2.3 (defensive): baseline mtime strictly advanced')
+  else bad('2.3 defensive', `baseline did not advance: before=${baselineM} after=${newBaselineM}`)
+}
+
+// 2.4 in-flight plan-pending (mtime > prior baseline) preserved
+{
+  const d = mkRepo('2-4'); cleanupDirs.push(d)
+  runSessionStart(d) // baseline at T0
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  const baselineM = fs.statSync(baseline).mtimeMs
+  fs.writeFileSync(planP, '')
+  setMtime(planP, baselineM + 5_000) // newer than prior baseline
+  // second SessionStart: plan-pending should NOT be cleared (in-flight)
+  runSessionStart(d)
+  if (fs.existsSync(planP)) ok('2.4: in-flight plan-pending preserved across SessionStart')
+  else bad('2.4: in-flight plan-pending wrongly cleared', 'plan-pending was newer than prior baseline')
+}
+
+// 2.5 first-ever run with leftover plan-pending leaves it alone
+{
+  const d = mkRepo('2-5'); cleanupDirs.push(d)
+  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  // No prior baseline exists.
+  runSessionStart(d)
+  if (fs.existsSync(planP)) ok('2.5: first-ever SessionStart leaves plan-pending alone (conservative)')
+  else bad('2.5: first-ever wrongly cleared plan-pending', 'baseline was absent — should be conservative')
+}
+
+// ============================================================================
+console.log('\n=== L3 — same-class extension, symlink defense, flag combo ===')
+// ============================================================================
+
+// 3.1 SessionStart clears ALL 3 stale task-signal markers (P1-2 fix).
+// Pre-fix: only .plan-approval-pending was cleared. Post-fix: all 3
+// (.checkpoint-required, .post-checkpoint-required, .plan-approval-pending).
+// Closes the cross-gate fractal P1-3 because write-gate then doesn't see
+// stale .checkpoint-required.
+{
+  const d = mkRepo('3-1'); cleanupDirs.push(d)
+  runSessionStart(d) // creates baseline
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  // Roll back baseline so we have a clear "older than" zone
+  setMtime(baseline, Date.now() - 60_000)
+  const baselineM = fs.statSync(baseline).mtimeMs
+  // Plant all 3 markers older than baseline
+  const markers = [
+    '.checkpoint-required',
+    '.post-checkpoint-required',
+    '.plan-approval-pending'
+  ].map(m => path.join(d, '.claude', m))
+  for (const m of markers) {
+    fs.writeFileSync(m, '')
+    setMtime(m, baselineM - 5_000)
+  }
+  runSessionStart(d)
+  // Defensive: confirm the markers we just planted existed at the moment
+  // we recorded their mtimes (per feedback_test_resource_existence_check.md).
+  // This isn't quite the canonical pattern (cleanup happened between plant
+  // and check), so we instead rely on the pre-cleanup writes succeeding.
+  const cleared = markers.map(m => !fs.existsSync(m))
+  if (cleared.every(Boolean)) ok('3.1: SessionStart clears all 3 stale task-signal markers (P1-2)')
+  else bad('3.1: same-class clear incomplete',
+    markers.map((m, i) => `${path.basename(m)}=${cleared[i] ? 'cleared' : 'PRESENT'}`).join(' '))
+}
+
+// 3.2 SessionStart preserves in-flight markers (newer than prior baseline).
+// Symmetric to 2.4 but covers all 3 markers, not just plan-pending.
+{
+  const d = mkRepo('3-2'); cleanupDirs.push(d)
+  runSessionStart(d)
+  const baseline = path.join(d, '.claude', '.session-baseline')
+  const baselineM = fs.statSync(baseline).mtimeMs
+  const markers = [
+    '.checkpoint-required',
+    '.post-checkpoint-required',
+    '.plan-approval-pending'
+  ].map(m => path.join(d, '.claude', m))
+  for (const m of markers) {
+    fs.writeFileSync(m, '')
+    setMtime(m, baselineM + 5_000) // in-flight (mid-session)
+  }
+  runSessionStart(d)
+  const preserved = markers.map(m => fs.existsSync(m))
+  if (preserved.every(Boolean)) ok('3.2: SessionStart preserves in-flight markers across all 3 class members')
+  else bad('3.2: in-flight wrongly cleared',
+    markers.map((m, i) => `${path.basename(m)}=${preserved[i] ? 'present' : 'CLEARED'}`).join(' '))
+}
+
+// 3.3 Symlink defense (P2-2): a symlinked baseline does not enable the
+// carve-out. Threat-model: honest-agent self-discipline; defense against
+// accidental symlinks (e.g. workspace setups), not adversarial.
+{
+  const d = mkRepo('3-3'); cleanupDirs.push(d)
+  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  // Create a real file elsewhere with very-old mtime, then symlink
+  // .session-baseline to it.
+  const realFile = path.join(d, '.claude', 'real-old-file')
+  fs.writeFileSync(realFile, '')
+  setMtime(realFile, Date.now() - 365 * 24 * 60 * 60 * 1000) // 1 year ago
+  fs.symlinkSync(realFile, path.join(d, '.claude', '.session-baseline'))
+  // Without symlink defense, lstat(real) would say baseline is older than
+  // markers → carve-out fires. With defense: symlink rejected → carve-out
+  // does not fire → block.
+  const r = runGateStop(d)
+  if (isBlock(r) && r.status === 0) ok('3.3: symlinked baseline rejected by carve-out')
+  else bad('3.3: symlink should defeat carve-out', `got: ${JSON.stringify(r)}`)
+}
+
+// 3.4 --session-start + --gate stop combo rejected at CLI parse (P2-5).
+// Prevents the silent failure mode where --gate stop's early exit skips
+// the SessionStart-only baseline write.
+{
+  const d = mkRepo('3-4'); cleanupDirs.push(d)
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--gate', 'stop'], {
+    cwd: d, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']
+  })
+  if (r.status === 1 && r.stdout.includes('cannot be combined')) {
+    ok('3.4: --session-start + --gate combo rejected at CLI parse')
+  } else {
+    bad('3.4: combo reject', `status=${r.status} stdout=${r.stdout}`)
+  }
+}
+
+// 3.5 stop-gate block reason still parses cleanly.
+{
+  const d = mkRepo('3-5'); cleanupDirs.push(d)
+  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  const r = runGateStop(d)
+  let reason = null
+  try { reason = JSON.parse(r.stdout).reason } catch {}
+  if (reason && reason.includes('post-checkpoint-done')) {
+    ok('3.5: stop-gate block reason names .post-checkpoint-done marker')
+  } else {
+    bad('3.5: stop-gate reason', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+// ============================================================================
+console.log('\n==================================================')
+console.log(`Results: ${pass} passed, ${fail} failed`)
+console.log('==================================================')
+if (fail > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  ${f}`)
+  process.exit(1)
+}
+process.exit(0)

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -598,6 +598,18 @@ test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next Sessio
   assert.ok(fs.existsSync(preReq), 'step 1: SessionStart should arm .checkpoint-required')
 
   // ----- Step 2: Stop fires; em-recall --gate stop returns block -----
+  // Post-#146 (A2 carve-out): SessionStart now writes .session-baseline.
+  // For Stop to block, a real mid-session task signal must exist. Without
+  // one, the carve-out correctly treats the turn as no-task-signal and
+  // allows stop. Simulate the post-arming task signal that a real
+  // implementation turn would produce by touching .post-checkpoint-required
+  // with a future mtime (mtime > baseline → carve-out denied).
+  const baseline = path.join(claudeDir, '.session-baseline')
+  if (fs.existsSync(baseline)) {
+    fs.writeFileSync(postReq, '')
+    const future = (Date.now() + 5_000) / 1000
+    fs.utimesSync(postReq, future, future)
+  }
   const stopOut = execSync(`node "${path.join(sessionScripts, 'em-recall.mjs')}" --gate stop`, {
     cwd: sessionProject, env: sessionEnv, encoding: 'utf8'
   })


### PR DESCRIPTION
## Summary

Closes the live deadlock from issue #146 where session-start hooks block all write tools (including writes to `.pre-checkpoint-done` itself) while requiring non-empty marker content.

Three locked-in fixes after planner adversarial review (8-axis matrix) + reviewer code-review pass (12 findings, 4 P1):

- **B1** — `checkpoint-gate.sh` block reasons emit absolute marker paths via `jq` so worktree-cwd agents write to the right place
- **A2** — `em-recall --session-start` writes `.session-baseline`; stop-gate carve-out allows clean stop when no `TASK_SIGNAL_MARKERS` member has `mtime > baseline`
- **A2-orphan / P1-2 / P1-3** — SessionStart clears all 3 stale task-signal markers (closes same-class fractal: `.checkpoint-required`, `.post-checkpoint-required`, `.plan-approval-pending` — not just plan-pending), so the write-gate doesn't see stale state either

## Process flow

| Step | Result |
|---|---|
| Plan-time 8-axis matrix (negative-scenario-planner) | 1 P0 (G1 — REJECT, defended), 2 P1 folded |
| Implementation + tests alongside | 6 files, 624 insertions |
| Code review (negative-scenario-reviewer) | 12 findings: 4 P1, 5 P2, 3 P3 |
| Reviewer fixes folded | P1-1 (comment), P1-2/3 combined, P1-4 (verified install), P2-1, P2-2, P2-3, P2-4, P2-5, P3-3 |
| Deferred | P3-1 → #168, P3-2 → #169 |
| Test sweep | 19 issue-#146 + full regression green; pre-existing #121 unrelated |

## Verdict synthesis on planner G1

The planner argued path-canonicalization in `marker_write` allowlist was required (REJECT plan as scoped). I defended REJECT-with-evidence: agents following the new absolute-path message use absolute path → `TARGET == $PRE_DONE` matches → no canonicalization needed. Canonicalization would double diff size and bring symlink/realpath edge cases (originally B2). Confidence: high. Belongs in B2 follow-up issue per OQ3, not v1.

## Files changed

```
 hooks/checkpoint-gate.sh        | 17 ++++++--
 hooks/em-recall-sessionstart.sh | 10 +++++-
 scripts/em-recall.mjs           | 132 ++++++++++++++++++++++++++++++++++-
 tests/test-checkpoint-gate.sh   | 51 +++++++++++++++++++
 tests/test-issue-146.mjs        | 322 ++++++++++++++++++++++++++++++++ (new)
 tests/test-rfc002-phase3.mjs    | 12 ++++++
 6 files changed, 624 insertions(+), 7 deletions(-)
```

## TASK_SIGNAL_MARKERS contract

New shared constant in `scripts/em-recall.mjs`. Future contributors adding a 4th marker (e.g. `.review-pending`) MUST add it here. Used by both `stopGateCarveOutApplies` and the SessionStart orphan-clear loop — single source of truth for the class.

## Test plan

- [x] `node tests/test-issue-146.mjs` — 19/19 green (carve-out logic, SessionStart side effects, same-class extension, symlink defense, flag-combo reject, B1 reason)
- [x] `bash tests/test-checkpoint-gate.sh` — 103/103 green (3 new B1 cases)
- [x] `bash tests/test-stop-gate.sh` — 24/24 green
- [x] `bash tests/test-em-recall-sessionstart.sh` — 9/9 green
- [x] `node tests/test-rfc002-phase3.mjs` — 29/29 green (T7k updated for A2 semantics)
- [x] Full suite regression — only failure is pre-existing #121 (unrelated)
- [ ] **E2E: verify behavior in a real fresh session after merge + `install.mjs --install-hooks-force`** (counterfactual per workplan v12: did the 4 operating defaults reduce this PR's burn vs PR #163's ~250k baseline?)

## Deployment note (P1-4)

Atomic deploy required: the new `--session-start` flag is silently ignored by the OLD installed em-recall.mjs (no strict-flag check). Result if user updates repo without `install.mjs --install-hooks-force`: `.session-baseline` never written → carve-out permanently inactive → original blocking behavior preserved (no regression, just no fix). Add release note: "Run `node install.mjs --install-hooks-force` after pulling to activate the carve-out."

## Out of scope (filed)

- B2 worktree-path canonicalization
- Issue #146 axis 3 orphan `.checkpoint-required` (now partially handled by SessionStart clear)
- #168 jq-missing fail-loud
- #169 unicode-path test gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)