### PR TITLE
docs: reflect second-opinion harness (PR #222) in README + user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Episodic-memory and user-preferences are fully independent — install either or
 | [RFC-003](docs/rfcs/RFC-003-pluggable-tool-adapters.md) | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | Accepted (Phase 1 not yet started) |
 | [RFC-004](docs/rfcs/RFC-004-bp1-auto-pilot.md) | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | Accepted (M0 + M1 shipped) |
 | [RFC-005](docs/rfcs/RFC-005-em-move.md) | em-move — atomic episode relocation between scopes | Draft |
-| [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Draft |
+| [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Accepted (harness shipped PR #222) |
 
 ## Scripts Reference
 
@@ -371,7 +371,37 @@ node ~/.episodic-memory/scripts/em-pattern-health.mjs --has-enforcement bp-006-p
 
 Searches `~/.claude/hooks/`, `<project>/.claude/hooks/`, `<project>/.git/hooks/`, and `<project>/.github/workflows/` for `pattern_id` references to detect mechanical enforcement. Patterns flagged `needs-enforcement` are violated repeatedly with no hook to stop them; `needs-attention` means an enforcement file exists but violations still occur (escalate to a human).
 
+### Second-Opinion Review Harness
+
+Pluggable cross-tool review at `scripts/second-opinion.mjs` (RFC-006 implementation, shipped PR #222). One callable entry point handles em-store request → provider dispatch → preamble composition → reply parsing → consensus iteration. Replaces the manual em-store + `codex exec` + watcher + reply-episode recipe.
+
+```bash
+# Single-shot: write request → dispatch → write reply (synchronous)
+node scripts/second-opinion.mjs request \
+  --provider codex --project . --storage episodic \
+  --body "review this diff..." --summary "diff review" --dispatch
+
+# Consensus loop: dispatch → parse verdict → rebuttal-cb → next round
+node scripts/second-opinion.mjs request \
+  --provider codex --project . --storage episodic \
+  --body-file plan.md --summary "plan review" \
+  --consensus --max-rounds 5 --rebuttal-cb scripts/my-rebuttal.mjs
+```
+
+Providers: `codex`, `claude-subagent`, `gemini`, `stub` (testing). Storage backends: `files` (`.review-store/`) or `episodic` (uses em-store; default for the cross-tool message bus). Preambles: per-provider defaults at `scripts/second-opinion/preambles/`, overridable via `--preamble <id>` or `<project>/.review-store/preambles/<provider>.md`.
+
+Bootstrap (writes the install snapshot consumed by validators + the Claude Code PreToolUse gate hook):
+
+```bash
+node install.mjs --tool claude-code --install-second-opinion
+```
+
+The PreToolUse hook (`hooks/second-opinion-gate.mjs`) blocks direct provider invocations (Bash + Agent variants) so reviews route through the harness; fail-closed on missing/malformed snapshot.
+
 ### Codex Watcher
+
+Underlying cursor mechanism for the harness's `episodic` storage backend, also usable standalone for the manual review fallback.
+
 ```bash
 # Poll project-local memory for new Codex replies (default scope: local)
 node ~/.episodic-memory/scripts/em-watch-codex.mjs
@@ -440,6 +470,8 @@ node ~/.episodic-memory/scripts/em-mine-transcripts.mjs \
 ```
 
 ### Review Request (Workflow Lifecycle Event)
+
+Lifecycle event for the workflow audit trail — orthogonal to the second-opinion harness above. This script records that a review *happened* (with refs to plan/approval/checkpoints/tests/etc.); the harness *runs* the review.
 
 ```bash
 # Build + store a workflow.lifecycle review-request event with full ref

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -275,7 +275,47 @@ AI:   I see from a previous session that you chose Tailwind CSS
 
 **How it works:** Both tools read from and write to `~/.episodic-memory/`. The instruction files are different per tool, but the data is shared.
 
-**Cross-tool messaging via Codex watcher.** When Codex writes review feedback as episodes (tagged `codex`, `codex-review`, or `codex-reply`), Claude Code or Cursor can poll for new replies with `em-watch-codex.mjs` — episodes act as a lightweight message bus between tools, with per-scope cursors so nothing is read twice.
+**Cross-tool messaging via the second-opinion harness.** When you ask one tool to review another's plan or diff, `scripts/second-opinion.mjs` writes the request as a local episode, dispatches it to the chosen provider (Codex, Claude subagent, Gemini), and writes the reply back as another episode. Both halves live in `.episodic-memory/` so any tool can read them later. Under the hood, `em-watch-codex.mjs` provides the per-scope cursors that keep replies from being read twice.
+
+---
+
+## Scenario 8b: Running a Second-Opinion Review on a Plan or Diff
+
+**What happens:** You're about to implement a non-trivial change and want a second model to sanity-check the plan before you commit time. Or you've finished a PR and want a class-completeness review before merging. Instead of manually writing the request, invoking the other tool, and stitching the reply back into your store, you invoke one harness and it does the round-trip for you.
+
+```
+You:  Get a second opinion on this plan from Codex before I start.
+
+AI:   Running scripts/second-opinion.mjs --provider codex --dispatch
+      with the plan body...
+
+      Codex replied (episode 20260510-...-1076): ACCEPT-with-FU.
+      Two findings — F1 (P1, accepted), F2 (P2, deferred as
+      follow-up). Want me to fold F1 into the plan?
+```
+
+**Single-shot review of a plan file:**
+
+```bash
+node scripts/second-opinion.mjs request \
+  --provider codex --project . --storage episodic \
+  --body-file plan.md --summary "plan review" --dispatch
+```
+
+**Consensus loop until both sides agree (or you hit the round cap):**
+
+```bash
+node scripts/second-opinion.mjs request \
+  --provider codex --project . --storage episodic \
+  --body-file plan.md --summary "plan review" \
+  --consensus --max-rounds 5 --rebuttal-cb scripts/my-rebuttal.mjs
+```
+
+The `--rebuttal-cb` is a script that takes the reviewer's verdict and decides what to send back next round — accept the findings, push back with new evidence, or stop. Each round is one request episode + one reply episode, so the whole conversation is auditable later via `em-search --tag codex-review --scope local`.
+
+**Providers available:** `codex` (OpenAI Codex CLI), `claude-subagent` (a separate Claude Code session), `gemini` (Google's CLI), and `stub` for testing harness behavior without spending tokens.
+
+**When to use it:** Rule 18 step 2 (any non-trivial implementation needs a second-opinion review on the plan before approval), PR-level reviews before merge, or any time you want a sanity check from a different model family on a load-bearing decision.
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -15,6 +15,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 6: Reaching a Milestone](#scenario-6-reaching-a-milestone)
 - [Scenario 7: Recording Project Context](#scenario-7-recording-project-context)
 - [Scenario 8: Switching Between Tools](#scenario-8-switching-between-tools)
+- [Scenario 8b: Running a Second-Opinion Review on a Plan or Diff](#scenario-8b-running-a-second-opinion-review-on-a-plan-or-diff)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)


### PR DESCRIPTION
## Summary

- README: mark RFC-006 as Accepted (harness shipped PR #222), add a "Second-Opinion Review Harness" section, reframe Codex Watcher and Review Request as orthogonal building blocks.
- USER_MANUAL: rewrite Scenario 8 cross-tool messaging paragraph to lead with the harness, add Scenario 8b walkthrough with single-shot and consensus-loop examples.
- Docs-only; no script changes. Brings user-facing docs in line with the second-opinion harness merged in #222.

## Test plan

- [ ] Render README.md on GitHub — RFC-006 row, new harness section, reframed leads on Codex Watcher + Review Request all read correctly.
- [ ] Render docs/USER_MANUAL.md on GitHub — Scenario 8 + new Scenario 8b read correctly; section anchors not broken.
- [ ] Spot-check that no other docs (CLAUDE.md project file already current, instructions/ deferred per plan) need a follow-up edit in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
