### PR TITLE
feat(bp1): RFC-004 M0 — activation gate + manifest builder + Rule-14 CI gates

### DIFF
--- a/.github/workflows/rfc-validate.yml
+++ b/.github/workflows/rfc-validate.yml
@@ -4,15 +4,37 @@ on:
   pull_request:
     paths:
       - 'docs/rfcs/**'
+      - 'install.mjs'
       - 'scripts/em-rfc-validate.mjs'
+      - 'scripts/validate-rfc-failure-table.mjs'
+      - 'scripts/validate-rfc-artifact-manifest.mjs'
+      - 'scripts/lib/bp1-manifest.mjs'
+      - 'scripts/bp1-build-artifact-manifest.mjs'
+      - 'scripts/bp1-flag-check.mjs'
       - 'tests/test-em-rfc-validate.mjs'
+      - 'tests/test-validate-rfc-failure-table.mjs'
+      - 'tests/test-validate-rfc-artifact-manifest.mjs'
+      - 'tests/test-bp1-flag-check.mjs'
+      - 'tests/test-bp1-build-artifact-manifest.mjs'
+      - 'tests/test-install-bp1.sh'
       - '.github/workflows/rfc-validate.yml'
   push:
     branches: [main]
     paths:
       - 'docs/rfcs/**'
+      - 'install.mjs'
       - 'scripts/em-rfc-validate.mjs'
+      - 'scripts/validate-rfc-failure-table.mjs'
+      - 'scripts/validate-rfc-artifact-manifest.mjs'
+      - 'scripts/lib/bp1-manifest.mjs'
+      - 'scripts/bp1-build-artifact-manifest.mjs'
+      - 'scripts/bp1-flag-check.mjs'
       - 'tests/test-em-rfc-validate.mjs'
+      - 'tests/test-validate-rfc-failure-table.mjs'
+      - 'tests/test-validate-rfc-artifact-manifest.mjs'
+      - 'tests/test-bp1-flag-check.mjs'
+      - 'tests/test-bp1-build-artifact-manifest.mjs'
+      - 'tests/test-install-bp1.sh'
 
 jobs:
   validate:
@@ -27,5 +49,26 @@ jobs:
       - name: Run RFC registry validator
         run: node scripts/em-rfc-validate.mjs
 
-      - name: Run validator self-tests
+      - name: Run RFC registry self-tests
         run: node tests/test-em-rfc-validate.mjs
+
+      - name: Validate RFC failure-table prose↔YAML mirror
+        run: node scripts/validate-rfc-failure-table.mjs
+
+      - name: Run failure-table validator self-tests
+        run: node tests/test-validate-rfc-failure-table.mjs
+
+      - name: Validate RFC artifact-manifest contract surfaces
+        run: node scripts/validate-rfc-artifact-manifest.mjs
+
+      - name: Run artifact-manifest validator self-tests
+        run: node tests/test-validate-rfc-artifact-manifest.mjs
+
+      - name: Run bp1-flag-check self-tests
+        run: node tests/test-bp1-flag-check.mjs
+
+      - name: Run bp1-build-artifact-manifest self-tests
+        run: node tests/test-bp1-build-artifact-manifest.mjs
+
+      - name: Run install.mjs BP-1 idempotence tests
+        run: bash tests/test-install-bp1.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@ node_modules/
 .env
 .env.*
 .episodic-memory/
+
+# Claude Code runtime markers (managed by hooks, never committed)
+.claude/.pre-checkpoint-done
+.claude/.post-checkpoint-done
+.claude/.checkpoint-required
+.claude/.post-checkpoint-required
+.claude/.plan-approval-pending
+.claude/settings.local.json
+
+# BP-1 per-run HMAC key (RFC-004)
+**/.episodic-memory/runs/*/run.key

--- a/docs/bp1/config-schema.md
+++ b/docs/bp1/config-schema.md
@@ -1,0 +1,72 @@
+# BP-1 Activation Map — `~/.episodic-memory/config.json`
+
+The activation map is a per-project safety envelope for [RFC-004 BP-1 Auto-Pilot](../rfcs/RFC-004-bp1-auto-pilot.md). It lives at `~/.episodic-memory/config.json` and is shared across all projects on a machine. Each entry binds an M5 dry-run proof to a canonical project root.
+
+## Schema
+
+```json
+{
+  "bp1": {
+    "schema_version": 1,
+    "activations": {
+      "<canonical_project_root>": {
+        "enabled": true,
+        "artifact_version_hash": "sha256:<hex>",
+        "enabled_at": "<ISO-8601 UTC>",
+        "enabled_via": "<dry-run-run_id>",
+        "verify_key_id": "<16-char hex fingerprint>"
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Source |
+|---|---|---|
+| `<canonical_project_root>` | string (key) | `git rev-parse --show-toplevel` then `realpath` (resolves symlinks) |
+| `enabled` | bool | `false` until M5's dry run flips it |
+| `artifact_version_hash` | string `sha256:<64hex>` | Output of `node scripts/bp1-build-artifact-manifest.mjs --project <root>` at activation time |
+| `enabled_at` | ISO-8601 UTC | M5 wall-clock timestamp |
+| `enabled_via` | string | `bp1-run-<ts>-<rfc-slug>-<rand6>` — the M5 dry-run run_id |
+| `verify_key_id` | string (16 hex) | First 16 chars of `HMAC-SHA256(key, "verify-key-fingerprint-v1")` over `~/.episodic-memory/.verify-key` |
+
+## Lifecycle
+
+1. **First install** — `install.mjs` creates `~/.episodic-memory/.verify-key` (32 random bytes, mode 0600) if missing, and writes the config skeleton `{"bp1":{"schema_version":1,"activations":{}}}` if missing. No project entries.
+2. **Per-project install** — `install.mjs` runs again per project to sync scripts/hooks/etc. Activation entry is **not** auto-created here.
+3. **M5 dry run** — `bp1-flag-flip.mjs` (M5 deliverable, future PR) takes the global config lock, completes the dry-run safety proof, then writes the project's activation entry with `enabled: true`.
+4. **Live use** — every gated artifact reads via `bp1-flag-check.mjs --project <root>`. The check passes iff:
+   - Map entry exists for the canonical project root
+   - `enabled === true`
+   - `artifact_version_hash` matches a fresh recomputation by `bp1-build-artifact-manifest.mjs`
+   - `verify_key_id` matches a fresh fingerprint of `~/.episodic-memory/.verify-key`
+5. **Disable** — `bp1-flag-flip.mjs --disable <project>` (M5 deliverable) removes the named project's entry. Other projects' entries are untouched.
+
+## Failure modes (RFC-004 §11.5 rows 25-29)
+
+| Row | Code | Trigger |
+|---|---|---|
+| 25 | `bp1-disabled-refusal` | Entry missing, or `enabled: false` |
+| 26 | `bp1-flag-version-drift` | Recomputed `artifact_version_hash` ≠ stored value (install drift since activation) |
+| 27 | `bp1-flag-key-drift` | Live verify-key fingerprint ≠ stored `verify_key_id` (key rotated without re-running M5) |
+| 28 | `bp1-flag-config-corrupt` | `config.json` parse error or schema mismatch |
+| 29 | `bp1-hmac-keyfile-fail` | `~/.episodic-memory/.verify-key` missing, mode ≠ 0600, or wrong size |
+
+Any of these → `bp1-flag-check.mjs` exits non-zero and (when invoked by a gated caller) emits a local-scope violation episode.
+
+## Concurrency
+
+The map is read/written through a `flock`-protected helper. Concurrent activations across projects serialize on the global config lock; each writer mutates only its own key.
+
+## File-mode invariants
+
+- `~/.episodic-memory/.verify-key` — `0600`. Asserted on every read by `bp1-flag-check.mjs` and orchestrator startup. `install.mjs` `chmod`s it on every run (defends against umask + manual touch drift).
+- `~/.episodic-memory/config.json` — default user mode (typically `0644`); contents are integrity-protected by `verify_key_id` cross-checks, not by file mode.
+
+## Related
+
+- [RFC-004 §83-210](../rfcs/RFC-004-bp1-auto-pilot.md) — full activation flag spec.
+- [RFC-004 §660-668](../rfcs/RFC-004-bp1-auto-pilot.md) — long-lived verify-key spec + rotation procedure (M5 `bp1-rotate-verify-key.mjs`).
+- `scripts/bp1-flag-check.mjs` — the gate.
+- `scripts/bp1-build-artifact-manifest.mjs` — manifest hash recomputation (single source of truth).
+- `scripts/lib/bp1-manifest.mjs` — shared library used by both.

--- a/docs/rfcs/RFC-004-bp1-auto-pilot.md
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.md
@@ -1092,7 +1092,7 @@ The token cap (default 200k) is enforced by `bp1-sentinel` as a pre-dispatch HAL
 | 17 | run_id collision (F5) | run-lock script | A (regen) | `bp1-runid-regen` | no |
 | 18 | Decision-log orphan (F3) | replay | B | `bp1-orphan-detected` | yes |
 | 19 | Branch-protection fail (Gap 4) | orchestrator startup | C | `bp1-rule17-violation` | yes |
-| 20 | Orchestrator crash | crash-classify | A or B | `bp1-crash-recovered` | yes (if A) |
+| 20 | Orchestrator crash | crash-classify | A or B | `bp1-crash-recovered` | conditional |
 | 21 | `gh pr create` fails | orchestrator | A→B (retry fail) | `bp1-pr-create-fail` | yes |
 | 22 | Codex PR-review request fails | em-review-request | A | `bp1-codex-request-fail` | no |
 | 23 | Abandoned >7 days | archive-ghosts | D | `bp1-ghost-archived` | yes |
@@ -1418,7 +1418,8 @@ graph TD
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| PR-1a (M0 part 1) | `scripts/lib/bp1-manifest.mjs`, `scripts/bp1-flag-check.mjs`, `scripts/bp1-build-artifact-manifest.mjs`, `scripts/validate-rfc-failure-table.mjs`, `scripts/validate-rfc-artifact-manifest.mjs`, `install.mjs` (verify-key + config skeleton + line-anchored .gitignore), `.github/workflows/rfc-validate.yml`, `docs/bp1/config-schema.md`; this row 20 prose lesson "yes (if A)" → "conditional" (matches YAML mirror) | `tests/test-bp1-flag-check.mjs` (9), `tests/test-bp1-build-artifact-manifest.mjs` (10), `tests/test-validate-rfc-failure-table.mjs` (10), `tests/test-validate-rfc-artifact-manifest.mjs` (5), `tests/test-install-bp1.sh` (12) — 46 cases | M0 deliverables landed pre-activation; both validators green on real RFC-004; 2 deferred findings (TOCTOU [#179](https://github.com/lantisprime/episodic-memory/issues/179), em-search fallback [#180](https://github.com/lantisprime/episodic-memory/issues/180)). Codex-ACCEPT'd plan from prior session; review-pass HOLD findings folded in pre-merge. |
+| PR-1b (M0 part 2) | _pending_ — `bp1-deadline-sweep.mjs --once` + `.claude/hooks/bp1-sweep-on-session.sh` H2 hook + scheduled-tasks probe | _pending_ | After PR-1a merges; depends on flag-check (call-site for activation gating). |
 
 ---
 

--- a/docs/rfcs/RFC-004-bp1-auto-pilot.md
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.md
@@ -108,6 +108,7 @@ All side-effecting bp1 artifacts are gated on a **per-project activation entry**
 
 ```yaml
 artifact_manifest:
+  schema_version: 1
   scripts:
     - path: "scripts/bp1-orchestrator.mjs"
       sha256: "<file-sha256>"

--- a/install.mjs
+++ b/install.mjs
@@ -17,6 +17,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import crypto from 'crypto'
 import { fileURLToPath } from 'url'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -114,14 +115,59 @@ if (fs.existsSync(repoPatternsIndex)) {
 const localDir = path.join(projectDir, '.episodic-memory')
 fs.mkdirSync(path.join(localDir, 'episodes'), { recursive: true })
 
-// Add to .gitignore if it exists
+// Add to .gitignore if it exists. Guards are line-anchored (not substring)
+// so a stale comment mention does not silently suppress a real append.
+function gitignoreHasPattern(content, pattern) {
+  return content.split('\n').some(line => {
+    const t = line.trim()
+    if (!t || t.startsWith('#')) return false
+    return t === pattern
+  })
+}
 const gitignorePath = path.join(projectDir, '.gitignore')
 if (fs.existsSync(gitignorePath)) {
   const content = fs.readFileSync(gitignorePath, 'utf8')
-  if (!content.includes('.episodic-memory')) {
+  if (!gitignoreHasPattern(content, '.episodic-memory/') &&
+      !gitignoreHasPattern(content, '.episodic-memory')) {
     fs.appendFileSync(gitignorePath, '\n# Episodic memory data\n.episodic-memory/\n')
     console.log('Added .episodic-memory/ to .gitignore')
   }
+  // RFC-004 §656 — per-run HMAC key file is project-local but must never be
+  // committed. Pattern is stable across the BP-1 lifecycle.
+  const runKeyPattern = '**/.episodic-memory/runs/*/run.key'
+  const refreshed = fs.readFileSync(gitignorePath, 'utf8')
+  if (!gitignoreHasPattern(refreshed, runKeyPattern)) {
+    fs.appendFileSync(gitignorePath, `\n# BP-1 per-run HMAC key (RFC-004)\n${runKeyPattern}\n`)
+    console.log(`Added ${runKeyPattern} to .gitignore`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2b. BP-1 long-lived verify-key + activation map skeleton (RFC-004 §660-668).
+// Generated once on first install; persists across runs and projects.
+// ---------------------------------------------------------------------------
+const verifyKeyPath = path.join(GLOBAL_DIR, '.verify-key')
+if (!fs.existsSync(verifyKeyPath)) {
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(verifyKeyPath, key, { mode: 0o600 })
+  // Defensive chmod: writeFileSync mode is umask-sensitive on some platforms.
+  fs.chmodSync(verifyKeyPath, 0o600)
+  console.log(`Created BP-1 verify-key at ${verifyKeyPath} (mode 0600)`)
+} else {
+  // Enforce mode invariant on every install — drift surfaces here, not at first
+  // call to bp1-flag-check. Failure mode 29 (bp1-hmac-keyfile-fail).
+  const mode = fs.statSync(verifyKeyPath).mode & 0o777
+  if (mode !== 0o600) {
+    fs.chmodSync(verifyKeyPath, 0o600)
+    console.log(`Re-chmod'd ${verifyKeyPath} from 0${mode.toString(8)} to 0600`)
+  }
+}
+
+const bp1ConfigPath = path.join(GLOBAL_DIR, 'config.json')
+if (!fs.existsSync(bp1ConfigPath)) {
+  const skeleton = { bp1: { schema_version: 1, activations: {} } }
+  fs.writeFileSync(bp1ConfigPath, JSON.stringify(skeleton, null, 2) + '\n')
+  console.log(`Created BP-1 config skeleton at ${bp1ConfigPath}`)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/bp1-build-artifact-manifest.mjs
+++ b/scripts/bp1-build-artifact-manifest.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * bp1-build-artifact-manifest.mjs — Emit the BP-1 runtime-artifact manifest
+ * (RFC-004 §107-152). Thin CLI wrapper over `lib/bp1-manifest.mjs`.
+ *
+ * Used by:
+ *   - install.mjs --bp1 (write into the activation entry)
+ *   - operators (debug install drift)
+ *   - tests (assert determinism)
+ *
+ * Determinism contract: two consecutive runs on the same install produce
+ * identical sha256. CI test A14 enforces this.
+ *
+ * Usage:
+ *   node bp1-build-artifact-manifest.mjs [--project <root>] [--yaml]
+ *
+ * Default output: JSON (sha256 + manifest object). Pass --yaml for the
+ * pretty YAML form (used by operators inspecting drift).
+ */
+
+import path from 'path'
+import { buildArtifactManifest, canonicalProjectRoot } from './lib/bp1-manifest.mjs'
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+const projectArg = flag('--project')
+const wantYaml = argv.includes('--yaml')
+
+const projectRoot = projectArg
+  ? path.resolve(projectArg)
+  : canonicalProjectRoot()
+
+if (!projectRoot) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: 'Could not resolve canonical project root from cwd. Pass --project explicitly.',
+  }))
+  process.exit(1)
+}
+
+const { manifest, sha256 } = buildArtifactManifest({ projectRoot })
+
+if (wantYaml) {
+  console.log(toYaml({ artifact_manifest: manifest, sha256: `sha256:${sha256}` }))
+} else {
+  console.log(JSON.stringify({ status: 'ok', sha256, project_root: projectRoot, manifest }, null, 2))
+}
+
+function toYaml(value, indent = 0) {
+  // Minimal YAML serializer for the manifest shape (objects + arrays + strings + numbers).
+  // Sorted keys for determinism.
+  const pad = ' '.repeat(indent)
+  if (value === null || value === undefined) return 'null'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+    return value.map(v => `${pad}- ${toYamlInline(v, indent + 2)}`).join('\n')
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort()
+    if (keys.length === 0) return '{}'
+    return keys.map(k => {
+      const v = value[k]
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        return `${pad}${k}:\n${toYaml(v, indent + 2)}`
+      }
+      if (Array.isArray(v)) {
+        if (v.length === 0) return `${pad}${k}: []`
+        return `${pad}${k}:\n${toYaml(v, indent + 2)}`
+      }
+      return `${pad}${k}: ${toYaml(v, indent + 2)}`
+    }).join('\n')
+  }
+  return JSON.stringify(value)
+}
+function toYamlInline(v, indent) {
+  if (v && typeof v === 'object' && !Array.isArray(v)) {
+    const keys = Object.keys(v).sort()
+    return keys.map(k => `${k}: ${toYaml(v[k], indent + 2)}`).join(', ')
+  }
+  return toYaml(v, indent)
+}

--- a/scripts/bp1-flag-check.mjs
+++ b/scripts/bp1-flag-check.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * bp1-flag-check.mjs — RFC-004 §158-167 activation gate.
+ *
+ * Every gated artifact reads via `bp1-flag-check.mjs --project <root>`
+ * (or auto-derived from cwd). The check passes iff ALL of:
+ *   1. Map entry exists for canonicalized current project root
+ *   2. enabled === true
+ *   3. artifact_version_hash matches the recomputed hash over the FULL
+ *      runtime-artifact manifest
+ *   4. verify_key_id matches the live verify-key fingerprint
+ *
+ * Plus invariants verified by the helper:
+ *   - Verify-key file exists at ~/.episodic-memory/.verify-key
+ *   - Verify-key file mode is 0600 (RFC-004 §665, failure row 29)
+ *
+ * Failure modes (RFC-004 failure table):
+ *   bp1-disabled-refusal      — entry missing or enabled=false (row 25)
+ *   bp1-flag-version-drift    — manifest hash mismatch          (row 26)
+ *   bp1-flag-key-drift        — verify-key fingerprint mismatch (row 27)
+ *   bp1-flag-config-corrupt   — config.json unparseable          (row 28)
+ *   bp1-hmac-keyfile-fail     — verify-key missing/mode/size     (row 29)
+ *
+ * On mismatch: exits non-zero, writes structured JSON to stdout, and (when
+ * --emit is on, default for production callers) emits a local-scope episode
+ * via em-store. Tests pass --no-emit to keep assertions hermetic.
+ *
+ * Usage:
+ *   node bp1-flag-check.mjs [--project <root>] [--config <path>] [--no-emit]
+ *
+ * Output is JSON to stdout in all cases (status: ok | fail). Use --no-emit
+ * to suppress the local-scope episode side-effect (tests use this).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { execFileSync } from 'child_process'
+import {
+  buildArtifactManifest,
+  readVerifyKey,
+  canonicalProjectRoot,
+  CONFIG_PATH,
+} from './lib/bp1-manifest.mjs'
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+function bool(name) {
+  return argv.includes(name)
+}
+
+const projectArg = flag('--project')
+const configArg = flag('--config') || CONFIG_PATH
+const emit = !bool('--no-emit')
+
+function fail(code, reason, extra = {}) {
+  const result = { status: 'fail', code, reason, ...extra }
+  console.log(JSON.stringify(result))
+  if (emit) tryEmitEpisode(code, reason, extra)
+  process.exit(2)
+}
+
+function ok(extra = {}) {
+  const result = { status: 'ok', ...extra }
+  console.log(JSON.stringify(result))
+  process.exit(0)
+}
+
+function tryEmitEpisode(code, reason, extra) {
+  // Local-scope episode for forensics. Best-effort; never let an emit failure
+  // mask the actual fail reason. Per RFC-004 §69-75 (local scope for halt /
+  // violation episodes).
+  try {
+    const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname))
+    const emStore = path.join(repoScripts, 'em-store.mjs')
+    if (!fs.existsSync(emStore)) return
+    const projectName = extra.project_root ? path.basename(extra.project_root) : 'unknown'
+    const summary = `bp1-flag-check ${code}: ${reason}`
+    const body = `# ${code}\n\n${reason}\n\n` +
+      '```json\n' + JSON.stringify(extra, null, 2) + '\n```\n'
+    execFileSync('node', [
+      emStore,
+      '--project', projectName,
+      '--category', 'violation',
+      '--tags', `bp1,${code}`,
+      '--scope', 'local',
+      '--summary', summary,
+      '--body', body,
+    ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000 })
+  } catch {
+    // swallow
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolve project root
+// ---------------------------------------------------------------------------
+let projectRoot
+try {
+  projectRoot = projectArg
+    ? fs.realpathSync(path.resolve(projectArg))
+    : canonicalProjectRoot()
+} catch (e) {
+  fail('bp1-disabled-refusal',
+    `Project root unresolvable: ${e.message}`,
+    { project_arg: projectArg, cwd: process.cwd() })
+}
+
+if (!projectRoot) {
+  fail('bp1-disabled-refusal', 'Could not resolve canonical project root from cwd', {
+    cwd: process.cwd(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Verify-key invariants (file mode 0600, size 32)
+// ---------------------------------------------------------------------------
+const vk = readVerifyKey()
+if (!vk.ok) {
+  fail('bp1-hmac-keyfile-fail',
+    `Verify-key ${vk.reason} (path: ${vk.path})`,
+    { project_root: projectRoot, verify_key_state: vk })
+}
+
+// ---------------------------------------------------------------------------
+// Read activation map
+// ---------------------------------------------------------------------------
+if (!fs.existsSync(configArg)) {
+  fail('bp1-disabled-refusal',
+    `Config file missing (no projects activated): ${configArg}`,
+    { project_root: projectRoot, config_path: configArg })
+}
+
+let config
+try {
+  config = JSON.parse(fs.readFileSync(configArg, 'utf8'))
+} catch (e) {
+  fail('bp1-flag-config-corrupt',
+    `Config JSON parse error: ${e.message}`,
+    { project_root: projectRoot, config_path: configArg })
+}
+
+const activations = (config && config.bp1 && config.bp1.activations) || null
+if (!activations || typeof activations !== 'object') {
+  fail('bp1-flag-config-corrupt',
+    'Config missing bp1.activations map (expected object)',
+    { project_root: projectRoot, config_path: configArg })
+}
+
+const entry = activations[projectRoot]
+if (!entry) {
+  fail('bp1-disabled-refusal',
+    `No activation entry for project root: ${projectRoot}`,
+    { project_root: projectRoot })
+}
+if (entry.enabled !== true) {
+  fail('bp1-disabled-refusal',
+    `Activation entry exists but enabled=${entry.enabled}`,
+    { project_root: projectRoot, entry })
+}
+
+// ---------------------------------------------------------------------------
+// Recompute artifact manifest hash
+// ---------------------------------------------------------------------------
+const { sha256: liveHash } = buildArtifactManifest({ projectRoot })
+const expected = entry.artifact_version_hash
+const expectedSha = typeof expected === 'string' && expected.startsWith('sha256:')
+  ? expected.slice('sha256:'.length)
+  : expected
+if (!expectedSha || expectedSha !== liveHash) {
+  fail('bp1-flag-version-drift',
+    'Artifact manifest hash mismatch — install drift since activation',
+    { project_root: projectRoot, expected: expectedSha, computed: liveHash })
+}
+
+// ---------------------------------------------------------------------------
+// Verify-key fingerprint
+// ---------------------------------------------------------------------------
+if (entry.verify_key_id !== vk.fingerprint) {
+  fail('bp1-flag-key-drift',
+    'verify_key_id does not match live verify-key fingerprint',
+    { project_root: projectRoot, expected: entry.verify_key_id, computed: vk.fingerprint })
+}
+
+ok({ project_root: projectRoot, artifact_version_hash: liveHash, verify_key_id: vk.fingerprint })

--- a/scripts/bp1-flag-check.mjs
+++ b/scripts/bp1-flag-check.mjs
@@ -163,9 +163,18 @@ if (entry.enabled !== true) {
 }
 
 // ---------------------------------------------------------------------------
-// Recompute artifact manifest hash
+// Recompute artifact manifest hash. Manifest-build can throw on permission /
+// IO errors when reading installed scripts/hooks/agents/settings; treat any
+// such throw as fail-closed version-drift rather than a raw Node exit.
 // ---------------------------------------------------------------------------
-const { sha256: liveHash } = buildArtifactManifest({ projectRoot })
+let liveHash
+try {
+  ;({ sha256: liveHash } = buildArtifactManifest({ projectRoot }))
+} catch (e) {
+  fail('bp1-flag-version-drift',
+    `Artifact manifest recomputation failed: ${e.message}`,
+    { project_root: projectRoot, builder_error: e.message })
+}
 const expected = entry.artifact_version_hash
 const expectedSha = typeof expected === 'string' && expected.startsWith('sha256:')
   ? expected.slice('sha256:'.length)

--- a/scripts/lib/bp1-manifest.mjs
+++ b/scripts/lib/bp1-manifest.mjs
@@ -140,25 +140,41 @@ function buildCanonicalPrompts(projectRoot, agentLoaders) {
 }
 
 function resolveLatestEpisodeId(referencedId) {
-  // Walk supersedes chain via em-search --history. Defensive: if unavailable,
-  // fall back to the referenced id (drift later detected by hash mismatch).
-  try {
-    const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
-    const script = path.join(repoScripts, 'em-search.mjs')
-    if (!fs.existsSync(script)) return referencedId
-    const out = execFileSync('node', [script, '--history', referencedId, '--no-track'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 5000,
-    })
-    const parsed = JSON.parse(out)
-    if (parsed && Array.isArray(parsed.episodes) && parsed.episodes.length) {
-      // History is ordered chain; terminal is the one not superseded.
-      const terminal = parsed.episodes.find(e => !e.superseded_by) || parsed.episodes[parsed.episodes.length - 1]
-      return terminal.id
-    }
-  } catch {
-    // fall through
+  // Walk supersedes chain via em-search --history.
+  //
+  // Two distinct failure classes:
+  //   - em-search not present (script file missing): expected legitimate
+  //     fallback to the referenced id. Tracked by #180 for M3 hardening.
+  //   - em-search present but the subprocess errored or returned malformed
+  //     JSON: a real signal that propagates. The outer try/catch in
+  //     bp1-flag-check.mjs catches it and surfaces as bp1-flag-version-drift.
+  //
+  // Codex round-3 finding: bare catch{} swallowing ALL errors made the
+  // I-P2-1 fail-closed invariant overbroad. Narrowed here.
+  const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+  const script = path.join(repoScripts, 'em-search.mjs')
+  if (!fs.existsSync(script)) return referencedId
+
+  // From here on, throw — flag-check's outer try/catch surfaces as drift.
+  const out = execFileSync('node', [script, '--history', referencedId, '--no-track'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 5000,
+  })
+  const parsed = JSON.parse(out)
+  // em-search --history emits {status, count, chain: [...]} — NOT episodes.
+  // (Round-3 bug: original lib checked parsed.episodes, masked by bare catch.)
+  // Three valid cases:
+  //   - {chain: [...]} non-empty → use terminal id
+  //   - {chain: []}            → id not in store, legitimate fallback
+  //   - parsed has no chain array at all → malformed, propagate
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.chain)) {
+    throw new Error(`em-search returned unexpected shape for history of ${referencedId}`)
+  }
+  if (parsed.chain.length) {
+    // History is ordered chain; terminal is the one not superseded.
+    const terminal = parsed.chain.find(e => !e.superseded_by) || parsed.chain[parsed.chain.length - 1]
+    return terminal.id
   }
   return referencedId
 }

--- a/scripts/lib/bp1-manifest.mjs
+++ b/scripts/lib/bp1-manifest.mjs
@@ -1,0 +1,248 @@
+/**
+ * bp1-manifest.mjs — Build the BP-1 runtime-artifact manifest (RFC-004 §107-152).
+ *
+ * Single source of truth for the artifact-version hash. Used by
+ * `bp1-flag-check.mjs` (recompute on every read) and
+ * `bp1-build-artifact-manifest.mjs` (CLI wrapper for install + ops).
+ *
+ * Six surfaces (sorted, deterministic):
+ *   scripts          — scripts/bp1-*.mjs + explicit non-bp1 extensions
+ *   hooks            — .claude/hooks/bp1-*.sh
+ *   settings_lines   — bp1-mentioning lines in .claude/settings.json (case-insensitive)
+ *   plugin_entries   — bp1-related entries in .claude-plugin/plugin.json
+ *   agent_loaders    — .claude/agents/bp1-*.md
+ *   canonical_prompts— latest prompt episode id referenced by each agent loader
+ *
+ * Determinism contract (CI test A14):
+ *   Two consecutive runs on the same install produce identical sha256.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+import { execFileSync } from 'child_process'
+
+// Explicit non-bp1-prefixed scripts BP1 depends on for safety contracts (RFC-004
+// v3.11 / CLI v3.10 F3). Closed list — additions require RFC update + builder
+// update + activation re-run.
+export const NON_BP1_SCRIPTS = ['scripts/em-review-request.mjs']
+
+// Episode-id pattern: <date>-<time>-<slug>-<rand>. Matches the
+// `<id>` token used in agent loader files for canonical prompt references.
+// Lowercase-only: the corpus convention is lowercase IDs and case-insensitive
+// matching would let two textually-different references resolve to the same
+// episode and produce different stored hashes pre/post canonicalization.
+const EPISODE_ID_RE = /\b(\d{8}-\d{6}-[a-z0-9-]+-[0-9a-f]+)\b/
+
+function sha256File(filePath) {
+  const h = crypto.createHash('sha256')
+  h.update(fs.readFileSync(filePath))
+  return h.digest('hex')
+}
+
+function sha256String(s) {
+  return crypto.createHash('sha256').update(s, 'utf8').digest('hex')
+}
+
+function listMatching(dir, pattern) {
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir)
+    .filter(f => pattern.test(f))
+    .sort()
+}
+
+function buildScripts(projectRoot) {
+  const scriptsDir = path.join(projectRoot, 'scripts')
+  const out = []
+
+  for (const f of listMatching(scriptsDir, /^bp1-.*\.mjs$/)) {
+    const rel = `scripts/${f}`
+    out.push({ path: rel, sha256: sha256File(path.join(projectRoot, rel)) })
+  }
+  for (const rel of NON_BP1_SCRIPTS) {
+    const abs = path.join(projectRoot, rel)
+    if (fs.existsSync(abs)) {
+      out.push({ path: rel, sha256: sha256File(abs) })
+    }
+  }
+  return out.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+function buildHooks(projectRoot) {
+  const hooksDir = path.join(projectRoot, '.claude', 'hooks')
+  return listMatching(hooksDir, /^bp1-.*\.sh$/).map(f => {
+    const rel = `.claude/hooks/${f}`
+    return { path: rel, sha256: sha256File(path.join(projectRoot, rel)) }
+  })
+}
+
+function buildSettingsLinesSha(projectRoot) {
+  const settingsPath = path.join(projectRoot, '.claude', 'settings.json')
+  if (!fs.existsSync(settingsPath)) return sha256String('')
+  const raw = fs.readFileSync(settingsPath, 'utf8')
+  const lines = raw.split('\n')
+    .filter(line => /bp1/i.test(line))
+    .map(line => line.trimEnd())
+    .sort()
+  return sha256String(lines.join('\n'))
+}
+
+function buildPluginEntriesSha(projectRoot) {
+  const pluginPath = path.join(projectRoot, '.claude-plugin', 'plugin.json')
+  if (!fs.existsSync(pluginPath)) return sha256String('')
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(pluginPath, 'utf8'))
+  } catch {
+    return sha256String('PLUGIN_PARSE_ERROR')
+  }
+  const filtered = {}
+  if (Array.isArray(parsed['scheduled-tasks'])) {
+    const bp1Tasks = parsed['scheduled-tasks']
+      .filter(t => t && typeof t === 'object' && /bp1/i.test(JSON.stringify(t)))
+    if (bp1Tasks.length) filtered['scheduled-tasks'] = bp1Tasks
+  }
+  if (Array.isArray(parsed['slash-commands'])) {
+    const bp1Cmds = parsed['slash-commands']
+      .filter(c => c && typeof c === 'object' && /^bp1-/.test(c.name || ''))
+    if (bp1Cmds.length) filtered['slash-commands'] = bp1Cmds
+  }
+  return sha256String(stableStringify(filtered))
+}
+
+function buildAgentLoaders(projectRoot) {
+  const agentsDir = path.join(projectRoot, '.claude', 'agents')
+  return listMatching(agentsDir, /^bp1-.*\.md$/).map(f => {
+    const rel = `.claude/agents/${f}`
+    return { path: rel, sha256: sha256File(path.join(projectRoot, rel)) }
+  })
+}
+
+function buildCanonicalPrompts(projectRoot, agentLoaders) {
+  // Each loader file has a "canonical prompt episode" reference. Find the
+  // first matching episode-id pattern in the loader, then resolve the
+  // terminal-revision episode-id via em-search (--history). For the M0 ship
+  // with zero bp1 agents installed, this returns an empty array.
+  const out = []
+  for (const loader of agentLoaders) {
+    const abs = path.join(projectRoot, loader.path)
+    const body = fs.readFileSync(abs, 'utf8')
+    const m = body.match(EPISODE_ID_RE)
+    if (!m) continue
+    const referencedId = m[1]
+    out.push({
+      loader: loader.path,
+      latest_prompt_episode_id: resolveLatestEpisodeId(referencedId)
+    })
+  }
+  return out
+}
+
+function resolveLatestEpisodeId(referencedId) {
+  // Walk supersedes chain via em-search --history. Defensive: if unavailable,
+  // fall back to the referenced id (drift later detected by hash mismatch).
+  try {
+    const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+    const script = path.join(repoScripts, 'em-search.mjs')
+    if (!fs.existsSync(script)) return referencedId
+    const out = execFileSync('node', [script, '--history', referencedId, '--no-track'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    })
+    const parsed = JSON.parse(out)
+    if (parsed && Array.isArray(parsed.episodes) && parsed.episodes.length) {
+      // History is ordered chain; terminal is the one not superseded.
+      const terminal = parsed.episodes.find(e => !e.superseded_by) || parsed.episodes[parsed.episodes.length - 1]
+      return terminal.id
+    }
+  } catch {
+    // fall through
+  }
+  return referencedId
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']'
+  }
+  const keys = Object.keys(value).sort()
+  return '{' + keys.map(k => JSON.stringify(k) + ':' + stableStringify(value[k])).join(',') + '}'
+}
+
+export function buildArtifactManifest({ projectRoot }) {
+  if (!projectRoot) throw new Error('buildArtifactManifest: projectRoot required')
+
+  const scripts = buildScripts(projectRoot)
+  const hooks = buildHooks(projectRoot)
+  const settings_lines = { sha256: buildSettingsLinesSha(projectRoot) }
+  const plugin_entries = { sha256: buildPluginEntriesSha(projectRoot) }
+  const agent_loaders = buildAgentLoaders(projectRoot)
+  const canonical_prompts = buildCanonicalPrompts(projectRoot, agent_loaders)
+
+  const manifest = {
+    schema_version: 1,
+    scripts,
+    hooks,
+    settings_lines,
+    plugin_entries,
+    agent_loaders,
+    canonical_prompts,
+  }
+  const sha256 = sha256String(stableStringify(manifest))
+  return { manifest, sha256 }
+}
+
+export const VERIFY_KEY_PATH = path.join(os.homedir(), '.episodic-memory', '.verify-key')
+export const CONFIG_PATH = path.join(os.homedir(), '.episodic-memory', 'config.json')
+const VERIFY_KEY_FINGERPRINT_LABEL = 'verify-key-fingerprint-v1'
+
+export function readVerifyKey() {
+  if (!fs.existsSync(VERIFY_KEY_PATH)) {
+    return { ok: false, reason: 'missing', path: VERIFY_KEY_PATH }
+  }
+  const stat = fs.statSync(VERIFY_KEY_PATH)
+  // Mode 0600 — owner read/write only. RFC-004 §665.
+  const mode = stat.mode & 0o777
+  if (mode !== 0o600) {
+    return { ok: false, reason: 'mode', mode: mode.toString(8), path: VERIFY_KEY_PATH }
+  }
+  let key
+  try {
+    key = fs.readFileSync(VERIFY_KEY_PATH)
+  } catch (e) {
+    return { ok: false, reason: 'unreadable', message: e.message, path: VERIFY_KEY_PATH }
+  }
+  if (key.length !== 32) {
+    return { ok: false, reason: 'size', size: key.length, path: VERIFY_KEY_PATH }
+  }
+  const fingerprint = crypto
+    .createHmac('sha256', key)
+    .update(VERIFY_KEY_FINGERPRINT_LABEL, 'utf8')
+    .digest('hex')
+    .slice(0, 16)
+  return { ok: true, key, fingerprint, path: VERIFY_KEY_PATH }
+}
+
+export function canonicalProjectRoot(cwd = process.cwd()) {
+  // git rev-parse --show-toplevel + realpath. Worktrees and submodules
+  // canonicalize to the toplevel of their containing git context.
+  let toplevel
+  try {
+    toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return null
+  }
+  if (!toplevel) return null
+  try {
+    return fs.realpathSync(toplevel)
+  } catch {
+    return toplevel
+  }
+}

--- a/scripts/validate-rfc-artifact-manifest.mjs
+++ b/scripts/validate-rfc-artifact-manifest.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * validate-rfc-artifact-manifest.mjs — RFC-004 §107-152 Rule-14 parity gate.
+ *
+ * The RFC documents the runtime-artifact manifest's shape in a fenced YAML
+ * block (`artifact_manifest:` with surfaces scripts/hooks/settings_lines/
+ * plugin_entries/agent_loaders/canonical_prompts). The builder script
+ * `bp1-build-artifact-manifest.mjs` is the single source of truth for that
+ * output (per RFC §154). This validator asserts the prose-illustrative YAML
+ * stays in sync with the builder by checking:
+ *
+ *   1. Every required surface is enumerated in the RFC YAML block.
+ *   2. Every explicit non-bp1-prefixed script the RFC mandates (closed list,
+ *      RFC v3.11 — currently `scripts/em-review-request.mjs`) appears in the
+ *      RFC's `scripts:` surface.
+ *   3. The builder's output shape contains the same surface set (no extras,
+ *      no missing).
+ *
+ * Scoped to RFC-004 (sole carrier of an artifact_manifest spec block today);
+ * extensible to future RFCs that publish their own artifact_manifest.
+ *
+ * Usage:
+ *   node validate-rfc-artifact-manifest.mjs                 # default RFC-004
+ *   node validate-rfc-artifact-manifest.mjs <path-to.md>    # validate one file
+ *   node validate-rfc-artifact-manifest.mjs --json
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { execFileSync } from 'child_process'
+import { NON_BP1_SCRIPTS, buildArtifactManifest } from './lib/bp1-manifest.mjs'
+
+const REQUIRED_SURFACES = [
+  'scripts',
+  'hooks',
+  'settings_lines',
+  'plugin_entries',
+  'agent_loaders',
+  'canonical_prompts',
+]
+
+const argv = process.argv.slice(2)
+const wantJson = argv.includes('--json')
+const positional = argv.filter(a => !a.startsWith('--'))
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const DEFAULT_RFC = path.join(REPO, 'docs', 'rfcs', 'RFC-004-bp1-auto-pilot.md')
+const targets = positional.length ? positional.map(p => path.resolve(p)) : [DEFAULT_RFC]
+
+const results = []
+for (const file of targets) {
+  results.push(validateFile(file))
+}
+
+const failed = results.filter(r => r.violations.length > 0)
+if (wantJson) {
+  console.log(JSON.stringify({
+    status: failed.length ? 'fail' : 'ok',
+    files_checked: results.length,
+    files_failed: failed.length,
+    results,
+  }, null, 2))
+} else {
+  for (const r of results) {
+    if (r.skipped) {
+      console.log(`SKIP  ${path.relative(REPO, r.file)}: ${r.reason}`)
+      continue
+    }
+    if (r.violations.length === 0) {
+      console.log(`OK    ${path.relative(REPO, r.file)}: ${REQUIRED_SURFACES.length} surfaces declared`)
+    } else {
+      console.log(`FAIL  ${path.relative(REPO, r.file)}:`)
+      for (const v of r.violations) console.log(`        ${v.kind}: ${v.detail}`)
+    }
+  }
+}
+process.exit(failed.length ? 1 : 0)
+
+// ---------------------------------------------------------------------------
+function validateFile(file) {
+  if (!fs.existsSync(file)) {
+    return { file, skipped: true, reason: 'not found', violations: [] }
+  }
+  const text = fs.readFileSync(file, 'utf8')
+  const block = extractArtifactManifestBlock(text)
+  if (!block) {
+    return { file, skipped: true, reason: 'no artifact_manifest YAML block', violations: [] }
+  }
+
+  const violations = []
+
+  // (1) Required surfaces present in the RFC YAML
+  for (const surface of REQUIRED_SURFACES) {
+    if (!hasSurfaceKey(block, surface)) {
+      violations.push({ kind: 'missing-surface-in-rfc', detail: `RFC artifact_manifest block missing required surface: ${surface}` })
+    }
+  }
+
+  // (2) Mandated non-bp1 scripts present in the RFC scripts: surface
+  const scriptsBlock = extractSurfaceBlock(block, 'scripts')
+  for (const required of NON_BP1_SCRIPTS) {
+    if (!scriptsBlock || !scriptsBlock.includes(required)) {
+      violations.push({ kind: 'missing-mandated-extension-script', detail: `RFC scripts: surface must explicitly enumerate "${required}" (RFC v3.11 closed-list contract)` })
+    }
+  }
+
+  // (3) Builder output structural parity
+  let manifestKeys = []
+  try {
+    const { manifest } = buildArtifactManifest({ projectRoot: REPO })
+    manifestKeys = Object.keys(manifest).filter(k => k !== 'schema_version').sort()
+  } catch (e) {
+    violations.push({ kind: 'builder-error', detail: `bp1-build-artifact-manifest failed: ${e.message}` })
+  }
+  const required = [...REQUIRED_SURFACES].sort()
+  for (const k of required) {
+    if (!manifestKeys.includes(k)) {
+      violations.push({ kind: 'missing-surface-in-builder', detail: `builder output missing surface: ${k}` })
+    }
+  }
+  for (const k of manifestKeys) {
+    if (!required.includes(k)) {
+      violations.push({ kind: 'unexpected-surface-in-builder', detail: `builder output has unspec'd surface: ${k}` })
+    }
+  }
+
+  return { file, skipped: false, surfaces: manifestKeys, violations }
+}
+
+function extractArtifactManifestBlock(text) {
+  const fenceRe = /```yaml\s*\n([\s\S]*?)\n```/g
+  let m
+  while ((m = fenceRe.exec(text)) !== null) {
+    const body = m[1]
+    if (/^\s*artifact_manifest:/m.test(body)) {
+      return body
+    }
+  }
+  return null
+}
+
+function hasSurfaceKey(yamlBody, key) {
+  // Two-space indent under artifact_manifest:
+  const re = new RegExp(`^\\s{2}${key}:`, 'm')
+  return re.test(yamlBody)
+}
+
+function extractSurfaceBlock(yamlBody, surface) {
+  // Pull the chunk from `^  <surface>:` until the next sibling key (also 2-space indent)
+  const lines = yamlBody.split('\n')
+  let start = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (new RegExp(`^\\s{2}${surface}:`).test(lines[i])) { start = i + 1; break }
+  }
+  if (start < 0) return null
+  const collected = []
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^\s{2}\S/.test(line)) break // next sibling
+    collected.push(line)
+  }
+  return collected.join('\n')
+}

--- a/scripts/validate-rfc-artifact-manifest.mjs
+++ b/scripts/validate-rfc-artifact-manifest.mjs
@@ -104,10 +104,14 @@ function validateFile(file) {
     }
   }
 
-  // (3) Builder output structural parity
+  // (3) Builder output structural parity. Compare both surface set AND
+  // top-level metadata keys (e.g. schema_version) — a future builder bump
+  // that adds/removes a metadata field must update the RFC YAML in lockstep.
   let manifestKeys = []
+  let manifestSchemaVersion = null
   try {
     const { manifest } = buildArtifactManifest({ projectRoot: REPO })
+    manifestSchemaVersion = manifest.schema_version
     manifestKeys = Object.keys(manifest).filter(k => k !== 'schema_version').sort()
   } catch (e) {
     violations.push({ kind: 'builder-error', detail: `bp1-build-artifact-manifest failed: ${e.message}` })
@@ -121,6 +125,18 @@ function validateFile(file) {
   for (const k of manifestKeys) {
     if (!required.includes(k)) {
       violations.push({ kind: 'unexpected-surface-in-builder', detail: `builder output has unspec'd surface: ${k}` })
+    }
+  }
+
+  // (4) schema_version parity — RFC YAML must declare the same schema_version
+  // value the builder emits. Without this, a builder bump can silently pass CI.
+  if (manifestSchemaVersion !== null) {
+    const rfcSchemaMatch = block.match(/^\s{2}schema_version:\s*(\d+)\s*$/m)
+    const rfcSchemaVersion = rfcSchemaMatch ? parseInt(rfcSchemaMatch[1], 10) : null
+    if (rfcSchemaVersion === null) {
+      violations.push({ kind: 'rfc-missing-schema-version', detail: `builder emits schema_version=${manifestSchemaVersion}; RFC artifact_manifest block does not declare schema_version` })
+    } else if (rfcSchemaVersion !== manifestSchemaVersion) {
+      violations.push({ kind: 'schema-version-drift', detail: `builder schema_version=${manifestSchemaVersion} != RFC declared ${rfcSchemaVersion}` })
     }
   }
 
@@ -140,9 +156,18 @@ function extractArtifactManifestBlock(text) {
 }
 
 function hasSurfaceKey(yamlBody, key) {
-  // Two-space indent under artifact_manifest:
-  const re = new RegExp(`^\\s{2}${key}:`, 'm')
-  return re.test(yamlBody)
+  // Scope the match to children of the `artifact_manifest:` root (two-space
+  // indent, but only inside that block). Codex P2: a sibling-context
+  // appearance with two-space indent could otherwise satisfy the check.
+  const lines = yamlBody.split('\n')
+  let inRoot = false
+  for (const raw of lines) {
+    if (/^artifact_manifest:\s*$/.test(raw)) { inRoot = true; continue }
+    if (!inRoot) continue
+    if (/^\S/.test(raw)) break // exited the root block on a sibling root key
+    if (new RegExp(`^\\s{2}${key}:`).test(raw)) return true
+  }
+  return false
 }
 
 function extractSurfaceBlock(yamlBody, surface) {

--- a/scripts/validate-rfc-failure-table.mjs
+++ b/scripts/validate-rfc-failure-table.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * validate-rfc-failure-table.mjs — RFC-004 §1072 CI gate.
+ *
+ * Parses the §11.5 failure-table prose markdown table AND the YAML mirror
+ * block beneath it; rejects:
+ *   - duplicate IDs (in either representation)
+ *   - prose↔YAML drift (id set parity, evidence tag parity, lesson parity)
+ *   - evidence-tag references that don't match the bp1-* vocabulary
+ *
+ * Targets: any RFC under docs/rfcs/ that contains both a markdown table
+ * with header `| # | Failure | ... | Evidence | Lesson? |` and a fenced
+ * `yaml` block with `failure_modes:`. RFCs without that pair are skipped.
+ *
+ * Per Rule 14 (machine-readable blocks for drift-prone state).
+ *
+ * Usage:
+ *   node validate-rfc-failure-table.mjs                # scan docs/rfcs/
+ *   node validate-rfc-failure-table.mjs <path-to.md>   # validate one file
+ *   node validate-rfc-failure-table.mjs --json         # machine-readable output
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const argv = process.argv.slice(2)
+const wantJson = argv.includes('--json')
+const positional = argv.filter(a => !a.startsWith('--'))
+
+const EVIDENCE_TAG_RE = /^bp1-[a-z][a-z0-9-]*$/
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const RFCS_DIR = path.join(REPO, 'docs', 'rfcs')
+
+const targets = positional.length
+  ? positional.map(p => path.resolve(p))
+  : fs.existsSync(RFCS_DIR)
+    ? fs.readdirSync(RFCS_DIR).filter(f => f.endsWith('.md')).map(f => path.join(RFCS_DIR, f))
+    : []
+
+const results = []
+for (const file of targets) {
+  results.push(validateFile(file))
+}
+
+const failed = results.filter(r => r.violations.length > 0)
+const skipped = results.filter(r => r.skipped)
+
+if (wantJson) {
+  console.log(JSON.stringify({
+    status: failed.length ? 'fail' : 'ok',
+    files_checked: results.length,
+    files_skipped: skipped.length,
+    files_failed: failed.length,
+    results,
+  }, null, 2))
+} else {
+  for (const r of results) {
+    if (r.skipped) continue
+    if (r.violations.length === 0) {
+      console.log(`OK    ${path.relative(REPO, r.file)}: ${r.row_count} rows, ${r.yaml_count} yaml`)
+    } else {
+      console.log(`FAIL  ${path.relative(REPO, r.file)}:`)
+      for (const v of r.violations) {
+        console.log(`        ${v.kind}: ${v.detail}`)
+      }
+    }
+  }
+  if (skipped.length) {
+    console.log(`(skipped ${skipped.length} files without a §11.5-shaped table)`)
+  }
+}
+
+process.exit(failed.length ? 1 : 0)
+
+// ---------------------------------------------------------------------------
+function validateFile(file) {
+  const text = fs.readFileSync(file, 'utf8')
+  const prose = extractProseTable(text)
+  const yaml = extractYamlMirror(text)
+  if (!prose && !yaml) {
+    return { file, skipped: true, reason: 'no failure-table markers', violations: [] }
+  }
+  if (!prose) {
+    return { file, skipped: false, violations: [{ kind: 'missing-prose-table', detail: 'YAML mirror present but no prose table found' }] }
+  }
+  if (!yaml) {
+    return { file, skipped: false, violations: [{ kind: 'missing-yaml-mirror', detail: 'prose table present but no YAML mirror found' }] }
+  }
+
+  const violations = []
+
+  // Duplicate IDs in prose
+  const proseIds = new Map()
+  for (const row of prose) {
+    if (proseIds.has(row.id)) {
+      violations.push({ kind: 'duplicate-id-prose', detail: `id ${row.id} appears at prose rows for "${proseIds.get(row.id).failure}" and "${row.failure}"` })
+    } else {
+      proseIds.set(row.id, row)
+    }
+  }
+  // Duplicate IDs in YAML
+  const yamlIds = new Map()
+  for (const row of yaml) {
+    if (yamlIds.has(row.id)) {
+      violations.push({ kind: 'duplicate-id-yaml', detail: `id ${row.id} appears twice in YAML mirror` })
+    } else {
+      yamlIds.set(row.id, row)
+    }
+  }
+  // ID set parity
+  for (const id of proseIds.keys()) {
+    if (!yamlIds.has(id)) {
+      violations.push({ kind: 'id-in-prose-not-yaml', detail: `id ${id} present in prose but missing from YAML mirror` })
+    }
+  }
+  for (const id of yamlIds.keys()) {
+    if (!proseIds.has(id)) {
+      violations.push({ kind: 'id-in-yaml-not-prose', detail: `id ${id} present in YAML mirror but missing from prose` })
+    }
+  }
+  // Per-ID drift: evidence tag + lesson
+  for (const [id, prow] of proseIds.entries()) {
+    const yrow = yamlIds.get(id)
+    if (!yrow) continue
+    if (prow.evidence_tag !== yrow.evidence) {
+      violations.push({ kind: 'evidence-drift', detail: `id ${id}: prose evidence tag "${prow.evidence_tag}" != yaml "${yrow.evidence}"` })
+    }
+    if (prow.lesson !== yrow.lesson) {
+      violations.push({ kind: 'lesson-drift', detail: `id ${id}: prose lesson "${prow.lesson_raw}" (=> ${prow.lesson}) != yaml ${JSON.stringify(yrow.lesson)}` })
+    }
+  }
+  // Evidence-tag pattern
+  for (const row of prose) {
+    if (!row.evidence_tag) {
+      violations.push({ kind: 'evidence-tag-missing', detail: `id ${row.id}: prose evidence cell has no \`bp1-*\` tag` })
+    } else if (!EVIDENCE_TAG_RE.test(row.evidence_tag)) {
+      violations.push({ kind: 'evidence-tag-shape', detail: `id ${row.id}: prose evidence tag "${row.evidence_tag}" does not match bp1-* pattern` })
+    }
+  }
+  for (const row of yaml) {
+    if (typeof row.evidence !== 'string' || !EVIDENCE_TAG_RE.test(row.evidence)) {
+      violations.push({ kind: 'evidence-tag-shape-yaml', detail: `id ${row.id}: yaml evidence "${row.evidence}" does not match bp1-* pattern` })
+    }
+  }
+
+  return { file, skipped: false, row_count: prose.length, yaml_count: yaml.length, violations }
+}
+
+// Match the §11.5 prose table by header signature.
+function extractProseTable(text) {
+  const lines = text.split('\n')
+  let headerIdx = -1
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^\|\s*#\s*\|\s*Failure\s*\|/i.test(line) && /Evidence/i.test(line) && /Lesson/i.test(line)) {
+      headerIdx = i
+      break
+    }
+  }
+  if (headerIdx < 0) return null
+  // Skip the divider row
+  const rows = []
+  for (let i = headerIdx + 2; i < lines.length; i++) {
+    const line = lines[i]
+    if (!line.startsWith('|')) break
+    const cells = parseRow(line)
+    if (cells.length < 6) continue
+    const id = parseInt(cells[0], 10)
+    if (Number.isNaN(id)) continue
+    const evidenceCell = cells[4]
+    const evidenceTagMatch = evidenceCell.match(/`(bp1-[a-z0-9-]+)`/)
+    const lessonRaw = cells[5].trim().toLowerCase()
+    const lesson = lessonRaw === 'yes' ? true
+      : lessonRaw === 'no' ? false
+      : lessonRaw === 'conditional' ? 'conditional'
+      : lessonRaw // unknown → preserve raw for drift detection
+    rows.push({
+      id,
+      failure: cells[1].trim(),
+      detector: cells[2].trim(),
+      terminal: cells[3].trim(),
+      evidence_cell: evidenceCell.trim(),
+      evidence_tag: evidenceTagMatch ? evidenceTagMatch[1] : null,
+      lesson_raw: lessonRaw,
+      lesson,
+    })
+  }
+  return rows.length ? rows : null
+}
+
+function parseRow(line) {
+  // Split on `|`, dropping the leading + trailing empties.
+  const parts = line.split('|')
+  if (parts.length < 2) return []
+  return parts.slice(1, -1).map(c => c.trim())
+}
+
+// Pull the YAML mirror block: a fenced ```yaml ``` block whose first
+// non-comment line is `failure_modes:`.
+function extractYamlMirror(text) {
+  const fenceRe = /```yaml\s*\n([\s\S]*?)\n```/g
+  let m
+  while ((m = fenceRe.exec(text)) !== null) {
+    const body = m[1]
+    if (/^\s*failure_modes:/m.test(body)) {
+      return parseFailureModesYaml(body)
+    }
+  }
+  return null
+}
+
+// Minimal YAML parser scoped to the failure_modes shape we expect.
+// Handles: `failure_modes:` followed by `- id: N` blocks with leaf scalars.
+function parseFailureModesYaml(body) {
+  const out = []
+  const lines = body.split('\n')
+  let cur = null
+  let inList = false
+  for (const raw of lines) {
+    const line = raw.replace(/#.*$/, '').replace(/\s+$/, '')
+    if (!line.trim()) continue
+    if (/^\s*failure_modes:\s*$/.test(line)) { inList = true; continue }
+    if (!inList) continue
+    const itemMatch = line.match(/^\s*-\s+id:\s*(\d+)\s*$/)
+    if (itemMatch) {
+      if (cur) out.push(cur)
+      cur = { id: parseInt(itemMatch[1], 10) }
+      continue
+    }
+    if (!cur) continue
+    const kv = line.match(/^\s+([a-zA-Z_][a-zA-Z_0-9]*):\s*(.+?)\s*$/)
+    if (kv) {
+      const key = kv[1]
+      let value = kv[2]
+      if (/^"(.*)"$/.test(value)) value = value.slice(1, -1)
+      else if (/^'(.*)'$/.test(value)) value = value.slice(1, -1)
+      else if (value === 'true') value = true
+      else if (value === 'false') value = false
+      else if (/^-?\d+$/.test(value)) value = parseInt(value, 10)
+      // 'conditional' stays a string
+      cur[key] = value
+    }
+  }
+  if (cur) out.push(cur)
+  return out
+}

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -181,6 +181,63 @@ tap('manifest has all six contract surfaces (even when empty)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Round-3 regression: em-search subprocess error must propagate, not be
+// swallowed by a bare catch in resolveLatestEpisodeId. Closes Codex round-3
+// finding: I-P2-1 invariant must cover the canonical_prompts em-search path.
+// ---------------------------------------------------------------------------
+tap('Codex round-3: em-search returning {episodes:[]} falls back, does not throw', () => {
+  // Exercises the legitimate fallback path: agent loader references an
+  // episode id em-search has no history for. Pre-fix bare-catch and post-fix
+  // explicit case both fall back to referencedId without throwing.
+  const proj = makeProj()
+  fs.writeFileSync(path.join(proj, '.claude', 'agents', 'bp1-fake.md'),
+    'Canonical prompt episode 20260506-100000-fake-slug-abcd.\n')
+  const r = run(proj)
+  assert.equal(r.status, 'ok')
+  // canonical_prompts populated with the fallback referencedId.
+  const cps = r.manifest.canonical_prompts
+  assert.equal(cps.length, 1)
+  assert.equal(cps[0].latest_prompt_episode_id, '20260506-100000-fake-slug-abcd')
+})
+
+tap('Codex round-3: em-search subprocess malformed-output error propagates', () => {
+  // Direct unit test on the lib via dynamic import — exercises the throw path
+  // when em-search returns unexpected shape. Stubs the em-search.mjs file in
+  // a temp scripts dir and points the lib at it via a copied lib + symlink
+  // strategy is too fragile; instead we do a focused process-level test:
+  // create a project that has its OWN scripts/em-search.mjs that prints
+  // garbage, and copy the bp1-* lib + scripts over to that scratch project.
+  const proj = makeProj()
+  // Loader referencing a non-existent id
+  fs.writeFileSync(path.join(proj, '.claude', 'agents', 'bp1-fake.md'),
+    'Canonical prompt episode 20260506-100000-fake-slug-abcd.\n')
+  // Copy the real lib + builder + a stubbed em-search into proj/scripts/
+  fs.mkdirSync(path.join(proj, 'scripts', 'lib'), { recursive: true })
+  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'bp1-manifest.mjs'),
+    path.join(proj, 'scripts', 'lib', 'bp1-manifest.mjs'))
+  fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    path.join(proj, 'scripts', 'bp1-build-artifact-manifest.mjs'))
+  // Stub em-search to return malformed JSON (no episodes array)
+  fs.writeFileSync(path.join(proj, 'scripts', 'em-search.mjs'),
+    `#!/usr/bin/env node
+console.log(JSON.stringify({status:'error', message:'simulated bad shape'}))
+`)
+  let threw = false
+  try {
+    execFileSync('node', [
+      path.join(proj, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+      '--project', proj,
+      '--json',
+    ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  } catch (e) {
+    threw = true
+    assert.ok(/unexpected shape/.test(e.message + (e.stderr || '')),
+      `expected "unexpected shape" in error; got ${e.message}`)
+  }
+  assert.ok(threw, 'builder must propagate em-search malformed-output error')
+})
+
+// ---------------------------------------------------------------------------
 // Sorted ordering: scripts always come back in path order
 // ---------------------------------------------------------------------------
 tap('scripts are returned in sorted order', () => {

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-build-artifact-manifest.mjs — Determinism + surface coverage tests.
+ *
+ * RFC-004 §107-152 + A14: two consecutive runs on the same install MUST
+ * produce identical sha256.
+ *
+ * Surface coverage (A9-A13, A15):
+ *   - bp1-* scripts inventoried; em-review-request.mjs explicitly listed
+ *   - bp1-*.sh hooks inventoried
+ *   - settings.json bp1 lines filtered + hashed
+ *   - plugin.json bp1 entries filtered + hashed
+ *   - bp1-* agent loaders inventoried
+ *   - canonical-prompt episode-id resolved per loader
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`) }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bp1-mfst-${label}-`))
+}
+
+function makeProj() {
+  const dir = makeTempDir('proj')
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true })
+  fs.mkdirSync(path.join(dir, '.claude', 'hooks'), { recursive: true })
+  fs.mkdirSync(path.join(dir, '.claude', 'agents'), { recursive: true })
+  fs.mkdirSync(path.join(dir, '.claude-plugin'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+
+function run(proj) {
+  const out = execFileSync('node', [SCRIPT, '--project', proj, '--json'], { encoding: 'utf8' })
+  return JSON.parse(out)
+}
+
+// ---------------------------------------------------------------------------
+// Determinism: empty install
+// ---------------------------------------------------------------------------
+tap('A14: empty install — two runs produce same sha256', () => {
+  const proj = makeProj()
+  const a = run(proj)
+  const b = run(proj)
+  assert.equal(a.sha256, b.sha256, 'sha256 drifts across runs')
+  assert.equal(a.status, 'ok')
+})
+
+// ---------------------------------------------------------------------------
+// Determinism: populated install
+// ---------------------------------------------------------------------------
+tap('A14: populated install — two runs produce same sha256', () => {
+  const proj = makeProj()
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-orchestrator.mjs'), '// orchestrator\n')
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-rfc-scan.mjs'), '// scan\n')
+  fs.writeFileSync(path.join(proj, '.claude', 'hooks', 'bp1-approval-check.sh'), '#!/usr/bin/env bash\n')
+  fs.writeFileSync(path.join(proj, '.claude', 'agents', 'bp1-orchestrator.md'), 'See episode 20260506-100000-some-slug-abcd.\n')
+  fs.writeFileSync(path.join(proj, '.claude', 'settings.json'), JSON.stringify({
+    hooks: { SessionStart: [{ command: '$CLAUDE_PROJECT_DIR/.claude/hooks/bp1-approval-check.sh' }] }
+  }))
+  fs.writeFileSync(path.join(proj, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    'scheduled-tasks': [{ name: 'bp1-deadline-tick', cron: '*/5 * * * *' }],
+    'slash-commands': [{ name: 'bp1-auto', script: 'foo.mjs' }],
+  }))
+  const a = run(proj)
+  const b = run(proj)
+  assert.equal(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A4 coverage: changing one bp1 script content changes the hash
+// ---------------------------------------------------------------------------
+tap('hash changes when a bp1-* script content drifts', () => {
+  const proj = makeProj()
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-foo.mjs'), '// v1\n')
+  const a = run(proj)
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-foo.mjs'), '// v2\n')
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A9: hook content drift changes hash
+// ---------------------------------------------------------------------------
+tap('A9: hook content drift changes hash', () => {
+  const proj = makeProj()
+  const hookPath = path.join(proj, '.claude', 'hooks', 'bp1-approval-check.sh')
+  fs.writeFileSync(hookPath, '#!/usr/bin/env bash\n# v1\n')
+  const a = run(proj)
+  fs.writeFileSync(hookPath, '#!/usr/bin/env bash\n# v2\n')
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A10: settings.json bp1 lines drift changes hash
+// ---------------------------------------------------------------------------
+tap('A10: settings.json bp1-line drift changes hash', () => {
+  const proj = makeProj()
+  const sp = path.join(proj, '.claude', 'settings.json')
+  fs.writeFileSync(sp, JSON.stringify({
+    hooks: { SessionStart: [{ command: 'bp1-approval-check.sh' }] }
+  }, null, 2))
+  const a = run(proj)
+  fs.writeFileSync(sp, JSON.stringify({
+    hooks: { SessionStart: [{ command: 'bp1-approval-check.sh' }, { command: 'bp1-sweep.sh' }] }
+  }, null, 2))
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A11: plugin.json bp1 entries drift changes hash
+// ---------------------------------------------------------------------------
+tap('A11: plugin.json bp1 entries drift changes hash', () => {
+  const proj = makeProj()
+  const pp = path.join(proj, '.claude-plugin', 'plugin.json')
+  fs.writeFileSync(pp, JSON.stringify({
+    'scheduled-tasks': [{ name: 'bp1-deadline-tick', cron: '*/5 * * * *' }]
+  }))
+  const a = run(proj)
+  fs.writeFileSync(pp, JSON.stringify({
+    'scheduled-tasks': [{ name: 'bp1-deadline-tick', cron: '*/1 * * * *' }]
+  }))
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A13: agent loader content drift changes hash
+// ---------------------------------------------------------------------------
+tap('A13: agent loader file drift changes hash', () => {
+  const proj = makeProj()
+  const lp = path.join(proj, '.claude', 'agents', 'bp1-orchestrator.md')
+  fs.writeFileSync(lp, 'v1 prompt episode 20260506-100000-some-slug-abcd.\n')
+  const a = run(proj)
+  fs.writeFileSync(lp, 'v2 prompt episode 20260506-100000-some-slug-abcd.\n')
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+// ---------------------------------------------------------------------------
+// A15: em-review-request.mjs is explicitly listed in the manifest
+// ---------------------------------------------------------------------------
+tap('A15: em-review-request.mjs is in the manifest scripts when present', () => {
+  const proj = makeProj()
+  fs.writeFileSync(path.join(proj, 'scripts', 'em-review-request.mjs'), '// extension\n')
+  const r = run(proj)
+  const found = r.manifest.scripts.find(s => s.path === 'scripts/em-review-request.mjs')
+  assert.ok(found, 'em-review-request.mjs missing from manifest')
+})
+
+// ---------------------------------------------------------------------------
+// Surface contract: empty manifest has expected six surfaces
+// ---------------------------------------------------------------------------
+tap('manifest has all six contract surfaces (even when empty)', () => {
+  const proj = makeProj()
+  const r = run(proj)
+  const m = r.manifest
+  assert.ok(Array.isArray(m.scripts))
+  assert.ok(Array.isArray(m.hooks))
+  assert.ok(typeof m.settings_lines.sha256 === 'string')
+  assert.ok(typeof m.plugin_entries.sha256 === 'string')
+  assert.ok(Array.isArray(m.agent_loaders))
+  assert.ok(Array.isArray(m.canonical_prompts))
+})
+
+// ---------------------------------------------------------------------------
+// Sorted ordering: scripts always come back in path order
+// ---------------------------------------------------------------------------
+tap('scripts are returned in sorted order', () => {
+  const proj = makeProj()
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-zzz.mjs'), '// z\n')
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-aaa.mjs'), '// a\n')
+  fs.writeFileSync(path.join(proj, 'scripts', 'bp1-mmm.mjs'), '// m\n')
+  const r = run(proj)
+  const paths = r.manifest.scripts.map(s => s.path)
+  const sorted = [...paths].sort()
+  assert.deepEqual(paths, sorted)
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) { console.log(`# FAILED ${fail} of ${pass + fail}`); process.exit(1) }
+else console.log(`# PASSED ${pass}`)

--- a/tests/test-bp1-flag-check.mjs
+++ b/tests/test-bp1-flag-check.mjs
@@ -239,6 +239,36 @@ tap('row 29: verify-key chmod 0644 → bp1-hmac-keyfile-fail', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Regression: manifest builder error during recomputation must surface as
+// bp1-flag-version-drift, not raw Node exit. Codex P2 finding (round 2).
+// ---------------------------------------------------------------------------
+tap('regression: manifest builder error → bp1-flag-version-drift exit 2', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const { fingerprint } = writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  // Make the scripts dir unreadable so buildArtifactManifest throws on its
+  // first readdirSync. Skip on roots that can read anything (tests run as
+  // root in some CI containers); use chmod 0000.
+  fs.chmodSync(path.join(proj, 'scripts'), 0o000)
+  try {
+    writeConfig(configPath, proj, {
+      enabled: true,
+      artifact_version_hash: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+      verify_key_id: fingerprint,
+    })
+    const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+    // Either the builder throws (preferred path under a non-root user) or
+    // it returns a hash that doesn't match the all-zero placeholder. Both
+    // paths must surface as version-drift, exit 2, structured JSON.
+    assert.equal(r.exitCode, 2)
+    assert.equal(r.parsed.code, 'bp1-flag-version-drift')
+  } finally {
+    fs.chmodSync(path.join(proj, 'scripts'), 0o755)
+  }
+})
+
+// ---------------------------------------------------------------------------
 // Regression: --project pointing to nonexistent path must fail-closed with
 // structured exit 2 (not throw a raw ENOENT). Finding 1, MAJOR, code-review.
 // ---------------------------------------------------------------------------

--- a/tests/test-bp1-flag-check.mjs
+++ b/tests/test-bp1-flag-check.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-flag-check.mjs — Hermetic tests for bp1-flag-check.mjs.
+ *
+ * Builds isolated temp project roots + verify-key + config.json fixtures
+ * per scenario; runs the script with --project, --config, --no-emit; asserts
+ * the failure code on stdout JSON.
+ *
+ * Scenarios cover RFC-004 failure-table rows 25-29 plus the happy path.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'bp1-flag-check.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function tap(name, fn) {
+  try {
+    fn()
+    pass++
+    console.log(`ok ${pass + fail} - ${name}`)
+  } catch (e) {
+    fail++
+    failures.push({ name, error: e })
+    console.log(`not ok ${pass + fail} - ${name}`)
+    console.log(`  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bp1-flag-check-${label}-`))
+}
+
+function writeVerifyKey(verifyKeyPath, mode = 0o600) {
+  fs.mkdirSync(path.dirname(verifyKeyPath), { recursive: true })
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(verifyKeyPath, key)
+  fs.chmodSync(verifyKeyPath, mode)
+  const fp = crypto.createHmac('sha256', key)
+    .update('verify-key-fingerprint-v1', 'utf8')
+    .digest('hex').slice(0, 16)
+  return { key, fingerprint: fp }
+}
+
+function makeProjectRoot() {
+  const dir = makeTempDir('proj')
+  // git init so canonical-root resolution works (we override via --project anyway)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+
+function buildExpectedHash(projectRoot) {
+  // Run the manifest builder to pre-compute the hash that flag-check expects.
+  const out = execFileSync('node', [
+    path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    '--project', projectRoot,
+    '--json',
+  ], { encoding: 'utf8' })
+  const parsed = JSON.parse(out)
+  return parsed.sha256
+}
+
+function writeConfig(configPath, projectRoot, entry) {
+  fs.mkdirSync(path.dirname(configPath), { recursive: true })
+  const config = {
+    bp1: {
+      schema_version: 1,
+      activations: { [projectRoot]: entry },
+    },
+  }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+function runFlagCheck({ projectRoot, configPath, env }) {
+  const r = spawnSync('node', [
+    SCRIPT,
+    '--project', projectRoot,
+    '--config', configPath,
+    '--no-emit',
+    '--json',
+  ], { encoding: 'utf8', env: { ...process.env, ...(env || {}) } })
+  return {
+    exitCode: r.status,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    parsed: r.stdout ? safeParse(r.stdout) : null,
+  }
+}
+
+function safeParse(s) {
+  try { return JSON.parse(s.trim()) } catch { return null }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: happy path
+// ---------------------------------------------------------------------------
+tap('happy path: enabled entry with matching hash + fingerprint → exit 0', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const verifyKeyPath = path.join(homeDir, '.episodic-memory', '.verify-key')
+  const { fingerprint } = writeVerifyKey(verifyKeyPath)
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  const hash = buildExpectedHash(proj)
+  writeConfig(configPath, proj, {
+    enabled: true,
+    artifact_version_hash: `sha256:${hash}`,
+    enabled_at: '2026-05-06T00:00:00Z',
+    enabled_via: 'test',
+    verify_key_id: fingerprint,
+  })
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 0, `expected exit 0; stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.ok(r.parsed)
+  assert.equal(r.parsed.status, 'ok')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-disabled-refusal (no entry)
+// ---------------------------------------------------------------------------
+tap('row 25: no activation entry → bp1-disabled-refusal', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { schema_version: 1, activations: {} } }))
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-disabled-refusal (enabled=false)
+// ---------------------------------------------------------------------------
+tap('row 25: enabled=false → bp1-disabled-refusal', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const { fingerprint } = writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  const hash = buildExpectedHash(proj)
+  writeConfig(configPath, proj, {
+    enabled: false,
+    artifact_version_hash: `sha256:${hash}`,
+    verify_key_id: fingerprint,
+  })
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-flag-version-drift (script content changed)
+// ---------------------------------------------------------------------------
+tap('row 26: script content drift → bp1-flag-version-drift', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const { fingerprint } = writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  // Create a bp1-foo.mjs and lock its hash
+  const fooPath = path.join(proj, 'scripts', 'bp1-foo.mjs')
+  fs.writeFileSync(fooPath, '// v1\n')
+  const hashV1 = buildExpectedHash(proj)
+  writeConfig(configPath, proj, {
+    enabled: true,
+    artifact_version_hash: `sha256:${hashV1}`,
+    verify_key_id: fingerprint,
+  })
+  // Drift the script
+  fs.writeFileSync(fooPath, '// v2 — content drifted\n')
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-flag-version-drift')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-flag-key-drift (verify-key rotated)
+// ---------------------------------------------------------------------------
+tap('row 27: verify-key rotated post-activation → bp1-flag-key-drift', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const verifyKeyPath = path.join(homeDir, '.episodic-memory', '.verify-key')
+  const { fingerprint: fp1 } = writeVerifyKey(verifyKeyPath)
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  const hash = buildExpectedHash(proj)
+  // Activated with fp1 fingerprint
+  writeConfig(configPath, proj, {
+    enabled: true,
+    artifact_version_hash: `sha256:${hash}`,
+    verify_key_id: fp1,
+  })
+  // Rotate the key without re-running activation
+  fs.unlinkSync(verifyKeyPath)
+  writeVerifyKey(verifyKeyPath)
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-flag-key-drift')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-flag-config-corrupt (parse error)
+// ---------------------------------------------------------------------------
+tap('row 28: corrupt config json → bp1-flag-config-corrupt', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.mkdirSync(path.dirname(configPath), { recursive: true })
+  fs.writeFileSync(configPath, '{not json')
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-flag-config-corrupt')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-hmac-keyfile-fail (mode != 0600)
+// ---------------------------------------------------------------------------
+tap('row 29: verify-key chmod 0644 → bp1-hmac-keyfile-fail', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  const verifyKeyPath = path.join(homeDir, '.episodic-memory', '.verify-key')
+  writeVerifyKey(verifyKeyPath, 0o644)
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-hmac-keyfile-fail')
+  assert.equal(r.parsed.verify_key_state.reason, 'mode')
+})
+
+// ---------------------------------------------------------------------------
+// Regression: --project pointing to nonexistent path must fail-closed with
+// structured exit 2 (not throw a raw ENOENT). Finding 1, MAJOR, code-review.
+// ---------------------------------------------------------------------------
+tap('regression: --project nonexistent → bp1-disabled-refusal exit 2', () => {
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  const r = runFlagCheck({
+    projectRoot: '/nonexistent/path/that/does/not/exist',
+    configPath,
+    env: { HOME: homeDir },
+  })
+  assert.equal(r.exitCode, 2, `expected exit 2; stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.ok(r.parsed)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+})
+
+// ---------------------------------------------------------------------------
+// Scenario: bp1-hmac-keyfile-fail (missing)
+// ---------------------------------------------------------------------------
+tap('row 29: verify-key missing → bp1-hmac-keyfile-fail', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  fs.mkdirSync(path.join(homeDir, '.episodic-memory'), { recursive: true })
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-hmac-keyfile-fail')
+  assert.equal(r.parsed.verify_key_state.reason, 'missing')
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) {
+  console.log(`# FAILED ${fail} of ${pass + fail}`)
+  process.exit(1)
+} else {
+  console.log(`# PASSED ${pass}`)
+}

--- a/tests/test-install-bp1.sh
+++ b/tests/test-install-bp1.sh
@@ -22,6 +22,16 @@ PASS=0
 FAIL=0
 SKIP_GIT=0
 
+# Cross-platform file mode reader. macOS BSD stat uses -f; GNU stat uses -c.
+# Selecting on `uname` is more reliable than `stat -f x || stat -c x` because
+# Linux `stat -f` is filesystem-stat (returns info, no error) — the || would
+# never fall through.
+if [ "$(uname)" = "Darwin" ]; then
+  stat_mode() { stat -f '%Lp' "$1"; }
+else
+  stat_mode() { stat -c '%a' "$1"; }
+fi
+
 check() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -47,7 +57,7 @@ check "verify-key exists" "1" "$([ -f "$HOME1/.episodic-memory/.verify-key" ] &&
 check "config.json exists" "1" "$([ -f "$HOME1/.episodic-memory/config.json" ] && echo 1)"
 
 # Mode 0600 — stat -f on macOS, stat -c on linux. Try macOS first.
-MODE=$(stat -f '%Lp' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null || stat -c '%a' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null)
+MODE=$(stat_mode "$HOME1/.episodic-memory/.verify-key")
 check "verify-key mode 0600" "600" "$MODE"
 
 SIZE=$(wc -c < "$HOME1/.episodic-memory/.verify-key" | tr -d ' ')
@@ -81,7 +91,7 @@ check ".gitignore line count stable across re-install" "$LINES_BEFORE" "$LINES_A
 # ---------------------------------------------------------------------------
 chmod 0644 "$HOME1/.episodic-memory/.verify-key"
 HOME="$HOME1" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ1" >/dev/null 2>&1
-MODE_AFTER=$(stat -f '%Lp' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null || stat -c '%a' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null)
+MODE_AFTER=$(stat_mode "$HOME1/.episodic-memory/.verify-key")
 check "verify-key mode healed back to 0600" "600" "$MODE_AFTER"
 
 # ---------------------------------------------------------------------------

--- a/tests/test-install-bp1.sh
+++ b/tests/test-install-bp1.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# test-install-bp1.sh — Idempotence + correctness tests for install.mjs's
+# BP-1 deltas (PR-1a / RFC-004 M0).
+#
+# Verifies:
+#   - First install creates ~/.episodic-memory/.verify-key (mode 0600, 32 bytes)
+#   - First install creates ~/.episodic-memory/config.json with bp1 skeleton
+#   - Re-install does not regenerate the verify-key
+#   - Re-install fixes 0644 → 0600 drift
+#   - .gitignore append for .episodic-memory/ is line-anchored
+#     (a comment mentioning .episodic-memory does NOT silently suppress the append)
+#   - .gitignore append is idempotent across two consecutive runs
+#   - .gitignore append for run.key pattern is line-anchored too
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+PASS=0
+FAIL=0
+SKIP_GIT=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "ok ${label}"
+  else
+    FAIL=$((FAIL + 1))
+    echo "not ok ${label}: expected '${expected}', got '${actual}'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: clean-slate install
+# ---------------------------------------------------------------------------
+HOME1="$TMP_ROOT/home1"
+PROJ1="$TMP_ROOT/proj1"
+mkdir -p "$HOME1" "$PROJ1"
+echo "" > "$PROJ1/.gitignore"
+
+HOME="$HOME1" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ1" >/dev/null 2>&1
+
+check "verify-key exists" "1" "$([ -f "$HOME1/.episodic-memory/.verify-key" ] && echo 1)"
+check "config.json exists" "1" "$([ -f "$HOME1/.episodic-memory/config.json" ] && echo 1)"
+
+# Mode 0600 — stat -f on macOS, stat -c on linux. Try macOS first.
+MODE=$(stat -f '%Lp' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null || stat -c '%a' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null)
+check "verify-key mode 0600" "600" "$MODE"
+
+SIZE=$(wc -c < "$HOME1/.episodic-memory/.verify-key" | tr -d ' ')
+check "verify-key 32 bytes" "32" "$SIZE"
+
+# config.json shape — minimal grep
+grep -q '"bp1"' "$HOME1/.episodic-memory/config.json" && BP1_KEY=1 || BP1_KEY=0
+check "config.json has bp1 key" "1" "$BP1_KEY"
+
+# .gitignore appends both patterns
+grep -qx '.episodic-memory/' "$PROJ1/.gitignore" && APP1=1 || APP1=0
+check ".gitignore: .episodic-memory/ appended" "1" "$APP1"
+grep -qx '\*\*/.episodic-memory/runs/\*/run\.key' "$PROJ1/.gitignore" && APP2=1 || APP2=0
+check ".gitignore: run.key pattern appended" "1" "$APP2"
+
+# ---------------------------------------------------------------------------
+# Test 2: re-install is idempotent (no double-append, no key regen)
+# ---------------------------------------------------------------------------
+KEY1=$(shasum -a 256 "$HOME1/.episodic-memory/.verify-key" | awk '{print $1}')
+LINES_BEFORE=$(wc -l < "$PROJ1/.gitignore")
+
+HOME="$HOME1" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ1" >/dev/null 2>&1
+
+KEY2=$(shasum -a 256 "$HOME1/.episodic-memory/.verify-key" | awk '{print $1}')
+LINES_AFTER=$(wc -l < "$PROJ1/.gitignore")
+check "verify-key not regenerated" "$KEY1" "$KEY2"
+check ".gitignore line count stable across re-install" "$LINES_BEFORE" "$LINES_AFTER"
+
+# ---------------------------------------------------------------------------
+# Test 3: chmod drift heals on re-install
+# ---------------------------------------------------------------------------
+chmod 0644 "$HOME1/.episodic-memory/.verify-key"
+HOME="$HOME1" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ1" >/dev/null 2>&1
+MODE_AFTER=$(stat -f '%Lp' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null || stat -c '%a' "$HOME1/.episodic-memory/.verify-key" 2>/dev/null)
+check "verify-key mode healed back to 0600" "600" "$MODE_AFTER"
+
+# ---------------------------------------------------------------------------
+# Test 4: line-anchored gitignore guard — comment mentioning .episodic-memory
+# does NOT suppress the real append. Finding 2, MAJOR, code-review.
+# ---------------------------------------------------------------------------
+HOME2="$TMP_ROOT/home2"
+PROJ2="$TMP_ROOT/proj2"
+mkdir -p "$HOME2" "$PROJ2"
+cat > "$PROJ2/.gitignore" <<'EOF'
+node_modules/
+# my notes about .episodic-memory data location
+EOF
+
+HOME="$HOME2" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ2" >/dev/null 2>&1
+
+grep -qx '.episodic-memory/' "$PROJ2/.gitignore" && C1=1 || C1=0
+check "comment mention does NOT suppress .episodic-memory/ append" "1" "$C1"
+
+# ---------------------------------------------------------------------------
+# Test 5: existing real entry is respected (no duplicate append)
+# ---------------------------------------------------------------------------
+HOME3="$TMP_ROOT/home3"
+PROJ3="$TMP_ROOT/proj3"
+mkdir -p "$HOME3" "$PROJ3"
+cat > "$PROJ3/.gitignore" <<'EOF'
+node_modules/
+.episodic-memory/
+EOF
+LINES_BEFORE3=$(wc -l < "$PROJ3/.gitignore")
+
+HOME="$HOME3" node "$REPO_DIR/install.mjs" --tool claude-code --project "$PROJ3" >/dev/null 2>&1
+
+# .episodic-memory/ count must not double, but run.key pattern is added once
+EM_COUNT=$(grep -cx '.episodic-memory/' "$PROJ3/.gitignore")
+check "no duplicate .episodic-memory/ entry" "1" "$EM_COUNT"
+
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "1..$TOTAL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "# FAILED $FAIL of $TOTAL"
+  exit 1
+else
+  echo "# PASSED $PASS"
+fi

--- a/tests/test-validate-rfc-artifact-manifest.mjs
+++ b/tests/test-validate-rfc-artifact-manifest.mjs
@@ -23,7 +23,7 @@ function makeTempDir(label) {
   return fs.mkdtempSync(path.join(os.tmpdir(), `rfc-mfst-${label}-`))
 }
 
-function fixture({ surfaces, includeEmReviewRequest = true }) {
+function fixture({ surfaces, includeEmReviewRequest = true, schemaVersion = 1 }) {
   let scriptsBlock = '  scripts:\n    - path: "scripts/bp1-orchestrator.mjs"\n      sha256: "<file-sha256>"\n'
   if (includeEmReviewRequest) {
     scriptsBlock += '    - path: "scripts/em-review-request.mjs"\n      sha256: "<file-sha256>"\n'
@@ -37,6 +37,7 @@ function fixture({ surfaces, includeEmReviewRequest = true }) {
     canonical_prompts: '  canonical_prompts:\n    - loader: ".claude/agents/bp1-orchestrator.md"\n      latest_prompt_episode_id: "20260506-X"\n',
   }
   let yaml = '```yaml\nartifact_manifest:\n'
+  if (schemaVersion !== null) yaml += `  schema_version: ${schemaVersion}\n`
   for (const s of surfaces) yaml += surfaceBlocks[s]
   yaml += '```\n'
   return `# Fixture\n\n## Activation flag\n\n${yaml}`
@@ -83,6 +84,34 @@ tap('skip files without an artifact_manifest yaml block', () => {
   const r = run(file)
   assert.equal(r.exitCode, 0)
   assert.ok(r.parsed.results[0].skipped)
+})
+
+tap('schema_version drift between RFC and builder → schema-version-drift', () => {
+  const file = writeFixture(fixture({ surfaces: ALL, schemaVersion: 99 }))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('schema-version-drift'))
+})
+
+tap('RFC missing schema_version → rfc-missing-schema-version', () => {
+  const file = writeFixture(fixture({ surfaces: ALL, schemaVersion: null }))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('rfc-missing-schema-version'))
+})
+
+tap('hasSurfaceKey: a key appearing only OUTSIDE artifact_manifest does not satisfy presence', () => {
+  // Sibling-context fence: artifact_manifest has only 5 surfaces, but a
+  // sibling root_block uses the same key name. Validator must NOT count it.
+  const yaml = '```yaml\nartifact_manifest:\n  schema_version: 1\n  scripts:\n    - path: "scripts/bp1-orchestrator.mjs"\n      sha256: "<sha>"\n    - path: "scripts/em-review-request.mjs"\n      sha256: "<sha>"\n  hooks:\n    - path: ".claude/hooks/bp1-approval-check.sh"\n      sha256: "<sha>"\n  settings_lines:\n    sha256: "<sha>"\n  plugin_entries:\n    sha256: "<sha>"\n  agent_loaders:\n    - path: ".claude/agents/bp1-orchestrator.md"\n      sha256: "<sha>"\n\n# sibling root block, NOT a child of artifact_manifest:\nother_block:\n  canonical_prompts:\n    - loader: "decoy"\n      latest_prompt_episode_id: "X"\n```\n'
+  const file = writeFixture(`# Fixture\n\n${yaml}`)
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('missing-surface-in-rfc'),
+    `expected missing-surface-in-rfc, got ${JSON.stringify(kinds)}`)
 })
 
 tap('real RFC-004 spec validates', () => {

--- a/tests/test-validate-rfc-artifact-manifest.mjs
+++ b/tests/test-validate-rfc-artifact-manifest.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * test-validate-rfc-artifact-manifest.mjs — drift tests for the Rule-14
+ * artifact-manifest parity validator.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'validate-rfc-artifact-manifest.mjs')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`) }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `rfc-mfst-${label}-`))
+}
+
+function fixture({ surfaces, includeEmReviewRequest = true }) {
+  let scriptsBlock = '  scripts:\n    - path: "scripts/bp1-orchestrator.mjs"\n      sha256: "<file-sha256>"\n'
+  if (includeEmReviewRequest) {
+    scriptsBlock += '    - path: "scripts/em-review-request.mjs"\n      sha256: "<file-sha256>"\n'
+  }
+  const surfaceBlocks = {
+    scripts: scriptsBlock,
+    hooks: '  hooks:\n    - path: ".claude/hooks/bp1-approval-check.sh"\n      sha256: "<sha>"\n',
+    settings_lines: '  settings_lines:\n    sha256: "<filtered-sha>"\n',
+    plugin_entries: '  plugin_entries:\n    sha256: "<filtered-sha>"\n',
+    agent_loaders: '  agent_loaders:\n    - path: ".claude/agents/bp1-orchestrator.md"\n      sha256: "<sha>"\n',
+    canonical_prompts: '  canonical_prompts:\n    - loader: ".claude/agents/bp1-orchestrator.md"\n      latest_prompt_episode_id: "20260506-X"\n',
+  }
+  let yaml = '```yaml\nartifact_manifest:\n'
+  for (const s of surfaces) yaml += surfaceBlocks[s]
+  yaml += '```\n'
+  return `# Fixture\n\n## Activation flag\n\n${yaml}`
+}
+
+function writeFixture(content) {
+  const dir = makeTempDir('fix')
+  const file = path.join(dir, 'RFC-fix.md')
+  fs.writeFileSync(file, content)
+  return file
+}
+
+function run(file) {
+  const r = spawnSync('node', [SCRIPT, file, '--json'], { encoding: 'utf8' })
+  return { exitCode: r.status, parsed: JSON.parse(r.stdout) }
+}
+
+const ALL = ['scripts', 'hooks', 'settings_lines', 'plugin_entries', 'agent_loaders', 'canonical_prompts']
+
+tap('happy path: all 6 surfaces present + em-review-request listed → exit 0', () => {
+  const file = writeFixture(fixture({ surfaces: ALL }))
+  const r = run(file)
+  assert.equal(r.exitCode, 0, JSON.stringify(r.parsed.results[0].violations))
+})
+
+tap('missing surface scripts → missing-surface-in-rfc', () => {
+  const file = writeFixture(fixture({ surfaces: ALL.filter(s => s !== 'hooks') }))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('missing-surface-in-rfc'))
+})
+
+tap('em-review-request.mjs missing from scripts surface → missing-mandated-extension-script', () => {
+  const file = writeFixture(fixture({ surfaces: ALL, includeEmReviewRequest: false }))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('missing-mandated-extension-script'))
+})
+
+tap('skip files without an artifact_manifest yaml block', () => {
+  const file = writeFixture('# stub RFC\n\nno yaml block here\n')
+  const r = run(file)
+  assert.equal(r.exitCode, 0)
+  assert.ok(r.parsed.results[0].skipped)
+})
+
+tap('real RFC-004 spec validates', () => {
+  const file = path.join(REPO, 'docs', 'rfcs', 'RFC-004-bp1-auto-pilot.md')
+  if (!fs.existsSync(file)) return
+  const r = run(file)
+  assert.equal(r.exitCode, 0, `RFC-004 should validate; got ${JSON.stringify(r.parsed.results[0].violations)}`)
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) { console.log(`# FAILED ${fail} of ${pass + fail}`); process.exit(1) }
+else console.log(`# PASSED ${pass}`)

--- a/tests/test-validate-rfc-failure-table.mjs
+++ b/tests/test-validate-rfc-failure-table.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * test-validate-rfc-failure-table.mjs — drift-detection self-tests.
+ *
+ * Builds a minimal RFC-shaped fixture per scenario, runs the validator,
+ * asserts on the violation kinds.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'validate-rfc-failure-table.mjs')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`) }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `rfc-failure-${label}-`))
+}
+
+function fixture(rows, yamlRows = rows) {
+  const tableHeader = `| # | Failure | Detector | Terminal | Evidence | Lesson? |\n|---|---|---|---|---|---|\n`
+  const proseRows = rows.map(r =>
+    `| ${r.id} | ${r.failure || 'F'} | ${r.detector || 'D'} | ${r.terminal || 'C'} | \`${r.evidence}\` | ${r.lesson === true ? 'yes' : r.lesson === false ? 'no' : r.lesson} |`
+  ).join('\n')
+  const yamlBlock = '```yaml\nfailure_modes:\n' + yamlRows.map(r =>
+    `  - id: ${r.id}\n    failure: ${r.failure || 'F'}\n    detector: ${r.detector || 'D'}\n    terminal: ${r.terminal || 'C'}\n    evidence: ${r.evidence}\n    lesson: ${typeof r.lesson === 'string' ? r.lesson : r.lesson ? 'true' : 'false'}`
+  ).join('\n') + '\n```\n'
+  return `# RFC fixture\n\n## §11.5 Failure modes & recovery table\n\n${tableHeader}${proseRows}\n\n${yamlBlock}`
+}
+
+function writeFixture(content) {
+  const dir = makeTempDir('fix')
+  const file = path.join(dir, 'RFC-test.md')
+  fs.writeFileSync(file, content)
+  return file
+}
+
+function run(file) {
+  const r = spawnSync('node', [SCRIPT, file, '--json'], { encoding: 'utf8' })
+  return { exitCode: r.status, parsed: JSON.parse(r.stdout) }
+}
+
+// ---------------------------------------------------------------------------
+tap('happy path — agreeing prose + YAML → exit 0', () => {
+  const file = writeFixture(fixture([
+    { id: 1, evidence: 'bp1-foo', lesson: true },
+    { id: 2, evidence: 'bp1-bar', lesson: false },
+  ]))
+  const r = run(file)
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.parsed.results[0].violations.length, 0)
+})
+
+tap('duplicate id in prose → duplicate-id-prose', () => {
+  const file = writeFixture(fixture([
+    { id: 1, evidence: 'bp1-foo', lesson: true },
+    { id: 1, evidence: 'bp1-bar', lesson: false },
+  ]))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'duplicate-id-prose'))
+})
+
+tap('duplicate id in yaml → duplicate-id-yaml', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }, { id: 2, evidence: 'bp1-bar', lesson: true }],
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }, { id: 1, evidence: 'bp1-bar', lesson: true }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'duplicate-id-yaml'))
+})
+
+tap('id in prose but missing from yaml → id-in-prose-not-yaml', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }, { id: 2, evidence: 'bp1-bar', lesson: true }],
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'id-in-prose-not-yaml'))
+})
+
+tap('id in yaml but missing from prose → id-in-yaml-not-prose', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }],
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }, { id: 5, evidence: 'bp1-extra', lesson: true }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'id-in-yaml-not-prose'))
+})
+
+tap('evidence tag drift between prose and yaml → evidence-drift', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }],
+    [{ id: 1, evidence: 'bp1-bar', lesson: true }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'evidence-drift'))
+})
+
+tap('lesson drift (prose yes, yaml false) → lesson-drift', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: true }],
+    [{ id: 1, evidence: 'bp1-foo', lesson: false }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  assert.ok(r.parsed.results[0].violations.some(v => v.kind === 'lesson-drift'))
+})
+
+tap('non-bp1 evidence tag → evidence-tag-shape', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'something-else', lesson: true }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 1)
+  // Prose evidence cell parsing requires a backtick-wrapped bp1-* tag —
+  // the prose row will trigger evidence-tag-missing; YAML row will trigger evidence-tag-shape-yaml.
+  const kinds = r.parsed.results[0].violations.map(v => v.kind)
+  assert.ok(kinds.includes('evidence-tag-shape-yaml') || kinds.includes('evidence-tag-missing'))
+})
+
+tap('conditional lesson value matches between prose and yaml', () => {
+  const file = writeFixture(fixture(
+    [{ id: 1, evidence: 'bp1-foo', lesson: 'conditional' }],
+    [{ id: 1, evidence: 'bp1-foo', lesson: 'conditional' }],
+  ))
+  const r = run(file)
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.parsed.results[0].violations.length, 0)
+})
+
+tap('real RFC-004 spec is currently valid', () => {
+  const file = path.join(REPO, 'docs', 'rfcs', 'RFC-004-bp1-auto-pilot.md')
+  if (!fs.existsSync(file)) return
+  const r = run(file)
+  assert.equal(r.exitCode, 0, `RFC-004 should validate; got ${JSON.stringify(r.parsed.results[0].violations)}`)
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) { console.log(`# FAILED ${fail} of ${pass + fail}`); process.exit(1) }
+else console.log(`# PASSED ${pass}`)


### PR DESCRIPTION
## Summary

PR-1a (M0 part 1) of [RFC-004 BP-1 Auto-Pilot](docs/rfcs/RFC-004-bp1-auto-pilot.md). Ships the M0 hard-dependency contract validators + the activation substrate. Inert by design until M5's dry run flips activation; this PR is the prerequisite for M1 and everything downstream.

- **Activation gate** — `scripts/bp1-flag-check.mjs` (RFC-004 §158-167): 4 conditions + verify-key invariants; emits one of `bp1-disabled-refusal` / `bp1-flag-version-drift` / `bp1-flag-key-drift` / `bp1-flag-config-corrupt` / `bp1-hmac-keyfile-fail` (failure-table rows 25-29).
- **Manifest builder** — `scripts/bp1-build-artifact-manifest.mjs` + `scripts/lib/bp1-manifest.mjs`: deterministic 6-surface manifest (scripts / hooks / settings_lines / plugin_entries / agent_loaders / canonical_prompts).
- **Install.mjs** — generates `~/.episodic-memory/.verify-key` (32B, 0600), creates the `config.json` activation map skeleton, line-anchored `.gitignore` append for `.episodic-memory/` + the BP-1 per-run HMAC key pattern.
- **CI Rule-14 gates** — `validate-rfc-failure-table.mjs` (RFC-004 §1072 prose↔YAML mirror); `validate-rfc-artifact-manifest.mjs` (surface parity).
- **Docs** — `docs/bp1/config-schema.md` schema + lifecycle reference.
- **RFC fix** — row 20 prose lesson `yes (if A)` → `conditional` to match the YAML mirror (the new validator surfaced this drift on first run against the real spec).

46 tests / 5 suites all green. Both validators OK on real RFC-004.

## Process notes

- Plan was Codex-ACCEPT'd in the prior session; reconstructed and re-approved in this session per Rule 8.
- `negative-scenario-reviewer` dispatched on the diff (Rule 18 step 6). Verdict: HOLD with 2 MAJOR + 3 MINOR findings.
  - F1 ACCEPT (fail-open on nonexistent `--project`): wrapped `realpathSync` + regression test.
  - F2 ACCEPT (substring `.gitignore` guard): line-anchored predicate; both siblings hardened + regression test (comment-only `.episodic-memory` mention no longer suppresses the real append).
  - F3 ACCEPT (dead `--json` flag): removed.
  - F4 DEFER → [#179](https://github.com/lantisprime/episodic-memory/issues/179) (TOCTOU stat→read; 5-field justification recorded).
  - F5 ACCEPT (case-insensitive episode-id regex): dropped `/i`.
  - F6 DEFER → [#180](https://github.com/lantisprime/episodic-memory/issues/180) (em-search fallback unreachable until M3).
  - F7 ACCEPT-WITH-MOD (`--json` in builder usage): docstring fixed.
- Commits: 3 logical units (lib+gate+builder; install.mjs; validators+docs+RFC fix+gitignore tightening).

## Test plan

- [ ] CI green on the new `rfc-validate.yml` workflow (5 test runs + 2 validator runs).
- [ ] Manual smoke: `node scripts/validate-rfc-failure-table.mjs docs/rfcs/RFC-004-bp1-auto-pilot.md` → `OK 37 rows / 37 yaml`.
- [ ] Manual smoke: `node scripts/validate-rfc-artifact-manifest.mjs` → `OK 6 surfaces declared`.
- [ ] Manual smoke: `node scripts/bp1-build-artifact-manifest.mjs` × 2 → identical sha256.
- [ ] Manual smoke: `bash tests/test-install-bp1.sh` → 12/12.
- [ ] Confirm `~/.episodic-memory/.verify-key` exists at mode 0600 after a fresh `node install.mjs --tool claude-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)