### PR TITLE
feat: transcript mining + compliance audit + weekly digest wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ node_modules/
 .claude/.plan-approval-pending
 .claude/settings.local.json
 
+# Per-session scratch (mining staging, codex requests/replies, etc.)
+.claude/scratch/
+
 # BP-1 per-run HMAC key (RFC-004)
 **/.episodic-memory/runs/*/run.key

--- a/scripts/em-audit-compliance.mjs
+++ b/scripts/em-audit-compliance.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * em-audit-compliance.mjs — measure rule-skip rates from session transcripts.
+ *
+ * Walks Claude Code session JSONLs via transcript-walker, classifies each
+ * session against three high-confidence heuristics:
+ *
+ *   - rule-9-handoff   : session has >= 20 records AND no Write to a
+ *                        session_handoff.md path during the session
+ *   - rule-8-plan-gate : session contains Edit/Write tool_use AND assistant
+ *                        text mentions "plan" AND no `.plan-approval-pending`
+ *                        marker touch was observed (the marker is what
+ *                        plan-gate.sh checks)
+ *   - rule-18-e2e      : session contains implementation Edit/Write
+ *                        (to .mjs/.ts/.js/.sh/.py) AND no Bash test run
+ *                        (node ... .mjs|.test.|jest|pytest|vitest|test-) AND
+ *                        no `gh issue create` (bug-logging step)
+ *
+ * Heuristic, not ground truth. False positives expected — short sessions
+ * legitimately have no handoff; documentation-only changes legitimately have
+ * no tests. Output is directionally useful for trend tracking, not
+ * authoritative.
+ *
+ * Usage:
+ *   node em-audit-compliance.mjs [--since <ISO>] [--slug <substring>]
+ *                                [--exclude-worktrees]
+ *                                [--format json|markdown]
+ *                                [--prior-since <ISO>]
+ *
+ * Defaults:
+ *   --since         7 days ago
+ *   --prior-since   14 days ago (used for trend delta vs prior week)
+ *   --format        json
+ *
+ * Output JSON to stdout: see schema in classifySession() and aggregate().
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import { walkTranscripts, groupBySession } from './lib/transcript-walker.mjs'
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2)
+function flag(name, def = undefined) {
+  const i = argv.indexOf(name)
+  if (i === -1) return def
+  if (i + 1 >= argv.length) return true
+  const next = argv[i + 1]
+  if (next.startsWith('--')) return true
+  return next
+}
+
+function isoDaysAgo(days) {
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  return d.toISOString()
+}
+
+const since = flag('--since') || isoDaysAgo(7)
+const priorSince = flag('--prior-since') || isoDaysAgo(14)
+const slugFilter = flag('--slug') === true ? undefined : flag('--slug')
+const excludeWorktrees = flag('--exclude-worktrees') === true
+const format = flag('--format') || 'json'
+
+// ---------------------------------------------------------------------------
+// Heuristics
+// ---------------------------------------------------------------------------
+
+const IMPL_FILE_RE = /\.(mjs|ts|tsx|js|jsx|sh|py|rb|go|rs)\b/
+const TEST_BASH_RE = /\b(node\s+\S*test|jest|pytest|vitest|tap\b|test-\S+\.(mjs|sh|py|js))/i
+const GH_ISSUE_RE = /\bgh\s+issue\s+create\b/i
+
+function getEditWriteTargetPath(rec) {
+  // tool_use record. Inspect input.file_path / input.path / etc.
+  const tu = rec.raw?.message?.content?.find((b) => b && b.type === 'tool_use')
+  if (!tu) return null
+  const i = tu.input || {}
+  return i.file_path || i.path || i.notebook_path || null
+}
+
+function getBashCommand(rec) {
+  const tu = rec.raw?.message?.content?.find((b) => b && b.type === 'tool_use')
+  if (!tu) return null
+  return tu.input?.command || null
+}
+
+function classifySession(records) {
+  let editWriteCount = 0
+  let implEditCount = 0
+  let handoffWrite = false
+  let planMentioned = false
+  let planApprovalMarker = false
+  let testRun = false
+  let issueCreate = false
+
+  for (const r of records) {
+    if (r.role === 'assistant' && r.text && /\bplan\b/i.test(r.text)) {
+      planMentioned = true
+    }
+    if (r.role === 'tool_use') {
+      if (r.toolName === 'Edit' || r.toolName === 'Write' || r.toolName === 'NotebookEdit') {
+        editWriteCount++
+        const target = getEditWriteTargetPath(r) || ''
+        if (IMPL_FILE_RE.test(target)) implEditCount++
+        if (/session_handoff\.md\b/.test(target)) handoffWrite = true
+      } else if (r.toolName === 'Bash') {
+        const cmd = getBashCommand(r) || ''
+        if (/\.plan-approval-pending\b/.test(cmd)) planApprovalMarker = true
+        if (TEST_BASH_RE.test(cmd)) testRun = true
+        if (GH_ISSUE_RE.test(cmd)) issueCreate = true
+      }
+    }
+  }
+
+  const skipped = []
+  // rule-9: long sessions w/o handoff
+  if (records.length >= 20 && !handoffWrite) skipped.push('rule-9-handoff')
+  // rule-8: edits + plan mention + no marker touch
+  if (editWriteCount > 0 && planMentioned && !planApprovalMarker) skipped.push('rule-8-plan-gate')
+  // rule-18: impl edits + no tests + no issue create
+  if (implEditCount > 0 && !testRun && !issueCreate) skipped.push('rule-18-e2e')
+
+  return {
+    sessionId: records[0].sessionId,
+    slug: records[0].slug,
+    firstTs: records[0].ts,
+    lastTs: records[records.length - 1].ts,
+    records: records.length,
+    editWriteCount,
+    implEditCount,
+    handoffWrite,
+    planMentioned,
+    planApprovalMarker,
+    testRun,
+    issueCreate,
+    skipped,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+const RULES = ['rule-9-handoff', 'rule-8-plan-gate', 'rule-18-e2e']
+
+function aggregate(classifications) {
+  const totalSessions = classifications.length
+  const rules = {}
+  for (const rule of RULES) {
+    const skipped = classifications.filter((c) => c.skipped.includes(rule)).length
+    const eligible = countEligible(rule, classifications)
+    rules[rule] = {
+      skipped,
+      eligibleSessions: eligible,
+      rate: eligible ? skipped / eligible : 0,
+    }
+  }
+  // top offenders: sessions with the most skipped rules
+  const topOffenders = classifications
+    .filter((c) => c.skipped.length)
+    .sort((a, b) => b.skipped.length - a.skipped.length)
+    .slice(0, 5)
+    .map((c) => ({
+      sessionId: c.sessionId,
+      slug: c.slug,
+      lastTs: c.lastTs,
+      records: c.records,
+      skipped: c.skipped,
+    }))
+  return { totalSessions, rules, topOffenders }
+}
+
+function countEligible(rule, classifications) {
+  // Eligibility = sessions that COULD have skipped (denominator).
+  // Tells us "of sessions where this rule applied, what % skipped."
+  switch (rule) {
+    case 'rule-9-handoff':
+      return classifications.filter((c) => c.records >= 20).length
+    case 'rule-8-plan-gate':
+      return classifications.filter((c) => c.editWriteCount > 0 && c.planMentioned).length
+    case 'rule-18-e2e':
+      return classifications.filter((c) => c.implEditCount > 0).length
+    default:
+      return classifications.length
+  }
+}
+
+async function audit(sinceVal) {
+  const generator = walkTranscripts({ slugFilter, excludeWorktrees, since: sinceVal })
+  const grouped = await groupBySession(generator)
+  const classifications = []
+  for (const [, records] of grouped) {
+    classifications.push(classifySession(records))
+  }
+  return aggregate(classifications)
+}
+
+// ---------------------------------------------------------------------------
+// Trend
+// ---------------------------------------------------------------------------
+
+function computeTrend(current, prior) {
+  const out = {}
+  for (const rule of RULES) {
+    const cur = current.rules[rule].rate
+    const prv = prior.rules[rule].rate
+    out[rule] = +(cur - prv).toFixed(3)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const current = await audit(since)
+let trend = null
+if (priorSince && priorSince !== since) {
+  // Prior window = [priorSince, since)
+  const priorAll = await audit(priorSince)
+  // Subtract current window's sessions to get just the prior window.
+  // For simplicity in v1 we just report rates over [priorSince, now];
+  // the delta is approximate but useful for direction. Documented as such.
+  trend = computeTrend(current, priorAll)
+}
+
+const result = {
+  status: 'ok',
+  generatedAt: new Date().toISOString(),
+  since,
+  priorSince,
+  slug: slugFilter || null,
+  excludeWorktrees,
+  ...current,
+  trendVsPriorWindow: trend,
+  notes: 'Heuristic; false positives expected. Trend compares current window to broader [priorSince, now] window.',
+}
+
+if (format === 'markdown') {
+  console.log(renderMarkdown(result))
+} else {
+  console.log(JSON.stringify(result, null, 2))
+}
+
+function renderMarkdown(r) {
+  const lines = [
+    `# Compliance audit — ${r.generatedAt.slice(0, 10)}`,
+    '',
+    `Window: \`${r.since}\` → now${r.slug ? ` · slug=${r.slug}` : ''}${r.excludeWorktrees ? ' · no worktrees' : ''}`,
+    `Total sessions: **${r.totalSessions}**`,
+    '',
+    '## Rule skip rates',
+    '',
+    '| Rule | Skipped | Eligible | Rate | Δ vs prior |',
+    '|------|--------:|---------:|-----:|-----------:|',
+  ]
+  for (const rule of RULES) {
+    const stats = r.rules[rule]
+    const trendStr = r.trendVsPriorWindow ? formatDelta(r.trendVsPriorWindow[rule]) : 'n/a'
+    lines.push(`| \`${rule}\` | ${stats.skipped} | ${stats.eligibleSessions} | ${(stats.rate * 100).toFixed(1)}% | ${trendStr} |`)
+  }
+  lines.push('')
+  if (r.topOffenders.length) {
+    lines.push('## Top offenders')
+    lines.push('')
+    for (const o of r.topOffenders) {
+      lines.push(`- \`${o.sessionId}\` (${o.records} records, ${o.lastTs}) — skipped: ${o.skipped.join(', ')}`)
+    }
+    lines.push('')
+  }
+  lines.push(`> ${r.notes}`)
+  return lines.join('\n')
+}
+
+function formatDelta(d) {
+  if (d == null) return 'n/a'
+  const sign = d > 0 ? '+' : ''
+  return `${sign}${(d * 100).toFixed(1)}pp`
+}

--- a/scripts/em-audit-compliance.mjs
+++ b/scripts/em-audit-compliance.mjs
@@ -188,11 +188,16 @@ function countEligible(rule, classifications) {
   }
 }
 
-async function audit(sinceVal) {
-  const generator = walkTranscripts({ slugFilter, excludeWorktrees, since: sinceVal })
+async function audit({ from, to } = {}) {
+  // Walker filters records by `since` (>= from). For an upper bound we filter
+  // sessions after grouping by their lastTs being strictly before `to`.
+  const generator = walkTranscripts({ slugFilter, excludeWorktrees, since: from })
   const grouped = await groupBySession(generator)
+  const toMs = to ? new Date(to).getTime() : Infinity
   const classifications = []
   for (const [, records] of grouped) {
+    const lastTs = records[records.length - 1].ts
+    if (lastTs && new Date(lastTs).getTime() >= toMs) continue
     classifications.push(classifySession(records))
   }
   return aggregate(classifications)
@@ -216,15 +221,13 @@ function computeTrend(current, prior) {
 // Main
 // ---------------------------------------------------------------------------
 
-const current = await audit(since)
+const current = await audit({ from: since })
 let trend = null
+let prior = null
 if (priorSince && priorSince !== since) {
-  // Prior window = [priorSince, since)
-  const priorAll = await audit(priorSince)
-  // Subtract current window's sessions to get just the prior window.
-  // For simplicity in v1 we just report rates over [priorSince, now];
-  // the delta is approximate but useful for direction. Documented as such.
-  trend = computeTrend(current, priorAll)
+  // Prior window: [priorSince, since) — strictly excludes the current window.
+  prior = await audit({ from: priorSince, to: since })
+  trend = computeTrend(current, prior)
 }
 
 const result = {
@@ -236,7 +239,8 @@ const result = {
   excludeWorktrees,
   ...current,
   trendVsPriorWindow: trend,
-  notes: 'Heuristic; false positives expected. Trend compares current window to broader [priorSince, now] window.',
+  priorWindowStats: prior ? { totalSessions: prior.totalSessions, rules: prior.rules } : null,
+  notes: 'Heuristic; false positives expected. Trend compares current window [since, now] vs prior window [priorSince, since).',
 }
 
 if (format === 'markdown') {

--- a/scripts/em-mine-transcripts.mjs
+++ b/scripts/em-mine-transcripts.mjs
@@ -124,13 +124,23 @@ function addIndexToCorpus(file, corpus) {
 }
 
 function alreadyCaptured(candidatePhrase, corpus) {
-  // Substring match in either direction; accommodates minor rephrases.
-  const lc = candidatePhrase.toLowerCase()
+  // Two-way containment on the FULL phrase (not a 60-char prefix). The prior
+  // prefix-containment branch over-suppressed candidates that shared
+  // boilerplate openings (e.g. canonical-prompt-as-episode, codex-review-*)
+  // with existing summaries — Codex F3, PR #187 round 1.
+  // Whitespace is normalized so trivial wrapping differences don't dodge
+  // the check.
+  const norm = (s) => s.toLowerCase().replace(/\s+/g, ' ').trim()
+  const lc = norm(candidatePhrase)
+  if (lc.length < 12) return false
   if (corpus.has(lc)) return true
   for (const summary of corpus) {
-    if (summary.length < 12) continue
-    // require at least 12 chars overlap to count as duplicate
-    if (lc.includes(summary) || summary.includes(lc.slice(0, 60))) return true
+    const ns = norm(summary)
+    if (ns.length < 12) continue
+    if (lc === ns) return true
+    // Full-phrase bidirectional containment only: candidate contained in an
+    // existing summary, or existing summary contained in candidate.
+    if (lc.includes(ns) || ns.includes(lc)) return true
   }
   return false
 }
@@ -247,8 +257,13 @@ function renderMarkdown(candidates, since) {
 
   const sections = candidates.map((c, i) => {
     const tagsStr = c.tags.join(',')
-    const escaped = c.salient.replace(/"/g, '\\"')
-    const cmd = `node scripts/em-store.mjs --project episodic-memory --scope local --category ${c.category} --tags "${tagsStr}" --summary "${escaped.slice(0, 120)}" --body "<expand from context>"`
+    // POSIX single-quote escape: wrap in '...', encode embedded ' as '\''.
+    // Resists $(...), backticks, $VAR, and backslash interpolation in the
+    // surrounding double-quoted form previously used. (Codex F2, PR #187.)
+    const sq = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'"
+    const summarySq = sq(c.salient.slice(0, 120))
+    const tagsSq = sq(tagsStr)
+    const cmd = `node scripts/em-store.mjs --project episodic-memory --scope local --category ${c.category} --tags ${tagsSq} --summary ${summarySq} --body '<expand from context>'`
     return [
       `## Candidate ${i + 1} — ${c.category}`,
       '',

--- a/scripts/em-mine-transcripts.mjs
+++ b/scripts/em-mine-transcripts.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * em-mine-transcripts.mjs — surface decisions/lessons/violations buried in
+ * Claude Code session transcripts that were never captured as episodes.
+ *
+ * Walks ~/.claude/projects/<slug>/<session>.jsonl via transcript-walker,
+ * scans user + assistant text for trigger phrases, dedupes against existing
+ * episodes (global + every project's local store), and writes a staging
+ * markdown file under .claude/scratch/. Each candidate ships with a
+ * suggested category, tags, surrounding context, and a copy-pasteable
+ * em-store command for human review.
+ *
+ * Cold-storage discipline: this script reads JSONL and writes a staging
+ * file. It NEVER calls em-store on its own. Per local episode
+ * 20260507-083352-treat-claude-code-jsonl-transcripts-as-c-1209.
+ *
+ * Usage:
+ *   node em-mine-transcripts.mjs [--since <ISO>] [--slug <substring>]
+ *                                [--exclude-worktrees]
+ *                                [--output <path>] [--dry-run]
+ *
+ * Defaults:
+ *   --since           7 days ago
+ *   --output          .claude/scratch/mining-candidates-<YYYYMMDD>.md
+ *   no slug filter    (walk all)
+ *   includes worktrees
+ *
+ * Output JSON to stdout: { status, since, candidates, output, dryRun }
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { walkTranscripts } from './lib/transcript-walker.mjs'
+import { resolveRepoRoot } from './lib/local-dir.mjs'
+
+// ---------------------------------------------------------------------------
+// Trigger config
+// ---------------------------------------------------------------------------
+
+const TRIGGERS = [
+  // category: phrases (lowercase-matched against record text)
+  { category: 'decision', phrases: ['we decided', "let's go with", 'the call is', 'going with', 'decided to', "we'll go with"] },
+  { category: 'lesson',   phrases: ['next time', 'lesson:', 'should have', 'we learned', 'in retrospect', 'in hindsight', "won't make that mistake"] },
+  { category: 'violation', phrases: ['you skipped', 'you forgot', 'rule violation', 'bp-001', 'you missed', 'rule 18', 'rule 9 ', 'you bypassed'] },
+]
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2)
+function flag(name, def = undefined) {
+  const i = argv.indexOf(name)
+  if (i === -1) return def
+  if (i + 1 >= argv.length) return true
+  const next = argv[i + 1]
+  if (next.startsWith('--')) return true
+  return next
+}
+
+const since = flag('--since') || isoDaysAgo(7)
+const slugFilter = flag('--slug') === true ? undefined : flag('--slug')
+const excludeWorktrees = flag('--exclude-worktrees') === true
+const dryRun = flag('--dry-run') === true
+const outputArg = flag('--output')
+
+function isoDaysAgo(days) {
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  return d.toISOString()
+}
+
+function defaultOutputPath() {
+  const root = resolveRepoRoot()
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+  return path.join(root, '.claude', 'scratch', `mining-candidates-${date}.md`)
+}
+
+const outputPath = outputArg && outputArg !== true ? outputArg : defaultOutputPath()
+
+// ---------------------------------------------------------------------------
+// Dedupe corpus: pull every existing episode summary + tags from index files
+// ---------------------------------------------------------------------------
+
+function loadDedupeCorpus() {
+  const indexFiles = []
+  // Global
+  const global = path.join(os.homedir(), '.episodic-memory', 'index.jsonl')
+  if (fs.existsSync(global)) indexFiles.push(global)
+  // Every project under ~/.claude/projects/<slug> may have a local store.
+  // The convention: project's working tree at .episodic-memory/index.jsonl.
+  // We only know slug -> dir mapping by reading transcripts' cwd field,
+  // but it's simpler to just scan the user's homedir for known repo roots.
+  // Quick win: read the local store of THIS repo (resolveRepoRoot) and
+  // also any sibling .episodic-memory/index.jsonl reachable from a small
+  // candidate set derived from cwds we've already seen during walking.
+  // Returning a Set of lowercased summary strings here; cwd-derived stores
+  // are added incrementally during the walk.
+  const corpus = new Set()
+  for (const f of indexFiles) {
+    addIndexToCorpus(f, corpus)
+  }
+  // Also seed with this repo's local store if present.
+  try {
+    const local = path.join(resolveRepoRoot(), '.episodic-memory', 'index.jsonl')
+    if (fs.existsSync(local)) addIndexToCorpus(local, corpus)
+  } catch { /* not a repo */ }
+  return corpus
+}
+
+function addIndexToCorpus(file, corpus) {
+  let raw
+  try { raw = fs.readFileSync(file, 'utf8') } catch { return }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const rec = JSON.parse(line)
+      if (rec.summary) corpus.add(rec.summary.toLowerCase())
+    } catch { /* skip malformed */ }
+  }
+}
+
+function alreadyCaptured(candidatePhrase, corpus) {
+  // Substring match in either direction; accommodates minor rephrases.
+  const lc = candidatePhrase.toLowerCase()
+  if (corpus.has(lc)) return true
+  for (const summary of corpus) {
+    if (summary.length < 12) continue
+    // require at least 12 chars overlap to count as duplicate
+    if (lc.includes(summary) || summary.includes(lc.slice(0, 60))) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Mining
+// ---------------------------------------------------------------------------
+
+function findTriggerHits(text) {
+  if (!text || typeof text !== 'string') return []
+  const lc = text.toLowerCase()
+  const hits = []
+  for (const { category, phrases } of TRIGGERS) {
+    for (const phrase of phrases) {
+      const idx = lc.indexOf(phrase)
+      if (idx !== -1) {
+        // Salient sentence: from start of containing line to end-of-sentence
+        const lineStart = text.lastIndexOf('\n', idx) + 1
+        const tail = text.slice(idx)
+        const sentEnd = tail.search(/[.!?\n]/)
+        const end = sentEnd === -1 ? Math.min(text.length, idx + 200) : idx + sentEnd
+        hits.push({
+          category,
+          phrase,
+          salient: text.slice(lineStart, end).trim().slice(0, 200),
+        })
+      }
+    }
+  }
+  return hits
+}
+
+function suggestTags(category, text) {
+  // Cheap keyword tagger; humans will refine.
+  const tags = new Set([category])
+  const map = [
+    [/\brfc-(\d+)/i, (m) => `rfc-${m[1]}`],
+    [/\bbp-?001\b/i, () => 'bp-001'],
+    [/\brule\s*(\d+)/i, (m) => `rule-${m[1]}`],
+    [/\bcodex\b/i, () => 'codex'],
+    [/\bworktree/i, () => 'worktree'],
+    [/\bhandoff\b/i, () => 'handoff'],
+    [/\bplan-gate\b/i, () => 'plan-gate'],
+    [/\btranscript/i, () => 'transcripts'],
+  ]
+  for (const [re, fn] of map) {
+    const m = re.exec(text || '')
+    if (m) tags.add(fn(m))
+  }
+  return [...tags]
+}
+
+async function mine() {
+  const corpus = loadDedupeCorpus()
+  const candidates = []
+  // Keep a small ring buffer of recent records per session for context.
+  const ringBySession = new Map()
+
+  for await (const rec of walkTranscripts({ slugFilter, excludeWorktrees, since })) {
+    const ring = ringBySession.get(rec.sessionId) || []
+    ring.push(rec)
+    if (ring.length > 5) ring.shift()
+    ringBySession.set(rec.sessionId, ring)
+
+    if (rec.role !== 'user' && rec.role !== 'assistant') continue
+    if (!rec.text) continue
+    const hits = findTriggerHits(rec.text)
+    if (!hits.length) continue
+    for (const hit of hits) {
+      if (alreadyCaptured(hit.salient, corpus)) continue
+      candidates.push({
+        sessionId: rec.sessionId,
+        slug: rec.slug,
+        ts: rec.ts,
+        cwd: rec.raw?.cwd || null,
+        category: hit.category,
+        phrase: hit.phrase,
+        salient: hit.salient,
+        tags: suggestTags(hit.category, rec.text),
+        contextPreview: ring
+          .filter((r) => r.role === 'user' || r.role === 'assistant')
+          .slice(-3)
+          .map((r) => `**${r.role}** (${r.ts}): ${r.text.slice(0, 240).replace(/\n+/g, ' ')}`)
+          .join('\n\n'),
+        // Add candidate to corpus so subsequent identical hits within this run
+        // are deduped against each other too.
+        _: corpus.add(hit.salient.toLowerCase()),
+      })
+    }
+  }
+  return candidates
+}
+
+// ---------------------------------------------------------------------------
+// Output formatter
+// ---------------------------------------------------------------------------
+
+function renderMarkdown(candidates, since) {
+  const header = [
+    `# Mining candidates — generated ${new Date().toISOString()}`,
+    '',
+    `Window: since ${since}`,
+    `Slug filter: ${slugFilter || '(all)'}`,
+    `Exclude worktrees: ${excludeWorktrees}`,
+    `Total candidates: ${candidates.length}`,
+    '',
+    '> Heuristic mining; review each before storing. False positives expected.',
+    '',
+    '---',
+    '',
+  ].join('\n')
+
+  if (!candidates.length) return header + '_No candidates found in this window._\n'
+
+  const sections = candidates.map((c, i) => {
+    const tagsStr = c.tags.join(',')
+    const escaped = c.salient.replace(/"/g, '\\"')
+    const cmd = `node scripts/em-store.mjs --project episodic-memory --scope local --category ${c.category} --tags "${tagsStr}" --summary "${escaped.slice(0, 120)}" --body "<expand from context>"`
+    return [
+      `## Candidate ${i + 1} — ${c.category}`,
+      '',
+      `- **Session:** \`${c.sessionId}\``,
+      `- **Slug:** \`${c.slug}\``,
+      `- **Timestamp:** ${c.ts}`,
+      `- **Cwd:** ${c.cwd || '(unknown)'}`,
+      `- **Triggered by phrase:** "${c.phrase}"`,
+      `- **Suggested tags:** ${tagsStr}`,
+      '',
+      `**Salient text:**`,
+      '',
+      `> ${c.salient}`,
+      '',
+      `**Context (last 3 messages):**`,
+      '',
+      c.contextPreview,
+      '',
+      `**Suggested em-store command:**`,
+      '',
+      '```bash',
+      cmd,
+      '```',
+      '',
+      '---',
+      '',
+    ].join('\n')
+  })
+
+  return header + sections.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const candidates = await mine()
+const md = renderMarkdown(candidates, since)
+
+if (dryRun) {
+  console.log(md)
+} else {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, md)
+}
+
+console.log(JSON.stringify({
+  status: 'ok',
+  since,
+  slug: slugFilter || null,
+  excludeWorktrees,
+  candidates: candidates.length,
+  output: dryRun ? null : outputPath,
+  dryRun,
+}, null, 2))

--- a/scripts/em-mine-transcripts.mjs
+++ b/scripts/em-mine-transcripts.mjs
@@ -260,7 +260,11 @@ function renderMarkdown(candidates, since) {
     // POSIX single-quote escape: wrap in '...', encode embedded ' as '\''.
     // Resists $(...), backticks, $VAR, and backslash interpolation in the
     // surrounding double-quoted form previously used. (Codex F2, PR #187.)
-    const sq = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'"
+    // Strip NUL and other C0 control bytes (except \t \n \r) before quoting:
+    // POSIX shell cannot represent NUL inside argv, and other control bytes
+    // make the rendered command unreadable. (Codex F5, PR #187 round 2.)
+    const stripCtl = (s) => String(s).replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    const sq = (s) => "'" + stripCtl(s).replace(/'/g, "'\\''") + "'"
     const summarySq = sq(c.salient.slice(0, 120))
     const tagsSq = sq(tagsStr)
     const cmd = `node scripts/em-store.mjs --project episodic-memory --scope local --category ${c.category} --tags ${tagsSq} --summary ${summarySq} --body '<expand from context>'`

--- a/scripts/lib/transcript-walker.mjs
+++ b/scripts/lib/transcript-walker.mjs
@@ -1,0 +1,251 @@
+/**
+ * transcript-walker.mjs — iterate Claude Code session transcripts.
+ *
+ * Claude Code writes per-session JSONL transcripts to:
+ *   ~/.claude/projects/<project-slug>/<session-uuid>.jsonl
+ *
+ * Each line is a JSON record. Shapes vary (queue-operation, attachment,
+ * user/assistant message, tool_use, tool_result, summary, etc.). This module
+ * normalizes the message-bearing records into a uniform shape and exposes
+ * helpers for downstream mining and audit scripts.
+ *
+ * Cold-storage discipline: this module READS transcripts only. It never
+ * modifies them.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import readline from 'node:readline'
+
+const PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects')
+
+// ---------------------------------------------------------------------------
+// Slug discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * List every project-slug directory that contains JSONL transcripts.
+ * Optionally filter by substring and exclude worktree slugs.
+ */
+export function listSlugs({ slugFilter, excludeWorktrees } = {}) {
+  if (!fs.existsSync(PROJECTS_DIR)) return []
+  const entries = fs.readdirSync(PROJECTS_DIR, { withFileTypes: true })
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => {
+      if (slugFilter && !name.includes(slugFilter)) return false
+      if (excludeWorktrees && /-claude-worktrees-/.test(name)) return false
+      return true
+    })
+    .sort()
+}
+
+/**
+ * List every JSONL transcript file under the matching slugs, with stat info.
+ * Returns [{ slug, sessionId, file, mtime, size }].
+ */
+export function listTranscripts({ slugFilter, excludeWorktrees, since } = {}) {
+  const sinceMs = since ? new Date(since).getTime() : 0
+  const slugs = listSlugs({ slugFilter, excludeWorktrees })
+  const out = []
+  for (const slug of slugs) {
+    const dir = path.join(PROJECTS_DIR, slug)
+    let files
+    try { files = fs.readdirSync(dir) } catch { continue }
+    for (const f of files) {
+      if (!f.endsWith('.jsonl')) continue
+      const full = path.join(dir, f)
+      let st
+      try { st = fs.statSync(full) } catch { continue }
+      if (sinceMs && st.mtimeMs < sinceMs) continue
+      out.push({
+        slug,
+        sessionId: f.replace(/\.jsonl$/, ''),
+        file: full,
+        mtime: st.mtime.toISOString(),
+        size: st.size,
+      })
+    }
+  }
+  return out.sort((a, b) => a.mtime.localeCompare(b.mtime))
+}
+
+// ---------------------------------------------------------------------------
+// Record normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull plain text out of a Claude Code message record. Handles the variety
+ * of `content` shapes: string, array of blocks, missing.
+ *
+ * Returns '' when no extractable text. Tool calls and tool results are
+ * collapsed to a short tag so they don't disappear from context windows but
+ * also don't masquerade as user/assistant prose.
+ */
+function extractText(record) {
+  // Top-level content from queue-operation enqueue (raw user prompt)
+  if (typeof record.content === 'string') return record.content
+
+  const msg = record.message
+  if (!msg) return ''
+
+  if (typeof msg.content === 'string') return msg.content
+
+  if (Array.isArray(msg.content)) {
+    const parts = []
+    for (const block of msg.content) {
+      if (!block || typeof block !== 'object') continue
+      if (block.type === 'text' && typeof block.text === 'string') {
+        parts.push(block.text)
+      } else if (block.type === 'tool_use') {
+        parts.push(`[tool_use:${block.name || '?'}]`)
+      } else if (block.type === 'tool_result') {
+        // Skip; usually noisy and not useful for mining
+        continue
+      } else if (block.type === 'thinking' && typeof block.thinking === 'string') {
+        // Skip thinking blocks for mining (not visible to user)
+        continue
+      }
+    }
+    return parts.join('\n').trim()
+  }
+  return ''
+}
+
+/**
+ * Classify a record into one of: 'user', 'assistant', 'tool_use', 'tool_result',
+ * 'system', 'meta', or 'skip'. Returns the role plus any tool name.
+ */
+function classify(record) {
+  if (record.type === 'queue-operation' && record.operation === 'enqueue') {
+    return { role: 'user', toolName: null }
+  }
+  if (record.type === 'queue-operation') return { role: 'skip', toolName: null }
+  if (record.type === 'attachment') return { role: 'meta', toolName: null }
+  if (record.type === 'summary') return { role: 'meta', toolName: null }
+  if (record.type === 'system') return { role: 'system', toolName: null }
+
+  if (record.type === 'user') {
+    // Could be a tool_result wrapped as user message
+    const msg = record.message
+    if (msg && Array.isArray(msg.content)) {
+      const onlyTool = msg.content.every((b) => b && b.type === 'tool_result')
+      if (onlyTool) return { role: 'tool_result', toolName: null }
+    }
+    return { role: 'user', toolName: null }
+  }
+
+  if (record.type === 'assistant') {
+    const msg = record.message
+    if (msg && Array.isArray(msg.content)) {
+      const toolUse = msg.content.find((b) => b && b.type === 'tool_use')
+      if (toolUse) {
+        return { role: 'tool_use', toolName: toolUse.name || null }
+      }
+    }
+    return { role: 'assistant', toolName: null }
+  }
+
+  return { role: 'skip', toolName: null }
+}
+
+// ---------------------------------------------------------------------------
+// Walking
+// ---------------------------------------------------------------------------
+
+/**
+ * Async generator that yields normalized records from every matching
+ * transcript. Each yield has shape:
+ *   { sessionId, slug, file, ts, role, toolName, text, raw }
+ *
+ * `text` may be empty for tool_use/tool_result/meta — callers filter as
+ * needed.
+ *
+ * Robust to malformed lines (logs warning, continues).
+ */
+export async function* walkTranscripts({ slugFilter, excludeWorktrees, since } = {}) {
+  const sinceMs = since ? new Date(since).getTime() : 0
+  // Note: pass `since` to listTranscripts only when we want to drop entire
+  // files. We omit it here so we can do per-record timestamp filtering below
+  // and still see records inside files whose mtime is recent but contain old
+  // events (rare, but accurate).
+  const transcripts = listTranscripts({ slugFilter, excludeWorktrees })
+  for (const t of transcripts) {
+    const stream = fs.createReadStream(t.file, { encoding: 'utf8' })
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
+    for await (const line of rl) {
+      if (!line.trim()) continue
+      let rec
+      try { rec = JSON.parse(line) } catch { continue }
+      const { role, toolName } = classify(rec)
+      if (role === 'skip') continue
+      if (sinceMs && rec.timestamp) {
+        const recMs = new Date(rec.timestamp).getTime()
+        if (Number.isFinite(recMs) && recMs < sinceMs) continue
+      }
+      const text = extractText(rec)
+      yield {
+        sessionId: t.sessionId,
+        slug: t.slug,
+        file: t.file,
+        ts: rec.timestamp || null,
+        role,
+        toolName,
+        text,
+        raw: rec,
+      }
+    }
+  }
+}
+
+/**
+ * Bucket a stream of normalized records by sessionId, in arrival order.
+ * Returns a Map<sessionId, records[]>.
+ *
+ * Caller is responsible for memory; suitable for sessions in the 100s,
+ * not 100,000s. For high-volume audits, walk twice: first pass for session
+ * IDs of interest, second pass collecting only those.
+ */
+export async function groupBySession(generator) {
+  const out = new Map()
+  for await (const rec of generator) {
+    if (!out.has(rec.sessionId)) out.set(rec.sessionId, [])
+    out.get(rec.sessionId).push(rec)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: human-readable session summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a one-line snapshot of a session: id, slug, message count, time
+ * span, last cwd. Useful for audit reports.
+ */
+export function sessionSnapshot(records) {
+  if (!records || !records.length) return null
+  const first = records[0]
+  const last = records[records.length - 1]
+  const userMsgs = records.filter((r) => r.role === 'user').length
+  const asstMsgs = records.filter((r) => r.role === 'assistant').length
+  const toolUses = records.filter((r) => r.role === 'tool_use').length
+  const cwd = last.raw?.cwd || first.raw?.cwd || null
+  return {
+    sessionId: first.sessionId,
+    slug: first.slug,
+    file: first.file,
+    firstTs: first.ts,
+    lastTs: last.ts,
+    userMessages: userMsgs,
+    assistantMessages: asstMsgs,
+    toolUses,
+    cwd,
+  }
+}
+
+export const __internal__ = { extractText, classify, PROJECTS_DIR }

--- a/tests/test-em-audit-compliance.mjs
+++ b/tests/test-em-audit-compliance.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * test-em-audit-compliance.mjs — integration test for em-audit-compliance.mjs.
+ *
+ * Builds a temp $HOME with three fixture sessions:
+ *   - clean: short, no impl, no plan, no skips
+ *   - skipper: long impl session that skips all three rules
+ *   - compliant: long impl session that touched plan-gate + ran tests +
+ *                wrote handoff
+ *
+ * Runs the audit script and asserts skip counts + eligibility denominators.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'em-audit-compliance.mjs')
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'em-audit-test-'))
+const projectsDir = path.join(TMP, '.claude', 'projects')
+fs.mkdirSync(path.join(projectsDir, '-Users-test-bar'), { recursive: true })
+
+function ts(min) {
+  return new Date(Date.UTC(2099, 0, 1, 10, min, 0)).toISOString()
+}
+
+function asst(text, min, sid) {
+  return { type: 'assistant', timestamp: ts(min), sessionId: sid, message: { content: [{ type: 'text', text }] } }
+}
+function user(text, min, sid) {
+  return { type: 'queue-operation', operation: 'enqueue', timestamp: ts(min), sessionId: sid, content: text }
+}
+function toolUse(name, input, min, sid) {
+  return { type: 'assistant', timestamp: ts(min), sessionId: sid, message: { content: [{ type: 'tool_use', name, id: `t${min}`, input }] } }
+}
+
+// --- session 1: clean (short, no impl) ----------------------------------
+const sid1 = 'aaaa1111-0000-0000-0000-000000000000'
+const session1 = [
+  user('what does this script do', 0, sid1),
+  asst('it does X', 1, sid1),
+]
+fs.writeFileSync(path.join(projectsDir, '-Users-test-bar', sid1 + '.jsonl'),
+  session1.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+// --- session 2: skipper (impl, plan mentioned, no marker, no tests, no issue) ---
+const sid2 = 'bbbb2222-0000-0000-0000-000000000000'
+const session2 = []
+for (let i = 0; i < 25; i++) session2.push(asst(`step ${i}`, i, sid2))
+session2.push(asst('here is my plan: ...', 26, sid2))
+session2.push(toolUse('Edit', { file_path: '/repo/scripts/foo.mjs', old_string: 'a', new_string: 'b' }, 27, sid2))
+session2.push(toolUse('Write', { file_path: '/repo/scripts/bar.mjs', content: 'x' }, 28, sid2))
+fs.writeFileSync(path.join(projectsDir, '-Users-test-bar', sid2 + '.jsonl'),
+  session2.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+// --- session 3: compliant ------------------------------------------------
+const sid3 = 'cccc3333-0000-0000-0000-000000000000'
+const session3 = []
+for (let i = 0; i < 25; i++) session3.push(asst(`step ${i}`, i, sid3))
+session3.push(asst('here is my plan', 26, sid3))
+session3.push(toolUse('Bash', { command: 'touch /repo/.claude/.plan-approval-pending' }, 27, sid3))
+session3.push(toolUse('Edit', { file_path: '/repo/scripts/foo.mjs', old_string: 'a', new_string: 'b' }, 28, sid3))
+session3.push(toolUse('Bash', { command: 'node tests/test-foo.mjs' }, 29, sid3))
+session3.push(toolUse('Write', { file_path: '/repo/memory/session_handoff.md', content: 'wrap-up' }, 30, sid3))
+fs.writeFileSync(path.join(projectsDir, '-Users-test-bar', sid3 + '.jsonl'),
+  session3.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+// --- TAP harness ---------------------------------------------------------
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${e.message}`); console.log(e.stack) }
+}
+
+function runScript(args) {
+  return execFileSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: TMP },
+    cwd: TMP,
+  })
+}
+
+tap('audit aggregates skips correctly', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-bar'])
+  const r = JSON.parse(out)
+  assert.equal(r.totalSessions, 3)
+  // rule-9: sessions >=20 records: session2 (28) + session3 (31) = 2 eligible
+  // session2 lacks handoff write, session3 has it -> 1 skipped
+  assert.equal(r.rules['rule-9-handoff'].eligibleSessions, 2)
+  assert.equal(r.rules['rule-9-handoff'].skipped, 1)
+  // rule-8: editWriteCount>0 AND planMentioned: session2 + session3 = 2
+  // session2 has no marker touch -> skipped. session3 has it -> not skipped.
+  assert.equal(r.rules['rule-8-plan-gate'].eligibleSessions, 2)
+  assert.equal(r.rules['rule-8-plan-gate'].skipped, 1)
+  // rule-18: implEditCount>0: session2 + session3 = 2
+  // session2 has no test run, no issue -> skipped. session3 ran tests -> not.
+  assert.equal(r.rules['rule-18-e2e'].eligibleSessions, 2)
+  assert.equal(r.rules['rule-18-e2e'].skipped, 1)
+})
+
+tap('top offenders surface session2', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-bar'])
+  const r = JSON.parse(out)
+  assert.ok(r.topOffenders.length >= 1)
+  assert.equal(r.topOffenders[0].sessionId, 'bbbb2222-0000-0000-0000-000000000000')
+  assert.deepEqual(r.topOffenders[0].skipped.sort(), ['rule-18-e2e', 'rule-8-plan-gate', 'rule-9-handoff'])
+})
+
+tap('clean session has no skips', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-bar'])
+  const r = JSON.parse(out)
+  // session1 should not appear in top offenders
+  const ids = r.topOffenders.map((o) => o.sessionId)
+  assert.ok(!ids.includes('aaaa1111-0000-0000-0000-000000000000'))
+})
+
+tap('--format markdown produces table', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-bar', '--format', 'markdown'])
+  assert.ok(out.includes('# Compliance audit'))
+  assert.ok(out.includes('| Rule | Skipped'))
+  assert.ok(out.includes('rule-9-handoff'))
+})
+
+tap('eligibility denominators exclude inapplicable sessions', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-bar'])
+  const r = JSON.parse(out)
+  // The clean session (2 records, no impl, no plan) should NOT be in any
+  // rule's eligibility denominator. Each rule's eligible should be exactly 2,
+  // not 3.
+  for (const rule of Object.keys(r.rules)) {
+    assert.equal(r.rules[rule].eligibleSessions, 2, `${rule} eligibility wrong`)
+  }
+})
+
+// --- cleanup -------------------------------------------------------------
+fs.rmSync(TMP, { recursive: true, force: true })
+
+console.log(`\n# ${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-em-audit-compliance.mjs
+++ b/tests/test-em-audit-compliance.mjs
@@ -138,6 +138,88 @@ tap('eligibility denominators exclude inapplicable sessions', () => {
   }
 })
 
+tap('prior window strictly excludes current window (Δ trend correct)', () => {
+  // Codex F4 regression: prior window must be [priorSince, since), not
+  // [priorSince, now]. Build a 4th session in the prior window so the prior
+  // aggregate has its own classifications distinct from current.
+  const sid4 = 'dddd4444-0000-0000-0000-000000000000'
+  // Place session4 entirely in the prior window: timestamps in 2098, before
+  // the current window's 2099-01-01.
+  function priorTs(min) {
+    return new Date(Date.UTC(2098, 11, 25, 10, min, 0)).toISOString()
+  }
+  function priorAsst(text, min) {
+    return { type: 'assistant', timestamp: priorTs(min), sessionId: sid4, message: { content: [{ type: 'text', text }] } }
+  }
+  function priorTU(name, input, min) {
+    return { type: 'assistant', timestamp: priorTs(min), sessionId: sid4, message: { content: [{ type: 'tool_use', name, id: `t${min}`, input }] } }
+  }
+  const session4 = []
+  for (let i = 0; i < 25; i++) session4.push(priorAsst(`prior step ${i}`, i))
+  session4.push(priorAsst('plan: do thing', 26))
+  session4.push(priorTU('Edit', { file_path: '/repo/scripts/foo.mjs', old_string: 'a', new_string: 'b' }, 27))
+  // No marker, no tests, no issue -> skipper in prior window
+  fs.writeFileSync(path.join(projectsDir, '-Users-test-bar', sid4 + '.jsonl'),
+    session4.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+  // Audit with --since 2099 and --prior-since 2098. Prior window should
+  // capture session4 only (and exclude the 2099 sessions).
+  const out = runScript([
+    '--since', '2099-01-01T00:00:00Z',
+    '--prior-since', '2098-01-01T00:00:00Z',
+    '--slug', 'test-bar',
+  ])
+  const r = JSON.parse(out)
+  // Prior should have exactly 1 session (the new prior-window one), not 4.
+  assert.ok(r.priorWindowStats, 'priorWindowStats should be present when --prior-since differs')
+  assert.equal(r.priorWindowStats.totalSessions, 1, `prior window must exclude current; got ${r.priorWindowStats.totalSessions}`)
+  // Current should have the 3 original sessions.
+  assert.equal(r.totalSessions, 3)
+  // Trend should be computed against the prior-only window.
+  assert.ok(r.trendVsPriorWindow, 'trend must be present')
+})
+
+tap('rising rate visible when prior had zero eligible (Codex F4 anchor)', () => {
+  // Build an isolated fixture: prior window has only a CLEAN session (no
+  // impl, no plan, short). Current window has a SKIPPER.
+  // We need a fresh tmp dir so prior fixtures don't bleed in.
+  const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-audit-test-f4-'))
+  const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-iso')
+  fs.mkdirSync(pd2, { recursive: true })
+  const sidP = 'eeee5555-0000-0000-0000-000000000000'
+  const sidC = 'ffff6666-0000-0000-0000-000000000000'
+  // Prior: clean short session, no impl edits => zero eligible for any rule
+  const priorRecs = [
+    { type: 'queue-operation', operation: 'enqueue', timestamp: '2098-12-25T10:00:00Z', sessionId: sidP, content: 'hello' },
+    { type: 'assistant', timestamp: '2098-12-25T10:00:01Z', sessionId: sidP, message: { content: [{ type: 'text', text: 'hi' }] } },
+  ]
+  fs.writeFileSync(path.join(pd2, sidP + '.jsonl'), priorRecs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+  // Current: long skipper
+  const curRecs = []
+  for (let i = 0; i < 25; i++) {
+    curRecs.push({ type: 'assistant', timestamp: new Date(Date.UTC(2099, 0, 1, 10, i, 0)).toISOString(), sessionId: sidC, message: { content: [{ type: 'text', text: `step ${i}` }] } })
+  }
+  curRecs.push({ type: 'assistant', timestamp: '2099-01-01T11:00:00Z', sessionId: sidC, message: { content: [{ type: 'text', text: 'plan: x' }] } })
+  curRecs.push({ type: 'assistant', timestamp: '2099-01-01T11:01:00Z', sessionId: sidC, message: { content: [{ type: 'tool_use', name: 'Edit', id: 't1', input: { file_path: '/repo/x.mjs', old_string: 'a', new_string: 'b' } }] } })
+  fs.writeFileSync(path.join(pd2, sidC + '.jsonl'), curRecs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+  const out = execFileSync('node', [SCRIPT,
+    '--since', '2099-01-01T00:00:00Z',
+    '--prior-since', '2098-01-01T00:00:00Z',
+    '--slug', 'test-iso',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: TMP2 }, cwd: TMP2 })
+  const r = JSON.parse(out)
+  // With the bug: prior window includes current, so prior rate matches current,
+  // delta is ~0, hiding the rise.
+  // With the fix: prior eligible = 0 for every rule, current has skips, delta
+  // should be POSITIVE (rate went from 0 to >0).
+  assert.ok(r.trendVsPriorWindow['rule-8-plan-gate'] > 0,
+    `rule-8 delta should be positive (rising); got ${r.trendVsPriorWindow['rule-8-plan-gate']}`)
+  assert.ok(r.trendVsPriorWindow['rule-18-e2e'] > 0,
+    `rule-18 delta should be positive (rising); got ${r.trendVsPriorWindow['rule-18-e2e']}`)
+  fs.rmSync(TMP2, { recursive: true, force: true })
+})
+
 // --- cleanup -------------------------------------------------------------
 fs.rmSync(TMP, { recursive: true, force: true })
 

--- a/tests/test-em-mine-transcripts.mjs
+++ b/tests/test-em-mine-transcripts.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * test-em-mine-transcripts.mjs — integration test for em-mine-transcripts.mjs.
+ *
+ * Builds a temp $HOME with:
+ *   - ~/.claude/projects/<slug>/<sid>.jsonl   (fixture transcripts)
+ *   - ~/.episodic-memory/index.jsonl          (fixture dedupe corpus)
+ * Runs the mining script and asserts:
+ *   - trigger hits are found
+ *   - already-captured candidates are deduped
+ *   - output JSON is well-formed
+ *   - markdown output is written when --dry-run is omitted
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPT = path.join(REPO, 'scripts', 'em-mine-transcripts.mjs')
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-test-'))
+
+const projectsDir = path.join(TMP, '.claude', 'projects')
+const memDir = path.join(TMP, '.episodic-memory')
+fs.mkdirSync(path.join(projectsDir, '-Users-test-foo'), { recursive: true })
+fs.mkdirSync(path.join(memDir, 'episodes'), { recursive: true })
+
+const sid = '11111111-aaaa-aaaa-aaaa-111111111111'
+
+// Fixture transcript: includes a NEW decision, a NEW lesson, a NEW violation,
+// and a duplicate of an already-stored decision.
+const records = [
+  { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-01-01T10:00:00Z', sessionId: sid, content: 'we decided to switch to bcrypt for password hashing this morning' },
+  { type: 'queue-operation', operation: 'dequeue', timestamp: '2099-01-01T10:00:01Z', sessionId: sid },
+  { type: 'assistant', timestamp: '2099-01-01T10:00:05Z', sessionId: sid, cwd: '/Users/test/foo', message: { content: [{ type: 'text', text: 'lesson: never run git push --force on main' }] } },
+  { type: 'assistant', timestamp: '2099-01-01T10:00:10Z', sessionId: sid, cwd: '/Users/test/foo', message: { content: [{ type: 'text', text: 'okay you skipped the plan-gate again, bp-001 violation' }] } },
+  // Duplicate of an existing index entry — should dedupe out
+  { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-01-01T10:00:20Z', sessionId: sid, content: 'we decided to use the existing weekly digest task instead of a new one' },
+  // Quiet message with no triggers
+  { type: 'assistant', timestamp: '2099-01-01T10:00:30Z', sessionId: sid, cwd: '/Users/test/foo', message: { content: [{ type: 'text', text: 'looking at the file now, will report back' }] } },
+]
+fs.writeFileSync(
+  path.join(projectsDir, '-Users-test-foo', sid + '.jsonl'),
+  records.map((r) => JSON.stringify(r)).join('\n') + '\n'
+)
+
+// Fixture index: pretend the duplicate decision was already stored
+const idx = [
+  { id: 'fake-1', date: '2099-01-01', time: '09:00', project: 'episodic-memory', category: 'decision', status: 'active', tags: ['process'], summary: 'we decided to use the existing weekly digest task instead of a new one' },
+  { id: 'fake-2', date: '2099-01-01', time: '09:00', project: 'global', category: 'context', status: 'active', tags: [], summary: 'unrelated entry' },
+]
+fs.writeFileSync(path.join(memDir, 'index.jsonl'), idx.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+// --- TAP harness -----------------------------------------------------------
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${e.message}`); console.log(e.stack) }
+}
+
+function runScript(args) {
+  return execFileSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: TMP },
+    cwd: TMP,
+  })
+}
+
+tap('--dry-run mines candidates and dedupes existing ones', () => {
+  // Use a since covering the future-dated fixtures; default 7d ago would miss them
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--dry-run', '--slug', 'test-foo'])
+  // Last block is the JSON status
+  const jsonStart = out.lastIndexOf('{\n  "status"')
+  assert.ok(jsonStart >= 0, 'expected JSON status block')
+  const status = JSON.parse(out.slice(jsonStart))
+  assert.equal(status.status, 'ok')
+  // We expect 3 candidates: the new decision, the lesson, the violation.
+  // The duplicate decision should be deduped.
+  assert.equal(status.candidates, 3, `expected 3 candidates, got ${status.candidates}\n${out}`)
+  // Markdown body should mention each category
+  assert.ok(out.includes('decision'), 'markdown should include decision candidate')
+  assert.ok(out.includes('lesson'), 'markdown should include lesson candidate')
+  assert.ok(out.includes('violation'), 'markdown should include violation candidate')
+})
+
+tap('writes markdown to default output when --dry-run omitted', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'test-foo', '--output', path.join(TMP, 'out.md')])
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  assert.equal(status.dryRun, false)
+  assert.equal(status.output, path.join(TMP, 'out.md'))
+  assert.ok(fs.existsSync(path.join(TMP, 'out.md')))
+  const md = fs.readFileSync(path.join(TMP, 'out.md'), 'utf8')
+  assert.ok(md.includes('# Mining candidates'))
+  assert.ok(md.includes('Candidate 1'))
+})
+
+tap('honors --slug filter (no candidates when slug missing)', () => {
+  const out = runScript(['--since', '2099-01-01T00:00:00Z', '--slug', 'nonexistent', '--dry-run'])
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  assert.equal(status.candidates, 0)
+})
+
+tap('honors --since filter (older window yields nothing)', () => {
+  const out = runScript(['--since', '2098-01-01T00:00:00Z', '--slug', 'test-foo', '--dry-run'])
+  // Records ARE within this window (2099 > 2098) so this should still match
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  assert.ok(status.candidates >= 1)
+})
+
+tap('--since after all records yields zero', () => {
+  const out = runScript(['--since', '2099-12-31T00:00:00Z', '--slug', 'test-foo', '--dry-run'])
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  assert.equal(status.candidates, 0)
+})
+
+// --- cleanup ---------------------------------------------------------------
+fs.rmSync(TMP, { recursive: true, force: true })
+
+console.log(`\n# ${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-em-mine-transcripts.mjs
+++ b/tests/test-em-mine-transcripts.mjs
@@ -190,6 +190,34 @@ tap('generated em-store command is shell-safe for transcript metacharacters (Cod
   fs.rmSync(TMP2, { recursive: true, force: true })
 })
 
+tap('generated em-store command strips NUL + control bytes (Codex F5 round 2)', () => {
+  const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-f5-'))
+  const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-zoo')
+  fs.mkdirSync(pd2, { recursive: true })
+  const sid = 'eeeeffff-1111-2222-3333-444444444444'
+  // Salient containing NUL ( ), bell (), backspace (), DEL ().
+  // Whitespace controls \t \n \r are preserved (extractText already collapses
+  // some of them but the dedupe key keeps them).
+  const evilTail = "we decided to add  NUL and bell and bs and DEL to the salient"
+  const recs = [
+    { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-06-01T10:00:00Z', sessionId: sid, content: evilTail },
+  ]
+  fs.writeFileSync(path.join(pd2, sid + '.jsonl'), recs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+  const out = execFileSync('node', [SCRIPT,
+    '--since', '2099-01-01T00:00:00Z', '--slug', 'test-zoo', '--dry-run',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: TMP2 }, cwd: TMP2 })
+  const m = out.match(/node scripts\/em-store\.mjs[^\n]*/)
+  assert.ok(m, 'expected an em-store command in the markdown body')
+  const cmd = m[0]
+  // No control bytes survive
+  assert.ok(!/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(cmd),
+    `control byte leaked into generated command`)
+  // bash -n still parses
+  execFileSync('bash', ['-n', '-c', cmd], { stdio: 'pipe' })
+  fs.rmSync(TMP2, { recursive: true, force: true })
+})
+
 tap('dedupe DOES suppress true duplicates after normalization', () => {
   // Existing summary and candidate identical except for whitespace + casing.
   const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-f3-dup-'))

--- a/tests/test-em-mine-transcripts.mjs
+++ b/tests/test-em-mine-transcripts.mjs
@@ -195,10 +195,10 @@ tap('generated em-store command strips NUL + control bytes (Codex F5 round 2)', 
   const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-zoo')
   fs.mkdirSync(pd2, { recursive: true })
   const sid = 'eeeeffff-1111-2222-3333-444444444444'
-  // Salient containing NUL ( ), bell (), backspace (), DEL ().
+  // Salient containing NUL (
   // Whitespace controls \t \n \r are preserved (extractText already collapses
   // some of them but the dedupe key keeps them).
-  const evilTail = "we decided to add  NUL and bell and bs and DEL to the salient"
+  const evilTail = `we decided to add ${String.fromCharCode(0)} NUL and ${String.fromCharCode(7)} bell and ${String.fromCharCode(8)} bs and ${String.fromCharCode(0x7f)} DEL to the salient`
   const recs = [
     { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-06-01T10:00:00Z', sessionId: sid, content: evilTail },
   ]

--- a/tests/test-em-mine-transcripts.mjs
+++ b/tests/test-em-mine-transcripts.mjs
@@ -118,6 +118,102 @@ tap('--since after all records yields zero', () => {
   assert.equal(status.candidates, 0)
 })
 
+tap('dedupe does NOT over-suppress shared-prefix candidates (Codex F3)', () => {
+  // Build an isolated tmp HOME with:
+  //   - existing index entry: a 90-char summary starting with a common
+  //     boilerplate prefix
+  //   - transcript: a NEW candidate that shares the first 60 chars but has
+  //     a divergent tail (different decision content)
+  const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-f3-'))
+  const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-zoo')
+  const md2 = path.join(TMP2, '.episodic-memory')
+  fs.mkdirSync(pd2, { recursive: true })
+  fs.mkdirSync(md2, { recursive: true })
+  const sid = '99999999-aaaa-aaaa-aaaa-999999999999'
+  // Existing entry — first 60 chars are a common boilerplate.
+  const boilerplate = 'codex review request for pr-NNN of the foo project '
+  const existing = boilerplate + 'with focus on cwd-binding axis and same-class completeness'
+  fs.writeFileSync(path.join(md2, 'index.jsonl'),
+    JSON.stringify({ id: 'e1', date: '2099-01-01', time: '09:00', project: 'x', category: 'context', status: 'active', summary: existing }) + '\n')
+  // New candidate — same first 60 chars but a substantively different tail.
+  // The whole sentence must contain the trigger phrase to be picked up.
+  const newSalient = boilerplate + "we decided to ship without staging because the dedupe gate is the bottleneck"
+  const recs = [
+    { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-06-01T10:00:00Z', sessionId: sid, content: newSalient },
+  ]
+  fs.writeFileSync(path.join(pd2, sid + '.jsonl'), recs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+  const out = execFileSync('node', [SCRIPT,
+    '--since', '2099-01-01T00:00:00Z', '--slug', 'test-zoo', '--dry-run',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: TMP2 }, cwd: TMP2 })
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  // With the bug: dedupe matches first 60 chars and suppresses -> 0 candidates.
+  // With the fix: full-phrase bidirectional check -> tail differs -> 1 candidate.
+  assert.equal(status.candidates, 1, `expected 1 candidate (divergent tail); got ${status.candidates}`)
+  fs.rmSync(TMP2, { recursive: true, force: true })
+})
+
+tap('generated em-store command is shell-safe for transcript metacharacters (Codex F2)', () => {
+  const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-f2-'))
+  const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-zoo')
+  fs.mkdirSync(pd2, { recursive: true })
+  const sid = 'cccccccc-dddd-eeee-ffff-000000000000'
+  // Transcript salient containing $(..), backticks, $VAR, backslash, single-quote
+  const evilTail = "we decided to run $(rm -rf /) and `whoami` with $HOME and \\backslash and 'quote'"
+  const recs = [
+    { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-06-01T10:00:00Z', sessionId: sid, content: evilTail },
+  ]
+  fs.writeFileSync(path.join(pd2, sid + '.jsonl'), recs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+
+  const out = execFileSync('node', [SCRIPT,
+    '--since', '2099-01-01T00:00:00Z', '--slug', 'test-zoo', '--dry-run',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: TMP2 }, cwd: TMP2 })
+
+  // Find the suggested em-store command line in the markdown body
+  const m = out.match(/node scripts\/em-store\.mjs[^\n]*/)
+  assert.ok(m, 'expected an em-store command in the markdown body')
+  const cmd = m[0]
+  // Metacharacters must NOT appear unquoted
+  assert.ok(!/\$\(/.test(cmd.replace(/'[^']*'/g, '')),
+    `unquoted $( found in: ${cmd}`)
+  assert.ok(!/`/.test(cmd.replace(/'[^']*'/g, '')),
+    `unquoted backtick found in: ${cmd}`)
+  // The single-quote in the salient must be encoded as '\''
+  assert.ok(/'\\''/.test(cmd), `single-quote not encoded as '\\'' in: ${cmd}`)
+  // sh -n parse-check: the command must be syntactically valid shell.
+  // Use bash -n if available, fall back to sh -n.
+  try {
+    execFileSync('bash', ['-n', '-c', cmd], { stdio: 'pipe' })
+  } catch (e) {
+    throw new Error(`generated command is not shell-parseable: ${e.stderr || e.message}\nCMD: ${cmd}`)
+  }
+  fs.rmSync(TMP2, { recursive: true, force: true })
+})
+
+tap('dedupe DOES suppress true duplicates after normalization', () => {
+  // Existing summary and candidate identical except for whitespace + casing.
+  const TMP2 = fs.mkdtempSync(path.join(os.tmpdir(), 'em-mine-f3-dup-'))
+  const pd2 = path.join(TMP2, '.claude', 'projects', '-Users-test-zoo')
+  const md2 = path.join(TMP2, '.episodic-memory')
+  fs.mkdirSync(pd2, { recursive: true })
+  fs.mkdirSync(md2, { recursive: true })
+  const sid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+  const text = "we decided to use the existing weekly digest task instead of a new one"
+  fs.writeFileSync(path.join(md2, 'index.jsonl'),
+    JSON.stringify({ id: 'd1', date: '2099-01-01', time: '09:00', project: 'x', category: 'decision', status: 'active', summary: text }) + '\n')
+  // Candidate has extra whitespace + uppercase
+  const recs = [
+    { type: 'queue-operation', operation: 'enqueue', timestamp: '2099-06-01T10:00:00Z', sessionId: sid, content: '  WE DECIDED  TO  USE the existing weekly digest task instead of a new one' },
+  ]
+  fs.writeFileSync(path.join(pd2, sid + '.jsonl'), recs.map((r) => JSON.stringify(r)).join('\n') + '\n')
+  const out = execFileSync('node', [SCRIPT,
+    '--since', '2099-01-01T00:00:00Z', '--slug', 'test-zoo', '--dry-run',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: TMP2 }, cwd: TMP2 })
+  const status = JSON.parse(out.slice(out.indexOf('{\n  "status"')))
+  assert.equal(status.candidates, 0, `expected 0 (true duplicate suppressed); got ${status.candidates}`)
+  fs.rmSync(TMP2, { recursive: true, force: true })
+})
+
 // --- cleanup ---------------------------------------------------------------
 fs.rmSync(TMP, { recursive: true, force: true })
 

--- a/tests/test-transcript-walker.mjs
+++ b/tests/test-transcript-walker.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * test-transcript-walker.mjs — unit tests for scripts/lib/transcript-walker.mjs.
+ *
+ * Builds a temporary projects dir with hand-crafted JSONL transcripts, points
+ * the walker at it via a mocked PROJECTS_DIR-equivalent, then asserts shape
+ * and classification.
+ *
+ * The walker hardcodes ~/.claude/projects, so we cannot inject a path. To
+ * test in isolation we override HOME for the duration of the test (the walker
+ * computes PROJECTS_DIR at module-load time, so we have to require it AFTER
+ * setting HOME).
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import assert from 'node:assert/strict'
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'em-walker-test-'))
+process.env.HOME = TMP
+
+const projectsDir = path.join(TMP, '.claude', 'projects')
+fs.mkdirSync(projectsDir, { recursive: true })
+
+// --- fixtures --------------------------------------------------------------
+const slug1 = '-Users-test-projects-foo'
+const slug2 = '-Users-test-projects-bar--claude-worktrees-feature-x'
+const sid1 = '11111111-1111-1111-1111-111111111111'
+const sid2 = '22222222-2222-2222-2222-222222222222'
+
+const session1 = [
+  { type: 'queue-operation', operation: 'enqueue', timestamp: '2026-05-01T10:00:00Z', sessionId: sid1, content: 'hey can you fix the auth bug' },
+  { type: 'queue-operation', operation: 'dequeue', timestamp: '2026-05-01T10:00:01Z', sessionId: sid1 },
+  { type: 'attachment', timestamp: '2026-05-01T10:00:02Z', sessionId: sid1, attachment: { type: 'hook_success', hookName: 'SessionStart' }, cwd: '/Users/test/foo' },
+  { type: 'assistant', timestamp: '2026-05-01T10:00:05Z', sessionId: sid1, cwd: '/Users/test/foo', message: { content: [{ type: 'text', text: 'looking at the auth code now' }] } },
+  { type: 'assistant', timestamp: '2026-05-01T10:00:06Z', sessionId: sid1, cwd: '/Users/test/foo', message: { content: [{ type: 'tool_use', name: 'Read', id: 't1', input: { file: 'auth.js' } }] } },
+  { type: 'user', timestamp: '2026-05-01T10:00:07Z', sessionId: sid1, message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: 'file content here' }] } },
+  { type: 'assistant', timestamp: '2026-05-01T10:00:10Z', sessionId: sid1, cwd: '/Users/test/foo', message: { content: [{ type: 'text', text: 'we decided to use bcrypt' }] } },
+]
+fs.mkdirSync(path.join(projectsDir, slug1), { recursive: true })
+fs.writeFileSync(
+  path.join(projectsDir, slug1, sid1 + '.jsonl'),
+  session1.map((r) => JSON.stringify(r)).join('\n') + '\n'
+)
+
+const session2 = [
+  { type: 'queue-operation', operation: 'enqueue', timestamp: '2026-05-02T10:00:00Z', sessionId: sid2, content: 'in a worktree session' },
+  { type: 'assistant', timestamp: '2026-05-02T10:00:01Z', sessionId: sid2, cwd: '/Users/test/bar/.claude/worktrees/feature-x', message: { content: [{ type: 'text', text: 'on it' }] } },
+]
+fs.mkdirSync(path.join(projectsDir, slug2), { recursive: true })
+fs.writeFileSync(
+  path.join(projectsDir, slug2, sid2 + '.jsonl'),
+  session2.map((r) => JSON.stringify(r)).join('\n') + '\n'
+)
+
+// Empty dir (should not break)
+fs.mkdirSync(path.join(projectsDir, '-Users-empty-project'), { recursive: true })
+
+// Garbage line (should not crash)
+fs.appendFileSync(path.join(projectsDir, slug1, sid1 + '.jsonl'), '{not valid json\n')
+
+// --- import after HOME is set ---------------------------------------------
+const walker = await import('../scripts/lib/transcript-walker.mjs')
+
+// --- TAP harness -----------------------------------------------------------
+let pass = 0, fail = 0
+async function tap(name, fn) {
+  try { await fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) { fail++; console.log(`not ok ${pass + fail} - ${name}\n  ${e.message}`); console.log(e.stack) }
+}
+
+await tap('listSlugs() returns all dirs sorted', () => {
+  const slugs = walker.listSlugs()
+  assert.deepEqual(slugs, [
+    '-Users-empty-project',
+    slug1,
+    slug2,
+  ].sort())
+})
+
+await tap('listSlugs({ excludeWorktrees }) drops worktree slugs', () => {
+  const slugs = walker.listSlugs({ excludeWorktrees: true })
+  assert.ok(slugs.includes(slug1))
+  assert.ok(!slugs.includes(slug2), 'worktree slug should be excluded')
+})
+
+await tap('listSlugs({ slugFilter }) substring-matches', () => {
+  const slugs = walker.listSlugs({ slugFilter: 'foo' })
+  assert.deepEqual(slugs, [slug1])
+})
+
+await tap('listTranscripts() finds JSONLs across slugs', () => {
+  const ts = walker.listTranscripts()
+  assert.equal(ts.length, 2)
+  const ids = ts.map((t) => t.sessionId).sort()
+  assert.deepEqual(ids, [sid1, sid2].sort())
+})
+
+await tap('walkTranscripts yields normalized records and skips garbage lines', async () => {
+  const recs = []
+  for await (const r of walker.walkTranscripts()) recs.push(r)
+  // Garbage line skipped, queue-op dequeue skipped
+  // session1: enqueue(user) + attachment(meta) + asst-text + asst-tool_use + user-tool_result + asst-text = 6
+  // session2: enqueue(user) + asst-text = 2
+  assert.equal(recs.length, 8, `expected 8 records, got ${recs.length}`)
+})
+
+await tap('classify: enqueue → user, asst tool_use → tool_use, tool_result wrapper → tool_result', async () => {
+  const recs = []
+  for await (const r of walker.walkTranscripts({ slugFilter: 'foo' })) recs.push(r)
+  assert.equal(recs[0].role, 'user')
+  assert.equal(recs[0].text, 'hey can you fix the auth bug')
+  const toolUse = recs.find((r) => r.role === 'tool_use')
+  assert.ok(toolUse, 'expected a tool_use record')
+  assert.equal(toolUse.toolName, 'Read')
+  const toolResult = recs.find((r) => r.role === 'tool_result')
+  assert.ok(toolResult, 'expected a tool_result record')
+})
+
+await tap('walkTranscripts honors slugFilter', async () => {
+  const recs = []
+  for await (const r of walker.walkTranscripts({ slugFilter: 'foo' })) recs.push(r)
+  assert.ok(recs.every((r) => r.slug === slug1))
+})
+
+await tap('walkTranscripts honors excludeWorktrees', async () => {
+  const recs = []
+  for await (const r of walker.walkTranscripts({ excludeWorktrees: true })) recs.push(r)
+  assert.ok(recs.every((r) => r.slug !== slug2))
+})
+
+await tap('walkTranscripts honors since filter', async () => {
+  const recs = []
+  for await (const r of walker.walkTranscripts({ since: '2026-05-02T00:00:00Z' })) recs.push(r)
+  // Only session2's transcript should pass
+  assert.ok(recs.every((r) => r.sessionId === sid2), 'since should drop older transcripts')
+})
+
+await tap('groupBySession buckets correctly', async () => {
+  const grouped = await walker.groupBySession(walker.walkTranscripts())
+  assert.equal(grouped.size, 2)
+  assert.ok(grouped.get(sid1).length >= 5)
+  assert.ok(grouped.get(sid2).length >= 2)
+})
+
+await tap('sessionSnapshot summarizes a session', async () => {
+  const grouped = await walker.groupBySession(walker.walkTranscripts({ slugFilter: 'foo' }))
+  const snap = walker.sessionSnapshot(grouped.get(sid1))
+  assert.equal(snap.sessionId, sid1)
+  assert.equal(snap.slug, slug1)
+  assert.ok(snap.userMessages >= 1)
+  assert.ok(snap.assistantMessages >= 2)
+  assert.equal(snap.cwd, '/Users/test/foo')
+})
+
+// --- cleanup ---------------------------------------------------------------
+fs.rmSync(TMP, { recursive: true, force: true })
+
+console.log(`\n# ${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
## Summary

Implements the three deliverables from the planning conversation in [decision episode 20260507-083352-treat-claude-code-jsonl-transcripts-as-c-1209](.episodic-memory/episodes/20260507-083352-treat-claude-code-jsonl-transcripts-as-c-1209.md):

1. **`scripts/lib/transcript-walker.mjs`** — zero-dep JSONL iterator over Claude Code session transcripts (read-only by design)
2. **`scripts/em-mine-transcripts.mjs`** — surfaces decisions/lessons/violations buried in transcripts that were never `em-store`d (writes staging markdown; never auto-stores)
3. **`scripts/em-audit-compliance.mjs`** — measures rule-9/8/18 skip rates with eligibility-aware denominators and Δ vs prior window
4. Wiring into the existing `episodic-memory-weekly-digest` scheduled task (Sunday 09:00 PHT) — no new scheduler entry

Real-data smoke test (last 7 days, 87 sessions): 52 mining candidates surfaced; rule-skip rates: rule-9-handoff 43.2% (-11.3pp), rule-8-plan-gate 26.9% (-17.8pp), rule-18-e2e 16.2% (-4.5pp). All trends improving.

## Test plan

- [x] `node tests/test-transcript-walker.mjs` — 11 passed
- [x] `node tests/test-em-mine-transcripts.mjs` — 5 passed
- [x] `node tests/test-em-audit-compliance.mjs` — 5 passed
- [x] Smoke test on real data — both scripts produce expected output
- [x] Weekly digest SKILL.md updated and references new scripts

## Notes

- Cold-storage discipline preserved: mining writes staging files for human review, never calls `em-store` itself
- Audit heuristics documented as directional, not authoritative — false positives expected (eligibility denominators added to give meaningful rates)
- `.claude/scratch/` added to `.gitignore` since both mining output and existing codex request/reply bodies live there

🤖 Generated with [Claude Code](https://claude.com/claude-code)