### PR TITLE
feat(bp1): RFC-004 M0 part 2 — fallback sweep + probe stub + manifest extension (PR-1b-A)

### DIFF
--- a/.github/workflows/rfc-validate.yml
+++ b/.github/workflows/rfc-validate.yml
@@ -9,13 +9,18 @@ on:
       - 'scripts/validate-rfc-failure-table.mjs'
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
+      - 'scripts/lib/bp1-sweep.mjs'
+      - 'scripts/lib/bp1-probe.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
+      - 'scripts/bp1-deadline-sweep.mjs'
       - 'tests/test-em-rfc-validate.mjs'
       - 'tests/test-validate-rfc-failure-table.mjs'
       - 'tests/test-validate-rfc-artifact-manifest.mjs'
       - 'tests/test-bp1-flag-check.mjs'
       - 'tests/test-bp1-build-artifact-manifest.mjs'
+      - 'tests/test-bp1-deadline-sweep.mjs'
+      - 'tests/test-bp1-probe.mjs'
       - 'tests/test-install-bp1.sh'
       - '.github/workflows/rfc-validate.yml'
   push:
@@ -27,13 +32,18 @@ on:
       - 'scripts/validate-rfc-failure-table.mjs'
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
+      - 'scripts/lib/bp1-sweep.mjs'
+      - 'scripts/lib/bp1-probe.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
+      - 'scripts/bp1-deadline-sweep.mjs'
       - 'tests/test-em-rfc-validate.mjs'
       - 'tests/test-validate-rfc-failure-table.mjs'
       - 'tests/test-validate-rfc-artifact-manifest.mjs'
       - 'tests/test-bp1-flag-check.mjs'
       - 'tests/test-bp1-build-artifact-manifest.mjs'
+      - 'tests/test-bp1-deadline-sweep.mjs'
+      - 'tests/test-bp1-probe.mjs'
       - 'tests/test-install-bp1.sh'
 
 jobs:
@@ -69,6 +79,12 @@ jobs:
 
       - name: Run bp1-build-artifact-manifest self-tests
         run: node tests/test-bp1-build-artifact-manifest.mjs
+
+      - name: Run bp1-deadline-sweep self-tests
+        run: node tests/test-bp1-deadline-sweep.mjs
+
+      - name: Run bp1-probe self-tests
+        run: node tests/test-bp1-probe.mjs
 
       - name: Run install.mjs BP-1 idempotence tests
         run: bash tests/test-install-bp1.sh

--- a/docs/rfcs/RFC-004-bp1-auto-pilot.md
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.md
@@ -108,7 +108,7 @@ All side-effecting bp1 artifacts are gated on a **per-project activation entry**
 
 ```yaml
 artifact_manifest:
-  schema_version: 1
+  schema_version: 2
   scripts:
     - path: "scripts/bp1-orchestrator.mjs"
       sha256: "<file-sha256>"
@@ -125,6 +125,20 @@ artifact_manifest:
     # contract (idempotency, signing, validation) must be enumerated here, even
     # if its filename doesn't start with bp1-. The list is closed (no glob);
     # additions require RFC update + M0 builder update + activation re-run.
+  scripts_lib:
+    # NEW v3.13 per PR-1b plan-review consensus (Codex round 1 Q3.2). Closes
+    # the load-bearing-helper drift hole: scripts/lib/bp1-*.mjs (e.g. the
+    # manifest builder itself, sweep helper, probe helper) MUST be in the
+    # artifact-version hash so that an M1 swap of probe-stub → real probe
+    # triggers bp1-flag-version-drift. Scope is exactly scripts/lib/bp1-*.mjs;
+    # other lib files (local-dir.mjs, etc.) are not BP1-runtime critical.
+    - path: "scripts/lib/bp1-manifest.mjs"
+      sha256: "<file-sha256>"
+    - path: "scripts/lib/bp1-sweep.mjs"
+      sha256: "<file-sha256>"
+    - path: "scripts/lib/bp1-probe.mjs"
+      sha256: "<file-sha256>"
+    # ... all scripts/lib/bp1-*.mjs
   hooks:
     - path: ".claude/hooks/bp1-approval-check.sh"
       sha256: "<file-sha256>"

--- a/scripts/bp1-deadline-sweep.mjs
+++ b/scripts/bp1-deadline-sweep.mjs
@@ -468,6 +468,11 @@ function emitEpisode({ category, tags, summary, body }) {
     return { ok: false, reason: 'missing_em_store' }
   }
   try {
+    // cwd: projectRoot — Codex follow-up bug (PR-186 post-ACCEPT): em-store
+    // resolves --scope local from cwd, NOT from --project. Without setting
+    // cwd here, evidence lands in the CALLER's .episodic-memory store, not
+    // the target project's. Same bug class as the worktree/local-store miss
+    // logged in episode 20260501-125543-...-9bb0.
     execFileSync('node', [
       EM_STORE,
       '--project', path.basename(projectRoot),
@@ -476,7 +481,7 @@ function emitEpisode({ category, tags, summary, body }) {
       '--scope', 'local',
       '--summary', summary,
       '--body', body,
-    ], { stdio: ['ignore', 'ignore', 'pipe'], timeout: 5000 })
+    ], { stdio: ['ignore', 'ignore', 'pipe'], timeout: 5000, cwd: projectRoot })
     emissionStats.succeeded++
     return { ok: true }
   } catch (e) {

--- a/scripts/bp1-deadline-sweep.mjs
+++ b/scripts/bp1-deadline-sweep.mjs
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+/**
+ * bp1-deadline-sweep.mjs --once — Unified Path A + Path B fallback executor.
+ *
+ * RFC-004 §556-577 (M0 part 2). Replays the logic that T1 (deadline-tick,
+ * Path A) and T1b (naked-entry-sweep, Path B) would have run, when the
+ * `mcp__scheduled-tasks` capability is unavailable. Auto-wired as a
+ * SessionStart hook (H2) in PR-1b-B.
+ *
+ * Plan-review consensus (Codex rounds 1-3, episodes ...-d36c, ...-2c25,
+ * ...-f8f2): this script OWNS all side effects. The pure helper
+ * `scripts/lib/bp1-sweep.mjs` is consulted for candidate detection only.
+ * Code-review round 1 Finding 2 + round 2: PR-1b-A keeps idempotency to
+ * within-invocation locks. The persistent request-claim contract (RFC
+ * §911-929 with claim_id, ttl_seconds, writer_run_id, HMAC) is M1's
+ * responsibility — PR-1b-A's executor only DETECTS candidates and emits
+ * `bp1-sweep-action-pending-m1` evidence; M1 introduces the persistent
+ * claim file + signed action evidence + em-review-request issuance.
+ *
+ * Behavior:
+ *   1. Call bp1-flag-check.mjs (which owns activation + dry-run bypass).
+ *      On refusal: emit bp1-disabled-sweep evidence (project-level
+ *      operational, non-authorizing — RFC §177) and exit 0.
+ *   2. Load active-run state from <project>/.episodic-memory/bp1-runs/
+ *      (or --input <fixture> for tests). Missing dir → zero runs.
+ *   3. Run the pure scan to derive candidates + counts.
+ *   4. For each candidate (Path A then Path B):
+ *      - Take per-entry advisory lock with stale-reclaim (>60s) per
+ *        RFC §909-923. Lock is per-invocation only — released at end.
+ *      - Re-read entry under lock; if state changed (already-issued or
+ *        cancelled), emit bp1-naked-sweep-superseded and continue
+ *        (RFC §973-981).
+ *      - Emit bp1-sweep-action-pending-m1 evidence describing the action
+ *        the M1 orchestrator should execute. M1 takes the persistent
+ *        claim and issues the request.
+ *      - Release lock.
+ *   5. Emit one bp1-sweep-tick operational episode (RFC §572) AFTER the
+ *      action loop so action_count is real. Project-level, non-authorizing,
+ *      no HMAC. Tagged bp1-evidence-snapshot, bp1-sweep-tick-operational.
+ *   6. Exit 0 with final JSON carrying counts + actions + evidence_emission
+ *      + load_issue.
+ *
+ * Output: one JSON line to stdout summarizing the invocation. Use --json
+ * for machine-readable output (default is human-readable line + final JSON).
+ *
+ * Usage:
+ *   node bp1-deadline-sweep.mjs --once
+ *   node bp1-deadline-sweep.mjs --once --project <root>
+ *   node bp1-deadline-sweep.mjs --once --input <fixture.json> --no-emit
+ */
+'use strict'
+
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import { execFileSync } from 'child_process'
+import { canonicalProjectRoot } from './lib/bp1-manifest.mjs'
+import { scanForCandidates } from './lib/bp1-sweep.mjs'
+
+// In-process lock TTL. Two concurrent --once invocations are the realistic
+// concurrency: each takes ≪1s to evaluate a candidate. A stale lock older
+// than this threshold is reclaimed (process crashed mid-evaluation).
+// Codex code-review round 1 Finding 2: locks must be crash/restart safe.
+const LOCK_TTL_MS = 60_000  // 60s, RFC §909-923 state-lock TTL contract
+
+// Emission accounting — Codex code-review round 1 Finding 3 + round 2 Finding 1.
+// Declared at module scope so the disabled-sweep path can call emitEpisode
+// without hitting a temporal-dead-zone crash on production (non-`--no-emit`)
+// invocations. emissionStats is mutated by emitEpisode and surfaced verbatim
+// in the final JSON for both ok and disabled paths.
+const emissionStats = { attempted: 0, succeeded: 0, failed: 0, missing_em_store: false, failures: [] }
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+function bool(name) { return argv.includes(name) }
+
+if (!bool('--once')) {
+  console.error('bp1-deadline-sweep: --once is required (this is a one-shot tool)')
+  process.exit(2)
+}
+
+const projectArg = flag('--project')
+const inputArg = flag('--input')
+const wantJson = bool('--json')
+const emit = !bool('--no-emit')
+
+const SCRIPT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname))
+const FLAG_CHECK = path.join(SCRIPT_DIR, 'bp1-flag-check.mjs')
+const EM_STORE = path.join(SCRIPT_DIR, 'em-store.mjs')
+
+// ---------------------------------------------------------------------------
+// Resolve project root
+// ---------------------------------------------------------------------------
+let projectRoot
+try {
+  projectRoot = projectArg
+    ? fs.realpathSync(path.resolve(projectArg))
+    : canonicalProjectRoot()
+} catch (e) {
+  emitFinalAndExit({
+    status: 'error',
+    code: 'project_root_unresolvable',
+    message: e.message,
+  }, 2)
+}
+if (!projectRoot) {
+  emitFinalAndExit({
+    status: 'error',
+    code: 'project_root_unresolvable',
+    message: 'canonicalProjectRoot() returned null',
+  }, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Activation gate: delegate to bp1-flag-check.mjs (owns the dry-run bypass
+// per RFC §563-571 v3.12).
+// ---------------------------------------------------------------------------
+const flagCheckArgs = ['--project', projectRoot, '--no-emit']
+let flagCheckResult
+try {
+  const out = execFileSync('node', [FLAG_CHECK, ...flagCheckArgs], {
+    encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 10000,
+  })
+  flagCheckResult = JSON.parse(out)
+} catch (e) {
+  // Exit code 2 from flag-check is the structured-fail path. Parse stdout.
+  if (e.stdout) {
+    try {
+      flagCheckResult = JSON.parse(e.stdout)
+    } catch {
+      // Truly unparseable — propagate as fail-closed.
+      emitDisabledSweep('flag_check_unparseable', { stdout: e.stdout, stderr: e.stderr })
+      emitFinalAndExit({
+        status: 'disabled', reason: 'flag_check_unparseable',
+        project_root: projectRoot,
+        evidence_emission: emissionStats,
+      }, 0)
+    }
+  } else {
+    emitDisabledSweep('flag_check_subprocess_error', { message: e.message })
+    emitFinalAndExit({
+      status: 'disabled', reason: 'flag_check_subprocess_error',
+      project_root: projectRoot,
+      evidence_emission: emissionStats,
+    }, 0)
+  }
+}
+
+if (!flagCheckResult || flagCheckResult.status !== 'ok') {
+  // RFC §177: --once invocation emits bp1-disabled-sweep evidence + exit 0.
+  // (H2 hook in PR-1b-B will exit 0 silently per RFC §178 — different mode.)
+  const code = (flagCheckResult && flagCheckResult.code) || 'unknown_refusal'
+  emitDisabledSweep(code, flagCheckResult || {})
+  emitFinalAndExit({
+    status: 'disabled',
+    reason: code,
+    project_root: projectRoot,
+    evidence_emission: emissionStats,
+  }, 0)
+}
+
+const mode = flagCheckResult.bypass === 'dry-run' ? 'dry_run' : 'native'
+const flagPassExtra = {
+  artifact_version_hash: flagCheckResult.artifact_version_hash,
+  verify_key_id: flagCheckResult.verify_key_id,
+}
+if (flagCheckResult.run_id) flagPassExtra.dry_run_id = flagCheckResult.run_id
+
+// ---------------------------------------------------------------------------
+// Load active runs
+// ---------------------------------------------------------------------------
+let activeRuns = []
+let loadIssue = null
+try {
+  if (inputArg) {
+    activeRuns = JSON.parse(fs.readFileSync(path.resolve(inputArg), 'utf8'))
+    if (!Array.isArray(activeRuns)) {
+      throw new TypeError(`--input file must contain a JSON array; got ${typeof activeRuns}`)
+    }
+  } else {
+    const runsDir = path.join(projectRoot, '.episodic-memory', 'bp1-runs')
+    activeRuns = loadActiveRunsFromDisk(runsDir)
+  }
+} catch (e) {
+  loadIssue = { code: 'active_runs_load_error', message: e.message }
+  activeRuns = []
+}
+
+// ---------------------------------------------------------------------------
+// Pure scan
+// ---------------------------------------------------------------------------
+const now = Date.now()
+const scan = scanForCandidates({ activeRuns, now })
+
+// (emissionStats declared at module scope above to satisfy disabled-path emit.)
+
+// ---------------------------------------------------------------------------
+// Action loop. Codex code-review round 1 Finding 2: PR-1b-A keeps locks as
+// within-invocation idempotency primitives only — no persistent claim file
+// (M1 owns request-claim persistence with full TTL/HMAC contract per RFC
+// §911-929). Stale locks (older than LOCK_TTL_MS) are reclaimed: a process
+// crashed mid-evaluation must not block subsequent sweeps.
+//
+// The action loop runs in candidate order: Path A first (longer-deadline
+// timeouts are higher priority), then Path B.
+// ---------------------------------------------------------------------------
+const actionResults = []
+for (const cand of [...scan.path_a_candidates, ...scan.path_b_candidates]) {
+  const lockResult = takeEntryLock(projectRoot, cand, now)
+  if (!lockResult.ok) {
+    actionResults.push({ ...cand, action: 'skipped_locked', reason: lockResult.reason })
+    if (emit) emitSuperseded(cand, 'locked_by_other_writer')
+    continue
+  }
+  try {
+    const reread = rereadEntry(projectRoot, cand)
+    if (reread.state === 'changed') {
+      actionResults.push({ ...cand, action: 'skipped_superseded', reason: reread.reason })
+      if (emit) emitSuperseded(cand, reread.reason)
+      continue
+    }
+    if (emit) emitSweepActionPendingM1(cand)
+    actionResults.push({ ...cand, action: 'pending_m1' })
+  } finally {
+    releaseEntryLock(lockResult)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emit operational tick (RFC §572) — project-level, non-authorizing.
+// Emitted AFTER the action loop so action_count is real (Codex Finding 1).
+// Schema follows D4 strict shape per consensus episode `...807f`.
+// ---------------------------------------------------------------------------
+const action_count = actionResults.filter(a => a.action === 'pending_m1').length
+const refusal_or_bypass = flagCheckResult.bypass === 'dry-run' ? 'dry_run_bypass' : 'activated'
+
+const tickPayload = {
+  timestamp: now,
+  project_root_sha256: projectRootSha(projectRoot),
+  mode: 'fallback',  // RFC §556-577: this script IS the fallback executor
+  candidate_count_path_a: scan.counts.path_a_candidate_count,
+  candidate_count_path_b: scan.counts.path_b_candidate_count,
+  action_count,
+  refusal_or_bypass,
+  // Carry-forward extras (test/operator visibility — outside D4 strict but
+  // useful and harmless for non-authorizing evidence):
+  invocation: '--once',
+  runs_inspected_count: scan.counts.runs_inspected_count,
+  entries_inspected_count: scan.counts.entries_inspected_count,
+  stale_or_corrupt_count: scan.counts.stale_or_corrupt_count,
+  artifact_version_hash: flagCheckResult.artifact_version_hash,
+  verify_key_id: flagCheckResult.verify_key_id,
+}
+if (flagCheckResult.run_id) tickPayload.dry_run_id = flagCheckResult.run_id
+if (loadIssue) tickPayload.load_issue = loadIssue
+
+if (emit) emitTick(tickPayload)
+
+emitFinalAndExit({
+  status: 'ok',
+  project_root: projectRoot,
+  project_root_sha256: projectRootSha(projectRoot),
+  mode: 'fallback',
+  activation_mode: mode,
+  ...flagPassExtra,
+  counts: scan.counts,
+  actions: actionResults,
+  action_count,
+  refusal_or_bypass,
+  load_issue: loadIssue,             // null when load was clean — explicit field
+  evidence_emission: emissionStats,  // operator-visible; --no-emit yields zeros
+}, 0)
+
+// ===========================================================================
+// Helpers
+// ===========================================================================
+
+function loadActiveRunsFromDisk(runsDir) {
+  // PR-1b-A scope: production loader. Walks <runs>/<run_id>/state.json files.
+  // M0 has no active runs (orchestrator is M1) — this returns [] in
+  // production until M1 starts writing run state. Test paths use --input.
+  if (!fs.existsSync(runsDir)) return []
+  let entries
+  try {
+    entries = fs.readdirSync(runsDir, { withFileTypes: true })
+  } catch (e) {
+    throw new Error(`runs dir read failed: ${e.message}`)
+  }
+  const out = []
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue
+    const statePath = path.join(runsDir, ent.name, 'state.json')
+    if (!fs.existsSync(statePath)) continue
+    let state
+    try {
+      state = JSON.parse(fs.readFileSync(statePath, 'utf8'))
+    } catch (e) {
+      // Bare-catch P1 lesson (PR-1a round 3): record the corruption,
+      // never silently swallow. Pure scan will count this as stale.
+      out.push({ run_id: ent.name, codex_review_entries: [], _corrupt: e.message })
+      continue
+    }
+    if (state && typeof state === 'object') {
+      out.push({
+        run_id: typeof state.run_id === 'string' ? state.run_id : ent.name,
+        codex_review_entries: Array.isArray(state.codex_review_entries) ? state.codex_review_entries : [],
+      })
+    }
+  }
+  return out
+}
+
+function entryLockPath(projectRoot, cand) {
+  // Per-entry advisory lock under <project>/.episodic-memory/bp1-locks/
+  return path.join(projectRoot, '.episodic-memory', 'bp1-locks',
+    `${cand.run_id}__${cand.entry_id}.lock`)
+}
+
+function projectRootSha(projectRoot) {
+  return crypto.createHash('sha256').update(projectRoot, 'utf8').digest('hex')
+}
+
+function takeEntryLock(projectRoot, cand, now) {
+  // Codex code-review round 1 Finding 2: stale-lock reclaim. A lock older
+  // than LOCK_TTL_MS is treated as orphaned (the holding process crashed)
+  // and overwritten. Lock body carries `{pid, claimed_at}`; we read the
+  // existing one before deciding to reclaim.
+  const lockPath = entryLockPath(projectRoot, cand)
+  try {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true })
+  } catch (e) {
+    return { ok: false, reason: `mkdir_failed:${e.message}` }
+  }
+
+  const tryCreate = () => {
+    try {
+      const fd = fs.openSync(lockPath, 'wx')  // O_CREAT | O_EXCL
+      fs.writeSync(fd, JSON.stringify({ pid: process.pid, claimed_at: now }))
+      return { ok: true, fd, lockPath }
+    } catch (e) {
+      if (e.code === 'EEXIST') return { ok: false, reason: 'EEXIST' }
+      return { ok: false, reason: e.code || e.message }
+    }
+  }
+
+  let r = tryCreate()
+  if (r.ok) return r
+  if (r.reason !== 'EEXIST') return r
+
+  // Existing lock — check age.
+  let existing
+  try {
+    existing = JSON.parse(fs.readFileSync(lockPath, 'utf8'))
+  } catch {
+    // Corrupt lock body. Treat as stale and reclaim.
+    existing = null
+  }
+  const claimedAt = existing && typeof existing.claimed_at === 'number' ? existing.claimed_at : 0
+  const ageMs = now - claimedAt
+  if (ageMs >= LOCK_TTL_MS) {
+    // Reclaim. Remove + retry.
+    try { fs.unlinkSync(lockPath) } catch { /* race: another writer reclaimed first */ }
+    r = tryCreate()
+    if (r.ok) {
+      r.reclaimed_stale = { previous: existing, age_ms: ageMs }
+    }
+    return r
+  }
+  return { ok: false, reason: 'EEXIST', held_by: existing, age_ms: ageMs }
+}
+
+function releaseEntryLock(lockResult) {
+  if (!lockResult || !lockResult.ok) return
+  try { fs.closeSync(lockResult.fd) } catch { /* descriptor already gone */ }
+  try { fs.unlinkSync(lockResult.lockPath) } catch { /* lock file may have been reclaimed by another process */ }
+}
+
+function rereadEntry(projectRoot, cand) {
+  // Re-read the run's state.json under lock and find the entry. If the
+  // entry now has request_sent=true (Path B candidate) or
+  // response_received=true (Path A candidate), the sweep is superseded.
+  if (inputArg) {
+    // Test mode: --input fixture is ground truth; no on-disk state to re-read.
+    return { state: 'unchanged', reason: 'fixture_mode' }
+  }
+  const statePath = path.join(projectRoot, '.episodic-memory', 'bp1-runs',
+    cand.run_id, 'state.json')
+  if (!fs.existsSync(statePath)) return { state: 'changed', reason: 'state_file_missing' }
+  let state
+  try {
+    state = JSON.parse(fs.readFileSync(statePath, 'utf8'))
+  } catch (e) {
+    return { state: 'changed', reason: `state_parse_error:${e.message}` }
+  }
+  const entries = Array.isArray(state && state.codex_review_entries) ? state.codex_review_entries : []
+  const entry = entries.find(e => e && e.entry_id === cand.entry_id)
+  if (!entry) return { state: 'changed', reason: 'entry_disappeared' }
+  if (entry.cancelled === true) return { state: 'changed', reason: 'cancelled' }
+  if (cand.path === 'path_a' && entry.response_received === true) {
+    return { state: 'changed', reason: 'response_received' }
+  }
+  if (cand.path === 'path_b' && entry.request_sent === true) {
+    return { state: 'changed', reason: 'request_already_sent' }
+  }
+  return { state: 'unchanged' }
+}
+
+function emitTick(payload) {
+  emitEpisode({
+    category: 'workflow.lifecycle',
+    tags: 'bp1,bp1-sweep-tick,bp1-sweep-tick-operational,bp1-evidence-snapshot',
+    summary: `bp1-sweep-tick: ${payload.candidate_count_path_a}A + ${payload.candidate_count_path_b}B candidates, ${payload.action_count} actions (mode=${payload.mode})`,
+    body: '# bp1-sweep-tick (operational, non-authorizing)\n\n' +
+      'Project-level operational evidence per RFC §572. NOT authorizing — must NOT be consulted by replay/decision logic. Per-run signed evidence (M1) lands separately via `bp1-sweep-action`.\n\n' +
+      '```json\n' + JSON.stringify(payload, null, 2) + '\n```\n',
+  })
+}
+
+function emitDisabledSweep(reason, extra) {
+  if (!emit) return
+  emitEpisode({
+    category: 'workflow.lifecycle',
+    tags: 'bp1,bp1-disabled-sweep,bp1-evidence-snapshot',
+    summary: `bp1-disabled-sweep: ${reason}`,
+    body: '# bp1-disabled-sweep\n\nFallback sweep refused by activation gate (RFC §177).\n\n' +
+      '```json\n' + JSON.stringify({ reason, project_root: projectRoot, ...extra }, null, 2) + '\n```\n',
+  })
+}
+
+function emitSuperseded(cand, reason) {
+  emitEpisode({
+    category: 'workflow.lifecycle',
+    tags: 'bp1,bp1-naked-sweep-superseded,bp1-evidence-snapshot',
+    summary: `bp1-naked-sweep-superseded: ${cand.run_id}/${cand.entry_id} (${reason})`,
+    body: '# bp1-naked-sweep-superseded\n\nCandidate skipped (RFC §973-981).\n\n' +
+      '```json\n' + JSON.stringify({ ...cand, reason }, null, 2) + '\n```\n',
+  })
+}
+
+function emitSweepActionPendingM1(cand) {
+  // PR-1b-A scope marker: candidate was detected within an in-process lock.
+  // M1 will introduce the persistent request claim (RFC §911-929) plus the
+  // actual em-review-request issuance + per-run HMAC-signed bp1-sweep-action.
+  emitEpisode({
+    category: 'workflow.lifecycle',
+    tags: 'bp1,bp1-sweep-action-pending-m1,bp1-evidence-snapshot',
+    summary: `bp1-sweep-action-pending-m1: ${cand.path} ${cand.run_id}/${cand.entry_id}`,
+    body: '# bp1-sweep-action-pending-m1\n\n' +
+      'Sweep candidate detected. Action execution deferred to M1 orchestrator (persistent request claim + per-run HMAC signing + em-review-request issuance).\n\n' +
+      '```json\n' + JSON.stringify(cand, null, 2) + '\n```\n',
+  })
+}
+
+function emitEpisode({ category, tags, summary, body }) {
+  // Codex code-review round 1 Finding 3: emission failures must be visible
+  // in the final stdout. Returns {ok, reason}; updates emissionStats so the
+  // final JSON carries accurate emission status.
+  if (!emit) return { ok: true, reason: 'no_emit_flag' }
+  emissionStats.attempted++
+  if (!fs.existsSync(EM_STORE)) {
+    emissionStats.missing_em_store = true
+    emissionStats.failed++
+    emissionStats.failures.push({ tags, reason: 'missing_em_store' })
+    return { ok: false, reason: 'missing_em_store' }
+  }
+  try {
+    execFileSync('node', [
+      EM_STORE,
+      '--project', path.basename(projectRoot),
+      '--category', category,
+      '--tags', tags,
+      '--scope', 'local',
+      '--summary', summary,
+      '--body', body,
+    ], { stdio: ['ignore', 'ignore', 'pipe'], timeout: 5000 })
+    emissionStats.succeeded++
+    return { ok: true }
+  } catch (e) {
+    emissionStats.failed++
+    emissionStats.failures.push({ tags, reason: e.code || e.message })
+    return { ok: false, reason: e.code || e.message }
+  }
+}
+
+function emitFinalAndExit(payload, code) {
+  if (wantJson) {
+    console.log(JSON.stringify(payload))
+  } else {
+    if (payload.status === 'ok') {
+      console.log(`bp1-deadline-sweep: OK (${payload.counts.path_a_candidate_count}A + ${payload.counts.path_b_candidate_count}B candidates, ${payload.actions.length} actions)`)
+    } else if (payload.status === 'disabled') {
+      console.log(`bp1-deadline-sweep: DISABLED (${payload.reason})`)
+    } else {
+      console.log(`bp1-deadline-sweep: ERROR (${payload.code || 'unknown'}: ${payload.message || ''})`)
+    }
+    console.log(JSON.stringify(payload))
+  }
+  process.exit(code)
+}

--- a/scripts/bp1-flag-check.mjs
+++ b/scripts/bp1-flag-check.mjs
@@ -34,6 +34,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import crypto from 'crypto'
 import { execFileSync } from 'child_process'
 import {
   buildArtifactManifest,
@@ -41,6 +42,16 @@ import {
   canonicalProjectRoot,
   CONFIG_PATH,
 } from './lib/bp1-manifest.mjs'
+
+// RFC-004 §563-571 (v3.12) — M5 dry-run bypass requires BOTH:
+//   (a) <project>/.episodic-memory/.bp1-dry-run.lock with project_root_sha256 + ttl_until + run_id
+//   (b) BP1_DRY_RUN_MODE env var value === sha256(canonical_project_root)
+// v3.12 fixes the cross-project bypass hole (CLI v3.11 F3): an inherited
+// BP1_DRY_RUN_MODE=1 from another project's M5 cannot bypass an inactive
+// project's gate, because both the lock file and env var must equal the same
+// canonical-root sha.
+const DRY_RUN_LOCK_REL = path.join('.episodic-memory', '.bp1-dry-run.lock')
+const DRY_RUN_ENV_VAR = 'BP1_DRY_RUN_MODE'
 
 const argv = process.argv.slice(2)
 function flag(name) {
@@ -67,6 +78,62 @@ function ok(extra = {}) {
   const result = { status: 'ok', ...extra }
   console.log(JSON.stringify(result))
   process.exit(0)
+}
+
+function projectRootSha256(projectRoot) {
+  return crypto.createHash('sha256').update(projectRoot, 'utf8').digest('hex')
+}
+
+function checkDryRunBypass(projectRoot) {
+  // Returns { ok: true, run_id, ttl_until, ttl_remaining_ms } on bypass-pass.
+  // Returns { ok: false, reason } on any mismatch (including legit absence).
+  // ANY mismatch → no bypass; caller falls through to activation gate.
+  const expectedSha = projectRootSha256(projectRoot)
+
+  const envValue = process.env[DRY_RUN_ENV_VAR]
+  if (!envValue) return { ok: false, reason: 'env_unset' }
+  if (envValue !== expectedSha) {
+    return { ok: false, reason: 'env_mismatch', env_len: envValue.length }
+  }
+
+  const lockPath = path.join(projectRoot, DRY_RUN_LOCK_REL)
+  if (!fs.existsSync(lockPath)) return { ok: false, reason: 'lock_missing' }
+
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(lockPath, 'utf8'))
+  } catch (e) {
+    return { ok: false, reason: 'lock_malformed', message: e.message }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, reason: 'lock_not_object' }
+  }
+  if (typeof parsed.run_id !== 'string' || parsed.run_id.length === 0) {
+    return { ok: false, reason: 'lock_missing_run_id' }
+  }
+  if (typeof parsed.project_root_sha256 !== 'string') {
+    return { ok: false, reason: 'lock_missing_sha' }
+  }
+  if (parsed.project_root_sha256 !== expectedSha) {
+    return { ok: false, reason: 'lock_sha_mismatch' }
+  }
+  if (typeof parsed.ttl_until !== 'number') {
+    return { ok: false, reason: 'lock_missing_ttl' }
+  }
+  const now = Date.now()
+  if (now > parsed.ttl_until) {
+    return { ok: false, reason: 'lock_ttl_expired',
+      now, ttl_until: parsed.ttl_until,
+      expired_ms_ago: now - parsed.ttl_until }
+  }
+
+  return {
+    ok: true,
+    run_id: parsed.run_id,
+    ttl_until: parsed.ttl_until,
+    ttl_remaining_ms: parsed.ttl_until - now,
+  }
 }
 
 function tryEmitEpisode(code, reason, extra) {
@@ -126,6 +193,72 @@ if (!vk.ok) {
 }
 
 // ---------------------------------------------------------------------------
+// M5 dry-run bypass (RFC-004 §563-571 v3.12). Checked BEFORE activation map
+// so a project being activated for the first time (no entry yet) can pass
+// the gate while the M5 dry-run runs end-to-end. Bypass requires BOTH lock
+// file (with project_root_sha256 matching canonical root) AND env var (value
+// === same sha). Any mismatch → no bypass; fall through to activation gate.
+//
+// Codex code-review round 1 Finding 4: when the bypass declines for a
+// non-trivial reason (env mismatch, lock malformed, TTL expired), we plumb
+// a redacted diagnostic to whichever refusal path the activation gate emits,
+// so the operator sees the bypass attempt without leaking the env value.
+//
+// On bypass: we still recompute the artifact manifest as a diagnostic but do
+// NOT compare against an entry (because the entry doesn't exist yet). The
+// verify-key invariants above still apply.
+// ---------------------------------------------------------------------------
+const bypass = checkDryRunBypass(projectRoot)
+const bypassDeclined = !bypass.ok && bypass.reason !== 'env_unset'
+  ? { reason: bypass.reason, ...(bypass.env_len ? { env_len: bypass.env_len } : {}),
+      ...(bypass.expired_ms_ago ? { expired_ms_ago: bypass.expired_ms_ago } : {}) }
+  : null
+if (bypass.ok) {
+  let liveHash
+  try {
+    ;({ sha256: liveHash } = buildArtifactManifest({ projectRoot }))
+  } catch (e) {
+    fail('bp1-flag-version-drift',
+      `Artifact manifest recomputation failed during dry-run bypass: ${e.message}`,
+      { project_root: projectRoot, builder_error: e.message, bypass: 'dry-run' })
+  }
+  // Audit-trail evidence for the bypass-pass. Tagged bp1-flag-bypass for
+  // forensics and for M5 dry-run replay.
+  if (emit) {
+    try {
+      const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname))
+      const emStore = path.join(repoScripts, 'em-store.mjs')
+      if (fs.existsSync(emStore)) {
+        execFileSync('node', [
+          emStore,
+          '--project', path.basename(projectRoot),
+          '--category', 'workflow.lifecycle',
+          '--tags', 'bp1,bp1-flag-bypass,dry-run',
+          '--scope', 'local',
+          '--summary', `bp1-flag-bypass: dry-run for ${path.basename(projectRoot)} (run ${bypass.run_id})`,
+          '--body', '# bp1-flag-bypass\n\nDry-run bypass passed for run `' + bypass.run_id + '`.\n\n' +
+            '```json\n' + JSON.stringify({
+              project_root: projectRoot, run_id: bypass.run_id,
+              ttl_until: bypass.ttl_until, ttl_remaining_ms: bypass.ttl_remaining_ms,
+              artifact_version_hash: liveHash,
+            }, null, 2) + '\n```\n',
+        ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000 })
+      }
+    } catch {
+      // forensics best-effort; never let an emit failure mask the bypass
+    }
+  }
+  ok({
+    project_root: projectRoot,
+    bypass: 'dry-run',
+    run_id: bypass.run_id,
+    artifact_version_hash: liveHash,
+    verify_key_id: vk.fingerprint,
+    ttl_remaining_ms: bypass.ttl_remaining_ms,
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Read activation map
 // ---------------------------------------------------------------------------
 if (!fs.existsSync(configArg)) {
@@ -154,12 +287,14 @@ const entry = activations[projectRoot]
 if (!entry) {
   fail('bp1-disabled-refusal',
     `No activation entry for project root: ${projectRoot}`,
-    { project_root: projectRoot })
+    { project_root: projectRoot,
+      ...(bypassDeclined ? { bypass_declined: bypassDeclined } : {}) })
 }
 if (entry.enabled !== true) {
   fail('bp1-disabled-refusal',
     `Activation entry exists but enabled=${entry.enabled}`,
-    { project_root: projectRoot, entry })
+    { project_root: projectRoot, entry,
+      ...(bypassDeclined ? { bypass_declined: bypassDeclined } : {}) })
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/bp1-flag-check.mjs
+++ b/scripts/bp1-flag-check.mjs
@@ -148,6 +148,11 @@ function tryEmitEpisode(code, reason, extra) {
     const summary = `bp1-flag-check ${code}: ${reason}`
     const body = `# ${code}\n\n${reason}\n\n` +
       '```json\n' + JSON.stringify(extra, null, 2) + '\n```\n'
+    // cwd: extra.project_root — em-store --scope local resolves the local
+    // store from cwd, NOT from --project. Without this, evidence lands in
+    // the caller's .episodic-memory store, not the target project's.
+    // Codex follow-up post-PR-186-ACCEPT (episode ...4c0f).
+    const cwdForEmit = extra.project_root || process.cwd()
     execFileSync('node', [
       emStore,
       '--project', projectName,
@@ -156,7 +161,7 @@ function tryEmitEpisode(code, reason, extra) {
       '--scope', 'local',
       '--summary', summary,
       '--body', body,
-    ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000 })
+    ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000, cwd: cwdForEmit })
   } catch {
     // swallow
   }
@@ -242,7 +247,7 @@ if (bypass.ok) {
               ttl_until: bypass.ttl_until, ttl_remaining_ms: bypass.ttl_remaining_ms,
               artifact_version_hash: liveHash,
             }, null, 2) + '\n```\n',
-        ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000 })
+        ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 5000, cwd: projectRoot })
       }
     } catch {
       // forensics best-effort; never let an emit failure mask the bypass

--- a/scripts/lib/bp1-manifest.mjs
+++ b/scripts/lib/bp1-manifest.mjs
@@ -5,8 +5,9 @@
  * `bp1-flag-check.mjs` (recompute on every read) and
  * `bp1-build-artifact-manifest.mjs` (CLI wrapper for install + ops).
  *
- * Six surfaces (sorted, deterministic):
+ * Seven surfaces (sorted, deterministic):
  *   scripts          — scripts/bp1-*.mjs + explicit non-bp1 extensions
+ *   scripts_lib      — scripts/lib/bp1-*.mjs (load-bearing helpers; PR-1b-A added)
  *   hooks            — .claude/hooks/bp1-*.sh
  *   settings_lines   — bp1-mentioning lines in .claude/settings.json (case-insensitive)
  *   plugin_entries   — bp1-related entries in .claude-plugin/plugin.json
@@ -67,6 +68,21 @@ function buildScripts(projectRoot) {
     }
   }
   return out.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+function buildScriptsLib(projectRoot) {
+  // PR-1b-A: load-bearing helpers under scripts/lib/. Only bp1-*.mjs files
+  // are hashed — other lib files (e.g. local-dir.mjs) are not BP1-runtime
+  // critical and not subject to drift detection here.
+  // Codex plan-review round 1 Q3.2: prior manifest scanned only top-level
+  // scripts/bp1-*.mjs, so changes to lib helpers (probe stub → real probe at
+  // M1, sweep helper logic) would NOT have triggered bp1-flag-version-drift.
+  // This surface closes that hole.
+  const libDir = path.join(projectRoot, 'scripts', 'lib')
+  return listMatching(libDir, /^bp1-.*\.mjs$/).map(f => {
+    const rel = `scripts/lib/${f}`
+    return { path: rel, sha256: sha256File(path.join(projectRoot, rel)) }
+  })
 }
 
 function buildHooks(projectRoot) {
@@ -192,6 +208,7 @@ export function buildArtifactManifest({ projectRoot }) {
   if (!projectRoot) throw new Error('buildArtifactManifest: projectRoot required')
 
   const scripts = buildScripts(projectRoot)
+  const scripts_lib = buildScriptsLib(projectRoot)
   const hooks = buildHooks(projectRoot)
   const settings_lines = { sha256: buildSettingsLinesSha(projectRoot) }
   const plugin_entries = { sha256: buildPluginEntriesSha(projectRoot) }
@@ -199,8 +216,9 @@ export function buildArtifactManifest({ projectRoot }) {
   const canonical_prompts = buildCanonicalPrompts(projectRoot, agent_loaders)
 
   const manifest = {
-    schema_version: 1,
+    schema_version: 2,
     scripts,
+    scripts_lib,
     hooks,
     settings_lines,
     plugin_entries,

--- a/scripts/lib/bp1-probe.mjs
+++ b/scripts/lib/bp1-probe.mjs
@@ -1,0 +1,129 @@
+/**
+ * bp1-probe.mjs — Scheduled-tasks capability probe (M0 stub, M1 contract pin).
+ *
+ * RFC-004 §550-577. The orchestrator must probe `mcp__scheduled-tasks` at
+ * cold start and record the result in the activation episode. PR-1b-A
+ * (M0 part 2) ships this HELPER only; the call site lives in M1's
+ * orchestrator runtime.
+ *
+ * Codex plan-review consensus (round 1 Q3.1): the M0 stub MUST be
+ * unambiguously degraded — it must never return capability='native', and the
+ * shape must be explicit enough that an M1 swap to the real probe is a
+ * surgical change inside this file (not a contract-level edit elsewhere).
+ *
+ * M1 implementation contract (deferred to issue #185):
+ *   - successful list_scheduled_tasks call → { capability: 'native', ... }
+ *   - ToolNotFound / connection error / schema mismatch → { capability:
+ *     'fallback', reason: 'tool_not_found' | 'connection_error' | 'schema_mismatch' }
+ *   - T2 weekly meta-audit has NO fallback path (RFC §573-575): t2_fallback
+ *     is always false.
+ *   - The activation episode's canonical payload must HMAC-cover all five
+ *     fields (capability, reason, native_probe_performed, t2_fallback,
+ *     degraded_mode_message). Tampering any field must fail verification.
+ */
+'use strict'
+
+/**
+ * Probe the scheduled-tasks MCP capability.
+ *
+ * M0 implementation: returns the explicit-fallback shape unconditionally.
+ * Does NOT attempt any MCP-from-script call (that pattern is M1 territory
+ * via the orchestrator agent).
+ *
+ * Callers should pass the result into the activation-episode canonical
+ * payload AS-IS. Operators reading the activation episode see exactly the
+ * degraded-mode statement to follow.
+ *
+ * @param {object} [_opts] Reserved for M1 (e.g. injected MCP client).
+ * @returns {ProbeResult}
+ *
+ * @typedef {object} ProbeResult
+ * @property {'fallback'} capability
+ *   M0 always returns 'fallback'. M1 may return 'native' on probe success.
+ * @property {string} reason
+ *   M0: 'm1_not_implemented'. M1: 'list_succeeded' | 'tool_not_found' |
+ *   'connection_error' | 'schema_mismatch'.
+ * @property {false} native_probe_performed
+ *   M0 always false. M1 sets true iff list_scheduled_tasks was actually
+ *   invoked (regardless of success/failure outcome).
+ * @property {false} t2_fallback
+ *   ALWAYS false. RFC §573-575: T2 weekly meta-audit has no fallback path.
+ *   Operators must run `node scripts/bp1-security-audit.mjs --once`
+ *   manually when capability='fallback'.
+ * @property {string} degraded_mode_message
+ *   Operator-facing instructions for fallback mode. Surfaced verbatim in
+ *   the activation episode body and in the operator runbook.
+ */
+export function probeScheduledTasksCapability(_opts) {
+  return {
+    capability: 'fallback',
+    reason: 'm1_not_implemented',
+    native_probe_performed: false,
+    t2_fallback: false,
+    degraded_mode_message: DEGRADED_MODE_MESSAGE,
+  }
+}
+
+export const DEGRADED_MODE_MESSAGE =
+  'Scheduled-tasks native probe is pending M1 (orchestrator runtime). ' +
+  'BP-1 will run T1 (deadline-tick) and T1b (naked-entry-sweep) via the ' +
+  '`bp1-deadline-sweep.mjs --once` fallback script (auto-wired as a ' +
+  'SessionStart hook in PR-1b-B). T2 (weekly security audit) has NO ' +
+  'fallback path — operators must run `node scripts/bp1-security-audit.mjs ' +
+  '--once` manually on the weekly cadence until M1 ships.'
+
+// ---------------------------------------------------------------------------
+// M1 contract assertions — exported so that M1's test harness can verify
+// the real implementation conforms to the same shape the M0 stub published.
+// Tests in tests/test-bp1-probe.mjs pin both the M0 stub AND these contract
+// expectations so M1 cannot silently break the activation-episode schema.
+// ---------------------------------------------------------------------------
+
+export const VALID_CAPABILITIES = Object.freeze(['native', 'fallback'])
+
+export const VALID_REASONS_M1 = Object.freeze([
+  'list_succeeded',     // capability=native
+  'tool_not_found',     // capability=fallback
+  'connection_error',   // capability=fallback
+  'schema_mismatch',    // capability=fallback
+  'm1_not_implemented', // capability=fallback (M0 stub only)
+])
+
+/**
+ * Validate a probe-result shape against the contract.
+ *
+ * Returns { ok: true } or { ok: false, errors: [...] }. M1's test harness
+ * uses this to assert the real probe still conforms.
+ */
+export function validateProbeResult(result) {
+  const errors = []
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return { ok: false, errors: ['result must be an object'] }
+  }
+  if (!VALID_CAPABILITIES.includes(result.capability)) {
+    errors.push(`capability must be one of ${VALID_CAPABILITIES.join('|')}; got ${JSON.stringify(result.capability)}`)
+  }
+  if (typeof result.reason !== 'string' || !VALID_REASONS_M1.includes(result.reason)) {
+    errors.push(`reason must be one of ${VALID_REASONS_M1.join('|')}; got ${JSON.stringify(result.reason)}`)
+  }
+  if (typeof result.native_probe_performed !== 'boolean') {
+    errors.push('native_probe_performed must be boolean')
+  }
+  if (result.t2_fallback !== false) {
+    errors.push('t2_fallback must be false (RFC §573-575: T2 has no fallback)')
+  }
+  if (typeof result.degraded_mode_message !== 'string' || result.degraded_mode_message.length === 0) {
+    errors.push('degraded_mode_message must be a non-empty string')
+  }
+  // Cross-field: capability=native must coincide with reason=list_succeeded
+  // and native_probe_performed=true.
+  if (result.capability === 'native') {
+    if (result.reason !== 'list_succeeded') {
+      errors.push("capability=native requires reason='list_succeeded'")
+    }
+    if (result.native_probe_performed !== true) {
+      errors.push('capability=native requires native_probe_performed=true')
+    }
+  }
+  return errors.length ? { ok: false, errors } : { ok: true }
+}

--- a/scripts/lib/bp1-sweep.mjs
+++ b/scripts/lib/bp1-sweep.mjs
@@ -1,0 +1,178 @@
+/**
+ * bp1-sweep.mjs — Pure helper for the unified deadline-sweep fallback.
+ *
+ * RFC-004 §556-577 (PR-1b-A). Replays Path A (request-issued timeout, 30min
+ * per RFC §321 / §385 / §845) and Path B (naked-entry recovery, 5min age
+ * threshold per RFC §555 / §177) against an in-memory list of active runs.
+ *
+ * Codex plan-review consensus (round 1 Q2.2 / round 3): this module is PURE.
+ *   - Zero I/O.
+ *   - No episode emission.
+ *   - No lock-taking.
+ *   - No subprocess spawning.
+ *
+ * The executor (scripts/bp1-deadline-sweep.mjs) feeds in active-run state
+ * read from disk, takes scanForCandidates' output, and runs the action loop
+ * under within-invocation per-entry advisory locks (RFC §909-923 with
+ * stale-reclaim). Persistent request-claim creation (RFC §911-929) is
+ * deferred to M1's orchestrator runtime — PR-1b-A only emits
+ * `bp1-sweep-action-pending-m1` evidence per detected candidate.
+ */
+'use strict'
+
+// RFC-004 anchored thresholds. Caller may override via config for tests, but
+// production callers should use the defaults to match the scheduled-task
+// behavior the fallback replays.
+export const PATH_A_TIMEOUT_MS = 30 * 60 * 1000  // 30 min, RFC §321/§385/§845
+export const PATH_B_AGE_THRESHOLD_MS = 5 * 60 * 1000  // 5 min, RFC §555/§177
+
+/**
+ * Scan active runs for sweep-eligible codex_review entries.
+ *
+ * @param {object} args
+ * @param {Array<RunInput>} args.activeRuns
+ *   Active-run state. Each run is an object with `run_id` (string) and
+ *   `codex_review_entries` (array of EntryInput). The executor is
+ *   responsible for assembling this from disk.
+ * @param {number} args.now Milliseconds since epoch (caller injects for
+ *   determinism in tests; production callers pass Date.now()).
+ * @param {object} [args.config]
+ * @param {number} [args.config.path_a_timeout_ms=PATH_A_TIMEOUT_MS]
+ * @param {number} [args.config.path_b_age_threshold_ms=PATH_B_AGE_THRESHOLD_MS]
+ *
+ * @returns {ScanResult}
+ *
+ * @typedef {object} EntryInput
+ * @property {string} entry_id
+ *   Stable identifier for this codex_review entry. The executor uses it to
+ *   take a per-entry advisory lock (within-invocation only — RFC §909-923
+ *   with stale-reclaim). Persistent request claim is M1's responsibility.
+ * @property {number|null|undefined} created_at
+ *   Entry created_at in ms. Missing/non-number → counted as stale_or_corrupt.
+ * @property {boolean} request_sent
+ *   True iff a `bp1-codex-request-sent` evidence episode exists for this
+ *   entry. Path B candidates have request_sent === false.
+ * @property {number|null|undefined} requested_at
+ *   ms timestamp of the request-sent event. Path A candidates have a value.
+ * @property {boolean} response_received
+ *   True iff a Codex reply has landed (or a synthetic terminal — needs_human,
+ *   cancelled, halted). Path A candidates have response_received === false.
+ * @property {boolean} cancelled
+ *   True iff the entry was cancelled / resolved by another path (e.g. user
+ *   rejected, parent run halted). Either Path A or B path skips a cancelled
+ *   entry.
+ *
+ * @typedef {object} RunInput
+ * @property {string} run_id
+ * @property {Array<EntryInput>} codex_review_entries
+ *
+ * @typedef {object} Candidate
+ * @property {string} run_id
+ * @property {string} entry_id
+ * @property {'path_a'|'path_b'} path
+ * @property {number} age_ms     ms since the relevant timestamp
+ * @property {number} threshold_ms The threshold this candidate exceeded
+ *
+ * @typedef {object} ScanResult
+ * @property {Array<Candidate>} path_a_candidates
+ * @property {Array<Candidate>} path_b_candidates
+ * @property {object} counts
+ * @property {number} counts.path_a_candidate_count
+ * @property {number} counts.path_b_candidate_count
+ * @property {number} counts.runs_inspected_count
+ * @property {number} counts.entries_inspected_count
+ * @property {number} counts.stale_or_corrupt_count
+ *   Entries with missing/non-number created_at, AND Path A entries with
+ *   request_sent=true but missing/non-number requested_at. Logged for the
+ *   operator; not an actionable candidate. Bare-catch P1 lesson (PR-1a
+ *   round 3): we count + classify, never silently swallow.
+ */
+export function scanForCandidates({ activeRuns, now, config } = {}) {
+  if (!Array.isArray(activeRuns)) {
+    throw new TypeError('scanForCandidates: activeRuns must be an array')
+  }
+  if (typeof now !== 'number' || !Number.isFinite(now)) {
+    throw new TypeError('scanForCandidates: now must be a finite number (ms since epoch)')
+  }
+  const cfg = config || {}
+  const pathATimeout = typeof cfg.path_a_timeout_ms === 'number' && cfg.path_a_timeout_ms > 0
+    ? cfg.path_a_timeout_ms : PATH_A_TIMEOUT_MS
+  const pathBThreshold = typeof cfg.path_b_age_threshold_ms === 'number' && cfg.path_b_age_threshold_ms > 0
+    ? cfg.path_b_age_threshold_ms : PATH_B_AGE_THRESHOLD_MS
+
+  const path_a_candidates = []
+  const path_b_candidates = []
+  let entries_inspected_count = 0
+  let stale_or_corrupt_count = 0
+
+  for (const run of activeRuns) {
+    if (!run || typeof run !== 'object') {
+      stale_or_corrupt_count++
+      continue
+    }
+    const runId = run.run_id
+    const entries = Array.isArray(run.codex_review_entries) ? run.codex_review_entries : []
+    for (const entry of entries) {
+      entries_inspected_count++
+      if (!entry || typeof entry !== 'object' || typeof entry.entry_id !== 'string') {
+        stale_or_corrupt_count++
+        continue
+      }
+      const ts = entry.created_at
+      if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+        stale_or_corrupt_count++
+        continue
+      }
+      if (entry.cancelled === true) continue
+
+      // Path A: request sent, no response, past requested_at + timeout.
+      if (entry.request_sent === true && entry.response_received !== true) {
+        const reqAt = entry.requested_at
+        if (typeof reqAt !== 'number' || !Number.isFinite(reqAt)) {
+          stale_or_corrupt_count++
+          continue
+        }
+        const age = now - reqAt
+        if (age >= pathATimeout) {
+          path_a_candidates.push({
+            run_id: runId, entry_id: entry.entry_id,
+            path: 'path_a', age_ms: age, threshold_ms: pathATimeout,
+          })
+        }
+        continue
+      }
+
+      // Path B: naked entry (no request sent), past created_at + age threshold.
+      if (entry.request_sent !== true) {
+        const age = now - ts
+        if (age >= pathBThreshold) {
+          path_b_candidates.push({
+            run_id: runId, entry_id: entry.entry_id,
+            path: 'path_b', age_ms: age, threshold_ms: pathBThreshold,
+          })
+        }
+      }
+    }
+  }
+
+  // Sort for deterministic output (downstream tick payload + idempotency).
+  path_a_candidates.sort(byRunThenEntry)
+  path_b_candidates.sort(byRunThenEntry)
+
+  return {
+    path_a_candidates,
+    path_b_candidates,
+    counts: {
+      path_a_candidate_count: path_a_candidates.length,
+      path_b_candidate_count: path_b_candidates.length,
+      runs_inspected_count: activeRuns.length,
+      entries_inspected_count,
+      stale_or_corrupt_count,
+    },
+  }
+}
+
+function byRunThenEntry(a, b) {
+  if (a.run_id !== b.run_id) return a.run_id < b.run_id ? -1 : 1
+  return a.entry_id < b.entry_id ? -1 : a.entry_id > b.entry_id ? 1 : 0
+}

--- a/scripts/validate-rfc-artifact-manifest.mjs
+++ b/scripts/validate-rfc-artifact-manifest.mjs
@@ -32,6 +32,7 @@ import { NON_BP1_SCRIPTS, buildArtifactManifest } from './lib/bp1-manifest.mjs'
 
 const REQUIRED_SURFACES = [
   'scripts',
+  'scripts_lib',
   'hooks',
   'settings_lines',
   'plugin_entries',

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -166,18 +166,57 @@ tap('A15: em-review-request.mjs is in the manifest scripts when present', () => 
 })
 
 // ---------------------------------------------------------------------------
-// Surface contract: empty manifest has expected six surfaces
+// Surface contract: empty manifest has expected SEVEN surfaces (PR-1b-A added
+// scripts_lib per Codex plan-review consensus round 1 Q3.2)
 // ---------------------------------------------------------------------------
-tap('manifest has all six contract surfaces (even when empty)', () => {
+tap('manifest has all seven contract surfaces (even when empty)', () => {
   const proj = makeProj()
   const r = run(proj)
   const m = r.manifest
+  assert.equal(m.schema_version, 2,
+    'schema_version=2 since PR-1b-A added scripts_lib surface')
   assert.ok(Array.isArray(m.scripts))
+  assert.ok(Array.isArray(m.scripts_lib))
   assert.ok(Array.isArray(m.hooks))
   assert.ok(typeof m.settings_lines.sha256 === 'string')
   assert.ok(typeof m.plugin_entries.sha256 === 'string')
   assert.ok(Array.isArray(m.agent_loaders))
   assert.ok(Array.isArray(m.canonical_prompts))
+})
+
+// ---------------------------------------------------------------------------
+// PR-1b-A: scripts_lib surface scopes to scripts/lib/bp1-*.mjs only
+// (Codex plan-review round 1 Q3.2 — closes the load-bearing-helper drift hole)
+// ---------------------------------------------------------------------------
+tap('PR-1b-A: scripts_lib picks up scripts/lib/bp1-*.mjs files', () => {
+  const proj = makeProj()
+  fs.mkdirSync(path.join(proj, 'scripts', 'lib'), { recursive: true })
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'bp1-helper.mjs'), '// helper\n')
+  const r = run(proj)
+  const found = r.manifest.scripts_lib.find(s => s.path === 'scripts/lib/bp1-helper.mjs')
+  assert.ok(found, 'bp1-helper.mjs must be in scripts_lib')
+})
+
+tap('PR-1b-A: scripts_lib excludes non-bp1 lib files (closed glob)', () => {
+  const proj = makeProj()
+  fs.mkdirSync(path.join(proj, 'scripts', 'lib'), { recursive: true })
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'bp1-keep.mjs'), '// keep\n')
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'local-dir.mjs'), '// not bp1\n')
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'helper.mjs'), '// not bp1\n')
+  const r = run(proj)
+  const paths = r.manifest.scripts_lib.map(s => s.path)
+  assert.deepEqual(paths.sort(), ['scripts/lib/bp1-keep.mjs'])
+})
+
+tap('PR-1b-A: scripts_lib drift changes artifact_version_hash', () => {
+  const proj = makeProj()
+  fs.mkdirSync(path.join(proj, 'scripts', 'lib'), { recursive: true })
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'bp1-thing.mjs'), '// v1\n')
+  const a = run(proj)
+  fs.writeFileSync(path.join(proj, 'scripts', 'lib', 'bp1-thing.mjs'), '// v2\n')
+  const b = run(proj)
+  assert.notEqual(a.sha256, b.sha256,
+    'changing scripts/lib/bp1-*.mjs MUST trigger artifact-version drift')
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/test-bp1-deadline-sweep.mjs
+++ b/tests/test-bp1-deadline-sweep.mjs
@@ -1,0 +1,552 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-deadline-sweep.mjs — Hermetic tests for the unified Path A + Path B
+ * fallback executor.
+ *
+ * RFC-004 §556-577 (PR-1b-A). Tests the three must-have scenarios from the
+ * Codex plan-review consensus (round 1 Q4.1):
+ *   1. Activation/dry-run-bypass matrix (RFC §177, §563-571).
+ *   2. Path A/B boundary scan (RFC §321/§385/§845 + §555/§177 + PR-1a
+ *      bare-catch lesson for stale_or_corrupt classification).
+ *   3. Concurrent/duplicate sweep idempotency (RFC §911-929, §973-981).
+ *
+ * Plus pure-helper unit tests for scripts/lib/bp1-sweep.mjs.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SWEEP = path.join(REPO, 'scripts', 'bp1-deadline-sweep.mjs')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bp1-sweep-${label}-`))
+}
+
+function makeProjectRoot() {
+  const dir = makeTempDir('proj')
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+
+function projectSha(projectRoot) {
+  return crypto.createHash('sha256').update(projectRoot, 'utf8').digest('hex')
+}
+
+function writeVerifyKey(homeDir) {
+  const verifyDir = path.join(homeDir, '.episodic-memory')
+  fs.mkdirSync(verifyDir, { recursive: true })
+  const verifyPath = path.join(verifyDir, '.verify-key')
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(verifyPath, key)
+  fs.chmodSync(verifyPath, 0o600)
+  const fp = crypto.createHmac('sha256', key)
+    .update('verify-key-fingerprint-v1', 'utf8')
+    .digest('hex').slice(0, 16)
+  return { fingerprint: fp, path: verifyPath }
+}
+
+function writeConfig(homeDir, projectRoot, entry) {
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  const config = entry
+    ? { bp1: { schema_version: 1, activations: { [projectRoot]: entry } } }
+    : { bp1: { schema_version: 1, activations: {} } }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+  return configPath
+}
+
+function buildHash(projectRoot) {
+  const out = execFileSync('node', [
+    path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    '--project', projectRoot, '--json',
+  ], { encoding: 'utf8' })
+  return JSON.parse(out).sha256
+}
+
+function runSweep({ projectRoot, homeDir, env, inputPath, allowEmit = false }) {
+  const args = [SWEEP, '--once', '--project', projectRoot, '--json']
+  if (!allowEmit) args.push('--no-emit')
+  if (inputPath) args.push('--input', inputPath)
+  const r = spawnSync('node', args, {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir, ...(env || {}) },
+  })
+  return {
+    exitCode: r.status, stdout: r.stdout, stderr: r.stderr,
+    parsed: r.stdout ? safeParse(r.stdout) : null,
+  }
+}
+
+function safeParse(s) {
+  // Sweep prints two lines (human + json) by default; with --json it prints one.
+  // Either way, the LAST non-empty line is the JSON record.
+  const lines = s.trim().split('\n').filter(Boolean)
+  try { return JSON.parse(lines[lines.length - 1]) } catch { return null }
+}
+
+function activationEntry(projectRoot, fingerprint) {
+  return {
+    enabled: true,
+    artifact_version_hash: 'sha256:' + buildHash(projectRoot),
+    enabled_at: new Date().toISOString(),
+    enabled_via: 'test-fixture',
+    verify_key_id: fingerprint,
+  }
+}
+
+// =============================================================================
+// Pure helper unit tests (scripts/lib/bp1-sweep.mjs)
+// =============================================================================
+const { scanForCandidates, PATH_A_TIMEOUT_MS, PATH_B_AGE_THRESHOLD_MS }
+  = await import('../scripts/lib/bp1-sweep.mjs')
+
+tap('pure: empty input → zero counts', () => {
+  const r = scanForCandidates({ activeRuns: [], now: 1_000_000_000_000 })
+  assert.equal(r.counts.path_a_candidate_count, 0)
+  assert.equal(r.counts.path_b_candidate_count, 0)
+  assert.equal(r.counts.runs_inspected_count, 0)
+  assert.equal(r.counts.entries_inspected_count, 0)
+  assert.equal(r.counts.stale_or_corrupt_count, 0)
+})
+
+tap('pure: rejects bad inputs (bare-catch P1 lesson)', () => {
+  assert.throws(() => scanForCandidates({ activeRuns: 'not array', now: 0 }), /must be an array/)
+  assert.throws(() => scanForCandidates({ activeRuns: [], now: 'not number' }), /must be a finite number/)
+  assert.throws(() => scanForCandidates({ activeRuns: [], now: NaN }), /must be a finite number/)
+})
+
+// -----------------------------------------------------------------------------
+// Must-have #2: Path A/B boundary scan (4 sub-cases + corrupt classification)
+// -----------------------------------------------------------------------------
+const NOW = 1_700_000_000_000
+
+tap('boundary: Path A 29:59 below threshold → no candidate', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - 30 * 60 * 1000,
+        request_sent: true, requested_at: NOW - (PATH_A_TIMEOUT_MS - 1000),
+        response_received: false, cancelled: false,
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_a_candidate_count, 0)
+})
+
+tap('boundary: Path A 30:00 at threshold → qualifies', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - 30 * 60 * 1000,
+        request_sent: true, requested_at: NOW - PATH_A_TIMEOUT_MS,
+        response_received: false, cancelled: false,
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_a_candidate_count, 1)
+  assert.equal(r.path_a_candidates[0].run_id, 'r1')
+})
+
+tap('boundary: Path B 4:59 below threshold → no candidate', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - (PATH_B_AGE_THRESHOLD_MS - 1000),
+        request_sent: false, response_received: false, cancelled: false,
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_b_candidate_count, 0)
+})
+
+tap('boundary: Path B 5:00 at threshold → qualifies', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - PATH_B_AGE_THRESHOLD_MS,
+        request_sent: false, response_received: false, cancelled: false,
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_b_candidate_count, 1)
+  assert.equal(r.path_b_candidates[0].run_id, 'r1')
+})
+
+tap('boundary: corrupt created_at (string/null/missing/NaN) → counted stale, not actioned', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [
+        { entry_id: 'e1', created_at: 'oops', request_sent: false },
+        { entry_id: 'e2', created_at: null, request_sent: false },
+        { entry_id: 'e3', request_sent: false },                       // missing
+        { entry_id: 'e4', created_at: NaN, request_sent: false },
+      ],
+    }],
+  })
+  assert.equal(r.counts.path_b_candidate_count, 0)
+  assert.equal(r.counts.stale_or_corrupt_count, 4)
+  assert.equal(r.counts.entries_inspected_count, 4)
+})
+
+tap('boundary: cancelled entry skipped regardless of age', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - 1_000_000_000,
+        request_sent: false, cancelled: true,
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_a_candidate_count, 0)
+  assert.equal(r.counts.path_b_candidate_count, 0)
+})
+
+tap('boundary: Path A entry without requested_at → stale', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r1', codex_review_entries: [{
+        entry_id: 'e1', created_at: NOW - 1_000_000,
+        request_sent: true, response_received: false, cancelled: false,
+        // requested_at missing
+      }],
+    }],
+  })
+  assert.equal(r.counts.path_a_candidate_count, 0)
+  assert.equal(r.counts.stale_or_corrupt_count, 1)
+})
+
+tap('determinism: candidates sorted by run_id then entry_id', () => {
+  const r = scanForCandidates({
+    now: NOW,
+    activeRuns: [{
+      run_id: 'r-z', codex_review_entries: [
+        { entry_id: 'e-b', created_at: NOW - PATH_B_AGE_THRESHOLD_MS, request_sent: false },
+        { entry_id: 'e-a', created_at: NOW - PATH_B_AGE_THRESHOLD_MS, request_sent: false },
+      ],
+    }, {
+      run_id: 'r-a', codex_review_entries: [
+        { entry_id: 'e-z', created_at: NOW - PATH_B_AGE_THRESHOLD_MS, request_sent: false },
+      ],
+    }],
+  })
+  assert.deepEqual(r.path_b_candidates.map(c => `${c.run_id}/${c.entry_id}`),
+    ['r-a/e-z', 'r-z/e-a', 'r-z/e-b'])
+})
+
+// =============================================================================
+// Executor integration tests (scripts/bp1-deadline-sweep.mjs --once)
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Must-have #1: Activation/dry-run-bypass matrix (RFC §177, §563-571 v3.12)
+// -----------------------------------------------------------------------------
+tap('activation: no entry + no bypass → bp1-disabled-sweep, exit 0', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  const r = runSweep({ projectRoot: proj, homeDir: home })
+  assert.equal(r.exitCode, 0, 'must exit 0 on disabled per RFC §177')
+  assert.equal(r.parsed.status, 'disabled')
+  assert.equal(r.parsed.reason, 'bp1-disabled-refusal')
+})
+
+// Codex code-review round 2 Finding 1: production-mode (non-`--no-emit`)
+// disabled-sweep path must not crash on TDZ. Pre-fix this hit
+// "Cannot access 'emissionStats' before initialization". Regression test.
+tap('disabled-path WITHOUT --no-emit: production emit attempt does not crash, exit 0', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  // Run with allowEmit=true so the script attempts a real em-store invocation.
+  // em-store is at scripts/em-store.mjs in the repo, so it'll try the call.
+  const r = runSweep({ projectRoot: proj, homeDir: home, allowEmit: true })
+  assert.equal(r.exitCode, 0, 'production disabled path must exit 0 (RFC §177)')
+  assert.equal(r.parsed.status, 'disabled')
+  assert.ok(r.parsed.evidence_emission,
+    'disabled-path final JSON must carry evidence_emission')
+})
+
+tap('bypass: lock-only (env unset) → no bypass, refused', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  fs.writeFileSync(path.join(proj, '.episodic-memory', '.bp1-dry-run.lock'),
+    JSON.stringify({ run_id: 'dry-1', ttl_until: Date.now() + 60_000,
+      project_root_sha256: projectSha(proj) }))
+  const r = runSweep({ projectRoot: proj, homeDir: home })
+  assert.equal(r.parsed.status, 'disabled', 'env-unset must NOT bypass')
+})
+
+tap('bypass: env-only (lock missing) → no bypass, refused', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  const r = runSweep({
+    projectRoot: proj, homeDir: home,
+    env: { BP1_DRY_RUN_MODE: projectSha(proj) },
+  })
+  assert.equal(r.parsed.status, 'disabled', 'lock-missing must NOT bypass')
+})
+
+tap('bypass: lock + env both for ANOTHER project → no bypass (cross-project safety, RFC v3.12)', () => {
+  const proj = makeProjectRoot()
+  const otherProj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  // Lock contains OTHER project's sha
+  fs.writeFileSync(path.join(proj, '.episodic-memory', '.bp1-dry-run.lock'),
+    JSON.stringify({ run_id: 'cross-1', ttl_until: Date.now() + 60_000,
+      project_root_sha256: projectSha(otherProj) }))
+  const r = runSweep({
+    projectRoot: proj, homeDir: home,
+    env: { BP1_DRY_RUN_MODE: projectSha(otherProj) },
+  })
+  assert.equal(r.parsed.status, 'disabled',
+    'cross-project bypass attempt must fail closed (CLI v3.11 F3 fix)')
+})
+
+tap('bypass: lock+env both match canonical root → bypass passes, sweep runs', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)  // no activation entry — bypass needed
+  const sha = projectSha(proj)
+  fs.writeFileSync(path.join(proj, '.episodic-memory', '.bp1-dry-run.lock'),
+    JSON.stringify({ run_id: 'good-1', ttl_until: Date.now() + 60_000,
+      project_root_sha256: sha }))
+  const r = runSweep({
+    projectRoot: proj, homeDir: home,
+    env: { BP1_DRY_RUN_MODE: sha },
+  })
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.parsed.status, 'ok')
+  assert.equal(r.parsed.mode, 'fallback', 'sweep is the fallback executor; mode is always fallback')
+  assert.equal(r.parsed.activation_mode, 'dry_run', 'activation came via dry-run bypass')
+  assert.equal(r.parsed.refusal_or_bypass, 'dry_run_bypass')
+  assert.equal(r.parsed.dry_run_id, 'good-1')
+})
+
+tap('bypass: TTL expired → no bypass even with matching env+sha', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  writeVerifyKey(home)
+  writeConfig(home, proj, null)
+  const sha = projectSha(proj)
+  fs.writeFileSync(path.join(proj, '.episodic-memory', '.bp1-dry-run.lock'),
+    JSON.stringify({ run_id: 'expired', ttl_until: Date.now() - 60_000,
+      project_root_sha256: sha }))
+  const r = runSweep({
+    projectRoot: proj, homeDir: home,
+    env: { BP1_DRY_RUN_MODE: sha },
+  })
+  assert.equal(r.parsed.status, 'disabled', 'expired TTL must NOT bypass')
+})
+
+tap('activation: enabled entry → sweep runs (mode=fallback, activation_mode=native)', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const r = runSweep({ projectRoot: proj, homeDir: home })
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.parsed.status, 'ok')
+  assert.equal(r.parsed.mode, 'fallback', 'sweep is the fallback executor')
+  assert.equal(r.parsed.activation_mode, 'native')
+  assert.equal(r.parsed.refusal_or_bypass, 'activated')
+  assert.equal(r.parsed.counts.path_a_candidate_count, 0)
+})
+
+// -----------------------------------------------------------------------------
+// Must-have #3: idempotency primitives (within-invocation lock + stale reclaim)
+//
+// PR-1b-A scope: locks are within-invocation idempotency only. Persistent
+// request-claim lifetime is M1 territory (RFC §911-929 with full TTL/HMAC
+// contract). PR-1b-A's executor takes a per-entry lock during the action
+// loop, emits the pending-m1 evidence, and releases the lock. Stale locks
+// (older than LOCK_TTL_MS) MUST be reclaimable so a crashed prior process
+// doesn't permanently block future sweeps.
+// -----------------------------------------------------------------------------
+tap('idempotency: within-invocation single candidate → exactly one pending_m1 emit', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const fixturePath = path.join(makeTempDir('fixture'), 'runs.json')
+  fs.writeFileSync(fixturePath, JSON.stringify([{
+    run_id: 'r-once', codex_review_entries: [{
+      entry_id: 'e-1', created_at: Date.now() - PATH_B_AGE_THRESHOLD_MS - 60_000,
+      request_sent: false,
+    }],
+  }]))
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: fixturePath })
+  assert.equal(r.parsed.status, 'ok')
+  assert.equal(r.parsed.actions.length, 1)
+  assert.equal(r.parsed.actions[0].action, 'pending_m1')
+  assert.equal(r.parsed.action_count, 1, 'tick action_count must reflect the action loop')
+})
+
+tap('idempotency: stale lock (>60s old) reclaimed by next sweep', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const fixturePath = path.join(makeTempDir('fixture'), 'runs.json')
+  fs.writeFileSync(fixturePath, JSON.stringify([{
+    run_id: 'r-stale', codex_review_entries: [{
+      entry_id: 'e-stale', created_at: Date.now() - PATH_B_AGE_THRESHOLD_MS - 60_000,
+      request_sent: false,
+    }],
+  }]))
+  // Pre-place a stale lock (claimed_at 5 minutes ago)
+  const lockDir = path.join(proj, '.episodic-memory', 'bp1-locks')
+  fs.mkdirSync(lockDir, { recursive: true })
+  fs.writeFileSync(path.join(lockDir, 'r-stale__e-stale.lock'),
+    JSON.stringify({ pid: 999_999, claimed_at: Date.now() - 5 * 60_000 }))
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: fixturePath })
+  assert.equal(r.parsed.actions[0].action, 'pending_m1',
+    'stale lock must be reclaimed (RFC §909 60s TTL contract)')
+})
+
+tap('idempotency: fresh lock (<60s old) blocks second sweep', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const fixturePath = path.join(makeTempDir('fixture'), 'runs.json')
+  fs.writeFileSync(fixturePath, JSON.stringify([{
+    run_id: 'r-fresh', codex_review_entries: [{
+      entry_id: 'e-fresh', created_at: Date.now() - PATH_B_AGE_THRESHOLD_MS - 60_000,
+      request_sent: false,
+    }],
+  }]))
+  // Pre-place a FRESH lock (claimed 5s ago) — simulates a concurrent process
+  const lockDir = path.join(proj, '.episodic-memory', 'bp1-locks')
+  fs.mkdirSync(lockDir, { recursive: true })
+  fs.writeFileSync(path.join(lockDir, 'r-fresh__e-fresh.lock'),
+    JSON.stringify({ pid: 123, claimed_at: Date.now() - 5_000 }))
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: fixturePath })
+  assert.equal(r.parsed.actions[0].action, 'skipped_locked',
+    'fresh lock must block — only stale locks are reclaimed')
+})
+
+tap('idempotency: corrupt lock body treated as stale and reclaimed', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const fixturePath = path.join(makeTempDir('fixture'), 'runs.json')
+  fs.writeFileSync(fixturePath, JSON.stringify([{
+    run_id: 'r-corrupt', codex_review_entries: [{
+      entry_id: 'e-corrupt', created_at: Date.now() - PATH_B_AGE_THRESHOLD_MS - 60_000,
+      request_sent: false,
+    }],
+  }]))
+  const lockDir = path.join(proj, '.episodic-memory', 'bp1-locks')
+  fs.mkdirSync(lockDir, { recursive: true })
+  fs.writeFileSync(path.join(lockDir, 'r-corrupt__e-corrupt.lock'), '{not json')
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: fixturePath })
+  assert.equal(r.parsed.actions[0].action, 'pending_m1',
+    'corrupt lock body must be treated as stale and reclaimed')
+})
+
+// -----------------------------------------------------------------------------
+// Edge: --once flag enforced
+// -----------------------------------------------------------------------------
+tap('cli: missing --once → exit 2', () => {
+  const r = spawnSync('node', [SWEEP, '--no-emit'], { encoding: 'utf8' })
+  assert.equal(r.status, 2)
+  assert.match(r.stderr, /--once is required/)
+})
+
+tap('cli: malformed --input file → load_issue surfaced in final JSON', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const badInput = path.join(makeTempDir('bad'), 'bad.json')
+  fs.writeFileSync(badInput, '{not json')
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: badInput })
+  assert.equal(r.exitCode, 0,
+    'malformed input is operator-visible but must not crash the sweep')
+  assert.equal(r.parsed.counts.runs_inspected_count, 0)
+  assert.ok(r.parsed.load_issue, 'final JSON must surface load_issue (Codex round 1 Finding 3)')
+  assert.equal(r.parsed.load_issue.code, 'active_runs_load_error')
+})
+
+// -----------------------------------------------------------------------------
+// Codex code-review round 1 Finding 3: emission status + load_issue surfaced
+// in final JSON.
+// -----------------------------------------------------------------------------
+tap('observability: --no-emit yields evidence_emission with zero attempts', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const r = runSweep({ projectRoot: proj, homeDir: home })
+  assert.ok(r.parsed.evidence_emission, 'final JSON must carry evidence_emission')
+  assert.equal(r.parsed.evidence_emission.attempted, 0,
+    '--no-emit means zero emission attempts')
+})
+
+tap('observability: load_issue is null when load is clean', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const r = runSweep({ projectRoot: proj, homeDir: home })
+  // Either null or undefined per JSON serialization of explicit null
+  assert.ok(r.parsed.load_issue === null || r.parsed.load_issue === undefined,
+    'no load issue when load is clean')
+})
+
+tap('tick schema D4: action_count, refusal_or_bypass, project_root_sha256 surfaced', () => {
+  const proj = makeProjectRoot()
+  const home = makeTempDir('home')
+  const vk = writeVerifyKey(home)
+  writeConfig(home, proj, activationEntry(proj, vk.fingerprint))
+  const fixturePath = path.join(makeTempDir('fixture'), 'runs.json')
+  fs.writeFileSync(fixturePath, JSON.stringify([{
+    run_id: 'r-tick', codex_review_entries: [{
+      entry_id: 'e-tick', created_at: Date.now() - PATH_B_AGE_THRESHOLD_MS - 60_000,
+      request_sent: false,
+    }],
+  }]))
+  const r = runSweep({ projectRoot: proj, homeDir: home, inputPath: fixturePath })
+  assert.equal(typeof r.parsed.project_root_sha256, 'string')
+  assert.equal(r.parsed.project_root_sha256.length, 64, 'sha256 hex')
+  assert.equal(r.parsed.action_count, 1)
+  assert.equal(r.parsed.refusal_or_bypass, 'activated')
+  assert.equal(r.parsed.mode, 'fallback')
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) { console.log(`# FAILED ${fail} of ${pass + fail}`); process.exit(1) }
+else console.log(`# PASSED ${pass}`)

--- a/tests/test-bp1-deadline-sweep.mjs
+++ b/tests/test-bp1-deadline-sweep.mjs
@@ -274,6 +274,45 @@ tap('activation: no entry + no bypass → bp1-disabled-sweep, exit 0', () => {
   assert.equal(r.parsed.reason, 'bp1-disabled-refusal')
 })
 
+// Codex post-PR-186 follow-up (episode 20260507-021838-...-4c0f): when
+// caller cwd != --project, evidence MUST land under target project root,
+// not caller cwd. Pre-fix `em-store --scope local` resolved the local
+// store from cwd. Same class as the worktree/local-store miss.
+tap('cwd != --project: evidence lands under TARGET project, not caller cwd', () => {
+  const callerCwd = makeProjectRoot()
+  const targetProj = makeProjectRoot()
+  const home = makeTempDir('home')
+  // No verify-key → bp1-hmac-keyfile-fail refusal path, which still emits
+  // bp1-disabled-sweep evidence per RFC §177. Perfect for proving the
+  // emission path lands under --project, not cwd.
+  const r = spawnSync('node', [
+    SWEEP, '--once', '--project', targetProj, '--json',
+  ], {
+    cwd: callerCwd,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  })
+  const parsed = safeParse(r.stdout)
+  assert.equal(r.status, 0)
+  assert.equal(parsed.evidence_emission.succeeded, 1,
+    'emission must succeed (em-store path is reachable)')
+
+  // Caller cwd MUST NOT have an episodes dir
+  const callerEpisodesDir = path.join(callerCwd, '.episodic-memory', 'episodes')
+  assert.ok(!fs.existsSync(callerEpisodesDir),
+    `evidence must NOT land in caller cwd; found dir: ${callerEpisodesDir}`)
+
+  // Target project MUST have at least one episode
+  const targetEpisodesDir = path.join(targetProj, '.episodic-memory', 'episodes')
+  assert.ok(fs.existsSync(targetEpisodesDir),
+    `evidence must land in target --project's .episodic-memory/episodes`)
+  const targetEpisodes = fs.readdirSync(targetEpisodesDir)
+  assert.ok(targetEpisodes.length >= 1,
+    `target project must have at least one disabled-sweep episode; got ${targetEpisodes.length}`)
+  assert.ok(targetEpisodes.some(e => /bp1-disabled-sweep|bp1-hmac-keyfile-fail/.test(e)),
+    'expected bp1-disabled-sweep evidence in target episodes')
+})
+
 // Codex code-review round 2 Finding 1: production-mode (non-`--no-emit`)
 // disabled-sweep path must not crash on TDZ. Pre-fix this hit
 // "Cannot access 'emissionStats' before initialization". Regression test.

--- a/tests/test-bp1-flag-check.mjs
+++ b/tests/test-bp1-flag-check.mjs
@@ -302,6 +302,199 @@ tap('row 29: verify-key missing → bp1-hmac-keyfile-fail', () => {
   assert.equal(r.parsed.verify_key_state.reason, 'missing')
 })
 
+// ============================================================================
+// PR-1b-A: M5 dry-run bypass matrix (RFC §563-571 v3.12)
+// Cross-project bypass safety per Codex plan-review consensus round 1 Q1.3.
+// Both halves must match canonical project root sha to bypass.
+// ============================================================================
+function projectSha(projectRoot) {
+  return crypto.createHash('sha256').update(projectRoot, 'utf8').digest('hex')
+}
+
+function writeLock(projectRoot, contents) {
+  const dir = path.join(projectRoot, '.episodic-memory')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, '.bp1-dry-run.lock'), contents)
+}
+
+tap('bypass: env unset → no bypass (regular activation gate runs)', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, JSON.stringify({
+    run_id: 'no-env', ttl_until: Date.now() + 60_000,
+    project_root_sha256: projectSha(proj),
+  }))
+  // No BP1_DRY_RUN_MODE in env → bypass declines, gate refuses (no entry)
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+  assert.notEqual(r.parsed.bypass, 'dry-run')
+})
+
+tap('bypass: lock missing → no bypass even with matching env', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: projectSha(proj) },
+  })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+})
+
+tap('bypass: env value for ANOTHER project → no bypass (cross-project safety)', () => {
+  const proj = makeProjectRoot()
+  const otherProj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  // Lock and env both contain the OTHER project's sha — cannot bypass THIS project
+  writeLock(proj, JSON.stringify({
+    run_id: 'cross', ttl_until: Date.now() + 60_000,
+    project_root_sha256: projectSha(otherProj),
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: projectSha(otherProj) },
+  })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal',
+    'cross-project env inheritance must not enable bypass (CLI v3.11 F3 fix)')
+})
+
+tap('bypass: env mismatched (wrong sha but lock right) → no bypass', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, JSON.stringify({
+    run_id: 'env-bad', ttl_until: Date.now() + 60_000,
+    project_root_sha256: projectSha(proj),
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: 'wrong-sha-value' },
+  })
+  assert.equal(r.exitCode, 2)
+})
+
+tap('bypass: malformed lock JSON → no bypass', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, '{not valid json')
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: projectSha(proj) },
+  })
+  assert.equal(r.exitCode, 2)
+})
+
+tap('bypass: TTL expired → no bypass', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, JSON.stringify({
+    run_id: 'expired', ttl_until: Date.now() - 60_000,  // already past
+    project_root_sha256: projectSha(proj),
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: projectSha(proj) },
+  })
+  assert.equal(r.exitCode, 2)
+})
+
+tap('bypass: lock missing run_id → no bypass', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, JSON.stringify({
+    ttl_until: Date.now() + 60_000,
+    project_root_sha256: projectSha(proj),
+    // run_id missing
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: projectSha(proj) },
+  })
+  assert.equal(r.exitCode, 2)
+})
+
+tap('bypass diagnostic: env mismatch → bypass_declined surfaces in activation refusal extras (Codex round 1 Finding 4)', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  writeLock(proj, JSON.stringify({
+    run_id: 'env-mismatch', ttl_until: Date.now() + 60_000,
+    project_root_sha256: projectSha(proj),
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: 'wrong-value-but-non-empty' },
+  })
+  assert.equal(r.exitCode, 2)
+  assert.equal(r.parsed.code, 'bp1-disabled-refusal')
+  assert.ok(r.parsed.bypass_declined,
+    'bypass-declined diagnostic must be plumbed to refusal extras')
+  assert.equal(r.parsed.bypass_declined.reason, 'env_mismatch')
+  assert.equal(typeof r.parsed.bypass_declined.env_len, 'number',
+    'env_len is the safe diagnostic — do not log the value itself')
+  assert.ok(!('value' in r.parsed.bypass_declined),
+    'never echo the env value into the artifact')
+})
+
+tap('bypass diagnostic: env_unset (no signal) → no bypass_declined in refusal', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  // No env set, no lock → bypass declines silently as env_unset
+  const r = runFlagCheck({ projectRoot: proj, configPath, env: { HOME: homeDir } })
+  assert.equal(r.exitCode, 2)
+  assert.ok(!r.parsed.bypass_declined,
+    'env_unset is a non-signal — refusal stays clean')
+})
+
+tap('bypass: both halves match → bypass passes (status=ok, bypass=dry-run, no entry needed)', () => {
+  const proj = makeProjectRoot()
+  const homeDir = makeTempDir('home')
+  writeVerifyKey(path.join(homeDir, '.episodic-memory', '.verify-key'))
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  // No activation entry — bypass is the only path that succeeds.
+  fs.writeFileSync(configPath, JSON.stringify({ bp1: { activations: {} } }))
+  const sha = projectSha(proj)
+  writeLock(proj, JSON.stringify({
+    run_id: 'happy-bypass', ttl_until: Date.now() + 60_000,
+    project_root_sha256: sha,
+  }))
+  const r = runFlagCheck({
+    projectRoot: proj, configPath,
+    env: { HOME: homeDir, BP1_DRY_RUN_MODE: sha },
+  })
+  assert.equal(r.exitCode, 0, `expected exit 0; stdout=${r.stdout}`)
+  assert.equal(r.parsed.status, 'ok')
+  assert.equal(r.parsed.bypass, 'dry-run')
+  assert.equal(r.parsed.run_id, 'happy-bypass')
+})
+
 console.log(`\n1..${pass + fail}`)
 if (fail) {
   console.log(`# FAILED ${fail} of ${pass + fail}`)

--- a/tests/test-bp1-probe.mjs
+++ b/tests/test-bp1-probe.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-probe.mjs — Hermetic tests for the scheduled-tasks capability probe.
+ *
+ * RFC-004 §550-577 (PR-1b-A). Three must-have scenarios from the Codex
+ * plan-review consensus (round 1 Q4.2):
+ *   1. M0 stub shape (5 fields, never returns 'native').
+ *   2. Manifest drift (changing the probe helper changes artifact_version_hash).
+ *   3. M1 placeholder contract (3 injectable outcomes pinned for M1's harness).
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  const handle = (e) => {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+  try {
+    const out = fn()
+    if (out && typeof out.then === 'function') {
+      return out.then(() => { pass++; console.log(`ok ${pass + fail} - ${name}`) }, handle)
+    }
+    pass++
+    console.log(`ok ${pass + fail} - ${name}`)
+  } catch (e) { handle(e) }
+}
+
+const probe = await import('../scripts/lib/bp1-probe.mjs')
+
+// =============================================================================
+// Must-have #1: M0 stub shape
+// =============================================================================
+tap('M0 stub: returns capability=fallback (NEVER native)', () => {
+  const r = probe.probeScheduledTasksCapability()
+  assert.equal(r.capability, 'fallback')
+  assert.notEqual(r.capability, 'native', 'M0 must never claim native')
+})
+
+tap('M0 stub: reason=m1_not_implemented', () => {
+  const r = probe.probeScheduledTasksCapability()
+  assert.equal(r.reason, 'm1_not_implemented')
+})
+
+tap('M0 stub: native_probe_performed=false', () => {
+  const r = probe.probeScheduledTasksCapability()
+  assert.equal(r.native_probe_performed, false)
+})
+
+tap('M0 stub: t2_fallback=false (RFC §573-575)', () => {
+  const r = probe.probeScheduledTasksCapability()
+  assert.equal(r.t2_fallback, false,
+    'T2 weekly meta-audit has NO fallback path per RFC §573-575')
+})
+
+tap('M0 stub: degraded_mode_message is non-empty + mentions T2 manual fallback', () => {
+  const r = probe.probeScheduledTasksCapability()
+  assert.equal(typeof r.degraded_mode_message, 'string')
+  assert.ok(r.degraded_mode_message.length > 0)
+  assert.match(r.degraded_mode_message, /T2/, 'must mention T2')
+  assert.match(r.degraded_mode_message, /bp1-security-audit\.mjs/,
+    'must point operator at the manual fallback script')
+})
+
+tap('M0 stub: shape has exactly the 5 contract fields, no extras', () => {
+  const r = probe.probeScheduledTasksCapability()
+  const keys = Object.keys(r).sort()
+  assert.deepEqual(keys, [
+    'capability', 'degraded_mode_message',
+    'native_probe_performed', 'reason', 't2_fallback',
+  ])
+})
+
+tap('M0 stub: validateProbeResult passes the M0 shape', () => {
+  const r = probe.probeScheduledTasksCapability()
+  const v = probe.validateProbeResult(r)
+  assert.equal(v.ok, true, `M0 shape must validate; errors: ${JSON.stringify(v.errors)}`)
+})
+
+// =============================================================================
+// Must-have #3: M1 placeholder contract — pin three outcomes for M1's harness
+// =============================================================================
+tap('M1 contract: success outcome shape (capability=native, reason=list_succeeded)', () => {
+  const synthetic = {
+    capability: 'native', reason: 'list_succeeded',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'native; no degradation',
+  }
+  const v = probe.validateProbeResult(synthetic)
+  assert.equal(v.ok, true, `errors: ${JSON.stringify(v.errors)}`)
+})
+
+tap('M1 contract: ToolNotFound outcome (capability=fallback, reason=tool_not_found)', () => {
+  const synthetic = {
+    capability: 'fallback', reason: 'tool_not_found',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'mcp__scheduled-tasks not registered',
+  }
+  const v = probe.validateProbeResult(synthetic)
+  assert.equal(v.ok, true)
+})
+
+tap('M1 contract: schema_mismatch outcome (capability=fallback, reason=schema_mismatch)', () => {
+  const synthetic = {
+    capability: 'fallback', reason: 'schema_mismatch',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'list_scheduled_tasks returned unexpected shape',
+  }
+  const v = probe.validateProbeResult(synthetic)
+  assert.equal(v.ok, true)
+})
+
+tap('M1 contract: connection_error outcome', () => {
+  const synthetic = {
+    capability: 'fallback', reason: 'connection_error',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'MCP server unreachable',
+  }
+  const v = probe.validateProbeResult(synthetic)
+  assert.equal(v.ok, true)
+})
+
+tap('M1 contract: invalid capability rejected', () => {
+  const v = probe.validateProbeResult({
+    capability: 'maybe', reason: 'list_succeeded',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'x',
+  })
+  assert.equal(v.ok, false)
+  assert.ok(v.errors.some(e => /capability must be one of/.test(e)))
+})
+
+tap('M1 contract: t2_fallback=true rejected (cannot subvert RFC §573-575)', () => {
+  const v = probe.validateProbeResult({
+    capability: 'native', reason: 'list_succeeded',
+    native_probe_performed: true, t2_fallback: true,  // ← invalid
+    degraded_mode_message: 'x',
+  })
+  assert.equal(v.ok, false)
+  assert.ok(v.errors.some(e => /t2_fallback must be false/.test(e)))
+})
+
+tap('M1 contract: capability=native requires reason=list_succeeded AND native_probe_performed=true', () => {
+  // capability=native + reason=tool_not_found → invalid
+  const v1 = probe.validateProbeResult({
+    capability: 'native', reason: 'tool_not_found',
+    native_probe_performed: true, t2_fallback: false,
+    degraded_mode_message: 'x',
+  })
+  assert.equal(v1.ok, false)
+  assert.ok(v1.errors.some(e => /capability=native requires reason='list_succeeded'/.test(e)))
+
+  // capability=native + native_probe_performed=false → invalid
+  const v2 = probe.validateProbeResult({
+    capability: 'native', reason: 'list_succeeded',
+    native_probe_performed: false, t2_fallback: false,
+    degraded_mode_message: 'x',
+  })
+  assert.equal(v2.ok, false)
+  assert.ok(v2.errors.some(e => /native_probe_performed=true/.test(e)))
+})
+
+tap('M1 contract: VALID_REASONS_M1 enumeration is frozen', () => {
+  assert.ok(Object.isFrozen(probe.VALID_REASONS_M1))
+  assert.ok(probe.VALID_REASONS_M1.includes('list_succeeded'))
+  assert.ok(probe.VALID_REASONS_M1.includes('tool_not_found'))
+  assert.ok(probe.VALID_REASONS_M1.includes('connection_error'))
+  assert.ok(probe.VALID_REASONS_M1.includes('schema_mismatch'))
+  assert.ok(probe.VALID_REASONS_M1.includes('m1_not_implemented'))
+})
+
+// =============================================================================
+// Must-have #2: Manifest drift — changing the probe helper changes the hash
+// =============================================================================
+tap('drift: changing scripts/lib/bp1-probe.mjs content changes artifact_version_hash', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-probe-drift-'))
+  execFileSync('git', ['init', '-q'], { cwd: tmp })
+  fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
+  // Copy the real builder + manifest lib + probe to the tmp project
+  fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
+  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'bp1-manifest.mjs'),
+    path.join(tmp, 'scripts', 'lib', 'bp1-manifest.mjs'))
+  // Initial probe content
+  fs.writeFileSync(path.join(tmp, 'scripts', 'lib', 'bp1-probe.mjs'),
+    'export function probeScheduledTasksCapability(){return{capability:"fallback"}}\n')
+  const a = JSON.parse(execFileSync('node',
+    [path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'), '--project', tmp, '--json'],
+    { encoding: 'utf8' }))
+  // Change probe content
+  fs.writeFileSync(path.join(tmp, 'scripts', 'lib', 'bp1-probe.mjs'),
+    'export function probeScheduledTasksCapability(){return{capability:"native"}}\n')
+  const b = JSON.parse(execFileSync('node',
+    [path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'), '--project', tmp, '--json'],
+    { encoding: 'utf8' }))
+  assert.notEqual(a.sha256, b.sha256,
+    'changing scripts/lib/bp1-probe.mjs content MUST change artifact_version_hash ' +
+    '(otherwise M1 swap of probe stub → real probe would not trigger bp1-flag-version-drift)')
+})
+
+tap('drift: changing scripts/lib/bp1-sweep.mjs content changes artifact_version_hash', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-sweep-drift-'))
+  execFileSync('git', ['init', '-q'], { cwd: tmp })
+  fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
+  fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
+  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'bp1-manifest.mjs'),
+    path.join(tmp, 'scripts', 'lib', 'bp1-manifest.mjs'))
+  fs.writeFileSync(path.join(tmp, 'scripts', 'lib', 'bp1-sweep.mjs'),
+    'export function scanForCandidates(){return{path_a_candidates:[],path_b_candidates:[],counts:{}}}\n')
+  const a = JSON.parse(execFileSync('node',
+    [path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'), '--project', tmp, '--json'],
+    { encoding: 'utf8' }))
+  fs.writeFileSync(path.join(tmp, 'scripts', 'lib', 'bp1-sweep.mjs'),
+    'export function scanForCandidates(){return{path_a_candidates:[{}],path_b_candidates:[],counts:{}}}\n')
+  const b = JSON.parse(execFileSync('node',
+    [path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'), '--project', tmp, '--json'],
+    { encoding: 'utf8' }))
+  assert.notEqual(a.sha256, b.sha256)
+})
+
+tap('drift: a non-bp1 lib file (e.g. scripts/lib/foo.mjs) is NOT in the manifest', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-non-bp1-lib-'))
+  execFileSync('git', ['init', '-q'], { cwd: tmp })
+  fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
+  fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
+  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'bp1-manifest.mjs'),
+    path.join(tmp, 'scripts', 'lib', 'bp1-manifest.mjs'))
+  fs.writeFileSync(path.join(tmp, 'scripts', 'lib', 'foo.mjs'), '// not bp1\n')
+  const r = JSON.parse(execFileSync('node',
+    [path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'), '--project', tmp, '--json'],
+    { encoding: 'utf8' }))
+  const fooFound = r.manifest.scripts_lib.find(s => s.path === 'scripts/lib/foo.mjs')
+  assert.equal(fooFound, undefined,
+    'scripts_lib must scope to scripts/lib/bp1-*.mjs ONLY (closed glob)')
+})
+
+console.log(`\n1..${pass + fail}`)
+if (fail) { console.log(`# FAILED ${fail} of ${pass + fail}`); process.exit(1) }
+else console.log(`# PASSED ${pass}`)

--- a/tests/test-validate-rfc-artifact-manifest.mjs
+++ b/tests/test-validate-rfc-artifact-manifest.mjs
@@ -23,13 +23,14 @@ function makeTempDir(label) {
   return fs.mkdtempSync(path.join(os.tmpdir(), `rfc-mfst-${label}-`))
 }
 
-function fixture({ surfaces, includeEmReviewRequest = true, schemaVersion = 1 }) {
+function fixture({ surfaces, includeEmReviewRequest = true, schemaVersion = 2 }) {
   let scriptsBlock = '  scripts:\n    - path: "scripts/bp1-orchestrator.mjs"\n      sha256: "<file-sha256>"\n'
   if (includeEmReviewRequest) {
     scriptsBlock += '    - path: "scripts/em-review-request.mjs"\n      sha256: "<file-sha256>"\n'
   }
   const surfaceBlocks = {
     scripts: scriptsBlock,
+    scripts_lib: '  scripts_lib:\n    - path: "scripts/lib/bp1-manifest.mjs"\n      sha256: "<sha>"\n',
     hooks: '  hooks:\n    - path: ".claude/hooks/bp1-approval-check.sh"\n      sha256: "<sha>"\n',
     settings_lines: '  settings_lines:\n    sha256: "<filtered-sha>"\n',
     plugin_entries: '  plugin_entries:\n    sha256: "<filtered-sha>"\n',
@@ -55,9 +56,9 @@ function run(file) {
   return { exitCode: r.status, parsed: JSON.parse(r.stdout) }
 }
 
-const ALL = ['scripts', 'hooks', 'settings_lines', 'plugin_entries', 'agent_loaders', 'canonical_prompts']
+const ALL = ['scripts', 'scripts_lib', 'hooks', 'settings_lines', 'plugin_entries', 'agent_loaders', 'canonical_prompts']
 
-tap('happy path: all 6 surfaces present + em-review-request listed → exit 0', () => {
+tap('happy path: all 7 surfaces present + em-review-request listed → exit 0', () => {
   const file = writeFixture(fixture({ surfaces: ALL }))
   const r = run(file)
   assert.equal(r.exitCode, 0, JSON.stringify(r.parsed.results[0].violations))


### PR DESCRIPTION
## Summary

PR-1b-A ships the unified Path A + Path B fallback executor for when `mcp__scheduled-tasks` is unavailable. Activation-gated; emits operational tick + per-candidate pending-m1 evidence. PR-1b-B (next) will ship the H2 SessionStart hook + install.mjs wiring.

- **`scripts/bp1-deadline-sweep.mjs --once`** — executor: flag-check delegate, within-invocation per-entry lock with stale-reclaim (RFC §909-923, 60s TTL), `bp1-sweep-tick` operational evidence (D4 schema), `bp1-sweep-action-pending-m1` per candidate.
- **`scripts/lib/bp1-sweep.mjs`** — pure helper: `scanForCandidates({activeRuns, now, config})` returns `{path_a_candidates, path_b_candidates, counts}`. Zero I/O.
- **`scripts/lib/bp1-probe.mjs`** — M0 stub returning explicit-fallback shape (5 fields, never `'native'`); pins M1 contract via `validateProbeResult()`.
- **`scripts/bp1-flag-check.mjs`** — RFC §563-571 v3.12 dry-run bypass: BOTH lock file `project_root_sha256` AND `BP1_DRY_RUN_MODE` env value must equal canonical project root sha (closes cross-project bypass hole). Redacted `bypass_declined` diagnostic plumbed to refusal extras.
- **`scripts/lib/bp1-manifest.mjs`** — new `scripts_lib` surface scopes `scripts/lib/bp1-*.mjs`; schema_version 1→2. Closes the drift hole that would have masked M1's probe-stub → real-probe swap.

### Plan-review (3 rounds, 12→1→0 findings)

Episode trail in `.episodic-memory/episodes/`:
- Request `20260506-234656-pr-1b-m0-part-2-plan-review-request-swee-6ae9`
- R1 reply `20260506-235144-codex-plan-review-reply-for-pr-1b-m0-par-d36c`
- Consensus `20260506-235405-pr-1b-plan-review-consensus-revised-plan-807f` (D1-D8 deltas)
- R3 ACCEPT `20260506-235818-codex-plan-review-round-3-reply-for-pr-1-f8f2`

### Code-review (4 rounds, 4→1→1→0 findings)

- R1 reply `20260507-002106-codex-code-review-reply-for-pr-1b-a-roun-50fc` (4 findings: tick schema D4, lock crash-safety, emission visibility, bypass diagnostic)
- R2 reply `20260507-003054-codex-code-review-round-2-reply-for-pr-1-d0c2` (TDZ crash on production disabled-path)
- R3 reply `20260507-010128-codex-code-review-round-3-reply-for-pr-1-3f9d` (stale JSDoc)
- R4 ACCEPT `20260507-010325-codex-code-review-round-4-reply-for-pr-1-8615`

### M1 deferred (issue #185)

Activation episode canonical payload must HMAC-sign `{scheduled_tasks_capability, probe_reason, native_probe_performed, t2_fallback, degraded_mode_message}`; tampering each field must fail verification.

### Test counts

| Suite | Cases |
|---|---|
| `test-bp1-deadline-sweep.mjs` | 27 (NEW) |
| `test-bp1-probe.mjs` | 18 (NEW) |
| `test-bp1-flag-check.mjs` | 20 (+bypass matrix) |
| `test-bp1-build-artifact-manifest.mjs` | 15 (+scripts_lib drift) |
| `test-validate-rfc-artifact-manifest.mjs` | 8 (schema_version=2 fixture) |
| `test-em-rfc-validate.mjs` | 9 |
| `test-validate-rfc-failure-table.mjs` | 10 |
| `test-install-bp1.sh` | 12 |
| **Total** | **119** |

All 3 RFC validators (failure-table, artifact-manifest, registry) green.

## Test plan

- [x] All 119 hermetic tests pass locally
- [x] Production-disabled repro (without `--no-emit`) exits 0 with `evidence_emission` populated
- [x] Manifest drift triggers when `scripts/lib/bp1-{sweep,probe,manifest}.mjs` changes
- [x] Cross-project dry-run bypass attempt fails closed
- [x] Stale lock (>60s) reclaim works; fresh lock blocks
- [ ] CI green on `rfc-validate` workflow
- [ ] User approves via GitHub UI Reviews tab

## RFC alignment

Implements RFC-004 v3.12 §556-577 (M0 part 2 fallback) + §563-571 v3.12 dry-run bypass + closes Codex plan-review Q3.2 manifest coverage hole. RFC artifact_manifest YAML block updated to declare `scripts_lib` and schema_version 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)