### PR TITLE
feat(scripts): add --body-file flag to em-store/em-revise/em-violation

### DIFF
--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -484,12 +484,27 @@ _classify_segment() {
   # If any output redirect targets a non-marker → has_nonmarker_redirect, which
   # forces shared_write later (overrides read-only command classification —
   # `echo hello > file.txt` is a write even though `echo` is read-only).
+  #
+  # Exception: device pseudo-files in /dev/ that are non-persistent sinks/sources
+  # (/dev/null, /dev/stdout, /dev/stderr, /dev/tty, /dev/zero) never affect
+  # shared state, so they must NOT upgrade the redirect-source command. A
+  # read-only command such as `ls >/dev/null` remains read_only; other commands
+  # keep their normal classification (e.g. `git push >/dev/null` still
+  # classifies as push_or_pr_create via its own command rule). Exact-string
+  # match — symlinks to /dev/null fall through to the conservative shared_write
+  # default.
   local r
   local has_nonmarker_redirect=0
   for r in ${REDIRS[@]+"${REDIRS[@]}"}; do
     local rop="${r%%	*}"
     local rtarget="${r#*	}"
     local rbase="$(basename "$rtarget")"
+    case "$rtarget" in
+      /dev/null|/dev/stdout|/dev/stderr|/dev/tty|/dev/zero)
+        # Benign device sink — skip the has_nonmarker_redirect upgrade.
+        continue
+        ;;
+    esac
     case "$rbase" in
       .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
         local abs_target

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -4,10 +4,14 @@
  *
  * Usage:
  *   node em-revise.mjs --original <id> --project <name> --tags <t1,t2>
- *                      --summary <text> --body <text> [--scope inherit|local|global]
+ *                      --summary <text> (--body <text> | --body-file <path>)
+ *                      [--scope inherit|local|global]
  *
  * --scope defaults to "inherit" (write the revision to the same store as the
  * original). Pass "local" or "global" only to force a cross-scope revision.
+ *
+ * `--body-file` reads body content from a file (UTF-8, BOM stripped, exactly
+ * one trailing newline stripped). Mutually exclusive with `--body`.
  *
  * Creates a new episode that supersedes the original. Marks the original
  * episode as superseded in both its file and the index.
@@ -19,6 +23,7 @@ import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readBodyFile } from './lib/body-file.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -38,7 +43,8 @@ const originalId = flag('--original')
 const project = flag('--project')
 const tagsRaw = flag('--tags')
 const summary = flag('--summary')
-const body = flag('--body')
+const bodyArg = flag('--body')
+const bodyFile = flag('--body-file')
 const scope = flag('--scope') || 'inherit'
 
 const VALID_SCOPES_REVISE = ['inherit', 'local', 'global']
@@ -47,10 +53,23 @@ if (!VALID_SCOPES_REVISE.includes(scope)) {
   process.exit(1)
 }
 
+if (bodyArg !== undefined && bodyFile !== undefined) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: '--body and --body-file are mutually exclusive; pass only one.'
+  }))
+  process.exit(1)
+}
+
+let body = bodyArg
+if (bodyFile !== undefined) {
+  body = readBodyFile(bodyFile)
+}
+
 if (!originalId || !summary || !body) {
   console.log(JSON.stringify({
     status: 'error',
-    message: 'Missing required args. Usage: --original <id> --project <name> --tags <t1,t2> --summary <text> --body <text> [--scope inherit|local|global]'
+    message: 'Missing required args. Usage: --original <id> --project <name> --tags <t1,t2> --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global]'
   }))
   process.exit(1)
 }

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -66,5 +66,6 @@ const scriptsDir = path.join(os.homedir(), '.episodic-memory', 'scripts')
 console.log(JSON.stringify({
   prompt: 'Were any behavioral patterns violated this session?',
   known_patterns: knownPatterns,
-  store_command: `node ${path.join(scriptsDir, 'em-violation.mjs')} --pattern <id> --summary "..." --body "..."`
+  store_command: `node ${path.join(scriptsDir, 'em-violation.mjs')} --pattern <id> --summary "..." --body "..."`,
+  store_command_long_body: `node ${path.join(scriptsDir, 'em-violation.mjs')} --pattern <id> --summary "..." --body-file <path>  # for multi-paragraph bodies (avoids unsafe-substitution permission gate)`
 }, null, 2))

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -4,7 +4,13 @@
  *
  * Usage:
  *   node em-store.mjs --project <name> --category <cat> --tags <t1,t2>
- *                     --summary <text> --body <text> [--scope local|global]
+ *                     --summary <text> (--body <text> | --body-file <path>)
+ *                     [--scope local|global]
+ *
+ * `--body-file` reads body content from a file (UTF-8, BOM stripped, exactly
+ * one trailing newline stripped). Mutually exclusive with `--body`. Use it
+ * when the body is long enough that `--body "$(cat …)"` would trigger
+ * Claude Code's unsafe-substitution permission gate.
  *
  * Writes a markdown episode file and appends an index entry.
  * Outputs JSON: { status, id, file, scope }
@@ -15,6 +21,7 @@ import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readBodyFile } from './lib/body-file.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -34,16 +41,32 @@ const project = flag('--project')
 const category = flag('--category')
 const tagsRaw = flag('--tags')
 const summary = flag('--summary')
-const body = flag('--body')
+const bodyArg = flag('--body')
+const bodyFile = flag('--body-file')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
 
 const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']
 
+const USAGE = `--project <name> --category <${VALID_CATEGORIES.join('|')}> --tags <t1,t2> --summary <text> (--body <text> | --body-file <path>) [--scope local|global]`
+
+if (bodyArg !== undefined && bodyFile !== undefined) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: '--body and --body-file are mutually exclusive; pass only one.'
+  }))
+  process.exit(1)
+}
+
+let body = bodyArg
+if (bodyFile !== undefined) {
+  body = readBodyFile(bodyFile)
+}
+
 if (!project || !category || !summary || !body) {
   console.log(JSON.stringify({
     status: 'error',
-    message: `Missing required args. Usage: --project <name> --category <${VALID_CATEGORIES.join('|')}> --tags <t1,t2> --summary <text> --body <text> [--scope local|global]`
+    message: `Missing required args. Usage: ${USAGE}`
   }))
   process.exit(1)
 }

--- a/scripts/em-violation.mjs
+++ b/scripts/em-violation.mjs
@@ -3,13 +3,18 @@
  * em-violation.mjs — Store a structured behavioral pattern violation.
  *
  * Usage:
- *   node em-violation.mjs --pattern <pattern_id> --summary "<text>" --body "<text>"
+ *   node em-violation.mjs --pattern <pattern_id> --summary "<text>"
+ *                         (--body "<text>" | --body-file <path>)
  *                         [--sequence "<action1,action2>"] [--correct "<action1,action2>"]
  *                         [--project <name>] [--tags "<extra_tags>"] [--scope global|local]
  *
+ * `--body-file` reads the "what happened" body from a file (UTF-8, BOM stripped,
+ * exactly one trailing newline stripped). Mutually exclusive with `--body`.
+ *
  * Validates pattern exists in patterns/_index.json, auto-tags with
  * violation + behavioral-pattern + violated:<pattern_id>, builds structured
- * body, then delegates to em-store.mjs.
+ * body, then delegates to em-store.mjs (always via `--body`, never forwards
+ * `--body-file` to the subprocess).
  *
  * Outputs JSON: { status, id, violated_pattern, file, scope }
  */
@@ -18,6 +23,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
+import { readBodyFile } from './lib/body-file.mjs'
 
 const SCRIPTS_DIR = path.dirname(new URL(import.meta.url).pathname)
 const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
@@ -35,12 +41,23 @@ function flag(name) {
 
 const patternId = flag('--pattern')
 const summary = flag('--summary')
-const bodyText = flag('--body')
+const bodyArg = flag('--body')
+const bodyFile = flag('--body-file')
 const sequence = flag('--sequence')
 const correct = flag('--correct')
 const project = flag('--project') || path.basename(process.cwd())
 const extraTags = flag('--tags')
 const scope = flag('--scope') || 'global'
+
+if (bodyArg !== undefined && bodyFile !== undefined) {
+  console.log(JSON.stringify({
+    status: 'error',
+    message: '--body and --body-file are mutually exclusive; pass only one.'
+  }))
+  process.exit(1)
+}
+
+const bodyText = bodyFile !== undefined ? readBodyFile(bodyFile) : bodyArg
 
 // ---------------------------------------------------------------------------
 // Validate scope
@@ -57,7 +74,7 @@ if (!VALID_SCOPES.includes(scope)) {
 if (!patternId || !summary || !bodyText) {
   console.log(JSON.stringify({
     status: 'error',
-    message: 'Missing required args. Usage: --pattern <pattern_id> --summary "<text>" --body "<text>" [--sequence "<actions>"] [--correct "<actions>"] [--project <name>] [--tags "<extra>"] [--scope global|local]'
+    message: 'Missing required args. Usage: --pattern <pattern_id> --summary "<text>" (--body "<text>" | --body-file <path>) [--sequence "<actions>"] [--correct "<actions>"] [--project <name>] [--tags "<extra>"] [--scope global|local]'
   }))
   process.exit(1)
 }

--- a/scripts/lib/body-file.mjs
+++ b/scripts/lib/body-file.mjs
@@ -1,0 +1,46 @@
+// body-file.mjs — Shared `--body-file <path>` reader for em-store, em-revise,
+// em-violation. Centralizes the read/strip/validate logic so the three CLIs
+// behave identically.
+//
+// On any failure (including empty argv `""`), prints a JSON `status: error`
+// envelope to stdout and calls `process.exit(1)` — matches the existing
+// validation pattern in the calling scripts.
+//
+// Strips a leading BOM and exactly one trailing `\n` or `\r\n`. Rejects
+// directories (statSync follows symlinks; symlink-to-file is allowed),
+// missing/unreadable paths, and empty post-strip content.
+
+import fs from 'fs'
+
+export function readBodyFile(p) {
+  if (!p) {
+    console.log(JSON.stringify({ status: 'error', message: '--body-file: empty path argument' }))
+    process.exit(1)
+  }
+  let st
+  try {
+    st = fs.statSync(p)
+  } catch (e) {
+    console.log(JSON.stringify({ status: 'error', message: `--body-file: cannot stat "${p}": ${e.message}` }))
+    process.exit(1)
+  }
+  if (!st.isFile()) {
+    console.log(JSON.stringify({ status: 'error', message: `--body-file: "${p}" is not a regular file` }))
+    process.exit(1)
+  }
+  let text
+  try {
+    text = fs.readFileSync(p, 'utf8')
+  } catch (e) {
+    console.log(JSON.stringify({ status: 'error', message: `--body-file: cannot read "${p}": ${e.message}` }))
+    process.exit(1)
+  }
+  if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1)
+  if (text.endsWith('\r\n')) text = text.slice(0, -2)
+  else if (text.endsWith('\n')) text = text.slice(0, -1)
+  if (text.length === 0) {
+    console.log(JSON.stringify({ status: 'error', message: `--body-file: "${p}" is empty` }))
+    process.exit(1)
+  }
+  return text
+}

--- a/scripts/lib/body-file.mjs
+++ b/scripts/lib/body-file.mjs
@@ -8,9 +8,20 @@
 //
 // Strips a leading BOM and exactly one trailing `\n` or `\r\n`. Rejects
 // directories (statSync follows symlinks; symlink-to-file is allowed),
-// missing/unreadable paths, and empty post-strip content.
+// missing/unreadable paths, files exceeding MAX_BODY_BYTES, and empty
+// post-strip content.
+//
+// Path semantics: relative paths resolve against the calling script's
+// process.cwd() — same as fs.statSync's default. Pass an absolute path or
+// run from the directory containing the body file.
+//
+// Size cap: MAX_BODY_BYTES guards against accidental 1GB-file blowups and
+// keeps em-violation's structuredBody within the OS argv limit when it
+// shells out to em-store via execFileSync.
 
 import fs from 'fs'
+
+export const MAX_BODY_BYTES = 1024 * 1024  // 1 MB
 
 export function readBodyFile(p) {
   if (!p) {
@@ -26,6 +37,10 @@ export function readBodyFile(p) {
   }
   if (!st.isFile()) {
     console.log(JSON.stringify({ status: 'error', message: `--body-file: "${p}" is not a regular file` }))
+    process.exit(1)
+  }
+  if (st.size > MAX_BODY_BYTES) {
+    console.log(JSON.stringify({ status: 'error', message: `--body-file: "${p}" is ${st.size} bytes; max is ${MAX_BODY_BYTES} bytes (1 MB)` }))
     process.exit(1)
   }
   let text

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -289,6 +289,51 @@ assert_label "T207 gh pr update-branch" "gh pr update-branch 113" "push_or_pr_cr
 assert_label "T208 gh pr revert" "gh pr revert 113" "push_or_pr_create"
 
 echo ""
+echo "--- /dev/null sink (issue: 2>/dev/null false-positive) ---"
+# Bug: any output redirect to a non-marker forced shared_write, even when
+# the redirect target was /dev/null (the universal sink). This made every
+# defensive `cmd 2>/dev/null` block under plan-gate, which was the dominant
+# false-positive trigger for permission prompts during planning sessions.
+# Fix: /dev/null targets bypass the has_nonmarker_redirect upgrade.
+assert_label "T220 ls 2>/dev/null" "ls /tmp 2>/dev/null" "read_only"
+assert_label "T221 ls >/dev/null" "ls /tmp >/dev/null" "read_only"
+assert_label "T222 ls &>/dev/null" "ls /tmp &>/dev/null" "read_only"
+assert_label "T223 cat 2>/dev/null" "cat /etc/hosts 2>/dev/null" "read_only"
+assert_label "T224 git status 2>/dev/null" "git status 2>/dev/null" "read_only"
+assert_label "T225 grep with stderr sink" "grep -r foo . 2>/dev/null" "read_only"
+# Compound: each segment classified independently, /dev/null exception applies.
+assert_label "T226 compound /dev/null" \
+  "ls /tmp 2>/dev/null; ls /var 2>/dev/null" "read_only"
+assert_label "T227 compound mixed sinks" \
+  "git status 2>/dev/null; ls /tmp 2>/dev/null" "read_only"
+# Negative: real writes (non-/dev/null targets) still upgrade to shared_write.
+assert_label "T228 echo to real file" "echo hello > /tmp/foo" "shared_write"
+assert_label "T229 ls to real file" "ls > /tmp/listing.txt" "shared_write"
+# Most-restrictive: /dev/null segment + real-write segment → shared_write.
+assert_label "T230 dev-null then write" \
+  "git status > /dev/null; echo x > /tmp/foo" "shared_write"
+# Most-restrictive: /dev/null read + push still pushes.
+assert_label "T231 dev-null then push" \
+  "git status 2>/dev/null && git push" "push_or_pr_create"
+# Marker-write redirect not masked by a sibling /dev/null redirect on the
+# same command. The marker check fires regardless of redirect order.
+assert_label "T232 write to marker + dev-null" \
+  "echo ok > .plan-approval-pending 2>/dev/null" "marker_write"
+assert_label "T233 dev-null + write to marker" \
+  "echo ok 2>/dev/null > .plan-approval-pending" "marker_write"
+# unsafe_complex still wins when a sink redirect is present.
+assert_label "T234 unsafe + dev-null" "eval foo 2>/dev/null" "unsafe_complex"
+assert_label "T235 backticks + dev-null" "echo \`whoami\` 2>/dev/null" "unsafe_complex"
+# Other benign device sinks — same exemption applies to read-only commands.
+assert_label "T236 ls >/dev/stdout" "ls /tmp >/dev/stdout" "read_only"
+assert_label "T237 ls 2>/dev/stderr" "ls /tmp 2>/dev/stderr" "read_only"
+assert_label "T238 cat >/dev/tty" "cat /etc/hosts >/dev/tty" "read_only"
+assert_label "T239 ls >/dev/zero" "ls /tmp >/dev/zero" "read_only"
+# Negative: /dev/null with similar but different path is still a real write.
+assert_label "T240 dev-null look-alike" "ls /tmp >/dev/null2" "shared_write"
+assert_label "T241 dev-not-null" "ls /tmp >/devnull" "shared_write"
+
+echo ""
 echo "--- classify_path ---"
 assert_path() {
   local desc="$1"

--- a/tests/test-em-body-file.mjs
+++ b/tests/test-em-body-file.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * test-em-body-file.mjs — Tests for `--body-file` flag on em-store, em-revise,
+ * em-violation. Permission-prompt step 3 fix (workplan v25 rank-28).
+ *
+ * Verifies:
+ *   - happy path: file body equals --body body
+ *   - missing file → JSON error
+ *   - directory target → JSON error
+ *   - empty file → JSON error
+ *   - both --body and --body-file → JSON error
+ *   - leading BOM stripped
+ *   - exactly one trailing \n stripped, \r\n stripped, no other whitespace touched
+ *   - em-violation: --body-file feeds bodyText, structuredBody built around it,
+ *     subprocess invocation uses --body (never forwards --body-file)
+ *
+ * Usage: node tests/test-em-body-file.mjs
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync, spawnSync } from 'child_process'
+import assert from 'assert'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+const REVISE = path.join(REPO, 'scripts', 'em-revise.mjs')
+const VIOLATION = path.join(REPO, 'scripts', 'em-violation.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function makeSandbox() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'em-body-file-test-')))
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  // Seed a patterns/_index.json so em-violation pattern check passes.
+  const patternsDir = path.join(home, '.episodic-memory', 'patterns')
+  fs.mkdirSync(patternsDir, { recursive: true })
+  fs.writeFileSync(path.join(patternsDir, '_index.json'), JSON.stringify({
+    patterns: [{ pattern_id: 'bp-test', name: 'Test pattern' }]
+  }))
+  return {
+    root,
+    home,
+    cwd,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function runJSON(cmd, args, sandbox) {
+  const r = spawnSync('node', [cmd, ...args], {
+    cwd: sandbox.cwd,
+    env: { ...process.env, HOME: sandbox.home },
+    encoding: 'utf8',
+  })
+  return { code: r.status, json: r.stdout ? JSON.parse(r.stdout.trim()) : null, stderr: r.stderr }
+}
+
+function readEpisodeBody(filePath) {
+  // Strip frontmatter + leading "# summary\n\n"
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const m = raw.match(/^---\n[\s\S]*?\n---\n\n# [^\n]*\n\n([\s\S]*)\n$/)
+  if (!m) throw new Error(`could not parse body from ${filePath}`)
+  return m[1]
+}
+
+// ---------------------------------------------------------------------------
+// em-store
+// ---------------------------------------------------------------------------
+console.log('\n--- em-store ---')
+
+test('happy path: --body-file body equals --body body', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'body.md')
+    const body = '# Heading\n\nFirst paragraph.\n\nSecond paragraph.'
+    fs.writeFileSync(bodyFile, body)
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0, 'expected exit 0')
+    assert.strictEqual(r.json.status, 'ok')
+    assert.strictEqual(readEpisodeBody(r.json.file), body)
+  } finally { sb.cleanup() }
+})
+
+test('missing file → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', '/nonexistent/path.md',
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /cannot stat/)
+  } finally { sb.cleanup() }
+})
+
+test('directory target → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const dir = path.join(sb.cwd, 'somedir')
+    fs.mkdirSync(dir)
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', dir,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /not a regular file/)
+  } finally { sb.cleanup() }
+})
+
+test('empty file → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'empty.md')
+    fs.writeFileSync(bodyFile, '')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /is empty/)
+  } finally { sb.cleanup() }
+})
+
+test('file containing only trailing newline → empty after strip → error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'just-newline.md')
+    fs.writeFileSync(bodyFile, '\n')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /is empty/)
+  } finally { sb.cleanup() }
+})
+
+test('--body-file "" (empty argv value) → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', '',
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /empty path argument/)
+  } finally { sb.cleanup() }
+})
+
+test('both --body and --body-file → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'b.md')
+    fs.writeFileSync(bodyFile, 'content')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body', 'inline', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /mutually exclusive/)
+  } finally { sb.cleanup() }
+})
+
+test('leading BOM stripped', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'bom.md')
+    fs.writeFileSync(bodyFile, '﻿body after BOM')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0)
+    assert.strictEqual(readEpisodeBody(r.json.file), 'body after BOM')
+  } finally { sb.cleanup() }
+})
+
+test('exactly one trailing \\n stripped (others preserved)', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'trailing.md')
+    fs.writeFileSync(bodyFile, 'line1\n\n\n')  // 3 trailing \n
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0)
+    // 1 stripped → 2 remain inside body; em-store appends 1 final \n on write
+    assert.strictEqual(readEpisodeBody(r.json.file), 'line1\n\n')
+  } finally { sb.cleanup() }
+})
+
+test('trailing \\r\\n stripped', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'crlf.md')
+    fs.writeFileSync(bodyFile, 'win-line\r\n')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0)
+    assert.strictEqual(readEpisodeBody(r.json.file), 'win-line')
+  } finally { sb.cleanup() }
+})
+
+test('leading whitespace preserved', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'lead.md')
+    fs.writeFileSync(bodyFile, '   indented\nnext line')
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0)
+    assert.strictEqual(readEpisodeBody(r.json.file), '   indented\nnext line')
+  } finally { sb.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// em-revise
+// ---------------------------------------------------------------------------
+console.log('\n--- em-revise ---')
+
+test('em-revise --body-file happy path', () => {
+  const sb = makeSandbox()
+  try {
+    // First store an original
+    const orig = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 'orig', '--body', 'original body', '--scope', 'local',
+    ], sb)
+    assert.strictEqual(orig.json.status, 'ok')
+
+    // Then revise via --body-file
+    const bodyFile = path.join(sb.cwd, 'revision.md')
+    const revBody = 'revised body\nwith multiple lines'
+    fs.writeFileSync(bodyFile, revBody)
+    const r = runJSON(REVISE, [
+      '--original', orig.json.id, '--project', 'p', '--tags', 't',
+      '--summary', 'rev', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0)
+    assert.strictEqual(r.json.status, 'ok')
+    // em-revise prepends "Revises: `<id>`\n\n" before body — verify body present
+    const written = fs.readFileSync(r.json.file, 'utf8')
+    assert.ok(written.includes(revBody), 'revised body should appear in file')
+  } finally { sb.cleanup() }
+})
+
+test('em-revise --body and --body-file together → error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'b.md')
+    fs.writeFileSync(bodyFile, 'content')
+    const r = runJSON(REVISE, [
+      '--original', 'fake-id', '--project', 'p', '--tags', 't',
+      '--summary', 's', '--body', 'inline', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.match(r.json.message, /mutually exclusive/)
+  } finally { sb.cleanup() }
+})
+
+test('em-revise --body-file missing → error', () => {
+  const sb = makeSandbox()
+  try {
+    const r = runJSON(REVISE, [
+      '--original', 'fake-id', '--project', 'p', '--tags', 't',
+      '--summary', 's', '--body-file', '/nonexistent.md',
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.match(r.json.message, /cannot stat/)
+  } finally { sb.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// em-violation
+// ---------------------------------------------------------------------------
+console.log('\n--- em-violation ---')
+
+test('em-violation --body-file feeds bodyText, structuredBody built around it', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'what.md')
+    const what = 'I skipped step 8 because I was tired.\nNot a good reason.'
+    fs.writeFileSync(bodyFile, what)
+    const r = runJSON(VIOLATION, [
+      '--pattern', 'bp-test', '--summary', 'skipped step 8',
+      '--body-file', bodyFile,
+      '--sequence', 'a,b,c', '--correct', 'a,b,c,d',
+      '--project', 'p', '--scope', 'local',
+    ], sb)
+    assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`)
+    assert.strictEqual(r.json.status, 'ok')
+    const written = fs.readFileSync(r.json.file, 'utf8')
+    // Body should contain "## What happened\n\n<file content>" + sequence + correct
+    assert.ok(written.includes('## What happened'), 'must include What happened')
+    assert.ok(written.includes(what), 'must include file body content')
+    assert.ok(written.includes('## Violation sequence\n\na,b,c'), 'must include sequence')
+    assert.ok(written.includes('## Correct sequence\n\na,b,c,d'), 'must include correct')
+  } finally { sb.cleanup() }
+})
+
+test('em-violation --body and --body-file together → error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'b.md')
+    fs.writeFileSync(bodyFile, 'content')
+    const r = runJSON(VIOLATION, [
+      '--pattern', 'bp-test', '--summary', 's',
+      '--body', 'inline', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.match(r.json.message, /mutually exclusive/)
+  } finally { sb.cleanup() }
+})
+
+test('em-violation --body-file empty file → error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'empty.md')
+    fs.writeFileSync(bodyFile, '')
+    const r = runJSON(VIOLATION, [
+      '--pattern', 'bp-test', '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.match(r.json.message, /is empty/)
+  } finally { sb.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('')
+console.log('==================================================')
+console.log(`Results: ${passed} passed, ${failed} failed`)
+console.log('==================================================')
+
+if (failed > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-em-body-file.mjs
+++ b/tests/test-em-body-file.mjs
@@ -246,6 +246,51 @@ test('leading whitespace preserved', () => {
   } finally { sb.cleanup() }
 })
 
+test('file exceeding MAX_BODY_BYTES → JSON error', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'huge.md')
+    // Write 1 MB + 1 byte
+    fs.writeFileSync(bodyFile, 'x'.repeat(1024 * 1024 + 1))
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 1)
+    assert.strictEqual(r.json.status, 'error')
+    assert.match(r.json.message, /max is 1048576 bytes/)
+  } finally { sb.cleanup() }
+})
+
+test('file at exactly MAX_BODY_BYTES → ok', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'maxed.md')
+    fs.writeFileSync(bodyFile, 'x'.repeat(1024 * 1024))
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', bodyFile,
+    ], sb)
+    assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`)
+    assert.strictEqual(r.json.status, 'ok')
+  } finally { sb.cleanup() }
+})
+
+test('relative path resolves against cwd', () => {
+  const sb = makeSandbox()
+  try {
+    const bodyFile = path.join(sb.cwd, 'rel.md')
+    fs.writeFileSync(bodyFile, 'relative-path body')
+    // Pass just the basename — script should resolve against process.cwd() (sb.cwd)
+    const r = runJSON(STORE, [
+      '--project', 'p', '--category', 'decision', '--tags', 't',
+      '--summary', 's', '--body-file', 'rel.md',
+    ], sb)
+    assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`)
+    assert.strictEqual(readEpisodeBody(r.json.file), 'relative-path body')
+  } finally { sb.cleanup() }
+})
+
 // ---------------------------------------------------------------------------
 // em-revise
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `--body-file <path>` flag to `em-store.mjs`, `em-revise.mjs`, `em-violation.mjs`. Removes the need for `\$(cat ...)` shell substitution when storing multi-paragraph episode bodies — that substitution classifies as `unsafe_complex` in the bash classifier and trips plan-gate under armed marker.
- Permission-prompt reduction step 3 (workplan v25 rank-28). Builds on PR #193 (the `/dev/null` sink fix) which removed the dominant prompt trigger; this PR removes the next-biggest one.
- Reader extracted to `scripts/lib/body-file.mjs` so the three CLIs share identical validation. 17 new tests; no regressions in adjacent test suites.

## Behavior

- Mutually exclusive with `--body`
- Strips a leading BOM and exactly one trailing `\n` or `\r\n`
- Rejects directories (`statSync` follows symlinks; symlink-to-file OK), missing/unreadable paths, empty argv (`""`), empty post-strip content
- em-violation reads file into `bodyText` BEFORE building `structuredBody`; subprocess invocation always uses `--body`, never forwards `--body-file`

## Test coverage (17 cases in `tests/test-em-body-file.mjs`)

| Case | Verdict |
|---|---|
| Happy path: file body equals --body body | ok |
| Missing file | error |
| Directory target | error |
| Empty file | error |
| File containing only `\n` (empty after strip) | error |
| `--body-file ""` empty argv | error |
| Both `--body` + `--body-file` | error (mutually-exclusive) |
| Leading BOM | stripped |
| Three trailing `\n` | exactly one stripped |
| Trailing `\r\n` | stripped |
| Leading whitespace | preserved |
| em-revise happy path | ok |
| em-revise both flags error | ok |
| em-revise missing file | ok |
| em-violation file feeds bodyText, structuredBody built around it | ok |
| em-violation both flags error | ok |
| em-violation empty file | ok |

E2E confirmed: `node scripts/em-store.mjs --body-file <scratch>.md` writes a real multi-paragraph episode under `.episodic-memory/` with full body content preserved.

## Codex review trail

- **Planning-phase (4 ACCEPT-WITH-MOD, all H):** F1 empty body → reject consistently; F2 plugin drift → canonical-only + filed [#195](https://github.com/lantisprime/episodic-memory/issues/195); F3 em-violation pass-through; F4 usage strings updated incl. `em-session-end-prompt.mjs` template.
- **Code-review (2 ACCEPT-WITH-MOD):** F1 extract `readBodyFile` to `scripts/lib/body-file.mjs`; F2 add `--body-file ""` regression test.

All 6 findings addressed before merge.

## Out of scope

- Plugin copies (`plugins/episodic-memory/scripts/em-{store,revise}.mjs`) have substantial pre-existing drift unrelated to this flag (different LOCAL_DIR, missing categories, no atomic-write, no tags.json). Cherry-picking just `--body-file` would amplify drift; sync-or-single-source tracked in [#195](https://github.com/lantisprime/episodic-memory/issues/195).
- Stdin (`-`) support — not needed for the prompt-reduction goal.
- Internal callers (`bp1-deadline-sweep`, `bp1-flag-check`) — pass body inline as JS strings, no shell-substitution issue.

## Test plan

- [x] `node tests/test-em-body-file.mjs` — 17 passed
- [x] Regression: `test-em-revise-scope-inherit`, `test-em-restore`, `test-rfc002-phase1`, `test-em-watch-codex` — all PASS
- [x] E2E: real `em-store --body-file` invocation against scratch payload writes correct episode
- [ ] Reviewer: spot-check that `scripts/lib/body-file.mjs` is the only new shared dependency introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)