### PR TITLE
fix(hooks): exempt /dev/null sink redirects from shared_write upgrade

### DIFF
--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -484,12 +484,27 @@ _classify_segment() {
   # If any output redirect targets a non-marker → has_nonmarker_redirect, which
   # forces shared_write later (overrides read-only command classification —
   # `echo hello > file.txt` is a write even though `echo` is read-only).
+  #
+  # Exception: device pseudo-files in /dev/ that are non-persistent sinks/sources
+  # (/dev/null, /dev/stdout, /dev/stderr, /dev/tty, /dev/zero) never affect
+  # shared state, so they must NOT upgrade the redirect-source command. A
+  # read-only command such as `ls >/dev/null` remains read_only; other commands
+  # keep their normal classification (e.g. `git push >/dev/null` still
+  # classifies as push_or_pr_create via its own command rule). Exact-string
+  # match — symlinks to /dev/null fall through to the conservative shared_write
+  # default.
   local r
   local has_nonmarker_redirect=0
   for r in ${REDIRS[@]+"${REDIRS[@]}"}; do
     local rop="${r%%	*}"
     local rtarget="${r#*	}"
     local rbase="$(basename "$rtarget")"
+    case "$rtarget" in
+      /dev/null|/dev/stdout|/dev/stderr|/dev/tty|/dev/zero)
+        # Benign device sink — skip the has_nonmarker_redirect upgrade.
+        continue
+        ;;
+    esac
     case "$rbase" in
       .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
         local abs_target

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -289,6 +289,51 @@ assert_label "T207 gh pr update-branch" "gh pr update-branch 113" "push_or_pr_cr
 assert_label "T208 gh pr revert" "gh pr revert 113" "push_or_pr_create"
 
 echo ""
+echo "--- /dev/null sink (issue: 2>/dev/null false-positive) ---"
+# Bug: any output redirect to a non-marker forced shared_write, even when
+# the redirect target was /dev/null (the universal sink). This made every
+# defensive `cmd 2>/dev/null` block under plan-gate, which was the dominant
+# false-positive trigger for permission prompts during planning sessions.
+# Fix: /dev/null targets bypass the has_nonmarker_redirect upgrade.
+assert_label "T220 ls 2>/dev/null" "ls /tmp 2>/dev/null" "read_only"
+assert_label "T221 ls >/dev/null" "ls /tmp >/dev/null" "read_only"
+assert_label "T222 ls &>/dev/null" "ls /tmp &>/dev/null" "read_only"
+assert_label "T223 cat 2>/dev/null" "cat /etc/hosts 2>/dev/null" "read_only"
+assert_label "T224 git status 2>/dev/null" "git status 2>/dev/null" "read_only"
+assert_label "T225 grep with stderr sink" "grep -r foo . 2>/dev/null" "read_only"
+# Compound: each segment classified independently, /dev/null exception applies.
+assert_label "T226 compound /dev/null" \
+  "ls /tmp 2>/dev/null; ls /var 2>/dev/null" "read_only"
+assert_label "T227 compound mixed sinks" \
+  "git status 2>/dev/null; ls /tmp 2>/dev/null" "read_only"
+# Negative: real writes (non-/dev/null targets) still upgrade to shared_write.
+assert_label "T228 echo to real file" "echo hello > /tmp/foo" "shared_write"
+assert_label "T229 ls to real file" "ls > /tmp/listing.txt" "shared_write"
+# Most-restrictive: /dev/null segment + real-write segment → shared_write.
+assert_label "T230 dev-null then write" \
+  "git status > /dev/null; echo x > /tmp/foo" "shared_write"
+# Most-restrictive: /dev/null read + push still pushes.
+assert_label "T231 dev-null then push" \
+  "git status 2>/dev/null && git push" "push_or_pr_create"
+# Marker-write redirect not masked by a sibling /dev/null redirect on the
+# same command. The marker check fires regardless of redirect order.
+assert_label "T232 write to marker + dev-null" \
+  "echo ok > .plan-approval-pending 2>/dev/null" "marker_write"
+assert_label "T233 dev-null + write to marker" \
+  "echo ok 2>/dev/null > .plan-approval-pending" "marker_write"
+# unsafe_complex still wins when a sink redirect is present.
+assert_label "T234 unsafe + dev-null" "eval foo 2>/dev/null" "unsafe_complex"
+assert_label "T235 backticks + dev-null" "echo \`whoami\` 2>/dev/null" "unsafe_complex"
+# Other benign device sinks — same exemption applies to read-only commands.
+assert_label "T236 ls >/dev/stdout" "ls /tmp >/dev/stdout" "read_only"
+assert_label "T237 ls 2>/dev/stderr" "ls /tmp 2>/dev/stderr" "read_only"
+assert_label "T238 cat >/dev/tty" "cat /etc/hosts >/dev/tty" "read_only"
+assert_label "T239 ls >/dev/zero" "ls /tmp >/dev/zero" "read_only"
+# Negative: /dev/null with similar but different path is still a real write.
+assert_label "T240 dev-null look-alike" "ls /tmp >/dev/null2" "shared_write"
+assert_label "T241 dev-not-null" "ls /tmp >/devnull" "shared_write"
+
+echo ""
 echo "--- classify_path ---"
 assert_path() {
   local desc="$1"


### PR DESCRIPTION
## Summary

- `hooks/lib/command-classifier.sh` was upgrading any read-only command with a redirect to `/dev/null` (or sibling device sinks) to `shared_write`, causing plan-gate to block defensive `cmd 2>/dev/null` patterns under armed `.plan-approval-pending`. This was the dominant false-positive trigger for permission prompts during planning sessions.
- Fix exempts `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/tty`, `/dev/zero` from the `has_nonmarker_redirect` upgrade. Read-only commands keep `read_only`; write/push/marker/unsafe commands keep their normal classification.
- 22 new regression tests across 6 axes; 186/186 tests pass. Codex review of the diff returned 4 ACCEPT-WITH-MOD findings — all addressed before commit.

## Discovery

User pain: Claude Code permission prompts firing constantly during planning sessions. Plan-gate's read-only carve-out at [plan-gate.sh:51](hooks/plan-gate.sh#L51) and [:67-71](hooks/plan-gate.sh#L67) was supposed to allow read-only Bash through, but the classifier was returning `shared_write` for anything with a `2>/dev/null`. Step-1 investigation traced this to [command-classifier.sh:489-503](hooks/lib/command-classifier.sh#L489) treating every non-marker redirect target as a real write.

## Invariants preserved

| Class | Test | Verdict |
|---|---|---|
| Real-file writes | T228, T229 | still `shared_write` |
| Compound dev-null + real-write | T230 | still `shared_write` (most-restrictive) |
| Push under dev-null | T231 | still `push_or_pr_create` |
| Marker write + sibling dev-null | T232, T233 | still `marker_write` |
| Unsafe (eval, backticks) + dev-null | T234, T235 | still `unsafe_complex` |
| Look-alike paths (/dev/null2, /devnull) | T240, T241 | still `shared_write` |
| Symlink to /dev/null | n/a (exact-string match) | falls through to `shared_write` (conservative) |

## Codex review findings (all addressed)

- F1 ACCEPT-WITH-MOD — completed device-sink class (added stdout/stderr/tty/zero)
- F2 ACCEPT-WITH-MOD — added marker+sink regression tests
- F3 ACCEPT-WITH-MOD — added unsafe+sink regression tests
- F4 ACCEPT-WITH-MOD — corrected docstring on what stays read-only vs. what keeps its class

Residual concern (out of scope): plan-gate's blanket `mcp__*` allow at [plan-gate.sh:51](hooks/plan-gate.sh#L51) bypasses write classification for MCP tools — filed as [#192](https://github.com/lantisprime/episodic-memory/issues/192).

## Test plan

- [x] `bash tests/test-command-classifier.sh` — 186 passed, 0 failed
- [x] E2E: install updated classifier globally; confirm originally-blocked `ls 2>/dev/null` chain now passes plan-gate
- [x] E2E: confirm `echo > /tmp/foo` still blocked under armed marker
- [x] E2E: confirm `git push` still blocked under armed marker
- [ ] Reviewer: spot-check that no test was relaxed (only additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)