### PR TITLE
fix(install): worktree session permission grant for canonical .checkpoints/ (#213)

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -335,6 +335,112 @@ if (tool === 'claude-code' || tool === 'all') {
 }
 
 // ---------------------------------------------------------------------------
+// 2d. Worktree session permission grant (issue #213).
+//
+// In a linked-worktree session, Claude Code's working-directory permission
+// scope is the worktree path. But Rule 18 hooks read/write markers at the
+// CANONICAL repo's `.checkpoints/` (lesson `20260509-044449-...-7836` —
+// markers MUST stay canonical so stop-gate / checkpoint-gate / em-recall
+// can find them). The mismatch surfaces as recurring "Path is outside
+// allowed working directories" prompts on every Rule 18 marker access.
+//
+// Fix: when projectDir is a linked worktree of a canonical repo, append
+// the canonical repo's `.checkpoints/` directory to
+// `<projectDir>/.claude/settings.local.json` `permissions.additionalDirectories`
+// (Claude Code's documented working-directory extension; see
+// https://code.claude.com/docs/en/permissions).
+//
+// Design notes (folded from Codex round-1 plan-review reply
+// `20260509-073135-...-4fb5`):
+//   - Target = settings.local.json (machine-specific; absolute paths
+//     belong here, not shared settings.json — Codex finding A).
+//   - Worktree detection = realpath(show-toplevel) !== realpath(canonical)
+//     using existing resolveRepoRoot primitive (Codex finding D).
+//   - Scope = `.checkpoints/` only; do NOT auto-grant `.episodic-memory/`
+//     or other hook-managed paths without a separate Claude-tool caller
+//     (Codex finding C).
+//   - Existing/future worktrees: rerun installer per worktree (Codex
+//     finding E; no auto-detect of new worktrees).
+//   - I-1' (no-prompt at runtime) is NOT locally verifiable — manual
+//     acceptance artifact only (Codex finding B).
+// ---------------------------------------------------------------------------
+if (tool === 'claude-code' || tool === 'all') {
+  const { execSync } = await import('child_process')
+  const { resolveRepoRoot } = await import(
+    new URL('./scripts/lib/local-dir.mjs', import.meta.url).href
+  )
+
+  // Realpath if the path exists, else path.resolve fallback. Used both for
+  // de-dup keying and for canonicalizing the grant we write.
+  const normalizePathForGrant = (p) => {
+    try { return fs.realpathSync(p) } catch { return path.resolve(p) }
+  }
+
+  // Detect linked worktree by comparing the git context's working tree
+  // (--show-toplevel) against the canonical repo root (main checkout).
+  // Returns { worktreeRoot, canonicalRoot } when distinct; null when
+  // projectDir is the main repo, not a git repo, or git is unavailable.
+  const detectLinkedWorktree = (cwd) => {
+    let top
+    try {
+      top = execSync('git rev-parse --show-toplevel', {
+        cwd,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString().trim()
+    } catch {
+      return null
+    }
+    if (!top) return null
+    const canonical = resolveRepoRoot(cwd)
+    if (!canonical) return null
+    const topReal = normalizePathForGrant(top)
+    const canonicalReal = normalizePathForGrant(canonical)
+    if (topReal === canonicalReal) return null
+    return { worktreeRoot: topReal, canonicalRoot: canonicalReal }
+  }
+
+  const wt = detectLinkedWorktree(projectDir)
+  if (wt) {
+    const checkpointsDir = path.join(wt.canonicalRoot, '.checkpoints')
+    const grantPath = normalizePathForGrant(checkpointsDir)
+    const settingsLocalPath = path.join(projectDir, '.claude', 'settings.local.json')
+
+    let localSettings = {}
+    let parseFailed = false
+    if (fs.existsSync(settingsLocalPath)) {
+      try {
+        localSettings = JSON.parse(fs.readFileSync(settingsLocalPath, 'utf8'))
+      } catch (e) {
+        // Refuse to silently overwrite malformed user JSON. Surface and skip.
+        console.log(`Error: ${settingsLocalPath} is not valid JSON (${e.message}); skipping additionalDirectories grant.`)
+        parseFailed = true
+      }
+    }
+
+    if (!parseFailed) {
+      if (!localSettings.permissions || typeof localSettings.permissions !== 'object') {
+        localSettings.permissions = {}
+      }
+      if (!Array.isArray(localSettings.permissions.additionalDirectories)) {
+        localSettings.permissions.additionalDirectories = []
+      }
+      // De-dup by realpath (handles symlink/literal aliasing). Preserve
+      // original entries verbatim — only skip if any existing entry
+      // realpath-matches the new grant.
+      const existingReal = new Set(
+        localSettings.permissions.additionalDirectories.map(normalizePathForGrant)
+      )
+      if (!existingReal.has(grantPath)) {
+        localSettings.permissions.additionalDirectories.push(grantPath)
+        writeJSONAtomic(settingsLocalPath, localSettings)
+        console.log(`Granted worktree permission for canonical .checkpoints/ in ${settingsLocalPath} (issue #213).`)
+      }
+      // Already granted — silent no-op for re-run idempotence.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 3. Install tool-specific instructions
 // ---------------------------------------------------------------------------
 const tools = tool === 'all' ? ['claude-code', 'cursor', 'codex', 'windsurf'] : [tool]

--- a/install.mjs
+++ b/install.mjs
@@ -559,11 +559,35 @@ function shellQuote(s) {
   return `'${s.replace(/'/g, "'\\''")}'`
 }
 
+// Per-writer unique temp suffix. The fixed `.tmp` form is not safe under
+// concurrent installer runs against the same target file: writer A's
+// rename can race writer B's write, producing ENOENT on rename. Codex
+// PR-level review of #214 reproduced this with 5 concurrent installers
+// against the same worktree settings.local.json. process.pid + random
+// is unique enough across local installer processes.
+function uniqueTmpPath(filePath) {
+  return `${filePath}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`
+}
+
+// Best-effort sweep of the legacy fixed-temp orphan `<filePath>.tmp`. With
+// unique-temp names (uniqueTmpPath), no live writer uses this exact path, so
+// removing it is safe and matches the prior contract that crashed-prior-run
+// orphans don't accumulate (test-install-hooks.sh T9a).
+function sweepLegacyOrphanTmp(filePath) {
+  try { fs.unlinkSync(filePath + '.tmp') } catch {}
+}
+
 function writeJSONAtomic(filePath, obj) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
-  const tmp = filePath + '.tmp'
-  fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), 'utf8')
-  fs.renameSync(tmp, filePath)
+  const tmp = uniqueTmpPath(filePath)
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), 'utf8')
+    fs.renameSync(tmp, filePath)
+    sweepLegacyOrphanTmp(filePath)
+  } catch (e) {
+    try { fs.unlinkSync(tmp) } catch {}
+    throw e
+  }
 }
 
 function writeJSONAtomicIfChanged(filePath, obj) {
@@ -572,9 +596,15 @@ function writeJSONAtomicIfChanged(filePath, obj) {
     return false
   }
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
-  const tmp = filePath + '.tmp'
-  fs.writeFileSync(tmp, next, 'utf8')
-  fs.renameSync(tmp, filePath)
+  const tmp = uniqueTmpPath(filePath)
+  try {
+    fs.writeFileSync(tmp, next, 'utf8')
+    fs.renameSync(tmp, filePath)
+    sweepLegacyOrphanTmp(filePath)
+  } catch (e) {
+    try { fs.unlinkSync(tmp) } catch {}
+    throw e
+  }
   return true
 }
 

--- a/tests/test-install-worktree-grant.mjs
+++ b/tests/test-install-worktree-grant.mjs
@@ -29,7 +29,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 import assert from 'assert'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
@@ -263,6 +263,54 @@ test('re-run idempotence: second install does not duplicate the grant', () => {
   const dirs2 = additionalDirsOf(ws2)
   assert.strictEqual(countGrantsFor(dirs2, f.canonicalCheckpoints), 1, 'second install: still exactly one grant entry (idempotent)')
   assert.deepStrictEqual(dirs1, dirs2, 'array contents identical across re-runs')
+})
+
+test('concurrent installs do not crash on shared atomic temp path', () => {
+  // Codex PR-level review (PR #214) found the fixed `.tmp` filename in
+  // writeJSONAtomic was not multi-writer safe: 5 concurrent installers
+  // against the same worktree settings.local.json produced ENOENT on
+  // rename. Fix uses pid + random in the temp filename. This regression
+  // launches N parallel installers via a tiny driver script (the test
+  // body is sync; the driver uses Promise.all to truly parallelize).
+  const f = freshFixture('concurrent')
+  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  const manualEntry = '/some/manual/dir'
+  fs.writeFileSync(
+    f.worktreeSettingsLocal,
+    JSON.stringify({ permissions: { additionalDirectories: [manualEntry] } }, null, 2)
+  )
+
+  const N = 5
+  const driver = path.join(f.root, 'concurrent-driver.mjs')
+  fs.writeFileSync(driver, [
+    `import { spawn } from 'child_process'`,
+    `const procs = Array.from({ length: ${N} }, () => new Promise((resolve) => {`,
+    `  const p = spawn(${JSON.stringify(process.execPath)}, [${JSON.stringify(INSTALL)}, '--tool', 'claude-code', '--project', ${JSON.stringify(f.worktreeRoot)}], {`,
+    `    cwd: ${JSON.stringify(f.worktreeRoot)},`,
+    `    env: { ...process.env, HOME: ${JSON.stringify(tmpHome)} },`,
+    `    stdio: ['ignore', 'pipe', 'pipe'],`,
+    `  })`,
+    `  let stderr = ''`,
+    `  p.stderr.on('data', d => { stderr += d })`,
+    `  p.on('exit', code => resolve({ code, stderr }))`,
+    `}))`,
+    `const results = await Promise.all(procs)`,
+    `console.log(JSON.stringify(results))`,
+  ].join('\n'))
+
+  const out = execSync(`node "${driver}"`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  const results = JSON.parse(out.trim())
+  for (const r of results) {
+    assert.strictEqual(r.code, 0, `concurrent install exited ${r.code}; stderr=${r.stderr}`)
+  }
+  // Final file invariants: manual entry preserved + exactly one grant.
+  const ws = readSettings(f.worktreeSettingsLocal)
+  const dirs = additionalDirsOf(ws)
+  assert.ok(dirs.includes(manualEntry), 'manual entry must be preserved across concurrent installs')
+  assert.strictEqual(
+    countGrantsFor(dirs, f.canonicalCheckpoints), 1,
+    `exactly one grant after ${N} concurrent installs; got ${dirs.length} entries: ${JSON.stringify(dirs)}`
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/test-install-worktree-grant.mjs
+++ b/tests/test-install-worktree-grant.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * test-install-worktree-grant.mjs — Tests for issue #213 install.mjs
+ * worktree session permission grant (canonical .checkpoints/ in
+ * settings.local.json `permissions.additionalDirectories`).
+ *
+ * Covers the 6-axis matrix from Codex round-1 plan-review reply
+ * `20260509-073135-...-4fb5`:
+ *   - Worktree case → grant added
+ *   - Non-worktree (main repo) case → no grant
+ *   - Manual existing entries preserved (read-modify-write merge)
+ *   - Symlink/literal de-dup (realpath-keyed)
+ *   - Malformed settings.local.json → fail-closed (no overwrite)
+ *   - Nested cwd inside worktree → still detected
+ *   - Re-run idempotence (no duplicate entries)
+ *
+ * Defensive ordering (per feedback_test_resource_existence_check.md):
+ * each positive assertion is paired with its negative — "grant present at
+ * worktree" + "grant absent at main" — so a misconfigured fixture cannot
+ * silently pass.
+ *
+ * Class-completeness reference: this is the regression test demanded by
+ * Codex finding F (issue #213 fix) + Rule 15 (regression at fix time).
+ *
+ * Usage: node tests/test-install-worktree-grant.mjs
+ * Zero dependencies.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+import assert from 'assert'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const INSTALL = path.join(REPO, 'install.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message, stack: e.stack })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+function runInstall(cwd, projectDir, opts = {}) {
+  // Run install.mjs --tool claude-code --project <projectDir> from <cwd>.
+  // Capture stdout for assertions about the grant message.
+  //
+  // Test hermeticity (Codex round-2 MAJOR finding, 2026-05-09): install.mjs
+  // Section 1 writes ~/.episodic-memory/{scripts,episodes,.verify-key,...}
+  // unconditionally. Without HOME isolation the test (a) fails in CI/reviewer
+  // sandboxes that can't write under the developer's real HOME, and (b) on
+  // an unrestricted dev shell would mutate the developer's real global
+  // episodic-memory install state and become order-dependent. Mirror the
+  // existing pattern from tests/test-install-hooks.sh / test-install-bp1-
+  // wiring.mjs by routing every installer subprocess through a per-test HOME.
+  const env = { ...process.env, HOME: opts.home || tmpHome, ...(opts.env || {}) }
+  return execSync(`node "${INSTALL}" --tool claude-code --project "${projectDir}"`, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+function readSettings(p) {
+  if (!fs.existsSync(p)) return null
+  return JSON.parse(fs.readFileSync(p, 'utf8'))
+}
+
+function additionalDirsOf(settings) {
+  if (!settings || !settings.permissions) return []
+  return settings.permissions.additionalDirectories || []
+}
+
+// Mirror install.mjs's normalizePathForGrant: realpath if the path exists,
+// path.resolve fallback otherwise. The implementation writes paths through
+// this normalization, so tests must compare entries through the same lens.
+function safeRealpath(p) {
+  try { return fs.realpathSync(p) } catch { return path.resolve(p) }
+}
+
+function hasGrantFor(dirs, canonicalCheckpointsReal) {
+  return dirs.some(d => safeRealpath(d) === canonicalCheckpointsReal)
+}
+
+function countGrantsFor(dirs, canonicalCheckpointsReal) {
+  return dirs.filter(d => safeRealpath(d) === canonicalCheckpointsReal).length
+}
+
+// ---------------------------------------------------------------------------
+// Setup: a single tmp root holding a main repo + linked worktree + non-git
+// dir. Each test below operates on a fresh sub-fixture under tmpRoot to
+// avoid cross-test settings.local.json bleed.
+//
+// tmpHome: dedicated temp dir used as HOME for every installer subprocess
+// (Codex round-2 hermeticity finding). install.mjs Section 1 writes under
+// ~/.episodic-memory/, so without this isolation the test mutates real
+// developer state and fails in sandboxes that can't write real HOME.
+// ---------------------------------------------------------------------------
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-install-wt-grant-'))
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-install-wt-grant-home-'))
+process.on('exit', () => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+function freshFixture(name) {
+  const root = path.join(tmpRoot, name)
+  const mainRepo = path.join(root, 'main')
+  const worktreeRoot = path.join(root, 'wt')
+  fs.mkdirSync(mainRepo, { recursive: true })
+  git(mainRepo, 'init -q -b main')
+  git(mainRepo, 'config user.email test@example.com')
+  git(mainRepo, 'config user.name test')
+  fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
+  git(mainRepo, 'add README.md')
+  git(mainRepo, 'commit -q -m init')
+  git(mainRepo, `worktree add -q -b ${name}-branch ${worktreeRoot}`)
+  return {
+    root,
+    mainRepo,
+    mainRepoReal: fs.realpathSync(mainRepo),
+    worktreeRoot,
+    worktreeRootReal: fs.realpathSync(worktreeRoot),
+    canonicalCheckpoints: path.join(fs.realpathSync(mainRepo), '.checkpoints'),
+    worktreeSettingsLocal: path.join(worktreeRoot, '.claude', 'settings.local.json'),
+    mainSettingsLocal: path.join(mainRepo, '.claude', 'settings.local.json'),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+console.log('test-install-worktree-grant.mjs — issue #213')
+
+test('worktree case: grant appended to <worktree>/.claude/settings.local.json', () => {
+  const f = freshFixture('basic-wt')
+  const stdout = runInstall(f.worktreeRoot, f.worktreeRoot)
+  const ws = readSettings(f.worktreeSettingsLocal)
+  assert.ok(ws, 'settings.local.json should exist after install in worktree')
+  const dirs = additionalDirsOf(ws)
+  assert.ok(
+    hasGrantFor(dirs, f.canonicalCheckpoints),
+    `expected grant for ${f.canonicalCheckpoints} in additionalDirectories; got ${JSON.stringify(dirs)}`
+  )
+  assert.ok(stdout.includes('Granted worktree permission'), 'stdout should announce the grant')
+})
+
+test('non-worktree case (main repo): no grant added', () => {
+  const f = freshFixture('basic-main')
+  runInstall(f.mainRepo, f.mainRepo)
+  const ms = readSettings(f.mainSettingsLocal)
+  const dirs = additionalDirsOf(ms || {})
+  assert.ok(
+    !hasGrantFor(dirs, f.canonicalCheckpoints),
+    `non-worktree install should not add the grant; got ${JSON.stringify(dirs)}`
+  )
+})
+
+test('manual existing entries are preserved (merge, not replace)', () => {
+  const f = freshFixture('preserve-manual')
+  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  const manualEntry = '/some/manual/dir'
+  fs.writeFileSync(
+    f.worktreeSettingsLocal,
+    JSON.stringify({
+      permissions: { additionalDirectories: [manualEntry] },
+      somethingElse: 'preserved',
+    }, null, 2)
+  )
+  runInstall(f.worktreeRoot, f.worktreeRoot)
+  const ws = readSettings(f.worktreeSettingsLocal)
+  const dirs = additionalDirsOf(ws)
+  assert.ok(dirs.includes(manualEntry), 'manual entry must be preserved')
+  assert.ok(
+    hasGrantFor(dirs, f.canonicalCheckpoints),
+    'canonical .checkpoints/ grant must be appended'
+  )
+  assert.strictEqual(ws.somethingElse, 'preserved', 'unrelated keys must survive')
+})
+
+test('symlink/literal de-dup: realpath-equal entries are not duplicated', () => {
+  const f = freshFixture('symlink-dedup')
+  fs.mkdirSync(f.canonicalCheckpoints, { recursive: true })
+  const symlink = path.join(f.root, 'cp-symlink')
+  fs.symlinkSync(f.canonicalCheckpoints, symlink)
+
+  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  fs.writeFileSync(
+    f.worktreeSettingsLocal,
+    JSON.stringify({ permissions: { additionalDirectories: [symlink] } }, null, 2)
+  )
+  runInstall(f.worktreeRoot, f.worktreeRoot)
+  const ws = readSettings(f.worktreeSettingsLocal)
+  const dirs = additionalDirsOf(ws)
+  assert.strictEqual(dirs.length, 1, `expected 1 entry after dedup; got ${dirs.length}: ${JSON.stringify(dirs)}`)
+})
+
+test('malformed settings.local.json: fail-closed, no overwrite', () => {
+  const f = freshFixture('malformed')
+  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  const bad = '{ this is not: valid json '
+  fs.writeFileSync(f.worktreeSettingsLocal, bad)
+  // Route through runInstall so HOME isolation applies (Codex round-2 fix).
+  let stderrOut = ''
+  let stdoutOut = ''
+  try {
+    stdoutOut = runInstall(f.worktreeRoot, f.worktreeRoot)
+  } catch (e) {
+    stderrOut = e.stderr ? e.stderr.toString() : ''
+    stdoutOut = e.stdout ? e.stdout.toString() : ''
+  }
+  // The install should NOT crash the whole process — it surfaces an Error
+  // log and skips just the grant. Other install steps continue.
+  // The malformed file must remain untouched (no atomic overwrite).
+  assert.strictEqual(fs.readFileSync(f.worktreeSettingsLocal, 'utf8'), bad,
+    'malformed settings.local.json must not be overwritten')
+  assert.ok(
+    stdoutOut.includes('not valid JSON') || stderrOut.includes('not valid JSON'),
+    `expected "not valid JSON" diagnostic; stdout=${stdoutOut} stderr=${stderrOut}`
+  )
+})
+
+test('nested cwd inside worktree: still detected as worktree', () => {
+  const f = freshFixture('nested-cwd')
+  const nested = path.join(f.worktreeRoot, 'a', 'b', 'c')
+  fs.mkdirSync(nested, { recursive: true })
+  // Run install from nested cwd, but --project still points at worktree root
+  // (matches realistic usage; install.mjs's projectDir is the --project flag).
+  runInstall(nested, f.worktreeRoot)
+  const ws = readSettings(f.worktreeSettingsLocal)
+  const dirs = additionalDirsOf(ws)
+  assert.ok(
+    hasGrantFor(dirs, f.canonicalCheckpoints),
+    'nested cwd within worktree should still produce the grant'
+  )
+})
+
+test('re-run idempotence: second install does not duplicate the grant', () => {
+  const f = freshFixture('idempotent')
+  runInstall(f.worktreeRoot, f.worktreeRoot)
+  const ws1 = readSettings(f.worktreeSettingsLocal)
+  const dirs1 = additionalDirsOf(ws1)
+  assert.strictEqual(countGrantsFor(dirs1, f.canonicalCheckpoints), 1, 'first install: exactly one grant entry')
+
+  runInstall(f.worktreeRoot, f.worktreeRoot)
+  const ws2 = readSettings(f.worktreeSettingsLocal)
+  const dirs2 = additionalDirsOf(ws2)
+  assert.strictEqual(countGrantsFor(dirs2, f.canonicalCheckpoints), 1, 'second install: still exactly one grant entry (idempotent)')
+  assert.deepStrictEqual(dirs1, dirs2, 'array contents identical across re-runs')
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log('')
+console.log(`Results: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) {
+    console.log(`\n✗ ${f.name}`)
+    console.log(f.stack || f.error)
+  }
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Fixes [#213](https://github.com/lantisprime/episodic-memory/issues/213) — recurring "Path is outside allowed working directories" prompts on every Rule 18 marker access in worktree sessions.
- New `install.mjs` Section 2d: when run in a linked worktree, append the canonical repo's `.checkpoints/` to `<worktree>/.claude/settings.local.json` `permissions.additionalDirectories`. Hooks continue to read/write markers at the canonical location (load-bearing per lesson `20260509-044449-...-7836`); only the session permission scope is widened.
- Detection via realpath comparison of `git rev-parse --show-toplevel` against `resolveRepoRoot(cwd)` — reuses the existing `scripts/lib/local-dir.mjs` primitive, no new heuristic.

## Background

PR #207 escaped Claude Code's *sensitive-file* guard by relocating Rule 18 markers from `.claude/.X` to `.checkpoints/.X`. That covered the Write-tool path. This PR closes the *working-directory* guard left over for worktree sessions: cwd is the worktree, hooks read canonical, the canonical `.checkpoints/` was outside the allowed-dirs set.

The original issue body proposed moving marker resolution to `git rev-parse --show-toplevel` (which would put markers in the worktree). That fix is **doubly wrong**:
1. Hooks canonicalize via `--git-common-dir` and would not see worktree-local markers (lesson `...7836`, observed today — infinite block loop).
2. The worktree path lives under `.claude/worktrees/<name>/`, so worktree-local `.checkpoints/` re-trips PR #207's sensitive-file guard.

Issue #213 has been amended with the corrected root cause + reference to the lesson.

## Codex review chain

| Round | Type | Verdict | Episode |
|---|---|---|---|
| 1 | plan-review | HOLD | `20260509-073135-codex-plan-review-reply-issue-213-option-4fb5` — 6 findings (3 P1, 3 P2), all ACCEPT, folded into v2 |
| 2 | code-review | HOLD | `20260509-075010-codex-code-review-round-2-issue-213-hold-68df` — 1 MAJOR test hermeticity, 0 impl blockers |
| 3 | code-review | **ACCEPT** | `20260509-075745-codex-code-review-round-3-issue-213-acce-dcb8` |

## Invariants

| ID | Invariant | LV? | Verifier |
|---|---|---|---|
| I-1 | Worktree install adds canonical `.checkpoints/` to `additionalDirectories` (realpath-normalized) | Yes | `tests/test-install-worktree-grant.mjs:basic-wt` |
| I-1' | Worktree session can Read/Write `<main>/.checkpoints/.X` without prompt | **No** | Manual: post-install Claude Code session probe |
| I-2 | Non-worktree install adds nothing | Yes | `:basic-main` |
| I-3 | Manual entries preserved (read-modify-write merge) | Yes | `:preserve-manual` |
| I-4 | Realpath de-dup correct (symlink/literal) | Yes | `:symlink-dedup` |
| I-5 | Malformed `settings.local.json` fail-closed | Yes | `:malformed` |
| I-6 | Nested cwd inside worktree still detected | Yes | `:nested-cwd` |
| I-7 | Re-run idempotence (no duplicate grants) | Yes | `:idempotent` |

## Test plan

- [x] `node tests/test-install-worktree-grant.mjs` — 7/0 (HOME-isolated)
- [x] `node tests/test-em-repo-root-worktree.mjs` — 12/0 (resolveRepoRoot regression)
- [x] `node tests/test-checkpoints-migration.mjs` — 6/0 (PR #207 regression)
- [x] `bash tests/test-install-hooks.sh` — 65/0 (install.mjs hook flow regression)
- [ ] **Manual I-1'**: after merge, in a worktree, run `node install.mjs --tool claude-code --project <worktree>`. Open a fresh Claude Code session in that worktree. Attempt Read/Write to `<main>/.checkpoints/.pre-checkpoint-done`. Confirm no "Path is outside allowed working directories" prompt.

## Out of scope

- Issue [#212](https://github.com/lantisprime/episodic-memory/issues/212) (Bash heredoc / sensitive-file guard) — separate.
- Removing `.claude/` legacy fallback (separate burn-in cleanup).
- Auto-detect of new worktrees — by design, rerun installer per worktree (Codex finding E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
