### PR TITLE
fix(install): write worktree grant to canonical settings.local.json (#215)

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -346,9 +346,11 @@ if (tool === 'claude-code' || tool === 'all') {
 //
 // Fix: when projectDir is a linked worktree of a canonical repo, append
 // the canonical repo's `.checkpoints/` directory to
-// `<projectDir>/.claude/settings.local.json` `permissions.additionalDirectories`
+// `<canonical>/.claude/settings.local.json` `permissions.additionalDirectories`
 // (Claude Code's documented working-directory extension; see
-// https://code.claude.com/docs/en/permissions).
+// https://code.claude.com/docs/en/permissions). Issue #215: must target the
+// CANONICAL settings.local.json, not the worktree's — Claude Code loads
+// project settings from the main repo, same canonicalization as our hooks.
 //
 // Design notes (folded from Codex round-1 plan-review reply
 // `20260509-073135-...-4fb5`):
@@ -403,7 +405,14 @@ if (tool === 'claude-code' || tool === 'all') {
   if (wt) {
     const checkpointsDir = path.join(wt.canonicalRoot, '.checkpoints')
     const grantPath = normalizePathForGrant(checkpointsDir)
-    const settingsLocalPath = path.join(projectDir, '.claude', 'settings.local.json')
+    // Issue #215 fix: write the grant to the CANONICAL repo's settings.local.json,
+    // not the worktree's. Claude Code loads project settings from the canonical
+    // repo root (the main checkout) — same canonicalization as our hooks. The
+    // original PR #214 wrote to <worktree>/.claude/settings.local.json which
+    // Claude Code never reads in a worktree session, so I-1' failed at runtime.
+    // Verified post-merge: the mechanism works (claude --add-dir <path>), but
+    // the settings file must live at <canonical>/.claude/settings.local.json.
+    const settingsLocalPath = path.join(wt.canonicalRoot, '.claude', 'settings.local.json')
 
     let localSettings = {}
     let parseFailed = false
@@ -433,7 +442,7 @@ if (tool === 'claude-code' || tool === 'all') {
       if (!existingReal.has(grantPath)) {
         localSettings.permissions.additionalDirectories.push(grantPath)
         writeJSONAtomic(settingsLocalPath, localSettings)
-        console.log(`Granted worktree permission for canonical .checkpoints/ in ${settingsLocalPath} (issue #213).`)
+        console.log(`Granted worktree permission for canonical .checkpoints/ in ${settingsLocalPath} (issues #213, #215).`)
       }
       // Already granted — silent no-op for re-run idempotence.
     }

--- a/tests/test-install-worktree-grant.mjs
+++ b/tests/test-install-worktree-grant.mjs
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 /**
- * test-install-worktree-grant.mjs — Tests for issue #213 install.mjs
- * worktree session permission grant (canonical .checkpoints/ in
- * settings.local.json `permissions.additionalDirectories`).
+ * test-install-worktree-grant.mjs — Tests for issues #213 + #215 install.mjs
+ * worktree session permission grant: canonical .checkpoints/ written to the
+ * CANONICAL repo's `.claude/settings.local.json` `permissions.additionalDirectories`.
+ *
+ * Issue #215 fix: the grant target is `<canonical>/.claude/settings.local.json`,
+ * NOT `<worktree>/.claude/settings.local.json`. Claude Code loads project
+ * settings from the canonical repo root. Writing to the worktree's settings
+ * file is silent — the runtime never reads it — and was the root cause of
+ * the I-1' failure post-merge of PR #214.
  *
  * Covers the 6-axis matrix from Codex round-1 plan-review reply
  * `20260509-073135-...-4fb5`:
@@ -16,8 +22,9 @@
  *
  * Defensive ordering (per feedback_test_resource_existence_check.md):
  * each positive assertion is paired with its negative — "grant present at
- * worktree" + "grant absent at main" — so a misconfigured fixture cannot
- * silently pass.
+ * canonical's settings.local.json" + "grant absent from worktree's
+ * settings.local.json" — so a misconfigured fixture cannot silently pass.
+ * The negative direction is what catches #215 regressions specifically.
  *
  * Class-completeness reference: this is the regression test demanded by
  * Codex finding F (issue #213 fix) + Rule 15 (regression at fix time).
@@ -146,19 +153,29 @@ function freshFixture(name) {
 // Tests
 // ---------------------------------------------------------------------------
 
-console.log('test-install-worktree-grant.mjs — issue #213')
+console.log('test-install-worktree-grant.mjs — issues #213 + #215')
 
-test('worktree case: grant appended to <worktree>/.claude/settings.local.json', () => {
+test('worktree case: grant appended to <canonical>/.claude/settings.local.json', () => {
   const f = freshFixture('basic-wt')
   const stdout = runInstall(f.worktreeRoot, f.worktreeRoot)
-  const ws = readSettings(f.worktreeSettingsLocal)
-  assert.ok(ws, 'settings.local.json should exist after install in worktree')
-  const dirs = additionalDirsOf(ws)
+  const ms = readSettings(f.mainSettingsLocal)
+  assert.ok(ms, 'canonical settings.local.json should exist after install run from worktree (#215)')
+  const dirs = additionalDirsOf(ms)
   assert.ok(
     hasGrantFor(dirs, f.canonicalCheckpoints),
     `expected grant for ${f.canonicalCheckpoints} in additionalDirectories; got ${JSON.stringify(dirs)}`
   )
   assert.ok(stdout.includes('Granted worktree permission'), 'stdout should announce the grant')
+  // Negative paired assertion (#215): worktree's own settings.local.json must
+  // NOT contain the grant — that was PR #214's bug, where the runtime never
+  // saw the entry because Claude Code loads from canonical, not worktree.
+  const ws = readSettings(f.worktreeSettingsLocal)
+  if (ws) {
+    assert.ok(
+      !hasGrantFor(additionalDirsOf(ws), f.canonicalCheckpoints),
+      'worktree settings.local.json must NOT have the grant (#215 — wrong target was the original bug)'
+    )
+  }
 })
 
 test('non-worktree case (main repo): no grant added', () => {
@@ -174,24 +191,24 @@ test('non-worktree case (main repo): no grant added', () => {
 
 test('manual existing entries are preserved (merge, not replace)', () => {
   const f = freshFixture('preserve-manual')
-  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  fs.mkdirSync(path.dirname(f.mainSettingsLocal), { recursive: true })
   const manualEntry = '/some/manual/dir'
   fs.writeFileSync(
-    f.worktreeSettingsLocal,
+    f.mainSettingsLocal,
     JSON.stringify({
       permissions: { additionalDirectories: [manualEntry] },
       somethingElse: 'preserved',
     }, null, 2)
   )
   runInstall(f.worktreeRoot, f.worktreeRoot)
-  const ws = readSettings(f.worktreeSettingsLocal)
-  const dirs = additionalDirsOf(ws)
+  const ms = readSettings(f.mainSettingsLocal)
+  const dirs = additionalDirsOf(ms)
   assert.ok(dirs.includes(manualEntry), 'manual entry must be preserved')
   assert.ok(
     hasGrantFor(dirs, f.canonicalCheckpoints),
     'canonical .checkpoints/ grant must be appended'
   )
-  assert.strictEqual(ws.somethingElse, 'preserved', 'unrelated keys must survive')
+  assert.strictEqual(ms.somethingElse, 'preserved', 'unrelated keys must survive')
 })
 
 test('symlink/literal de-dup: realpath-equal entries are not duplicated', () => {
@@ -200,22 +217,22 @@ test('symlink/literal de-dup: realpath-equal entries are not duplicated', () => 
   const symlink = path.join(f.root, 'cp-symlink')
   fs.symlinkSync(f.canonicalCheckpoints, symlink)
 
-  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  fs.mkdirSync(path.dirname(f.mainSettingsLocal), { recursive: true })
   fs.writeFileSync(
-    f.worktreeSettingsLocal,
+    f.mainSettingsLocal,
     JSON.stringify({ permissions: { additionalDirectories: [symlink] } }, null, 2)
   )
   runInstall(f.worktreeRoot, f.worktreeRoot)
-  const ws = readSettings(f.worktreeSettingsLocal)
-  const dirs = additionalDirsOf(ws)
+  const ms = readSettings(f.mainSettingsLocal)
+  const dirs = additionalDirsOf(ms)
   assert.strictEqual(dirs.length, 1, `expected 1 entry after dedup; got ${dirs.length}: ${JSON.stringify(dirs)}`)
 })
 
 test('malformed settings.local.json: fail-closed, no overwrite', () => {
   const f = freshFixture('malformed')
-  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  fs.mkdirSync(path.dirname(f.mainSettingsLocal), { recursive: true })
   const bad = '{ this is not: valid json '
-  fs.writeFileSync(f.worktreeSettingsLocal, bad)
+  fs.writeFileSync(f.mainSettingsLocal, bad)
   // Route through runInstall so HOME isolation applies (Codex round-2 fix).
   let stderrOut = ''
   let stdoutOut = ''
@@ -228,8 +245,8 @@ test('malformed settings.local.json: fail-closed, no overwrite', () => {
   // The install should NOT crash the whole process — it surfaces an Error
   // log and skips just the grant. Other install steps continue.
   // The malformed file must remain untouched (no atomic overwrite).
-  assert.strictEqual(fs.readFileSync(f.worktreeSettingsLocal, 'utf8'), bad,
-    'malformed settings.local.json must not be overwritten')
+  assert.strictEqual(fs.readFileSync(f.mainSettingsLocal, 'utf8'), bad,
+    'malformed canonical settings.local.json must not be overwritten')
   assert.ok(
     stdoutOut.includes('not valid JSON') || stderrOut.includes('not valid JSON'),
     `expected "not valid JSON" diagnostic; stdout=${stdoutOut} stderr=${stderrOut}`
@@ -243,24 +260,24 @@ test('nested cwd inside worktree: still detected as worktree', () => {
   // Run install from nested cwd, but --project still points at worktree root
   // (matches realistic usage; install.mjs's projectDir is the --project flag).
   runInstall(nested, f.worktreeRoot)
-  const ws = readSettings(f.worktreeSettingsLocal)
-  const dirs = additionalDirsOf(ws)
+  const ms = readSettings(f.mainSettingsLocal)
+  const dirs = additionalDirsOf(ms)
   assert.ok(
     hasGrantFor(dirs, f.canonicalCheckpoints),
-    'nested cwd within worktree should still produce the grant'
+    'nested cwd within worktree should still produce the grant on canonical'
   )
 })
 
 test('re-run idempotence: second install does not duplicate the grant', () => {
   const f = freshFixture('idempotent')
   runInstall(f.worktreeRoot, f.worktreeRoot)
-  const ws1 = readSettings(f.worktreeSettingsLocal)
-  const dirs1 = additionalDirsOf(ws1)
+  const ms1 = readSettings(f.mainSettingsLocal)
+  const dirs1 = additionalDirsOf(ms1)
   assert.strictEqual(countGrantsFor(dirs1, f.canonicalCheckpoints), 1, 'first install: exactly one grant entry')
 
   runInstall(f.worktreeRoot, f.worktreeRoot)
-  const ws2 = readSettings(f.worktreeSettingsLocal)
-  const dirs2 = additionalDirsOf(ws2)
+  const ms2 = readSettings(f.mainSettingsLocal)
+  const dirs2 = additionalDirsOf(ms2)
   assert.strictEqual(countGrantsFor(dirs2, f.canonicalCheckpoints), 1, 'second install: still exactly one grant entry (idempotent)')
   assert.deepStrictEqual(dirs1, dirs2, 'array contents identical across re-runs')
 })
@@ -268,15 +285,15 @@ test('re-run idempotence: second install does not duplicate the grant', () => {
 test('concurrent installs do not crash on shared atomic temp path', () => {
   // Codex PR-level review (PR #214) found the fixed `.tmp` filename in
   // writeJSONAtomic was not multi-writer safe: 5 concurrent installers
-  // against the same worktree settings.local.json produced ENOENT on
+  // against the same canonical settings.local.json produced ENOENT on
   // rename. Fix uses pid + random in the temp filename. This regression
   // launches N parallel installers via a tiny driver script (the test
   // body is sync; the driver uses Promise.all to truly parallelize).
   const f = freshFixture('concurrent')
-  fs.mkdirSync(path.dirname(f.worktreeSettingsLocal), { recursive: true })
+  fs.mkdirSync(path.dirname(f.mainSettingsLocal), { recursive: true })
   const manualEntry = '/some/manual/dir'
   fs.writeFileSync(
-    f.worktreeSettingsLocal,
+    f.mainSettingsLocal,
     JSON.stringify({ permissions: { additionalDirectories: [manualEntry] } }, null, 2)
   )
 
@@ -303,9 +320,10 @@ test('concurrent installs do not crash on shared atomic temp path', () => {
   for (const r of results) {
     assert.strictEqual(r.code, 0, `concurrent install exited ${r.code}; stderr=${r.stderr}`)
   }
-  // Final file invariants: manual entry preserved + exactly one grant.
-  const ws = readSettings(f.worktreeSettingsLocal)
-  const dirs = additionalDirsOf(ws)
+  // Final file invariants: manual entry preserved + exactly one grant
+  // (target is canonical's settings.local.json per #215).
+  const ms = readSettings(f.mainSettingsLocal)
+  const dirs = additionalDirsOf(ms)
   assert.ok(dirs.includes(manualEntry), 'manual entry must be preserved across concurrent installs')
   assert.strictEqual(
     countGrantsFor(dirs, f.canonicalCheckpoints), 1,


### PR DESCRIPTION
## Summary

- Fixes [#215](https://github.com/lantisprime/episodic-memory/issues/215). [PR #214](https://github.com/lantisprime/episodic-memory/pull/214) wrote `permissions.additionalDirectories` to `<worktree>/.claude/settings.local.json`, but Claude Code loads project settings from the canonical repo root — so the runtime never read the grant and I-1' (no-prompt at runtime) failed post-merge despite all 8 unit tests passing.
- One-line install.mjs change: write the grant to `<canonical>/.claude/settings.local.json`. Test suite rewired across 8 cases + a new negative paired assertion (worktree's settings.local.json must NOT have the grant).

## Empirical verification

| Probe | Result |
|---|---|
| `claude --add-dir <main>/.checkpoints/` in worktree | No prompt — mechanism works |
| Hot-fix grant to `<main>/.claude/settings.local.json` + fresh worktree session | No prompt — diagnosis confirmed |
| Pre-merge post-build install run | Grant lands in canonical settings.local.json |

## Why this slipped past 5 prior review rounds

PR #214 went through 3 per-commit Codex rounds + PR-level + closeout — all ACCEPT. None probed runtime. I-1' was labeled "not locally verifiable" and deferred to a manual post-merge probe. **Lesson:** when a non-LV invariant is the load-bearing one, the manual probe MUST run pre-merge as Rule 18 step 8, not deferred.

Same class as PR-186's #20 binding miss — installer's `--project` flag is not the runtime's project root.

## Codex review chain (this PR)

| Round | Verdict | Episode |
|---|---|---|
| 1 | HOLD (BLOCKER: branch readiness, MINOR: comment drift) | `20260509-084544-...-26d9` |
| 2 (closeout, pending) | TBD | |

Round-1 BLOCKER fixed by committing (this commit `b61c1c3`). MINOR fixed in same commit (comment drift in install.mjs:347 + tests:23-25 corrected to describe the new canonical-target invariant).

## Diff

| File | Change |
|---|---|
| `install.mjs` | Section 2d settings target: `projectDir` → `wt.canonicalRoot`; comment + log message updated |
| `tests/test-install-worktree-grant.mjs` | All 8 test cases updated to assert on canonical's settings.local.json; new negative paired assertion in case 1 (worktree must NOT have the grant) |

## Test plan

- [x] `node tests/test-install-worktree-grant.mjs` — 8/0 (incl. new negative assertion)
- [x] `node tests/test-em-repo-root-worktree.mjs` — 12/0
- [x] `node tests/test-checkpoints-migration.mjs` — 6/0
- [x] `bash tests/test-install-hooks.sh` — 65/0
- [x] **Empirical I-1'** confirmed via hot-fix probe (this conversation's diagnostic)
- [ ] **Post-merge I-1'** : after merge, run `node install.mjs --tool claude-code --project <worktree>` from a worktree, open fresh Claude Code session, confirm no prompt on `<main>/.checkpoints/.X` Read

## Out of scope

- Cleanup of stale grants written to worktree's settings.local.json by PR #214 — separate hygiene if needed.
- Auto-detect new worktrees — by design out of scope (Codex round-1.E from PR #214).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
