### PR TITLE
docs: refresh README + USER_MANUAL for PRs #144..#206

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The installer:
 2. Copies `patterns/_index.json` to `~/.episodic-memory/patterns/` for global pattern validation
 3. Creates `.episodic-memory/` in the target project for local episodes
 4. Copies the appropriate instruction file for your tool
-5. With `--install-hooks`: copies `hooks/*.sh` into `~/.claude/hooks/` and `hooks/lib/*.sh` into `~/.claude/hooks/lib/`, then registers PreToolUse (checkpoint-gate + plan-gate, from `~/.claude/hooks/`), SessionStart (em-recall-sessionstart, from `~/.claude/hooks/`), and SessionEnd (em-session-end-prompt, run directly from `~/.episodic-memory/scripts/`) hooks in `~/.claude/settings.json` (Claude Code only, opt-in). Use `--install-hooks-force` to overwrite locally edited hook files.
+5. With `--install-hooks`: copies `hooks/*.sh` into `~/.claude/hooks/` and `hooks/lib/*.sh` into `~/.claude/hooks/lib/`, then registers PreToolUse (checkpoint-gate + plan-gate + stop-gate, from `~/.claude/hooks/`), SessionStart (em-recall-sessionstart + BP-1 fallback sweep, from `~/.claude/hooks/`), and SessionEnd (em-session-end-prompt, run directly from `~/.episodic-memory/scripts/`) hooks in `~/.claude/settings.json` (Claude Code only, opt-in). Re-running the installer warns when an installed hook has drifted from the source-of-truth copy ([#201](https://github.com/lantisprime/episodic-memory/pull/201)). Use `--install-hooks-force` to overwrite locally edited hook files.
 
 ## Supported Tools
 
@@ -175,13 +175,14 @@ Patterns are seeded into the global episode store via `em-seed-patterns.mjs` so 
 
 ### Enforcement
 
-Behavioral patterns are documentation — they tell AI assistants **what** to follow, but don't mechanically **prevent** violations. The system provides two layers of enforcement:
+Behavioral patterns are documentation by default — but the most-violated patterns get escalated to mechanical enforcement (see BP-1 Auto-Pilot below). The system provides two layers:
 
 **Built-in (episodic-memory):**
 - **Violation tracking** (`em-violation.mjs`) — structured storage with pattern linkage, searchable by `--category violation` and `--tag violated:<pattern_id>`
 - **Session-end prompt** (`em-session-end-prompt.mjs`) — SessionEnd hook that asks about violations
 - **Proactive recall** (`em-recall.mjs`) — surfaces past violations at session start as pre-flight warnings
 - **Checkpoint enforcement gate** (RFC-002 Phase 3b, shipped + activated 2026-05-02 via [#78](https://github.com/lantisprime/episodic-memory/pull/78) and [#84](https://github.com/lantisprime/episodic-memory/pull/84)) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done. Opt-in via `node install.mjs --tool claude-code --install-hooks --project <path>`; registers SessionStart + PreToolUse + SessionEnd hooks in `~/.claude/settings.json`.
+- **BP-1 Auto-Pilot** (RFC-004, M0 + M1 shipped 2026-05-06..09 via [#181](https://github.com/lantisprime/episodic-memory/pull/181), [#186](https://github.com/lantisprime/episodic-memory/pull/186), [#188](https://github.com/lantisprime/episodic-memory/pull/188), [#200](https://github.com/lantisprime/episodic-memory/pull/200), [#206](https://github.com/lantisprime/episodic-memory/pull/206)) — activation gate, deadline sweep, finalize-replay state machine, and HMAC-signed run manifests that mechanically enforce bp-001 (implementation workflow). Replaces documentation-only enforcement for the workflow lifecycle.
 
 **External ([user-preferences](https://github.com/lantisprime/user-preferences)):**
 - **Pre-tool hooks** (e.g., `plan-gate.sh`) that block writes during the planning phase
@@ -197,6 +198,9 @@ Episodic-memory and user-preferences are fully independent — install either or
 | [RFC-001](docs/rfcs/RFC-001-memory-improvements.md) | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, Semantic Consolidation | Accepted (Phases 1-3 shipped) |
 | [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Accepted (Phases 1-3 + 3b shipped + runtime-deployed) |
 | [RFC-003](docs/rfcs/RFC-003-pluggable-tool-adapters.md) | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | Accepted (Phase 1 not yet started) |
+| [RFC-004](docs/rfcs/RFC-004-bp1-auto-pilot.md) | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | Accepted (M0 + M1 shipped) |
+| [RFC-005](docs/rfcs/RFC-005-em-move.md) | em-move — atomic episode relocation between scopes | Draft |
+| [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Draft |
 
 ## Scripts Reference
 
@@ -211,6 +215,11 @@ node ~/.episodic-memory/scripts/em-store.mjs \
   --summary "Chose JWT over session cookies" \
   --body "JWT simplifies our stateless API design..." \
   --scope global
+
+# For long bodies (e.g. plan documents), use --body-file instead of --body (#196)
+node ~/.episodic-memory/scripts/em-store.mjs \
+  --project my-project --category decision --summary "..." \
+  --body-file ./decision-body.md
 ```
 
 ### Revise
@@ -220,6 +229,8 @@ node ~/.episodic-memory/scripts/em-revise.mjs \
   --summary "Switched to session cookies" \
   --body "JWT token size became a problem..." \
   --tags "auth,security"
+
+# --body-file is also supported (#196)
 ```
 
 ### Search
@@ -320,6 +331,8 @@ node ~/.episodic-memory/scripts/em-violation.mjs \
   --body "Details..." \
   --sequence "plan,code,push" \
   --correct "plan,checkpoint,code,review,push"
+
+# --body-file is also supported (#196)
 ```
 
 ### Workflow Validation (Lifecycle Episode Chains)
@@ -386,6 +399,80 @@ node ~/.episodic-memory/scripts/em-session-end-prompt.mjs
 ### Rebuild Index
 ```bash
 node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
+```
+
+### BP-1 Auto-Pilot (RFC-004)
+
+The BP-1 Auto-Pilot suite mechanically enforces the bp-001 implementation workflow. These scripts are normally driven by `install.mjs --bp1` and the SessionStart hook — operators usually don't invoke them directly.
+
+```bash
+# Activation gate — every gated artifact reads via flag-check (RFC-004 §158-167)
+node ~/.episodic-memory/scripts/bp1-flag-check.mjs --project <root>
+
+# Build the runtime-artifact manifest (single source of truth, RFC-004 §107-152)
+node ~/.episodic-memory/scripts/bp1-build-artifact-manifest.mjs [--project <root>] [--yaml]
+
+# Canonicalize an episode for HMAC signing (debug/inspection)
+node ~/.episodic-memory/scripts/bp1-canonicalize.mjs --episode <path> [--pretty]
+
+# Path A + Path B fallback executor (auto-wired as SessionStart H2 hook)
+node ~/.episodic-memory/scripts/bp1-deadline-sweep.mjs --once [--project <root>]
+
+# Orchestrator subcommands: init-run, finalize-run, finalize-recover (M1)
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs init-run --project <root>
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-run --run-id <id>
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-recover --run-id <id>
+```
+
+### Compliance Audit & Transcript Mining
+
+```bash
+# Measure rule-skip rates from Claude Code session JSONL transcripts
+# (heuristic — false positives expected; useful for trend tracking)
+node ~/.episodic-memory/scripts/em-audit-compliance.mjs \
+  [--since <ISO>] [--slug <substr>] [--exclude-worktrees] [--format json|markdown]
+
+# Surface decisions/lessons/violations buried in transcripts that were never
+# captured as episodes; writes a staging file under .claude/scratch/, never
+# calls em-store directly (cold-storage discipline)
+node ~/.episodic-memory/scripts/em-mine-transcripts.mjs \
+  [--since <ISO>] [--slug <substr>] [--output <path>] [--dry-run]
+```
+
+### Review Request (Workflow Lifecycle Event)
+
+```bash
+# Build + store a workflow.lifecycle review-request event with full ref
+# validation (plan, approval, pre/post-checkpoint, tests, code review,
+# bug log, command inventory). RFC-002 Phase 3b-H1 PR-D (#118).
+node ~/.episodic-memory/scripts/em-review-request.mjs \
+  --task <id> \
+  --plan-ref <episode:id|file:path|url> \
+  --approval-ref <episode:id> \
+  --pre-checkpoint-ref <episode:id> \
+  --post-checkpoint-ref <episode:id> \
+  --tests-ref <episode:id|file:path> \
+  --code-review-ref <episode:id> \
+  [--bug-log-ref <issue-url>]+ | [--no-new-bugs] \
+  [--command-inventory-ref <ref>] [--dry-run]
+```
+
+### RFC Validation (Rule-14 CI Gates)
+
+These are CI-only validators that diff prose-tier RFC content against the machine-readable source of truth. Per Rule 14 (machine-readable blocks for drift-prone state).
+
+```bash
+# Cross-check _index.json + RFC frontmatter + Active RFCs table in README.md
+node ~/.episodic-memory/scripts/em-rfc-validate.mjs [--json]
+
+# RFC-004 §107-152: artifact-manifest YAML block ↔ builder output parity
+node ~/.episodic-memory/scripts/validate-rfc-artifact-manifest.mjs [--json]
+
+# RFC-004 §689-719: canonical-fields spec ↔ bp1-canonicalize.mjs lib parity
+node ~/.episodic-memory/scripts/validate-rfc-canonical-fields.mjs [--json]
+
+# RFC-004 §1072: §11.5 failure-table prose markdown ↔ YAML mirror parity
+node ~/.episodic-memory/scripts/validate-rfc-failure-table.mjs [--json]
 ```
 
 ## License

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -57,6 +57,7 @@ That's the only manual step. After this, your AI assistant reads the instruction
 2. Creates `.episodic-memory/` in your project for local memories
 3. Adds the right instruction file for your tool
 4. Updates `.gitignore` to exclude memory data
+5. With `--install-hooks` (Claude Code only): registers PreToolUse (checkpoint-gate, plan-gate, stop-gate), SessionStart (recall + BP-1 fallback sweep), and SessionEnd hooks. Re-running the installer warns when any installed hook has drifted from the source-of-truth copy.
 
 ---
 
@@ -384,18 +385,16 @@ AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
       write the checkpoint marker before continuing.
 ```
 
-**Why this exists:** The checkpoint enforcement gate (RFC-002 Phase 3b) is a PreToolUse hook that prevents the AI from skipping the plan → review → approval steps of the implementation workflow (bp-001). It's the mechanical version of the rules described in Scenario 11 — instead of relying on the AI to remember, the hook physically blocks edits until a checkpoint is recorded.
+**Why this exists:** The checkpoint enforcement gates (RFC-002 Phase 3b + RFC-004 BP-1 Auto-Pilot) are PreToolUse hooks that prevent the AI from skipping the plan → review → approval → testing steps of the implementation workflow (bp-001). It's the mechanical version of the rules described in Scenario 11 — instead of relying on the AI to remember, the hooks physically block edits until each checkpoint is recorded.
 
-**Two gates:**
-- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until `.claude/.pre-checkpoint-done` exists with the plan summary.
-- **Push-gate** — blocks `git push` until E2E testing and bug-logging steps are complete.
+**Three gates:**
+- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until the AI has printed its plan and you've approved it.
+- **Stop-gate (post-checkpoint)** — blocks turn-end until E2E testing has run and any bugs found are logged ([#144](https://github.com/lantisprime/episodic-memory/pull/144)).
+- **Push-gate** — blocks `git push` until all wrap-up steps are complete.
 
-**To clear the gate (intentionally):**
+**To clear a gate:** Approve the AI's plan in chat. The AI writes the checkpoint marker on your behalf — you don't run any commands manually. (The marker location is an internal implementation detail and has migrated once already.)
 
-```bash
-# After the AI has shown its plan and you've approved it:
-echo "ok" > .claude/.pre-checkpoint-done
-```
+**Behind the scenes — BP-1 Auto-Pilot (RFC-004).** These three gates are part of a run-lifecycle system that signs each implementation run with HMAC, tracks state across crashes, and replays unfinished work via a finalize-recovery state machine. You don't interact with it directly — the gates above are its user-facing edges.
 
 **To opt out entirely:** Don't pass `--install-hooks` during install, or remove the hook entries from `~/.claude/settings.json`.
 
@@ -595,3 +594,37 @@ rm -rf ~/.episodic-memory/episodes/*
 rm -rf my-project/.episodic-memory/episodes/*
 node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 ```
+
+### "I want to back up my memories or move them to a new machine"
+
+`em-backup.mjs` mirrors your memory directories to a private GitHub repo with PII / secret redaction applied to the staging copy (source files are never modified):
+
+```bash
+# Preview what would be redacted, no writes
+node ~/.episodic-memory/scripts/em-backup.mjs --audit
+
+# One-time setup: create the private repo + initial commit + push
+node ~/.episodic-memory/scripts/em-backup.mjs --init
+
+# Daily run: rsync sources, redact, commit, push
+node ~/.episodic-memory/scripts/em-backup.mjs --sync
+```
+
+Config lives at `~/.config/em-backup/config.json`; see `examples/em-backup.config.example.json`. Refuses `--init` / `--sync` without a config to prevent shipping raw personal memory.
+
+`em-restore.mjs` selectively restores from a cloned backup repo — filterable by tag, date, or category, with conflict modes for handling existing files:
+
+```bash
+# Dry-run (default): show what would happen, no disk writes
+node ~/.episodic-memory/scripts/em-restore.mjs \
+  --from /path/to/cloned-backup-repo \
+  --source-map home-em=$HOME/.episodic-memory \
+  --tag workplan --from-date 2026-04-01
+
+# Apply with full doc tree (MEMORY.md, knowledge_base/, etc.)
+node ~/.episodic-memory/scripts/em-restore.mjs \
+  --from /path/to/backup --source-map home-em=$HOME/.episodic-memory \
+  --include-docs --apply
+```
+
+**Restore is one-way:** it can't undo redaction. Frame it as "spin up a fresh machine from backup," not "recover the originals." Files redacted via `extra_redact_strings` retain their `[REDACTED]` tokens; binary / oversized / symlinked files are absent and only summarized in the report.


### PR DESCRIPTION
## Summary

Brings top-level user-facing docs in line with state shipped between PR #144 (stop-gate) and PR #206 (RFC-004 M1 BP-1 finalize-replay). 8 edits, 2 files, +131/−11.

| File | Edits |
|---|---|
| `README.md` | Installer hooks list (stop-gate + SessionStart sweep + #201 warner); enforcement section (BP-1 Auto-Pilot bullet); RFC table (+RFC-004 Accepted, RFC-005/006 Draft); `--body-file` (#196) notes; **4 new script subsections** covering 12 previously-undocumented scripts |
| `docs/USER_MANUAL.md` | Scenario 12 → 3 gates instead of 2; removed misleading manual-marker recipe; BP-1 Auto-Pilot framing; installer step 5 (hooks); new backup/restore troubleshooting entry |

## Why

Top-level `README.md` and `USER_MANUAL.md` had no Rule-14 CI parity gate, so they silently drifted across recent PRs. The `docs/rfcs/` files stayed current (em-rfc-validate.mjs covers them); the top-level docs lagged behind.

## Verification

- All 12 new script descriptions sourced from each script's docblock header (verify-by-artifact discipline).
- RFC statuses mirrored from `docs/rfcs/_index.json` (RFC-004 `accepted`, RFC-005/006 `draft`).
- Same-class completeness audit: docs/rfcs/README.md, _index.json, pending-analysis.md, PRINCIPLES.md, instructions/* all current — top-level docs were the only stale surfaces.
- Marker-path claim in USER_MANUAL Scenario 12 cross-referenced against CLAUDE.md burn-in clause; softened to omit path entirely (the AI writes the marker, user approves the plan).

## Follow-up

Filed #210 — CI gate extension to detect this drift class in CI (per Rule 13 + Rule 14). Out of scope for this PR; tracked separately.

## Test plan

- [ ] Render README.md on GitHub — verify RFC table, scripts subsections render correctly
- [ ] Render USER_MANUAL.md on GitHub — verify Scenario 12 + new backup troubleshooting entry render correctly
- [ ] Spot-check links: 3 RFC links + PR links (#144, #181, #186, #188, #196, #200, #201, #206) resolve
- [ ] Confirm em-rfc-validate.mjs CI gate still passes (this PR doesn't touch docs/rfcs/, so should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
