### PR TITLE
feat: migrate Rule 18 markers to .checkpoints/ to escape sensitive-file guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,16 @@ node_modules/
 .episodic-memory/
 
 # Claude Code runtime markers (managed by hooks, never committed)
+# 2026-05-09 .checkpoints/ migration: marker writes now land at .checkpoints/
+# instead of .claude/. Both roots are kept in this ignore set during burn-in.
+.checkpoints/
+.checkpoints-migration-roots
 .claude/.pre-checkpoint-done
 .claude/.post-checkpoint-done
 .claude/.checkpoint-required
 .claude/.post-checkpoint-required
 .claude/.plan-approval-pending
+.claude/.session-baseline
 .claude/settings.local.json
 
 # Per-session scratch (mining staging, codex requests/replies, etc.)

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -377,7 +377,7 @@ AI:   ⚠️ Pre-flight warning: bp-001 (implementation workflow) was
 AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
 
       "Checkpoint required. Write the Rule 18 pre-implementation
-      checkpoint block to .claude/.pre-checkpoint-done before write
+      checkpoint block to .checkpoints/.pre-checkpoint-done before write
       tools are unblocked."
 
       I'll print my implementation plan, get your approval, then
@@ -387,14 +387,20 @@ AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
 **Why this exists:** The checkpoint enforcement gate (RFC-002 Phase 3b) is a PreToolUse hook that prevents the AI from skipping the plan → review → approval steps of the implementation workflow (bp-001). It's the mechanical version of the rules described in Scenario 11 — instead of relying on the AI to remember, the hook physically blocks edits until a checkpoint is recorded.
 
 **Two gates:**
-- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until `.claude/.pre-checkpoint-done` exists with the plan summary.
+- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until `.checkpoints/.pre-checkpoint-done` exists with the plan summary.
 - **Push-gate** — blocks `git push` until E2E testing and bug-logging steps are complete.
+
+**Marker location (.checkpoints/ migration, 2026-05-09):** Marker writes
+land at `<repo-root>/.checkpoints/.X` (PRIMARY); reads also honor
+`<repo-root>/.claude/.X` (LEGACY) during burn-in. Markers under `.claude/`
+trigger Claude Code's built-in sensitive-file prompt; the `.checkpoints/`
+relocation escapes it.
 
 **To clear the gate (intentionally):**
 
 ```bash
 # After the AI has shown its plan and you've approved it:
-echo "ok" > .claude/.pre-checkpoint-done
+echo "ok" > .checkpoints/.pre-checkpoint-done
 ```
 
 **To opt out entirely:** Don't pass `--install-hooks` during install, or remove the hook entries from `~/.claude/settings.json`.

--- a/docs/rfcs/RFC-002-learning-loop.md
+++ b/docs/rfcs/RFC-002-learning-loop.md
@@ -165,6 +165,20 @@ Add a violation-aware recall pass:
 
 ### Phase 3b: Checkpoint Enforcement Gate
 
+> **2026-05-09 .checkpoints/ migration note:** Marker WRITES under
+> `<repo>/.claude/.X` triggered Claude Code's built-in sensitive-file
+> guard, which blocked unattended Rule 18 marker writes (especially under
+> scheduled remote agents). The marker set has migrated to
+> `<repo>/.checkpoints/.X` (PRIMARY); reads honor BOTH `.checkpoints/`
+> and `.claude/` during burn-in via the shared
+> `hooks/lib/marker-paths.sh` + `scripts/lib/marker-paths.mjs` helpers.
+> Cleanup sweeps both roots until the legacy fallback is removed in a
+> follow-up commit. Doc references below to `.claude/.X` paths describe
+> the spec at the time it was written; runtime paths are now under
+> `.checkpoints/`. See `tools/migration-cutover.mjs` and
+> `tools/migration-sweep.mjs` for the parity check + state-based exit
+> gate.
+
 **Motivation:** Across 3+ sessions, bp-001 was violated 6+ times despite documentation in CLAUDE.md, bp-001 v2.0.0, MEMORY.md, and session handoffs. The only mechanism that ever prevented a violation was `plan-gate.sh` (a PreToolUse hook). Documentation-based enforcement fails under momentum — only mechanical gates work (bp-010). Two distinct failure modes observed: (1) skipping the pre-implementation checkpoint before coding starts, and (2) skipping E2E testing + bug logging before pushing — steps 8 and 9 are skipped 100% of the time because they come after the work "feels done."
 
 **New hook: `checkpoint-gate.sh`** — PreToolUse hook, follows `plan-gate.sh` architecture.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -18,8 +18,23 @@ Phase 3b (RFC-002) introduces user-level hooks that need to be installed into `~
 | Hook | Event | Purpose |
 |------|-------|---------|
 | `checkpoint-gate.sh` | PreToolUse | RFC-002 Phase 3b two-gate write/push enforcement |
-| `plan-gate.sh` | PreToolUse | Blocks write tools while `.claude/.plan-approval-pending` exists; allows read-only tools (canonical list lives in the `case` at `hooks/plan-gate.sh` — do not duplicate here). Issue #86 PR-A canonicalized this from a previously user-maintained file. |
+| `plan-gate.sh` | PreToolUse | Blocks write tools while `.plan-approval-pending` exists at the repo root; allows read-only tools (canonical list lives in the `case` at `hooks/plan-gate.sh` — do not duplicate here). Issue #86 PR-A canonicalized this from a previously user-maintained file. |
 | `em-recall-sessionstart.sh` | SessionStart | Mechanically invokes em-recall so its activator can arm checkpoint-gate before any user interaction |
+| `stop-gate.sh` | Stop / SubagentStop | Blocks turn-end when post-checkpoint required but absent (#128). |
+| `lib/marker-paths.sh` | sourced | Shared marker-path constants and dual-root helpers (2026-05-09 .checkpoints/ migration) |
+| `lib/repo-root.sh` | sourced | `resolve_repo_root` git-common-dir walker (PR #105 / #85) |
+| `lib/command-classifier.sh` | sourced | Quote/heredoc-aware Bash classifier (#86 PR-B / #89 / #101) |
+
+## Marker storage (.checkpoints/ migration, 2026-05-09)
+
+Marker WRITES land at `<repo-root>/.checkpoints/.X` (PRIMARY); reads check
+PRIMARY first then fall back to `<repo-root>/.claude/.X` (LEGACY) until the
+fallback branch is removed. CLEANUP sweeps BOTH roots until then. Migration
+exists because Claude Code's built-in sensitive-file guard prompts on every
+Write to a `.X` basename inside any `.claude/` segment, regardless of
+allowlist. See `tools/migration-cutover.mjs` and `tools/migration-sweep.mjs`
+for the install-parity check and burn-in exit gate that protect the
+fallback-removal commit.
 
 ## Installation
 

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# episodic-memory-hook-version: 2026-05-08.1
+# episodic-memory-hook-version: 2026-05-09.1
 # checkpoint-gate.sh — RFC-002 Phase 3b PreToolUse hook.
 #
 # Session 1 rewrite (#86 PR-B / #89 / #101): replaces the regex-based
@@ -9,60 +9,92 @@ set -e
 # git-push / gh-pr-create regex (lines ~125-141) with the shared classifier
 # from hooks/lib/command-classifier.sh.
 #
-# Two gates with shared marker state in <repo-root>/.claude/:
+# 2026-05-09 .checkpoints/ migration: marker WRITES now go to
+# <repo-root>/.checkpoints/ via hooks/lib/marker-paths.sh, while READS check
+# .checkpoints/ first then fall back to .claude/ (until the legacy branch is
+# removed in a follow-up commit). CLEANUP sweeps BOTH roots. Closes the
+# Claude Code sensitive-file-guard prompt class for marker writes.
+#
+# Two gates with shared marker state:
 #
 #   pre-checkpoint:
 #     Blocks Edit/Write/MultiEdit/Bash/NotebookEdit when .checkpoint-required
-#     exists AND .pre-checkpoint-done is missing/empty. Activator:
-#     em-recall.mjs touches .checkpoint-required when bp-001 violations
-#     surface in pre-flight (Phase 3, em-recall.mjs:347-369).
+#     exists (either root) AND .pre-checkpoint-done is missing/empty (both
+#     roots). Activator: em-recall.mjs touches .checkpoint-required when
+#     bp-001 violations surface in pre-flight.
 #
 #   push-gate:
 #     Blocks Bash classified as push_or_pr_create OR shared_write that mutates
-#     external GitHub state when .post-checkpoint-required exists AND
-#     .post-checkpoint-done is missing/empty. Allowed pushes clean all 4
-#     markers (task complete).
+#     external GitHub state when .post-checkpoint-required exists (either
+#     root) AND .post-checkpoint-done is missing/empty (both roots). Allowed
+#     pushes clean all task-signal markers across BOTH roots.
 #
-# .post-checkpoint-required is armed on every allowed write that passed the
-# pre-gate (idempotent touch).
+# .post-checkpoint-required is armed (always at PRIMARY) on every allowed
+# write that passed the pre-gate (idempotent touch).
 #
-# Marker-write allowlist (deadlock prevention) is now classifier-driven:
+# Marker-write allowlist (deadlock prevention) is classifier-driven:
 # Bash classified as marker_write whose TARGET is one of the repo-root
-# checkpoint markers passes the pre-gate iff:
-#   - .pre-checkpoint-done write: requires .checkpoint-required exists AND
-#     .pre-checkpoint-done is missing/empty (writing into the gate's expected
-#     state, not bypassing it).
+# checkpoint markers AT EITHER ROOT passes the pre-gate iff:
+#   - .pre-checkpoint-done write: requires .checkpoint-required exists
+#     (either root) AND .pre-checkpoint-done is missing/empty (both roots).
 #   - .post-checkpoint-done write: requires .post-checkpoint-required exists
 #     AND .post-checkpoint-done is missing/empty.
 # Cross-gate invariant (Codex ...3503 P1): checkpoint marker writes are
-# blocked while the repo-root .plan-approval-pending marker exists. Both
-# gates independently enforce the invariant; do not rely on Claude hook
-# order.
+# blocked while .plan-approval-pending exists (either root). Both gates
+# independently enforce.
 
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-# Source classifier + repo-root resolver. Use BASH_SOURCE for symlink safety.
+# Source classifier + repo-root resolver + shared marker paths. Use
+# BASH_SOURCE for symlink safety.
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 LIB_DIR="$HOOK_DIR/lib"
-if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ]; then
-  echo '{"decision": "block", "reason": "checkpoint-gate.sh: hooks/lib/ not found alongside hook. Re-run install.mjs --install-hooks."}'
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ]; then
+  echo '{"decision": "block", "reason": "checkpoint-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh). Re-run install.mjs --install-hooks."}'
   exit 0
 fi
 # shellcheck disable=SC1091
 source "$LIB_DIR/repo-root.sh"
 # shellcheck disable=SC1091
 source "$LIB_DIR/command-classifier.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/marker-paths.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
-MARKER_DIR="$REPO_ROOT/.claude"
-PRE_REQ="$MARKER_DIR/.checkpoint-required"
-PRE_DONE="$MARKER_DIR/.pre-checkpoint-done"
-POST_REQ="$MARKER_DIR/.post-checkpoint-required"
-POST_DONE="$MARKER_DIR/.post-checkpoint-done"
-PLAN_PENDING="$MARKER_DIR/.plan-approval-pending"
+
+# Canonical WRITE paths (always primary). Used in block-message paths so the
+# agent knows where to write the checkpoint block.
+PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
+POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
+PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
+
+PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"
+LEGACY_DIR="$REPO_ROOT/$LEGACY_MARKER_DIR"
+
+# ---------------------------------------------------------------------------
+# Dual-root marker helpers (burn-in only; collapse to primary-only when the
+# fallback branch is removed).
+# ---------------------------------------------------------------------------
+# marker_exists <basename> — true if the marker exists at either root.
+marker_exists() {
+  [ -e "$PRIMARY_DIR/$1" ] || [ -e "$LEGACY_DIR/$1" ]
+}
+# marker_nonempty <basename> — true if either root's copy is non-empty.
+marker_nonempty() {
+  [ -s "$PRIMARY_DIR/$1" ] || [ -s "$LEGACY_DIR/$1" ]
+}
+# marker_basename_for_target <abs-path> — echoes the basename if the path
+# is under either marker dir, else echoes nothing (caller branches on empty).
+marker_basename_for_target() {
+  local target="$1"
+  case "$target" in
+    "$PRIMARY_DIR"/*|"$LEGACY_DIR"/*) basename "$target" ;;
+    *) printf '' ;;
+  esac
+}
 
 # Read-only tools — always allowed
 case "$TOOL_NAME" in
@@ -72,22 +104,20 @@ case "$TOOL_NAME" in
 esac
 
 # Helper: emit a block decision.
-# Reason strings include the ABSOLUTE marker path (#146 B1). Worktree-cwd
-# sessions resolve relative paths against the worktree, but markers live at
-# the main-repo .claude/. Without the absolute path the agent guesses wrong
-# and deadlocks (issue #146 live reproducer comment 4378971459).
+# Reason strings include the canonical WRITE path (always primary —
+# .checkpoints/) so the agent writes to the new location.
 _block_pre() {
-  jq -nc --arg path "$PRE_DONE" \
+  jq -nc --arg path "$PRE_DONE_W" \
     '{decision: "block", reason: ("Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to " + $path + " (must be non-empty) before write tools are unblocked. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
 _block_post() {
-  jq -nc --arg path "$POST_DONE" \
+  jq -nc --arg path "$POST_DONE_W" \
     '{decision: "block", reason: ("Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to " + $path + " (must be non-empty) before pushing. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
 _block_plan_pending() {
-  jq -nc --arg path "$PLAN_PENDING" \
+  jq -nc --arg path "$PLAN_PENDING_W" \
     '{decision: "block", reason: ("Plan approval pending. Checkpoint marker writes are blocked while " + $path + " exists. Approve the plan first. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
@@ -112,28 +142,34 @@ if [ "$TOOL_NAME" = "Bash" ]; then
   # marker_write deadlock-prevention allowlist. Only allow when the gate's
   # state expects that specific marker write. All other marker_write Bash
   # falls through to the pre-gate as a normal write.
+  #
+  # Dual-root acceptance: TARGET is an absolute path that may point at
+  # either .checkpoints/.X (new canonical) or .claude/.X (legacy fallback,
+  # tolerated during burn-in for backward compat).
   if [ "$LABEL" = "marker_write" ]; then
+    TARGET_BN="$(marker_basename_for_target "$TARGET")"
+
     # Cross-gate invariant: checkpoint marker writes are blocked while
     # .plan-approval-pending exists (Codex ...3503 P1).
-    if [ -f "$PLAN_PENDING" ]; then
-      if [ "$TARGET" = "$PLAN_PENDING" ]; then
+    if marker_exists .plan-approval-pending; then
+      if [ "$TARGET_BN" = ".plan-approval-pending" ]; then
         # Allow plan-marker removal — plan-gate.sh is what cares about this.
         exit 0
       fi
       _block_plan_pending
     fi
-    case "$TARGET" in
-      "$PRE_DONE")
-        if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
+    case "$TARGET_BN" in
+      .pre-checkpoint-done)
+        if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
           exit 0
         fi
         ;;
-      "$POST_DONE")
-        if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+      .post-checkpoint-done)
+        if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
           exit 0
         fi
         ;;
-      "$PLAN_PENDING")
+      .plan-approval-pending)
         exit 0
         ;;
     esac
@@ -155,22 +191,23 @@ case "$TOOL_NAME" in
       REST="${RESULT#*	}"
       TARGET="${REST%%	*}"
       if [ "$LABEL" = "marker_write" ]; then
+        TARGET_BN="$(marker_basename_for_target "$TARGET")"
         # Cross-gate invariant
-        if [ -f "$PLAN_PENDING" ] && [ "$TARGET" != "$PLAN_PENDING" ]; then
+        if marker_exists .plan-approval-pending && [ "$TARGET_BN" != ".plan-approval-pending" ]; then
           _block_plan_pending
         fi
-        case "$TARGET" in
-          "$PRE_DONE")
-            if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
+        case "$TARGET_BN" in
+          .pre-checkpoint-done)
+            if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
               exit 0
             fi
             ;;
-          "$POST_DONE")
-            if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+          .post-checkpoint-done)
+            if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
               exit 0
             fi
             ;;
-          "$PLAN_PENDING")
+          .plan-approval-pending)
             exit 0
             ;;
         esac
@@ -179,7 +216,7 @@ case "$TOOL_NAME" in
     ;;
 esac
 
-if [ -f "$PRE_REQ" ] && [ ! -s "$PRE_DONE" ]; then
+if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
   _block_pre
 fi
 
@@ -187,7 +224,7 @@ fi
 # Push-gate: only fires for Bash classified as push_or_pr_create.
 # ---------------------------------------------------------------------------
 if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
-  if [ -f "$POST_REQ" ] && [ ! -s "$POST_DONE" ]; then
+  if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
     _block_post
   fi
   # Audit P1: marker cleanup is gated on plan-gate not pending. PreToolUse
@@ -196,20 +233,30 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   # tool will not actually run). Cleanup only when plan-gate is clear —
   # in that case, push_or_pr_create has reached the user's intended
   # task-complete moment.
-  if [ ! -f "$PLAN_PENDING" ]; then
-    rm -f "$PRE_REQ" "$PRE_DONE" "$POST_REQ" "$POST_DONE" 2>/dev/null || true
+  #
+  # Dual-root sweep (Codex round-1 F2): rm at BOTH .checkpoints/ and
+  # .claude/ until fallback is removed. Iteration over the shared
+  # TASK_SIGNAL_MARKERS array keeps the cleanup set in lockstep with the
+  # carve-out's marker set in em-recall.mjs.
+  if ! marker_exists .plan-approval-pending; then
+    for _m in "${CHECKPOINT_CLEANUP_MARKERS[@]}"; do
+      rm -f "$PRIMARY_DIR/$_m" "$LEGACY_DIR/$_m" 2>/dev/null || true
+    done
+    unset _m
   fi
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
-# Allowed write — arm post-tracking if pre-checkpoint was satisfied
+# Allowed write — arm post-tracking if pre-checkpoint was satisfied.
+# Always armed at PRIMARY (write-side never touches legacy); dual-root
+# cleanup later removes both.
 # ---------------------------------------------------------------------------
 case "$TOOL_NAME" in
   Edit|Write|MultiEdit|Bash|NotebookEdit)
-    if [ -f "$PRE_REQ" ] && [ -s "$PRE_DONE" ]; then
-      mkdir -p "$MARKER_DIR" 2>/dev/null || true
-      touch "$POST_REQ" 2>/dev/null || true
+    if marker_exists .checkpoint-required && marker_nonempty .pre-checkpoint-done; then
+      ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
+      touch "$(write_marker_path "$REPO_ROOT" .post-checkpoint-required)" 2>/dev/null || true
     fi
     ;;
 esac

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -86,14 +86,23 @@ marker_exists() {
 marker_nonempty() {
   [ -s "$PRIMARY_DIR/$1" ] || [ -s "$LEGACY_DIR/$1" ]
 }
-# marker_basename_for_target <abs-path> — echoes the basename if the path
-# is under either marker dir, else echoes nothing (caller branches on empty).
+# marker_basename_for_target <abs-path> — echoes the basename if the TARGET
+# matches an EXACT authoritative marker path at either root (primary or
+# legacy). Echoes nothing for descendants like
+# `<root>/.checkpoints/sub/.pre-checkpoint-done` so the marker_write
+# allowlist can't be bypassed via path-traversal-shaped names. Codex
+# round-1 F1 (path: hooks/checkpoint-gate.sh:91-95): the prior prefix
+# match accepted any descendant with a marker basename, mirroring the
+# pre-fix #146 deadlock class.
 marker_basename_for_target() {
-  local target="$1"
-  case "$target" in
-    "$PRIMARY_DIR"/*|"$LEGACY_DIR"/*) basename "$target" ;;
-    *) printf '' ;;
-  esac
+  local target="$1" m
+  for m in .pre-checkpoint-done .post-checkpoint-done .plan-approval-pending; do
+    if [ "$target" = "$PRIMARY_DIR/$m" ] || [ "$target" = "$LEGACY_DIR/$m" ]; then
+      printf '%s' "$m"
+      return 0
+    fi
+  done
+  printf ''
 }
 
 # Read-only tools — always allowed

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -12,13 +12,27 @@
 # `.checkpoints/` first, fallback `.claude/` second) until the legacy
 # branch is removed in a follow-up commit.
 #
-# Six markers in scope (5 task-signal + 1 baseline):
-#   .checkpoint-required          (activator, armed by em-recall.mjs)
-#   .post-checkpoint-required     (activator, armed by checkpoint-gate.sh)
-#   .plan-approval-pending        (Rule 8 plan-approval gate)
-#   .pre-checkpoint-done          (Rule 18 pre-impl checkpoint)
-#   .post-checkpoint-done         (Rule 18 post-impl checkpoint)
-#   .session-baseline             (stop-gate carve-out reference mtime)
+# Six markers in migration scope:
+#
+#   Marker name                    | Set membership
+#   ---                            | ---
+#   .checkpoint-required           | TASK_SIGNAL + CHECKPOINT_CLEANUP
+#   .post-checkpoint-required      | TASK_SIGNAL + CHECKPOINT_CLEANUP
+#   .plan-approval-pending         | TASK_SIGNAL only (not cleared by push)
+#   .pre-checkpoint-done           | CHECKPOINT_CLEANUP only
+#   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
+#   .session-baseline              | BASELINE only
+#
+# Set semantics:
+#   TASK_SIGNAL_MARKERS         3 markers — em-recall stop-gate carve-out
+#                               class (mid-session mtime > baseline = task
+#                               work in progress). Mirrors em-recall.mjs:97.
+#   CHECKPOINT_CLEANUP_MARKERS  4 markers — push-gate clears on successful
+#                               push (Codex round-1 F2: must sweep BOTH
+#                               .checkpoints/ AND .claude/ during burn-in).
+#                               Mirrors prior checkpoint-gate.sh:200.
+#   ALL_MIGRATED_MARKERS        6 names — full migration scope used by
+#                               tests, sweep tools, and SessionEnd cleanup.
 #
 # Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
 
@@ -26,20 +40,29 @@ PRIMARY_MARKER_DIR=".checkpoints"
 LEGACY_MARKER_DIR=".claude"
 BASELINE_NAME=".session-baseline"
 
-# Task-signal markers (per em-recall.mjs:97-101 + the two -done markers).
-# Used by stop-gate carve-out, push cleanup, SessionStart orphan-clear.
-# Bash 3.2 indexed array (no associative arrays per macOS portability lesson
-# 20260508-021131).
+# Task-signal markers — em-recall stop-gate carve-out class. Mirrors
+# em-recall.mjs:97-101 (TASK_SIGNAL_MARKERS in JS). Bash 3.2 indexed array
+# (no associative arrays per macOS portability lesson 20260508-021131).
 TASK_SIGNAL_MARKERS=(
   ".checkpoint-required"
   ".post-checkpoint-required"
   ".plan-approval-pending"
+)
+
+# Push-gate cleanup class — markers cleared on a successful push that has
+# satisfied the post-checkpoint. .plan-approval-pending is intentionally
+# NOT here (its lifecycle is plan-gate's marker_write allowance, not
+# checkpoint cleanup). Mirrors the prior checkpoint-gate.sh:200 list.
+CHECKPOINT_CLEANUP_MARKERS=(
+  ".checkpoint-required"
   ".pre-checkpoint-done"
+  ".post-checkpoint-required"
   ".post-checkpoint-done"
 )
 
-# All migrated markers = task-signal + baseline.
-ALL_MARKERS=(
+# Full migration scope = task-signal + done markers + baseline = 6 names.
+# Used by sweep tools and tests to validate completeness.
+ALL_MIGRATED_MARKERS=(
   ".checkpoint-required"
   ".post-checkpoint-required"
   ".plan-approval-pending"

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# episodic-memory-hook-version: 2026-05-09.1
+# marker-paths.sh — Shared marker-path constants and helpers.
+#
+# Mirrors scripts/lib/marker-paths.mjs (single source of truth split for
+# shell/node parity). Source from a hook and call the helpers below.
+#
+# Background: Claude Code's built-in sensitive-file guard prompts on Write
+# to any basename matching `.X` inside a `.claude/` segment, regardless of
+# allowlist. To escape the prompt, marker writes go to a sibling
+# `.checkpoints/` directory. Reads honor both during burn-in (primary
+# `.checkpoints/` first, fallback `.claude/` second) until the legacy
+# branch is removed in a follow-up commit.
+#
+# Six markers in scope (5 task-signal + 1 baseline):
+#   .checkpoint-required          (activator, armed by em-recall.mjs)
+#   .post-checkpoint-required     (activator, armed by checkpoint-gate.sh)
+#   .plan-approval-pending        (Rule 8 plan-approval gate)
+#   .pre-checkpoint-done          (Rule 18 pre-impl checkpoint)
+#   .post-checkpoint-done         (Rule 18 post-impl checkpoint)
+#   .session-baseline             (stop-gate carve-out reference mtime)
+#
+# Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
+
+PRIMARY_MARKER_DIR=".checkpoints"
+LEGACY_MARKER_DIR=".claude"
+BASELINE_NAME=".session-baseline"
+
+# Task-signal markers (per em-recall.mjs:97-101 + the two -done markers).
+# Used by stop-gate carve-out, push cleanup, SessionStart orphan-clear.
+# Bash 3.2 indexed array (no associative arrays per macOS portability lesson
+# 20260508-021131).
+TASK_SIGNAL_MARKERS=(
+  ".checkpoint-required"
+  ".post-checkpoint-required"
+  ".plan-approval-pending"
+  ".pre-checkpoint-done"
+  ".post-checkpoint-done"
+)
+
+# All migrated markers = task-signal + baseline.
+ALL_MARKERS=(
+  ".checkpoint-required"
+  ".post-checkpoint-required"
+  ".plan-approval-pending"
+  ".pre-checkpoint-done"
+  ".post-checkpoint-done"
+  ".session-baseline"
+)
+
+# primary_marker_path <repo-root> <basename> → echoes <root>/.checkpoints/<basename>
+primary_marker_path() {
+  printf '%s/%s/%s' "$1" "$PRIMARY_MARKER_DIR" "$2"
+}
+
+# legacy_marker_path <repo-root> <basename> → echoes <root>/.claude/<basename>
+legacy_marker_path() {
+  printf '%s/%s/%s' "$1" "$LEGACY_MARKER_DIR" "$2"
+}
+
+# resolve_marker_read <repo-root> <basename> → echoes the primary path if it
+# exists, otherwise the legacy path if it exists, otherwise nothing (exit 1).
+# Used by readers that need a single-path semantic (e.g. `[ -s ]` checks).
+# Symlink-aware via -e (test against the link target). Callers that need
+# symlink-fail-closed semantics must re-check with lstat-equivalent (`[ -L ]`).
+resolve_marker_read() {
+  local primary legacy
+  primary="$(primary_marker_path "$1" "$2")"
+  legacy="$(legacy_marker_path "$1" "$2")"
+  if [ -e "$primary" ]; then
+    printf '%s' "$primary"
+    return 0
+  fi
+  if [ -e "$legacy" ]; then
+    printf '%s' "$legacy"
+    return 0
+  fi
+  return 1
+}
+
+# write_marker_path <repo-root> <basename> → echoes the primary path (always).
+# Use this for ALL writes. The legacy branch is read-only during burn-in.
+write_marker_path() {
+  primary_marker_path "$1" "$2"
+}
+
+# both_marker_paths <repo-root> <basename> → echoes primary then legacy on
+# separate lines. Use for cleanup (rm both) and orphan-clear sweeps that must
+# touch both roots until fallback removal.
+both_marker_paths() {
+  primary_marker_path "$1" "$2"
+  printf '\n'
+  legacy_marker_path "$1" "$2"
+  printf '\n'
+}
+
+# ensure_primary_dir <repo-root> → mkdir -p the primary marker directory.
+# Idempotent. Used before write_marker_path writes.
+ensure_primary_dir() {
+  mkdir -p "$1/$PRIMARY_MARKER_DIR" 2>/dev/null
+}

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-# episodic-memory-hook-version: 2026-05-08.1
+# episodic-memory-hook-version: 2026-05-09.1
 # plan-gate.sh — PreToolUse hook
 #
-# Blocks write tools while .claude/.plan-approval-pending exists in the
-# repo root. Read-only tools are always allowed (planning needs them).
+# Blocks write tools while .plan-approval-pending exists (at either root)
+# in the repo root. Read-only tools are always allowed (planning needs them).
+#
+# 2026-05-09 .checkpoints/ migration: marker WRITES go to
+# <repo-root>/.checkpoints/ via hooks/lib/marker-paths.sh; READS check
+# .checkpoints/ first then fall back to .claude/ until burn-in completes.
+# Marker REMOVAL is allowed at EITHER path during burn-in.
 #
 # Bash classification uses hooks/lib/command-classifier.sh (Session 1,
 # closes #86 PR-B). Replaces the prior regex-based marker-rm allowlist
@@ -16,8 +21,8 @@ set -e
 # Allowlist:
 #   - Read-only tools (always)
 #   - Bash with classifier label `read_only` (#89: ls, cat, git status, etc.)
-#   - Bash that classifies as `marker_write` whose TARGET is exactly
-#     repo-root .claude/.plan-approval-pending (deadlock prevention).
+#   - Bash that classifies as `marker_write` whose TARGET basename is
+#     .plan-approval-pending under either marker dir (deadlock prevention).
 #     Codex review ...3503: plan marker REMOVAL is the only plan-gate marker
 #     action allowed; checkpoint pre/post writes are NOT allowed by plan-gate.
 #
@@ -28,24 +33,30 @@ TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-# Source classifier + repo-root resolver. Use BASH_SOURCE so symlinked hook
-# invocations resolve correctly (Codex ...3503: $(dirname "$0") breaks under
-# macOS without coreutils readlink -f).
+# Source classifier + repo-root resolver + marker paths. Use BASH_SOURCE so
+# symlinked hook invocations resolve correctly (Codex ...3503: $(dirname
+# "$0") breaks under macOS without coreutils readlink -f).
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 LIB_DIR="$HOOK_DIR/lib"
-if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ]; then
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ]; then
   # Lib missing — fail loud rather than silently allowing
-  echo '{"decision": "block", "reason": "plan-gate.sh: hooks/lib/ not found alongside hook. Re-run install.mjs --install-hooks."}'
+  echo '{"decision": "block", "reason": "plan-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh). Re-run install.mjs --install-hooks."}'
   exit 0
 fi
 # shellcheck disable=SC1091
 source "$LIB_DIR/repo-root.sh"
 # shellcheck disable=SC1091
 source "$LIB_DIR/command-classifier.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/marker-paths.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
-MARKER="$REPO_ROOT/.claude/.plan-approval-pending"
-EXPECTED_MARKER_ABS="$MARKER"
+
+# Canonical write path (always primary). Used in the block-message reason
+# so the agent knows where to put a fresh marker if needed.
+PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
+PRIMARY_PATH="$REPO_ROOT/$PRIMARY_MARKER_DIR/.plan-approval-pending"
+LEGACY_PATH="$REPO_ROOT/$LEGACY_MARKER_DIR/.plan-approval-pending"
 
 # Read-only tools — always allowed.
 case "$TOOL_NAME" in
@@ -54,8 +65,10 @@ case "$TOOL_NAME" in
     ;;
 esac
 
-# If no marker, allow everything
-[ ! -f "$MARKER" ] && exit 0
+# If no marker at either root, allow everything.
+if [ ! -e "$PRIMARY_PATH" ] && [ ! -e "$LEGACY_PATH" ]; then
+  exit 0
+fi
 
 # Classifier-driven Bash gating
 if [ "$TOOL_NAME" = "Bash" ]; then
@@ -71,16 +84,21 @@ if [ "$TOOL_NAME" = "Bash" ]; then
       exit 0
       ;;
     marker_write)
-      # Only allow exact removal of the plan-approval marker.
-      # Codex ...3503 P1: target must equal repo-root .plan-approval-pending,
-      # not any other marker. Path traversal / symlink / cwd≠repo blocked
-      # by the equality check against the resolved repo-root path.
-      if [ "$TARGET" = "$EXPECTED_MARKER_ABS" ]; then
+      # Only allow exact removal/touch of the plan-approval marker at either
+      # root. Codex ...3503 P1: TARGET must equal one of the two marker
+      # paths, not any other marker. Path traversal / symlink / cwd≠repo
+      # blocked by the equality check against the resolved repo-root paths.
+      #
+      # Dual-root acceptance during burn-in: legacy `.claude/` rm targets
+      # are still allowed so cleanup of orphan markers works without flag
+      # changes.
+      if [ "$TARGET" = "$PRIMARY_PATH" ] || [ "$TARGET" = "$LEGACY_PATH" ]; then
         exit 0
       fi
       ;;
   esac
 fi
 
-# Marker exists — block
-echo '{"decision": "block", "reason": "Plan approval pending. Review the plan above and approve before implementation. To approve, say \"go\" or \"approved\". The .claude/.plan-approval-pending marker will be removed and implementation will proceed."}'
+# Marker exists — block.
+jq -nc --arg path "$PLAN_PENDING_W" \
+  '{decision: "block", reason: ("Plan approval pending. Review the plan above and approve before implementation. To approve, say \"go\" or \"approved\". The " + $path + " marker will be removed and implementation will proceed.")}'

--- a/install.mjs
+++ b/install.mjs
@@ -680,47 +680,14 @@ if (installHooks) {
       }
     }
 
-    // 5a. Hook specs (file → event + matcher + timeout + canonical command).
-    const hookSpecs = [
-      {
-        file: 'checkpoint-gate.sh',
-        event: 'PreToolUse',
-        matcher: 'Edit|Write|MultiEdit|Bash|NotebookEdit',
-        timeout: 5
-      },
-      // plan-gate.sh: no matcher — must run on every PreToolUse so the
-      // tool-name allowlist (read-only tools) is the sole filter for what
-      // bypasses the marker. Issue #86 (PR-A): canonicalized into the repo
-      // and registered by the installer; Bash command-level allowlisting
-      // is deferred to PR-B.
-      {
-        file: 'plan-gate.sh',
-        event: 'PreToolUse',
-        timeout: 5
-      },
-      {
-        file: 'em-recall-sessionstart.sh',
-        event: 'SessionStart',
-        timeout: 10
-      },
-      // stop-gate.sh: registered on both Stop AND SubagentStop. SubagentStop
-      // is the conversion of Stop for subagent contexts per
-      // claude-code-hooks-reference.md:409 — without explicit SubagentStop
-      // registration, subagent shape-4 (docs-only-summarize-as-done from
-      // inside a Skill / Plan / Explore agent) is uncovered. Issue #128.
-      // Phase 3b primitive; future RFC-003 Phase 2 subsumes into
-      // adapters/claude-code/capabilities/enforcement.mjs.
-      {
-        file: 'stop-gate.sh',
-        event: 'Stop',
-        timeout: 5
-      },
-      {
-        file: 'stop-gate.sh',
-        event: 'SubagentStop',
-        timeout: 5
-      }
-    ]
+    // 5a. Hook specs imported from scripts/lib/install-manifest.mjs (single
+    // source of truth shared with tools/migration-cutover.mjs). Closes
+    // Codex round-2 implementation attention point: avoid a second
+    // hardcoded copy list.
+    const { HOOK_SPECS } = await import(
+      new URL('./scripts/lib/install-manifest.mjs', import.meta.url).href
+    )
+    const hookSpecs = HOOK_SPECS
 
     // 5b. Copy hook files; track which got installed for registration eligibility.
     const fileResults = {} // spec.file → result

--- a/patterns/implementation-workflow.md
+++ b/patterns/implementation-workflow.md
@@ -62,7 +62,7 @@ Required visible block before the first Edit/Write in any Full or Light task:
 ```
 
 - This is documentation of intent (medium enforcement per bp-010)
-- Claude Code: backed by `plan-gate.sh` which hard-blocks Edit/Write when `.plan-approval-pending` exists (strong enforcement)
+- Claude Code: backed by `plan-gate.sh` which hard-blocks Edit/Write when `.plan-approval-pending` exists at the repo root (strong enforcement). 2026-05-09 `.checkpoints/` migration: marker writes go to `<repo>/.checkpoints/.plan-approval-pending` (PRIMARY); reads also honor `<repo>/.claude/.plan-approval-pending` (LEGACY) during burn-in.
 - Other tools: checkpoint block is the best available gate
 
 ## Post-implementation Checkpoint

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -20,6 +20,16 @@ import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
 import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
+import {
+  TASK_SIGNAL_MARKERS,
+  BASELINE_NAME,
+  primaryMarkerPath,
+  legacyMarkerPath,
+  resolveMarkerRead,
+  writeMarkerPath,
+  ensurePrimaryDir,
+  bothMarkerPaths
+} from './lib/marker-paths.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -89,16 +99,16 @@ if (sessionStartFlag && gateFlag !== undefined) {
 }
 
 // ---------------------------------------------------------------------------
-// Task-signal markers (#146 P3-3): the closed set of files whose mtime
-// distinguishes "fresh task work this session" from "stale from prior".
-// Extended class members (e.g. a future .review-pending) MUST be added here
-// to keep stopGateCarveOutApplies and the SessionStart orphan-clear in sync.
+// Task-signal markers — the closed set of files whose mtime distinguishes
+// "fresh task work this session" from "stale from prior". Imported from
+// scripts/lib/marker-paths.mjs (single source of truth shared with hook).
+// Extended class members MUST be added there.
+//
+// 2026-05-09 .checkpoints/ migration: marker writes go to PRIMARY (.checkpoints/)
+// only; reads check PRIMARY first then fall back to LEGACY (.claude/) until
+// burn-in completes. Carve-out, orphan-clear, and baseline checks all use
+// the shared marker-paths helpers — see scripts/lib/marker-paths.mjs.
 // ---------------------------------------------------------------------------
-const TASK_SIGNAL_MARKERS = [
-  '.checkpoint-required',
-  '.post-checkpoint-required',
-  '.plan-approval-pending'
-]
 
 // ---------------------------------------------------------------------------
 // Stop-gate carve-out (#146 A2). Pure function — testable in isolation.
@@ -107,13 +117,19 @@ const TASK_SIGNAL_MARKERS = [
 // real task signal (e.g. session-start handoff y/n + workplan display) and
 // allow stop despite an armed .checkpoint-required.
 //
-// Invariant: every TASK_SIGNAL_MARKERS member must be either absent or
-// have mtime <= .session-baseline mtime. A signal mtime > baseline means it
-// was created/touched mid-session, which is the case the gate must catch.
+// Invariant: every TASK_SIGNAL_MARKERS member at EITHER root (primary or
+// legacy) must be either absent or have mtime <= .session-baseline mtime.
+// A signal mtime > baseline means it was created/touched mid-session,
+// which is the case the gate must catch.
+//
+// Dual-root semantics (.checkpoints/ migration): baselineMtime is the MAX
+// of primary and legacy baseline mtimes (whichever is most recent).
+// Per-marker mtime is the MAX across both roots.
 //
 // .session-baseline is written/touched by em-recall --session-start (called
-// from hooks/em-recall-sessionstart.sh). If it's missing, the carve-out does
-// not apply (conservative — pre-existing sessions before this fix shipped).
+// from hooks/em-recall-sessionstart.sh). If missing at both roots, the
+// carve-out does not apply (conservative — pre-existing sessions before
+// this fix shipped).
 //
 // SubagentStop semantics (P1-1): the same predicate runs for SubagentStop.
 // A subagent that wrote files would have caused checkpoint-gate to arm
@@ -122,36 +138,42 @@ const TASK_SIGNAL_MARKERS = [
 // as the parent's no-task-signal turn, which is the desired behavior.
 //
 // Symlink defense (P2-2): uses lstatSync so a symlink to an old file cannot
-// trick the carve-out into firing. ANY symlink — baseline or marker —
-// causes the carve-out to FAIL CLOSED (return false / deny). Same-class
-// symmetry per feedback_same_class_completeness.md: a symlinked marker
-// could represent an active mid-session signal masked behind the symlink,
-// so treating it as absent (skip) is unsafe. Codex round-1 P2 finding
-// (episode 20260505-124511-...-845f) reproduced the asymmetry. Threat
-// model is honest-agent self-discipline, not adversarial.
+// trick the carve-out into firing. ANY symlink — baseline or marker, at
+// EITHER root — causes the carve-out to FAIL CLOSED. Same-class symmetry
+// per feedback_same_class_completeness.md. Codex round-1 P2 finding
+// (episode 20260505-124511-...-845f) reproduced the asymmetry.
 // ---------------------------------------------------------------------------
-function stopGateCarveOutApplies(claudeDir) {
-  const baseline = path.join(claudeDir, '.session-baseline')
-  let baselineMtime
-  try {
-    const st = fs.lstatSync(baseline)
-    if (st.isSymbolicLink()) return false
-    baselineMtime = st.mtimeMs
-  } catch {
-    return false
-  }
-  for (const name of TASK_SIGNAL_MARKERS) {
-    const p = path.join(claudeDir, name)
-    let mt
+function _maxMtimeAcrossRoots(repoRoot, basename) {
+  // Returns { mtime, hadSymlink, anyExisted }. mtime is the max across both
+  // roots. If either side is a symlink, hadSymlink=true (caller fails closed).
+  let mtime = -Infinity
+  let hadSymlink = false
+  let anyExisted = false
+  for (const p of [primaryMarkerPath(repoRoot, basename), legacyMarkerPath(repoRoot, basename)]) {
     try {
       const st = fs.lstatSync(p)
-      // Symmetric with baseline: any marker symlink fails carve-out closed.
-      // SessionStart cleanup still skips symlinks (won't unlink them), but
-      // gate evaluation must not treat them as absent.
-      if (st.isSymbolicLink()) return false
-      mt = st.mtimeMs
-    } catch { continue }
-    if (mt > baselineMtime) return false
+      if (st.isSymbolicLink()) { hadSymlink = true; continue }
+      anyExisted = true
+      if (st.mtimeMs > mtime) mtime = st.mtimeMs
+    } catch {}
+  }
+  return { mtime, hadSymlink, anyExisted }
+}
+
+function stopGateCarveOutApplies(repoRoot) {
+  const base = _maxMtimeAcrossRoots(repoRoot, BASELINE_NAME)
+  if (base.hadSymlink) return false
+  if (!base.anyExisted) return false
+  const baselineMtime = base.mtime
+
+  for (const name of TASK_SIGNAL_MARKERS) {
+    const m = _maxMtimeAcrossRoots(repoRoot, name)
+    // Symlink at either root → fail closed.
+    if (m.hadSymlink) return false
+    // Marker absent at both roots → no signal; skip.
+    if (!m.anyExisted) continue
+    // Mid-session signal → fail closed.
+    if (m.mtime > baselineMtime) return false
   }
   return true
 }
@@ -161,14 +183,21 @@ if (gateFlag === 'stop') {
   // from scripts/lib/local-dir.mjs. This converges with the hook readers in
   // hooks/checkpoint-gate.sh + hooks/plan-gate.sh that use repo-root.sh.
   // Closes #106's worktree-orphan class for this gate.
-  const claudeDir = path.join(REPO_ROOT, '.claude')
-  const preReq = path.join(claudeDir, '.checkpoint-required')
-  const postDone = path.join(claudeDir, '.post-checkpoint-done')
+  //
+  // Dual-root .checkpoints/ migration: PRE_REQ existence is checked at
+  // EITHER root (resolveMarkerRead returns the path of whichever exists,
+  // primary preferred). POST_DONE non-empty check uses the resolved path.
+  // The carve-out helper handles both roots internally.
+  const preReqPath = resolveMarkerRead(REPO_ROOT, '.checkpoint-required')
+  const postDonePath = resolveMarkerRead(REPO_ROOT, '.post-checkpoint-done')
   let postDoneSize = 0
-  try { postDoneSize = fs.statSync(postDone).size } catch {}
-  if (fs.existsSync(preReq) && postDoneSize === 0) {
-    if (!stopGateCarveOutApplies(claudeDir)) {
-      const reason = 'Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to .claude/.post-checkpoint-done (must be non-empty), then end your turn again. Hook: stop-gate.sh.'
+  if (postDonePath) {
+    try { postDoneSize = fs.statSync(postDonePath).size } catch {}
+  }
+  if (preReqPath && postDoneSize === 0) {
+    if (!stopGateCarveOutApplies(REPO_ROOT)) {
+      const writePath = writeMarkerPath(REPO_ROOT, '.post-checkpoint-done')
+      const reason = `Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to ${writePath} (must be non-empty), then end your turn again. Hook: stop-gate.sh.`
       console.log(JSON.stringify({ decision: 'block', reason }))
     }
     // else: carve-out applies — emit nothing (allow stop).
@@ -380,14 +409,18 @@ function shouldArmBp001Checkpoint(activeEntries, now) {
 
 // ---------------------------------------------------------------------------
 // Idempotent marker arming. Best-effort — failures are swallowed so a
-// non-writable .claude dir doesn't take down the whole recall.
+// non-writable .checkpoints/ dir doesn't take down the whole recall.
+//
+// Writes go to PRIMARY (.checkpoints/) only. If the legacy marker exists
+// at .claude/, it's still honored by readers via resolveMarkerRead during
+// burn-in. So "armed" here is satisfied if EITHER root has the marker.
 // ---------------------------------------------------------------------------
 function armCheckpointMarker(repoRoot) {
   try {
-    const claudeDir = path.join(repoRoot, '.claude')
-    fs.mkdirSync(claudeDir, { recursive: true })
-    const markerPath = path.join(claudeDir, '.checkpoint-required')
-    if (!fs.existsSync(markerPath)) fs.writeFileSync(markerPath, '')
+    // Already armed at either root → no-op.
+    if (resolveMarkerRead(repoRoot, '.checkpoint-required')) return
+    ensurePrimaryDir(repoRoot)
+    fs.writeFileSync(writeMarkerPath(repoRoot, '.checkpoint-required'), '')
   } catch {
     // Best-effort: marker creation failure leaves Phase 3b gate inactive
     // for this session.
@@ -494,31 +527,42 @@ const preflight_warnings = []
 // SessionStart orphan-clear (#146 P1-2 + P1-3). MUST run BEFORE arming so
 // a freshly armed .checkpoint-required isn't a cleanup candidate.
 //
-// For every TASK_SIGNAL_MARKERS member that exists with mtime <= prior
-// baseline: rm. Skipped entirely if no prior baseline (first session ever).
+// Dual-root sweep (.checkpoints/ migration): for every TASK_SIGNAL_MARKERS
+// member at EITHER root that exists with mtime <= prior baseline: rm at
+// THAT root (don't touch the other side; iterate independently).
+//
+// priorBaselineMtime is the MAX of primary and legacy baseline mtimes
+// (whichever is most recent). If neither baseline exists (first session
+// ever after migration), skipped entirely.
+//
 // Symlinks ignored (lstat-based; threat-model: honest-agent only).
 // ---------------------------------------------------------------------------
 let priorBaselineMtime = null
 if (sessionStartFlag) {
   try {
-    const claudeDir = path.join(REPO_ROOT, '.claude')
-    fs.mkdirSync(claudeDir, { recursive: true })
-    const baseline = path.join(claudeDir, '.session-baseline')
-    try {
-      const st = fs.lstatSync(baseline)
-      if (!st.isSymbolicLink()) priorBaselineMtime = st.mtimeMs
-    } catch {}
+    ensurePrimaryDir(REPO_ROOT)
+    // Read baseline mtime from BOTH roots; take the most recent.
+    for (const baselinePath of [primaryMarkerPath(REPO_ROOT, BASELINE_NAME), legacyMarkerPath(REPO_ROOT, BASELINE_NAME)]) {
+      try {
+        const st = fs.lstatSync(baselinePath)
+        if (st.isSymbolicLink()) continue
+        if (priorBaselineMtime === null || st.mtimeMs > priorBaselineMtime) {
+          priorBaselineMtime = st.mtimeMs
+        }
+      } catch {}
+    }
 
     if (priorBaselineMtime !== null) {
       for (const name of TASK_SIGNAL_MARKERS) {
-        const p = path.join(claudeDir, name)
-        try {
-          const st = fs.lstatSync(p)
-          if (st.isSymbolicLink()) continue
-          if (st.mtimeMs <= priorBaselineMtime) {
-            fs.rmSync(p, { force: true })
-          }
-        } catch {}
+        for (const p of bothMarkerPaths(REPO_ROOT, name)) {
+          try {
+            const st = fs.lstatSync(p)
+            if (st.isSymbolicLink()) continue
+            if (st.mtimeMs <= priorBaselineMtime) {
+              fs.rmSync(p, { force: true })
+            }
+          } catch {}
+        }
       }
     }
   } catch {
@@ -546,17 +590,19 @@ if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
 // so a fresh `.checkpoint-required` armed for this session has mtime <=
 // baseline mtime (carve-out treats it as "armed at session start").
 //
+// .checkpoints/ migration: baseline written at PRIMARY only. Carve-out
+// reader takes the MAX of primary + legacy baseline mtimes, so a stale
+// .claude/.session-baseline with newer mtime would still be honored
+// (defensive). Once burn-in completes and fallback drops, only primary
+// is read.
+//
 // fs.utimesSync forces baseline mtime to Date.now() — guarantees ordering
 // against the arm above regardless of filesystem mtime resolution (P2-1).
-// The orphan-clear for stale TASK_SIGNAL_MARKERS members ran earlier
-// (before arming) using the *prior* baseline mtime as the staleness
-// threshold.
 // ---------------------------------------------------------------------------
 if (sessionStartFlag) {
   try {
-    const claudeDir = path.join(REPO_ROOT, '.claude')
-    fs.mkdirSync(claudeDir, { recursive: true })
-    const baseline = path.join(claudeDir, '.session-baseline')
+    ensurePrimaryDir(REPO_ROOT)
+    const baseline = writeMarkerPath(REPO_ROOT, BASELINE_NAME)
     fs.writeFileSync(baseline, '')
     const now = Date.now() / 1000
     fs.utimesSync(baseline, now, now)

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -16,6 +16,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveRepoRoot } from './lib/local-dir.mjs'
+import { ALL_MIGRATED_MARKERS, bothMarkerPaths } from './lib/marker-paths.mjs'
 
 // ---------------------------------------------------------------------------
 // Load known patterns from _index.json
@@ -34,24 +35,26 @@ function loadPatternsIndex() {
   return []
 }
 
-// Phase 3b SessionEnd sweep: remove all four checkpoint markers so they
-// don't persist into the next session and create false-positive gates.
-// Cleans orphaned states too (e.g. .post-checkpoint-required without
-// .checkpoint-required, per RFC-002 line 207). Failure is silent — markers
-// may not exist or .claude/ may be missing in some workflows.
+// Phase 3b SessionEnd sweep: remove all six migrated markers (5 .X markers
+// + .session-baseline) so they don't persist into the next session and
+// create false-positive gates. Cleans orphaned states too (e.g.
+// .post-checkpoint-required without .checkpoint-required, per RFC-002:207).
+// Failure is silent — markers may not exist in some workflows.
 //
-// resolveRepoRoot ensures we clean the SAME .claude/ that armCheckpointMarker
+// Dual-root sweep (.checkpoints/ migration, Codex round-1 F2): iterate the
+// shared ALL_MIGRATED_MARKERS list and rm at BOTH .checkpoints/ AND .claude/
+// during burn-in. .session-baseline is included so carve-out state doesn't
+// leak across sessions.
+//
+// resolveRepoRoot ensures we clean the SAME root that armCheckpointMarker
 // (em-recall) and the hooks (hooks/lib/repo-root.sh) target — a worktree-cwd
-// would otherwise sweep an empty worktree-local .claude/ while leaving the
-// real markers stranded at the main repo root. Closes #106.
-const claudeDir = path.join(resolveRepoRoot(), '.claude')
-for (const marker of [
-  '.checkpoint-required',
-  '.pre-checkpoint-done',
-  '.post-checkpoint-required',
-  '.post-checkpoint-done'
-]) {
-  try { fs.unlinkSync(path.join(claudeDir, marker)) } catch {}
+// would otherwise sweep an empty worktree-local marker dir while leaving
+// the real markers stranded at the main repo root. Closes #106.
+const repoRoot = resolveRepoRoot()
+for (const marker of ALL_MIGRATED_MARKERS) {
+  for (const p of bothMarkerPaths(repoRoot, marker)) {
+    try { fs.unlinkSync(p) } catch {}
+  }
 }
 
 const patterns = loadPatternsIndex()

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -88,16 +88,21 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
   // Hooks — driven by HOOK_SPECS (subset of hooks/*.sh that we wire).
   // Deduped on file basename so stop-gate.sh (registered twice for
   // Stop + SubagentStop) appears once in the file manifest.
+  //
+  // Codex round-1 F3 (path: scripts/lib/install-manifest.mjs:95-98):
+  // entries are emitted UNCONDITIONALLY for HOOK_SPECS so a wrong/empty
+  // --repo can't return an empty manifest that vacuously passes the
+  // cutover check. compareFiles in migration-cutover.mjs reports
+  // SOURCE_GONE when repoPath is missing, which the gate counts as
+  // failure.
   const hookFiles = new Set()
   for (const spec of HOOK_SPECS) {
     if (hookFiles.has(spec.file)) continue
     hookFiles.add(spec.file)
     const rel = `hooks/${spec.file}`
-    const repoPath = path.join(repoDir, rel)
-    if (!fs.existsSync(repoPath)) continue
     entries.push({
       relativePath: rel,
-      repoPath,
+      repoPath: path.join(repoDir, rel),
       installedPath: path.join(HOME_HOOKS(homeDir), spec.file),
       kind: 'hook'
     })

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -1,0 +1,169 @@
+/**
+ * install-manifest.mjs — Single source of truth for what install.mjs deploys.
+ *
+ * Used by both install.mjs (to know what to copy) and tools/migration-cutover.mjs
+ * (to verify installed copies are byte-identical to repo sources). Closes Codex
+ * round-2 implementation attention point: "install.mjs should expose actual
+ * scriptSpecs manifest reused by tools/migration-cutover.mjs — avoid second
+ * hardcoded copy list."
+ *
+ * Manifest entry shape:
+ *   {
+ *     relativePath: 'hooks/checkpoint-gate.sh',  // path under repo root
+ *     repoPath: '<repoDir>/hooks/checkpoint-gate.sh',
+ *     installedPath: '<homeDir>/.claude/hooks/checkpoint-gate.sh',
+ *     kind: 'hook' | 'hook-lib' | 'script' | 'script-lib' | 'pattern' | 'config',
+ *     // hook-only:
+ *     event?: 'PreToolUse' | 'SessionStart' | 'SessionEnd' | 'Stop' | 'SubagentStop',
+ *     matcher?: string,
+ *     timeout?: number
+ *   }
+ *
+ * Hook specs (event + matcher + timeout) live here so install.mjs's
+ * registration logic and the cutover smoke test agree on what hooks should
+ * be wired and where their files land.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+export const HOOK_SPECS = [
+  {
+    file: 'checkpoint-gate.sh',
+    event: 'PreToolUse',
+    matcher: 'Edit|Write|MultiEdit|Bash|NotebookEdit',
+    timeout: 5
+  },
+  // plan-gate.sh: no matcher — must run on every PreToolUse so the
+  // tool-name allowlist (read-only tools) is the sole filter for what
+  // bypasses the marker. Issue #86 (PR-A): canonicalized into the repo
+  // and registered by the installer.
+  {
+    file: 'plan-gate.sh',
+    event: 'PreToolUse',
+    timeout: 5
+  },
+  {
+    file: 'em-recall-sessionstart.sh',
+    event: 'SessionStart',
+    timeout: 10
+  },
+  // stop-gate.sh: registered on both Stop AND SubagentStop. SubagentStop
+  // is the conversion of Stop for subagent contexts per
+  // claude-code-hooks-reference.md:409. Issue #128.
+  {
+    file: 'stop-gate.sh',
+    event: 'Stop',
+    timeout: 5
+  },
+  {
+    file: 'stop-gate.sh',
+    event: 'SubagentStop',
+    timeout: 5
+  }
+]
+
+// SessionEnd hook is em-session-end-prompt.mjs invoked from the global
+// scripts dir (canonical at $HOME/.episodic-memory/scripts/). The hook
+// command string is built by install.mjs at registration time.
+export const SESSION_END_SCRIPT = 'em-session-end-prompt.mjs'
+
+const HOME_HOOKS = (homeDir) => path.join(homeDir, '.claude', 'hooks')
+const HOME_HOOKS_LIB = (homeDir) => path.join(homeDir, '.claude', 'hooks', 'lib')
+const HOME_SCRIPTS = (homeDir) => path.join(homeDir, '.episodic-memory', 'scripts')
+const HOME_SCRIPTS_LIB = (homeDir) => path.join(homeDir, '.episodic-memory', 'scripts', 'lib')
+
+/**
+ * Build the full install manifest for a given repo + home dir. Filesystem
+ * I/O scoped to the source repo only (the installed-side paths are
+ * predicted, not stat'd here — callers do that).
+ *
+ * Returns an array of manifest entries in deterministic order (sorted by
+ * relativePath) for stable diffs and reproducible cutover output.
+ */
+export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
+  const entries = []
+
+  // Hooks — driven by HOOK_SPECS (subset of hooks/*.sh that we wire).
+  // Deduped on file basename so stop-gate.sh (registered twice for
+  // Stop + SubagentStop) appears once in the file manifest.
+  const hookFiles = new Set()
+  for (const spec of HOOK_SPECS) {
+    if (hookFiles.has(spec.file)) continue
+    hookFiles.add(spec.file)
+    const rel = `hooks/${spec.file}`
+    const repoPath = path.join(repoDir, rel)
+    if (!fs.existsSync(repoPath)) continue
+    entries.push({
+      relativePath: rel,
+      repoPath,
+      installedPath: path.join(HOME_HOOKS(homeDir), spec.file),
+      kind: 'hook'
+    })
+  }
+
+  // Hook lib — every .sh under hooks/lib/.
+  const repoHooksLib = path.join(repoDir, 'hooks', 'lib')
+  if (fs.existsSync(repoHooksLib)) {
+    for (const f of fs.readdirSync(repoHooksLib).filter(n => n.endsWith('.sh'))) {
+      const rel = `hooks/lib/${f}`
+      entries.push({
+        relativePath: rel,
+        repoPath: path.join(repoDir, rel),
+        installedPath: path.join(HOME_HOOKS_LIB(homeDir), f),
+        kind: 'hook-lib'
+      })
+    }
+  }
+
+  // Scripts — every .mjs under scripts/.
+  const repoScripts = path.join(repoDir, 'scripts')
+  if (fs.existsSync(repoScripts)) {
+    for (const f of fs.readdirSync(repoScripts).filter(n => n.endsWith('.mjs'))) {
+      const rel = `scripts/${f}`
+      entries.push({
+        relativePath: rel,
+        repoPath: path.join(repoDir, rel),
+        installedPath: path.join(HOME_SCRIPTS(homeDir), f),
+        kind: 'script'
+      })
+    }
+  }
+
+  // Script lib — every .mjs under scripts/lib/.
+  const repoScriptsLib = path.join(repoDir, 'scripts', 'lib')
+  if (fs.existsSync(repoScriptsLib)) {
+    for (const f of fs.readdirSync(repoScriptsLib).filter(n => n.endsWith('.mjs'))) {
+      const rel = `scripts/lib/${f}`
+      entries.push({
+        relativePath: rel,
+        repoPath: path.join(repoDir, rel),
+        installedPath: path.join(HOME_SCRIPTS_LIB(homeDir), f),
+        kind: 'script-lib'
+      })
+    }
+  }
+
+  // Patterns index — copied into the global patterns dir.
+  const repoPatternsIndex = path.join(repoDir, 'patterns', '_index.json')
+  if (fs.existsSync(repoPatternsIndex)) {
+    entries.push({
+      relativePath: 'patterns/_index.json',
+      repoPath: repoPatternsIndex,
+      installedPath: path.join(homeDir, '.episodic-memory', 'patterns', '_index.json'),
+      kind: 'pattern'
+    })
+  }
+
+  return entries.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+}
+
+/**
+ * Compute the SessionEnd hook command string. install.mjs uses this at
+ * registration time; cutover may use it to verify the registered command
+ * still references the canonical install path.
+ */
+export function sessionEndHookCommand(homeDir = os.homedir()) {
+  return `node ${path.join(HOME_SCRIPTS(homeDir), SESSION_END_SCRIPT)}`
+}

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -1,0 +1,92 @@
+/**
+ * marker-paths.mjs — Shared marker-path constants and helpers.
+ *
+ * Mirrors hooks/lib/marker-paths.sh (single source of truth split for
+ * shell/node parity). Import from em-* scripts and use the helpers below.
+ *
+ * Background: Claude Code's built-in sensitive-file guard prompts on Write
+ * to any basename matching `.X` inside a `.claude/` segment, regardless of
+ * allowlist. To escape the prompt, marker writes go to a sibling
+ * `.checkpoints/` directory. Reads honor both during burn-in (primary
+ * `.checkpoints/` first, fallback `.claude/` second) until the legacy
+ * branch is removed in a follow-up commit.
+ *
+ * Six markers in scope (5 task-signal + 1 baseline):
+ *   .checkpoint-required          (activator, armed by em-recall.mjs)
+ *   .post-checkpoint-required     (activator, armed by checkpoint-gate.sh)
+ *   .plan-approval-pending        (Rule 8 plan-approval gate)
+ *   .pre-checkpoint-done          (Rule 18 pre-impl checkpoint)
+ *   .post-checkpoint-done         (Rule 18 post-impl checkpoint)
+ *   .session-baseline             (stop-gate carve-out reference mtime)
+ *
+ * Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+export const PRIMARY_MARKER_DIR = '.checkpoints'
+export const LEGACY_MARKER_DIR = '.claude'
+export const BASELINE_NAME = '.session-baseline'
+
+// Task-signal markers (mirrors em-recall.mjs:97-101 + the two -done markers).
+// Used by stop-gate carve-out, push cleanup, SessionStart orphan-clear.
+export const TASK_SIGNAL_MARKERS = [
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.plan-approval-pending',
+  '.pre-checkpoint-done',
+  '.post-checkpoint-done'
+]
+
+// All migrated markers = task-signal + baseline.
+export const ALL_MARKERS = [...TASK_SIGNAL_MARKERS, BASELINE_NAME]
+
+export function primaryMarkerPath(repoRoot, basename) {
+  return path.join(repoRoot, PRIMARY_MARKER_DIR, basename)
+}
+
+export function legacyMarkerPath(repoRoot, basename) {
+  return path.join(repoRoot, LEGACY_MARKER_DIR, basename)
+}
+
+/**
+ * Returns the primary path if it exists, otherwise the legacy path if it
+ * exists, otherwise null. Use for readers that need a single-path semantic
+ * (e.g. fs.statSync to read mtime/size).
+ *
+ * Symlink-aware via fs.existsSync (which follows links). Callers that need
+ * symlink-fail-closed semantics (e.g. stop-gate carve-out per
+ * 20260505-124511-...-845f) MUST re-check with fs.lstatSync after.
+ */
+export function resolveMarkerRead(repoRoot, basename) {
+  const primary = primaryMarkerPath(repoRoot, basename)
+  if (fs.existsSync(primary)) return primary
+  const legacy = legacyMarkerPath(repoRoot, basename)
+  if (fs.existsSync(legacy)) return legacy
+  return null
+}
+
+/**
+ * Returns the primary path (always). Use for ALL writes. The legacy branch
+ * is read-only during burn-in.
+ */
+export function writeMarkerPath(repoRoot, basename) {
+  return primaryMarkerPath(repoRoot, basename)
+}
+
+/**
+ * Returns [primaryPath, legacyPath]. Use for cleanup (rm both) and
+ * orphan-clear sweeps that must touch both roots until fallback removal.
+ */
+export function bothMarkerPaths(repoRoot, basename) {
+  return [primaryMarkerPath(repoRoot, basename), legacyMarkerPath(repoRoot, basename)]
+}
+
+/**
+ * Ensure the primary marker directory exists. Idempotent. Use before
+ * writeMarkerPath writes.
+ */
+export function ensurePrimaryDir(repoRoot) {
+  fs.mkdirSync(path.join(repoRoot, PRIMARY_MARKER_DIR), { recursive: true })
+}

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -11,13 +11,27 @@
  * `.checkpoints/` first, fallback `.claude/` second) until the legacy
  * branch is removed in a follow-up commit.
  *
- * Six markers in scope (5 task-signal + 1 baseline):
- *   .checkpoint-required          (activator, armed by em-recall.mjs)
- *   .post-checkpoint-required     (activator, armed by checkpoint-gate.sh)
- *   .plan-approval-pending        (Rule 8 plan-approval gate)
- *   .pre-checkpoint-done          (Rule 18 pre-impl checkpoint)
- *   .post-checkpoint-done         (Rule 18 post-impl checkpoint)
- *   .session-baseline             (stop-gate carve-out reference mtime)
+ * Six markers in migration scope:
+ *
+ *   Marker name                    | Set membership
+ *   ---                            | ---
+ *   .checkpoint-required           | TASK_SIGNAL + CHECKPOINT_CLEANUP
+ *   .post-checkpoint-required      | TASK_SIGNAL + CHECKPOINT_CLEANUP
+ *   .plan-approval-pending         | TASK_SIGNAL only (not cleared by push)
+ *   .pre-checkpoint-done           | CHECKPOINT_CLEANUP only
+ *   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
+ *   .session-baseline              | BASELINE only
+ *
+ * Set semantics:
+ *   TASK_SIGNAL_MARKERS         3 markers — em-recall stop-gate carve-out
+ *                               class (mid-session mtime > baseline = task
+ *                               work in progress). Mirrors em-recall.mjs:97.
+ *   CHECKPOINT_CLEANUP_MARKERS  4 markers — push-gate clears on successful
+ *                               push (Codex round-1 F2: must sweep BOTH
+ *                               .checkpoints/ AND .claude/ during burn-in).
+ *                               Mirrors prior checkpoint-gate.sh:200.
+ *   ALL_MIGRATED_MARKERS        6 names — full migration scope used by
+ *                               tests, sweep tools, and SessionEnd cleanup.
  *
  * Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
  */
@@ -29,18 +43,35 @@ export const PRIMARY_MARKER_DIR = '.checkpoints'
 export const LEGACY_MARKER_DIR = '.claude'
 export const BASELINE_NAME = '.session-baseline'
 
-// Task-signal markers (mirrors em-recall.mjs:97-101 + the two -done markers).
-// Used by stop-gate carve-out, push cleanup, SessionStart orphan-clear.
+// Task-signal markers — em-recall stop-gate carve-out class. Mirrors
+// em-recall.mjs:97-101 (TASK_SIGNAL_MARKERS).
 export const TASK_SIGNAL_MARKERS = [
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.plan-approval-pending'
+]
+
+// Push-gate cleanup class — markers cleared on a successful push that has
+// satisfied the post-checkpoint. .plan-approval-pending is intentionally
+// NOT here (its lifecycle is plan-gate's marker_write allowance, not
+// checkpoint cleanup). Mirrors the prior checkpoint-gate.sh:200 list.
+export const CHECKPOINT_CLEANUP_MARKERS = [
+  '.checkpoint-required',
+  '.pre-checkpoint-done',
+  '.post-checkpoint-required',
+  '.post-checkpoint-done'
+]
+
+// Full migration scope = task-signal + done markers + baseline = 6 names.
+// Used by sweep tools and tests to validate completeness.
+export const ALL_MIGRATED_MARKERS = [
   '.checkpoint-required',
   '.post-checkpoint-required',
   '.plan-approval-pending',
   '.pre-checkpoint-done',
-  '.post-checkpoint-done'
+  '.post-checkpoint-done',
+  '.session-baseline'
 ]
-
-// All migrated markers = task-signal + baseline.
-export const ALL_MARKERS = [...TASK_SIGNAL_MARKERS, BASELINE_NAME]
 
 export function primaryMarkerPath(repoRoot, basename) {
   return path.join(repoRoot, PRIMARY_MARKER_DIR, basename)

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -335,6 +335,21 @@ assert_blocked "49. Bash '>> .post-checkpoint-done' BLOCKED (POST_REQ not armed)
 assert_blocked "50. Bash 'tee .post-checkpoint-done' BLOCKED (POST_REQ not armed)" \
   "$(mock_json 'Bash' "echo content | tee $POST_DONE")" "Checkpoint required"
 
+# Codex round-1 F1 regression: nested marker-like paths under .checkpoints/
+# or .claude/ must NOT pass the marker_write allowlist. Pre-fix the
+# allowlist matched any descendant by basename; post-fix it requires an
+# EXACT match against the canonical primary or legacy marker path.
+mkdir -p "$MARKER_DIR/sub" "$LEGACY_MARKER_DIR/sub"
+assert_blocked "50a. nested .checkpoints/sub/.pre-checkpoint-done — NOT allowed (F1)" \
+  "$(mock_json 'Bash' "echo content > $MARKER_DIR/sub/.pre-checkpoint-done")" "Checkpoint required"
+assert_blocked "50b. nested .claude/sub/.pre-checkpoint-done — NOT allowed (F1)" \
+  "$(mock_json 'Bash' "echo content > $LEGACY_MARKER_DIR/sub/.pre-checkpoint-done")" "Checkpoint required"
+# Edit tool path-equivalent of 50a
+edit_nested_json=$(jq -nc --arg fp "$MARKER_DIR/sub/.pre-checkpoint-done" --arg cwd "$TEST_DIR" \
+  '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd}')
+assert_blocked "50c. Edit nested .checkpoints/sub/.pre-checkpoint-done — NOT allowed (F1)" \
+  "$edit_nested_json" "Checkpoint required"
+
 # ============================================================================
 echo ""
 echo "--- #66: heredoc-body bypass blocked (pre-<< check) ---"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -25,7 +25,12 @@ TEST_HOME="$(cd -P "$TEST_HOME" && pwd)"
 # Session 1 (#86 PR-B): checkpoint-gate sources hooks/lib/command-classifier.sh
 # and resolves repo-root via git-common-dir. Initialize TEST_DIR as a git repo.
 git -C "$TEST_DIR" init -q 2>/dev/null
-MARKER_DIR="$TEST_DIR/.claude"
+# 2026-05-09 .checkpoints/ migration: hook now writes/arms at PRIMARY
+# (.checkpoints/) and reads at PRIMARY-then-LEGACY. Tests target the
+# primary path for write-side assertions and arming-state setup. Legacy
+# paths are still exercised by tests/test-checkpoints-migration.mjs.
+MARKER_DIR="$TEST_DIR/.checkpoints"
+LEGACY_MARKER_DIR="$TEST_DIR/.claude"
 PRE_REQ="$MARKER_DIR/.checkpoint-required"
 PRE_DONE="$MARKER_DIR/.pre-checkpoint-done"
 POST_REQ="$MARKER_DIR/.post-checkpoint-required"
@@ -38,7 +43,7 @@ cleanup() { rm -rf "$TEST_DIR" "$TEST_HOME"; }
 trap cleanup EXIT
 
 reset_state() {
-  rm -rf "$MARKER_DIR"
+  rm -rf "$MARKER_DIR" "$LEGACY_MARKER_DIR"
   mkdir -p "$MARKER_DIR"
 }
 
@@ -606,7 +611,11 @@ if [ -z "$PLAN_GATE" ]; then
   echo "  ⊘ Skipping composition tests — plan-gate.sh not found at $PLAN_GATE_REPO or $PLAN_GATE_USER"
 else
   reset_state
+  # .checkpoints/ migration: setup writes plan-marker at LEGACY (.claude/) to
+  # exercise the dual-root fallback read; checkpoint-gate's reset_state no
+  # longer mkdirs the legacy dir, so create it here.
   PLAN_MARKER="$TEST_DIR/.claude/.plan-approval-pending"
+  mkdir -p "$TEST_DIR/.claude"
   touch "$PRE_REQ"
   touch "$PLAN_MARKER"
 
@@ -673,7 +682,9 @@ echo "--- #146 B1: block-reason includes ABSOLUTE marker path ---"
 reset_state
 touch "$PRE_REQ"
 b1_out=$(echo "$(mock_json 'Edit')" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null || true)
-B1_EXPECTED="$TEST_DIR/.claude/.pre-checkpoint-done"
+# .checkpoints/ migration: block reason embeds the PRIMARY write path so
+# the agent writes to the new location.
+B1_EXPECTED="$TEST_DIR/.checkpoints/.pre-checkpoint-done"
 if echo "$b1_out" | grep -qF "$B1_EXPECTED"; then
   echo "  ✓ B1.pre. _block_pre reason embeds absolute pre-checkpoint path"
   ((passed++))
@@ -690,27 +701,31 @@ else
   echo "  ✗ B1.pre defensive: trigger=$([ -f "$PRE_REQ" ] && echo Y || echo N) PRE_DONE=$PRE_DONE expected=$B1_EXPECTED"
   ((failed++))
 fi
-# Plan-pending block reason also gets absolute path
+# Plan-pending block reason also gets absolute path. Setup writes the
+# legacy-path marker (exercises fallback read); block message references
+# the PRIMARY write path (where the agent should put any new marker).
 reset_state
 touch "$PRE_REQ"
-PLAN_MARKER="$TEST_DIR/.claude/.plan-approval-pending"
-touch "$PLAN_MARKER"
+PLAN_MARKER_LEGACY="$TEST_DIR/.claude/.plan-approval-pending"
+PLAN_MARKER_PRIMARY="$TEST_DIR/.checkpoints/.plan-approval-pending"
+mkdir -p "$TEST_DIR/.claude"
+touch "$PLAN_MARKER_LEGACY"
 # A Bash command targeting the pre-checkpoint marker fires the
 # plan-pending block (cross-gate invariant). Reason should embed
-# absolute plan-pending path.
+# the absolute PRIMARY plan-pending path.
 plan_block_json=$(jq -nc \
-  --arg cmd "echo block > $TEST_DIR/.claude/.pre-checkpoint-done" \
+  --arg cmd "echo block > $PRE_DONE" \
   --arg cwd "$TEST_DIR" \
   '{tool_name: "Bash", cwd: $cwd, tool_input: {command: $cmd}}')
 plan_out=$(echo "$plan_block_json" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null || true)
-if echo "$plan_out" | grep -qF "$PLAN_MARKER"; then
-  echo "  ✓ B1.plan. _block_plan_pending reason embeds absolute plan-pending path"
+if echo "$plan_out" | grep -qF "$PLAN_MARKER_PRIMARY"; then
+  echo "  ✓ B1.plan. _block_plan_pending reason embeds absolute plan-pending path (primary)"
   ((passed++))
 else
-  echo "  ✗ B1.plan. expected absolute path '$PLAN_MARKER' in: $plan_out"
+  echo "  ✗ B1.plan. expected absolute path '$PLAN_MARKER_PRIMARY' in: $plan_out"
   ((failed++))
 fi
-rm -f "$PLAN_MARKER"
+rm -f "$PLAN_MARKER_LEGACY"
 
 # ============================================================================
 echo ""

--- a/tests/test-checkpoints-migration.mjs
+++ b/tests/test-checkpoints-migration.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * test-checkpoints-migration.mjs — Regression tests for the dual-root
+ * marker behaviour introduced by the .checkpoints/ migration.
+ *
+ * Codex round-1 F2 (split-brain marker state during burn-in): cleanup,
+ * orphan-clear, baseline reads, and carve-out evaluation must all
+ * iterate BOTH roots until the legacy fallback is removed. These tests
+ * exercise that contract end-to-end via em-recall and em-session-end-prompt.
+ *
+ * Defensive ordering per feedback_test_resource_existence_check.md: each
+ * assertion of "marker removed" pairs with an explicit positive check
+ * that the file did exist before the action.
+ *
+ * Layer-2 integration tests over em-recall.mjs (subprocess) and
+ * em-session-end-prompt.mjs (subprocess). Layer-1 lib unit tests are
+ * in tests/test-marker-paths.{sh,mjs}; this file does not retest
+ * primaryMarkerPath / legacyMarkerPath / etc.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+
+const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
+const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
+const SESSION_END = path.join(SCRIPTS, 'em-session-end-prompt.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+function assertExists(p, msg) {
+  if (!fs.existsSync(p)) throw new Error(`${msg || 'expected to exist'}: ${p}`)
+}
+function assertMissing(p, msg) {
+  if (fs.existsSync(p)) throw new Error(`${msg || 'expected to be missing'}: ${p}`)
+}
+
+function setupRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em-cp-mig-'))
+  process.on('exit', () => fs.rmSync(root, { recursive: true, force: true }))
+  git(root, 'init -q -b main')
+  git(root, 'config user.email test@example.com')
+  git(root, 'config user.name test')
+  fs.writeFileSync(path.join(root, 'README.md'), '# t\n')
+  git(root, 'add README.md')
+  git(root, 'commit -q -m init')
+  return root
+}
+
+function runRecall(cwd, args = [], extraEnv = {}) {
+  // HOME isolation: em-recall reads GLOBAL_DIR = $HOME/.episodic-memory which
+  // in the host environment has real bp-001 violations and would re-arm
+  // .checkpoint-required mid-test. Point HOME at the test's repo to give
+  // em-recall an empty global store.
+  return execSync(`node ${RECALL} ${args.join(' ')}`, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    env: { ...process.env, HOME: cwd, ...extraEnv }
+  }).toString()
+}
+
+function gateStop(cwd) {
+  return runRecall(cwd, ['--gate', 'stop'])
+}
+
+function sessionStart(cwd) {
+  // --session-start writes baseline + arms checkpoint marker if
+  // bp-001 violation activation predicate fires. For these tests we don't
+  // care about violations — we just want the SessionStart side effects.
+  return runRecall(cwd, ['--session-start'])
+}
+
+console.log('SessionStart writes baseline at PRIMARY (.checkpoints/):')
+test('baseline lands at .checkpoints/.session-baseline, NOT .claude/', () => {
+  const root = setupRepo()
+  sessionStart(root)
+  assertExists(path.join(root, '.checkpoints', '.session-baseline'), 'primary baseline')
+  assertMissing(path.join(root, '.claude', '.session-baseline'), 'legacy baseline must not be created')
+})
+
+console.log('\narmCheckpointMarker writes to PRIMARY only:')
+test('writes .checkpoints/.checkpoint-required, never touches .claude/', () => {
+  const root = setupRepo()
+  // Force activation by seeding a recent bp-001 violation in local store.
+  const localEpisodes = path.join(root, '.episodic-memory', 'episodes')
+  fs.mkdirSync(localEpisodes, { recursive: true })
+  const violationId = '20260509-000000-test-bp001-violation-aaaa'
+  fs.writeFileSync(
+    path.join(localEpisodes, `${violationId}.md`),
+    `---
+id: ${violationId}
+date: 2026-05-09
+project: test
+category: violation
+status: active
+tags: [violated:bp-001-implementation-workflow]
+summary: test
+---
+test
+`
+  )
+  // Build a minimal index.jsonl so loadIndex picks it up.
+  const indexLine = JSON.stringify({
+    id: violationId,
+    date: '2026-05-09',
+    project: 'test',
+    category: 'violation',
+    status: 'active',
+    tags: ['violated:bp-001-implementation-workflow'],
+    summary: 'test'
+  })
+  fs.writeFileSync(path.join(root, '.episodic-memory', 'index.jsonl'), indexLine + '\n')
+
+  sessionStart(root)
+  assertExists(path.join(root, '.checkpoints', '.checkpoint-required'), 'primary marker')
+  assertMissing(path.join(root, '.claude', '.checkpoint-required'), 'legacy marker must not be created')
+})
+
+console.log('\nstop-gate carve-out reads BOTH roots:')
+
+test('legacy-only marker with mtime > baseline → fail closed (block)', () => {
+  const root = setupRepo()
+  sessionStart(root)
+  const baselineP = path.join(root, '.checkpoints', '.session-baseline')
+  assertExists(baselineP, 'primary baseline written')
+
+  // Prime PRE_REQ + force POST_DONE empty (default). Then create a LEGACY
+  // task signal marker with mtime AFTER the baseline. Carve-out should
+  // fail closed → gate block.
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  // PRE_REQ at legacy — gate condition fires.
+  fs.writeFileSync(path.join(root, '.claude', '.checkpoint-required'), '')
+  const future = (Date.now() + 5000) / 1000
+  fs.utimesSync(path.join(root, '.claude', '.checkpoint-required'), future, future)
+  // POST_REQ at legacy with newer mtime → carve-out should deny.
+  fs.writeFileSync(path.join(root, '.claude', '.post-checkpoint-required'), '')
+  fs.utimesSync(path.join(root, '.claude', '.post-checkpoint-required'), future, future)
+
+  const out = gateStop(root)
+  if (!out.includes('Post-implementation checkpoint required')) {
+    throw new Error(`expected block decision, got: ${out || '(empty)'}`)
+  }
+})
+
+test('primary baseline newer than legacy markers → carve-out applies (no block)', () => {
+  const root = setupRepo()
+  // Pre-existing legacy markers from a PRIOR session, with older mtime.
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  fs.writeFileSync(path.join(root, '.claude', '.checkpoint-required'), '')
+  const past = (Date.now() - 60000) / 1000  // 60s ago
+  fs.utimesSync(path.join(root, '.claude', '.checkpoint-required'), past, past)
+
+  // Now SessionStart writes a fresh primary baseline (mtime ~now).
+  sessionStart(root)
+  // POST_DONE empty by default → if PRE_REQ exists at legacy, gate would
+  // block UNLESS carve-out applies. Carve-out should apply because the
+  // legacy marker mtime <= primary baseline mtime.
+  const out = gateStop(root)
+  if (out.length > 0 && out.includes('"decision":"block"')) {
+    throw new Error(`expected carve-out to allow stop (no block), got: ${out}`)
+  }
+})
+
+console.log('\nSessionStart orphan-clear sweeps BOTH roots:')
+
+test('removes stale legacy + primary markers below prior baseline', () => {
+  const root = setupRepo()
+  // Seed an OLD baseline at primary (sets priorBaselineMtime).
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  const baseline = path.join(root, '.checkpoints', '.session-baseline')
+  fs.writeFileSync(baseline, '')
+  const past = (Date.now() - 60000) / 1000
+  fs.utimesSync(baseline, past, past)
+
+  // Stale markers at BOTH roots, mtime older than baseline → should be cleared.
+  for (const dir of ['.checkpoints', '.claude']) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true })
+    for (const name of ['.checkpoint-required', '.post-checkpoint-required', '.plan-approval-pending']) {
+      const p = path.join(root, dir, name)
+      fs.writeFileSync(p, '')
+      const older = past - 10  // 10s older than baseline
+      fs.utimesSync(p, older, older)
+      assertExists(p, 'pre-condition: stale marker exists')
+    }
+  }
+
+  sessionStart(root)
+
+  // After SessionStart: orphan-clear should have removed all stale markers
+  // at BOTH roots (em-recall.mjs SessionStart orphan-clear uses
+  // bothMarkerPaths). Then a NEW baseline + possibly a fresh
+  // .checkpoint-required at primary may be re-armed if violations exist —
+  // for this test there are no seeded violations, so neither marker is re-armed.
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const name of ['.checkpoint-required', '.post-checkpoint-required', '.plan-approval-pending']) {
+      assertMissing(path.join(root, dir, name), `stale ${dir}/${name} should be cleared`)
+    }
+  }
+})
+
+console.log('\nSessionEnd cleanup sweeps BOTH roots for ALL_MIGRATED_MARKERS:')
+
+test('em-session-end-prompt removes 6 markers across both roots', () => {
+  const root = setupRepo()
+  // Seed all 6 markers at BOTH roots.
+  const markers = [
+    '.checkpoint-required',
+    '.post-checkpoint-required',
+    '.plan-approval-pending',
+    '.pre-checkpoint-done',
+    '.post-checkpoint-done',
+    '.session-baseline'
+  ]
+  for (const dir of ['.checkpoints', '.claude']) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true })
+    for (const name of markers) {
+      const p = path.join(root, dir, name)
+      fs.writeFileSync(p, 'x')
+      assertExists(p, `pre-condition: ${dir}/${name}`)
+    }
+  }
+
+  // em-session-end-prompt resolves the repo root via resolveRepoRoot —
+  // running from within the test repo's cwd resolves to that repo. HOME
+  // isolation matches runRecall.
+  execSync(`node ${SESSION_END}`, {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    env: { ...process.env, HOME: root }
+  })
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const name of markers) {
+      assertMissing(path.join(root, dir, name), `${dir}/${name} should be removed by SessionEnd sweep`)
+    }
+  }
+})
+
+console.log()
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('Failures:')
+  for (const f of failures) console.log(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-em-repo-root-worktree.mjs
+++ b/tests/test-em-repo-root-worktree.mjs
@@ -155,18 +155,28 @@ test('resolveRepoRoot: submodule resolves to SUBMODULE working tree, not superpr
 // Layer 2 — Integration regression tests for #106
 // ---------------------------------------------------------------------------
 
-const mainClaudeDir = path.join(mainRepoReal, '.claude')
-const worktreeClaudeDir = path.join(worktreeRootReal, '.claude')
-const mainMarker = path.join(mainClaudeDir, '.checkpoint-required')
-const worktreeMarker = path.join(worktreeClaudeDir, '.checkpoint-required')
+// 2026-05-09 .checkpoints/ migration: em-recall writes/arms at PRIMARY
+// (.checkpoints/) and reads at PRIMARY-then-LEGACY. The #106 invariant
+// (marker lands at MAIN repo, NOT WORKTREE) is preserved — the marker
+// just lives at .checkpoints/ now instead of .claude/. Tests assert the
+// new write path; legacy paths still exercised by clearMarkers (sweep).
+const mainPrimaryDir = path.join(mainRepoReal, '.checkpoints')
+const mainLegacyDir = path.join(mainRepoReal, '.claude')
+const worktreePrimaryDir = path.join(worktreeRootReal, '.checkpoints')
+const worktreeLegacyDir = path.join(worktreeRootReal, '.claude')
+const mainMarker = path.join(mainPrimaryDir, '.checkpoint-required')
+const mainMarkerLegacy = path.join(mainLegacyDir, '.checkpoint-required')
+const worktreeMarker = path.join(worktreePrimaryDir, '.checkpoint-required')
+const worktreeMarkerLegacy = path.join(worktreeLegacyDir, '.checkpoint-required')
 
 function clearMarkers() {
-  for (const dir of [mainClaudeDir, worktreeClaudeDir]) {
+  for (const dir of [mainPrimaryDir, mainLegacyDir, worktreePrimaryDir, worktreeLegacyDir]) {
     for (const m of [
       '.checkpoint-required',
       '.pre-checkpoint-done',
       '.post-checkpoint-required',
       '.post-checkpoint-done',
+      '.session-baseline',
     ]) {
       try { fs.unlinkSync(path.join(dir, m)) } catch {}
     }
@@ -217,39 +227,46 @@ test('em-recall from nested cwd inside worktree still writes marker at <main>/.c
   assert.ok(!fs.existsSync(worktreeMarker), `marker leaked into worktree from nested cwd`)
 })
 
-test('em-session-end-prompt from worktree cleans markers at <main>/.claude/, not worktree', () => {
+test('em-session-end-prompt from worktree cleans markers at <main>, not worktree', () => {
   clearMarkers()
-  // Seed both stores with the full marker set so we can prove which one
-  // gets swept.
-  fs.mkdirSync(mainClaudeDir, { recursive: true })
-  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
+  // Seed both stores at LEGACY (.claude/) — the dual-root sweep clears both
+  // .checkpoints/ AND .claude/ at the resolved root. Seeding at legacy
+  // proves the fallback-sweep branch executes; if we seeded only at
+  // primary we wouldn't catch a regression that drops the legacy sweep.
+  fs.mkdirSync(mainLegacyDir, { recursive: true })
+  fs.mkdirSync(worktreeLegacyDir, { recursive: true })
   for (const m of [
     '.checkpoint-required',
     '.pre-checkpoint-done',
     '.post-checkpoint-required',
     '.post-checkpoint-done',
   ]) {
-    fs.writeFileSync(path.join(mainClaudeDir, m), 'seed')
-    fs.writeFileSync(path.join(worktreeClaudeDir, m), 'worktree-seed')
+    fs.writeFileSync(path.join(mainLegacyDir, m), 'seed')
+    fs.writeFileSync(path.join(worktreeLegacyDir, m), 'worktree-seed')
   }
 
   // Confirm setup is real (defensive — guards against a refactor that
   // accidentally clears the seed before the cleanup runs).
-  assert.ok(fs.existsSync(mainMarker), 'pre-condition: main marker seeded')
-  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: worktree marker seeded')
+  assert.ok(fs.existsSync(mainMarkerLegacy), 'pre-condition: main legacy marker seeded')
+  assert.ok(fs.existsSync(worktreeMarkerLegacy), 'pre-condition: worktree legacy marker seeded')
 
   execSync(`node ${SESSION_END}`, {
     cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
   })
 
-  // Positive: main markers swept.
-  assert.ok(!fs.existsSync(mainMarker), `expected ${mainMarker} cleaned after SessionEnd from worktree`)
-  // Negative: worktree markers untouched (proves the sweep targeted main).
-  // After #106, em-session-end-prompt should NOT touch worktree-local markers
-  // unless the worktree is a non-git cwd (which it isn't here).
+  // Positive: main markers swept (both .claude/ legacy and .checkpoints/
+  // primary if any existed).
+  assert.ok(!fs.existsSync(mainMarkerLegacy),
+    `expected ${mainMarkerLegacy} cleaned after SessionEnd from worktree`)
+  assert.ok(!fs.existsSync(mainMarker),
+    `expected ${mainMarker} cleaned after SessionEnd from worktree`)
+  // Negative: worktree markers untouched (proves the sweep targeted MAIN
+  // via resolveRepoRoot, not the worktree-local dir). After #106,
+  // em-session-end-prompt should NOT touch worktree-local markers unless
+  // the worktree is a non-git cwd (which it isn't here).
   assert.ok(
-    fs.existsSync(worktreeMarker),
-    `worktree marker swept unexpectedly — em-session-end-prompt resolved to worktree, not main (regressed #106)`,
+    fs.existsSync(worktreeMarkerLegacy),
+    `worktree legacy marker swept unexpectedly — em-session-end-prompt resolved to worktree, not main (regressed #106)`,
   )
 })
 
@@ -263,25 +280,28 @@ test('em-session-end-prompt from worktree cleans markers at <main>/.claude/, not
 test('NEG: stale worktree-local marker (pre-fix legacy state) is preserved, not migrated', () => {
   clearMarkers()
   // Simulate a user who ran em-recall from this worktree BEFORE PR #106 landed.
-  // The pre-fix bug left a marker in <worktree>/.claude/. After the fix:
-  //   - new arming writes to <main>/.claude/ (correct)
+  // The pre-fix bug left a marker in <worktree>/.claude/. After the fix
+  // AND the .checkpoints/ migration:
+  //   - new arming writes to <main>/.checkpoints/ (correct, primary)
   //   - the legacy worktree-local marker is OUT OF BAND — we do not auto-migrate
-  //   - em-session-end-prompt now sweeps main-only, so the worktree marker
-  //     persists forever (acceptable: hooks read from main, so it's inert)
-  fs.mkdirSync(worktreeClaudeDir, { recursive: true })
-  fs.writeFileSync(worktreeMarker, 'legacy-from-pre-106')
-  assert.ok(fs.existsSync(worktreeMarker), 'pre-condition: legacy worktree marker seeded')
+  //   - em-session-end-prompt sweeps MAIN's roots (both .checkpoints/ and
+  //     .claude/), so the worktree-local marker persists forever (acceptable:
+  //     hooks resolve to main, so it's inert)
+  fs.mkdirSync(worktreeLegacyDir, { recursive: true })
+  fs.writeFileSync(worktreeMarkerLegacy, 'legacy-from-pre-106')
+  assert.ok(fs.existsSync(worktreeMarkerLegacy), 'pre-condition: legacy worktree marker seeded')
 
   execSync(`node ${RECALL} --scope local --project test --no-track`, {
     cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
   })
 
-  // New behavior: marker now lives at main.
-  assert.ok(fs.existsSync(mainMarker), 'new arming should land at main')
-  // Legacy marker preserved verbatim — we don't read or modify worktree state.
-  assert.ok(fs.existsSync(worktreeMarker), 'legacy worktree marker should be untouched')
+  // New behavior: marker now lives at main, in the PRIMARY (.checkpoints/) dir.
+  assert.ok(fs.existsSync(mainMarker), 'new arming should land at main/.checkpoints/')
+  // Legacy worktree marker preserved verbatim — we don't read or modify
+  // worktree-local state.
+  assert.ok(fs.existsSync(worktreeMarkerLegacy), 'legacy worktree marker should be untouched')
   assert.strictEqual(
-    fs.readFileSync(worktreeMarker, 'utf8'),
+    fs.readFileSync(worktreeMarkerLegacy, 'utf8'),
     'legacy-from-pre-106',
     'legacy marker contents should not be rewritten',
   )
@@ -330,7 +350,11 @@ test('NEG: em-recall with no recent bp-001 violation does NOT arm marker (activa
   git(cleanRepo, 'commit -q -m init')
 
   const cleanRepoReal = fs.realpathSync(cleanRepo)
-  const cleanMarker = path.join(cleanRepoReal, '.claude', '.checkpoint-required')
+  // .checkpoints/ migration: new arming writes to .checkpoints/, so the
+  // negative assertion targets the primary path. Legacy .claude/ is also
+  // checked to guard against a regression that re-introduces legacy writes.
+  const cleanMarkerPrimary = path.join(cleanRepoReal, '.checkpoints', '.checkpoint-required')
+  const cleanMarkerLegacy = path.join(cleanRepoReal, '.claude', '.checkpoint-required')
 
   // No --project test → don't pick up the seeded violation in mainRepo.
   execSync(`node ${RECALL} --scope local --no-track`, {
@@ -338,16 +362,24 @@ test('NEG: em-recall with no recent bp-001 violation does NOT arm marker (activa
   })
 
   assert.ok(
-    !fs.existsSync(cleanMarker),
-    `unexpected marker at ${cleanMarker} — activator armed without violation evidence`,
+    !fs.existsSync(cleanMarkerPrimary),
+    `unexpected marker at ${cleanMarkerPrimary} — activator armed without violation evidence`,
   )
-  // Defensive: prove the dir would have existed if marker WERE written
-  // (the parent .claude/ dir would have been mkdir'd by armCheckpointMarker).
-  // We assert .claude/ doesn't exist either — proves armCheckpointMarker
-  // never ran, not just that the marker file was missing.
+  assert.ok(
+    !fs.existsSync(cleanMarkerLegacy),
+    `unexpected legacy marker at ${cleanMarkerLegacy} — activator wrote to legacy path`,
+  )
+  // Defensive: prove neither dir was mkdir'd by armCheckpointMarker. After
+  // .checkpoints/ migration, ensurePrimaryDir is the gate; if armCheckpoint
+  // had run we'd see .checkpoints/. Legacy .claude/ also asserted absent
+  // because armCheckpointMarker should never touch it.
+  assert.ok(
+    !fs.existsSync(path.join(cleanRepoReal, '.checkpoints')),
+    `.checkpoints/ dir created without arming — armCheckpointMarker ran spuriously`,
+  )
   assert.ok(
     !fs.existsSync(path.join(cleanRepoReal, '.claude')),
-    `.claude/ dir created without arming — armCheckpointMarker ran spuriously`,
+    `.claude/ dir created without arming — legacy write path live`,
   )
 })
 

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -93,7 +93,10 @@ manifest_source=$(jq -r '.source_repo' "$TEST_HOME/.episodic-memory/hook-install
 assert_eq "T1b7 hook freshness manifest records source repo (#103)" "$REPO_ROOT" "$manifest_source"
 
 managed_count=$(jq '[.files[]? | select(.relative_path | test("^hooks/.*\\.sh$"))] | length' "$TEST_HOME/.episodic-memory/hook-install.json")
-assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "6" "$managed_count"
+# 4 hook .sh files (checkpoint-gate, plan-gate, em-recall-sessionstart,
+# stop-gate) + 3 hooks/lib/.sh files (command-classifier, repo-root, +
+# marker-paths added 2026-05-09 with the .checkpoints/ migration) = 7.
+assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "7" "$managed_count"
 
 pg_manifest=$(jq -r '.files[] | select(.relative_path == "hooks/plan-gate.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
 assert_eq "T1b9 hook freshness manifest records plan-gate install path (#103)" "$TEST_HOME/.claude/hooks/plan-gate.sh" "$pg_manifest"

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -55,7 +55,7 @@ function mkRepo(label) {
   execSync(`git -C "${d}" config user.name t`)
   fs.writeFileSync(path.join(d, 'README.md'), 'x\n')
   execSync(`git -C "${d}" add . && git -C "${d}" commit -q -m init`)
-  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
   return d
 }
 
@@ -120,13 +120,13 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // SessionStart hook has shipped on this machine).
 {
   const d = mkRepo('1-1'); cleanupDirs.push(d)
-  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  fs.writeFileSync(path.join(d, '.checkpoints', '.checkpoint-required'), '')
   const r = runGateStop(d)
   if (isBlock(r) && r.status === 0) ok('1.1: armed + no baseline → block (back-compat)')
   else bad('1.1: armed + no baseline → block', `got: ${JSON.stringify(r)}`)
 
   // Defensive: marker still present after gate runs
-  if (fs.existsSync(path.join(d, '.claude', '.checkpoint-required')))
+  if (fs.existsSync(path.join(d, '.checkpoints', '.checkpoint-required')))
     ok('1.1 (defensive): marker still present at check time')
   else bad('1.1 defensive', 'marker disappeared')
 }
@@ -134,7 +134,7 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // 1.2 baseline + all-stale → allow (carve-out fires)
 {
   const d = mkRepo('1-2'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   // Make checkpoint-required older
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
@@ -148,7 +148,7 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // 1.3 baseline + plan-pending newer than baseline → block
 {
   const d = mkRepo('1-3'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
@@ -166,7 +166,7 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // 1.4 .checkpoint-required re-armed mid-session (newer than baseline) → block
 {
   const d = mkRepo('1-4'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
   const preReq = path.join(claudeDir, '.checkpoint-required')
   fs.writeFileSync(preReq, '')
@@ -179,7 +179,7 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // 1.5 .post-checkpoint-required newer than baseline → block
 {
   const d = mkRepo('1-5'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
@@ -194,7 +194,7 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
 // 1.6 plan-pending OLDER than baseline (orphan) → allow
 {
   const d = mkRepo('1-6'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   const planP = path.join(claudeDir, '.plan-approval-pending')
@@ -213,7 +213,7 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
 // 2.1 first run creates .session-baseline
 {
   const d = mkRepo('2-1'); cleanupDirs.push(d)
-  const baseline = path.join(d, '.claude', '.session-baseline')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
   if (fs.existsSync(baseline)) bad('2.1 setup', 'baseline pre-existed')
   const r = runSessionStart(d)
   if (r.status === 0 && fs.existsSync(baseline)) ok('2.1: --session-start creates .session-baseline')
@@ -224,7 +224,7 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
 {
   const d = mkRepo('2-2'); cleanupDirs.push(d)
   runSessionStart(d)
-  const baseline = path.join(d, '.claude', '.session-baseline')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
   const m1 = fs.statSync(baseline).mtimeMs
   // Force temporal separation
   setMtime(baseline, m1 - 60_000)
@@ -239,8 +239,8 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
 {
   const d = mkRepo('2-3'); cleanupDirs.push(d)
   runSessionStart(d) // creates baseline
-  const baseline = path.join(d, '.claude', '.session-baseline')
-  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
   // Force temporal separation: roll back baseline by 60s so we have
   // unambiguous past/future zones to test against.
   setMtime(baseline, Date.now() - 60_000)
@@ -264,8 +264,8 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
 {
   const d = mkRepo('2-4'); cleanupDirs.push(d)
   runSessionStart(d) // baseline at T0
-  const baseline = path.join(d, '.claude', '.session-baseline')
-  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
   const baselineM = fs.statSync(baseline).mtimeMs
   fs.writeFileSync(planP, '')
   setMtime(planP, baselineM + 5_000) // newer than prior baseline
@@ -278,7 +278,7 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
 // 2.5 first-ever run with leftover plan-pending leaves it alone
 {
   const d = mkRepo('2-5'); cleanupDirs.push(d)
-  const planP = path.join(d, '.claude', '.plan-approval-pending')
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
   fs.writeFileSync(planP, '')
   // No prior baseline exists.
   runSessionStart(d)
@@ -298,7 +298,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 {
   const d = mkRepo('3-1'); cleanupDirs.push(d)
   runSessionStart(d) // creates baseline
-  const baseline = path.join(d, '.claude', '.session-baseline')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
   // Roll back baseline so we have a clear "older than" zone
   setMtime(baseline, Date.now() - 60_000)
   const baselineM = fs.statSync(baseline).mtimeMs
@@ -307,7 +307,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
     '.checkpoint-required',
     '.post-checkpoint-required',
     '.plan-approval-pending'
-  ].map(m => path.join(d, '.claude', m))
+  ].map(m => path.join(d, '.checkpoints', m))
   for (const m of markers) {
     fs.writeFileSync(m, '')
     setMtime(m, baselineM - 5_000)
@@ -328,13 +328,13 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 {
   const d = mkRepo('3-2'); cleanupDirs.push(d)
   runSessionStart(d)
-  const baseline = path.join(d, '.claude', '.session-baseline')
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
   const baselineM = fs.statSync(baseline).mtimeMs
   const markers = [
     '.checkpoint-required',
     '.post-checkpoint-required',
     '.plan-approval-pending'
-  ].map(m => path.join(d, '.claude', m))
+  ].map(m => path.join(d, '.checkpoints', m))
   for (const m of markers) {
     fs.writeFileSync(m, '')
     setMtime(m, baselineM + 5_000) // in-flight (mid-session)
@@ -351,13 +351,13 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 // accidental symlinks (e.g. workspace setups), not adversarial.
 {
   const d = mkRepo('3-3'); cleanupDirs.push(d)
-  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  fs.writeFileSync(path.join(d, '.checkpoints', '.checkpoint-required'), '')
   // Create a real file elsewhere with very-old mtime, then symlink
   // .session-baseline to it.
-  const realFile = path.join(d, '.claude', 'real-old-file')
+  const realFile = path.join(d, '.checkpoints', 'real-old-file')
   fs.writeFileSync(realFile, '')
   setMtime(realFile, Date.now() - 365 * 24 * 60 * 60 * 1000) // 1 year ago
-  fs.symlinkSync(realFile, path.join(d, '.claude', '.session-baseline'))
+  fs.symlinkSync(realFile, path.join(d, '.checkpoints', '.session-baseline'))
   // Without symlink defense, lstat(real) would say baseline is older than
   // markers → carve-out fires. With defense: symlink rejected → carve-out
   // does not fire → block.
@@ -373,7 +373,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 // fails the carve-out closed, symmetric with baseline.
 {
   const d = mkRepo('3-3b-post'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
@@ -388,7 +388,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 }
 {
   const d = mkRepo('3-3b-checkpoint'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
   // Symlinked .checkpoint-required newer than baseline. The gate-stop
   // path requires preReq to exist (real or symlink) before evaluating
@@ -404,7 +404,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 }
 {
   const d = mkRepo('3-3b-plan'); cleanupDirs.push(d)
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
@@ -435,7 +435,7 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
 // 3.5 stop-gate block reason still parses cleanly.
 {
   const d = mkRepo('3-5'); cleanupDirs.push(d)
-  fs.writeFileSync(path.join(d, '.claude', '.checkpoint-required'), '')
+  fs.writeFileSync(path.join(d, '.checkpoints', '.checkpoint-required'), '')
   const r = runGateStop(d)
   let reason = null
   try { reason = JSON.parse(r.stdout).reason } catch {}
@@ -468,9 +468,14 @@ function mkE2EHome() {
   const scripts = path.join(home, '.episodic-memory', 'scripts')
   fs.mkdirSync(path.join(scripts, 'lib'), { recursive: true })
   fs.copyFileSync(EM_RECALL, path.join(scripts, 'em-recall.mjs'))
-  // em-recall imports scripts/lib/local-dir.mjs at module load
-  const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', 'local-dir.mjs')
-  fs.copyFileSync(libSrc, path.join(scripts, 'lib', 'local-dir.mjs'))
+  // em-recall imports scripts/lib/{local-dir,marker-paths}.mjs at module load.
+  // .checkpoints/ migration: marker-paths.mjs ships alongside local-dir.mjs;
+  // omit it and em-recall fails to load (same fix as test-stop-gate.sh's
+  // mk_fake_home).
+  for (const lib of ['local-dir.mjs', 'marker-paths.mjs']) {
+    const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', lib)
+    fs.copyFileSync(libSrc, path.join(scripts, 'lib', lib))
+  }
   // Empty episodes dir so shouldArmBp001Checkpoint returns false
   fs.mkdirSync(path.join(home, '.episodic-memory', 'episodes'), { recursive: true })
   return home
@@ -498,7 +503,7 @@ function runHook(hookPath, inputJson, cwd, home) {
 {
   const d = mkRepo('4-1'); cleanupDirs.push(d)
   const home = mkE2EHome()
-  const claudeDir = path.join(d, '.claude')
+  const claudeDir = path.join(d, '.checkpoints')
   const baseline = path.join(claudeDir, '.session-baseline')
   const preReq = path.join(claudeDir, '.checkpoint-required')
   const postReq = path.join(claudeDir, '.post-checkpoint-required')
@@ -573,8 +578,8 @@ function runHook(hookPath, inputJson, cwd, home) {
 {
   const d = mkRepo('4-2'); cleanupDirs.push(d)
   const home = mkE2EHome()
-  const preReq = path.join(d, '.claude', '.checkpoint-required')
-  const preDone = path.join(d, '.claude', '.pre-checkpoint-done')
+  const preReq = path.join(d, '.checkpoints', '.checkpoint-required')
+  const preDone = path.join(d, '.checkpoints', '.pre-checkpoint-done')
   fs.writeFileSync(preReq, '') // armed
   // pre-done absent (empty) → gate must block
   const editInput = JSON.stringify({
@@ -608,8 +613,8 @@ function runHook(hookPath, inputJson, cwd, home) {
 {
   const d = mkRepo('4-3'); cleanupDirs.push(d)
   const home = mkE2EHome()
-  const preReq = path.join(d, '.claude', '.checkpoint-required')
-  const preDone = path.join(d, '.claude', '.pre-checkpoint-done')
+  const preReq = path.join(d, '.checkpoints', '.checkpoint-required')
+  const preDone = path.join(d, '.checkpoints', '.pre-checkpoint-done')
   fs.writeFileSync(preReq, '')
   // preDone absent → gate's marker_write allowlist condition met
   const writeInput = JSON.stringify({

--- a/tests/test-marker-paths.mjs
+++ b/tests/test-marker-paths.mjs
@@ -19,7 +19,8 @@ import {
   LEGACY_MARKER_DIR,
   BASELINE_NAME,
   TASK_SIGNAL_MARKERS,
-  ALL_MARKERS,
+  CHECKPOINT_CLEANUP_MARKERS,
+  ALL_MIGRATED_MARKERS,
   primaryMarkerPath,
   legacyMarkerPath,
   resolveMarkerRead,
@@ -57,13 +58,23 @@ console.log('Constants:')
 test('PRIMARY_MARKER_DIR is .checkpoints', () => eq(PRIMARY_MARKER_DIR, '.checkpoints'))
 test('LEGACY_MARKER_DIR is .claude', () => eq(LEGACY_MARKER_DIR, '.claude'))
 test('BASELINE_NAME is .session-baseline', () => eq(BASELINE_NAME, '.session-baseline'))
-test('TASK_SIGNAL_MARKERS length is 5', () => eq(TASK_SIGNAL_MARKERS.length, 5))
-test('ALL_MARKERS length is 6', () => eq(ALL_MARKERS.length, 6))
+test('TASK_SIGNAL_MARKERS length is 3 (em-recall carve-out class)', () => eq(TASK_SIGNAL_MARKERS.length, 3))
+test('CHECKPOINT_CLEANUP_MARKERS length is 4 (push-gate cleanup class)', () => eq(CHECKPOINT_CLEANUP_MARKERS.length, 4))
+test('ALL_MIGRATED_MARKERS length is 6 (full migration scope)', () => eq(ALL_MIGRATED_MARKERS.length, 6))
 test('TASK_SIGNAL_MARKERS contains .checkpoint-required', () => {
   if (!TASK_SIGNAL_MARKERS.includes('.checkpoint-required')) throw new Error('missing')
 })
-test('ALL_MARKERS contains .session-baseline', () => {
-  if (!ALL_MARKERS.includes('.session-baseline')) throw new Error('missing')
+test('TASK_SIGNAL_MARKERS does NOT contain .pre-checkpoint-done', () => {
+  if (TASK_SIGNAL_MARKERS.includes('.pre-checkpoint-done')) throw new Error('leaked into carve-out class')
+})
+test('CHECKPOINT_CLEANUP_MARKERS contains .pre-checkpoint-done', () => {
+  if (!CHECKPOINT_CLEANUP_MARKERS.includes('.pre-checkpoint-done')) throw new Error('missing')
+})
+test('CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approval-pending', () => {
+  if (CHECKPOINT_CLEANUP_MARKERS.includes('.plan-approval-pending')) throw new Error('leaked into push cleanup')
+})
+test('ALL_MIGRATED_MARKERS contains .session-baseline', () => {
+  if (!ALL_MIGRATED_MARKERS.includes('.session-baseline')) throw new Error('missing')
 })
 
 console.log('\nPath helpers:')

--- a/tests/test-marker-paths.mjs
+++ b/tests/test-marker-paths.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * test-marker-paths.mjs — Tests for scripts/lib/marker-paths.mjs shared helpers.
+ *
+ * Layer-1 unit tests over the helpers used by em-recall / em-session-end-prompt
+ * during the .checkpoints/ migration. Pairs with tests/test-marker-paths.sh
+ * for the bash-side mirror.
+ *
+ * Defensive ordering per feedback_test_resource_existence_check.md: every
+ * state assertion is paired with an existence check on the artifact at
+ * check time.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import {
+  PRIMARY_MARKER_DIR,
+  LEGACY_MARKER_DIR,
+  BASELINE_NAME,
+  TASK_SIGNAL_MARKERS,
+  ALL_MARKERS,
+  primaryMarkerPath,
+  legacyMarkerPath,
+  resolveMarkerRead,
+  writeMarkerPath,
+  bothMarkerPaths,
+  ensurePrimaryDir
+} from '../scripts/lib/marker-paths.mjs'
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function eq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg || 'eq'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-marker-paths-'))
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+
+console.log('Constants:')
+test('PRIMARY_MARKER_DIR is .checkpoints', () => eq(PRIMARY_MARKER_DIR, '.checkpoints'))
+test('LEGACY_MARKER_DIR is .claude', () => eq(LEGACY_MARKER_DIR, '.claude'))
+test('BASELINE_NAME is .session-baseline', () => eq(BASELINE_NAME, '.session-baseline'))
+test('TASK_SIGNAL_MARKERS length is 5', () => eq(TASK_SIGNAL_MARKERS.length, 5))
+test('ALL_MARKERS length is 6', () => eq(ALL_MARKERS.length, 6))
+test('TASK_SIGNAL_MARKERS contains .checkpoint-required', () => {
+  if (!TASK_SIGNAL_MARKERS.includes('.checkpoint-required')) throw new Error('missing')
+})
+test('ALL_MARKERS contains .session-baseline', () => {
+  if (!ALL_MARKERS.includes('.session-baseline')) throw new Error('missing')
+})
+
+console.log('\nPath helpers:')
+test('primaryMarkerPath returns .checkpoints/<basename>', () => {
+  eq(primaryMarkerPath('/repo', '.X'), path.join('/repo', '.checkpoints', '.X'))
+})
+test('legacyMarkerPath returns .claude/<basename>', () => {
+  eq(legacyMarkerPath('/repo', '.X'), path.join('/repo', '.claude', '.X'))
+})
+test('writeMarkerPath === primaryMarkerPath', () => {
+  eq(writeMarkerPath('/repo', '.X'), primaryMarkerPath('/repo', '.X'))
+})
+test('bothMarkerPaths returns [primary, legacy]', () => {
+  const [p, l] = bothMarkerPaths('/repo', '.X')
+  eq(p, path.join('/repo', '.checkpoints', '.X'))
+  eq(l, path.join('/repo', '.claude', '.X'))
+})
+
+console.log('\nresolveMarkerRead fallback chain:')
+
+test('neither marker present → null', () => {
+  const root = path.join(tmpRoot, 'none')
+  fs.mkdirSync(root, { recursive: true })
+  if (resolveMarkerRead(root, '.pre-checkpoint-done') !== null) {
+    throw new Error('expected null')
+  }
+})
+
+test('legacy only → returns legacy path', () => {
+  const root = path.join(tmpRoot, 'legacy')
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  fs.writeFileSync(path.join(root, '.claude', '.pre-checkpoint-done'), 'body')
+  const out = resolveMarkerRead(root, '.pre-checkpoint-done')
+  eq(out, path.join(root, '.claude', '.pre-checkpoint-done'))
+  if (!fs.existsSync(out)) throw new Error('result file does not exist')
+})
+
+test('primary only → returns primary path', () => {
+  const root = path.join(tmpRoot, 'primary')
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.writeFileSync(path.join(root, '.checkpoints', '.pre-checkpoint-done'), 'body')
+  const out = resolveMarkerRead(root, '.pre-checkpoint-done')
+  eq(out, path.join(root, '.checkpoints', '.pre-checkpoint-done'))
+  if (!fs.existsSync(out)) throw new Error('result file does not exist')
+})
+
+test('both present → primary wins', () => {
+  const root = path.join(tmpRoot, 'both')
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  fs.writeFileSync(path.join(root, '.checkpoints', '.pre-checkpoint-done'), 'p')
+  fs.writeFileSync(path.join(root, '.claude', '.pre-checkpoint-done'), 'l')
+  const out = resolveMarkerRead(root, '.pre-checkpoint-done')
+  eq(out, path.join(root, '.checkpoints', '.pre-checkpoint-done'))
+})
+
+console.log('\nensurePrimaryDir:')
+
+test('creates .checkpoints/ when absent', () => {
+  const root = path.join(tmpRoot, 'ensure-1')
+  fs.mkdirSync(root, { recursive: true })
+  ensurePrimaryDir(root)
+  if (!fs.statSync(path.join(root, '.checkpoints')).isDirectory()) {
+    throw new Error('directory not created')
+  }
+})
+
+test('idempotent on second call', () => {
+  const root = path.join(tmpRoot, 'ensure-2')
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  ensurePrimaryDir(root)
+  ensurePrimaryDir(root)
+  if (!fs.statSync(path.join(root, '.checkpoints')).isDirectory()) {
+    throw new Error('directory removed by second call')
+  }
+})
+
+console.log()
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('Failures:')
+  for (const f of failures) console.log(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-marker-paths.sh
+++ b/tests/test-marker-paths.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test-marker-paths.sh — Tests for hooks/lib/marker-paths.sh shared helpers.
+#
+# Layer-1 unit tests over the helpers used by checkpoint-gate / plan-gate
+# during the .checkpoints/ migration. Pairs with tests/test-marker-paths.mjs
+# for the node-side mirror.
+#
+# Defensive ordering per feedback_test_resource_existence_check.md: every
+# state assertion is paired with an existence check on the artifact at
+# check time.
+
+set -e
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB="$REPO_ROOT/hooks/lib/marker-paths.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: $LIB not found"
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$LIB"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ✓ $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1: $2")
+  echo "  ✗ $1: $2"
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$name"
+  else
+    fail "$name" "expected '$expected', got '$actual'"
+  fi
+}
+
+# Build a temp dir for filesystem tests.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Constants:"
+assert_eq "PRIMARY_MARKER_DIR is .checkpoints" ".checkpoints" "$PRIMARY_MARKER_DIR"
+assert_eq "LEGACY_MARKER_DIR is .claude" ".claude" "$LEGACY_MARKER_DIR"
+assert_eq "BASELINE_NAME is .session-baseline" ".session-baseline" "$BASELINE_NAME"
+assert_eq "TASK_SIGNAL_MARKERS count is 5" "5" "${#TASK_SIGNAL_MARKERS[@]}"
+assert_eq "ALL_MARKERS count is 6" "6" "${#ALL_MARKERS[@]}"
+
+# Spot-check membership (any one acts as a contract sentinel).
+case " ${TASK_SIGNAL_MARKERS[*]} " in
+  *" .checkpoint-required "*) pass "TASK_SIGNAL_MARKERS contains .checkpoint-required" ;;
+  *) fail "TASK_SIGNAL_MARKERS contains .checkpoint-required" "missing" ;;
+esac
+case " ${ALL_MARKERS[*]} " in
+  *" .session-baseline "*) pass "ALL_MARKERS contains .session-baseline" ;;
+  *) fail "ALL_MARKERS contains .session-baseline" "missing" ;;
+esac
+
+echo
+echo "Path helpers:"
+assert_eq "primary_marker_path /repo .X" \
+  "/repo/.checkpoints/.X" \
+  "$(primary_marker_path /repo .X)"
+assert_eq "legacy_marker_path /repo .X" \
+  "/repo/.claude/.X" \
+  "$(legacy_marker_path /repo .X)"
+assert_eq "write_marker_path === primary_marker_path" \
+  "/repo/.checkpoints/.X" \
+  "$(write_marker_path /repo .X)"
+
+# both_marker_paths emits two lines; capture into array per Bash 3.2 (no
+# mapfile per macOS portability lesson 20260508-021131).
+both_out="$(both_marker_paths /repo .X)"
+expected_both=$'/repo/.checkpoints/.X\n/repo/.claude/.X'
+assert_eq "both_marker_paths emits primary then legacy" "$expected_both" "$both_out"
+
+echo
+echo "resolve_marker_read fallback chain:"
+
+# Case 1: neither exists → return code 1, empty stdout.
+ROOT_NONE="$TMP/root-none"
+mkdir -p "$ROOT_NONE"
+out="$(resolve_marker_read "$ROOT_NONE" .pre-checkpoint-done 2>/dev/null || echo "MISS")"
+assert_eq "neither marker present → MISS sentinel" "MISS" "$out"
+
+# Case 2: legacy only → returns legacy path.
+ROOT_LEG="$TMP/root-legacy"
+mkdir -p "$ROOT_LEG/.claude"
+echo body > "$ROOT_LEG/.claude/.pre-checkpoint-done"
+out="$(resolve_marker_read "$ROOT_LEG" .pre-checkpoint-done)"
+assert_eq "legacy only → returns legacy path" \
+  "$ROOT_LEG/.claude/.pre-checkpoint-done" \
+  "$out"
+[ -f "$out" ] && pass "legacy-only result file exists" || fail "legacy-only result file exists" "missing"
+
+# Case 3: primary only → returns primary path.
+ROOT_PRI="$TMP/root-primary"
+mkdir -p "$ROOT_PRI/.checkpoints"
+echo body > "$ROOT_PRI/.checkpoints/.pre-checkpoint-done"
+out="$(resolve_marker_read "$ROOT_PRI" .pre-checkpoint-done)"
+assert_eq "primary only → returns primary path" \
+  "$ROOT_PRI/.checkpoints/.pre-checkpoint-done" \
+  "$out"
+[ -f "$out" ] && pass "primary-only result file exists" || fail "primary-only result file exists" "missing"
+
+# Case 4: both exist → primary wins.
+ROOT_BOTH="$TMP/root-both"
+mkdir -p "$ROOT_BOTH/.checkpoints" "$ROOT_BOTH/.claude"
+echo primary > "$ROOT_BOTH/.checkpoints/.pre-checkpoint-done"
+echo legacy > "$ROOT_BOTH/.claude/.pre-checkpoint-done"
+out="$(resolve_marker_read "$ROOT_BOTH" .pre-checkpoint-done)"
+assert_eq "both present → primary wins" \
+  "$ROOT_BOTH/.checkpoints/.pre-checkpoint-done" \
+  "$out"
+
+echo
+echo "ensure_primary_dir:"
+ROOT_ENS="$TMP/root-ensure"
+mkdir -p "$ROOT_ENS"
+ensure_primary_dir "$ROOT_ENS"
+[ -d "$ROOT_ENS/.checkpoints" ] && pass "ensure_primary_dir creates .checkpoints/" \
+  || fail "ensure_primary_dir creates .checkpoints/" "directory missing"
+
+# Idempotent re-call.
+ensure_primary_dir "$ROOT_ENS"
+[ -d "$ROOT_ENS/.checkpoints" ] && pass "ensure_primary_dir is idempotent" \
+  || fail "ensure_primary_dir is idempotent" "directory missing after second call"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do echo "  $f"; done
+  exit 1
+fi

--- a/tests/test-marker-paths.sh
+++ b/tests/test-marker-paths.sh
@@ -54,17 +54,32 @@ echo "Constants:"
 assert_eq "PRIMARY_MARKER_DIR is .checkpoints" ".checkpoints" "$PRIMARY_MARKER_DIR"
 assert_eq "LEGACY_MARKER_DIR is .claude" ".claude" "$LEGACY_MARKER_DIR"
 assert_eq "BASELINE_NAME is .session-baseline" ".session-baseline" "$BASELINE_NAME"
-assert_eq "TASK_SIGNAL_MARKERS count is 5" "5" "${#TASK_SIGNAL_MARKERS[@]}"
-assert_eq "ALL_MARKERS count is 6" "6" "${#ALL_MARKERS[@]}"
+assert_eq "TASK_SIGNAL_MARKERS count is 3 (em-recall carve-out class)" "3" "${#TASK_SIGNAL_MARKERS[@]}"
+assert_eq "CHECKPOINT_CLEANUP_MARKERS count is 4 (push-gate cleanup class)" "4" "${#CHECKPOINT_CLEANUP_MARKERS[@]}"
+assert_eq "ALL_MIGRATED_MARKERS count is 6 (full migration scope)" "6" "${#ALL_MIGRATED_MARKERS[@]}"
 
-# Spot-check membership (any one acts as a contract sentinel).
+# Spot-check membership of each set.
 case " ${TASK_SIGNAL_MARKERS[*]} " in
   *" .checkpoint-required "*) pass "TASK_SIGNAL_MARKERS contains .checkpoint-required" ;;
   *) fail "TASK_SIGNAL_MARKERS contains .checkpoint-required" "missing" ;;
 esac
-case " ${ALL_MARKERS[*]} " in
-  *" .session-baseline "*) pass "ALL_MARKERS contains .session-baseline" ;;
-  *) fail "ALL_MARKERS contains .session-baseline" "missing" ;;
+case " ${TASK_SIGNAL_MARKERS[*]} " in
+  *" .pre-checkpoint-done "*)
+    fail "TASK_SIGNAL_MARKERS does NOT contain .pre-checkpoint-done" "leaked into carve-out class" ;;
+  *) pass "TASK_SIGNAL_MARKERS does NOT contain .pre-checkpoint-done" ;;
+esac
+case " ${CHECKPOINT_CLEANUP_MARKERS[*]} " in
+  *" .pre-checkpoint-done "*) pass "CHECKPOINT_CLEANUP_MARKERS contains .pre-checkpoint-done" ;;
+  *) fail "CHECKPOINT_CLEANUP_MARKERS contains .pre-checkpoint-done" "missing" ;;
+esac
+case " ${CHECKPOINT_CLEANUP_MARKERS[*]} " in
+  *" .plan-approval-pending "*)
+    fail "CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approval-pending" "leaked into push cleanup" ;;
+  *) pass "CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approval-pending" ;;
+esac
+case " ${ALL_MIGRATED_MARKERS[*]} " in
+  *" .session-baseline "*) pass "ALL_MIGRATED_MARKERS contains .session-baseline" ;;
+  *) fail "ALL_MIGRATED_MARKERS contains .session-baseline" "missing" ;;
 esac
 
 echo

--- a/tests/test-migration-cutover.mjs
+++ b/tests/test-migration-cutover.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * test-migration-cutover.mjs — Tests for tools/migration-cutover.mjs and
+ * scripts/lib/install-manifest.mjs.
+ *
+ * Verifies the install parity check correctly distinguishes OK / DIFF /
+ * MISSING / SOURCE_GONE per file in the manifest. Closes Codex round-1 F1
+ * (runtime install parity) by ensuring the cutover tool catches stale
+ * installed copies before push.
+ *
+ * Layered:
+ *   Layer 1 — install-manifest unit tests (manifest contents from a tmp repo)
+ *   Layer 2 — migration-cutover integration tests (run subprocess against
+ *             a synthetic repo + home pair, parse JSON output, assert state
+ *             counts and per-file statuses)
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import { buildInstallManifest, HOOK_SPECS } from '../scripts/lib/install-manifest.mjs'
+
+const TESTS_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_ROOT = path.resolve(TESTS_DIR, '..')
+const CUTOVER = path.join(REPO_ROOT, 'tools', 'migration-cutover.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function eq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg || 'eq'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-cutover-'))
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+
+// ---------------------------------------------------------------------------
+// Synthetic repo + home setup
+// ---------------------------------------------------------------------------
+// We mirror the repo's hooks/ + scripts/ + patterns/ structure but with
+// minimal placeholder content. The cutover tool walks the manifest, so we
+// only need files at the expected relative paths.
+const synthRepo = path.join(tmpRoot, 'repo')
+const synthHome = path.join(tmpRoot, 'home')
+
+function mkfile(p, content = 'x') {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, content)
+}
+
+// Mirror real hook + lib + script + script-lib + pattern files.
+mkfile(path.join(synthRepo, 'hooks/checkpoint-gate.sh'), 'cp\n')
+mkfile(path.join(synthRepo, 'hooks/plan-gate.sh'), 'plan\n')
+mkfile(path.join(synthRepo, 'hooks/stop-gate.sh'), 'stop\n')
+mkfile(path.join(synthRepo, 'hooks/em-recall-sessionstart.sh'), 'sess\n')
+mkfile(path.join(synthRepo, 'hooks/lib/marker-paths.sh'), 'mp\n')
+mkfile(path.join(synthRepo, 'hooks/lib/repo-root.sh'), 'rr\n')
+mkfile(path.join(synthRepo, 'hooks/lib/command-classifier.sh'), 'cc\n')
+mkfile(path.join(synthRepo, 'scripts/em-recall.mjs'), 'er\n')
+mkfile(path.join(synthRepo, 'scripts/em-store.mjs'), 'es\n')
+mkfile(path.join(synthRepo, 'scripts/lib/local-dir.mjs'), 'ld\n')
+mkfile(path.join(synthRepo, 'scripts/lib/marker-paths.mjs'), 'mp-mjs\n')
+mkfile(path.join(synthRepo, 'patterns/_index.json'), '{}\n')
+
+console.log('Layer 1 — install-manifest:')
+
+test('HOOK_SPECS contains the 5 canonical hooks (incl. stop-gate twice)', () => {
+  // 5 entries (stop-gate registered for Stop AND SubagentStop).
+  eq(HOOK_SPECS.length, 5)
+  const files = HOOK_SPECS.map(s => s.file)
+  for (const f of ['checkpoint-gate.sh', 'plan-gate.sh', 'em-recall-sessionstart.sh', 'stop-gate.sh']) {
+    if (!files.includes(f)) throw new Error(`missing hook file: ${f}`)
+  }
+})
+
+test('buildInstallManifest enumerates hooks + libs + scripts + script-libs + patterns', () => {
+  const m = buildInstallManifest(synthRepo, synthHome)
+  // Expected count: 4 unique hooks + 3 hook libs + 2 scripts + 2 script libs + 1 pattern = 12
+  eq(m.length, 12)
+  const byKind = m.reduce((acc, e) => {
+    acc[e.kind] = (acc[e.kind] || 0) + 1
+    return acc
+  }, {})
+  eq(byKind.hook, 4)        // dedup stop-gate (registered twice)
+  eq(byKind['hook-lib'], 3)
+  eq(byKind.script, 2)
+  eq(byKind['script-lib'], 2)
+  eq(byKind.pattern, 1)
+})
+
+test('buildInstallManifest sorts entries by relativePath', () => {
+  const m = buildInstallManifest(synthRepo, synthHome)
+  for (let i = 1; i < m.length; i++) {
+    if (m[i].relativePath < m[i - 1].relativePath) {
+      throw new Error(`unsorted at index ${i}: ${m[i - 1].relativePath} > ${m[i].relativePath}`)
+    }
+  }
+})
+
+test('buildInstallManifest installedPath uses HOME_DIR for hook + script roots', () => {
+  const m = buildInstallManifest(synthRepo, synthHome)
+  const checkpoint = m.find(e => e.relativePath === 'hooks/checkpoint-gate.sh')
+  eq(checkpoint.installedPath, path.join(synthHome, '.claude', 'hooks', 'checkpoint-gate.sh'))
+  const recall = m.find(e => e.relativePath === 'scripts/em-recall.mjs')
+  eq(recall.installedPath, path.join(synthHome, '.episodic-memory', 'scripts', 'em-recall.mjs'))
+})
+
+console.log('\nLayer 2 — migration-cutover:')
+
+function runCutover(repoDir, homeDir) {
+  const out = execSync(`node ${CUTOVER} --repo ${repoDir} --home ${homeDir} --json`, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30000
+  }).toString()
+  return JSON.parse(out)
+}
+
+function runCutoverExpectFail(repoDir, homeDir) {
+  try {
+    execSync(`node ${CUTOVER} --repo ${repoDir} --home ${homeDir} --json`, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 30000
+    })
+    throw new Error('cutover unexpectedly exited 0')
+  } catch (e) {
+    if (e.message === 'cutover unexpectedly exited 0') throw e
+    if (e.status !== 1) throw new Error(`expected exit 1, got ${e.status}`)
+    return JSON.parse(e.stdout.toString())
+  }
+}
+
+test('all-MISSING (empty home) → exit 1, all entries MISSING', () => {
+  // Fresh home — nothing installed.
+  const result = runCutoverExpectFail(synthRepo, synthHome)
+  eq(result.allOk, false)
+  eq(result.counts.MISSING, 12)
+  if (result.counts.OK) throw new Error(`unexpected OK count: ${result.counts.OK}`)
+})
+
+test('all-OK (home installed identically) → exit 0', () => {
+  // Mirror every manifest entry into the home.
+  const m = buildInstallManifest(synthRepo, synthHome)
+  for (const entry of m) {
+    fs.mkdirSync(path.dirname(entry.installedPath), { recursive: true })
+    fs.copyFileSync(entry.repoPath, entry.installedPath)
+  }
+  const result = runCutover(synthRepo, synthHome)
+  eq(result.allOk, true)
+  eq(result.counts.OK, 12)
+})
+
+test('one DIFF surfaces correctly → exit 1', () => {
+  // Mutate the installed em-recall to differ from the repo source.
+  const installedRecall = path.join(synthHome, '.episodic-memory', 'scripts', 'em-recall.mjs')
+  fs.writeFileSync(installedRecall, 'DRIFTED CONTENT\n')
+  const result = runCutoverExpectFail(synthRepo, synthHome)
+  eq(result.counts.DIFF, 1)
+  const recallEntry = result.results.find(r => r.relativePath === 'scripts/em-recall.mjs')
+  if (!recallEntry || recallEntry.status !== 'DIFF') {
+    throw new Error(`expected DIFF for em-recall, got ${JSON.stringify(recallEntry)}`)
+  }
+  // Restore for next test.
+  fs.copyFileSync(path.join(synthRepo, 'scripts/em-recall.mjs'), installedRecall)
+})
+
+test('one MISSING surfaces correctly → exit 1', () => {
+  const installedClassifier = path.join(synthHome, '.claude', 'hooks', 'lib', 'command-classifier.sh')
+  fs.unlinkSync(installedClassifier)
+  const result = runCutoverExpectFail(synthRepo, synthHome)
+  eq(result.counts.MISSING, 1)
+  const cc = result.results.find(r => r.relativePath === 'hooks/lib/command-classifier.sh')
+  if (!cc || cc.status !== 'MISSING') {
+    throw new Error(`expected MISSING for command-classifier, got ${JSON.stringify(cc)}`)
+  }
+  // Restore.
+  fs.copyFileSync(path.join(synthRepo, 'hooks/lib/command-classifier.sh'), installedClassifier)
+})
+
+console.log()
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('Failures:')
+  for (const f of failures) console.log(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-migration-cutover.mjs
+++ b/tests/test-migration-cutover.mjs
@@ -104,6 +104,24 @@ test('buildInstallManifest enumerates hooks + libs + scripts + script-libs + pat
   eq(byKind.pattern, 1)
 })
 
+// Codex round-1 F3 regression: HOOK_SPECS entries are emitted even when the
+// repo source files don't exist. Otherwise a wrong --repo produces a
+// vacuously-empty manifest that passes the gate.
+test('buildInstallManifest emits HOOK_SPECS entries even when repo sources missing', () => {
+  const phantomRepo = path.join(tmpRoot, 'phantom-for-manifest-test')
+  // Don't create any files — phantomRepo doesn't even exist.
+  const m = buildInstallManifest(phantomRepo, synthHome)
+  const hookEntries = m.filter(e => e.kind === 'hook')
+  eq(hookEntries.length, 4)  // checkpoint-gate, plan-gate, em-recall-sessionstart, stop-gate
+  // Each hook entry's repoPath should point at the phantom repo's hooks/ dir
+  // (which doesn't exist — that's the point: cutover catches it as SOURCE_GONE).
+  for (const e of hookEntries) {
+    if (!e.repoPath.startsWith(phantomRepo)) {
+      throw new Error(`hook entry repoPath outside phantom repo: ${e.repoPath}`)
+    }
+  }
+})
+
 test('buildInstallManifest sorts entries by relativePath', () => {
   const m = buildInstallManifest(synthRepo, synthHome)
   for (let i = 1; i < m.length; i++) {
@@ -151,6 +169,34 @@ test('all-MISSING (empty home) → exit 1, all entries MISSING', () => {
   eq(result.allOk, false)
   eq(result.counts.MISSING, 12)
   if (result.counts.OK) throw new Error(`unexpected OK count: ${result.counts.OK}`)
+})
+
+// Codex round-1 F3 regression: wrong/empty --repo must NOT vacuously pass.
+test('empty/wrong --repo → exit 1, emptyManifest=false (HOOK_SPECS still emitted) + SOURCE_GONE', () => {
+  // Synthetic empty repo: directory exists but contains no hooks/scripts.
+  const emptyRepo = path.join(tmpRoot, 'empty-repo')
+  fs.mkdirSync(emptyRepo, { recursive: true })
+  const result = runCutoverExpectFail(emptyRepo, synthHome)
+  eq(result.allOk, false)
+  // HOOK_SPECS entries are now emitted unconditionally — 4 unique hook
+  // .sh files (checkpoint-gate, plan-gate, em-recall-sessionstart, stop-gate)
+  // appear with status SOURCE_GONE because the empty-repo paths don't exist.
+  eq(result.emptyManifest, false)
+  if (!result.counts.SOURCE_GONE || result.counts.SOURCE_GONE < 4) {
+    throw new Error(`expected ≥4 SOURCE_GONE entries, got ${JSON.stringify(result.counts)}`)
+  }
+})
+
+test('truly empty manifest (no HOOK_SPECS sources possible) → emptyManifest=true, exit 1', () => {
+  // Construct a "repo" with NO hooks/ subdir AT ALL (HOOK_SPECS would still
+  // emit entries that fail SOURCE_GONE — proves the failure routes through
+  // the SOURCE_GONE counts, not just emptyManifest).
+  const phantomRepo = path.join(tmpRoot, 'phantom-repo-not-a-dir')
+  // Don't even mkdir it. buildInstallManifest still emits HOOK_SPECS entries
+  // (they're unconditional now), so emptyManifest is false; SOURCE_GONE is
+  // the load-bearing failure mode.
+  const result = runCutoverExpectFail(phantomRepo, synthHome)
+  eq(result.allOk, false)
 })
 
 test('all-OK (home installed identically) → exit 0', () => {

--- a/tests/test-migration-sweep.mjs
+++ b/tests/test-migration-sweep.mjs
@@ -130,6 +130,26 @@ test('config with comments and blank lines parsed correctly', () => {
   eq(result.allClean, true)
 })
 
+// Codex round-1 F2 regression: comment-only / empty config must fail closed.
+test('empty config (comments + blanks only) → exit 1, noRootsConfigured', () => {
+  const cfg = path.join(tmpRoot, 'roots-comments-only.txt')
+  fs.writeFileSync(cfg, `# only comments\n\n# nothing enrolled\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.noRootsConfigured, true)
+  eq(result.allClean, false)
+  eq(result.rootsScanned, 0)
+})
+
+test('completely empty config file → exit 1, noRootsConfigured', () => {
+  const cfg = path.join(tmpRoot, 'roots-empty.txt')
+  fs.writeFileSync(cfg, '')
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.noRootsConfigured, true)
+  eq(result.allClean, false)
+})
+
 test('all enrolled roots clean → exit 0', () => {
   const a = mkRoot('cfg-clean-a')
   const b = mkRoot('cfg-clean-b')

--- a/tests/test-migration-sweep.mjs
+++ b/tests/test-migration-sweep.mjs
@@ -212,6 +212,41 @@ test('config path is a directory → exit 1, configError=not_a_file', () => {
   eq(result.allClean, false)
 })
 
+console.log('\nCodex round-3 F5: relative-entry pre-resolve validation:')
+
+test('config with `.` (relative cwd) → exit 1, not_absolute (NOT silently resolved)', () => {
+  const cfg = path.join(tmpRoot, 'roots-dot.txt')
+  fs.writeFileSync(cfg, '.\n')
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.allClean, false)
+  if (!result.invalidConfigEntries || result.invalidConfigEntries.length !== 1) {
+    throw new Error(`expected 1 invalid entry, got ${JSON.stringify(result.invalidConfigEntries)}`)
+  }
+  eq(result.invalidConfigEntries[0].reason, 'not_absolute')
+  eq(result.invalidConfigEntries[0].root, '.')  // raw, not resolved
+})
+
+test('config with relative path that exists in cwd → exit 1, not_absolute', () => {
+  const cfg = path.join(tmpRoot, 'roots-relative-exists.txt')
+  fs.writeFileSync(cfg, 'tmp\n')
+  // Run sweep with cwd=tmpRoot so 'tmp' would resolve to an existing dir
+  // if path.resolve happened first.
+  const realDir = path.join(tmpRoot, 'tmp')
+  fs.mkdirSync(realDir, { recursive: true })
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.invalidConfigEntries[0].reason, 'not_absolute')
+})
+
+test('config with Windows-style path on POSIX → exit 1, not_absolute', () => {
+  const cfg = path.join(tmpRoot, 'roots-windows.txt')
+  fs.writeFileSync(cfg, 'C:\\demo\n')
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.invalidConfigEntries[0].reason, 'not_absolute')
+})
+
 test('all enrolled roots clean → exit 0', () => {
   const a = mkRoot('cfg-clean-a')
   const b = mkRoot('cfg-clean-b')

--- a/tests/test-migration-sweep.mjs
+++ b/tests/test-migration-sweep.mjs
@@ -150,6 +150,68 @@ test('completely empty config file → exit 1, noRootsConfigured', () => {
   eq(result.allClean, false)
 })
 
+console.log('\nCodex round-2 F4: malformed config content fails closed:')
+
+test('config with binary garbage line → exit 1, control_chars validation', () => {
+  // 0x00 NUL + 0x01 SOH bytes embedded in a "path" line — the kind of
+  // content a corrupted file might contain.
+  const cfg = path.join(tmpRoot, 'roots-binary.txt')
+  const garbage = '\x00\x01garbled-bytes\x1f'
+  fs.writeFileSync(cfg, `${garbage}\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.allClean, false)
+  if (!result.invalidConfigEntries || result.invalidConfigEntries.length !== 1) {
+    throw new Error(`expected 1 invalid entry, got ${JSON.stringify(result.invalidConfigEntries)}`)
+  }
+  eq(result.invalidConfigEntries[0].reason, 'control_chars')
+})
+
+test('config with non-absolute path → exit 1, not_absolute', () => {
+  const cfg = path.join(tmpRoot, 'roots-relative.txt')
+  fs.writeFileSync(cfg, 'relative/path\n')
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  // path.resolve makes the entry absolute — so the validation that fails
+  // is does_not_exist (because the resolved path doesn't exist), not
+  // not_absolute. This is acceptable: either failure mode is fail-closed.
+  if (!result.invalidConfigEntries || result.invalidConfigEntries.length !== 1) {
+    throw new Error(`expected 1 invalid entry, got ${JSON.stringify(result.invalidConfigEntries)}`)
+  }
+})
+
+test('config with path-to-file (not directory) → exit 1, not_a_directory', () => {
+  const cfg = path.join(tmpRoot, 'roots-file.txt')
+  const someFile = path.join(tmpRoot, 'a-real-file.txt')
+  fs.writeFileSync(someFile, 'I am a file')
+  fs.writeFileSync(cfg, `${someFile}\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.invalidConfigEntries[0].reason, 'not_a_directory')
+})
+
+test('mixed valid + invalid entries → exit 1 (one bad line taints whole config)', () => {
+  const goodRoot = mkRoot('cfg-mixed-good')
+  const cfg = path.join(tmpRoot, 'roots-mixed.txt')
+  fs.writeFileSync(cfg, `${goodRoot}\n/nonexistent/path/${Date.now()}\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.allClean, false)
+  // Good root is still scanned + clean, but allClean fails closed because
+  // the bad entry is unverified.
+  eq(result.rootsScanned, 1)
+  eq(result.invalidConfigEntries.length, 1)
+})
+
+test('config path is a directory → exit 1, configError=not_a_file', () => {
+  const cfgDir = path.join(tmpRoot, 'config-as-dir')
+  fs.mkdirSync(cfgDir)
+  const { result, exitCode } = runSweep(`--config ${cfgDir}`)
+  eq(exitCode, 1)
+  eq(result.configError, 'not_a_file')
+  eq(result.allClean, false)
+})
+
 test('all enrolled roots clean → exit 0', () => {
   const a = mkRoot('cfg-clean-a')
   const b = mkRoot('cfg-clean-b')

--- a/tests/test-migration-sweep.mjs
+++ b/tests/test-migration-sweep.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * test-migration-sweep.mjs — Tests for tools/migration-sweep.mjs.
+ *
+ * Closes Codex round-1 F4 verification: the state-based exit gate must
+ * correctly distinguish clean vs dirty enrolled roots and fail closed
+ * when the config is missing.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+
+const TESTS_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_ROOT = path.resolve(TESTS_DIR, '..')
+const SWEEP = path.join(REPO_ROOT, 'tools', 'migration-sweep.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function eq(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg || 'eq'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-sweep-'))
+process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
+
+function runSweep(args) {
+  // --json always; convert exit-1 from execSync exception to {result, exitCode}.
+  try {
+    const out = execSync(`node ${SWEEP} ${args} --json`, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15000
+    }).toString()
+    return { result: JSON.parse(out), exitCode: 0 }
+  } catch (e) {
+    if (typeof e.status !== 'number') throw e
+    return { result: JSON.parse(e.stdout.toString()), exitCode: e.status }
+  }
+}
+
+function mkRoot(name) {
+  const d = path.join(tmpRoot, name)
+  fs.mkdirSync(d, { recursive: true })
+  return d
+}
+
+function seedLegacyMarker(root, name) {
+  const dir = path.join(root, '.claude')
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, name), 'x')
+}
+
+console.log('Single-root mode (--root):')
+
+test('clean root → exit 0, allClean true, totalLegacy 0', () => {
+  const root = mkRoot('clean')
+  const { result, exitCode } = runSweep(`--root ${root}`)
+  eq(exitCode, 0)
+  eq(result.allClean, true)
+  eq(result.totalLegacy, 0)
+})
+
+test('one legacy marker → exit 1, allClean false, totalLegacy 1', () => {
+  const root = mkRoot('one-legacy')
+  seedLegacyMarker(root, '.checkpoint-required')
+  const { result, exitCode } = runSweep(`--root ${root}`)
+  eq(exitCode, 1)
+  eq(result.allClean, false)
+  eq(result.totalLegacy, 1)
+  const scan = result.scans[0]
+  eq(scan.count, 1)
+  eq(scan.markers[0].name, '.checkpoint-required')
+})
+
+test('all 6 legacy markers seeded → totalLegacy 6', () => {
+  const root = mkRoot('all-legacy')
+  for (const name of [
+    '.checkpoint-required',
+    '.post-checkpoint-required',
+    '.plan-approval-pending',
+    '.pre-checkpoint-done',
+    '.post-checkpoint-done',
+    '.session-baseline'
+  ]) {
+    seedLegacyMarker(root, name)
+  }
+  const { result, exitCode } = runSweep(`--root ${root}`)
+  eq(exitCode, 1)
+  eq(result.totalLegacy, 6)
+})
+
+console.log('\nConfig file mode:')
+
+test('config with one clean root + one dirty root → exit 1, totalLegacy 1', () => {
+  const cleanRoot = mkRoot('cfg-clean')
+  const dirtyRoot = mkRoot('cfg-dirty')
+  seedLegacyMarker(dirtyRoot, '.plan-approval-pending')
+  const cfg = path.join(tmpRoot, 'roots-1.txt')
+  fs.writeFileSync(cfg, `${cleanRoot}\n${dirtyRoot}\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.rootsScanned, 2)
+  eq(result.totalLegacy, 1)
+})
+
+test('config with comments and blank lines parsed correctly', () => {
+  const root = mkRoot('cfg-comments')
+  const cfg = path.join(tmpRoot, 'roots-comments.txt')
+  fs.writeFileSync(cfg, `# enrolled roots\n${root}\n\n# end\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 0)
+  eq(result.rootsScanned, 1)
+  eq(result.allClean, true)
+})
+
+test('all enrolled roots clean → exit 0', () => {
+  const a = mkRoot('cfg-clean-a')
+  const b = mkRoot('cfg-clean-b')
+  const cfg = path.join(tmpRoot, 'roots-clean.txt')
+  fs.writeFileSync(cfg, `${a}\n${b}\n`)
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 0)
+  eq(result.totalLegacy, 0)
+  eq(result.allClean, true)
+})
+
+console.log('\nMissing-config fail-closed:')
+
+test('missing config + no --root → exit 1 with configMissing flag', () => {
+  // Default config path inside the repo doesn't exist for tests.
+  // Pass a non-existent path explicitly so we don't depend on cwd state.
+  const cfg = path.join(tmpRoot, 'does-not-exist.txt')
+  const { result, exitCode } = runSweep(`--config ${cfg}`)
+  eq(exitCode, 1)
+  eq(result.configMissing, true)
+  // Defaults to cwd scan (which is the test dir). allClean false because
+  // config-missing fails closed even if cwd happens to be clean.
+  eq(result.allClean, false)
+})
+
+console.log()
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('Failures:')
+  for (const f of failures) console.log(`  ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -123,7 +123,11 @@ function setBranch(name) {
   execSync(`git checkout -q -B ${name}`, { cwd: tmpProject })
 }
 
-const markerPath = path.join(tmpProject, '.claude', '.checkpoint-required')
+// 2026-05-09 .checkpoints/ migration: armed markers now land at
+// PRIMARY (.checkpoints/). Test reads check primary first, then fall
+// back to legacy via the same dual-root semantics the hooks use.
+const markerPath = path.join(tmpProject, '.checkpoints', '.checkpoint-required')
+const markerPathLegacy = path.join(tmpProject, '.claude', '.checkpoint-required')
 
 const ALL_PHASE3B_MARKERS = [
   '.checkpoint-required',
@@ -134,13 +138,15 @@ const ALL_PHASE3B_MARKERS = [
 
 function clearMarker() {
   try { fs.unlinkSync(markerPath) } catch {}
+  try { fs.unlinkSync(markerPathLegacy) } catch {}
 }
 
-// Clear all 4 Phase 3b markers — used by tests that exercise the full
-// state machine, so subsequent tests start from a known-clean .claude/
-// regardless of what state the previous test left behind.
+// Clear all Phase 3b markers across BOTH roots — used by tests that
+// exercise the full state machine, so subsequent tests start from a
+// known-clean state regardless of what the previous test left behind.
 function clearAllMarkers() {
   for (const m of ALL_PHASE3B_MARKERS) {
+    try { fs.unlinkSync(path.join(tmpProject, '.checkpoints', m)) } catch {}
     try { fs.unlinkSync(path.join(tmpProject, '.claude', m)) } catch {}
   }
 }
@@ -512,8 +518,11 @@ test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (P
   execSync(`node "${REBUILD}" --scope all`, { cwd: sessionProject, env: sessionEnv })
 
   const hookPath = path.join(REPO_ROOT, 'hooks', 'em-recall-sessionstart.sh')
-  const markerOut = path.join(sessionProject, '.claude', '.checkpoint-required')
-  assert.ok(!fs.existsSync(markerOut), 'precondition: marker should not exist')
+  // .checkpoints/ migration: hook arms at PRIMARY (.checkpoints/).
+  const markerOut = path.join(sessionProject, '.checkpoints', '.checkpoint-required')
+  const markerOutLegacy = path.join(sessionProject, '.claude', '.checkpoint-required')
+  assert.ok(!fs.existsSync(markerOut), 'precondition: primary marker should not exist')
+  assert.ok(!fs.existsSync(markerOutLegacy), 'precondition: legacy marker should not exist')
 
   const stdin = JSON.stringify({ cwd: sessionProject })
   // Run the hook EXACTLY the way Claude Code would: stdin JSON, HOME pointing
@@ -584,7 +593,11 @@ test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next Sessio
   execSync(`node "${REBUILD}" --scope all`, { cwd: sessionProject, env: sessionEnv })
 
   const hookPath = path.join(REPO_ROOT, 'hooks', 'em-recall-sessionstart.sh')
-  const claudeDir = path.join(sessionProject, '.claude')
+  // .checkpoints/ migration: hook arms markers at PRIMARY (.checkpoints/);
+  // SessionEnd sweeps both PRIMARY and LEGACY. Tests assert at primary
+  // for arming; sweep negative assertion at primary suffices because
+  // setup writes go to primary too.
+  const claudeDir = path.join(sessionProject, '.checkpoints')
   const preReq = path.join(claudeDir, '.checkpoint-required')
   const postReq = path.join(claudeDir, '.post-checkpoint-required')
   const preDone = path.join(claudeDir, '.pre-checkpoint-done')
@@ -604,6 +617,7 @@ test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next Sessio
   // allows stop. Simulate the post-arming task signal that a real
   // implementation turn would produce by touching .post-checkpoint-required
   // with a future mtime (mtime > baseline → carve-out denied).
+  // Baseline at PRIMARY (.checkpoints/.session-baseline) per migration.
   const baseline = path.join(claudeDir, '.session-baseline')
   if (fs.existsSync(baseline)) {
     fs.writeFileSync(postReq, '')

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -73,6 +73,10 @@ mk_fake_home() {
   mkdir -p "$fake_home/.episodic-memory/scripts/lib"
   cp "$REPO_ROOT/scripts/em-recall.mjs" "$fake_home/.episodic-memory/scripts/em-recall.mjs"
   cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$fake_home/.episodic-memory/scripts/lib/local-dir.mjs"
+  # 2026-05-09 .checkpoints/ migration: em-recall now also imports
+  # marker-paths.mjs; without it the module fails to load and the hook
+  # falls back to the canned em-recall-non-zero error message.
+  cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$fake_home/.episodic-memory/scripts/lib/marker-paths.mjs"
 }
 
 TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"

--- a/tools/migration-cutover.mjs
+++ b/tools/migration-cutover.mjs
@@ -64,7 +64,10 @@ const counts = results.reduce((acc, r) => {
   return acc
 }, {})
 
-const allOk = (counts.OK || 0) === results.length
+// Codex round-1 F3: an empty manifest (wrong --repo, missing source tree)
+// must NOT report allOk. fail-closed when there's nothing to verify.
+const emptyManifest = results.length === 0
+const allOk = !emptyManifest && (counts.OK || 0) === results.length
 
 if (JSON_OUTPUT) {
   console.log(JSON.stringify({
@@ -72,6 +75,7 @@ if (JSON_OUTPUT) {
     homeDir: HOME_DIR,
     counts,
     allOk,
+    emptyManifest,
     results
   }, null, 2))
 } else {
@@ -95,6 +99,8 @@ if (JSON_OUTPUT) {
   console.log(`Summary: ${summary} (total=${results.length})`)
   if (allOk) {
     console.log('All entries match. Cutover safe to proceed.')
+  } else if (emptyManifest) {
+    console.log('Manifest is empty — no entries to verify. Check --repo points at the episodic-memory repo root.')
   } else {
     console.log('Mismatches found. Re-run install.mjs --tool claude-code --install-hooks --install-hooks-force.')
   }

--- a/tools/migration-cutover.mjs
+++ b/tools/migration-cutover.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * migration-cutover.mjs — verify installed copies are byte-identical to
+ * repo sources for every entry in the install manifest.
+ *
+ * Closes Codex round-1 F1 (runtime install parity): hooks reference scripts
+ * at $HOME/.episodic-memory/scripts/, but install.mjs's freshness manifest
+ * only covered hooks/*. Without an end-to-end parity check, a stale
+ * installed em-recall.mjs would silently disagree with the repo source
+ * after a migration commit.
+ *
+ * Usage:
+ *   node tools/migration-cutover.mjs [--repo <dir>] [--home <dir>] [--json]
+ *
+ * Behavior:
+ *   - Builds the install manifest from <repo> via scripts/lib/install-manifest.mjs.
+ *   - For each entry, computes the diff state:
+ *       OK            installed file exists and is byte-identical to source
+ *       MISSING       installed file does not exist
+ *       DIFF          installed file exists but content differs
+ *       SOURCE_GONE   source file does not exist (manifest says it should)
+ *   - Prints a per-file table to stdout (or JSON with --json).
+ *   - Exits 0 if all OK, 1 otherwise.
+ *
+ * Run before pushing the .checkpoints/ migration. Re-run as the burn-in
+ * exit gate (plan v3 §D.3).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { fileURLToPath } from 'url'
+import { buildInstallManifest } from '../scripts/lib/install-manifest.mjs'
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const REPO_DIR = flag('--repo') || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const HOME_DIR = flag('--home') || os.homedir()
+const JSON_OUTPUT = argv.includes('--json')
+
+function compareFiles(repoPath, installedPath) {
+  if (!fs.existsSync(repoPath)) return 'SOURCE_GONE'
+  if (!fs.existsSync(installedPath)) return 'MISSING'
+  const a = fs.readFileSync(repoPath)
+  const b = fs.readFileSync(installedPath)
+  return a.equals(b) ? 'OK' : 'DIFF'
+}
+
+const manifest = buildInstallManifest(REPO_DIR, HOME_DIR)
+const results = manifest.map(entry => ({
+  relativePath: entry.relativePath,
+  installedPath: entry.installedPath,
+  kind: entry.kind,
+  status: compareFiles(entry.repoPath, entry.installedPath)
+}))
+
+const counts = results.reduce((acc, r) => {
+  acc[r.status] = (acc[r.status] || 0) + 1
+  return acc
+}, {})
+
+const allOk = (counts.OK || 0) === results.length
+
+if (JSON_OUTPUT) {
+  console.log(JSON.stringify({
+    repoDir: REPO_DIR,
+    homeDir: HOME_DIR,
+    counts,
+    allOk,
+    results
+  }, null, 2))
+} else {
+  console.log(`Cutover check: repo=${REPO_DIR}`)
+  console.log(`               home=${HOME_DIR}`)
+  console.log()
+  // Print sorted by status (non-OK first) then by relativePath.
+  const STATUS_ORDER = { DIFF: 0, MISSING: 1, SOURCE_GONE: 2, OK: 3 }
+  const sorted = [...results].sort((a, b) => {
+    const so = (STATUS_ORDER[a.status] ?? 99) - (STATUS_ORDER[b.status] ?? 99)
+    if (so !== 0) return so
+    return a.relativePath.localeCompare(b.relativePath)
+  })
+  for (const r of sorted) {
+    const mark = r.status === 'OK' ? ' ' : '!'
+    console.log(`${mark} ${r.status.padEnd(12)} ${r.kind.padEnd(11)} ${r.relativePath}`)
+    if (r.status !== 'OK') console.log(`               installed: ${r.installedPath}`)
+  }
+  console.log()
+  const summary = Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(' ')
+  console.log(`Summary: ${summary} (total=${results.length})`)
+  if (allOk) {
+    console.log('All entries match. Cutover safe to proceed.')
+  } else {
+    console.log('Mismatches found. Re-run install.mjs --tool claude-code --install-hooks --install-hooks-force.')
+  }
+}
+
+process.exit(allOk ? 0 : 1)

--- a/tools/migration-sweep.mjs
+++ b/tools/migration-sweep.mjs
@@ -19,6 +19,12 @@
  *   - The file is GITIGNORED (user-local state). Operators add
  *     project roots they want to track during burn-in.
  *
+ * Validation: each parsed entry must (a) be non-empty, (b) contain no
+ * control characters (rejects binary garbage), (c) be an absolute path,
+ * (d) point at an existing directory. Any invalid entry causes the gate
+ * to fail closed (Codex round-2 F4: garbage config content was previously
+ * treated as a clean enrolled root).
+ *
  * If --root is passed, it overrides the config and scans only that root.
  * If neither is provided and the config file is missing, the tool defaults
  * to scanning the cwd and prints a hint about the config file.
@@ -30,7 +36,9 @@
  *
  * Exit codes:
  *   0 → all enrolled roots clean (zero legacy markers)
- *   1 → one or more legacy markers found (or config missing without --root)
+ *   1 → one or more legacy markers found, OR config missing without --root,
+ *       OR config exists but enrolls zero valid roots, OR any config entry
+ *       failed validation.
  *
  * Pair with tools/migration-cutover.mjs (parity check) and the 7-day floor
  * to decide when the fallback branch can be removed.
@@ -56,14 +64,46 @@ const JSON_OUTPUT = argv.includes('--json')
 
 function readConfigRoots(p) {
   if (!fs.existsSync(p)) return null
-  return fs.readFileSync(p, 'utf8')
+  // Reject directory or unreadable inputs upfront so we don't try to
+  // readFileSync a non-file (which would throw with a confusing error).
+  let st
+  try { st = fs.statSync(p) } catch { return { error: 'unreadable' } }
+  if (!st.isFile()) return { error: 'not_a_file' }
+  let raw
+  try { raw = fs.readFileSync(p, 'utf8') } catch { return { error: 'unreadable' } }
+  return raw
     .split('\n')
     .map(line => line.replace(/#.*$/, '').trim())
     .filter(Boolean)
 }
 
+// Codex round-2 F4: garbage / non-path content in the config must NOT
+// be treated as a valid enrolled root.
+//
+// charCode scan rather than a literal regex so the source file stays
+// free of embedded control bytes (which break basic editor tooling).
+function _hasControlChar(s) {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i)
+    if (c < 32 || c === 127) return true
+  }
+  return false
+}
+
+function validateRoot(r) {
+  if (typeof r !== 'string' || r.length === 0) return { valid: false, reason: 'empty' }
+  if (_hasControlChar(r)) return { valid: false, reason: 'control_chars' }
+  if (!path.isAbsolute(r)) return { valid: false, reason: 'not_absolute' }
+  let st
+  try { st = fs.statSync(r) } catch { return { valid: false, reason: 'does_not_exist' } }
+  if (!st.isDirectory()) return { valid: false, reason: 'not_a_directory' }
+  return { valid: true }
+}
+
 let roots = []
 let configMissing = false
+let configError = null
+let invalidConfigEntries = []
 
 if (singleRoot) {
   roots = [path.resolve(singleRoot)]
@@ -72,8 +112,16 @@ if (singleRoot) {
   if (fromConfig === null) {
     configMissing = true
     roots = [process.cwd()]
+  } else if (fromConfig && typeof fromConfig === 'object' && fromConfig.error) {
+    configError = fromConfig.error
+    roots = []
   } else {
-    roots = fromConfig.map(r => path.resolve(r))
+    const candidates = fromConfig.map(r => path.resolve(r))
+    const validations = candidates.map(r => ({ root: r, ...validateRoot(r) }))
+    invalidConfigEntries = validations.filter(v => !v.valid).map(v => ({
+      root: v.root, reason: v.reason
+    }))
+    roots = validations.filter(v => v.valid).map(v => v.root)
   }
 }
 
@@ -101,13 +149,18 @@ const totalLegacy = scans.reduce((sum, s) => sum + s.count, 0)
 // roots=[] and would otherwise vacuously pass the gate. Treat zero
 // enrolled roots as a failed gate (noRootsConfigured).
 const noRootsConfigured = !singleRoot && roots.length === 0
-const allClean = totalLegacy === 0 && !configMissing && !noRootsConfigured
+// Codex round-2 F4: any invalid config entry fails closed (one bad line
+// taints the whole config).
+const hasInvalidEntries = invalidConfigEntries.length > 0
+const allClean = totalLegacy === 0 && !configMissing && !noRootsConfigured && !configError && !hasInvalidEntries
 
 if (JSON_OUTPUT) {
   console.log(JSON.stringify({
     configPath: singleRoot ? null : configPath,
     configMissing,
+    configError,
     noRootsConfigured,
+    invalidConfigEntries,
     rootsScanned: roots.length,
     totalLegacy,
     allClean,
@@ -118,6 +171,17 @@ if (JSON_OUTPUT) {
     console.log(`Note: ${configPath} not found. Defaulting to cwd scan.`)
     console.log(`Create the config to enroll project roots for burn-in tracking:`)
     console.log(`  printf '%s\\n' "$PWD" > ${configPath}`)
+    console.log()
+  }
+  if (configError) {
+    console.log(`Config error: ${configPath} → ${configError}`)
+    console.log()
+  }
+  if (hasInvalidEntries) {
+    console.log(`Invalid config entries (${invalidConfigEntries.length}):`)
+    for (const e of invalidConfigEntries) {
+      console.log(`  ! ${e.reason.padEnd(18)} ${e.root}`)
+    }
     console.log()
   }
   console.log(`Scanning ${roots.length} root${roots.length === 1 ? '' : 's'} for legacy markers under .claude/`)
@@ -138,8 +202,12 @@ if (JSON_OUTPUT) {
     console.log('All enrolled roots are clean. Fallback branch removal safe (combine with cutover + 7-day floor).')
   } else if (configMissing && !singleRoot) {
     console.log('Config missing — exit 1 (treat as failed gate until enrolled roots are explicit).')
+  } else if (configError) {
+    console.log(`Config error (${configError}) — exit 1 (fix the config file before re-running).`)
   } else if (noRootsConfigured) {
-    console.log(`Config exists but enrolls zero roots — exit 1 (add at least one absolute project root to ${configPath}).`)
+    console.log(`Config exists but enrolls zero VALID roots — exit 1 (add at least one absolute project root to ${configPath} that resolves to an existing directory).`)
+  } else if (hasInvalidEntries) {
+    console.log(`Config has ${invalidConfigEntries.length} invalid entr${invalidConfigEntries.length === 1 ? 'y' : 'ies'} — exit 1 (one bad line taints the whole config; fix or remove).`)
   } else {
     console.log('Migrate or remove the listed legacy markers, then re-run sweep.')
   }

--- a/tools/migration-sweep.mjs
+++ b/tools/migration-sweep.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * migration-sweep.mjs — Inventory legacy `.claude/.X` markers across enrolled
+ * project roots so the .checkpoints/ migration can drop the legacy fallback
+ * branch only when ALL enrolled projects are clean.
+ *
+ * Closes Codex round-1 F4 (state-based fallback removal): time-based
+ * burn-in is not a safety signal. Plan v3 §D.3 requires zero legacy
+ * markers across configured roots before the fallback branch can be
+ * removed (in addition to the 7-day floor).
+ *
+ * Usage:
+ *   node tools/migration-sweep.mjs [--config <path>] [--root <dir>] [--json]
+ *
+ * Config file format (default `<repo>/.checkpoints-migration-roots`):
+ *   - One absolute project root per line
+ *   - Lines starting with `#` are comments
+ *   - Blank lines ignored
+ *   - The file is GITIGNORED (user-local state). Operators add
+ *     project roots they want to track during burn-in.
+ *
+ * If --root is passed, it overrides the config and scans only that root.
+ * If neither is provided and the config file is missing, the tool defaults
+ * to scanning the cwd and prints a hint about the config file.
+ *
+ * Behavior per root:
+ *   - Lists every legacy marker present at <root>/.claude/.X for the 6
+ *     migrated names (5 .X + .session-baseline).
+ *   - Reports filename + mtime per marker.
+ *
+ * Exit codes:
+ *   0 → all enrolled roots clean (zero legacy markers)
+ *   1 → one or more legacy markers found (or config missing without --root)
+ *
+ * Pair with tools/migration-cutover.mjs (parity check) and the 7-day floor
+ * to decide when the fallback branch can be removed.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { ALL_MIGRATED_MARKERS, LEGACY_MARKER_DIR } from '../scripts/lib/marker-paths.mjs'
+
+const argv = process.argv.slice(2)
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const REPO_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const DEFAULT_CONFIG = path.join(REPO_DIR, '.checkpoints-migration-roots')
+const configPath = flag('--config') || DEFAULT_CONFIG
+const singleRoot = flag('--root')
+const JSON_OUTPUT = argv.includes('--json')
+
+function readConfigRoots(p) {
+  if (!fs.existsSync(p)) return null
+  return fs.readFileSync(p, 'utf8')
+    .split('\n')
+    .map(line => line.replace(/#.*$/, '').trim())
+    .filter(Boolean)
+}
+
+let roots = []
+let configMissing = false
+
+if (singleRoot) {
+  roots = [path.resolve(singleRoot)]
+} else {
+  const fromConfig = readConfigRoots(configPath)
+  if (fromConfig === null) {
+    configMissing = true
+    roots = [process.cwd()]
+  } else {
+    roots = fromConfig.map(r => path.resolve(r))
+  }
+}
+
+function scanRoot(root) {
+  const legacyDir = path.join(root, LEGACY_MARKER_DIR)
+  const markers = []
+  for (const name of ALL_MIGRATED_MARKERS) {
+    const markerPath = path.join(legacyDir, name)
+    try {
+      const st = fs.statSync(markerPath)
+      markers.push({
+        name,
+        path: markerPath,
+        mtime: new Date(st.mtimeMs).toISOString(),
+        size: st.size
+      })
+    } catch {}
+  }
+  return { root, legacyDir, markers, count: markers.length }
+}
+
+const scans = roots.map(scanRoot)
+const totalLegacy = scans.reduce((sum, s) => sum + s.count, 0)
+const allClean = totalLegacy === 0 && !configMissing
+
+if (JSON_OUTPUT) {
+  console.log(JSON.stringify({
+    configPath: singleRoot ? null : configPath,
+    configMissing,
+    rootsScanned: roots.length,
+    totalLegacy,
+    allClean,
+    scans
+  }, null, 2))
+} else {
+  if (configMissing && !singleRoot) {
+    console.log(`Note: ${configPath} not found. Defaulting to cwd scan.`)
+    console.log(`Create the config to enroll project roots for burn-in tracking:`)
+    console.log(`  printf '%s\\n' "$PWD" > ${configPath}`)
+    console.log()
+  }
+  console.log(`Scanning ${roots.length} root${roots.length === 1 ? '' : 's'} for legacy markers under .claude/`)
+  console.log()
+  for (const scan of scans) {
+    if (scan.count === 0) {
+      console.log(`  ✓ clean   ${scan.root}`)
+    } else {
+      console.log(`  ! ${String(scan.count).padStart(2)} fnd  ${scan.root}`)
+      for (const m of scan.markers) {
+        console.log(`             ${m.name.padEnd(28)} ${m.mtime}  ${m.size}b`)
+      }
+    }
+  }
+  console.log()
+  console.log(`Total legacy markers found: ${totalLegacy}`)
+  if (allClean) {
+    console.log('All enrolled roots are clean. Fallback branch removal safe (combine with cutover + 7-day floor).')
+  } else if (configMissing && !singleRoot) {
+    console.log('Config missing — exit 1 (treat as failed gate until enrolled roots are explicit).')
+  } else {
+    console.log('Migrate or remove the listed legacy markers, then re-run sweep.')
+  }
+}
+
+process.exit(allClean ? 0 : 1)

--- a/tools/migration-sweep.mjs
+++ b/tools/migration-sweep.mjs
@@ -97,12 +97,17 @@ function scanRoot(root) {
 
 const scans = roots.map(scanRoot)
 const totalLegacy = scans.reduce((sum, s) => sum + s.count, 0)
-const allClean = totalLegacy === 0 && !configMissing
+// Codex round-1 F2: an existing-but-empty / comment-only config produces
+// roots=[] and would otherwise vacuously pass the gate. Treat zero
+// enrolled roots as a failed gate (noRootsConfigured).
+const noRootsConfigured = !singleRoot && roots.length === 0
+const allClean = totalLegacy === 0 && !configMissing && !noRootsConfigured
 
 if (JSON_OUTPUT) {
   console.log(JSON.stringify({
     configPath: singleRoot ? null : configPath,
     configMissing,
+    noRootsConfigured,
     rootsScanned: roots.length,
     totalLegacy,
     allClean,
@@ -133,6 +138,8 @@ if (JSON_OUTPUT) {
     console.log('All enrolled roots are clean. Fallback branch removal safe (combine with cutover + 7-day floor).')
   } else if (configMissing && !singleRoot) {
     console.log('Config missing — exit 1 (treat as failed gate until enrolled roots are explicit).')
+  } else if (noRootsConfigured) {
+    console.log(`Config exists but enrolls zero roots — exit 1 (add at least one absolute project root to ${configPath}).`)
   } else {
     console.log('Migrate or remove the listed legacy markers, then re-run sweep.')
   }

--- a/tools/migration-sweep.mjs
+++ b/tools/migration-sweep.mjs
@@ -116,8 +116,12 @@ if (singleRoot) {
     configError = fromConfig.error
     roots = []
   } else {
-    const candidates = fromConfig.map(r => path.resolve(r))
-    const validations = candidates.map(r => ({ root: r, ...validateRoot(r) }))
+    // Codex round-3 F5: validate the RAW config string before path.resolve.
+    // path.resolve('.') → cwd (absolute, exists), so a `.` entry would
+    // otherwise pass the isAbsolute + isDirectory checks and silently
+    // enroll the caller's cwd. Likewise `C:\demo` on POSIX would resolve
+    // to <cwd>/C:\demo. Raw-first validation closes both classes.
+    const validations = fromConfig.map(r => ({ root: r, ...validateRoot(r) }))
     invalidConfigEntries = validations.filter(v => !v.valid).map(v => ({
       root: v.root, reason: v.reason
     }))


### PR DESCRIPTION
## Summary

Migrate Rule 18 marker writes from `.claude/.X` → `.checkpoints/.X` to escape Claude Code's built-in sensitive-file guard, which prompts on every Write to a `.X` basename inside any `.claude/` segment regardless of allowlist. Without this, unattended marker writes (especially under scheduled remote agents / routines) deadlock the checkpoint flow.

- Six markers migrated (`.checkpoint-required`, `.post-checkpoint-required`, `.plan-approval-pending`, `.pre-checkpoint-done`, `.post-checkpoint-done`, `.session-baseline`) via shared `hooks/lib/marker-paths.sh` + `scripts/lib/marker-paths.mjs`.
- Hooks + scripts read PRIMARY (`.checkpoints/`) first, fall back to LEGACY (`.claude/`) during burn-in. Cleanup sweeps both. Writes go to PRIMARY only.
- New tooling: `tools/migration-cutover.mjs` (install parity check) and `tools/migration-sweep.mjs` (state-based exit gate for fallback removal).
- Atomic single-commit write+read change (commit 2) keeps active sessions in any project working through the cutover.

## Codex review trail

- Round 1 plan review: **HOLD** with 4 findings (F1 install parity, F2 dual-root cleanup + `.session-baseline`, F3 test inventory, F4 state-based exit gate). Reply: `20260509-043408-codex-plan-review-reply-round-1-checkpoi-9d8d`.
- Round 2 plan review: **ACCEPT**, 0 findings. Reply: `20260509-044331-codex-plan-review-reply-round-2-checkpoi-bc1c`.
- Code-review of as-built diff: pending (will trigger after PR opens).

## Test plan

All test suites green locally (573/573 across 15 suites). Key suites:

- [x] `node tests/test-marker-paths.mjs` (21 lib unit tests)
- [x] `bash tests/test-marker-paths.sh` (23 lib unit tests)
- [x] `node tests/test-checkpoints-migration.mjs` (6 dual-root regression tests — primary-only writes, dual-root carve-out, orphan-clear sweep, SessionEnd cleanup)
- [x] `node tests/test-migration-cutover.mjs` (8 parity-check tests)
- [x] `node tests/test-migration-sweep.mjs` (7 state-based-gate tests)
- [x] `bash tests/test-checkpoint-gate.sh` (103/103, includes B1 absolute-path assertion at primary)
- [x] `bash tests/test-plan-gate.sh` (34/34)
- [x] `bash tests/test-stop-gate.sh` (24/24, mk_fake_home updated)
- [x] `node tests/test-em-repo-root-worktree.mjs` (12/12, dual-root path constants)
- [x] `node tests/test-rfc002-phase3.mjs` (29/29)
- [x] `node tests/test-issue-146.mjs` (32/32, mkE2EHome updated)
- [x] `bash tests/test-install-hooks.sh` (65/65, T1b8 count 6→7)
- [x] `bash tests/test-command-classifier.sh` (186/186, no changes)
- [x] `node tests/test-em-audit-compliance.mjs` (7/7, no changes — synthetic data)
- [x] `bash tests/test-em-recall-sessionstart.sh` (13/13)

## Cutover steps (post-merge, owned by maintainer)

1. From main repo: `node install.mjs --tool claude-code --install-hooks --install-hooks-force`
2. Verify parity: `node tools/migration-cutover.mjs` → expect `allOk: true`.
3. Burn-in ~1 week. Periodically `node tools/migration-sweep.mjs --root <project>` to track legacy markers.
4. After zero-legacy across enrolled roots + cutover passing + 7d → follow-up PR drops the legacy fallback branch from hooks + scripts.

## Out of scope (intentional)

- **Worktree relocation** (moving `.claude/worktrees/` outside `.claude/`) — considered and deferred. Doesn't fix the prompts (basename rule fires regardless of worktree path); separate cleanup ticket.
- **`user-preferences/hooks/plan-gate.sh` stale copy** — divergent older copy in a sibling repo; resolve in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
