### PR TITLE
feat(bp1): RFC-004 M0 part 2 — H2 SessionStart fallback sweep wiring (PR-1b-B)

### DIFF
--- a/.claude/hooks/bp1-sweep-on-session.sh
+++ b/.claude/hooks/bp1-sweep-on-session.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -e
+
+# bp1-sweep-on-session.sh — RFC-004 H2 SessionStart hook (PR-1b-B / M0 part 2).
+#
+# Best-effort liveness for T1 (Path A request-issued timeout) and T1b (Path B
+# naked-entry recovery) when `mcp__scheduled-tasks` is unavailable. Calls the
+# unified fallback `bp1-deadline-sweep.mjs --once` per Claude session start.
+#
+# Activation gate (RFC §178 silent-refusal contract):
+#   - Calls bp1-flag-check.mjs FIRST. On refusal, exits 0 SILENTLY — no stdout,
+#     no stderr, no episode emission. Distinct from `--once` which DOES emit a
+#     `bp1-disabled-sweep` evidence episode (RFC §191) — H2 must NOT replicate
+#     that emission, so flag-check is checked separately here before invoking
+#     the sweep.
+#
+# cwd-binding (discipline #20, mirrors hooks/em-recall-sessionstart.sh:34-54):
+#   - Reads SessionStart stdin JSON, parses `.cwd` field, falls back to `pwd`.
+#   - cd "$CWD" BEFORE any node invocation. cd-fail → exit 0 silently.
+#   - Passes `--project "$CWD"` explicitly to BOTH subprocesses; does NOT rely
+#     on subprocess `process.cwd()` defaulting.
+#
+# Script resolution (codex code-review A1, 2026-05-07):
+#   bp1 scripts are installed GLOBALLY at $HOME/.episodic-memory/scripts/ by
+#   install.mjs section 1 (lines 82-99). NOT under <projectRoot>/scripts/.
+#   Resolving via $CWD/scripts would silently no-op for any installed project
+#   that isn't this repo (which is the only one where the source-of-truth and
+#   the install destination overlap). Mirrors em-recall-sessionstart.sh:38
+#   resolution pattern.
+#
+# Idempotent: re-firing on the same project is harmless. Sweep is stateless.
+
+INPUT="$(cat)"
+CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+# If $CWD is invalid (nonexistent / unreadable / permission-denied), fail soft.
+# Mirrors em-recall-sessionstart.sh:51 — never fall back to the hook process's
+# inherited cwd; that could route bp1 artifacts to an unrelated project.
+if ! cd "$CWD" 2>/dev/null; then
+  exit 0
+fi
+
+EM_SCRIPTS_DIR="$HOME/.episodic-memory/scripts"
+FLAG_CHECK="$EM_SCRIPTS_DIR/bp1-flag-check.mjs"
+SWEEP="$EM_SCRIPTS_DIR/bp1-deadline-sweep.mjs"
+
+# Soft-fail if bp1 scripts aren't installed globally yet (project never ran
+# install.mjs --tool claude-code, or running in a stale activation state).
+if [ ! -f "$FLAG_CHECK" ] || [ ! -f "$SWEEP" ]; then
+  exit 0
+fi
+
+# Activation gate first. Silent on refusal per §178.
+#   --no-emit: H2 fires on EVERY Claude session start; default flag-check
+#   audit-emits a bp1-flag-check episode per call. Suppress here to:
+#     (1) preserve the §178 "no episodes on refusal" contract literally;
+#     (2) avoid filling .episodic-memory/episodes/ with one
+#         bp1-flag-check episode per session for inactive projects.
+#   The sweep itself emits its own bp1-sweep-tick / bp1-disabled-sweep
+#   episode for the audit trail when active or refused-via-sweep.
+if ! node "$FLAG_CHECK" --project "$CWD" --no-emit >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Project is active and capability == fallback (M0: probe stub always returns
+# fallback). Run the sweep. The sweep itself is activation-gated AND emits its
+# own bp1-sweep-tick evidence episode under the project root.
+node "$SWEEP" --once --project "$CWD" >/dev/null 2>&1 || true
+
+exit 0

--- a/.github/workflows/rfc-validate.yml
+++ b/.github/workflows/rfc-validate.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'docs/rfcs/**'
       - 'install.mjs'
+      - '.claude/hooks/bp1-sweep-on-session.sh'
       - 'scripts/em-rfc-validate.mjs'
       - 'scripts/validate-rfc-failure-table.mjs'
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
       - 'scripts/lib/bp1-sweep.mjs'
       - 'scripts/lib/bp1-probe.mjs'
+      - 'scripts/lib/bp1-install-helpers.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
       - 'scripts/bp1-deadline-sweep.mjs'
@@ -21,19 +23,23 @@ on:
       - 'tests/test-bp1-build-artifact-manifest.mjs'
       - 'tests/test-bp1-deadline-sweep.mjs'
       - 'tests/test-bp1-probe.mjs'
+      - 'tests/test-bp1-sweep-on-session.mjs'
       - 'tests/test-install-bp1.sh'
+      - 'tests/test-install-bp1-wiring.mjs'
       - '.github/workflows/rfc-validate.yml'
   push:
     branches: [main]
     paths:
       - 'docs/rfcs/**'
       - 'install.mjs'
+      - '.claude/hooks/bp1-sweep-on-session.sh'
       - 'scripts/em-rfc-validate.mjs'
       - 'scripts/validate-rfc-failure-table.mjs'
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
       - 'scripts/lib/bp1-sweep.mjs'
       - 'scripts/lib/bp1-probe.mjs'
+      - 'scripts/lib/bp1-install-helpers.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
       - 'scripts/bp1-deadline-sweep.mjs'
@@ -44,7 +50,9 @@ on:
       - 'tests/test-bp1-build-artifact-manifest.mjs'
       - 'tests/test-bp1-deadline-sweep.mjs'
       - 'tests/test-bp1-probe.mjs'
+      - 'tests/test-bp1-sweep-on-session.mjs'
       - 'tests/test-install-bp1.sh'
+      - 'tests/test-install-bp1-wiring.mjs'
 
 jobs:
   validate:
@@ -88,3 +96,9 @@ jobs:
 
       - name: Run install.mjs BP-1 idempotence tests
         run: bash tests/test-install-bp1.sh
+
+      - name: Run bp1-sweep-on-session H2 hook self-tests
+        run: node tests/test-bp1-sweep-on-session.mjs
+
+      - name: Run install.mjs BP-1 H2 wiring self-tests
+        run: node tests/test-install-bp1-wiring.mjs

--- a/install.mjs
+++ b/install.mjs
@@ -171,6 +171,162 @@ if (!fs.existsSync(bp1ConfigPath)) {
 }
 
 // ---------------------------------------------------------------------------
+// 2c. BP-1 H2 SessionStart hook + settings.json wiring (RFC-004 §559 H-cfg).
+//
+// PR-1b-B / M0 part 2. Project-local: writes <projectDir>/.claude/settings.json
+// (NEVER ~/.claude/settings.json — that's the legacy --install-hooks block in
+// section 5 below). Invariant I10: this code path does NOT mutate HOME settings.
+// If the user combines --install-hooks with this install, HOME settings may
+// change only because of the legacy block; this block stays project-local.
+//
+// Only fires for tool=claude-code or tool=all (other tools don't use the
+// Claude Code SessionStart hook system).
+//
+// H2 wiring contract decisions (RFC-004 §559 H-cfg):
+//  - Target file: <projectRoot>/.claude/settings.json (project-local; NEVER HOME).
+//  - Ordering: H2 appended to SessionStart end. M2 inserts H1 just-before this
+//    H2 entry (relative-positioning, NOT SessionStart[0]) — preserves any
+//    unrelated pre-existing SessionStart entries.
+//  - Idempotence: re-run preserves H2 entry count = 1; mergeSessionStartH2Hook
+//    in scripts/lib/bp1-install-helpers.mjs deep-clones input (invariant I2).
+//  - cwd-binding: projectDir resolved from --project flag (line 37); fallback
+//    is process.cwd(). Test fixtures cover caller-cwd ≠ --project (F1, F2, F3).
+//  - Manifest hash: adding H2 changes settings_lines sha256; warn user once on
+//    add only (B8 — suppress on no-op re-run).
+//  - HOME isolation: ~/.claude/settings.json is NEVER touched here (I10).
+// ---------------------------------------------------------------------------
+if (tool === 'claude-code' || tool === 'all') {
+  const { mergeSessionStartH2Hook } = await import(
+    new URL('./scripts/lib/bp1-install-helpers.mjs', import.meta.url).href
+  )
+
+  const repoH2HookSrc = path.join(REPO_DIR, '.claude', 'hooks', 'bp1-sweep-on-session.sh')
+  const projHooksDir = path.join(projectDir, '.claude', 'hooks')
+  const projH2HookDst = path.join(projHooksDir, 'bp1-sweep-on-session.sh')
+  const projSettingsPath = path.join(projectDir, '.claude', 'settings.json')
+
+  if (!fs.existsSync(repoH2HookSrc)) {
+    console.log(`Warning: BP-1 H2 hook source not found at ${repoH2HookSrc}; skipping wiring.`)
+  } else {
+    fs.mkdirSync(projHooksDir, { recursive: true })
+    let h2HookCopied = false
+    let h2DivergentSkipped = false
+    if (!fs.existsSync(projH2HookDst)) {
+      fs.copyFileSync(repoH2HookSrc, projH2HookDst)
+      fs.chmodSync(projH2HookDst, 0o755)
+      console.log(`Installed BP-1 H2 SessionStart hook at ${projH2HookDst}`)
+      h2HookCopied = true
+    } else {
+      const a = fs.readFileSync(repoH2HookSrc)
+      const b = fs.readFileSync(projH2HookDst)
+      if (!a.equals(b)) {
+        // Codex code-review round-2 Finding 1 fix: gate force-overwrite on
+        // BOTH --install-hooks AND --install-hooks-force, matching the
+        // legacy contract (`install.mjs:42-47` warns that force-alone has no
+        // effect; T11 in tests/test-install-hooks.sh enforces). This keeps
+        // a single coherent meaning of --install-hooks-force across legacy
+        // HOME hooks and the new project-local H2 path.
+        if (installHooks && installHooksForce) {
+          // Operator opted in via --install-hooks --install-hooks-force.
+          // Overwrite + register.
+          fs.copyFileSync(repoH2HookSrc, projH2HookDst)
+          fs.chmodSync(projH2HookDst, 0o755)
+          console.log(`Overwrote divergent ${projH2HookDst} (--install-hooks-force).`)
+          h2HookCopied = true
+        } else {
+          // Codex code-review round-1 B2 fix: mirror legacy installHookFile
+          // skipped-divergent semantics — withhold settings registration AS
+          // WELL AS file overwrite. Otherwise install would wire a stale or
+          // user-edited H2 path into settings.json. Re-run with
+          // --install-hooks --install-hooks-force to overwrite + register.
+          console.log(`Note: ${projH2HookDst} differs from repo source; not overwriting AND withholding settings registration. Re-run with --install-hooks --install-hooks-force to accept.`)
+          h2DivergentSkipped = true
+        }
+      }
+    }
+
+    let existingSettings = {}
+    let parseFailed = false
+    if (fs.existsSync(projSettingsPath)) {
+      try {
+        existingSettings = JSON.parse(fs.readFileSync(projSettingsPath, 'utf8'))
+      } catch (e) {
+        // Class 4 (Empty / malformed) fixture from planner — refuse to silently
+        // overwrite the user's malformed JSON; surface and skip.
+        console.log(`Error: ${projSettingsPath} is not valid JSON (${e.message}); skipping H2 settings wiring.`)
+        parseFailed = true
+      }
+    }
+
+    if (!parseFailed && !h2DivergentSkipped) {
+      // Codex code-review B1 fix: migrate any flat-shape entries (top-level
+      // {command, ...}) to canonical nested ({hooks: [{type, command, ...}]})
+      // BEFORE the idempotence check. Otherwise a pre-existing flat-shape H2
+      // canonical entry would be detected as "already present" and skip the
+      // merge — leaving a non-executable hook entry in settings.json. Mirrors
+      // the legacy hook-install path which calls migrateMalformedEntries
+      // before its idempotence check (install.mjs:542).
+      let migratedCount = 0
+      if (existingSettings && typeof existingSettings === 'object' &&
+          existingSettings.hooks && typeof existingSettings.hooks === 'object') {
+        migratedCount = migrateMalformedEntries(existingSettings.hooks)
+        if (migratedCount > 0) {
+          console.log(`Migrated ${migratedCount} flat-shape SessionStart entr${migratedCount === 1 ? 'y' : 'ies'} to canonical shape in ${projSettingsPath}`)
+        }
+      }
+
+      const result = mergeSessionStartH2Hook(existingSettings, projH2HookDst, { timeout: 30 })
+      const needsWrite = result.changed || migratedCount > 0
+      if (needsWrite) {
+        writeJSONAtomic(projSettingsPath, result.settings)
+        if (result.changed) {
+          console.log(`Wired BP-1 H2 SessionStart hook into ${projSettingsPath}`)
+          console.log('Note: artifact_version_hash changed; activated projects must re-run M5 to regenerate.')
+        }
+      } else if (h2HookCopied) {
+        // Hook file was newly copied but settings already had the canonical
+        // entry — unusual mid-state, surface for visibility.
+        console.log(`BP-1 H2 entry already present in ${projSettingsPath}.`)
+      }
+
+      // Codex code-review R6 follow-up: surface stale-canonical entries
+      // explicitly so operators see them rather than only via cat settings.json.
+      // detectStaleCanonicalEntries scans for entries that reference the H2
+      // basename but at a different path than the canonical install location.
+      // We do NOT auto-delete (preserves operator visibility); just warn.
+      if (result.settings && result.settings.hooks &&
+          typeof result.settings.hooks === 'object') {
+        const stale = detectStaleCanonicalEntries(result.settings.hooks, {
+          'bp1-sweep-on-session.sh': projH2HookDst,
+        })
+        for (const s of stale) {
+          console.log(`Note: stale BP-1 H2 entry in ${s.event} → ${s.command} (canonical: ${projH2HookDst}). Operator can remove the stale entry; not auto-deleted.`)
+        }
+      }
+      // Otherwise: silent no-op (B8 — regen warning suppressed on re-run).
+    }
+
+    // §559 partial-coverage TODO:
+    //
+    // RFC §559 (H-cfg row) v3.12 calls for install.mjs to wire BOTH H1
+    // (bp1-approval-check.sh) AND H2 (bp1-sweep-on-session.sh) into the
+    // SessionStart array. PR-1b-B (M0 part 2) ships H2 only. H1 depends on
+    // bp1-marker-validate.mjs which lands in M2 (per RFC §552 / artifact-
+    // table H1 row).
+    //
+    // Insertion semantics for M2: M2's install.mjs MUST find the existing H2
+    // entry's index in SessionStart and splice H1 just-before it (relative
+    // positioning). NOT unconditional SessionStart[0] — that reading would
+    // reorder unrelated pre-existing SessionStart entries (e.g. em-recall-
+    // sessionstart). The §559 ordering invariant ("approval-check FIRST,
+    // sweep SECOND") is read as relative ordering between the two BP-1
+    // hooks, not absolute index in the global SessionStart array.
+    //
+    // TODO(M2): wire H1 bp1-approval-check.sh per RFC §559 (H-cfg).
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 3. Install tool-specific instructions
 // ---------------------------------------------------------------------------
 const tools = tool === 'all' ? ['claude-code', 'cursor', 'codex', 'windsurf'] : [tool]

--- a/scripts/lib/bp1-install-helpers.mjs
+++ b/scripts/lib/bp1-install-helpers.mjs
@@ -1,0 +1,105 @@
+/**
+ * bp1-install-helpers.mjs — Pure helpers for BP-1 install.mjs settings.json
+ * wiring (PR-1b-B / RFC-004 §559 H-cfg).
+ *
+ * Zero I/O. install.mjs is the call site that reads/writes settings.json via
+ * its existing writeJSONAtomic helper. install.mjs's `migrateMalformedEntries`
+ * (install.mjs:343) and `detectStaleCanonicalEntries` (:375) handle R4
+ * (wrong-shape migration) and R6 (stale-canonical-path warning) — this lib
+ * does NOT reinvent those paths.
+ *
+ * Tracked by manifest's `scripts_lib` surface (PR-1a) — automatic drift
+ * coverage on changes.
+ */
+
+/**
+ * Deep-clones a JSON-safe object. Used by mergeSessionStartH2Hook to prove
+ * invariant I2 (input not mutated).
+ */
+export function deepClone(obj) {
+  return obj == null ? obj : JSON.parse(JSON.stringify(obj))
+}
+
+/**
+ * Ensures settings.hooks.SessionStart exists as an array. MUTATES input.
+ * Used internally by mergeSessionStartH2Hook AFTER deep-cloning.
+ */
+export function ensureSessionStartArray(settings) {
+  if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {}
+  if (!Array.isArray(settings.hooks.SessionStart)) settings.hooks.SessionStart = []
+  return settings.hooks.SessionStart
+}
+
+/**
+ * Builds the canonical H2 command string for a given hook script path.
+ * Mirrors install.mjs's pattern: `bash <quoted-path>`.
+ */
+export function makeH2Command(hookPath) {
+  return `bash ${shellQuote(hookPath)}`
+}
+
+/**
+ * Idempotent merge of the H2 SessionStart hook into a settings JSON object.
+ *
+ * §559 ordering interpretation: H2 is appended to the END of SessionStart.
+ * M2 (future PR) inserts H1 just-before this H2 entry — that is, H2's
+ * relative position is preserved across M0-part-2 → M2 transitions, and
+ * unrelated SessionStart entries are NOT reordered.
+ *
+ * Returns { settings, changed, reason }:
+ *   - settings: NEW object (input never mutated — invariant I2).
+ *   - changed: true iff a new entry was appended.
+ *   - reason: "h2-added" | "h2-already-present".
+ */
+export function mergeSessionStartH2Hook(existingSettings, hookPath, options = {}) {
+  const timeout = typeof options.timeout === 'number' ? options.timeout : 30
+  const command = makeH2Command(hookPath)
+  const settings = deepClone(existingSettings || {})
+  const arr = ensureSessionStartArray(settings)
+  if (arr.some(e => entryHasExactCommand(e, command))) {
+    return { settings, changed: false, reason: 'h2-already-present' }
+  }
+  arr.push({ hooks: [{ type: 'command', command, timeout }] })
+  return { settings, changed: true, reason: 'h2-added' }
+}
+
+/**
+ * Predicate: does the SessionStart array contain an entry whose command
+ * matches the H2 hook (after normalize-shell-quoting)?
+ */
+export function containsSessionStartH2Hook(settings, hookPath) {
+  const arr = settings?.hooks?.SessionStart
+  if (!Array.isArray(arr)) return false
+  const command = makeH2Command(hookPath)
+  return arr.some(e => entryHasExactCommand(e, command))
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers — duplicated from install.mjs to keep this lib I/O-free
+// and dependency-free. (install.mjs's helpers are not exported; refactoring
+// install.mjs to expose them is out of scope for PR-1b-B.)
+// ---------------------------------------------------------------------------
+
+function entryHasExactCommand(entry, command) {
+  const target = normalizeCommand(command)
+  if (entry?.command && normalizeCommand(entry.command) === target) return true
+  if (Array.isArray(entry?.hooks)) {
+    return entry.hooks.some(h => h && normalizeCommand(h.command) === target)
+  }
+  return false
+}
+
+function normalizeCommand(s) {
+  if (typeof s !== 'string') return s
+  if (s.length > 1 && s.startsWith("'") && s.endsWith("'")) {
+    return s.slice(1, -1).replace(/'\\''/g, "'")
+  }
+  const m = s.match(/^(.*\s)'((?:[^']|'\\'')+)'$/)
+  if (m) return m[1] + m[2].replace(/'\\''/g, "'")
+  return s
+}
+
+function shellQuote(s) {
+  if (/^[A-Za-z0-9_\-./:=,]+$/.test(s)) return s
+  return `'${s.replace(/'/g, "'\\''")}'`
+}

--- a/tests/test-bp1-sweep-on-session.mjs
+++ b/tests/test-bp1-sweep-on-session.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-sweep-on-session.mjs — Hermetic tests for the H2 SessionStart hook.
+ *
+ * RFC-004 §178 (silent-refusal) + §559 (H-cfg wiring contract). Per plan v3
+ * negative-scenario matrix + codex code-review round 1 finding A1, fixtures
+ * exercise the REAL installed shape: bp1 scripts live at
+ * $HOME/.episodic-memory/scripts/ (NOT under <projectRoot>/scripts/), so each
+ * fixture installs scripts into a fake HOME and never symlinks repo `scripts/`
+ * into project roots — that symlink would mask the cross-project install bug
+ * codex caught.
+ *
+ *   F4 — happy path: caller cwd != stdin.cwd, project active → sweep-tick
+ *        episode lands under TARGET, ZERO under caller (I8).
+ *   F5 — silent: project inactive → exit 0, stdout empty, stderr empty,
+ *        no episodes anywhere (I7, RFC §178).
+ *   F6a — cd-fail nonexistent cwd → exit 0 silently.
+ *   F6b — empty stdin {} → falls back to pwd (caller cwd), proceeds per
+ *         caller's activation state.
+ *   F6c — null cwd → same as F6b.
+ *   F6d — permission-denied cwd → exit 0 silently (codex FU-3).
+ *   B6 — cross-project bypass: project A's dry-run lock+env in scope, hook
+ *        fires for project B which is inactive → fail closed (RFC §577-585
+ *        v3.12). No sweep at B.
+ *   no-install — codex A1 regression: HOME has NO bp1 scripts → H2 silently
+ *        no-ops (the soft-fail branch).
+ *
+ * Zero deps; Node stdlib only. Mirrors test-bp1-deadline-sweep.mjs patterns.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const HOOK = path.join(REPO, '.claude', 'hooks', 'bp1-sweep-on-session.sh')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bp1-h2-${label}-`))
+}
+
+/**
+ * Make a project root. NO symlink to repo `scripts/` — exercises the real
+ * post-install shape per codex finding A1.
+ */
+function makeProjectRoot() {
+  const dir = makeTempDir('proj')
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+
+/**
+ * Install bp1 scripts globally under <homeDir>/.episodic-memory/scripts/,
+ * mirroring install.mjs section 1 (lines 82-99). H2 resolves scripts from
+ * $HOME/.episodic-memory/scripts/ post-codex-A1-fix.
+ */
+function installBp1ScriptsToHome(homeDir) {
+  const dst = path.join(homeDir, '.episodic-memory', 'scripts')
+  fs.mkdirSync(dst, { recursive: true })
+  const repoScripts = path.join(REPO, 'scripts')
+  for (const file of fs.readdirSync(repoScripts).filter(f => f.endsWith('.mjs'))) {
+    fs.copyFileSync(path.join(repoScripts, file), path.join(dst, file))
+    fs.chmodSync(path.join(dst, file), 0o755)
+  }
+  // scripts/lib/ subtree for transitive imports (e.g. bp1-sweep.mjs).
+  const repoLib = path.join(repoScripts, 'lib')
+  if (fs.existsSync(repoLib)) {
+    const dstLib = path.join(dst, 'lib')
+    fs.mkdirSync(dstLib, { recursive: true })
+    for (const file of fs.readdirSync(repoLib).filter(f => f.endsWith('.mjs'))) {
+      fs.copyFileSync(path.join(repoLib, file), path.join(dstLib, file))
+    }
+  }
+}
+
+function projectSha(projectRoot) {
+  return crypto.createHash('sha256').update(projectRoot, 'utf8').digest('hex')
+}
+
+function writeVerifyKey(homeDir) {
+  const verifyDir = path.join(homeDir, '.episodic-memory')
+  fs.mkdirSync(verifyDir, { recursive: true })
+  const verifyPath = path.join(verifyDir, '.verify-key')
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(verifyPath, key)
+  fs.chmodSync(verifyPath, 0o600)
+  const fp = crypto.createHmac('sha256', key)
+    .update('verify-key-fingerprint-v1', 'utf8')
+    .digest('hex').slice(0, 16)
+  return { fingerprint: fp }
+}
+
+function writeConfig(homeDir, projectRoot, entry) {
+  const configPath = path.join(homeDir, '.episodic-memory', 'config.json')
+  const config = entry
+    ? { bp1: { schema_version: 1, activations: { [projectRoot]: entry } } }
+    : { bp1: { schema_version: 1, activations: {} } }
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+}
+
+function buildHashAgainstHome(projectRoot, homeDir) {
+  const out = execFileSync('node', [
+    path.join(homeDir, '.episodic-memory', 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    '--project', projectRoot, '--json',
+  ], { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })
+  return JSON.parse(out).sha256
+}
+
+function activationEntry(projectRoot, homeDir, fingerprint) {
+  return {
+    enabled: true,
+    artifact_version_hash: 'sha256:' + buildHashAgainstHome(projectRoot, homeDir),
+    enabled_at: new Date().toISOString(),
+    enabled_via: 'test-fixture',
+    verify_key_id: fingerprint,
+  }
+}
+
+/**
+ * Drive the H2 bash hook with stdin JSON + caller cwd + HOME override.
+ * Returns { exitCode, stdout, stderr }.
+ */
+function runHook({ stdinJSON, callerCwd, homeDir, env }) {
+  const r = spawnSync('bash', [HOOK], {
+    cwd: callerCwd,
+    encoding: 'utf8',
+    input: typeof stdinJSON === 'string' ? stdinJSON : JSON.stringify(stdinJSON),
+    env: { ...process.env, HOME: homeDir, ...(env || {}) },
+  })
+  return { exitCode: r.status, stdout: r.stdout, stderr: r.stderr }
+}
+
+function episodesDirOf(projectRoot) {
+  return path.join(projectRoot, '.episodic-memory', 'episodes')
+}
+
+function listEpisodes(projectRoot) {
+  const dir = episodesDirOf(projectRoot)
+  return fs.existsSync(dir) ? fs.readdirSync(dir) : []
+}
+
+// =============================================================================
+// F4 — happy path: caller cwd != stdin.cwd, project active
+// =============================================================================
+tap('F4 happy: caller cwd != stdin.cwd, project active → sweep-tick under TARGET, none under caller (I8)', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  const { fingerprint } = writeVerifyKey(home)
+  writeConfig(home, target, activationEntry(target, home, fingerprint))
+
+  const r = runHook({
+    stdinJSON: { cwd: target },
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'H2 must exit 0')
+
+  // Sweep evidence lands under target, NOT caller.
+  const callerEps = listEpisodes(caller)
+  const targetEps = listEpisodes(target)
+  assert.equal(callerEps.length, 0,
+    `evidence must NOT land in caller cwd; found ${callerEps.length}`)
+  assert.ok(targetEps.length >= 1,
+    `target project must have a sweep episode; got ${targetEps.length}`)
+  assert.ok(targetEps.some(e => /bp1-sweep-tick|bp1-sweep-noop/.test(e)),
+    `expected bp1-sweep-tick or bp1-sweep-noop in target episodes; got ${targetEps.join(', ')}`)
+})
+
+// =============================================================================
+// F5 — silent: inactive project → exit 0, no stdout, no stderr, no episodes
+// =============================================================================
+tap('F5 silent: inactive project → exit 0, stdout empty, stderr empty, no episodes anywhere (I7, §178)', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+  writeConfig(home, target, null)  // empty activations → inactive
+
+  const r = runHook({
+    stdinJSON: { cwd: target },
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'must exit 0 silently per §178')
+  assert.equal(r.stdout, '',
+    `silent-refusal must NOT emit stdout; got: ${JSON.stringify(r.stdout)}`)
+  assert.equal(r.stderr, '',
+    `silent-refusal must NOT emit stderr; got: ${JSON.stringify(r.stderr)}`)
+  assert.equal(listEpisodes(target).length, 0,
+    'silent-refusal must NOT emit any episode under target')
+  assert.equal(listEpisodes(caller).length, 0,
+    'silent-refusal must NOT emit any episode under caller')
+})
+
+// =============================================================================
+// F6a — cd-fail: nonexistent cwd
+// =============================================================================
+tap('F6a cd-fail nonexistent: stdin .cwd points at /nonexistent/path → exit 0 silently', () => {
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+
+  const fakeCwd = path.join(os.tmpdir(), `bp1-h2-nonexistent-${crypto.randomBytes(4).toString('hex')}`)
+
+  const r = runHook({
+    stdinJSON: { cwd: fakeCwd },
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'cd-fail on nonexistent must exit 0 silently')
+  assert.equal(r.stdout, '', 'cd-fail must not emit stdout')
+  assert.equal(r.stderr, '', 'cd-fail must not emit stderr')
+})
+
+// =============================================================================
+// F6b — empty stdin {} → falls back to caller cwd's pwd
+// =============================================================================
+tap('F6b empty stdin {}: falls back to pwd (caller cwd), proceeds per caller activation state', () => {
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+  writeConfig(home, caller, null)  // caller is inactive
+
+  const r = runHook({
+    stdinJSON: {},
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'must exit 0')
+  assert.equal(r.stdout, '', 'inactive caller must produce no stdout')
+  assert.equal(listEpisodes(caller).length, 0, 'no episodes on silent refusal')
+})
+
+// =============================================================================
+// F6c — null cwd → falls back to pwd
+// =============================================================================
+tap('F6c null cwd: stdin {"cwd": null} → falls back to pwd (same shape as F6b)', () => {
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+  writeConfig(home, caller, null)
+
+  const r = runHook({
+    stdinJSON: { cwd: null },
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'must exit 0')
+  assert.equal(r.stdout, '', 'inactive caller must produce no stdout')
+  assert.equal(listEpisodes(caller).length, 0, 'no episodes on silent refusal')
+})
+
+// =============================================================================
+// F6d — permission-denied cwd (codex FU-3)
+// =============================================================================
+tap('F6d cd-fail permission-denied: stdin .cwd points at unreadable dir → exit 0 silently', () => {
+  if (process.platform === 'win32') {
+    console.log('# skipping F6d on win32 — chmod semantics differ')
+    return
+  }
+  if (typeof process.getuid === 'function' && process.getuid() === 0) {
+    console.log('# skipping F6d when running as root — chmod 000 ineffective')
+    return
+  }
+
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+
+  const lockedDir = makeTempDir('locked')
+  fs.chmodSync(lockedDir, 0o000)
+  try {
+    const r = runHook({
+      stdinJSON: { cwd: lockedDir },
+      callerCwd: caller,
+      homeDir: home,
+    })
+    assert.equal(r.exitCode, 0, 'cd into permission-denied dir must exit 0 silently')
+    assert.equal(r.stdout, '', 'cd-fail must not emit stdout')
+    assert.equal(r.stderr, '', 'cd-fail must not emit stderr')
+  } finally {
+    fs.chmodSync(lockedDir, 0o700)
+    fs.rmSync(lockedDir, { recursive: true, force: true })
+  }
+})
+
+// =============================================================================
+// B6 — cross-project bypass: project A's lock+env in scope, hook fires for B
+// =============================================================================
+tap('B6 cross-project bypass: A has lock+env, B is inactive, hook for B → fail closed, no sweep at B (§577-585)', () => {
+  const projA = makeProjectRoot()
+  const projB = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  installBp1ScriptsToHome(home)
+  writeVerifyKey(home)
+  writeConfig(home, projB, null)  // B is inactive
+
+  // Project A has its own valid dry-run lock...
+  fs.writeFileSync(
+    path.join(projA, '.episodic-memory', '.bp1-dry-run.lock'),
+    JSON.stringify({
+      run_id: 'dry-A-1',
+      ttl_until: Date.now() + 60_000,
+      project_root_sha256: projectSha(projA),
+    })
+  )
+
+  const r = runHook({
+    stdinJSON: { cwd: projB },
+    callerCwd: caller,
+    homeDir: home,
+    env: { BP1_DRY_RUN_MODE: projectSha(projA) },
+  })
+
+  assert.equal(r.exitCode, 0, 'cross-project must fail closed silently')
+  assert.equal(r.stdout, '', 'cross-project bypass must NOT emit stdout')
+  assert.equal(listEpisodes(projB).length, 0,
+    'cross-project bypass must NOT emit sweep evidence under B')
+})
+
+// =============================================================================
+// no-install — codex A1 regression: HOME has no bp1 scripts → soft no-op
+// =============================================================================
+tap('no-install (codex A1): HOME without bp1 scripts → H2 silently no-ops', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  // Deliberately NO installBp1ScriptsToHome — verifies the soft-fail branch.
+
+  const r = runHook({
+    stdinJSON: { cwd: target },
+    callerCwd: caller,
+    homeDir: home,
+  })
+
+  assert.equal(r.exitCode, 0, 'missing scripts must exit 0 silently')
+  assert.equal(r.stdout, '', 'no stdout when scripts unavailable')
+  assert.equal(r.stderr, '', 'no stderr when scripts unavailable')
+  assert.equal(listEpisodes(target).length, 0, 'no episodes when scripts unavailable')
+})
+
+// =============================================================================
+// installed-shape (codex A1): post-install.mjs invocation works end-to-end
+// =============================================================================
+tap('installed-shape (codex A1): real install.mjs → H2 invocation finds scripts at $HOME/.episodic-memory/scripts/', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  // Run install.mjs end-to-end. This both copies scripts to $HOME and wires H2.
+  const installer = spawnSync('node', [
+    path.join(REPO, 'install.mjs'),
+    '--tool', 'claude-code',
+    '--project', target,
+  ], {
+    cwd: caller,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  })
+  assert.equal(installer.status, 0, `install.mjs failed: ${installer.stderr}`)
+
+  // Activation gate setup so the sweep is allowed to run.
+  const { fingerprint } = writeVerifyKey(home)
+  writeConfig(home, target, activationEntry(target, home, fingerprint))
+
+  // Now invoke the INSTALLED H2 hook (lives under <target>/.claude/hooks/) with
+  // stdin pointing at the activated target. NO symlink in <target>/scripts —
+  // codex A1's regression check.
+  const installedHook = path.join(target, '.claude', 'hooks', 'bp1-sweep-on-session.sh')
+  assert.ok(fs.existsSync(installedHook), 'install.mjs must have copied H2 hook')
+
+  const r = spawnSync('bash', [installedHook], {
+    cwd: caller,
+    encoding: 'utf8',
+    input: JSON.stringify({ cwd: target }),
+    env: { ...process.env, HOME: home },
+  })
+  assert.equal(r.status, 0, 'installed H2 must exit 0')
+
+  // The sweep must have actually fired: at least one bp1-sweep episode under target.
+  const targetEps = listEpisodes(target)
+  assert.ok(targetEps.some(e => /bp1-sweep/.test(e)),
+    `installed H2 must produce a sweep episode at target; got ${targetEps.join(', ')}`)
+})
+
+// =============================================================================
+// Summary
+// =============================================================================
+console.log(`# tests ${pass + fail}`)
+console.log(`# pass  ${pass}`)
+console.log(`# fail  ${fail}`)
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/test-install-bp1-wiring.mjs
+++ b/tests/test-install-bp1-wiring.mjs
@@ -1,0 +1,517 @@
+#!/usr/bin/env node
+/**
+ * test-install-bp1-wiring.mjs — Hermetic tests for install.mjs section 2c
+ * (BP-1 H2 SessionStart hook + project-local settings.json wiring).
+ *
+ * RFC-004 §559 H-cfg. Per plan v3:
+ *   F1 — caller cwd ≠ --project: settings.json under TARGET only; HOME bp1
+ *        lines unchanged (I1, I10).
+ *        FU-1: exact install command spelled out, NO --install-hooks.
+ *   F2 — no --project: falls back to caller cwd; settings.json there.
+ *   F3 — worktree: caller in main repo, --project <worktree-path>; settings
+ *        under worktree only.
+ *   R1 — fresh install creates settings.json with one canonical H2 entry.
+ *   R2 — re-run preserves H2 count = 1; regen warning suppressed (B8).
+ *   R3 — pre-seeded H1 at index 0 → order [H1, H2] (forward-compat for M2).
+ *   R4 — flat-shape pre-seed → migrated by helper.
+ *   R5 — canonical pre-seed → byte-stable.
+ *   R6 — H2 at non-canonical path → existing detectStaleCanonicalEntries
+ *        warning emitted (informational).
+ *   manifest-hash — H2 wiring changes settings_lines sha256 (I9).
+ *   regen-warning — fires on add only; suppressed on no-op (B8 specific).
+ *   helper-purity — mergeSessionStartH2Hook does not mutate input (I2).
+ *
+ * Note (FU-2): if --install-hooks is combined with --tool claude-code, HOME
+ * settings may change due to the legacy hook-install block (section 5).
+ * H2's project-local wiring stays project-local regardless. This test
+ * exercises plain --tool claude-code (no --install-hooks) so HOME
+ * isolation is testable cleanly.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+import assert from 'node:assert/strict'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const INSTALL = path.join(REPO, 'install.mjs')
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeTempDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `bp1-install-${label}-`))
+}
+
+function makeProjectRoot() {
+  const dir = makeTempDir('proj')
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  return fs.realpathSync(dir)
+}
+
+/**
+ * Run install.mjs in a fully sandboxed environment.
+ *
+ * Per FU-1: command is exactly `node install.mjs --tool claude-code --project <target>`.
+ * NO --install-hooks (legacy HOME-write block). Per I10, HOME settings.json
+ * stays untouched.
+ *
+ * `homeDir` overrides HOME so global state writes (~/.episodic-memory/scripts/,
+ * ~/.claude/) don't pollute the user's real environment.
+ */
+function runInstall({ projectDir, callerCwd, homeDir, env }) {
+  return spawnSync('node', [INSTALL, '--tool', 'claude-code', '--project', projectDir], {
+    cwd: callerCwd || projectDir,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir, ...(env || {}) },
+  })
+}
+
+function readSettings(p) {
+  return fs.existsSync(p) ? JSON.parse(fs.readFileSync(p, 'utf8')) : null
+}
+
+function h2Command(projectDir) {
+  return `bash ${path.join(projectDir, '.claude', 'hooks', 'bp1-sweep-on-session.sh')}`
+}
+
+function h1CommandStub(projectDir) {
+  // Synthetic H1 entry for forward-compat tests. Not a real path; we just need
+  // a distinct command string to verify ordering.
+  return `bash ${path.join(projectDir, '.claude', 'hooks', 'bp1-approval-check.sh')}`
+}
+
+function settingsFor(projectDir) {
+  return path.join(projectDir, '.claude', 'settings.json')
+}
+
+function homeSettingsBp1Hash(homeDir) {
+  // Snapshot of HOME ~/.claude/settings.json content. Used to assert I10.
+  // Returns null if file doesn't exist (fresh HOME).
+  const p = path.join(homeDir, '.claude', 'settings.json')
+  if (!fs.existsSync(p)) return null
+  const buf = fs.readFileSync(p)
+  return crypto.createHash('sha256').update(buf).digest('hex')
+}
+
+function manifestHashFor(projectDir) {
+  // Compute artifact-version-hash via the manifest builder. Used for I9.
+  const out = execFileSync('node', [
+    path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
+    '--project', projectDir, '--json',
+  ], { encoding: 'utf8' })
+  return JSON.parse(out).sha256
+}
+
+// =============================================================================
+// F1 — caller cwd ≠ --project: settings under target only; HOME unchanged (I1, I10)
+// =============================================================================
+tap('F1: caller cwd != --project → settings under TARGET; caller has no .claude; HOME bp1 lines unchanged (I1, I10)', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  const homeHashBefore = homeSettingsBp1Hash(home)
+
+  const r = runInstall({ projectDir: target, callerCwd: caller, homeDir: home })
+  assert.equal(r.status, 0, `install failed: ${r.stderr}`)
+
+  // I1: settings.json under TARGET, NOT caller.
+  assert.ok(fs.existsSync(settingsFor(target)),
+    `target settings.json must exist at ${settingsFor(target)}`)
+  assert.ok(!fs.existsSync(settingsFor(caller)),
+    `caller settings.json must NOT exist at ${settingsFor(caller)}`)
+  // Hook script under target.
+  const hookPath = path.join(target, '.claude', 'hooks', 'bp1-sweep-on-session.sh')
+  assert.ok(fs.existsSync(hookPath), `H2 hook must be installed at ${hookPath}`)
+
+  // I10: HOME settings.json content snapshot unchanged. The plain --tool
+  // claude-code (no --install-hooks) path is the contract — HOME-touching is
+  // only reachable via --install-hooks (FU-2 note).
+  const homeHashAfter = homeSettingsBp1Hash(home)
+  assert.equal(homeHashAfter, homeHashBefore,
+    'HOME settings.json must be unchanged by --tool claude-code (no --install-hooks)')
+
+  // settings.json shape includes one canonical H2 entry.
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 1, 'exactly one SessionStart entry')
+  assert.equal(s.hooks.SessionStart[0].hooks[0].command, h2Command(target),
+    'SessionStart entry command must reference the canonical H2 path')
+})
+
+// =============================================================================
+// F2 — no --project: falls back to caller cwd
+// =============================================================================
+tap('F2: no --project flag → settings under caller cwd (process.cwd() fallback)', () => {
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+  // Run install.mjs without --project; spawnSync's cwd = caller is the source
+  // for process.cwd() inside install.mjs.
+  const r = spawnSync('node', [INSTALL, '--tool', 'claude-code'], {
+    cwd: caller, encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  })
+  assert.equal(r.status, 0, `install failed: ${r.stderr}`)
+  assert.ok(fs.existsSync(settingsFor(caller)),
+    `caller settings.json must exist when --project omitted`)
+})
+
+// =============================================================================
+// F3 — worktree-style: caller is "main repo", target is a separate dir
+// =============================================================================
+tap('F3: caller cwd is one project, --project points at another → settings under TARGET only', () => {
+  const target = makeProjectRoot()
+  const caller = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  const r = runInstall({ projectDir: target, callerCwd: caller, homeDir: home })
+  assert.equal(r.status, 0)
+  assert.ok(fs.existsSync(settingsFor(target)))
+  assert.ok(!fs.existsSync(settingsFor(caller)),
+    'caller (linked-worktree main repo) must remain unchanged')
+})
+
+// =============================================================================
+// R1 — fresh install creates settings with one canonical H2 entry
+// =============================================================================
+tap('R1: fresh install → settings.json created with one canonical H2 entry', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0)
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 1)
+  assert.equal(s.hooks.SessionStart[0].hooks[0].type, 'command')
+  assert.equal(s.hooks.SessionStart[0].hooks[0].command, h2Command(target))
+  assert.equal(typeof s.hooks.SessionStart[0].hooks[0].timeout, 'number')
+})
+
+// =============================================================================
+// R2 — re-run preserves H2 count = 1; regen-warning suppressed on no-op (B8)
+// =============================================================================
+tap('R2: re-run idempotent → H2 count stays 1; regen warning fires on FIRST install only (B8)', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  const r1 = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r1.status, 0)
+  assert.match(r1.stdout, /artifact_version_hash changed/,
+    'regen warning must fire on FIRST install')
+
+  const settingsAfterR1 = fs.readFileSync(settingsFor(target), 'utf8')
+
+  const r2 = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r2.status, 0)
+  // B8: no regen warning on no-op re-run.
+  assert.doesNotMatch(r2.stdout, /artifact_version_hash changed/,
+    'regen warning must NOT fire on no-op re-run (B8)')
+  // Idempotence: settings byte-stable.
+  const settingsAfterR2 = fs.readFileSync(settingsFor(target), 'utf8')
+  assert.equal(settingsAfterR2, settingsAfterR1,
+    'settings.json must be byte-identical across re-run (idempotence)')
+
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 1, 'H2 entry count must remain 1')
+})
+
+// =============================================================================
+// R3 — pre-seeded H1 → order [H1, H2] (forward-compat for M2 §559 ordering)
+// =============================================================================
+tap('R3: pre-seeded H1 entry → H2 appended; order = [H1, H2] (M2 forward-compat per §559)', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  // Pre-seed settings.json with an H1-style entry at index 0 (synthetic; H1
+  // doesn't ship until M2, but install.mjs must not reorder existing entries).
+  const dotClaude = path.join(target, '.claude')
+  fs.mkdirSync(dotClaude, { recursive: true })
+  const preseedSettings = {
+    hooks: {
+      SessionStart: [
+        { hooks: [{ type: 'command', command: h1CommandStub(target), timeout: 10 }] },
+      ],
+    },
+  }
+  fs.writeFileSync(settingsFor(target), JSON.stringify(preseedSettings, null, 2))
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0)
+
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 2, 'H1 + H2 = 2 entries')
+  assert.equal(s.hooks.SessionStart[0].hooks[0].command, h1CommandStub(target),
+    'H1 must remain at index 0 (preserves pre-existing entry)')
+  assert.equal(s.hooks.SessionStart[1].hooks[0].command, h2Command(target),
+    'H2 must be appended at index 1')
+})
+
+// =============================================================================
+// R4 — flat-shape pre-seed → migrated to canonical (codex code-review B1)
+// =============================================================================
+tap('R4: pre-seeded H2 in flat shape {command, timeout} → migrated to nested canonical (B1)', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  // Pre-seed settings.json with the H2 entry in FLAT shape (legacy /
+  // misconfigured user state). install.mjs section 2c must migrate this to
+  // nested canonical shape before the idempotence check, otherwise the
+  // mergeSessionStartH2Hook would detect the canonical command as "already
+  // present" and leave a non-executable flat entry in place.
+  const dotClaude = path.join(target, '.claude')
+  fs.mkdirSync(dotClaude, { recursive: true })
+  const flatSettings = {
+    hooks: {
+      SessionStart: [
+        {
+          // Flat shape: top-level command + timeout, NO inner hooks array.
+          command: h2Command(target),
+          timeout: 10,
+        },
+      ],
+    },
+  }
+  fs.writeFileSync(settingsFor(target), JSON.stringify(flatSettings, null, 2))
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0, `install failed: ${r.stderr}`)
+
+  // install.mjs must announce the migration (visibility).
+  assert.match(r.stdout, /Migrated \d+ flat-shape SessionStart entr/,
+    'install must surface flat-shape migration')
+
+  // Post-state: exactly one H2 entry, in nested canonical shape.
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 1, 'one entry post-migration (no duplicate)')
+  const entry = s.hooks.SessionStart[0]
+  assert.ok(Array.isArray(entry.hooks),
+    `migrated entry must have nested .hooks array; got ${JSON.stringify(entry)}`)
+  assert.equal(entry.hooks.length, 1, 'nested .hooks array has one inner hook')
+  assert.equal(entry.hooks[0].type, 'command')
+  assert.equal(entry.hooks[0].command, h2Command(target))
+  // Flat top-level .command must NOT survive in nested shape.
+  assert.equal(entry.command, undefined,
+    `flat top-level .command must be removed post-migration; got ${entry.command}`)
+})
+
+// =============================================================================
+// R5 — canonical pre-seed → byte-stable
+// =============================================================================
+tap('R5: canonical H2 pre-seed → byte-stable across install', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  const r1 = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r1.status, 0)
+
+  const before = fs.readFileSync(settingsFor(target), 'utf8')
+  const r2 = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r2.status, 0)
+  const after = fs.readFileSync(settingsFor(target), 'utf8')
+  assert.equal(after, before, 'settings.json byte-stable on re-run with canonical entry')
+})
+
+// =============================================================================
+// R6 — H2 at non-canonical path: install adds canonical + emits stale warning
+//      (codex code-review R6 follow-up: explicit warning, not just dup entry)
+// =============================================================================
+tap('R6: pre-seeded H2 at non-canonical path → install adds canonical + emits stale-entry warning', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const dotClaude = path.join(target, '.claude')
+  fs.mkdirSync(dotClaude, { recursive: true })
+  const stalePath = '/old/path/bp1-sweep-on-session.sh'
+  const staleSettings = {
+    hooks: {
+      SessionStart: [
+        { hooks: [{ type: 'command', command: `bash ${stalePath}`, timeout: 10 }] },
+      ],
+    },
+  }
+  fs.writeFileSync(settingsFor(target), JSON.stringify(staleSettings, null, 2))
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0)
+
+  const s = readSettings(settingsFor(target))
+  // Helper's exact-command idempotence check (normalizeCommand-based) sees the
+  // stale path as a different command, so canonical H2 is appended.
+  assert.equal(s.hooks.SessionStart.length, 2,
+    'stale + canonical → 2 entries (operator can clean up the stale one)')
+  const commands = s.hooks.SessionStart.flatMap(e => e.hooks.map(h => h.command))
+  assert.ok(commands.includes(`bash ${stalePath}`), 'stale entry preserved (no auto-delete)')
+  assert.ok(commands.includes(h2Command(target)), 'canonical H2 added')
+  // R6 explicit warning surfaced via detectStaleCanonicalEntries.
+  assert.match(r.stdout, /stale BP-1 H2 entry/,
+    'install must surface a stale-canonical warning when H2 entry references a non-canonical path')
+})
+
+// =============================================================================
+// B2 — divergent H2 file at destination, no force → settings registration withheld
+//      (codex code-review B2 fix: mirror legacy installHookFile semantics)
+// =============================================================================
+tap('B2: divergent H2 hook + no --install-hooks-force → file NOT overwritten AND settings NOT registered', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const projHooksDir = path.join(target, '.claude', 'hooks')
+  const projH2HookDst = path.join(projHooksDir, 'bp1-sweep-on-session.sh')
+  fs.mkdirSync(projHooksDir, { recursive: true })
+
+  // Pre-seed a "divergent" H2 file (different content from repo source).
+  const divergentContent = '#!/usr/bin/env bash\n# Divergent / user-edited H2.\nexit 0\n'
+  fs.writeFileSync(projH2HookDst, divergentContent)
+  fs.chmodSync(projH2HookDst, 0o755)
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0)
+  // Warning surfaced.
+  assert.match(r.stdout, /differs from repo source.*withholding settings registration/,
+    'install must surface divergent-file + withholding-registration warning')
+  // File NOT overwritten.
+  assert.equal(fs.readFileSync(projH2HookDst, 'utf8'), divergentContent,
+    'divergent H2 file must NOT be overwritten without --install-hooks-force')
+  // settings.json NOT created (or, if pre-existed, no H2 entry registered).
+  // Since target has no settings.json pre-test, the file should not exist post-install.
+  assert.ok(!fs.existsSync(settingsFor(target)),
+    'settings.json must NOT be created when H2 file is divergent and no force flag')
+})
+
+tap('B2: divergent H2 hook + --install-hooks + --install-hooks-force → file overwritten AND settings registered', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const projHooksDir = path.join(target, '.claude', 'hooks')
+  const projH2HookDst = path.join(projHooksDir, 'bp1-sweep-on-session.sh')
+  fs.mkdirSync(projHooksDir, { recursive: true })
+
+  fs.writeFileSync(projH2HookDst, '#!/usr/bin/env bash\n# Divergent / user-edited H2.\nexit 0\n')
+  fs.chmodSync(projH2HookDst, 0o755)
+
+  const r = spawnSync('node', [INSTALL,
+    '--tool', 'claude-code',
+    '--project', target,
+    '--install-hooks',
+    '--install-hooks-force',
+  ], {
+    cwd: target,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  })
+  assert.equal(r.status, 0)
+  assert.match(r.stdout, /Overwrote divergent .*bp1-sweep-on-session\.sh/,
+    'install must announce overwrite under --install-hooks --install-hooks-force')
+  // File matches repo source now.
+  const repoH2 = fs.readFileSync(path.join(REPO, '.claude', 'hooks', 'bp1-sweep-on-session.sh'))
+  assert.ok(repoH2.equals(fs.readFileSync(projH2HookDst)),
+    'overwrite must restore repo-source contents')
+  // settings.json registered.
+  assert.ok(fs.existsSync(settingsFor(target)),
+    'settings.json must be registered after force overwrite')
+  const s = readSettings(settingsFor(target))
+  assert.equal(s.hooks.SessionStart.length, 1)
+  assert.equal(s.hooks.SessionStart[0].hooks[0].command, h2Command(target))
+})
+
+// Codex code-review round-2 Finding 1: --install-hooks-force ALONE (without
+// --install-hooks) must NOT overwrite divergent project-local H2 — matches
+// legacy T11 contract that says force-alone has no effect on hooks.
+tap('B2 force-alone (codex r2 Finding 1): --install-hooks-force without --install-hooks → divergent H2 NOT overwritten', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const projHooksDir = path.join(target, '.claude', 'hooks')
+  const projH2HookDst = path.join(projHooksDir, 'bp1-sweep-on-session.sh')
+  fs.mkdirSync(projHooksDir, { recursive: true })
+
+  const divergentContent = '#!/usr/bin/env bash\n# Divergent / user-edited H2.\nexit 0\n'
+  fs.writeFileSync(projH2HookDst, divergentContent)
+  fs.chmodSync(projH2HookDst, 0o755)
+
+  const r = spawnSync('node', [INSTALL,
+    '--tool', 'claude-code',
+    '--project', target,
+    '--install-hooks-force',  // FORCE alone, no --install-hooks
+  ], {
+    cwd: target,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  })
+  assert.equal(r.status, 0)
+  // Legacy T11a warning fires.
+  assert.match(r.stdout, /--install-hooks-force has no effect without --install-hooks/,
+    'install must surface the legacy force-alone warning')
+  // Section 2c also surfaces its withholding-registration message.
+  assert.match(r.stdout, /not overwriting AND withholding settings registration/,
+    'install must surface section 2c divergent withholding message')
+  // File NOT overwritten — force-alone is impotent.
+  assert.equal(fs.readFileSync(projH2HookDst, 'utf8'), divergentContent,
+    'divergent H2 must NOT be overwritten with --install-hooks-force ALONE')
+  // settings.json NOT registered.
+  assert.ok(!fs.existsSync(settingsFor(target)),
+    'settings.json must NOT be created when force is provided alone')
+})
+
+// =============================================================================
+// manifest-hash — H2 wiring changes settings_lines sha256 (I9)
+// =============================================================================
+tap('manifest-hash: H2 wiring changes artifact_version_hash settings_lines (I9)', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+
+  // Baseline manifest BEFORE H2 wiring (no .claude/ in target yet).
+  const hashBefore = manifestHashFor(target)
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  assert.equal(r.status, 0)
+
+  const hashAfter = manifestHashFor(target)
+  assert.notEqual(hashAfter, hashBefore,
+    'artifact_version_hash must change after H2 wiring lands (I9)')
+})
+
+// =============================================================================
+// helper-purity — I2: mergeSessionStartH2Hook does not mutate input
+// =============================================================================
+tap('helper-purity: mergeSessionStartH2Hook does NOT mutate input (I2)', async () => {
+  const { mergeSessionStartH2Hook } = await import('../scripts/lib/bp1-install-helpers.mjs')
+  const input = { hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'bash /x', timeout: 10 }] }] } }
+  const inputClone = JSON.parse(JSON.stringify(input))
+  const result = mergeSessionStartH2Hook(input, '/y')
+  assert.deepEqual(input, inputClone, 'input must not be mutated (I2)')
+  assert.equal(result.changed, true)
+  assert.equal(result.settings.hooks.SessionStart.length, 2)
+})
+
+// =============================================================================
+// malformed-json — install.mjs refuses to silently overwrite bad JSON
+// =============================================================================
+tap('malformed-json: pre-existing invalid JSON → install surfaces error and skips H2 wiring (no overwrite)', () => {
+  const target = makeProjectRoot()
+  const home = makeTempDir('home')
+  const dotClaude = path.join(target, '.claude')
+  fs.mkdirSync(dotClaude, { recursive: true })
+  fs.writeFileSync(settingsFor(target), '{ this is not valid JSON', 'utf8')
+
+  const r = runInstall({ projectDir: target, callerCwd: target, homeDir: home })
+  // install.mjs surfaces and continues; exit 0 still happens for the rest.
+  assert.equal(r.status, 0)
+  assert.match(r.stdout, /not valid JSON/, 'install must surface malformed JSON')
+  // settings.json content unchanged (no silent overwrite).
+  assert.equal(fs.readFileSync(settingsFor(target), 'utf8'), '{ this is not valid JSON',
+    'install must NOT overwrite malformed settings.json silently')
+})
+
+// =============================================================================
+// Summary
+// =============================================================================
+console.log(`# tests ${pass + fail}`)
+console.log(`# pass  ${pass}`)
+console.log(`# fail  ${fail}`)
+process.exit(fail === 0 ? 0 : 1)


### PR DESCRIPTION
## Summary

- Adds **H2 SessionStart hook** (`.claude/hooks/bp1-sweep-on-session.sh`) that runs `bp1-deadline-sweep.mjs --once` on every Claude session when `scheduled_tasks_capability == fallback` (RFC-004 §192/§559). Activation-gated; silent on flag-check refusal per §178.
- Adds **install.mjs section 2c** for project-local SessionStart wiring + a small helper lib (`scripts/lib/bp1-install-helpers.mjs`) for idempotent settings.json merging. Project-local; never touches `~/.claude/settings.json` (I10).
- Plugin.json scheduled-task registration is **out of scope** — that lands in M5 (T1, T1b) and M6 (T2) per RFC §1411 milestone graph.

## What it ships

| Component | File | LOC |
|---|---|---|
| H2 SessionStart hook | `.claude/hooks/bp1-sweep-on-session.sh` | 71 |
| Helper lib | `scripts/lib/bp1-install-helpers.mjs` | 105 |
| install.mjs section 2c | `install.mjs` | +120 |
| H2 hook tests | `tests/test-bp1-sweep-on-session.mjs` (9) | 360 |
| Install wiring tests | `tests/test-install-bp1-wiring.mjs` (15) | 520 |
| CI | `.github/workflows/rfc-validate.yml` | +14 |

## Review chain (consensus reached)

- **Plan:** v1 → v2 (scope creep removed: plugin.json out) → v3 (4 planner blockers folded). Codex second-opinion on plan v3 = ACCEPT-with-FU; 3 FUs folded inline during impl.
- **Code review (codex CLI foreground via episode-messaging):**
  - R1: HOLD (2 P1 + 1 P2 + 1 P2-DEFER)
  - R2: HOLD (R1 findings closed; 1 new P2 = force-flag contract drift)
  - R3: **ACCEPT** — Finding 1 closed, zero new findings, spec-cycle convergence (4 → 1 → 0)

## Known follow-ups

- §559 partial-coverage: H1 (`bp1-approval-check.sh`) wiring deferred to M2 since the script depends on `bp1-marker-validate.mjs` which lands in M2. Marked with `TODO(M2)` comment in `install.mjs` section 2c. Tracking issue to be filed post-merge.

## Test plan

- [x] H2 hook unit tests (9/9 pass) — F4 happy + F5 silent + F6a/b/c/d cd-fail variants + B6 cross-project bypass + no-install soft-fail + end-to-end installed-shape.
- [x] Install wiring tests (15/15 pass) — F1-F3 cwd-binding + R1-R6 idempotence + flat-shape migration + divergent-skip both flag scenarios + R6 stale-canonical warning + manifest-hash + helper-purity + malformed-JSON.
- [x] Existing bp1 suite (81/81 pass) — `test-bp1-flag-check.mjs`, `test-bp1-deadline-sweep.mjs`, `test-bp1-build-artifact-manifest.mjs`, `test-bp1-probe.mjs`.
- [x] Legacy install regression — `test-install-bp1.sh` + `test-install-hooks.sh` (T11 still passes).
- [x] RFC validators — `em-rfc-validate`, `validate-rfc-failure-table`, `validate-rfc-artifact-manifest`.
- [x] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
