### PR TITLE
fix(#103): warn on stale installed hooks

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# episodic-memory-hook-version: 2026-05-08.1
 # checkpoint-gate.sh — RFC-002 Phase 3b PreToolUse hook.
 #
 # Session 1 rewrite (#86 PR-B / #89 / #101): replaces the regex-based

--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# episodic-memory-hook-version: 2026-05-08.1
 # em-recall-sessionstart.sh — RFC-002 Phase 3b SessionStart hook
 #
 # Mechanically invokes em-recall at session start. The effective side effect
@@ -36,6 +37,77 @@ CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
 EM_RECALL="$HOME/.episodic-memory/scripts/em-recall.mjs"
+
+_em_join_list() {
+  local out=""
+  local item
+  for item in "$@"; do
+    [ -n "$out" ] && out="$out, "
+    out="$out$item"
+  done
+  printf '%s' "$out"
+}
+
+warn_hook_freshness() {
+  local manifest="$HOME/.episodic-memory/hook-install.json"
+  [ -f "$manifest" ] || return 0
+
+  local source_repo
+  if ! source_repo="$(jq -r '.source_repo // empty' "$manifest" 2>/dev/null)"; then
+    echo "episodic-memory: hook freshness warning: could not parse $manifest"
+    return 0
+  fi
+  [ -n "$source_repo" ] || return 0
+
+  if [ ! -d "$source_repo/hooks" ]; then
+    echo "episodic-memory: hook freshness warning: source repo unavailable: $source_repo"
+    echo "episodic-memory: installed Claude hooks may be stale; re-run install.mjs --install-hooks from the current episodic-memory repo."
+    return 0
+  fi
+
+  local rows
+  if ! rows="$(jq -r '.files[]? | select((.relative_path // "") != "" and (.installed_path // "") != "") | [.relative_path, .installed_path] | @tsv' "$manifest" 2>/dev/null)"; then
+    echo "episodic-memory: hook freshness warning: could not read file list from $manifest"
+    return 0
+  fi
+  [ -n "$rows" ] || return 0
+
+  local stale=()
+  local missing_installed=()
+  local missing_source=()
+  local rel installed src
+  while IFS=$'\t' read -r rel installed; do
+    [ -n "$rel" ] || continue
+    src="$source_repo/$rel"
+    if [ ! -f "$src" ]; then
+      missing_source+=("$rel")
+    elif [ ! -f "$installed" ]; then
+      missing_installed+=("$rel")
+    elif ! cmp -s "$src" "$installed"; then
+      stale+=("$rel")
+    fi
+  done <<< "$rows"
+
+  if [ "${#stale[@]}" -eq 0 ] \
+    && [ "${#missing_installed[@]}" -eq 0 ] \
+    && [ "${#missing_source[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "${#stale[@]}" -gt 0 ]; then
+    echo "episodic-memory: installed Claude hooks differ from source repo: $(_em_join_list "${stale[@]}")"
+  fi
+  if [ "${#missing_installed[@]}" -gt 0 ]; then
+    echo "episodic-memory: installed Claude hooks are missing: $(_em_join_list "${missing_installed[@]}")"
+  fi
+  if [ "${#missing_source[@]}" -gt 0 ]; then
+    echo "episodic-memory: hook freshness manifest references missing source files: $(_em_join_list "${missing_source[@]}")"
+  fi
+  echo "episodic-memory: no files were overwritten. Inspect the diff or opt in with:"
+  echo "episodic-memory: node \"$source_repo/install.mjs\" --tool claude-code --project \"$CWD\" --install-hooks --install-hooks-force"
+}
+
+warn_hook_freshness
 
 # Soft-fail if em-recall isn't installed — sessions without episodic-memory
 # should still start cleanly.

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# episodic-memory-hook-version: 2026-05-08.1
 # command-classifier.sh — Quote/heredoc-aware Bash command classifier.
 #
 # Closes #86 PR-B + #89 + #101 via a shared helper. Replaces ad-hoc regex

--- a/hooks/lib/repo-root.sh
+++ b/hooks/lib/repo-root.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# episodic-memory-hook-version: 2026-05-08.1
 # repo-root.sh — Resolve the canonical repo root for marker-path resolution.
 #
 # Mirrors scripts/lib/local-dir.mjs (PR #105 / #85 algorithm). Source from a

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# episodic-memory-hook-version: 2026-05-08.1
 # plan-gate.sh — PreToolUse hook
 #
 # Blocks write tools while .claude/.plan-approval-pending exists in the

--- a/hooks/stop-gate.sh
+++ b/hooks/stop-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+# episodic-memory-hook-version: 2026-05-08.1
 # stop-gate.sh — Stop / SubagentStop hook for bp-001 wrap-up enforcement.
 #
 # Closes shape-4 docs-only-summarize-as-done hole (issue #128). When the

--- a/install.mjs
+++ b/install.mjs
@@ -460,6 +460,59 @@ function writeJSONAtomic(filePath, obj) {
   fs.renameSync(tmp, filePath)
 }
 
+function writeJSONAtomicIfChanged(filePath, obj) {
+  const next = JSON.stringify(obj, null, 2)
+  if (fs.existsSync(filePath) && fs.readFileSync(filePath, 'utf8') === next) {
+    return false
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const tmp = filePath + '.tmp'
+  fs.writeFileSync(tmp, next, 'utf8')
+  fs.renameSync(tmp, filePath)
+  return true
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+function hookVersion(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8')
+  const m = text.match(/^# episodic-memory-hook-version:\s*(.+)$/m)
+  return m ? m[1].trim() : null
+}
+
+function buildHookFreshnessManifest(hookSpecs, libFiles, userHooksDir, userHooksLibDir) {
+  const filesByRelativePath = new Map()
+  const add = (relativePath, installedPath) => {
+    const sourcePath = path.join(REPO_DIR, relativePath)
+    if (!fs.existsSync(sourcePath)) return
+    const installedExists = fs.existsSync(installedPath)
+    filesByRelativePath.set(relativePath, {
+      relative_path: relativePath,
+      installed_path: installedPath,
+      source_sha256: sha256File(sourcePath),
+      installed_sha256: installedExists ? sha256File(installedPath) : null,
+      source_version: hookVersion(sourcePath)
+    })
+  }
+
+  for (const spec of hookSpecs) {
+    add(path.join('hooks', spec.file), path.join(userHooksDir, spec.file))
+  }
+  for (const file of libFiles) {
+    add(path.join('hooks', 'lib', file), path.join(userHooksLibDir, file))
+  }
+
+  return {
+    schema_version: 1,
+    source_repo: REPO_DIR,
+    hooks_dir: userHooksDir,
+    files: [...filesByRelativePath.values()].sort((a, b) =>
+      a.relative_path.localeCompare(b.relative_path))
+  }
+}
+
 function entryReferencesSubstring(entry, substring) {
   if (entry.command && entry.command.includes(substring)) return true
   if (Array.isArray(entry.hooks)) {
@@ -594,11 +647,12 @@ if (installHooks) {
     // lib at runtime and fail loud (or worse, silently behave wrong if user's
     // divergent lib is incomplete).
     const libResults = {}
+    let hookLibFiles = []
     let anyLibSkippedDivergent = false
     if (fs.existsSync(REPO_HOOKS_LIB)) {
       fs.mkdirSync(userHooksLibDir, { recursive: true })
-      const libFiles = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh'))
-      for (const file of libFiles) {
+      hookLibFiles = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh')).sort()
+      for (const file of hookLibFiles) {
         const src = path.join(REPO_HOOKS_LIB, file)
         const dst = path.join(userHooksLibDir, file)
         const result = installHookFile(src, dst, installHooksForce)
@@ -799,6 +853,13 @@ if (installHooks) {
 
     writeJSONAtomic(settingsPath, settings)
     if (touched.settings.length > 0) touched.hooks.push(settingsPath)
+
+    const manifestPath = path.join(GLOBAL_DIR, 'hook-install.json')
+    const manifest = buildHookFreshnessManifest(hookSpecs, hookLibFiles, userHooksDir, userHooksLibDir)
+    if (writeJSONAtomicIfChanged(manifestPath, manifest)) {
+      console.log(`Wrote hook freshness manifest: ${manifestPath}`)
+      touched.hooks.push(manifestPath)
+    }
 
     // 5d. Consent legibility (Codex non-blocking guidance): list everything
     // touched so the user can audit the install.

--- a/tests/test-em-recall-sessionstart.sh
+++ b/tests/test-em-recall-sessionstart.sh
@@ -30,6 +30,11 @@ run_hook() {
   HOME="$TEST_HOME" bash -c "echo '{\"cwd\": \"$cwd\"}' | bash '$HOOK'" 2>/dev/null
 }
 
+run_hook_capture() {
+  local cwd="${1:-$TEST_DIR}"
+  HOME="$TEST_HOME" bash -c "echo '{\"cwd\": \"$cwd\"}' | bash '$HOOK'" 2>&1
+}
+
 assert_exit_zero() {
   local test_name="$1"
   local cwd="${2:-$TEST_DIR}"
@@ -161,6 +166,94 @@ if [ "$REPO_ROOT_BEFORE" = "$REPO_ROOT_AFTER" ]; then
 else
   echo "  ✗ 7. Hook polluted REPO_ROOT (regression of #63):"
   echo "    diff: $(diff <(echo "$REPO_ROOT_BEFORE") <(echo "$REPO_ROOT_AFTER"))"
+  ((failed++))
+fi
+
+# ============================================================================
+echo ""
+echo "--- #103 hook freshness warnings ---"
+# ============================================================================
+FRESH_SRC="$TEST_DIR/fresh-source-repo"
+FRESH_INSTALLED="$TEST_HOME/.claude/hooks"
+mkdir -p "$FRESH_SRC/hooks/lib" "$FRESH_INSTALLED/lib" "$TEST_HOME/.episodic-memory"
+cp "$REPO_ROOT/hooks/plan-gate.sh" "$FRESH_SRC/hooks/plan-gate.sh"
+cp "$REPO_ROOT/hooks/em-recall-sessionstart.sh" "$FRESH_SRC/hooks/em-recall-sessionstart.sh"
+cp "$REPO_ROOT/hooks/lib/command-classifier.sh" "$FRESH_SRC/hooks/lib/command-classifier.sh"
+cp "$FRESH_SRC/hooks/plan-gate.sh" "$FRESH_INSTALLED/plan-gate.sh"
+cp "$FRESH_SRC/hooks/em-recall-sessionstart.sh" "$FRESH_INSTALLED/em-recall-sessionstart.sh"
+cp "$FRESH_SRC/hooks/lib/command-classifier.sh" "$FRESH_INSTALLED/lib/command-classifier.sh"
+
+cat > "$TEST_HOME/.episodic-memory/hook-install.json" <<EOF
+{
+  "schema_version": 1,
+  "source_repo": "$FRESH_SRC",
+  "hooks_dir": "$FRESH_INSTALLED",
+  "files": [
+    {
+      "relative_path": "hooks/plan-gate.sh",
+      "installed_path": "$FRESH_INSTALLED/plan-gate.sh",
+      "source_sha256": "unused-in-runtime",
+      "source_version": "2026-05-08.1"
+    },
+    {
+      "relative_path": "hooks/em-recall-sessionstart.sh",
+      "installed_path": "$FRESH_INSTALLED/em-recall-sessionstart.sh",
+      "source_sha256": "unused-in-runtime",
+      "source_version": "2026-05-08.1"
+    },
+    {
+      "relative_path": "hooks/lib/command-classifier.sh",
+      "installed_path": "$FRESH_INSTALLED/lib/command-classifier.sh",
+      "source_sha256": "unused-in-runtime",
+      "source_version": "2026-05-08.1"
+    }
+  ]
+}
+EOF
+
+output="$(run_hook_capture)"
+if ! echo "$output" | grep -q "hook freshness warning" \
+  && ! echo "$output" | grep -q "installed Claude hooks differ"; then
+  echo "  ✓ 10. Current installed hooks are quiet"
+  ((passed++))
+else
+  echo "  ✗ 10. Current installed hooks produced a freshness warning"
+  echo "    output: $output"
+  ((failed++))
+fi
+
+printf '\n# local edit without version bump\n' >> "$FRESH_INSTALLED/plan-gate.sh"
+output="$(run_hook_capture)"
+if echo "$output" | grep -q "hooks/plan-gate.sh" \
+  && echo "$output" | grep -q -- "--install-hooks-force"; then
+  echo "  ✓ 11. Manual installed hook edit is reported without overwrite"
+  ((passed++))
+else
+  echo "  ✗ 11. Manual installed hook edit was not reported clearly"
+  echo "    output: $output"
+  ((failed++))
+fi
+
+cp "$FRESH_SRC/hooks/plan-gate.sh" "$FRESH_INSTALLED/plan-gate.sh"
+printf '\n# local lib edit without version bump\n' >> "$FRESH_INSTALLED/lib/command-classifier.sh"
+output="$(run_hook_capture)"
+if echo "$output" | grep -q "hooks/lib/command-classifier.sh"; then
+  echo "  ✓ 12. Managed hook lib drift is reported"
+  ((passed++))
+else
+  echo "  ✗ 12. Managed hook lib drift was not reported"
+  echo "    output: $output"
+  ((failed++))
+fi
+
+mv "$FRESH_SRC" "$FRESH_SRC.moved"
+output="$(run_hook_capture)"
+if echo "$output" | grep -q "source repo unavailable"; then
+  echo "  ✓ 13. Missing source repo is reported"
+  ((passed++))
+else
+  echo "  ✗ 13. Missing source repo was not reported"
+  echo "    output: $output"
   ((failed++))
 fi
 

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -86,6 +86,18 @@ assert_eq "T1b4 hooks/lib/repo-root.sh installed (Session 1)" "true" "$r"
 HOME="$TEST_HOME" bash -c "source $TEST_HOME/.claude/hooks/lib/command-classifier.sh && type classify_command >/dev/null 2>&1" && r=true || r=false
 assert_eq "T1b5 installed lib sources successfully and exports classify_command" "true" "$r"
 
+[ -f "$TEST_HOME/.episodic-memory/hook-install.json" ] && r=true || r=false
+assert_eq "T1b6 hook freshness manifest written (#103)" "true" "$r"
+
+manifest_source=$(jq -r '.source_repo' "$TEST_HOME/.episodic-memory/hook-install.json")
+assert_eq "T1b7 hook freshness manifest records source repo (#103)" "$REPO_ROOT" "$manifest_source"
+
+managed_count=$(jq '[.files[]? | select(.relative_path | test("^hooks/.*\\.sh$"))] | length' "$TEST_HOME/.episodic-memory/hook-install.json")
+assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "6" "$managed_count"
+
+pg_manifest=$(jq -r '.files[] | select(.relative_path == "hooks/plan-gate.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
+assert_eq "T1b9 hook freshness manifest records plan-gate install path (#103)" "$TEST_HOME/.claude/hooks/plan-gate.sh" "$pg_manifest"
+
 cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T1c PreToolUse contains exactly one checkpoint-gate entry" "1" "$cg_count"
 


### PR DESCRIPTION
## Summary

Fixes #103 by adding a hook freshness manifest during `install.mjs --install-hooks` and checking it from the installed SessionStart hook.

The issue was that user-level Claude hooks under `~/.claude/hooks/` could become stale after repo hook changes. Re-running install manually worked, but there was no SessionStart-time signal that installed hooks no longer matched the source repo.

## Changes

- Write `~/.episodic-memory/hook-install.json` with the source repo path, managed hook/lib paths, source hashes, installed hashes, and human-readable hook versions.
- Add SessionStart-time freshness checks that compare installed hook/lib bytes against the current source repo files.
- Warn clearly when installed hooks differ, installed hooks are missing, source files are missing, or the source repo has moved.
- Preserve the no-silent-overwrite behavior: warnings point to `--install-hooks-force`, but SessionStart does not modify files.
- Add version stamp comments to managed hook and hook-lib files for human diagnostics.
- Add regression coverage for quiet/current state, manual installed edits, hook-lib drift, missing source repo, and manifest creation.

## Verification

- `bash tests/test-install-hooks.sh` -> 65/65
- `bash tests/test-em-recall-sessionstart.sh` -> 13/13
- `bash tests/test-plan-gate.sh` -> 34/34
- `bash tests/test-checkpoint-gate.sh` -> 103/103
- `bash tests/test-stop-gate.sh` -> 24/24
- `bash -n hooks/em-recall-sessionstart.sh hooks/checkpoint-gate.sh hooks/plan-gate.sh hooks/stop-gate.sh hooks/lib/command-classifier.sh hooks/lib/repo-root.sh tests/test-em-recall-sessionstart.sh tests/test-install-hooks.sh`
- `node --check install.mjs`
- `git diff --check`

## Review Notes

BP-1 audit completed before PR creation. The main process miss was that I did not emit the literal pre-implementation `Rule 18 checkpoint` block before editing; implementation review, 8-axis review, code review, and verification were completed before commit/PR.

Bootstrap caveat: users need to install this updated SessionStart hook once before future hook drift can be detected at SessionStart.