### PR TITLE
feat(launchd): em-lock primitive + install-launchd-routines bootstrap

### DIFF
--- a/install-launchd-routines.sh
+++ b/install-launchd-routines.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+# install-launchd-routines.sh — single-action bootstrap for episodic-memory
+# scheduled tasks. User-run trust boundary (sidesteps Claude auto-mode classifier).
+#
+# Writes 4 LaunchAgent plists, lints with plutil, bootstraps via launchctl,
+# kickstarts a smoke run for the daily-mining job, tails its log briefly.
+#
+# Usage:
+#   bash install-launchd-routines.sh --dry-run        # preview, no writes
+#   bash install-launchd-routines.sh                  # install (no smoke)
+#   bash install-launchd-routines.sh --smoke          # install + kickstart daily-mining
+#   bash install-launchd-routines.sh --uninstall      # bootout + delete plists
+#
+# Reversible: --uninstall undoes everything this script created.
+
+set -e
+
+DRY_RUN=0
+SMOKE=0
+UNINSTALL=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --smoke) SMOKE=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    *) echo "Unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+UID_GUI=$(id -u)
+LA_DIR="$HOME/Library/LaunchAgents"
+LOG_DIR="$HOME/Library/Logs/episodic-memory"
+PROJECT_DIR="$HOME/Developer/projects/episodic-memory"
+SCHEDULED_TASKS_DIR="$HOME/.claude/scheduled-tasks"
+
+# Pin absolute binaries at install time (round-3 fix: don't rely on PATH lookup at runtime)
+NODE_BIN=$(command -v node)
+GH_BIN=$(command -v gh)
+CLAUDE_BIN=$(command -v claude)
+
+if [ -z "$NODE_BIN" ] || [ -z "$CLAUDE_BIN" ]; then
+  echo "ERROR: node and claude must be on PATH at install time. Found: node=$NODE_BIN claude=$CLAUDE_BIN" >&2
+  exit 3
+fi
+
+# Plist labels
+LABELS=(
+  "com.charltonho.em-daily-mining"
+  "com.charltonho.em-weekly-digest"
+  "com.charltonho.instruction-hygiene"
+  "com.charltonho.em-backup-sync"
+)
+
+if [ "$UNINSTALL" -eq 1 ]; then
+  echo "=== Uninstalling ==="
+  for label in "${LABELS[@]}"; do
+    plist="$LA_DIR/$label.plist"
+    if launchctl print "gui/$UID_GUI/$label" >/dev/null 2>&1; then
+      [ "$DRY_RUN" -eq 1 ] && echo "[dry-run] launchctl bootout gui/$UID_GUI $plist" \
+                          || launchctl bootout "gui/$UID_GUI" "$plist" || true
+    fi
+    if [ -f "$plist" ]; then
+      [ "$DRY_RUN" -eq 1 ] && echo "[dry-run] rm $plist" \
+                          || rm -f "$plist"
+    fi
+    echo "  - $label removed"
+  done
+  echo "Uninstall complete. Logs preserved in $LOG_DIR."
+  exit 0
+fi
+
+echo "=== Pre-flight ==="
+echo "  UID:           $UID_GUI"
+echo "  LaunchAgents:  $LA_DIR"
+echo "  Logs:          $LOG_DIR"
+echo "  Project:       $PROJECT_DIR"
+echo "  node:          $NODE_BIN"
+echo "  gh:            ${GH_BIN:-not found (weekly-digest depends on this)}"
+echo "  claude:        $CLAUDE_BIN"
+
+# Verify scheduled-task SKILL.md files exist
+for skill in episodic-memory-daily-mining episodic-memory-weekly-digest instruction-hygiene-maintenance; do
+  if [ ! -f "$SCHEDULED_TASKS_DIR/$skill/SKILL.md" ]; then
+    echo "ERROR: missing $SCHEDULED_TASKS_DIR/$skill/SKILL.md" >&2
+    exit 4
+  fi
+done
+
+# Verify wrapper exists for em-backup-sync
+if [ ! -x "$SCHEDULED_TASKS_DIR/em-backup-sync-wrapper.sh" ]; then
+  echo "ERROR: missing or non-executable $SCHEDULED_TASKS_DIR/em-backup-sync-wrapper.sh" >&2
+  exit 4
+fi
+
+# Verify em-lock.mjs is in place (round-3 FU-2)
+if [ ! -f "$PROJECT_DIR/scripts/em-lock.mjs" ]; then
+  echo "ERROR: missing $PROJECT_DIR/scripts/em-lock.mjs (needed by auto-promote and backup-sync wrapper)" >&2
+  exit 4
+fi
+
+mkdir -p "$LOG_DIR"
+
+# Per-plist invocation builders --------------------------------------------------
+
+claude_skill_invocation() {
+  # $1 = skill name (e.g. episodic-memory-daily-mining)
+  cat <<EOF
+        <string>$CLAUDE_BIN</string>
+        <string>-p</string>
+        <string>--permission-mode</string>
+        <string>bypassPermissions</string>
+        <string>--setting-sources</string>
+        <string>project,local</string>
+        <string>--settings</string>
+        <string>{"hooks":{}}</string>
+        <string>/$1</string>
+EOF
+}
+
+backup_invocation() {
+  cat <<EOF
+        <string>/bin/bash</string>
+        <string>$SCHEDULED_TASKS_DIR/em-backup-sync-wrapper.sh</string>
+EOF
+}
+
+write_plist() {
+  # $1 = label, $2 = invocation block, $3 = StartCalendarInterval block, $4 = log basename
+  local label="$1"
+  local invocation="$2"
+  local schedule="$3"
+  local logname="$4"
+  local plist="$LA_DIR/$label.plist"
+
+  cat > "$plist.tmp" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$label</string>
+    <key>ProgramArguments</key>
+    <array>
+$invocation
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$PROJECT_DIR</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>$HOME</string>
+    </dict>
+$schedule
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/$logname.log</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/$logname.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>
+EOF
+
+  # Lint
+  if ! plutil -lint "$plist.tmp" >/dev/null; then
+    echo "ERROR: plist lint failed for $label" >&2
+    rm -f "$plist.tmp"
+    exit 5
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] would write $plist:"
+    sed 's/^/    /' "$plist.tmp"
+    rm -f "$plist.tmp"
+    return
+  fi
+
+  mv "$plist.tmp" "$plist"
+  echo "  ✓ wrote $plist"
+}
+
+# Schedule blocks -------------------------------------------------------------
+
+DAILY_19_30='    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>19</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>'
+
+SUNDAY_09_00='    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>'
+
+SUNDAY_11_00='    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>11</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>'
+
+DAILY_23_00='    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>23</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>'
+
+# Write plists ---------------------------------------------------------------
+
+echo ""
+echo "=== Writing plists ==="
+write_plist com.charltonho.em-daily-mining "$(claude_skill_invocation episodic-memory-daily-mining)" "$DAILY_19_30" em-daily-mining
+write_plist com.charltonho.em-weekly-digest "$(claude_skill_invocation episodic-memory-weekly-digest)" "$SUNDAY_09_00" em-weekly-digest
+write_plist com.charltonho.instruction-hygiene "$(claude_skill_invocation instruction-hygiene-maintenance)" "$SUNDAY_11_00" instruction-hygiene
+write_plist com.charltonho.em-backup-sync "$(backup_invocation)" "$DAILY_23_00" em-backup-sync
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo ""
+  echo "[dry-run complete] Re-run without --dry-run to install."
+  exit 0
+fi
+
+# Bootstrap -----------------------------------------------------------------
+
+echo ""
+echo "=== Bootstrapping ==="
+for label in "${LABELS[@]}"; do
+  plist="$LA_DIR/$label.plist"
+  # bootout existing instance if present (idempotent re-install)
+  if launchctl print "gui/$UID_GUI/$label" >/dev/null 2>&1; then
+    launchctl bootout "gui/$UID_GUI" "$plist" 2>/dev/null || true
+  fi
+  if launchctl bootstrap "gui/$UID_GUI" "$plist"; then
+    echo "  ✓ bootstrap $label"
+  else
+    echo "  ✗ bootstrap $label FAILED" >&2
+    exit 6
+  fi
+done
+
+# Verify
+echo ""
+echo "=== Verification ==="
+for label in "${LABELS[@]}"; do
+  if launchctl print "gui/$UID_GUI/$label" >/dev/null 2>&1; then
+    echo "  ✓ $label loaded"
+  else
+    echo "  ✗ $label NOT loaded" >&2
+    exit 7
+  fi
+done
+
+# Smoke test (optional)
+if [ "$SMOKE" -eq 1 ]; then
+  echo ""
+  echo "=== Smoke: kickstart em-daily-mining ==="
+  launchctl kickstart -kp "gui/$UID_GUI/com.charltonho.em-daily-mining"
+  echo "Waiting 30s for output..."
+  sleep 30
+  echo ""
+  echo "Last 30 lines of $LOG_DIR/em-daily-mining.log:"
+  tail -30 "$LOG_DIR/em-daily-mining.log" 2>/dev/null || echo "(no log content yet)"
+fi
+
+echo ""
+echo "=== Install complete ==="
+echo "Logs:        $LOG_DIR/"
+echo "Uninstall:   bash $0 --uninstall"
+echo ""
+echo "FU items to verify post-install:"
+echo "  - Phase 0a: gh auth status (you should already have run 'gh auth login')"
+echo "  - Phase 0b: hook-bypass + skill resolution under launchd env"
+echo "  - Phase 0d: em-backup git push under launchd env"
+echo "  - Phase 0d': gh auth status under launchd env"
+echo "Manual probe commands are in the v3 plan episode 20260510-080404-codex-review-request-round-3-surgical-cl-40bb"

--- a/scripts/em-lock.mjs
+++ b/scripts/em-lock.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// em-lock.mjs — zero-dep atomic file lock with timeout.
+// Replaces flock(1) for the auto-promote + em-backup-sync paths on macOS where
+// flock is not present by default. Project rule: zero external deps.
+//
+// Usage:
+//   node em-lock.mjs --file <lockpath> --timeout <seconds> -- <cmd> [args...]
+//
+// Semantics:
+//   - Acquires <lockpath> via O_WRONLY|O_CREAT|O_EXCL (kernel-atomic).
+//   - On EEXIST, polls every 100ms up to <timeout> seconds. Stale-lock guard:
+//     if pid in lockfile is gone, takes over.
+//   - On acquisition, writes own pid + iso timestamp + ppid to the lockfile.
+//   - Spawns <cmd> as child, inherits stdio, waits for exit.
+//   - Releases lock on child exit (and on SIGINT/SIGTERM/uncaught error).
+//   - Exits with child's exit code (or 1 on lock-acquire timeout).
+//
+// JSON output on lock-acquire timeout (to stdout, then exit 1):
+//   {"status":"error","code":"lock-timeout","file":"...","held_by_pid":N,"timeout_s":N}
+//
+// Exit codes:
+//   - child's exit code on success path
+//   - 1 if lock acquire times out
+//   - 2 on usage error
+
+import fs from 'node:fs'
+import { spawn } from 'node:child_process'
+
+const args = process.argv.slice(2)
+const dashDash = args.indexOf('--')
+if (dashDash === -1 || dashDash === args.length - 1) {
+  console.error(JSON.stringify({ status: 'error', code: 'usage', message: 'Usage: em-lock.mjs --file <path> --timeout <seconds> -- <cmd> [args...]' }))
+  process.exit(2)
+}
+
+const flagArgs = args.slice(0, dashDash)
+const cmdArgs = args.slice(dashDash + 1)
+
+function getFlag(name) {
+  const idx = flagArgs.indexOf(name)
+  if (idx === -1 || idx === flagArgs.length - 1) return null
+  return flagArgs[idx + 1]
+}
+
+const lockFile = getFlag('--file')
+const timeoutS = parseInt(getFlag('--timeout') ?? '60', 10)
+
+if (!lockFile || !cmdArgs.length || Number.isNaN(timeoutS) || timeoutS < 0) {
+  console.error(JSON.stringify({ status: 'error', code: 'usage', message: 'Required: --file <path> --timeout <seconds> -- <cmd> [args...]' }))
+  process.exit(2)
+}
+
+const POLL_MS = 100
+const startMs = Date.now()
+const deadlineMs = startMs + timeoutS * 1000
+
+function tryAcquire() {
+  try {
+    const fd = fs.openSync(lockFile, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644)
+    fs.writeSync(fd, `${process.pid}\n${new Date().toISOString()}\n${process.ppid}\n`)
+    fs.closeSync(fd)
+    return { ok: true }
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err
+    // Stale-lock detection: read pid, check if alive
+    try {
+      const txt = fs.readFileSync(lockFile, 'utf8')
+      const pid = parseInt(txt.split('\n')[0], 10)
+      if (pid > 0) {
+        try {
+          process.kill(pid, 0) // probe — does not actually signal
+          return { ok: false, heldBy: pid }
+        } catch (probeErr) {
+          if (probeErr.code === 'ESRCH') {
+            // Holder is gone. Steal.
+            try {
+              fs.unlinkSync(lockFile)
+              return tryAcquire()
+            } catch (unlinkErr) {
+              if (unlinkErr.code === 'ENOENT') return tryAcquire()
+              throw unlinkErr
+            }
+          }
+          // EPERM or other — treat as held
+          return { ok: false, heldBy: pid }
+        }
+      }
+      return { ok: false, heldBy: null }
+    } catch (readErr) {
+      if (readErr.code === 'ENOENT') return tryAcquire() // race; retry
+      throw readErr
+    }
+  }
+}
+
+async function acquire() {
+  while (true) {
+    const result = tryAcquire()
+    if (result.ok) return
+    if (Date.now() >= deadlineMs) {
+      console.error(JSON.stringify({
+        status: 'error',
+        code: 'lock-timeout',
+        file: lockFile,
+        held_by_pid: result.heldBy,
+        timeout_s: timeoutS,
+      }))
+      process.exit(1)
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS))
+  }
+}
+
+function release() {
+  try {
+    const txt = fs.readFileSync(lockFile, 'utf8')
+    const pid = parseInt(txt.split('\n')[0], 10)
+    if (pid === process.pid) fs.unlinkSync(lockFile)
+  } catch (_err) {
+    // already gone or unreadable — fine
+  }
+}
+
+let released = false
+function safeRelease() {
+  if (released) return
+  released = true
+  release()
+}
+
+process.on('SIGINT', () => { safeRelease(); process.exit(130) })
+process.on('SIGTERM', () => { safeRelease(); process.exit(143) })
+process.on('uncaughtException', (err) => {
+  safeRelease()
+  console.error(JSON.stringify({ status: 'error', code: 'uncaught', message: err.message }))
+  process.exit(1)
+})
+
+await acquire()
+
+const child = spawn(cmdArgs[0], cmdArgs.slice(1), { stdio: 'inherit' })
+
+child.on('exit', (code, signal) => {
+  safeRelease()
+  if (signal) process.kill(process.pid, signal)
+  else process.exit(code ?? 0)
+})
+
+child.on('error', (err) => {
+  safeRelease()
+  console.error(JSON.stringify({ status: 'error', code: 'spawn-error', message: err.message }))
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- New `scripts/em-lock.mjs` — zero-dep atomic file lock with timeout, replacing flock(1) which macOS lacks. Smoke-tested both the acquire/exec/release path and contention timeout (structured `lock-timeout` JSON + exit 1).
- New `install-launchd-routines.sh` — bootstrap script for the 4 scheduled-task LaunchAgents (em-daily-mining, em-weekly-digest, instruction-hygiene, em-backup-sync). User-run trust boundary that sidesteps the auto-mode classifier's correct objection to agent-installed unattended bypassPermissions jobs.
- Together these complete the launchd-routines workstream (workstreams 1+2+3 of the 2026-05-10 plan). Workstream 4 (episode pruning/archival) deferred to a separate RFC cycle.

## Why
- `~/.episodic-memory/.global-write.lock` is needed to coordinate two writers: weekly-digest auto-promote (Sun 09:00 PHT) and em-backup-sync (daily 23:00 PHT, plus manual kickstarts). macOS has no flock(1) by default — only shlock(1) without timeout semantics. em-lock.mjs fills the gap with zero deps per project rule.
- Past unattended runs of these skills failed because permission prompts blocked them. `bypassPermissions` + `--setting-sources project,local --settings '{"hooks":{}}'` is the proposed bypass mechanism for hooks; FU-1 below collects the runtime artifact proving it works under launchd.

## Plan-review chain
Three rounds of codex second-opinion before this landed:
- Round 1 → HOLD (9 broad findings)
- Round 2 → HOLD (4 surgical blockers — probe-under-launchd-env, separate gh auth probe, lock-on-auto-promote-em-store, em-revise --status invalid)
- Round 3 → ACCEPT-with-FU (all 4 closed; flock-missing FU resolved in same turn via em-lock.mjs)

Episodes (local scope): `20260510-071432-codex-review-request-schedule-episodic-m-b306`, `20260510-075104-hold-launchd-plan-needs-runtime-hook-ski-8aab`, `20260510-075625-codex-review-request-round-2-launchd-rou-08c0`, `20260510-080128-hold-round-2-launchd-routines-v2-plan-st-37ce`, `20260510-080404-codex-review-request-round-3-surgical-cl-40bb`.

## Out-of-scope (intentional)
- The 4 plists themselves are NOT in this PR — they're written on the user's machine by `install-launchd-routines.sh`. Keeping plists out of git avoids checking in machine-specific paths and means the install script is the single source of truth for plist shape.
- `~/.claude/scheduled-tasks/em-backup-sync-wrapper.sh` and the `episodic-memory-weekly-digest/SKILL.md` step-4.5 edit live under `~/.claude/scheduled-tasks/` (user-global), not in this repo. They're part of the same workstream but the right home is the user's `~/.claude/` tree.

## Test plan
- [x] `node scripts/em-lock.mjs --file /tmp/test.lock --timeout 5 -- echo ok` — acquire/exec/release works, lockfile cleaned up
- [x] Contention test — second em-lock with timeout 2 against a held lock returns `{"status":"error","code":"lock-timeout","held_by_pid":N,"timeout_s":2}` and exit 1
- [ ] **FU-1**: `bash install-launchd-routines.sh --dry-run` previews 4 plists without writing
- [ ] **FU-1**: `bash install-launchd-routines.sh --smoke` installs + kickstarts daily-mining; tail log shows mining ran AND no hook events fired (proves `--settings '{"hooks":{}}'` suppresses hooks under launchd) AND `/episodic-memory-daily-mining` resolved as a skill
- [ ] **FU-1**: `launchctl asuser $UID env -i HOME=$HOME PATH=... gh auth status` exits 0 (gh auth works under launchd-env)
- [ ] **FU-1**: `launchctl asuser $UID env -i HOME=$HOME PATH=... git -C ~/Developer/projects/episodic-memory-backup push --dry-run` exits 0 (em-backup git push works under launchd-env)
- [ ] First weekly-digest run hits dry-run mode (counter file at `~/.episodic-memory/.auto-promote-run-count` shows `1`); next 2 runs also dry-run; 4th run promotes if any PROMOTE-flagged lessons
- [ ] Auto-promote kill-switch: `touch ~/.episodic-memory/.no-auto-promote` then trigger digest; verify no promotions, only recommend-only output
- [ ] em-backup-sync wrapper alert path: temporarily break em-backup config; verify osascript notification fires

## Reversibility
`bash install-launchd-routines.sh --uninstall` cleanly bootouts and deletes all 4 plists. Logs preserved for audit. The 2 files in this PR are inert until the install script is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
