### PR TITLE
feat(#102): terminal-anchored chain selection in em-workflow-validate

### DIFF
--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -283,18 +283,76 @@ check meaningful, **`--head` is required when `--gate push-allowed` or
 `--gate review-request`** — the validator exits with a usage error if it is
 omitted.
 
-### Multi-`review-request` per task (pre-#102 chain-walk fallback)
+### Terminal-anchored chain selection (#102)
 
-When multiple `review-request` episodes exist for the same task (e.g. user
-re-runs `em-review-request` after fixing a missed ref), the validator picks
-the **latest by timestamp** as the terminal review-request. Older
-review-request episodes are surfaced as warnings (not errors); any errors
-keyed to non-terminal review-request ids are downgraded to warnings.
+Pre-#102: `validateChain` validated all events of a task in bulk; a parallel
+chain (legit + spliced from a prior attempt) could both contribute to required-
+event presence, and #119's push-gate cache had no stable evidence-chain id to
+key on.
 
-This is a pragmatic pre-#102 (chain-walk) fallback. The canonical multi-
-attempt path is `em-revise --original <id>` to make the supersedes chain
-explicit. After [#102](https://github.com/lantisprime/episodic-memory/issues/102)
-lands, chain-walk anchors at the terminal explicitly; this rule will tighten.
+Post-#102: the validator anchors at the **terminal event** for the gate, walks
+refs backward, and produces a `selectedChain` set of episode ids. Out-of-chain
+episodes still appear in `episodes[]` (with `in_chain: false`) but their
+errors are downgraded to warnings and they don't satisfy required-event
+presence.
+
+#### Walk axes per terminal
+
+| Terminal event | Walk refs |
+|---|---|
+| `pre-checkpoint` | `approval_ref` |
+| `post-checkpoint` | `pre_checkpoint_ref` → its `approval_ref` |
+| `push-allowed` | `post_checkpoint_ref` → its `pre_checkpoint_ref` → its `approval_ref` |
+| `review-request` | `post_checkpoint_ref` → its `pre_checkpoint_ref` → its `approval_ref`, plus coalescence assertions on the rr's own `pre_checkpoint_ref` and `approval_ref` (see below) |
+
+#### Terminal selection (tiebreak)
+
+When multiple events match `TERMINAL_FOR_GATE[gate]`:
+
+1. **Head match** — when `--head` is passed, candidates whose `ctx.head ===
+   --head` are preferred over those that don't match.
+2. **Latest by timestamp** (descending) within the matching pool.
+3. **Lex desc on `entry.id`** as the tail tiebreak. Counter-suffixed ids are
+   monotonic, so this is deterministic across filesystems (avoids macOS vs
+   Linux flakes).
+
+#### `review-request` coalescence (Gap #1, PR #156 F1 same-class)
+
+A `review-request` carries three independent chain refs (`approval_ref`,
+`pre_checkpoint_ref`, `post_checkpoint_ref`). Walking via `post_checkpoint_ref`
+alone would silently accept divergent refs that all happen to be same-task /
+right-event-type but don't form a coherent chain. The validator additionally
+asserts:
+
+- `rr.pre_checkpoint_ref === post.pre_checkpoint_ref` (where `post` is the
+  walked target of `rr.post_checkpoint_ref`)
+- `rr.approval_ref === pre.approval_ref` (where `pre` is the walked target of
+  `post.pre_checkpoint_ref`)
+
+Mismatch produces a coalescence error keyed to the review-request, blocking
+the gate.
+
+This closes the same-class gap that bit PR #156 review F1 (lesson
+`20260505-070434-...-90c7`): fixing one chain-ref check requires auditing all
+three parallel members at the deferral moment, not the fix moment.
+
+#### `episodes[]` JSON shape
+
+Every event in `events[]` (any task-matching `workflow.lifecycle` episode)
+appears in `episodes[]` regardless of chain membership. The `in_chain: bool`
+field marks chain membership. Cache consumers (#119) use this to derive a
+stable evidence-chain id from the in-chain set.
+
+Pre-#102 callers reading `episodes[]` for "all task episodes" continue to
+work; new callers can filter by `in_chain: true` for the gated chain.
+
+#### Multi-`review-request` per task
+
+Older review-requests (re-runs after fixing missed refs) become out-of-chain
+under terminal-anchored selection. The canonical multi-attempt path remains
+`em-revise --original <id>` to make the supersedes chain explicit; the
+terminal-anchored fallback emits a "superseded by terminal review-request"
+warning to surface the implicit chain even when supersedes wasn't recorded.
 
 ### Wrapper-validator scope-parity contract
 

--- a/docs/specs/workflow-lifecycle.md
+++ b/docs/specs/workflow-lifecycle.md
@@ -318,11 +318,11 @@ When multiple events match `TERMINAL_FOR_GATE[gate]`:
 
 #### `review-request` coalescence (Gap #1, PR #156 F1 same-class)
 
-A `review-request` carries three independent chain refs (`approval_ref`,
-`pre_checkpoint_ref`, `post_checkpoint_ref`). Walking via `post_checkpoint_ref`
-alone would silently accept divergent refs that all happen to be same-task /
-right-event-type but don't form a coherent chain. The validator additionally
-asserts:
+A `review-request` carries three independent chain identity refs
+(`approval_ref`, `pre_checkpoint_ref`, `post_checkpoint_ref`). Walking via
+`post_checkpoint_ref` alone would silently accept divergent refs that all
+happen to be same-task / right-event-type but don't form a coherent chain.
+The validator additionally asserts:
 
 - `rr.pre_checkpoint_ref === post.pre_checkpoint_ref` (where `post` is the
   walked target of `rr.post_checkpoint_ref`)
@@ -331,6 +331,14 @@ asserts:
 
 Mismatch produces a coalescence error keyed to the review-request, blocking
 the gate.
+
+`plan_ref` is **NOT** coalescence-checked. It points to the plan artifact (a
+file, URL, or arbitrary episode containing the plan), distinct from
+`approval_ref` which points to the `plan-approved` lifecycle episode. Per
+spec above, episode-shaped `plan_ref` MAY point at a non-lifecycle plan-doc
+episode used consistently across `plan-approved`, `pre-checkpoint`, and
+`review-request`. Treating it as a chain identity ref would false-reject this
+legitimate pattern (Codex PR #171 review catch).
 
 This closes the same-class gap that bit PR #156 review F1 (lesson
 `20260505-070434-...-90c7`): fixing one chain-ref check requires auditing all

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -756,20 +756,16 @@ function validateChain(events, errors, warnings, gateArg, headArg, selectedChain
         if (walkedApprovalRef && rrApprovalRef && walkedApprovalRef !== rrApprovalRef) {
           errors.push(`episode:${rr.entry.id}: approval_ref "${rrApprovalRef}" does not coalesce with pre-checkpoint's approval_ref "${walkedApprovalRef}" (chain refs must converge — divergent refs indicate splice or cross-chain forgery)`)
         }
-        // plan_ref coalescence (review M1: 4-member class, was 3-member).
-        // When rr.plan_ref is episode-shaped, it must equal the walked
-        // plan-approved id (i.e., pre.approval_ref). free-form plan_ref
-        // (file/URL) is not coalescence-checked — only episode-shaped refs
-        // can carry chain identity. Closes the same forgery vector as the
-        // pre/approval coalescence: rr could otherwise carry plan_ref:
-        // episode:<unrelated-plan-approved> while the walked path lands at
-        // the canonical chain (PR #156 F1 same-class shape, full sweep).
-        const rrPlanRef = rr.payload.plan_ref
-        if (typeof rrPlanRef === 'string' && rrPlanRef.startsWith('episode:') &&
-            walkedApprovalRef && rrPlanRef !== walkedApprovalRef) {
-          errors.push(`episode:${rr.entry.id}: plan_ref "${rrPlanRef}" does not coalesce with walked plan-approved "${walkedApprovalRef}" (when plan_ref is episode-shaped, chain refs must converge)`)
-        }
       }
+      // NOTE: plan_ref is NOT coalescence-checked. plan_ref points to the plan
+      // artifact (a doc, episode, or URL) — distinct from approval_ref which
+      // points to the plan-approved lifecycle episode. Spec workflow-lifecycle.md:151
+      // explicitly allows rr.plan_ref to be episode-shaped pointing to a
+      // separate plan-document episode. Codex review on PR #171 caught a
+      // false-rejection where I had treated plan_ref as a chain-identity ref;
+      // the correct semantics is "witness/artifact ref, resolved via
+      // checkEpisodeRefs but not bound to chain identity." See T102-22 for
+      // the legitimate episode-shaped plan_ref pattern.
     }
   }
   for (const rr of reviewRequests) {

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -564,11 +564,112 @@ function resolveEpisodeRef(ref, indexById, currentEpisode, opts = {}) {
 // Free-form strings are rejected (was previously unvalidated — #98 finding 2).
 const ISSUE_REF_RE = /^(https:\/\/github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+|gh:[^\/\s]+\/[^\/\s#]+#\d+)$/
 
-function validateChain(events, errors, warnings, gateArg, headArg) {
+// ---------------------------------------------------------------------------
+// Terminal-anchored chain selection (#102).
+//
+// Pre-#102: validateChain validated ALL events of every type for a task in
+// bulk; presentEvents was the union of every event type observed. Two parallel
+// chains (legit + spliced from prior attempt) both contributed to required-
+// event presence, and #119's push-gate cache had no stable "evidence-chain id"
+// to key on.
+//
+// Post-#102: anchor at the terminal event for the gate, walk refs backward
+// through approval_ref / pre_checkpoint_ref / post_checkpoint_ref, return the
+// selected chain id-set. validateChain runs splice-resistance against ALL
+// events as before, but errors keyed to out-of-chain episodes are migrated to
+// warnings, and presentEvents is computed from selectedChain only.
+//
+// Tiebreak when multiple terminal candidates exist:
+//   1. ctx.head === --head exact (when --head passed)
+//   2. Latest by (date, time) descending
+//   3. entry.id lex descending  (id has counter suffix → monotonic & deterministic)
+//
+// Walk axes per terminal event:
+//   pre-checkpoint   →  approval_ref
+//   post-checkpoint  →  pre_checkpoint_ref → its approval_ref
+//   push-allowed     →  post_checkpoint_ref → its pre_checkpoint_ref → approval_ref
+//   review-request   →  post_checkpoint_ref → its pre_checkpoint_ref → approval_ref
+//                       PLUS coalescence assertions on rr's own pre_checkpoint_ref
+//                       and approval_ref (Gap #1: PR #156 F1 same-class shape).
+// ---------------------------------------------------------------------------
+function pickTerminal(candidates, headArg) {
+  // Prefer ctx.head === --head exact match when --head is provided.
+  let pool = candidates
+  if (headArg) {
+    const matched = candidates.filter(c => c.payload.context && c.payload.context.head === headArg)
+    if (matched.length > 0) pool = matched
+  }
+  // Then latest by (date, time) desc; tail tiebreak by entry.id lex desc.
+  // Stable lex compare on date+' '+time works because ISO timestamps are
+  // zero-padded.
+  return pool.slice().sort((a, b) => {
+    const ka = `${a.entry.date} ${a.entry.time}`
+    const kb = `${b.entry.date} ${b.entry.time}`
+    if (ka < kb) return 1
+    if (ka > kb) return -1
+    if (a.entry.id < b.entry.id) return 1
+    if (a.entry.id > b.entry.id) return -1
+    return 0
+  })[0]
+}
+
+function selectChain(events, gateArg, headArg) {
+  const terminalEvent = TERMINAL_FOR_GATE[gateArg]
+  const candidates = events.filter(e => e.payload.event === terminalEvent)
+  if (candidates.length === 0) {
+    return { selectedChain: new Set(), terminal: null }
+  }
+  const terminal = pickTerminal(candidates, headArg)
+  const selectedChain = new Set([terminal.entry.id])
+
+  // Build event lookup by id for walking.
+  const byId = new Map()
+  for (const e of events) byId.set(e.entry.id, e)
+
+  // Walk axes — ordered list of refs to follow from the current event.
+  // Cycle guard: visited Set prevents infinite loops if refs form a cycle
+  // (resolveEpisodeRef already rejects self-witness and timestamp inversions,
+  // but defensive guard keeps walker safe even under malformed inputs).
+  function walk(startEvent) {
+    const queue = [startEvent]
+    while (queue.length > 0) {
+      const current = queue.shift()
+      const refs = []
+      switch (current.payload.event) {
+        case 'review-request':
+        case 'push-allowed':
+          refs.push(current.payload.post_checkpoint_ref)
+          break
+        case 'post-checkpoint':
+          refs.push(current.payload.pre_checkpoint_ref)
+          break
+        case 'pre-checkpoint':
+          refs.push(current.payload.approval_ref)
+          break
+        // plan-approved is the chain root — nothing to walk back to.
+      }
+      for (const ref of refs) {
+        const targetId = refTarget(ref)
+        if (!targetId) continue                 // null/placeholder/non-episode — already errored upstream
+        if (selectedChain.has(targetId)) continue // cycle/visited guard
+        const target = byId.get(targetId)
+        if (!target) continue                   // missing — already errored upstream
+        selectedChain.add(targetId)
+        queue.push(target)
+      }
+    }
+  }
+  walk(terminal)
+  return { selectedChain, terminal }
+}
+
+function validateChain(events, errors, warnings, gateArg, headArg, selectedChain, terminal) {
   const byEvent = {}
+  const eventById = new Map()
   for (const e of events) {
     if (!byEvent[e.payload.event]) byEvent[e.payload.event] = []
     byEvent[e.payload.event].push(e)
+    eventById.set(e.entry.id, e)
   }
   // pre-checkpoint.approval_ref must point to a plan-approved episode for same task
   for (const pre of (byEvent['pre-checkpoint'] || [])) {
@@ -618,27 +719,57 @@ function validateChain(events, errors, warnings, gateArg, headArg) {
     }
   }
   // review-request handling (#118).
-  // 1) Multi-review-request "latest-by-timestamp wins" pre-#102 chain-walk
-  //    fallback (folded gap #1). Older review-request episodes' errors get
-  //    downgraded to warnings — they may have stale refs from prior attempts,
-  //    which is OK as long as the terminal review-request is clean.
-  // 2) post_checkpoint_ref chain-link check (mirrors push-allowed contract).
+  // post_checkpoint_ref chain-link check (mirrors push-allowed contract).
+  // Multi-review-request resolution is now terminal-anchored via selectChain
+  // (#102): the gate's terminal is the chain anchor, non-terminal review-
+  // requests are out-of-chain and their errors get migrated to warnings by the
+  // generalized out-of-chain migration below.
   const reviewRequests = byEvent['review-request'] || []
-  let nonTerminalRrIds = new Set()
-  if (reviewRequests.length > 1) {
-    const sorted = reviewRequests.slice().sort((a, b) => {
-      const ka = `${a.entry.date} ${a.entry.time}`
-      const kb = `${b.entry.date} ${b.entry.time}`
-      // ISO date strings are zero-padded, so plain ASCII compare is correct.
-      // Descending: latest first.
-      if (ka < kb) return 1
-      if (ka > kb) return -1
-      return 0
-    })
-    const terminal = sorted[0]
-    nonTerminalRrIds = new Set(sorted.slice(1).map(e => e.entry.id))
-    for (const ntId of nonTerminalRrIds) {
-      warnings.push(`episode:${ntId}: superseded by review-request episode:${terminal.entry.id} (latest-by-timestamp wins; consider em-revise to make the supersedes chain explicit)`)
+  if (gateArg === 'review-request' && terminal && reviewRequests.length > 1) {
+    for (const rr of reviewRequests) {
+      if (rr.entry.id === terminal.entry.id) continue
+      warnings.push(`episode:${rr.entry.id}: superseded by terminal review-request episode:${terminal.entry.id} (chain-walk anchored at terminal; consider em-revise to make the supersedes chain explicit)`)
+    }
+  }
+  // Coalescence assertions on terminal review-request (#102 Gap #1, the PR #156
+  // F1 same-class shape). When the chain walks rr → post → pre → approval but
+  // rr ALSO carries its own pre_checkpoint_ref + approval_ref, those refs MUST
+  // converge to the same chain — otherwise a forged or accidentally cross-
+  // pointing rr could pass with three valid same-task refs that don't form a
+  // coherent chain. Without coalescence, walking via post_checkpoint_ref alone
+  // would silently accept the divergent refs.
+  if (gateArg === 'review-request' && terminal && terminal.payload.event === 'review-request') {
+    const rr = terminal
+    const postId = refTarget(rr.payload.post_checkpoint_ref)
+    if (postId && eventById.get(postId)) {
+      const post = eventById.get(postId)
+      const walkedPreRef = post.payload.pre_checkpoint_ref
+      const rrPreRef = rr.payload.pre_checkpoint_ref
+      if (walkedPreRef && rrPreRef && walkedPreRef !== rrPreRef) {
+        errors.push(`episode:${rr.entry.id}: pre_checkpoint_ref "${rrPreRef}" does not coalesce with post-checkpoint's pre_checkpoint_ref "${walkedPreRef}" (chain refs must converge — divergent refs indicate splice or cross-chain forgery)`)
+      }
+      const preId = refTarget(walkedPreRef)
+      if (preId && eventById.get(preId)) {
+        const pre = eventById.get(preId)
+        const walkedApprovalRef = pre.payload.approval_ref
+        const rrApprovalRef = rr.payload.approval_ref
+        if (walkedApprovalRef && rrApprovalRef && walkedApprovalRef !== rrApprovalRef) {
+          errors.push(`episode:${rr.entry.id}: approval_ref "${rrApprovalRef}" does not coalesce with pre-checkpoint's approval_ref "${walkedApprovalRef}" (chain refs must converge — divergent refs indicate splice or cross-chain forgery)`)
+        }
+        // plan_ref coalescence (review M1: 4-member class, was 3-member).
+        // When rr.plan_ref is episode-shaped, it must equal the walked
+        // plan-approved id (i.e., pre.approval_ref). free-form plan_ref
+        // (file/URL) is not coalescence-checked — only episode-shaped refs
+        // can carry chain identity. Closes the same forgery vector as the
+        // pre/approval coalescence: rr could otherwise carry plan_ref:
+        // episode:<unrelated-plan-approved> while the walked path lands at
+        // the canonical chain (PR #156 F1 same-class shape, full sweep).
+        const rrPlanRef = rr.payload.plan_ref
+        if (typeof rrPlanRef === 'string' && rrPlanRef.startsWith('episode:') &&
+            walkedApprovalRef && rrPlanRef !== walkedApprovalRef) {
+          errors.push(`episode:${rr.entry.id}: plan_ref "${rrPlanRef}" does not coalesce with walked plan-approved "${walkedApprovalRef}" (when plan_ref is episode-shaped, chain refs must converge)`)
+        }
+      }
     }
   }
   for (const rr of reviewRequests) {
@@ -682,22 +813,28 @@ function validateChain(events, errors, warnings, gateArg, headArg) {
       }
     }
   }
-  // Migrate any errors KEYED TO non-terminal review-request ids → warnings.
-  // Errors emitted in validatePayload are anchored to `episode:<id>:` at the
-  // start (see fp = `episode:${entry.id}` at validatePayload:220). We only
-  // migrate errors that BEGIN with `episode:<ntId>:` — substring match would
-  // false-migrate errors that mention a non-terminal id elsewhere in the
-  // string (e.g. terminal review-request citing an older one) (review M1).
-  if (nonTerminalRrIds.size > 0) {
+  // Migrate errors KEYED TO out-of-chain episode ids → warnings (#102).
+  //
+  // Generalizes the prior non-terminal-review-request migration: any error
+  // whose anchor id (the `episode:<id>:` prefix at error start) is NOT in
+  // selectedChain is downgraded to a warning. Errors anchored to in-chain ids
+  // stay as errors. Substring-match avoidance preserved (review M1): use
+  // `startsWith` so an in-chain error that mentions an out-of-chain id
+  // mid-string (e.g. "X cites missing Y" where X is in-chain) is NOT migrated.
+  //
+  // Errors not anchored to any episode id (synthetic chain-link errors that
+  // start with something other than `episode:`) are left as errors — they
+  // surface chain-shape violations that aren't tied to a specific event.
+  if (selectedChain && selectedChain.size > 0) {
     const migrated = []
     for (let i = errors.length - 1; i >= 0; i--) {
       const err = errors[i]
-      for (const ntId of nonTerminalRrIds) {
-        if (err.startsWith(`episode:${ntId}:`)) {
-          migrated.push(`(non-terminal review-request) ${err}`)
-          errors.splice(i, 1)
-          break
-        }
+      const m = err.match(/^episode:([^:]+):/)
+      if (!m) continue
+      const anchorId = m[1]
+      if (!selectedChain.has(anchorId)) {
+        migrated.push(`(out-of-chain) ${err}`)
+        errors.splice(i, 1)
       }
     }
     warnings.push(...migrated)
@@ -762,9 +899,26 @@ for (const entry of workflowEntries) {
   events.push({ entry, payload })
 }
 
-validateChain(events, errors, warnings, gate, head)
+// Terminal-anchored chain selection (#102). selectedChain identifies the chain
+// reachable by walking refs backward from the gate's terminal event. Out-of-
+// chain events still appear in episodes[] with `in_chain: false`, but their
+// errors are migrated to warnings and they don't satisfy required-event
+// presence — closing the bulk-validation parallel-chain gap.
+const { selectedChain, terminal } = selectChain(events, gate, head)
 
-const presentEvents = new Set(events.map(e => e.payload.event))
+validateChain(events, errors, warnings, gate, head, selectedChain, terminal)
+
+// presentEvents counts only events in selectedChain — parallel chains' events
+// no longer satisfy required-event presence (#102).
+//
+// Fallback (review m2): when no terminal exists for the gate (selectedChain
+// empty), compute presentEvents from ALL task events. This preserves the
+// pre-#102 UX of "missing only the terminal" instead of "missing everything"
+// when a user has plan/pre/post recorded but forgot the terminal — the
+// actionable signal stays visible.
+const presentEvents = selectedChain.size > 0
+  ? new Set(events.filter(e => selectedChain.has(e.entry.id)).map(e => e.payload.event))
+  : new Set(events.map(e => e.payload.event))
 const required = REQUIRED_FOR_GATE[gate] || []
 const missing = required.filter(e => !presentEvents.has(e))
 
@@ -783,6 +937,7 @@ const output = {
   episodes: events.map(e => ({
     id: e.entry.id,
     event: e.payload.event,
+    in_chain: selectedChain.has(e.entry.id),
     date: e.entry.date,
     time: e.entry.time,
     branch: e.payload.context && e.payload.context.branch,

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -2139,34 +2139,54 @@ test('T102-20 single coherent chain: regression — gate passes, all events in_c
   assert.deepStrictEqual(inChainEvents.sort(), ['plan-approved', 'post-checkpoint', 'pre-checkpoint'].sort())
 })
 
-test('T102-22 review-request coalescence: rr.plan_ref (episode-shaped) diverges from walked plan-approved', () => {
-  // Review M1 catch: plan_ref is the 4th member of the rr-coalescence class.
-  // When rr.plan_ref is episode-shaped, it must equal the walked plan-approved.
-  // Forgery vector: a parallel plan-approved exists for the same task; rr's
-  // chain refs (post→pre→approval) point at canonical chain, but rr.plan_ref
-  // points at the rogue plan. Without this assertion, divergent plan_ref
-  // would silently pass.
-  const chain = mkBaseChainForReview()
-  const rogueePlanId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'rogue.md' } })
-  // rr's chain refs are coherent (point at chain), but plan_ref points elsewhere.
-  mkReviewRequest({
-    chain,
-    extra: { plan_ref: `episode:${rogueePlanId}` },
+test('T102-22 review-request: legitimate episode-shaped plan_ref (plan-doc episode) PASSES', () => {
+  // Codex PR #171 review repro: rr.plan_ref points at a separate non-lifecycle
+  // plan-document episode (which the plan-approved + pre-checkpoint also
+  // reference as their plan_ref). This is a legitimate pattern per spec
+  // workflow-lifecycle.md:151. plan_ref is the plan artifact, NOT the
+  // plan-approved lifecycle episode. An earlier (incorrect) coalescence
+  // assertion conflated these and false-rejected this shape; this test locks
+  // the correct semantics.
+  //
+  // Build chain manually (mkBaseChainForReview hardcodes plan_ref='p.md').
+  const planDocId = mkWitness({ category: 'discovery', summary: 'plan doc as episode' })
+  const lId = mkWitness({ summary: 'log-pd' })
+  const rId = mkWitness({ summary: 'review-pd' })
+  const eId = mkWitness({ summary: 'e2e-pd' })
+  const planId = mkEpisode({
+    event: 'plan-approved',
+    extra: { plan_ref: `episode:${planDocId}` },
   })
+  const preId = mkEpisode({
+    event: 'pre-checkpoint',
+    extra: { plan_ref: `episode:${planDocId}`, approval_ref: `episode:${planId}` },
+  })
+  const postId = mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      pre_checkpoint_ref: `episode:${preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+  // rr with all chain refs coherent + episode-shaped plan_ref to the doc.
+  const chain = { planId, preId, postId, logId: lId, reviewId: rId, e2eId: eId }
+  mkReviewRequest({ chain, extra: { plan_ref: `episode:${planDocId}` } })
   const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
-  assert.strictEqual(r.json.valid, false, `plan_ref divergence must reject; errors: ${JSON.stringify(r.json.errors)}`)
-  assert.ok(r.json.errors.some(e => e.includes('plan_ref') && e.includes('coalesce')),
-    `expected coalescence error on plan_ref, got: ${JSON.stringify(r.json.errors)}`)
+  assert.strictEqual(r.json.valid, true, `legitimate episode-shaped plan_ref must pass; errors: ${JSON.stringify(r.json.errors)}`)
 })
 
-test('T102-23 review-request: rr.plan_ref as file/URL (free-form) does NOT trigger coalescence', () => {
-  // Regression guard: free-form plan_ref (file path or URL) must continue to
-  // pass — only episode-shaped plan_ref triggers coalescence (since only
-  // episode refs carry chain identity).
+test('T102-23 review-request: rr.plan_ref as file/URL (free-form) PASSES', () => {
+  // Regression guard: free-form plan_ref (file path or URL) is the most common
+  // case per spec.
   const chain = mkBaseChainForReview()
   mkReviewRequest({ chain, extra: { plan_ref: 'docs/plan-with-different-text.md' } })
   const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
-  assert.strictEqual(r.json.valid, true, `free-form plan_ref must not trigger coalescence; errors: ${JSON.stringify(r.json.errors)}`)
+  assert.strictEqual(r.json.valid, true, `free-form plan_ref must pass; errors: ${JSON.stringify(r.json.errors)}`)
 })
 
 test('T102-21 semantic-flip vs T58: chain-walk picks DIFFERENT rr than latest-by-timestamp would', () => {

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -1131,10 +1131,12 @@ test('T58 multi-review-request: latest-by-timestamp wins, older becomes warning'
   mkReviewRequest({ chain })
   const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
   assert.strictEqual(r.json.valid, true, `terminal review-request is valid; errors: ${JSON.stringify(r.json.errors)}`)
-  assert.ok(r.json.warnings.some(w => w.includes(olderId) && w.includes('superseded by review-request')),
+  // Post-#102: terminal-anchored chain selection. Older review-request is
+  // out-of-chain; supersedes warning + its errors are migrated.
+  assert.ok(r.json.warnings.some(w => w.includes(olderId) && w.includes('superseded by terminal review-request')),
     `expected supersedes warning, got: ${JSON.stringify(r.json.warnings)}`)
-  assert.ok(r.json.warnings.some(w => w.includes('non-terminal review-request')),
-    `expected migrated error → warning, got: ${JSON.stringify(r.json.warnings)}`)
+  assert.ok(r.json.warnings.some(w => w.includes('(out-of-chain)') && w.includes(olderId)),
+    `expected out-of-chain migrated warning, got: ${JSON.stringify(r.json.warnings)}`)
 })
 
 test('T59 push-allowed regression: still works WITHOUT review-request in chain', () => {
@@ -1765,6 +1767,462 @@ test('T67 wrapper: --dry-run prints payload without writing', () => {
   // No new episode file written.
   const afterFiles = fs.readdirSync(episodesDir).length
   assert.strictEqual(afterFiles, beforeFiles, 'dry-run should not write episode file')
+})
+
+// ===========================================================================
+// #102 — terminal-anchored chain selection
+// ===========================================================================
+
+// Helper: build a parallel post-checkpoint episode in the same task that is
+// NOT chain-linked from any terminal. Used to verify the new contract that
+// out-of-chain post-checkpoints don't satisfy required-event presence.
+function mkParallelPostCheckpoint({ chain }) {
+  const lId = mkWitness({ summary: 'log-parallel' })
+  const rId = mkWitness({ summary: 'review-parallel' })
+  const eId = mkWitness({ summary: 'e2e-parallel' })
+  return mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      pre_checkpoint_ref: `episode:${chain.preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+}
+
+test('T102-1 selectChain: two post-checkpoints, only one chain-linked from push-allowed', () => {
+  const chain = mkBaseChainForReview()
+  const parallelPostId = mkParallelPostCheckpoint({ chain })
+  // push-allowed references the canonical post-checkpoint, not the parallel.
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `gate should pass; errors: ${JSON.stringify(r.json.errors)}`)
+  // Parallel post-ckpt is in episodes[] but in_chain: false.
+  const parallel = r.json.episodes.find(e => e.id === parallelPostId)
+  assert.ok(parallel, `parallel post should appear in episodes[]`)
+  assert.strictEqual(parallel.in_chain, false, `parallel post must NOT be in selectedChain`)
+  // Canonical post is in_chain: true.
+  const canon = r.json.episodes.find(e => e.id === chain.postId)
+  assert.strictEqual(canon.in_chain, true)
+})
+
+test('T102-2 selectChain: in_chain set includes plan/pre/post for push-allowed walk', () => {
+  const chain = mkBaseChainForReview()
+  const paId = mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true)
+  const inChainIds = new Set(r.json.episodes.filter(e => e.in_chain).map(e => e.id))
+  assert.ok(inChainIds.has(chain.planId), 'plan-approved should be in chain')
+  assert.ok(inChainIds.has(chain.preId), 'pre-checkpoint should be in chain')
+  assert.ok(inChainIds.has(chain.postId), 'post-checkpoint should be in chain')
+  assert.ok(inChainIds.has(paId), 'push-allowed terminal should be in chain')
+})
+
+test('T102-3 selectChain: multiple plan-approved revisions, only chain-linked one in selectedChain', () => {
+  const chain = mkBaseChainForReview()
+  // Build a parallel plan-approved that's NOT referenced.
+  const parallelPlanId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p2.md' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  const parallel = r.json.episodes.find(e => e.id === parallelPlanId)
+  assert.ok(parallel)
+  assert.strictEqual(parallel.in_chain, false, `unreferenced plan-approved must NOT be in selectedChain`)
+  const canon = r.json.episodes.find(e => e.id === chain.planId)
+  assert.strictEqual(canon.in_chain, true)
+})
+
+test('T102-4 review-request gate: chain-walk picks coherent chain, parallel chain warned', () => {
+  // Two complete chains for same task; only chain1 has a review-request.
+  const chain1 = mkBaseChainForReview()
+  const lId2 = mkWitness({ summary: 'log2' })
+  const rId2 = mkWitness({ summary: 'review2' })
+  const eId2 = mkWitness({ summary: 'e2e2' })
+  const planId2 = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p2.md' } })
+  const preId2 = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p2.md', approval_ref: `episode:${planId2}` } })
+  const postId2 = mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      pre_checkpoint_ref: `episode:${preId2}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId2}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId2}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId2}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+  mkReviewRequest({ chain: chain1 })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `gate should pass; errors: ${JSON.stringify(r.json.errors)}`)
+  const inChain = new Set(r.json.episodes.filter(e => e.in_chain).map(e => e.id))
+  assert.ok(inChain.has(chain1.planId) && inChain.has(chain1.preId) && inChain.has(chain1.postId),
+    'chain1 entirely in selectedChain')
+  assert.ok(!inChain.has(planId2) && !inChain.has(preId2) && !inChain.has(postId2),
+    'chain2 entirely out-of-chain')
+})
+
+test('T102-5 out-of-chain post-checkpoint with branch mismatch: error migrated to warning', () => {
+  // A parallel post-ckpt with mismatched branch produces a branch-mismatch
+  // error pre-fix; post-fix it's out-of-chain so the error becomes a warning
+  // and gate still passes against the canonical chain. Branch mismatch is
+  // enforced unconditionally in validatePayload (no git dependency, unlike
+  // the head ancestor check).
+  const chain = mkBaseChainForReview()
+  const lId = mkWitness({ summary: 'log-x' })
+  const rId = mkWitness({ summary: 'review-x' })
+  const eId = mkWitness({ summary: 'e2e-x' })
+  const parallelPostId = mkEpisode({
+    event: 'post-checkpoint',
+    branch: 'feature-other',
+    extra: {
+      pre_checkpoint_ref: `episode:${chain.preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234', '--branch', 'main'])
+  assert.strictEqual(r.json.valid, true, `gate must pass; errors: ${JSON.stringify(r.json.errors)}`)
+  // The branch-mismatch text is now in warnings, prefixed (out-of-chain).
+  assert.ok(r.json.warnings.some(w => w.includes('(out-of-chain)') && w.includes(parallelPostId) && w.includes('branch')),
+    `expected migrated branch-mismatch warning, got: ${JSON.stringify(r.json.warnings)}`)
+})
+
+test('T102-6 broken ref mid-chain: terminal references missing post-checkpoint id', () => {
+  // selectChain walker tolerates missing refs (validatePayload already errored
+  // upstream). Walk halts; selectedChain only contains terminal. presentEvents
+  // missing post-checkpoint → gate fails with missing[].
+  const chain = mkBaseChainForReview()
+  // push-allowed cites a non-existent post-checkpoint id.
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: 'episode:does-not-exist-xyz' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  // The original "not found" error is preserved (precise error string, not
+  // synthesized "chain unselectable").
+  assert.ok(r.json.errors.some(e => e.includes('does-not-exist-xyz')),
+    `expected precise not-found error preserved, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-7 triggered_by NOT walked into selectedChain', () => {
+  const chain = mkBaseChainForReview()
+  const trigId = mkWitness({ category: 'lesson', summary: 'trigger lesson' })
+  mkReviewRequest({ chain, extra: { triggered_by: `episode:${trigId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true)
+  const trig = r.json.episodes.find(e => e.id === trigId)
+  // Witness episodes (lesson category) aren't in workflow.lifecycle pre-filter
+  // so they don't appear in episodes[] at all. selectChain must not pull them.
+  assert.strictEqual(trig, undefined, 'triggered_by witness should not be in episodes[]')
+})
+
+test('T102-8 second_opinion.reply_ref NOT in selectedChain', () => {
+  // pre-checkpoint with second_opinion.reply_ref to a non-lifecycle witness.
+  // selectedChain walks approval_ref only; reply_ref is a witness, not a chain link.
+  const lId = mkWitness({ summary: 'so-reply' })
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({
+    event: 'pre-checkpoint',
+    extra: {
+      plan_ref: 'p.md',
+      approval_ref: `episode:${planId}`,
+      second_opinion: { status: 'done', recipient: 'codex', reply_ref: `episode:${lId}` },
+    },
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  // Witness lId is non-lifecycle; not in episodes[]. Confirms it didn't sneak in.
+  const witnessInEpisodes = r.json.episodes.find(e => e.id === lId)
+  assert.strictEqual(witnessInEpisodes, undefined)
+})
+
+test('T102-9 walk hits cross-category ref: error preserved, missing populated', () => {
+  // pre-checkpoint approval_ref points to non-lifecycle category (caught by
+  // expectedCategory check upstream). selectChain walks anyway but the error
+  // is raised by validatePayload + checkEpisodeRefs.
+  const witnessId = mkWitness({ category: 'discovery', summary: 'fake plan' })
+  mkEpisode({
+    event: 'pre-checkpoint',
+    extra: { plan_ref: 'p.md', approval_ref: `episode:${witnessId}` },
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref') && e.includes('category')),
+    `expected category-mismatch error preserved, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-10 no-terminal: gate=post-checkpoint with only plan+pre → missing[] populated, no crash', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.missing.includes('post-checkpoint'),
+    `expected missing post-checkpoint, got: ${JSON.stringify(r.json.missing)}`)
+})
+
+test('T102-11 placeholder approval_ref in terminal: walk halts, plan-approved missing', () => {
+  // pre-checkpoint with placeholder approval_ref. validatePayload errors;
+  // selectChain walk halts at terminal; plan-approved not in selectedChain.
+  // Even if a plan-approved exists for the task, it's not in selectedChain.
+  mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: 'episode:' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  // missing reflects out-of-chain plan-approved.
+  assert.ok(r.json.missing.includes('plan-approved'),
+    `expected missing plan-approved (not in selectedChain), got: ${JSON.stringify(r.json.missing)}`)
+  // Schema error still surfaces.
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref') && e.includes('placeholder')),
+    `expected placeholder error preserved, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-12 wrong-shape approval_ref: walk halts, error preserved', () => {
+  mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: 'file:plans/foo.md' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref') && e.includes('episode reference')),
+    `expected non-episode error preserved, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-13 wrong-semantic: post_checkpoint_ref points to pre-checkpoint id', () => {
+  const chain = mkBaseChainForReview()
+  // push-allowed.post_checkpoint_ref points at preId (wrong event type).
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.preId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false)
+  // Original "not a post-checkpoint" error preserved.
+  assert.ok(r.json.errors.some(e => e.includes('post_checkpoint_ref') && e.includes('not a post-checkpoint')),
+    `expected wrong-event-type error preserved, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-14 tiebreak: multiple terminals at identical timestamp, id-lex desc wins (deterministic)', () => {
+  // Two pre-checkpoints with same timestamp (same date/time fields). selectChain
+  // tiebreak: lex desc on entry.id. Counter-suffixed ids are monotonic so
+  // the LATER-CREATED one (higher counter → lex larger) wins deterministically.
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p.md' } })
+  const pre1 = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const pre2 = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p.md', approval_ref: `episode:${planId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  // pre2 has higher counter → lex larger → terminal.
+  const terminal = r.json.episodes.find(e => e.id === pre2)
+  assert.strictEqual(terminal.in_chain, true, 'pre2 (lex-larger id) should be terminal')
+  const other = r.json.episodes.find(e => e.id === pre1)
+  assert.strictEqual(other.in_chain, false, 'pre1 (lex-smaller) should be out-of-chain')
+})
+
+test('T102-15 head disambiguation: multiple terminals, --head selects matching one', () => {
+  // Two post-checkpoints at different heads. push-allowed --head selects the
+  // matching post via head-equality (mediated by post_checkpoint_ref + the
+  // existing head-equality enforcement at validateChain). Test that both ARE
+  // referenced via separate push-alloweds and selectChain picks the head-match.
+  // Simplification: build chain with one post at abc1234 (chain.postId) and one
+  // parallel push-allowed referencing a parallel post at differenthead.
+  const chain = mkBaseChainForReview()
+  const lId = mkWitness({ summary: 'log-h' })
+  const rId = mkWitness({ summary: 'review-h' })
+  const eId = mkWitness({ summary: 'e2e-h' })
+  const altPostId = mkEpisode({
+    event: 'post-checkpoint',
+    head: 'differenthead',
+    extra: {
+      pre_checkpoint_ref: `episode:${chain.preId}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+  // Two push-allowed terminals at different heads. selectChain prefers
+  // ctx.head === --head exact match.
+  const paAlt = mkEpisode({ event: 'push-allowed', head: 'differenthead', extra: { post_checkpoint_ref: `episode:${altPostId}` } })
+  const paGood = mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  // paGood has matching head → terminal.
+  const goodIn = r.json.episodes.find(e => e.id === paGood).in_chain
+  const altIn = r.json.episodes.find(e => e.id === paAlt).in_chain
+  assert.strictEqual(goodIn, true)
+  assert.strictEqual(altIn, false)
+})
+
+test('T102-16 review-request coalescence: rr.pre_checkpoint_ref diverges from post.pre_checkpoint_ref', () => {
+  // Build two complete chains, then create a review-request whose
+  // post_checkpoint_ref points at chain1.postId BUT pre_checkpoint_ref points
+  // at chain2.preId. Both refs are individually same-task / right event-type
+  // — but they don't coalesce. Pre-#102 + Gap#1 fix would silently accept;
+  // post-fix coalescence assertion must reject.
+  const chain1 = mkBaseChainForReview()
+  const planId2 = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p2.md' } })
+  const preId2 = mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'p2.md', approval_ref: `episode:${planId2}` } })
+  const lId2 = mkWitness({ summary: 'log2' })
+  const rId2 = mkWitness({ summary: 'review2' })
+  const eId2 = mkWitness({ summary: 'e2e2' })
+  mkEpisode({
+    event: 'post-checkpoint',
+    extra: {
+      pre_checkpoint_ref: `episode:${preId2}`,
+      evidence: {
+        tests: [{ command: 'x', status: 'passed', log_ref: `episode:${lId2}` }],
+        code_review: { status: 'done', reply_ref: `episode:${rId2}` },
+        e2e: { status: 'passed', log_ref: `episode:${eId2}` },
+        bug_logging: { status: 'done', issues: [] },
+      },
+    },
+  })
+  // rr: post points to chain1.postId, but pre points to chain2's preId2.
+  mkReviewRequest({
+    chain: { ...chain1, preId: preId2 }, // splice pre, keep post=chain1.postId, approval=chain1.planId
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false, `coalescence violation must reject; errors: ${JSON.stringify(r.json.errors)}`)
+  assert.ok(r.json.errors.some(e => e.includes('pre_checkpoint_ref') && e.includes('coalesce')),
+    `expected coalescence error on pre_checkpoint_ref, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-17 review-request coalescence: rr.approval_ref diverges from pre.approval_ref', () => {
+  // Two plan-approveds for same task, both same task. rr.approval_ref points
+  // at planId2 while the walked path (rr → post → pre → approval) lands at
+  // planId1. Coalescence assertion must reject.
+  const chain = mkBaseChainForReview()
+  const planId2 = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'p2.md' } })
+  // rr.approval_ref points at planId2 (NOT chain.planId).
+  mkReviewRequest({
+    chain,
+    extra: { approval_ref: `episode:${planId2}` },
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false, `coalescence violation must reject; errors: ${JSON.stringify(r.json.errors)}`)
+  assert.ok(r.json.errors.some(e => e.includes('approval_ref') && e.includes('coalesce')),
+    `expected coalescence error on approval_ref, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-18 review-request coalescence: all three refs coherent → passes', () => {
+  // Regression guard: a properly-formed review-request with all three chain
+  // refs converging on the same chain must still pass post-#102.
+  const chain = mkBaseChainForReview()
+  mkReviewRequest({ chain })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `coherent chain must pass; errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-19 in_chain flag: classified episode not in chain (not required for any gate)', () => {
+  const chain = mkBaseChainForReview()
+  // classified is not a chain-link event for any gate per workflow-lifecycle.md:407.
+  const classifiedId = mkEpisode({ event: 'classified', extra: { classification: 'full' } })
+  mkEpisode({ event: 'push-allowed', extra: { post_checkpoint_ref: `episode:${chain.postId}` } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'push-allowed', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  // classified appears in episodes[] (backward-compat) with in_chain: false.
+  const classified = r.json.episodes.find(e => e.id === classifiedId)
+  assert.ok(classified, 'classified should appear in episodes[]')
+  assert.strictEqual(classified.in_chain, false)
+})
+
+test('T102-20 single coherent chain: regression — gate passes, all events in_chain', () => {
+  // The simplest case: one chain, one terminal, no parallels. Must continue
+  // passing post-refactor.
+  const chain = mkBaseChainForReview()
+  const r = runValidate(['--task', 'TEST', '--gate', 'post-checkpoint', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `errors: ${JSON.stringify(r.json.errors)}`)
+  const inChainEvents = r.json.episodes.filter(e => e.in_chain).map(e => e.event).sort()
+  assert.deepStrictEqual(inChainEvents.sort(), ['plan-approved', 'post-checkpoint', 'pre-checkpoint'].sort())
+})
+
+test('T102-22 review-request coalescence: rr.plan_ref (episode-shaped) diverges from walked plan-approved', () => {
+  // Review M1 catch: plan_ref is the 4th member of the rr-coalescence class.
+  // When rr.plan_ref is episode-shaped, it must equal the walked plan-approved.
+  // Forgery vector: a parallel plan-approved exists for the same task; rr's
+  // chain refs (post→pre→approval) point at canonical chain, but rr.plan_ref
+  // points at the rogue plan. Without this assertion, divergent plan_ref
+  // would silently pass.
+  const chain = mkBaseChainForReview()
+  const rogueePlanId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'rogue.md' } })
+  // rr's chain refs are coherent (point at chain), but plan_ref points elsewhere.
+  mkReviewRequest({
+    chain,
+    extra: { plan_ref: `episode:${rogueePlanId}` },
+  })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, false, `plan_ref divergence must reject; errors: ${JSON.stringify(r.json.errors)}`)
+  assert.ok(r.json.errors.some(e => e.includes('plan_ref') && e.includes('coalesce')),
+    `expected coalescence error on plan_ref, got: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-23 review-request: rr.plan_ref as file/URL (free-form) does NOT trigger coalescence', () => {
+  // Regression guard: free-form plan_ref (file path or URL) must continue to
+  // pass — only episode-shaped plan_ref triggers coalescence (since only
+  // episode refs carry chain identity).
+  const chain = mkBaseChainForReview()
+  mkReviewRequest({ chain, extra: { plan_ref: 'docs/plan-with-different-text.md' } })
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `free-form plan_ref must not trigger coalescence; errors: ${JSON.stringify(r.json.errors)}`)
+})
+
+test('T102-21 semantic-flip vs T58: chain-walk picks DIFFERENT rr than latest-by-timestamp would', () => {
+  // Pre-#102 latest-by-timestamp would always pick the newest rr. Post-#102
+  // chain-walk picks the rr identified as the gate's terminal. To exercise
+  // the difference: build two rr's where the OLDER rr has valid refs and the
+  // NEWER rr has invalid refs. T58b already locks "newer (terminal) wins" as
+  // contract; this test confirms that under multi-rr selection, the terminal-
+  // anchor identity is what gates, not "any chain that happens to validate."
+  //
+  // Setup: chain has plan/pre/post. Older rr is valid. Newer rr has bogus
+  // post_checkpoint_ref. With pre-#102 latest-by-timestamp on multi-rr, newer
+  // rr is terminal → fail. With post-#102 chain-walk, terminal = pickTerminal
+  // (latest by timestamp under same conditions) → newer rr → fail. Both pass
+  // the same test; behavior unchanged for this specific axis.
+  //
+  // The genuine semantic-flip happens when --head differentiates: build two
+  // rr's at different heads, --head matching the OLDER one. Pre-#102 latest-
+  // by-timestamp ignored --head for terminal selection. Post-#102 head-match
+  // wins, so the older rr is terminal.
+  const chain = mkBaseChainForReview()
+  // Older rr at head=abc1234 (matches --head). Newer rr at differenthead.
+  // Use mkReviewRequest to build the older one with default ctx.head abc1234.
+  // Then build a newer rr at differenthead via direct mkEpisode.
+  mkReviewRequest({ chain }) // older rr at default 12:00
+  // Newer rr at later time, different head. Built directly to control time.
+  counter++
+  const newerId = `20260502-1300${String(counter).padStart(2, '0')}-rr-newer-${counter.toString(16).padStart(4, '0')}`
+  const newerPayload = {
+    event: 'review-request',
+    pattern_id: 'bp-001-implementation-workflow',
+    task: 'TEST',
+    context: { worktree: tmpCwd, branch: 'main', head: 'differenthead' },
+    plan_ref: 'p.md',
+    approval_ref: `episode:${chain.planId}`,
+    pre_checkpoint_ref: `episode:${chain.preId}`,
+    post_checkpoint_ref: `episode:${chain.postId}`,
+    evidence: {
+      tests_ref: `episode:${chain.logId}`,
+      code_review_ref: `episode:${chain.reviewId}`,
+      bug_logging: { status: 'no-new-bugs' },
+    },
+  }
+  const newerFm = `---\nid: ${newerId}\ndate: 2026-05-02\ntime: "13:00"\nproject: test\ncategory: workflow.lifecycle\nstatus: active\ntags: []\nsummary: rr newer differenthead\n---\n`
+  const newerBody = `# x\n\n\`\`\`json\n${JSON.stringify(newerPayload)}\n\`\`\`\n`
+  fs.writeFileSync(path.join(episodesDir, `${newerId}.md`), newerFm + '\n' + newerBody)
+  fs.appendFileSync(indexFile, JSON.stringify({
+    id: newerId, date: '2026-05-02', time: '13:00', project: 'test',
+    category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: 'newer rr',
+  }) + '\n')
+  // Run with --head abc1234. Post-#102 chain-walk picks the older rr (head match).
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'])
+  assert.strictEqual(r.json.valid, true, `older rr at matching --head must be terminal; errors: ${JSON.stringify(r.json.errors)}`)
+  // The newer rr (differenthead) is out-of-chain.
+  const newer = r.json.episodes.find(e => e.id === newerId)
+  assert.strictEqual(newer.in_chain, false, 'newer rr at differenthead should NOT be terminal under --head=abc1234')
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes [#102](https://github.com/lantisprime/episodic-memory/issues/102).

- Replace bulk validation of all task lifecycle events with terminal-anchored chain selection. `selectChain()` picks the gate's terminal event, walks refs backward, returns a `selectedChain` id-set.
- Add `in_chain: bool` to `episodes[]` JSON output (backward-compat additive). Out-of-chain events' errors are downgraded to warnings; `presentEvents` is computed from `selectedChain` only.
- Add **review-request coalescence assertions** on the 3 chain-identity refs (`post_checkpoint_ref`, `pre_checkpoint_ref`, `approval_ref`) to close the same-class forgery vector that bit PR [#156](https://github.com/lantisprime/episodic-memory/pull/156) F1. `plan_ref` is **NOT** coalescence-checked — it's the plan artifact (per spec workflow-lifecycle.md:151), distinct from `approval_ref` which is the plan-approved lifecycle episode.
- Generalize the out-of-chain error → warning migration from rr-specific to gate-agnostic.

## Toolkit application + lessons

- **Plan-time planner** found 8 gaps; HIGH-priority Gap #1 (rr coalescence on `approval_ref` + `pre_checkpoint_ref`) caught before code.
- **Code reviewer** caught what looked like a 4-member class with `plan_ref` as the missing 4th — but **plan_ref has a different semantic role (artifact vs chain identity)**. The reviewer's structural enumeration was correct; the semantic role distinction was missed by both internal agents.
- **Codex round 1** caught the false rejection introduced by adding `plan_ref` to coalescence. Round 2: SHIP after `plan_ref` removed from coalescence.
- **Lesson:** discipline #12 (per-class-member structural audit) needs a companion **#13: semantic role audit per member**. Filed as global lesson `20260506-002554-...-54ea` and feedback `feedback_semantic_role_audit.md`.

Codex burn = 1 round. Workplan v15 counterfactual partially met (target 0; defaults+#12 caught structural gaps but not semantic role mismatch).

## Behavior

### Walk axes per terminal

| Terminal event | Walk refs |
|---|---|
| `pre-checkpoint` | `approval_ref` |
| `post-checkpoint` | `pre_checkpoint_ref` → its `approval_ref` |
| `push-allowed` | `post_checkpoint_ref` → its `pre_checkpoint_ref` → its `approval_ref` |
| `review-request` | `post_checkpoint_ref` → its `pre_checkpoint_ref` → its `approval_ref` + coalescence on rr's own `pre_checkpoint_ref` and `approval_ref` (NOT plan_ref) |

### Tiebreak when multiple terminal candidates

1. `ctx.head === --head` exact (when `--head` passed)
2. Latest by `(date, time)` desc
3. `entry.id` lex desc (counter-suffixed → monotonic, FS-deterministic)

### `presentEvents` fallback (review m2)

When no terminal candidate exists, `presentEvents` falls back to all task events. Preserves pre-#102 UX of "missing only the terminal" instead of "missing everything" when a user records plan/pre/post but forgets the terminal.

## Test plan

- [x] Baseline: 87/87 pre-existing tests pass after refactor
- [x] T58 updated for new contract wording (terminal-anchored, out-of-chain prefix)
- [x] 23 new tests (T102-1..T102-23). Includes T102-22 locking the Codex repro: legitimate episode-shaped `plan_ref` pointing to a plan-doc episode passes.
- [x] Total: **110/110 passing**
- [x] L1+L3 integration via `runValidate` (real Node subprocess, real index/episodes)
- [ ] L4 hook-chain runtime integration: deferred to [#119](https://github.com/lantisprime/episodic-memory/issues/119) (this PR is a pure validator; hook wiring is #119's scope)

## Spec

`docs/specs/workflow-lifecycle.md`: replaces "Multi-review-request per task (pre-#102 chain-walk fallback)" section with "Terminal-anchored chain selection (#102)" — documents walk axes, tiebreak, coalescence (3 chain-identity refs only), `episodes[].in_chain` field, and the explicit `plan_ref` exclusion.

## Review trail

- Plan-time planner: 8 gaps, all addressed before code.
- Code reviewer: 1 MAJOR (M1 plan_ref — initially actioned, rolled back per Codex feedback) + 2 minors (m1, m2) + 2 nits (n1, n2). m2, n1 fixed in this PR. m1 + n2 documented trade-offs filed as [#172](https://github.com/lantisprime/episodic-memory/issues/172) + [#173](https://github.com/lantisprime/episodic-memory/issues/173).
- Codex round 1: HOLD on plan_ref P2 (`20260506-001628-...-819d`).
- Codex round 2: SHIP at `63a58ee` (`20260506-002344-...-68a2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)