### PR TITLE
fix(second-opinion): post-#222 review fold-ins for snapshot validator + install quarantine (#221)

### DIFF
--- a/hooks/second-opinion-gate.mjs
+++ b/hooks/second-opinion-gate.mjs
@@ -42,10 +42,31 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
-import { validateProviderRegistry } from './lib/registry-validator.mjs'
-
 const SNAPSHOT_PATH = process.env.SO_INSTALL_SNAPSHOT_PATH ||
   path.join(os.homedir(), '.claude', 'hooks', 'second-opinion-providers.json')
+
+// Dynamic import of validator so the hook can emit a structured block
+// decision if the colocated ./lib/registry-validator.mjs is missing or
+// malformed (partial install / orphan hook). A static import would crash
+// the hook at module-load with empty stdout — ambiguous fail-open class.
+// F4 from post-implementation code review.
+let validateProviderRegistry
+try {
+  const mod = await import(new URL('./lib/registry-validator.mjs', import.meta.url).href)
+  validateProviderRegistry = mod.validateProviderRegistry
+} catch (e) {
+  // Emit a fail-closed block decision and exit. Same envelope shape as
+  // every other block path so Claude Code can parse the JSON.
+  console.log(JSON.stringify({
+    decision: 'block',
+    code: 'snapshot-validator-load-failed',
+    reason: `second-opinion-gate: cannot load validator at ./lib/registry-validator.mjs ` +
+      `(detail: ${e.message}). Run: node install.mjs --install-second-opinion to ` +
+      `reinstall the colocated validator lib.`,
+    detail: e.message,
+  }))
+  process.exit(0)
+}
 
 function emitBlock(reason, extra = {}) {
   console.log(JSON.stringify({ decision: 'block', reason, ...extra }))

--- a/install.mjs
+++ b/install.mjs
@@ -119,37 +119,76 @@ if (installSecondOpinion) {
   }
 }
 
+// I-NEW-C completeness (PR-level review P1): the unconditional script + lib +
+// second-opinion subtree copies below mutate the active second-opinion runtime
+// surface. A throw there (e.g., a directory blocking a destination file)
+// would leave the pre-existing snapshot pointing at superseded source.
+// Hoisted helper invoked from the runtime-copy catch when installSecondOpinion
+// is true.
+async function quarantinePreExistingSnapshotForFailedInstall() {
+  try {
+    const { snapshotPath } = await import(
+      new URL('./scripts/second-opinion/lib/install-snapshot.mjs', import.meta.url).href
+    )
+    const target = snapshotPath()
+    if (fs.existsSync(target)) {
+      const quarantineName = `${target}.stale.${Date.now()}`
+      fs.renameSync(target, quarantineName)
+      console.error(`Quarantined pre-existing snapshot to: ${quarantineName}`)
+    }
+  } catch (qe) {
+    console.error(`Quarantine attempt failed: ${qe.message}`)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // 1. Install scripts globally
+//
+// Second-opinion runtime surface: scripts/*.mjs (incl. scripts/second-opinion.mjs
+// harness entrypoint) + scripts/lib/ (shared deps) + scripts/second-opinion/
+// subtree. A copy failure here while installSecondOpinion is true must
+// quarantine the pre-existing snapshot so the hook fail-closes on next call.
 // ---------------------------------------------------------------------------
 fs.mkdirSync(SCRIPTS_DIR, { recursive: true })
 fs.mkdirSync(path.join(GLOBAL_DIR, 'episodes'), { recursive: true })
 
-const scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(f => f.endsWith('.mjs'))
-for (const file of scriptFiles) {
-  const src = path.join(REPO_SCRIPTS, file)
-  const dst = path.join(SCRIPTS_DIR, file)
-  fs.copyFileSync(src, dst)
-  fs.chmodSync(dst, 0o755)
-}
-// scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-* scripts.
-const REPO_SCRIPTS_LIB = path.join(REPO_SCRIPTS, 'lib')
-if (fs.existsSync(REPO_SCRIPTS_LIB)) {
-  const libDst = path.join(SCRIPTS_DIR, 'lib')
-  fs.mkdirSync(libDst, { recursive: true })
-  for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs'))) {
-    fs.copyFileSync(path.join(REPO_SCRIPTS_LIB, file), path.join(libDst, file))
+let scriptFiles
+try {
+  scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(f => f.endsWith('.mjs'))
+  for (const file of scriptFiles) {
+    const src = path.join(REPO_SCRIPTS, file)
+    const dst = path.join(SCRIPTS_DIR, file)
+    fs.copyFileSync(src, dst)
+    fs.chmodSync(dst, 0o755)
   }
-}
+  // scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-* scripts.
+  const REPO_SCRIPTS_LIB = path.join(REPO_SCRIPTS, 'lib')
+  if (fs.existsSync(REPO_SCRIPTS_LIB)) {
+    const libDst = path.join(SCRIPTS_DIR, 'lib')
+    fs.mkdirSync(libDst, { recursive: true })
+    for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs'))) {
+      fs.copyFileSync(path.join(REPO_SCRIPTS_LIB, file), path.join(libDst, file))
+    }
+  }
 
-// scripts/second-opinion/ — pluggable second-opinion review harness subtree.
-// Recursively copy preambles/, providers/, storage/, lib/. Done unconditionally
-// alongside scripts/*.mjs so the harness module imports resolve at runtime; the
-// install snapshot at ~/.claude/hooks/second-opinion-providers.json is only
-// written when --install-second-opinion is passed (separate concern).
-if (fs.existsSync(REPO_SECOND_OPINION)) {
-  const soDst = path.join(SCRIPTS_DIR, 'second-opinion')
-  copyDirRecursive(REPO_SECOND_OPINION, soDst)
+  // scripts/second-opinion/ — pluggable second-opinion review harness subtree.
+  // Recursively copy preambles/, providers/, storage/, lib/. Done unconditionally
+  // alongside scripts/*.mjs so the harness module imports resolve at runtime; the
+  // install snapshot at ~/.claude/hooks/second-opinion-providers.json is only
+  // written when --install-second-opinion is passed (separate concern).
+  if (fs.existsSync(REPO_SECOND_OPINION)) {
+    const soDst = path.join(SCRIPTS_DIR, 'second-opinion')
+    copyDirRecursive(REPO_SECOND_OPINION, soDst)
+  }
+} catch (copyErr) {
+  if (installSecondOpinion) {
+    console.error(`Runtime copy failed during second-opinion install: ${copyErr.message}`)
+    console.error(`Active runtime may be partially modified; quarantining snapshot.`)
+    await quarantinePreExistingSnapshotForFailedInstall()
+    process.exit(1)
+  }
+  // No second-opinion install requested → legacy behavior (rethrow).
+  throw copyErr
 }
 
 function copyDirRecursive(src, dst) {

--- a/install.mjs
+++ b/install.mjs
@@ -1118,16 +1118,40 @@ if (installSecondOpinion) {
     installFailed = true
   }
 
+  // Unified quarantine: if ANY snapshot-refresh step fails after the global
+  // source-copy completed (validator-lib copy, Gate 2 validation, or
+  // writeSnapshot), the pre-existing snapshot must be quarantined so the
+  // hook fail-closes (snapshot-not-installed) rather than reading a
+  // stale-valid snapshot against newly-updated source. Uses snapshotPath()
+  // — the same resolution writeSnapshot() uses — so env override
+  // (SO_INSTALL_SNAPSHOT_PATH) routes both to the same target. F1+F2 from
+  // post-implementation code review.
+  let snapshotPathFn = null
+  function quarantineExistingSnapshot() {
+    if (!snapshotPathFn) return
+    try {
+      const target = snapshotPathFn()
+      if (fs.existsSync(target)) {
+        const quarantineName = `${target}.stale.${Date.now()}`
+        fs.renameSync(target, quarantineName)
+        console.error(`Quarantined pre-existing snapshot to: ${quarantineName}`)
+      }
+    } catch (qe) {
+      console.error(`Quarantine attempt failed: ${qe.message}`)
+    }
+  }
+
   try {
     const { computeSourceHash } = await import(
       new URL('./scripts/second-opinion/lib/source-hash.mjs', import.meta.url).href
     )
-    const { writeSnapshot, DEFAULT_SNAPSHOT_PATH } = await import(
+    const { writeSnapshot, snapshotPath } = await import(
       new URL('./scripts/second-opinion/lib/install-snapshot.mjs', import.meta.url).href
     )
     const { validateProviderRegistry } = await import(
       new URL('./scripts/second-opinion/lib/registry-validator.mjs', import.meta.url).href
     )
+    snapshotPathFn = snapshotPath  // expose to outer-catch quarantine helper
 
     // Hash against the GLOBAL installed copy (what runtime will see), NOT the
     // source repo. This ensures harness gate compares apples-to-apples.
@@ -1173,27 +1197,10 @@ if (installSecondOpinion) {
       try {
         validateProviderRegistry({ schema_version: 1, providers: installedProviders })
       } catch (gateErr) {
-        installFailed = true
         console.error(`Snapshot validation failed: ${gateErr.message}`)
         if (gateErr.field) console.error(`  field: ${gateErr.field}`)
         if (gateErr.provider) console.error(`  provider: ${gateErr.provider}`)
-
-        // Quarantine any pre-existing snapshot so the hook fail-closes
-        // (snapshot-not-installed) rather than reading a stale-valid snapshot
-        // while the active source has been updated. Rename (not delete) to
-        // preserve forensic evidence.
-        try {
-          const existingSnap = DEFAULT_SNAPSHOT_PATH
-          if (fs.existsSync(existingSnap)) {
-            const quarantineName = `${existingSnap}.stale.${Date.now()}`
-            fs.renameSync(existingSnap, quarantineName)
-            console.error(`Quarantined pre-existing snapshot to: ${quarantineName}`)
-          }
-        } catch (qe) {
-          console.error(`Quarantine attempt failed: ${qe.message}`)
-        }
-        // Skip the writeSnapshot call below.
-        throw gateErr
+        throw gateErr  // unified outer-catch quarantines + sets installFailed
       }
 
       const snapshot = {
@@ -1216,6 +1223,9 @@ if (installSecondOpinion) {
       console.error(`Failed to install second-opinion snapshot: ${e.message}`)
       installFailed = true
     }
+    // Unified quarantine: any snapshot-refresh failure path (Gate 2 throw,
+    // writeSnapshot throw, dynamic-import failure mid-flight) ends here.
+    quarantineExistingSnapshot()
   }
 
   if (installFailed) process.exitCode = 1

--- a/tests/test-install-second-opinion-e2e.mjs
+++ b/tests/test-install-second-opinion-e2e.mjs
@@ -169,6 +169,12 @@ function preInstallValidSnapshot(tempHome) {
 // caller cwd != --project axis) and HOME overridden to tempHome. Returns
 // spawn result.
 function runInstall(tempRepoCopy, tempProject, tempHome, callerCwd, extraEnv = {}) {
+  // Hermeticity: scrub SO_INSTALL_SNAPSHOT_PATH so the install resolves the
+  // snapshot path via HOME (the production default). Otherwise an inherited
+  // env override from the test shell breaks the temp-HOME isolation. F3
+  // from post-implementation code review.
+  const env = { ...process.env, HOME: tempHome, ...extraEnv }
+  delete env.SO_INSTALL_SNAPSHOT_PATH
   return spawnSync('node', [
     path.join(tempRepoCopy, 'install.mjs'),
     '--tool', 'claude-code',
@@ -176,7 +182,7 @@ function runInstall(tempRepoCopy, tempProject, tempHome, callerCwd, extraEnv = {
     '--install-second-opinion',
   ], {
     cwd: callerCwd,
-    env: { ...process.env, HOME: tempHome, ...extraEnv },
+    env,
     encoding: 'utf8',
     timeout: 60000,
   })
@@ -343,6 +349,57 @@ test('Gate 2 with populated HOME + all-unavailable: snapshot quarantined to .sta
   // Quarantine file content byte-identical to original valid snapshot.
   const quarantineContent = fs.readFileSync(path.join(hooksDir, quarantineFiles[0]), 'utf8')
   assert.strictEqual(quarantineContent, preSnapshotContent,
+    'quarantined snapshot must be byte-identical to original')
+})
+
+// ---------------------------------------------------------------------------
+// Case 5: writeSnapshot failure path (F1 unified-quarantine regression).
+// Block writeSnapshot's atomic rename by pre-creating a directory at the
+// .tmp target. Validates that quarantine ALSO fires when writeSnapshot
+// throws (not just when Gate 2 validation throws).
+// ---------------------------------------------------------------------------
+console.log('\n## Case 5 — writeSnapshot failure (F1 unified-quarantine regression)')
+test('writeSnapshot blocked: quarantine still fires via unified outer-catch', () => {
+  const tempBase = mkTempBase('case5')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+
+  // Pre-populate tempHome with valid snapshot.
+  const snapPath = preInstallValidSnapshot(tempHome)
+  const preSnapshotContent = fs.readFileSync(snapPath, 'utf8')
+
+  // Block writeSnapshot's atomic temp-then-rename by pre-creating a
+  // DIRECTORY at the .tmp path. fs.writeFileSync into a directory throws.
+  // writeSnapshot uses `${targetPath}.tmp` per install-snapshot.mjs.
+  fs.mkdirSync(`${snapPath}.tmp`, { recursive: true })
+
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.notStrictEqual(r.status, 0,
+    `writeSnapshot block must exit nonzero; got ${r.status}, stderr=${r.stderr}`)
+  assert.ok(!r.stdout.includes('Done!'),
+    `no Done! on writeSnapshot failure; stdout=${r.stdout}`)
+
+  // F1 invariant: current snapshot must be quarantined (renamed).
+  assert.ok(!fs.existsSync(snapPath),
+    `current snapshot must be quarantined; still exists at ${snapPath}`)
+
+  // Quarantine file must exist.
+  const hooksDir = path.dirname(snapPath)
+  const quarantineFiles = fs.readdirSync(hooksDir).filter(
+    f => f.startsWith('second-opinion-providers.json.stale.')
+  )
+  assert.strictEqual(quarantineFiles.length, 1,
+    `expected 1 quarantine file, found ${quarantineFiles.length}: ${quarantineFiles}`)
+  assert.strictEqual(
+    fs.readFileSync(path.join(hooksDir, quarantineFiles[0]), 'utf8'),
+    preSnapshotContent,
     'quarantined snapshot must be byte-identical to original')
 })
 

--- a/tests/test-install-second-opinion-e2e.mjs
+++ b/tests/test-install-second-opinion-e2e.mjs
@@ -404,6 +404,66 @@ test('writeSnapshot blocked: quarantine still fires via unified outer-catch', ()
 })
 
 // ---------------------------------------------------------------------------
+// Case 6: PR-level review P1 regression — runtime copy failure quarantines.
+// Reproduces codex's repro: replace the destination providers/index.json with
+// a DIRECTORY in tempHome's installed runtime so copyDirRecursive throws when
+// it tries to overwrite. Asserts quarantine fires from the runtime-copy
+// catch (not the snapshot-refresh catch), exit 1, no Done!, snapshot
+// renamed to .stale.<ts>.
+// ---------------------------------------------------------------------------
+console.log('\n## Case 6 — runtime copy failure quarantines (PR-level review P1)')
+test('runtime copy throws (blocked destination): quarantine fires from copy catch', () => {
+  const tempBase = mkTempBase('case6')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+
+  // First install: happy path. Snapshot lands, source lands.
+  const happyResult = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+  assert.strictEqual(happyResult.status, 0, 'prior happy install must succeed')
+  const snapPath = path.join(tempHome, '.claude/hooks/second-opinion-providers.json')
+  assert.ok(fs.existsSync(snapPath), 'snapshot must exist after happy install')
+  const preSnapshotContent = fs.readFileSync(snapPath, 'utf8')
+
+  // Now block the second-opinion subtree copy by replacing the destination
+  // providers/index.json with a DIRECTORY. fs.copyFileSync into a dir
+  // throws EISDIR.
+  const destRegFile = path.join(tempHome, '.episodic-memory/scripts/second-opinion/providers/index.json')
+  fs.rmSync(destRegFile, { force: true })
+  fs.mkdirSync(destRegFile, { recursive: true })
+
+  // Re-run install. Gate 1 passes (registry shape is valid in repo copy).
+  // copyDirRecursive then throws when trying to overwrite providers/index.json.
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.notStrictEqual(r.status, 0,
+    `runtime copy failure must exit nonzero; got ${r.status}, stderr=${r.stderr}`)
+  assert.ok(!r.stdout.includes('Done!'),
+    `no Done! on runtime-copy failure; stdout=${r.stdout}`)
+
+  // PR-level P1 invariant: pre-existing snapshot must be quarantined.
+  assert.ok(!fs.existsSync(snapPath),
+    `current snapshot must be quarantined when runtime copy throws; still exists at ${snapPath}`)
+
+  // Quarantine file exists matching .stale.<digits>.
+  const hooksDir = path.dirname(snapPath)
+  const quarantineFiles = fs.readdirSync(hooksDir).filter(
+    f => f.startsWith('second-opinion-providers.json.stale.')
+  )
+  assert.strictEqual(quarantineFiles.length, 1,
+    `expected 1 quarantine file from runtime-copy catch, found ${quarantineFiles.length}: ${quarantineFiles}`)
+  assert.strictEqual(
+    fs.readFileSync(path.join(hooksDir, quarantineFiles[0]), 'utf8'),
+    preSnapshotContent,
+    'quarantined snapshot must be byte-identical to pre-install original')
+})
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 console.log(`\n${passed} passed, ${failed} failed`)

--- a/tests/test-second-opinion-gate.mjs
+++ b/tests/test-second-opinion-gate.mjs
@@ -219,6 +219,41 @@ test('malformed cli_match (invalid regex) → block snapshot-invalid-providers',
   assert.strictEqual(r.decision.provider, 'codex')
 })
 
+// F4 regression: installed hook with MISSING lib (partial install / orphan
+// hook) must emit snapshot-validator-load-failed block decision rather than
+// crashing at module-load with empty stdout (ambiguous fail-open class).
+test('installed hook with missing validator lib → block snapshot-validator-load-failed', () => {
+  const tempBase = fs.mkdtempSync(path.join(os.tmpdir(), 'so-orphan-hook-'))
+  tmpDirs.push(tempBase)
+  const installedHooksDir = path.join(tempBase, '.claude', 'hooks')
+  fs.mkdirSync(installedHooksDir, { recursive: true })
+
+  // Copy ONLY the hook — deliberately omit the validator lib to simulate
+  // partial filesystem failure.
+  fs.copyFileSync(HOOK, path.join(installedHooksDir, 'second-opinion-gate.mjs'))
+
+  // Snapshot path doesn't matter (hook fails before reading snapshot).
+  const snapPath = path.join(installedHooksDir, 'second-opinion-providers.json')
+  const outsideCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'so-orphan-cwd-'))
+  tmpDirs.push(outsideCwd)
+  const r = spawnSync('node', [path.join(installedHooksDir, 'second-opinion-gate.mjs')], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'codex exec "hi"', run_in_background: true },
+      cwd: outsideCwd,
+    }),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: outsideCwd,
+    env: { ...process.env, SO_INSTALL_SNAPSHOT_PATH: snapPath },
+    encoding: 'utf8',
+  })
+
+  assert.strictEqual(r.status, 0, `hook should exit 0 with block JSON; got status=${r.status}, stderr=${r.stderr}`)
+  const decision = JSON.parse(r.stdout)
+  assert.strictEqual(decision.decision, 'block')
+  assert.strictEqual(decision.code, 'snapshot-validator-load-failed')
+})
+
 // R3-F1 / R7-F1: installed-hook test. Copy hook + dereferenced validator
 // lib to a temp ~/.claude/hooks-shaped dir; run the COPIED hook from cwd
 // outside the repo against a malformed snapshot. Verifies the install


### PR DESCRIPTION
## Summary

Closes #221 (P2 snapshot-validator extension). Originally a 6-commit / +1250 LOC branch covering validator extension + atomic install + hook fail-closed. **Commits 1–4 reached `main` via PR #222 (`e3c8dc9` harness merge)** — `git rebase origin/main` correctly dropped them as "patch contents already upstream."

**This PR now contains only the post-#222 review fold-ins:**

1. `76d2d51` — **code-review fold-ins (4 findings):** unified quarantine, snapshotPath()-honoring, hermetic test env, dynamic validator import + 2 regression tests (orphan-hook, writeSnapshot-block).
2. `2dd2821` — **PR-level review fold-in (HOLD-1):** wrap runtime-copy step in quarantine catch (Gate 1 → runtime copy → Gate 2 → writeSnapshot all under one outer-catch); +1 E2E case (runtime-copy throw → quarantine fires).

## Invariants on `main` after merge

- **I-NEW-B** (LV:YES) — snapshot provider entries validated by same shape contract as the source registry. Single shared `validateProviderRegistry` called from install (Gate 1 + Gate 2), `readSnapshot`, and the hook. Shipped via #222; reinforced here by hook dynamic-import + regression tests.
- **I-NEW-C** (LV:YES) — `--install-second-opinion` atomic across **5 failure paths**: Gate 1 hard-stop pre-copy, quarantine on (a) runtime-copy throw, (b) validator-lib throw, (c) Gate 2 throw, (d) writeSnapshot throw. Quarantine uses `snapshotPath()` (env-honoring) and renames pre-existing snapshot to `.stale.<unix-ms>`.

## Test plan

- [x] `node tests/test-install-second-opinion-e2e.mjs` — 6/6 (happy + Gate 1 empty/populated + Gate 2 quarantine + writeSnapshot-block + runtime-copy-throw)
- [x] `node tests/test-second-opinion-gate.mjs` — 20/20 (in-tree fail-closed + installed-hook + orphan-hook regression)

## Review trajectory

7-round plan review (R1 4 → R7 ACCEPT-with-FU per toolkit v9.4 #19) → code-review HOLD-4 (commit 5) → PR-level codex review HOLD-1 (commit 6). Commits 1–4 of that trajectory landed on `main` via PR #222. Per toolkit pin "PR-level codex review … Cap at 1 round" — review budget exhausted; ready for `--approve`.

## Note on the rebase

Previous PR head was `ef8a13b` (6 commits, +1250 LOC). Force-pushed to `2dd2821` (2 commits, +267 LOC) after `git rebase origin/main` dropped the 4 redundant commits. Bot review by `lantiscooperdev` was against the prior SHA — semantically still valid (the dropped commits are bit-for-bit on `main` via #222), but a fresh bot-review pass against the new tip is fine if preferred before approval.

## Out-of-scope (deferred)

- Issues #223 (CLAUDE_CONFIG_DIR honor) + #224 (claude-subagent SessionStart-hijack) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
