### PR TITLE
fix(launchd): wrapper-mechanism for SKILL-driven routines (Unknown command)

### DIFF
--- a/hooks/lib/registry-validator.mjs
+++ b/hooks/lib/registry-validator.mjs
@@ -1,0 +1,1 @@
+../../scripts/second-opinion/lib/registry-validator.mjs

--- a/hooks/second-opinion-gate.mjs
+++ b/hooks/second-opinion-gate.mjs
@@ -42,6 +42,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
+import { validateProviderRegistry } from './lib/registry-validator.mjs'
+
 const SNAPSHOT_PATH = process.env.SO_INSTALL_SNAPSHOT_PATH ||
   path.join(os.homedir(), '.claude', 'hooks', 'second-opinion-providers.json')
 
@@ -93,6 +95,19 @@ function loadSnapshot() {
   }
   if (!parsed.source_hash) {
     return { error: 'snapshot-missing-source-hash' }
+  }
+  // I-NEW-B: validate providers[] shape so the hook fail-closes on bad
+  // registry rather than silently skipping providers with bad regex via
+  // compileCliMatch's null-return fallback.
+  try {
+    validateProviderRegistry({ schema_version: 1, providers: parsed.providers })
+  } catch (e) {
+    return {
+      error: 'snapshot-invalid-providers',
+      detail: e.message,
+      field: e.field,
+      provider: e.provider,
+    }
   }
   return { snapshot: parsed }
 }
@@ -201,10 +216,18 @@ if (!input) {
 
 const snap = loadSnapshot()
 if (snap.error) {
+  const extra = { code: snap.error }
+  if (snap.field) extra.field = snap.field
+  if (snap.provider) extra.provider = snap.provider
+  if (snap.detail) extra.detail = snap.detail
+  const detailSuffix = snap.field
+    ? ` (field: ${snap.field}${snap.provider ? `, provider: ${snap.provider}` : ''})`
+    : ''
   emitBlock(
-    `second-opinion-gate: ${snap.error}. Run: node install.mjs --install-second-opinion to install the registry. ` +
-    `(Direct provider calls cannot be safely gated without the install snapshot.)`,
-    { code: snap.error }
+    `second-opinion-gate: ${snap.error}${detailSuffix}. ` +
+    `Run: node install.mjs --install-second-opinion to install/refresh the registry. ` +
+    `(Direct provider calls cannot be safely gated without a valid install snapshot.)`,
+    extra
   )
 }
 

--- a/install-launchd-routines.sh
+++ b/install-launchd-routines.sh
@@ -14,6 +14,7 @@
 # Reversible: --uninstall undoes everything this script created.
 
 set -e
+set -o pipefail
 
 DRY_RUN=0
 SMOKE=0
@@ -32,16 +33,13 @@ LA_DIR="$HOME/Library/LaunchAgents"
 LOG_DIR="$HOME/Library/Logs/episodic-memory"
 PROJECT_DIR="$HOME/Developer/projects/episodic-memory"
 SCHEDULED_TASKS_DIR="$HOME/.claude/scheduled-tasks"
+WRAPPER_TMPL="$PROJECT_DIR/scripts/em-skill-wrapper.sh.tmpl"
+WRAPPER_OUT="$SCHEDULED_TASKS_DIR/em-skill-wrapper.sh"
+VALIDATION_LIB="$PROJECT_DIR/scripts/lib/render-input-validation.sh"
 
-# Pin absolute binaries at install time (round-3 fix: don't rely on PATH lookup at runtime)
-NODE_BIN=$(command -v node)
-GH_BIN=$(command -v gh)
-CLAUDE_BIN=$(command -v claude)
-
-if [ -z "$NODE_BIN" ] || [ -z "$CLAUDE_BIN" ]; then
-  echo "ERROR: node and claude must be on PATH at install time. Found: node=$NODE_BIN claude=$CLAUDE_BIN" >&2
-  exit 3
-fi
+# Binary + template resolution deferred until install branch so --uninstall
+# remains fail-open: it must remove known runtime artifacts without requiring
+# node/claude/template/skill files to be present.
 
 # Plist labels
 LABELS=(
@@ -53,6 +51,12 @@ LABELS=(
 
 if [ "$UNINSTALL" -eq 1 ]; then
   echo "=== Uninstalling ==="
+  # Fail-open: only remove what exists, don't require any binaries or repo files.
+  if [ -f "$WRAPPER_OUT" ]; then
+    [ "$DRY_RUN" -eq 1 ] && echo "[dry-run] rm $WRAPPER_OUT" \
+                        || rm -f "$WRAPPER_OUT"
+    echo "  - em-skill-wrapper.sh removed"
+  fi
   for label in "${LABELS[@]}"; do
     plist="$LA_DIR/$label.plist"
     if launchctl print "gui/$UID_GUI/$label" >/dev/null 2>&1; then
@@ -69,6 +73,31 @@ if [ "$UNINSTALL" -eq 1 ]; then
   exit 0
 fi
 
+# --- Install-only preflight (skipped on --uninstall above) ---
+NODE_BIN=$(command -v node)
+# gh is optional (only weekly-digest uses it); `|| true` prevents `set -e`
+# from killing the script when gh is absent so the ${GH_BIN:-not found}
+# fallback in the pre-flight printout can render.
+GH_BIN=$(command -v gh || true)
+CLAUDE_BIN=$(command -v claude)
+if [ -z "$NODE_BIN" ] || [ -z "$CLAUDE_BIN" ]; then
+  echo "ERROR: node and claude must be on PATH at install time. Found: node=$NODE_BIN claude=$CLAUDE_BIN" >&2
+  exit 3
+fi
+if [ ! -f "$WRAPPER_TMPL" ]; then
+  echo "ERROR: missing $WRAPPER_TMPL (commit the template before installing)" >&2
+  exit 4
+fi
+if [ ! -f "$VALIDATION_LIB" ]; then
+  echo "ERROR: missing $VALIDATION_LIB" >&2
+  exit 4
+fi
+# shellcheck disable=SC1090
+source "$VALIDATION_LIB"
+if ! validate_render_inputs; then
+  exit 9
+fi
+
 echo "=== Pre-flight ==="
 echo "  UID:           $UID_GUI"
 echo "  LaunchAgents:  $LA_DIR"
@@ -77,6 +106,7 @@ echo "  Project:       $PROJECT_DIR"
 echo "  node:          $NODE_BIN"
 echo "  gh:            ${GH_BIN:-not found (weekly-digest depends on this)}"
 echo "  claude:        $CLAUDE_BIN"
+echo "  wrapper tmpl:  $WRAPPER_TMPL"
 
 # Verify scheduled-task SKILL.md files exist
 for skill in episodic-memory-daily-mining episodic-memory-weekly-digest instruction-hygiene-maintenance; do
@@ -103,17 +133,14 @@ mkdir -p "$LOG_DIR"
 # Per-plist invocation builders --------------------------------------------------
 
 claude_skill_invocation() {
-  # $1 = skill name (e.g. episodic-memory-daily-mining)
+  # $1 = skill name; invocation goes via the rendered wrapper so the SKILL.md
+  # body is inlined as the prompt and the project root is cd'd before claude
+  # starts. Replaces the prior `claude -p /<skill-name>` form which failed
+  # with "Unknown command" — scheduled-task SKILLs are not slash commands.
   cat <<EOF
-        <string>$CLAUDE_BIN</string>
-        <string>-p</string>
-        <string>--permission-mode</string>
-        <string>bypassPermissions</string>
-        <string>--setting-sources</string>
-        <string>project,local</string>
-        <string>--settings</string>
-        <string>{"hooks":{}}</string>
-        <string>/$1</string>
+        <string>/bin/bash</string>
+        <string>$WRAPPER_OUT</string>
+        <string>$1</string>
 EOF
 }
 
@@ -151,6 +178,8 @@ $invocation
         <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>$HOME</string>
+        <key>CLAUDE_SCHEDULED_TASK</key>
+        <string>1</string>
     </dict>
 $schedule
     <key>StandardOutPath</key>
@@ -229,6 +258,34 @@ write_plist com.charltonho.em-daily-mining "$(claude_skill_invocation episodic-m
 write_plist com.charltonho.em-weekly-digest "$(claude_skill_invocation episodic-memory-weekly-digest)" "$SUNDAY_09_00" em-weekly-digest
 write_plist com.charltonho.instruction-hygiene "$(claude_skill_invocation instruction-hygiene-maintenance)" "$SUNDAY_11_00" instruction-hygiene
 write_plist com.charltonho.em-backup-sync "$(backup_invocation)" "$DAILY_23_00" em-backup-sync
+
+# Render wrapper -------------------------------------------------------------
+#
+# CLAUDE_BIN / PROJECT_DIR were validated by validate_render_inputs upstream,
+# so sed-unsafe characters cannot reach this substitution. The sentinel grep
+# after render still catches malformed templates (placeholder typos etc.).
+
+echo ""
+echo "=== Rendering wrapper ==="
+render_wrapper() {
+  sed -e "s|@CLAUDE_BIN@|$CLAUDE_BIN|g" \
+      -e "s|@PROJECT_DIR@|$PROJECT_DIR|g" \
+      "$WRAPPER_TMPL"
+}
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[dry-run] would render $WRAPPER_OUT:"
+  render_wrapper | sed 's/^/    /'
+else
+  render_wrapper > "$WRAPPER_OUT.tmp"
+  if grep -q '@CLAUDE_BIN@\|@PROJECT_DIR@' "$WRAPPER_OUT.tmp"; then
+    echo "ERROR: wrapper render incomplete (unsubstituted placeholders in $WRAPPER_OUT.tmp)" >&2
+    rm -f "$WRAPPER_OUT.tmp"
+    exit 8
+  fi
+  chmod 755 "$WRAPPER_OUT.tmp"
+  mv "$WRAPPER_OUT.tmp" "$WRAPPER_OUT"
+  echo "  ✓ wrote $WRAPPER_OUT (chmod 755)"
+fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   echo ""

--- a/install.mjs
+++ b/install.mjs
@@ -39,6 +39,12 @@ const installHooks = argv.includes('--install-hooks')
 const installHooksForce = argv.includes('--install-hooks-force')
 const installSecondOpinion = argv.includes('--install-second-opinion')
 const REPO_HOOKS = path.join(REPO_DIR, 'hooks')
+const REPO_SECOND_OPINION = path.join(REPO_SCRIPTS, 'second-opinion')
+
+// I-NEW-C: --install-second-opinion is atomic w.r.t. its own validation.
+// installFailed is tracked across all sub-steps so the final "Done!" banner
+// can be suppressed and process.exitCode set on any failure.
+let installFailed = false
 
 // P2 (code review): warn if --install-hooks-force passed without --install-hooks.
 // Without the base flag, the entire hook-install block is skipped; a force flag
@@ -87,6 +93,33 @@ if (!VALID_TOOLS.includes(tool)) {
 }
 
 // ---------------------------------------------------------------------------
+// GATE 1: --install-second-opinion pre-flight registry validation (I-NEW-C).
+//
+// Runs BEFORE any file copies so a malformed source registry produces a
+// hard-stop with the active runtime byte-identical to its pre-install state.
+// Closes the stale-snapshot class: failed install cannot leave new top-level
+// harness files or subtree copies in place while the snapshot stays old.
+// ---------------------------------------------------------------------------
+if (installSecondOpinion) {
+  try {
+    const repoRegPath = path.join(REPO_SECOND_OPINION, 'providers', 'index.json')
+    const repoReg = JSON.parse(fs.readFileSync(repoRegPath, 'utf8'))
+    const { validateProviderRegistry } = await import(
+      new URL('./scripts/second-opinion/lib/registry-validator.mjs', import.meta.url).href
+    )
+    validateProviderRegistry(repoReg)
+  } catch (e) {
+    console.error(`Pre-flight registry validation failed: ${e.message}`)
+    if (e.code) console.error(`  code: ${e.code}`)
+    if (e.field) console.error(`  field: ${e.field}`)
+    if (e.provider) console.error(`  provider: ${e.provider}`)
+    if (e.observed !== undefined) console.error(`  observed: ${JSON.stringify(e.observed)}`)
+    console.error(`Aborting install. No files touched.`)
+    process.exit(1)
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 1. Install scripts globally
 // ---------------------------------------------------------------------------
 fs.mkdirSync(SCRIPTS_DIR, { recursive: true })
@@ -114,7 +147,6 @@ if (fs.existsSync(REPO_SCRIPTS_LIB)) {
 // alongside scripts/*.mjs so the harness module imports resolve at runtime; the
 // install snapshot at ~/.claude/hooks/second-opinion-providers.json is only
 // written when --install-second-opinion is passed (separate concern).
-const REPO_SECOND_OPINION = path.join(REPO_SCRIPTS, 'second-opinion')
 if (fs.existsSync(REPO_SECOND_OPINION)) {
   const soDst = path.join(SCRIPTS_DIR, 'second-opinion')
   copyDirRecursive(REPO_SECOND_OPINION, soDst)
@@ -1044,9 +1076,10 @@ if (installHooks) {
 // --install-hooks alongside --install-second-opinion.
 // ---------------------------------------------------------------------------
 if (installSecondOpinion) {
+  const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
+  const userHooksLibDir = path.join(userHooksDir, 'lib')
   try {
     // Copy hooks/second-opinion-gate.mjs to ~/.claude/hooks/.
-    const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
     fs.mkdirSync(userHooksDir, { recursive: true })
     const repoGateSrc = path.join(REPO_HOOKS, 'second-opinion-gate.mjs')
     const userGateDst = path.join(userHooksDir, 'second-opinion-gate.mjs')
@@ -1056,10 +1089,35 @@ if (installSecondOpinion) {
       console.log(`Installed second-opinion gate hook: ${userGateDst}`)
     } else {
       console.log(`Warning: ${repoGateSrc} not found; hook gate not installed.`)
+      installFailed = true
     }
   } catch (e) {
-    console.log(`Note: could not copy second-opinion gate hook: ${e.message}`)
+    console.error(`Failed to copy second-opinion gate hook: ${e.message}`)
+    installFailed = true
   }
+
+  try {
+    // Copy registry-validator.mjs alongside the hook so the installed hook can
+    // import './lib/registry-validator.mjs' (single source of truth — in-tree
+    // hook tests resolve through the hooks/lib/ symlink; installed hook reads
+    // this dereferenced copy).
+    fs.mkdirSync(userHooksLibDir, { recursive: true })
+    const repoValidatorSrc = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
+    const userValidatorDst = path.join(userHooksLibDir, 'registry-validator.mjs')
+    if (fs.existsSync(repoValidatorSrc)) {
+      // fs.copyFileSync dereferences symlinks by default — destination is a
+      // regular file with the validator source's content.
+      fs.copyFileSync(repoValidatorSrc, userValidatorDst)
+      console.log(`Installed second-opinion validator lib: ${userValidatorDst}`)
+    } else {
+      console.log(`Warning: ${repoValidatorSrc} not found; validator lib not installed.`)
+      installFailed = true
+    }
+  } catch (e) {
+    console.error(`Failed to copy second-opinion validator lib: ${e.message}`)
+    installFailed = true
+  }
+
   try {
     const { computeSourceHash } = await import(
       new URL('./scripts/second-opinion/lib/source-hash.mjs', import.meta.url).href
@@ -1067,12 +1125,16 @@ if (installSecondOpinion) {
     const { writeSnapshot, DEFAULT_SNAPSHOT_PATH } = await import(
       new URL('./scripts/second-opinion/lib/install-snapshot.mjs', import.meta.url).href
     )
+    const { validateProviderRegistry } = await import(
+      new URL('./scripts/second-opinion/lib/registry-validator.mjs', import.meta.url).href
+    )
 
     // Hash against the GLOBAL installed copy (what runtime will see), NOT the
     // source repo. This ensures harness gate compares apples-to-apples.
     const globalSecondOpinion = path.join(SCRIPTS_DIR, 'second-opinion')
     if (!fs.existsSync(globalSecondOpinion)) {
       console.log(`Warning: ${globalSecondOpinion} not found; cannot write install snapshot.`)
+      installFailed = true
     } else {
       const hashed = computeSourceHash(globalSecondOpinion)
 
@@ -1104,6 +1166,36 @@ if (installSecondOpinion) {
         }
       }
 
+      // GATE 2: validate filtered installedProviders before writing snapshot.
+      // Gate 1 already passed (source registry shape was valid), so a Gate 2
+      // failure means the available() filter reduced providers to a malformed
+      // set (typically empty when no provider CLI is on PATH — N1 fires).
+      try {
+        validateProviderRegistry({ schema_version: 1, providers: installedProviders })
+      } catch (gateErr) {
+        installFailed = true
+        console.error(`Snapshot validation failed: ${gateErr.message}`)
+        if (gateErr.field) console.error(`  field: ${gateErr.field}`)
+        if (gateErr.provider) console.error(`  provider: ${gateErr.provider}`)
+
+        // Quarantine any pre-existing snapshot so the hook fail-closes
+        // (snapshot-not-installed) rather than reading a stale-valid snapshot
+        // while the active source has been updated. Rename (not delete) to
+        // preserve forensic evidence.
+        try {
+          const existingSnap = DEFAULT_SNAPSHOT_PATH
+          if (fs.existsSync(existingSnap)) {
+            const quarantineName = `${existingSnap}.stale.${Date.now()}`
+            fs.renameSync(existingSnap, quarantineName)
+            console.error(`Quarantined pre-existing snapshot to: ${quarantineName}`)
+          }
+        } catch (qe) {
+          console.error(`Quarantine attempt failed: ${qe.message}`)
+        }
+        // Skip the writeSnapshot call below.
+        throw gateErr
+      }
+
       const snapshot = {
         schema_version: 1,
         source_hash: hashed.source_hash,
@@ -1120,11 +1212,16 @@ if (installSecondOpinion) {
       console.log(`  fragments:   ${hashed.fragments.length}`)
     }
   } catch (e) {
-    console.log(`Note: could not install second-opinion snapshot: ${e.message}`)
+    if (!installFailed) {
+      console.error(`Failed to install second-opinion snapshot: ${e.message}`)
+      installFailed = true
+    }
   }
+
+  if (installFailed) process.exitCode = 1
 }
 
-console.log('\nDone! Episodic memory is ready.')
+if (!installFailed) console.log('\nDone! Episodic memory is ready.')
 console.log(`Global data:  ${GLOBAL_DIR}/`)
 console.log(`Local data:   ${localDir}/`)
 console.log(`Scripts:      ${SCRIPTS_DIR}/`)

--- a/scripts/em-skill-wrapper.sh.tmpl
+++ b/scripts/em-skill-wrapper.sh.tmpl
@@ -1,0 +1,44 @@
+#!/bin/bash
+# em-skill-wrapper.sh — launchd invocation wrapper for SKILL-driven routines.
+# RENDERED from scripts/em-skill-wrapper.sh.tmpl by install-launchd-routines.sh.
+# Do not edit the rendered copy under ~/.claude/scheduled-tasks/.
+#
+# Two placeholders are substituted at install time: the absolute claude
+# binary path (from `command -v claude`) and the absolute project root.
+#
+# Reads ~/.claude/scheduled-tasks/<skill-name>/SKILL.md and passes its body
+# as the prompt to `claude -p`. Replaces the broken `claude -p /<skill-name>`
+# pattern which failed with "Unknown command" because scheduled-task SKILLs
+# are not registered as slash commands.
+
+set -e
+
+SKILL_NAME="${1:-}"
+if [ -z "$SKILL_NAME" ]; then
+  echo "ERROR: skill name required (usage: $0 <skill-name>)" >&2
+  exit 2
+fi
+
+SKILL_PATH="$HOME/.claude/scheduled-tasks/$SKILL_NAME/SKILL.md"
+if [ ! -f "$SKILL_PATH" ]; then
+  echo "ERROR: SKILL.md not found at $SKILL_PATH" >&2
+  exit 3
+fi
+
+# Honor session-handoff-prompt.sh guard (defense-in-depth alongside plist env).
+export CLAUDE_SCHEDULED_TASK="${CLAUDE_SCHEDULED_TASK:-1}"
+
+# Hard-bind project root before launching Claude. resolveRepoRoot() in
+# em-mine-transcripts.mjs et al is cwd-sensitive; launchd WorkingDirectory
+# is one layer of defense, this cd is the second.
+cd "@PROJECT_DIR@"
+
+# Absolute path baked at install time — no runtime PATH lookup.
+# `--` separates options from the positional prompt. Required because SKILL.md
+# starts with YAML frontmatter (`---`) which the arg parser would otherwise
+# interpret as a long-option flag.
+exec "@CLAUDE_BIN@" -p \
+  --permission-mode bypassPermissions \
+  --setting-sources project,local \
+  --settings '{"hooks":{}}' \
+  -- "$(cat "$SKILL_PATH")"

--- a/scripts/lib/launchd-routines-e2e-test.sh
+++ b/scripts/lib/launchd-routines-e2e-test.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# launchd-routines-e2e-test.sh — end-to-end test suite for the wrapper-fix.
+# Covers 14 cases from the codex-approved R7 plan (...a48b ACCEPT).
+#
+# Assumes installer has already been run. Tests 4/5/6/7/8/12 invoke the
+# wrapper directly (light side effects: candidate markdown under
+# .claude/scratch/), tests 11/10 use launchctl on the installed jobs,
+# test 13 exercises uninstall+reinstall.
+
+set -u  # not -e: we want to count failures, not exit on first
+PASS=0
+FAIL=0
+SKIP=0
+FAILED_TESTS=()
+
+PROJECT_DIR="/Users/charltond.ho/Developer/projects/episodic-memory"
+SCHEDULED_TASKS_DIR="$HOME/.claude/scheduled-tasks"
+WRAPPER="$SCHEDULED_TASKS_DIR/em-skill-wrapper.sh"
+LA_DIR="$HOME/Library/LaunchAgents"
+UID_GUI=$(id -u)
+EXPECTED_CLAUDE="$(command -v claude)"
+
+run_test() {
+  local name="$1"; shift
+  echo ""
+  echo "===== $name ====="
+  if "$@"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL: $name"
+  fi
+}
+
+skip_test() {
+  local name="$1" reason="$2"
+  echo ""
+  echo "===== $name ====="
+  echo "  SKIP: $reason"
+  SKIP=$((SKIP + 1))
+}
+
+# ---------------- Test 1: dry-run, no persistent writes ----------------
+test_1_dry_run() {
+  bash "$PROJECT_DIR/install-launchd-routines.sh" --dry-run >/dev/null 2>&1 \
+    || { echo "    dry-run exited non-zero"; return 1; }
+  local p
+  for p in com.charltonho.em-daily-mining com.charltonho.em-weekly-digest \
+           com.charltonho.instruction-hygiene com.charltonho.em-backup-sync; do
+    if [ -f "$LA_DIR/$p.plist.tmp" ]; then
+      echo "    FAIL: leaked $LA_DIR/$p.plist.tmp"
+      return 1
+    fi
+  done
+  # Note: $WRAPPER was already rendered by the prior install; dry-run does
+  # not overwrite it, so we don't assert "$WRAPPER absent" — that would fail
+  # against the legitimate post-install state.
+  return 0
+}
+
+# ---------------- Test 2: uninstall fail-open with stubbed binaries ----
+test_2_uninstall_fail_open() {
+  local stubdir=/tmp/em-test-stubs
+  rm -rf "$stubdir" /tmp/em-test-stub-called-*
+  mkdir -p "$stubdir"
+  local b
+  for b in node claude; do
+    printf '#!/bin/bash\ntouch /tmp/em-test-stub-called-%s\nexit 1\n' "$b" > "$stubdir/$b"
+    chmod +x "$stubdir/$b"
+  done
+  # Run uninstall on a freshly installed system; should succeed without
+  # invoking the stub node/claude. /bin is required for launchctl.
+  PATH="$stubdir:/bin:/usr/bin" bash "$PROJECT_DIR/install-launchd-routines.sh" --uninstall >/dev/null 2>&1 \
+    || { echo "    uninstall exited non-zero"; return 1; }
+  if compgen -G "/tmp/em-test-stub-called-*" >/dev/null; then
+    echo "    FAIL: stub binaries were invoked during uninstall"
+    return 1
+  fi
+  rm -rf "$stubdir" /tmp/em-test-stub-called-*
+  # Re-install for subsequent tests.
+  bash "$PROJECT_DIR/install-launchd-routines.sh" >/dev/null 2>&1 \
+    || { echo "    re-install after uninstall failed"; return 1; }
+  return 0
+}
+
+# ---------------- Test 3: install + content verification ---------------
+test_3_install_content() {
+  [ -f "$WRAPPER" ] || { echo "    wrapper missing"; return 1; }
+  [ -x "$WRAPPER" ] || { echo "    wrapper not executable"; return 1; }
+  if ! grep -qF "$EXPECTED_CLAUDE" "$WRAPPER"; then
+    echo "    expected claude path not baked in: $EXPECTED_CLAUDE"
+    return 1
+  fi
+  if grep -q '@CLAUDE_BIN@\|@PROJECT_DIR@' "$WRAPPER"; then
+    echo "    unsubstituted placeholders in wrapper"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 4a: positive cwd-binding via stub Claude -------
+# Codex impl-review P2 follow-up (...c30f): negative-only assertion isn't
+# sufficient proof of cwd-binding. Renders a test wrapper with a stub claude
+# that writes a sentinel file using `pwd`. Asserts the sentinel lands under
+# PROJECT_DIR (proves `cd "@PROJECT_DIR@"` actually executed) AND that the
+# caller cwd has no leak.
+test_4a_positive_cwd_binding_stub() {
+  local stub test_wrapper
+  stub=$(mktemp)
+  chmod +x "$stub"
+  cat > "$stub" <<'STUB_EOF'
+#!/bin/bash
+pwd > /tmp/em-cwd-sentinel
+STUB_EOF
+  test_wrapper=$(mktemp)
+  sed -e "s|@CLAUDE_BIN@|$stub|g" \
+      -e "s|@PROJECT_DIR@|$PROJECT_DIR|g" \
+      "$PROJECT_DIR/scripts/em-skill-wrapper.sh.tmpl" > "$test_wrapper"
+  chmod +x "$test_wrapper"
+  rm -f /tmp/em-cwd-sentinel
+  rm -rf /tmp/.claude
+  (cd /tmp && "$test_wrapper" episodic-memory-daily-mining >/dev/null 2>&1)
+  rm -f "$stub" "$test_wrapper"
+  if [ ! -f /tmp/em-cwd-sentinel ]; then
+    echo "    stub claude was not invoked"
+    return 1
+  fi
+  local recorded_pwd
+  recorded_pwd=$(cat /tmp/em-cwd-sentinel)
+  rm -f /tmp/em-cwd-sentinel
+  if [ "$recorded_pwd" != "$PROJECT_DIR" ]; then
+    echo "    cwd at claude-launch was '$recorded_pwd', expected '$PROJECT_DIR'"
+    return 1
+  fi
+  if [ -d /tmp/.claude ]; then
+    echo "    FAIL: /tmp/.claude leaked despite cd-binding"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 4: artifact-location, /tmp caller ---------------
+# Verifies the cd "@PROJECT_DIR@" in the wrapper holds against a caller cwd
+# in /tmp. We assert the negative (no .claude/scratch/ created under /tmp)
+# rather than positive file existence, because the mining script itself may
+# legitimately produce no candidate file (e.g. if today's transcripts can't
+# be read). The wrapper-mechanism contract is "don't create artifacts in
+# caller cwd"; whether the SKILL emits anything at all is the SKILL's
+# concern, not the wrapper's.
+test_4_artifact_location_tmp() {
+  rm -rf /tmp/.claude
+  (cd /tmp && "$WRAPPER" episodic-memory-daily-mining >/dev/null 2>&1) || {
+    echo "    wrapper exited non-zero from /tmp"
+    return 1
+  }
+  if [ -d /tmp/.claude/scratch ] || [ -d /tmp/.claude ]; then
+    echo "    FAIL: /tmp/.claude exists (artifact leaked to caller cwd)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 5: detached-worktree caller ---------------------
+# Negative-only artifact-location check (same rationale as T4).
+test_5_worktree_caller() {
+  local wt_dir
+  wt_dir=$(mktemp -d)
+  rmdir "$wt_dir"
+  trap "git -C \"$PROJECT_DIR\" worktree remove --force \"$wt_dir\" 2>/dev/null; rm -rf \"$wt_dir\"" RETURN
+  git -C "$PROJECT_DIR" worktree add --detach "$wt_dir" HEAD >/dev/null 2>&1 || {
+    echo "    worktree add failed"
+    return 1
+  }
+  (cd "$wt_dir" && "$WRAPPER" episodic-memory-daily-mining >/dev/null 2>&1) || {
+    echo "    wrapper exited non-zero from worktree"
+    return 1
+  }
+  if [ -d "$wt_dir/.claude/scratch" ]; then
+    echo "    FAIL: $wt_dir/.claude/scratch/ exists (artifact leaked to worktree)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 6: HOME-elsewhere ------------------------------
+test_6_home_elsewhere() {
+  local fakehome=/tmp/em-fakehome
+  rm -rf "$fakehome"
+  mkdir -p "$fakehome"
+  local out rc
+  out=$(HOME="$fakehome" "$WRAPPER" episodic-memory-daily-mining 2>&1)
+  rc=$?
+  rm -rf "$fakehome"
+  [ "$rc" = "3" ] || { echo "    exit code $rc, expected 3"; echo "$out"; return 1; }
+  if ! printf '%s' "$out" | grep -qF "SKILL.md not found"; then
+    echo "    stderr did not contain 'SKILL.md not found'"
+    echo "$out"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 7: PATH-poison (binary pinning) ----------------
+test_7_path_poison() {
+  local bogus=/tmp/bogus-bin
+  rm -rf "$bogus"
+  mkdir -p "$bogus"
+  printf '#!/bin/bash\necho WRONG-BINARY\nexit 0\n' > "$bogus/claude"
+  chmod +x "$bogus/claude"
+  local out
+  out=$(PATH="$bogus:$PATH" "$WRAPPER" episodic-memory-daily-mining 2>&1) || {
+    # Wrapper exits non-zero only if the real claude fails; we just check
+    # the stub was NOT invoked.
+    :
+  }
+  rm -rf "$bogus"
+  if printf '%s' "$out" | grep -qF "WRONG-BINARY"; then
+    echo "    FAIL: stub claude was invoked (output contained WRONG-BINARY)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 8: stub-Claude argv contract -------------------
+test_8_stub_argv() {
+  local stub test_wrapper sentinel
+  stub=$(mktemp)
+  chmod +x "$stub"
+  cat > "$stub" <<'STUB_EOF'
+#!/bin/bash
+{
+  printf 'argc=%d\n' "$#"
+  for i in $(seq 1 "$#"); do
+    eval "printf 'argv%d=%s\\n' $i \"\${$i}\""
+  done
+} > /tmp/em-argv-sentinel
+STUB_EOF
+  test_wrapper=$(mktemp)
+  sed -e "s|@CLAUDE_BIN@|$stub|g" \
+      -e "s|@PROJECT_DIR@|$PROJECT_DIR|g" \
+      "$PROJECT_DIR/scripts/em-skill-wrapper.sh.tmpl" > "$test_wrapper"
+  chmod +x "$test_wrapper"
+  sentinel=/tmp/em-argv-sentinel
+  rm -f "$sentinel"
+  "$test_wrapper" episodic-memory-daily-mining >/dev/null 2>&1
+  if [ ! -f "$sentinel" ]; then
+    echo "    sentinel file not created by stub"
+    rm -f "$stub" "$test_wrapper"
+    return 1
+  fi
+  local argc argv8_head
+  # 9 args now: -p, --permission-mode, bypassPermissions, --setting-sources,
+  # project,local, --settings, {"hooks":{}}, --, <prompt>
+  argc=$(grep '^argc=' "$sentinel" | sed 's/argc=//')
+  local argv8_val argv9_head
+  argv8_val=$(grep '^argv8=' "$sentinel" | sed 's/argv8=//')
+  argv9_head=$(grep '^argv9=' "$sentinel" | head -c 12)
+  rm -f "$stub" "$test_wrapper" "$sentinel"
+  [ "$argc" = "9" ] || { echo "    argc=$argc, expected 9"; return 1; }
+  [ "$argv8_val" = "--" ] || { echo "    argv8=$argv8_val, expected --"; return 1; }
+  case "$argv9_head" in
+    "argv9=---"*) ;;
+    *) echo "    argv9 head was '$argv9_head', expected to start with 'argv9=---'"; return 1 ;;
+  esac
+  return 0
+}
+
+# ---------------- Test 9: validation-lib unit test (delegate) ---------
+test_9_validation_unit() {
+  bash "$PROJECT_DIR/scripts/lib/render-input-validation-test.sh" >/dev/null
+}
+
+# ---------------- Test 10: launchctl print all 3 wrapped ----------------
+test_10_launchctl_print() {
+  local label out
+  for label in com.charltonho.em-daily-mining com.charltonho.em-weekly-digest com.charltonho.instruction-hygiene; do
+    out=$(launchctl print "gui/$UID_GUI/$label" 2>&1) || {
+      echo "    launchctl print failed for $label"
+      return 1
+    }
+    if ! printf '%s' "$out" | grep -qF "em-skill-wrapper.sh"; then
+      echo "    $label loaded-state argv missing wrapper"
+      return 1
+    fi
+    if ! printf '%s' "$out" | grep -q "CLAUDE_SCHEDULED_TASK"; then
+      echo "    $label loaded-state env missing CLAUDE_SCHEDULED_TASK"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# ---------------- Test 11: kickstart smoke, daily-mining only ----------
+# Verifies the launchd-mediated path. The "Unknown command" failure mode
+# was the original bug; we assert it's gone. We do NOT require the SKILL
+# to fully succeed (it may emit candidates=0 today due to root-owned
+# transcript files — separate bug, not in scope for this fix), only that
+# the wrapper-mechanism reaches claude execution.
+test_11_kickstart_daily() {
+  local logfile="$HOME/Library/Logs/episodic-memory/em-daily-mining.log"
+  : > "$logfile"
+  launchctl kickstart -k "gui/$UID_GUI/com.charltonho.em-daily-mining" >/dev/null 2>&1
+  # Wait for completion signal: either "Unknown command" (FAIL), or claude
+  # exits and writes a final newline / claude-shaped output, or 180s timeout.
+  local i=0
+  while [ "$i" -lt 180 ]; do
+    # If the original failure signature appears, bail early.
+    if grep -qF "Unknown command" "$logfile" 2>/dev/null; then
+      break
+    fi
+    # If the log has non-trivial content AND no further bytes for 5s, run
+    # has likely completed. Simpler: check if launchctl job is still active.
+    if ! launchctl print "gui/$UID_GUI/com.charltonho.em-daily-mining" 2>/dev/null \
+         | grep -q 'state = running'; then
+      # Not in 'running' state — and we kicked it. So it ran and exited.
+      if [ "$i" -gt 2 ]; then  # debounce: give launchctl a moment to register
+        break
+      fi
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  if grep -qF "Unknown command" "$logfile"; then
+    echo "    FAIL: 'Unknown command' in log after wrapper-fix"
+    tail -10 "$logfile"
+    return 1
+  fi
+  # Job must have produced SOME output (proves wrapper reached claude).
+  if [ ! -s "$logfile" ]; then
+    echo "    FAIL: log empty after kickstart (wrapper never reached claude)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 12: nested-cwd from <project>/scripts ------------
+# Negative-only artifact-location check (same rationale as T4/T5).
+test_12_nested_cwd() {
+  rm -rf "$PROJECT_DIR/scripts/.claude"
+  (cd "$PROJECT_DIR/scripts" && "$WRAPPER" episodic-memory-daily-mining >/dev/null 2>&1) || {
+    echo "    wrapper exited non-zero from nested cwd"
+    return 1
+  }
+  if [ -d "$PROJECT_DIR/scripts/.claude" ]; then
+    echo "    FAIL: $PROJECT_DIR/scripts/.claude exists (artifact leaked to nested cwd)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------- Test 13: rollback ------------------------------------
+test_13_rollback() {
+  bash "$PROJECT_DIR/install-launchd-routines.sh" --uninstall >/dev/null 2>&1 \
+    || { echo "    uninstall exited non-zero"; return 1; }
+  [ ! -f "$WRAPPER" ] || { echo "    wrapper survived uninstall"; return 1; }
+  local p
+  for p in com.charltonho.em-daily-mining com.charltonho.em-weekly-digest \
+           com.charltonho.instruction-hygiene com.charltonho.em-backup-sync; do
+    if launchctl print "gui/$UID_GUI/$p" >/dev/null 2>&1; then
+      echo "    $p still loaded after uninstall"
+      return 1
+    fi
+    if [ -f "$LA_DIR/$p.plist" ]; then
+      echo "    $LA_DIR/$p.plist survived uninstall"
+      return 1
+    fi
+  done
+  [ -f "$PROJECT_DIR/scripts/em-skill-wrapper.sh.tmpl" ] || {
+    echo "    repo template was removed (should be untouched)"
+    return 1
+  }
+  # Re-install so we leave the system in working state.
+  bash "$PROJECT_DIR/install-launchd-routines.sh" >/dev/null 2>&1 \
+    || { echo "    re-install after rollback failed"; return 1; }
+  return 0
+}
+
+# ---------------- Test 14: plist content verification ------------------
+test_14_plist_content() {
+  local line label skill exp_hour exp_min exp_wd plist arg1 wd sop
+  # Format: label:skill:Hour:Minute:Weekday (Weekday empty = daily)
+  for line in \
+      "com.charltonho.em-daily-mining:episodic-memory-daily-mining:19:30:" \
+      "com.charltonho.em-weekly-digest:episodic-memory-weekly-digest:9:0:0" \
+      "com.charltonho.instruction-hygiene:instruction-hygiene-maintenance:11:0:0"; do
+    IFS=: read -r label skill exp_hour exp_min exp_wd <<< "$line"
+    plist="$LA_DIR/$label.plist"
+    [ -f "$plist" ] || { echo "    $plist missing"; return 1; }
+    # ProgramArguments exact indices
+    [ "$(plutil -extract ProgramArguments.0 raw -o - "$plist")" = "/bin/bash" ] \
+      || { echo "    $label argv[0] != /bin/bash"; return 1; }
+    arg1=$(plutil -extract ProgramArguments.1 raw -o - "$plist")
+    case "$arg1" in
+      *"em-skill-wrapper.sh") ;;
+      *) echo "    $label argv[1] = $arg1, expected to end with em-skill-wrapper.sh"; return 1 ;;
+    esac
+    [ "$(plutil -extract ProgramArguments.2 raw -o - "$plist")" = "$skill" ] \
+      || { echo "    $label argv[2] != $skill"; return 1; }
+    if plutil -extract ProgramArguments.3 raw -o - "$plist" >/dev/null 2>&1; then
+      echo "    $label has unexpected ProgramArguments.3"
+      return 1
+    fi
+    # Env
+    [ "$(plutil -extract EnvironmentVariables.CLAUDE_SCHEDULED_TASK raw -o - "$plist")" = "1" ] \
+      || { echo "    $label CLAUDE_SCHEDULED_TASK != 1"; return 1; }
+    plutil -extract EnvironmentVariables.HOME raw -o - "$plist" >/dev/null \
+      || { echo "    $label missing HOME env"; return 1; }
+    plutil -extract EnvironmentVariables.PATH raw -o - "$plist" >/dev/null \
+      || { echo "    $label missing PATH env"; return 1; }
+    # WorkingDirectory
+    wd=$(plutil -extract WorkingDirectory raw -o - "$plist")
+    [ "$wd" = "$PROJECT_DIR" ] || { echo "    $label WD=$wd != $PROJECT_DIR"; return 1; }
+    # Schedule
+    [ "$(plutil -extract StartCalendarInterval.Hour raw -o - "$plist")" = "$exp_hour" ] \
+      || { echo "    $label Hour mismatch"; return 1; }
+    [ "$(plutil -extract StartCalendarInterval.Minute raw -o - "$plist")" = "$exp_min" ] \
+      || { echo "    $label Minute mismatch"; return 1; }
+    if [ -n "$exp_wd" ]; then
+      [ "$(plutil -extract StartCalendarInterval.Weekday raw -o - "$plist")" = "$exp_wd" ] \
+        || { echo "    $label Weekday mismatch"; return 1; }
+    else
+      if plutil -extract StartCalendarInterval.Weekday raw -o - "$plist" >/dev/null 2>&1; then
+        echo "    $label has unexpected Weekday key"
+        return 1
+      fi
+    fi
+    # Log path
+    sop=$(plutil -extract StandardOutPath raw -o - "$plist")
+    case "$sop" in
+      "$HOME/Library/Logs/episodic-memory/"*) ;;
+      *) echo "    $label log path: $sop"; return 1 ;;
+    esac
+  done
+  return 0
+}
+
+# ---------------- Run all -----------------
+run_test "T1  dry-run / no persistent writes"           test_1_dry_run
+run_test "T2  uninstall fail-open w/ stubbed bins"      test_2_uninstall_fail_open
+run_test "T3  install + wrapper content"                test_3_install_content
+run_test "T4a positive cwd-binding via stub Claude"     test_4a_positive_cwd_binding_stub
+run_test "T4  artifact-location, /tmp caller"           test_4_artifact_location_tmp
+run_test "T5  detached-worktree caller"                 test_5_worktree_caller
+run_test "T6  HOME-elsewhere"                           test_6_home_elsewhere
+run_test "T7  PATH-poison (binary pinning)"             test_7_path_poison
+run_test "T8  stub-Claude argv contract"                test_8_stub_argv
+run_test "T9  validation-lib unit"                      test_9_validation_unit
+run_test "T10 launchctl print all 3 wrapped"            test_10_launchctl_print
+run_test "T11 kickstart smoke, daily-mining"            test_11_kickstart_daily
+run_test "T12 nested-cwd from <project>/scripts"        test_12_nested_cwd
+run_test "T13 rollback (uninstall+reinstall)"           test_13_rollback
+run_test "T14 plist content verification (3 plists)"    test_14_plist_content
+
+echo ""
+echo "=================================================="
+echo "Results: $PASS pass / $FAIL fail / $SKIP skip"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+echo "All tests passed."

--- a/scripts/lib/render-input-validation-test.sh
+++ b/scripts/lib/render-input-validation-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Unit tests for validate_render_inputs.
+# Covers: 1 safe case × 2 vars + 4 unsafe characters × 2 vars = 9 cases.
+
+set -e
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/render-input-validation.sh"
+
+# --- Positive case ---
+CLAUDE_BIN="/usr/local/bin/claude" PROJECT_DIR="/Users/foo/episodic-memory" \
+  validate_render_inputs || { echo "FAIL: rejected safe input"; exit 1; }
+echo "  ok  safe inputs accepted"
+
+# --- Negative fan-out: each unsafe char × each input var ---
+UNSAFE_VALUES=( '/bin/has|pipe' '/bin/has\backslash' '/bin/has&amp' $'/bin/has\nnewline' )
+neg_count=0
+for unsafe in "${UNSAFE_VALUES[@]}"; do
+  if CLAUDE_BIN="$unsafe" PROJECT_DIR=/ok validate_render_inputs 2>/dev/null; then
+    echo "FAIL: accepted unsafe CLAUDE_BIN=$(printf '%q' "$unsafe")"; exit 1
+  fi
+  neg_count=$((neg_count + 1))
+  if CLAUDE_BIN=/ok PROJECT_DIR="$unsafe" validate_render_inputs 2>/dev/null; then
+    echo "FAIL: accepted unsafe PROJECT_DIR=$(printf '%q' "$unsafe")"; exit 1
+  fi
+  neg_count=$((neg_count + 1))
+done
+echo "  ok  $neg_count negative cases (2 vars × 4 unsafe chars) all rejected"
+
+echo "PASS"

--- a/scripts/lib/render-input-validation.sh
+++ b/scripts/lib/render-input-validation.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# render-input-validation.sh — sourceable validator for installer render inputs.
+#
+# This is a DENY-LIST validator (not a strict allowlist). It rejects the four
+# characters that would break sed `s|@…@|…|g` substitution with `|` delimiter:
+#   |  (delimiter collision)
+#   \  (escape sequence)
+#   &  (sed back-reference)
+#   \n (sed pattern-space terminator)
+#
+# Other shell-sensitive characters (`"`, `$`, backtick, `;`, etc.) are NOT
+# rejected. The current production inputs (paths under /Users/.../) cannot
+# contain them, but a hostile caller controlling CLAUDE_BIN or PROJECT_DIR
+# could in principle inject shell metacharacters into the rendered wrapper.
+# That's an out-of-scope threat model for a user-run installer; callers who
+# need defense against it should switch to a generated wrapper that uses
+# `printf '%q'` quoting rather than raw sed substitution.
+#
+# Usage:
+#   source scripts/lib/render-input-validation.sh
+#   CLAUDE_BIN=... PROJECT_DIR=... validate_render_inputs
+#   # returns 0 on safe input, 9 on rejection (prints reason to stderr)
+
+validate_render_inputs() {
+  local var val
+  for var in CLAUDE_BIN PROJECT_DIR; do
+    val="${!var}"
+    case "$val" in
+      *'|'*|*'\'*|*'&'*|*$'\n'*)
+        echo "ERROR: $var contains sed-unsafe character (|, \\, &, or newline): $val" >&2
+        echo "       Refusing to render wrapper template with unsafe substitution." >&2
+        return 9
+        ;;
+    esac
+  done
+  return 0
+}

--- a/scripts/second-opinion/lib/audit-table.mjs
+++ b/scripts/second-opinion/lib/audit-table.mjs
@@ -111,6 +111,71 @@ export const AUDIT_TABLE = {
         'install.mjs',
       ],
     },
+    {
+      // I-NEW-B (issue #221): snapshot provider entries validated by the same
+      // shape contract as the source registry, before any hook reads them.
+      reader: 'Hook + readSnapshot (provider registry shape)',
+      reads_from: 'snapshot.providers[] entries (cli_match / binary / agent_block_patterns / agent_allow_patterns / id / prompt_max_chars)',
+      canonicalized_via: 'shared validateProviderRegistry (single source of truth)',
+      writer: 'install.mjs --install-second-opinion (Gate 2 pre-write validation)',
+      risk_class: 'Fail-open on missing/malformed provider fields the hook depends on (empty providers[] vacuous-pass; invalid cli_match regex silent-skip)',
+      mitigation: 'Shared validateProviderRegistry called at install (Gate 1 source-registry + Gate 2 installedProviders), readSnapshot (read-time), hook (gate-time via ./lib/registry-validator.mjs). All three fail-closed on violation. In-tree hook resolves via hooks/lib/registry-validator.mjs symlink; installed hook reads dereferenced copy at ~/.claude/hooks/lib/registry-validator.mjs.',
+      verifying_paths: [
+        'scripts/second-opinion/lib/registry-validator.mjs',
+        'scripts/second-opinion/lib/install-snapshot.mjs',
+        'install.mjs',
+        'hooks/second-opinion-gate.mjs',
+        'hooks/lib/registry-validator.mjs',
+        'tests/test-second-opinion-preamble.mjs',
+        'tests/test-second-opinion-install-snapshot.mjs',
+        'tests/test-second-opinion-gate.mjs',
+        'tests/test-install-second-opinion-e2e.mjs',
+      ],
+    },
+    {
+      // I-NEW-C (issue #221): --install-second-opinion is atomic w.r.t. its
+      // own validation — Gate 1 hard-stops before any side effects; Gate 2
+      // quarantines pre-existing snapshot on failure so hook fail-closes.
+      reader: 'install.mjs --install-second-opinion atomicity guard',
+      reads_from: 'REPO_DIR/scripts/second-opinion/providers/index.json (Gate 1, pre-copy); in-memory installedProviders (Gate 2, post-available()-filter)',
+      canonicalized_via: 'Gate 1 via import.meta.url-relative repo path; Gate 2 in-memory after copy + filter',
+      writer: 'install.mjs (writeSnapshot or rename to .stale.<unix-ms> on failure)',
+      risk_class: 'Stale-snapshot fail-open class: failed install leaves snapshot pointing at superseded source',
+      mitigation: 'Gate 1 hard-stops via process.exit(1) BEFORE any fs.copy / mkdir / write. Gate 2 quarantines pre-existing snapshot via fs.renameSync(snap, snap + ".stale." + Date.now()) on validation failure, so hook reads snapshot-not-installed and fail-closes. installFailed flag suppresses Done! success banner and sets process.exitCode = 1.',
+      verifying_paths: [
+        'install.mjs',
+        'tests/test-install-second-opinion-e2e.mjs',
+      ],
+    },
+    {
+      // R7-F2: installed-hook validator import root.
+      reader: 'Installed hook validator import',
+      reads_from: '~/.claude/hooks/lib/registry-validator.mjs (dereferenced copy of repo symlink target)',
+      canonicalized_via: 'Relative ./lib/ resolution from ~/.claude/hooks/second-opinion-gate.mjs',
+      writer: 'install.mjs --install-second-opinion (fs.copyFileSync dereferences source-side symlink)',
+      risk_class: 'Drift between in-tree validator (via symlink) and installed copy',
+      mitigation: 'Single canonical source at scripts/second-opinion/lib/registry-validator.mjs. In-tree hook tests resolve through symlink; installed hook reads copy. Both paths verified by test-second-opinion-gate.mjs (in-tree) + test-install-second-opinion-e2e.mjs (installed copy).',
+      verifying_paths: [
+        'hooks/lib/registry-validator.mjs',
+        'install.mjs',
+        'tests/test-second-opinion-gate.mjs',
+        'tests/test-install-second-opinion-e2e.mjs',
+      ],
+    },
+    {
+      // R7-F2: SO_INSTALL_SNAPSHOT_PATH env override (test path).
+      reader: 'SO_INSTALL_SNAPSHOT_PATH env override',
+      reads_from: 'process.env.SO_INSTALL_SNAPSHOT_PATH (if set) overrides ~/.claude/hooks/second-opinion-providers.json',
+      canonicalized_via: 'env var; honored by snapshotPath() in install-snapshot.mjs and SNAPSHOT_PATH in hooks/second-opinion-gate.mjs',
+      writer: 'Tests + harness E2E set this to redirect snapshot writes/reads',
+      risk_class: 'Test/runtime divergence if only one half honors the override',
+      mitigation: 'Both readers (snapshotPath + hook SNAPSHOT_PATH) check the same env var name. Existing test-second-opinion-install-snapshot tests assert override is honored end-to-end.',
+      verifying_paths: [
+        'scripts/second-opinion/lib/install-snapshot.mjs',
+        'hooks/second-opinion-gate.mjs',
+        'tests/test-second-opinion-install-snapshot.mjs',
+      ],
+    },
   ],
 }
 

--- a/scripts/second-opinion/lib/install-snapshot.mjs
+++ b/scripts/second-opinion/lib/install-snapshot.mjs
@@ -29,6 +29,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
+import { validateProviderRegistry } from './registry-validator.mjs'
+
 export const DEFAULT_SNAPSHOT_PATH = path.join(
   os.homedir(),
   '.claude',
@@ -57,6 +59,11 @@ export function writeSnapshot(snapshot, customPath) {
  *   - 'snapshot-not-installed' if file missing
  *   - 'snapshot-parse-failed' if JSON malformed
  *   - 'snapshot-missing-source-hash' if source_hash field absent
+ *   - 'snapshot-invalid-providers' if providers[] entries violate the
+ *     shared validator contract (I-NEW-B: hook depends on cli_match /
+ *     binary / agent_block_patterns / agent_allow_patterns shape; we
+ *     reject malformed entries here so the hook fail-closes on read
+ *     rather than silently skipping providers with bad regex).
  */
 export function readSnapshot(customPath) {
   const targetPath = customPath || snapshotPath()
@@ -83,6 +90,23 @@ export function readSnapshot(customPath) {
     const err = new Error(`Snapshot at ${targetPath} missing source_hash field`)
     err.code = 'snapshot-missing-source-hash'
     err.snapshotPath = targetPath
+    throw err
+  }
+  // I-NEW-B: validate providers[] against the shared shape contract.
+  try {
+    validateProviderRegistry({ schema_version: 1, providers: parsed.providers })
+  } catch (e) {
+    const err = new Error(
+      `Snapshot at ${targetPath} has invalid providers[]: ${e.message}`
+    )
+    err.code = 'snapshot-invalid-providers'
+    err.snapshotPath = targetPath
+    err.field = e.field
+    err.provider = e.provider
+    err.observed = e.observed
+    if (e.regexError) err.regexError = e.regexError
+    if (e.index !== undefined) err.index = e.index
+    if (e.duplicate) err.duplicate = e.duplicate
     throw err
   }
   return parsed

--- a/scripts/second-opinion/lib/registry-validator.mjs
+++ b/scripts/second-opinion/lib/registry-validator.mjs
@@ -1,13 +1,20 @@
 /**
  * registry-validator.mjs — Validate provider registry shape.
  *
- * v3.3 contract: each provider entry must have:
+ * Contract: each provider entry must have:
  *   - id: non-empty string
  *   - prompt_max_chars: Number.isInteger(x) && x >= 0
+ *   - cli_match: non-empty string + compilable regex (per hook block-class 1-3)
+ *   - binary: non-empty string (per hook binary-resolution path)
+ *   - agent_block_patterns: array of strings (per hook Agent branch block)
+ *   - agent_allow_patterns: array of strings (per hook Agent branch allow)
  *
- * Plus inline FU N1 (empty providers vacuous-pass) + N10 (duplicate id dedupe)
- * per planner round 2 final-sanity finding (`feedback_inline_fu_heuristic.md`
- * sub-3-LOC same-surface fixes; applied during commit 1 implementation).
+ * Plus N1 (empty providers vacuous-pass) + N10 (duplicate id dedupe).
+ *
+ * I-NEW-B: snapshot provider entries are validated against the same shape
+ * contract as the source registry, before any hook reads them. This module
+ * is invoked at install (write-time), readSnapshot (read-time), and hook
+ * (gate-time) — single shared validator, single source of truth.
  *
  * Throws { code, message, ... } on first failure; caller maps to exit.
  */
@@ -71,6 +78,73 @@ export function validateProviderRegistry(reg) {
       err.field = 'prompt_max_chars'
       err.observed = max
       throw err
+    }
+
+    // cli_match — non-empty string + compilable as RegExp.
+    const cliMatch = provider.cli_match
+    if (typeof cliMatch !== 'string' || cliMatch.length === 0) {
+      const err = new Error(
+        `Provider ${id} has invalid cli_match: observed ${JSON.stringify(cliMatch)}, expected non-empty string`
+      )
+      err.code = 'registry-invalid'
+      err.provider = id
+      err.field = 'cli_match'
+      err.observed = cliMatch
+      throw err
+    }
+    try {
+      new RegExp(cliMatch)
+    } catch (regexErr) {
+      const err = new Error(
+        `Provider ${id} has invalid cli_match regex: ${regexErr.message}`
+      )
+      err.code = 'registry-invalid'
+      err.provider = id
+      err.field = 'cli_match'
+      err.observed = cliMatch
+      err.regexError = regexErr.message
+      throw err
+    }
+
+    // binary — non-empty string.
+    const binary = provider.binary
+    if (typeof binary !== 'string' || binary.length === 0) {
+      const err = new Error(
+        `Provider ${id} has invalid binary: observed ${JSON.stringify(binary)}, expected non-empty string`
+      )
+      err.code = 'registry-invalid'
+      err.provider = id
+      err.field = 'binary'
+      err.observed = binary
+      throw err
+    }
+
+    // agent_block_patterns / agent_allow_patterns — arrays of strings.
+    for (const field of ['agent_block_patterns', 'agent_allow_patterns']) {
+      const arr = provider[field]
+      if (!Array.isArray(arr)) {
+        const err = new Error(
+          `Provider ${id} has invalid ${field}: observed ${JSON.stringify(arr)}, expected array of strings`
+        )
+        err.code = 'registry-invalid'
+        err.provider = id
+        err.field = field
+        err.observed = arr
+        throw err
+      }
+      for (let i = 0; i < arr.length; i++) {
+        if (typeof arr[i] !== 'string') {
+          const err = new Error(
+            `Provider ${id} has non-string entry in ${field}[${i}]: observed ${JSON.stringify(arr[i])}`
+          )
+          err.code = 'registry-invalid'
+          err.provider = id
+          err.field = field
+          err.observed = arr[i]
+          err.index = i
+          throw err
+        }
+      }
     }
   }
 

--- a/tests/test-install-second-opinion-e2e.mjs
+++ b/tests/test-install-second-opinion-e2e.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+/**
+ * test-install-second-opinion-e2e.mjs — End-to-end tests for I-NEW-C
+ * (--install-second-opinion atomicity).
+ *
+ * Coverage:
+ *   Case 1 — Happy install: empty HOME + unmutated registry → exit 0,
+ *     Done! printed, full active surface populated, snapshot valid.
+ *
+ *   Case 2 — Gate 1 failure with empty HOME: mutated cli_match in temp repo
+ *     copy → exit 1, no Done!, walkAllFiles(tempHome).length === 0
+ *     (NO files anywhere under tempHome — not just second-opinion surface;
+ *     R6-F1 full-tree check), target project untouched.
+ *
+ *   Case 3 — Gate 1 failure with populated HOME: pre-existing happy install
+ *     in tempHome → mutate registry in temp repo copy → run install →
+ *     full-tree hash byte-identical pre vs post (active runtime untouched).
+ *
+ *   Case 4 — Gate 2 failure with quarantine: pre-existing happy snapshot →
+ *     overwrite all 4 provider modules in temp repo copy so every
+ *     available() returns {ok: false} → install passes Gate 1 (source
+ *     registry shape is valid) but Gate 2 fails (installedProviders is
+ *     empty → N1) → quarantine pre-existing snapshot to .stale.<ts> so
+ *     hook fail-closes (R6-F3 all-unavailable fixture).
+ *
+ * R7-F1: all 4 cases are bound to the caller-cwd != --project axis
+ * (toolkit #20). Caller cwd is set to a separate tempBase dir; assertions
+ * verify no artifacts land at caller cwd.
+ *
+ * Zero deps. Node assert + fs + child_process + crypto.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+const tmpDirs = []
+process.on('exit', () => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+function mkTempBase(label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `install-so-e2e-${label}-`))
+  tmpDirs.push(dir)
+  return dir
+}
+
+// Walk every regular file under root. Returns sorted absolute paths.
+function walkAllFiles(root) {
+  const out = []
+  if (!fs.existsSync(root)) return out
+  function walk(d) {
+    let entries
+    try { entries = fs.readdirSync(d, { withFileTypes: true }) } catch { return }
+    for (const ent of entries) {
+      const p = path.join(d, ent.name)
+      if (ent.isDirectory()) walk(p)
+      else if (ent.isFile() || ent.isSymbolicLink()) out.push(p)
+    }
+  }
+  walk(root)
+  return out.sort()
+}
+
+// Stable hash over the entire file tree under root: each file's relative path
+// + null byte + its content + null byte, in sorted order. Comparing this hash
+// pre vs post-install detects ANY change anywhere in the tree.
+function treeHash(root) {
+  const h = crypto.createHash('sha256')
+  for (const f of walkAllFiles(root)) {
+    const rel = path.relative(root, f)
+    h.update(rel).update('\0')
+    try {
+      // readFileSync would throw on broken symlinks; lstat first.
+      const st = fs.lstatSync(f)
+      if (st.isSymbolicLink()) {
+        h.update('SYMLINK:').update(fs.readlinkSync(f))
+      } else {
+        h.update(fs.readFileSync(f))
+      }
+    } catch (e) {
+      h.update(`ERR:${e.message}`)
+    }
+    h.update('\0')
+  }
+  return h.digest('hex')
+}
+
+// Copy a directory tree from src → dst, dereference: false to preserve symlinks
+// (so mutating the COPY's registry doesn't mutate the live repo via symlink).
+function copyRepo(src, dst) {
+  fs.cpSync(src, dst, { recursive: true, dereference: false })
+}
+
+// Mutate the provider registry in a temp repo copy to introduce an invalid
+// cli_match regex on the first provider entry. Triggers Gate 1.
+function mutateRegistryInvalid(tempRepoCopy) {
+  const regPath = path.join(tempRepoCopy, 'scripts/second-opinion/providers/index.json')
+  const reg = JSON.parse(fs.readFileSync(regPath, 'utf8'))
+  reg.providers[0].cli_match = '['  // unclosed regex group → throws on new RegExp
+  fs.writeFileSync(regPath, JSON.stringify(reg, null, 2))
+}
+
+// R6-F3: overwrite every provider module so every available() returns
+// {ok: false}. installedProviders becomes empty → Gate 2 N1 fires.
+function makeAllProvidersUnavailable(tempRepoCopy) {
+  const providersDir = path.join(tempRepoCopy, 'scripts/second-opinion/providers')
+  for (const name of ['stub', 'codex', 'claude-subagent', 'gemini']) {
+    fs.writeFileSync(
+      path.join(providersDir, `${name}.mjs`),
+      `export const id = '${name}'\n` +
+      `export const binary = '${name}'\n` +
+      `export function available() { return { ok: false, reason: 'test-fixture-unavailable' } }\n` +
+      `export function dispatch({ prompt, projectRoot }) {\n` +
+      `  if (!prompt) throw new Error('prompt is required')\n` +
+      `  if (!projectRoot) throw new Error('projectRoot is required')\n` +
+      `  return { ok: false, exitCode: 1, stdout: '', stderr: 'test-fixture' }\n` +
+      `}\n`
+    )
+  }
+}
+
+// Build a pre-existing valid snapshot under tempHome to simulate a prior
+// successful install. Returns the snapshot path so callers can hash it.
+function preInstallValidSnapshot(tempHome) {
+  fs.mkdirSync(path.join(tempHome, '.claude', 'hooks'), { recursive: true })
+  fs.mkdirSync(path.join(tempHome, '.episodic-memory', 'scripts', 'second-opinion'), { recursive: true })
+  const snapPath = path.join(tempHome, '.claude', 'hooks', 'second-opinion-providers.json')
+  const snap = {
+    schema_version: 1,
+    source_hash: 'pre-existing-valid-hash',
+    source_repo: '/pre-existing',
+    install_timestamp: new Date(0).toISOString(),
+    providers: [
+      { id: 'stub', binary: 'stub', cli_match: '^stub', prompt_max_chars: 100,
+        agent_block_patterns: [], agent_allow_patterns: [] },
+    ],
+    fragments: [],
+    file_hashes: {},
+  }
+  fs.writeFileSync(snapPath, JSON.stringify(snap, null, 2))
+  return snapPath
+}
+
+// Run install.mjs from tempRepoCopy with caller-cwd in tempBase (R7-F1:
+// caller cwd != --project axis) and HOME overridden to tempHome. Returns
+// spawn result.
+function runInstall(tempRepoCopy, tempProject, tempHome, callerCwd, extraEnv = {}) {
+  return spawnSync('node', [
+    path.join(tempRepoCopy, 'install.mjs'),
+    '--tool', 'claude-code',
+    '--project', tempProject,
+    '--install-second-opinion',
+  ], {
+    cwd: callerCwd,
+    env: { ...process.env, HOME: tempHome, ...extraEnv },
+    encoding: 'utf8',
+    timeout: 60000,
+  })
+}
+
+console.log('# test-install-second-opinion-e2e')
+
+// ---------------------------------------------------------------------------
+// Case 1: happy install
+// ---------------------------------------------------------------------------
+console.log('\n## Case 1 — happy install (R7-F1 caller-cwd axis)')
+test('happy install: exit 0, Done!, full surface populated, snapshot valid', () => {
+  const tempBase = mkTempBase('case1')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.strictEqual(r.status, 0,
+    `expected exit 0, got ${r.status}; stdout=${r.stdout}; stderr=${r.stderr}`)
+  assert.ok(r.stdout.includes('Done!'), `expected Done! in stdout; got: ${r.stdout}`)
+
+  // Active surface populated.
+  const harness = path.join(tempHome, '.episodic-memory/scripts/second-opinion.mjs')
+  const hook = path.join(tempHome, '.claude/hooks/second-opinion-gate.mjs')
+  const hookLib = path.join(tempHome, '.claude/hooks/lib/registry-validator.mjs')
+  const snapshot = path.join(tempHome, '.claude/hooks/second-opinion-providers.json')
+  assert.ok(fs.existsSync(harness), `harness must exist at ${harness}`)
+  assert.ok(fs.existsSync(hook), `hook must exist at ${hook}`)
+  assert.ok(fs.existsSync(hookLib), `hook lib must exist at ${hookLib}`)
+  assert.ok(fs.existsSync(snapshot), `snapshot must exist at ${snapshot}`)
+
+  // Snapshot has at least one provider (stub is always available()).
+  const snap = JSON.parse(fs.readFileSync(snapshot, 'utf8'))
+  assert.ok(Array.isArray(snap.providers) && snap.providers.length >= 1,
+    `snapshot.providers must be non-empty, got ${JSON.stringify(snap.providers)}`)
+
+  // R7-F1: caller cwd untouched (no .episodic-memory / .claude there).
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.episodic-memory')),
+    'caller cwd must not have .episodic-memory')
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.claude')),
+    'caller cwd must not have .claude')
+})
+
+// ---------------------------------------------------------------------------
+// Case 2: Gate 1 failure with empty HOME (R6-F1 full-tree check)
+// ---------------------------------------------------------------------------
+console.log('\n## Case 2 — Gate 1 failure, empty HOME (R6-F1 full-tree)')
+test('Gate 1 with empty HOME: exit 1, no Done!, tempHome remains EMPTY (all files)', () => {
+  const tempBase = mkTempBase('case2')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+
+  mutateRegistryInvalid(tempRepoCopy)
+
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.notStrictEqual(r.status, 0,
+    `expected nonzero exit on Gate 1 failure; got ${r.status}`)
+  assert.ok(!r.stdout.includes('Done!'),
+    `Done! must not appear on failure; got stdout: ${r.stdout}`)
+
+  // R6-F1: full HOME tree assertion — NOTHING under tempHome (not just
+  // second-opinion surface). Gate 1 hard-stops before any file write.
+  const files = walkAllFiles(tempHome)
+  assert.strictEqual(files.length, 0,
+    `Gate 1 failure must leave tempHome empty, but found ${files.length} file(s): ${files.slice(0, 5).join(', ')}`)
+
+  // R7-F1: caller cwd untouched.
+  assert.strictEqual(walkAllFiles(callerCwd).length, 0,
+    `caller cwd must remain empty on Gate 1 failure`)
+
+  // Target project: install creates .episodic-memory unconditionally early
+  // (line ~150) — but Gate 1 runs BEFORE that, so target should be untouched.
+  const projectFiles = walkAllFiles(tempProject)
+  assert.strictEqual(projectFiles.length, 0,
+    `target project must be untouched on Gate 1 failure, found: ${projectFiles}`)
+})
+
+// ---------------------------------------------------------------------------
+// Case 3: Gate 1 failure with populated HOME (R4-F1 stale-snapshot)
+// ---------------------------------------------------------------------------
+console.log('\n## Case 3 — Gate 1 failure, populated HOME (R4-F1 stale-snapshot)')
+test('Gate 1 with populated HOME: full-tree hash byte-identical pre vs post', () => {
+  const tempBase = mkTempBase('case3')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+
+  // Simulate prior successful install (full surface present).
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+  const happyResult = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+  assert.strictEqual(happyResult.status, 0, 'prior happy install setup must succeed')
+
+  const preHash = treeHash(tempHome)
+
+  // Now mutate the temp repo registry (does NOT affect what's already on
+  // tempHome) and re-run install.
+  mutateRegistryInvalid(tempRepoCopy)
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.notStrictEqual(r.status, 0, 'Gate 1 must reject mutated registry')
+  assert.ok(!r.stdout.includes('Done!'), 'no Done! on Gate 1 failure')
+
+  const postHash = treeHash(tempHome)
+  assert.strictEqual(postHash, preHash,
+    'full HOME tree must be byte-identical after Gate 1 failure (atomic install)')
+})
+
+// ---------------------------------------------------------------------------
+// Case 4: Gate 2 failure with quarantine (R6-F3 all-unavailable + R4-F1)
+// ---------------------------------------------------------------------------
+console.log('\n## Case 4 — Gate 2 failure with quarantine (R6-F3 all-unavailable)')
+test('Gate 2 with populated HOME + all-unavailable: snapshot quarantined to .stale.<ts>', () => {
+  const tempBase = mkTempBase('case4')
+  const tempRepoCopy = path.join(tempBase, 'repo')
+  const tempProject = path.join(tempBase, 'project')
+  const tempHome = path.join(tempBase, 'home')
+  const callerCwd = path.join(tempBase, 'caller')
+
+  copyRepo(REPO_ROOT, tempRepoCopy)
+  fs.mkdirSync(tempProject, { recursive: true })
+  fs.mkdirSync(callerCwd, { recursive: true })
+
+  // Pre-populate tempHome with valid snapshot (simulating prior install).
+  const snapPath = preInstallValidSnapshot(tempHome)
+  const preSnapshotContent = fs.readFileSync(snapPath, 'utf8')
+
+  // Make all providers unavailable in the COPY only.
+  makeAllProvidersUnavailable(tempRepoCopy)
+
+  const r = runInstall(tempRepoCopy, tempProject, tempHome, callerCwd)
+
+  assert.notStrictEqual(r.status, 0,
+    `Gate 2 must fail (empty installedProviders → N1); got exit ${r.status}, stderr=${r.stderr}`)
+  assert.ok(!r.stdout.includes('Done!'),
+    `no Done! on Gate 2 failure; stdout: ${r.stdout}`)
+
+  // Current snapshot file must be GONE (renamed).
+  assert.ok(!fs.existsSync(snapPath),
+    `current snapshot must be quarantined (renamed away); still exists at ${snapPath}`)
+
+  // Quarantine file must exist matching snapPath + .stale.<digits>.
+  const hooksDir = path.dirname(snapPath)
+  const quarantineFiles = fs.readdirSync(hooksDir).filter(
+    f => f.startsWith('second-opinion-providers.json.stale.')
+  )
+  assert.strictEqual(quarantineFiles.length, 1,
+    `expected 1 quarantine file, found ${quarantineFiles.length}: ${quarantineFiles}`)
+
+  // Quarantine file content byte-identical to original valid snapshot.
+  const quarantineContent = fs.readFileSync(path.join(hooksDir, quarantineFiles[0]), 'utf8')
+  assert.strictEqual(quarantineContent, preSnapshotContent,
+    'quarantined snapshot must be byte-identical to original')
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-second-opinion-consensus-e2e.mjs
+++ b/tests/test-second-opinion-consensus-e2e.mjs
@@ -74,6 +74,11 @@ process.stdout.write(\`Rebuttal: addressing reply \${replyId} from \${replyFile}
 
 function runHarness(args, { cwd, expectError = false, extraEnv = {} } = {}) {
   const env = { ...process.env, ...extraEnv }
+  // Dev-mode skip of I-27a (stale dev-box snapshot otherwise breaks every
+  // harness test orthogonal to the freshness gate).
+  if (env.SO_INSTALL_SNAPSHOT_PATH === undefined) {
+    env.SO_INSTALL_SNAPSHOT_PATH = '/nonexistent/snapshot-for-consensus-e2e-dev-mode.json'
+  }
   const result = spawnSync('node', [HARNESS, ...args], {
     cwd: cwd || process.cwd(),
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/test-second-opinion-dispatch.mjs
+++ b/tests/test-second-opinion-dispatch.mjs
@@ -54,10 +54,22 @@ function makeTmpProject() {
   return tmp
 }
 
-function runHarness(args, { cwd, expectError = false } = {}) {
+function runHarness(args, { cwd, expectError = false, snapshotPath, extraEnv = {} } = {}) {
+  const env = { ...process.env, ...extraEnv }
+  // Default: redirect to a non-existent snapshot path so the harness skips
+  // I-27a (dev mode). Tests that need to exercise the freshness gate or the
+  // new snapshot-invalid-providers branch pass snapshotPath explicitly.
+  // Without this default, a stale ~/.claude/hooks/second-opinion-providers.json
+  // on a dev box would fail tests that have nothing to do with the gate.
+  if (snapshotPath !== undefined) {
+    env.SO_INSTALL_SNAPSHOT_PATH = snapshotPath
+  } else if (env.SO_INSTALL_SNAPSHOT_PATH === undefined) {
+    env.SO_INSTALL_SNAPSHOT_PATH = '/nonexistent/snapshot-for-dispatch-tests-dev-mode.json'
+  }
   const result = spawnSync('node', [HARNESS, ...args], {
     cwd: cwd || process.cwd(),
     stdio: ['ignore', 'pipe', 'pipe'],
+    env,
   })
   const stdout = result.stdout.toString()
   let parsed
@@ -212,6 +224,102 @@ test('--dispatch on provider in registry but missing .mjs file → provider-modu
   // runs first). This documents the order of defenses.
   assert.strictEqual(result.code, 'unknown-provider')
 })
+
+// ---------------------------------------------------------------------------
+// Issue #221 — harness pre-flight (checkRegistryFreshness) rejects
+// invalid-providers snapshot BEFORE any request artifact is written.
+// 5-axis matrix bound to caller-cwd != --project (toolkit #20 / R7-F1).
+// ---------------------------------------------------------------------------
+console.log('\n## Issue #221 — harness fails-closed on invalid snapshot, no side effects')
+
+function writeInvalidProvidersSnapshot(snapPath) {
+  fs.mkdirSync(path.dirname(snapPath), { recursive: true })
+  fs.writeFileSync(snapPath, JSON.stringify({
+    schema_version: 1,
+    source_hash: 'dummy-source-hash',
+    providers: [{
+      id: 'codex', binary: 'codex', cli_match: '[', prompt_max_chars: 1000,
+      agent_block_patterns: [], agent_allow_patterns: [],
+    }],
+  }), 'utf8')
+}
+
+// Axis (a): caller cwd != --project (non-git caller), files storage.
+// Asserts no .review-store under EITHER caller or target.
+test('axis (a) — caller cwd != --project (non-git caller): no side effects on invalid snapshot', () => {
+  const targetProj = makeTmpProject()
+  const callerCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'so-axis-a-caller-'))
+  tmpDirs.push(callerCwd)
+  const snapPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'so-axis-a-snap-')), 'snap.json')
+  tmpDirs.push(path.dirname(snapPath))
+  writeInvalidProvidersSnapshot(snapPath)
+
+  const result = runHarness([
+    'request',
+    '--provider', 'codex',
+    '--project', targetProj,
+    '--storage', 'files',
+    '--body', 'should-not-write',
+    '--summary', 'axis-a',
+    '--dispatch',
+  ], { cwd: callerCwd, snapshotPath: snapPath, expectError: true })
+
+  assert.strictEqual(result.code, 'snapshot-invalid-providers',
+    `expected snapshot-invalid-providers, got: ${JSON.stringify(result)}`)
+  // No .review-store at either location.
+  assert.ok(!fs.existsSync(path.join(targetProj, '.review-store')),
+    'no .review-store under target')
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.review-store')),
+    'no .review-store under caller cwd (R7-F1 axis a)')
+})
+
+// Axis (b): linked worktree as --project target. Same fail-closed assertions.
+test('axis (b) — linked worktree as --project target: no side effects on invalid snapshot', () => {
+  const mainRepo = makeTmpProject()
+  // Bootstrap one commit so worktree add succeeds.
+  execFileSync('git', ['-C', mainRepo, 'commit', '--allow-empty', '-q', '-m', 'init'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+  })
+  const worktreePath = path.join(path.dirname(mainRepo), `wt-${path.basename(mainRepo)}-221b`)
+  tmpDirs.push(worktreePath)
+  execFileSync('git', ['-C', mainRepo, 'worktree', 'add', '-q', '-b', `wt-221b-${Date.now()}`, worktreePath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const callerCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'so-axis-b-caller-'))
+  tmpDirs.push(callerCwd)
+  const snapPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'so-axis-b-snap-')), 'snap.json')
+  tmpDirs.push(path.dirname(snapPath))
+  writeInvalidProvidersSnapshot(snapPath)
+
+  const result = runHarness([
+    'request',
+    '--provider', 'codex',
+    '--project', worktreePath,
+    '--storage', 'files',
+    '--body', 'should-not-write',
+    '--summary', 'axis-b',
+    '--dispatch',
+  ], { cwd: callerCwd, snapshotPath: snapPath, expectError: true })
+
+  assert.strictEqual(result.code, 'snapshot-invalid-providers')
+  // No .review-store under worktree OR canonical OR caller.
+  assert.ok(!fs.existsSync(path.join(worktreePath, '.review-store')),
+    'no .review-store under linked worktree target')
+  assert.ok(!fs.existsSync(path.join(mainRepo, '.review-store')),
+    'no .review-store under canonical main repo')
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.review-store')),
+    'no .review-store under caller cwd')
+})
+
+// Axes (c)/(d)/(e) are documented as equivalent under early-exit:
+// (c) non-git caller — already covered by axis (a) above (callerCwd is plain dir).
+// (d) wrong inherited subprocess cwd — under early-exit no subprocess spawns;
+//     the non-error path's cwd: projectRoot binding is verified by
+//     test-second-opinion-storage.mjs.
+// (e) HOME / CLAUDE_CONFIG_DIR redirect — tracked under issue #223; orthogonal
+//     to this branch since SO_INSTALL_SNAPSHOT_PATH plumbs through whichever
+//     HOME readSnapshot resolves to.
 
 // ---------------------------------------------------------------------------
 // Summary

--- a/tests/test-second-opinion-gate.mjs
+++ b/tests/test-second-opinion-gate.mjs
@@ -181,6 +181,100 @@ test('snapshot missing source_hash → block', () => {
   assert.strictEqual(r.decision.code, 'snapshot-missing-source-hash')
 })
 
+// I-NEW-B: snapshot providers[] validated by same contract as source
+// registry. Hook fail-closes on invalid shape rather than silent-skip
+// in compileCliMatch.
+test('empty providers[] snapshot → block snapshot-invalid-providers', () => {
+  const tmp = makeTmpSnapshotPath()
+  fs.mkdirSync(path.dirname(tmp), { recursive: true })
+  fs.writeFileSync(tmp, JSON.stringify({
+    schema_version: 1, source_hash: 'dummy', providers: [],
+  }), 'utf8')
+  const r = runHook(
+    { tool_name: 'Bash', tool_input: { command: 'codex exec "hi"', run_in_background: true }, cwd: '/tmp' },
+    { snapshotPath: tmp },
+  )
+  assert.strictEqual(r.decision.decision, 'block')
+  assert.strictEqual(r.decision.code, 'snapshot-invalid-providers')
+  assert.strictEqual(r.decision.field, 'providers')
+})
+
+test('malformed cli_match (invalid regex) → block snapshot-invalid-providers', () => {
+  const tmp = makeTmpSnapshotPath()
+  fs.mkdirSync(path.dirname(tmp), { recursive: true })
+  fs.writeFileSync(tmp, JSON.stringify({
+    schema_version: 1, source_hash: 'dummy',
+    providers: [{
+      id: 'codex', binary: 'codex', cli_match: '[', prompt_max_chars: 1000,
+      agent_block_patterns: [], agent_allow_patterns: [],
+    }],
+  }), 'utf8')
+  const r = runHook(
+    { tool_name: 'Bash', tool_input: { command: 'codex exec "hi"', run_in_background: true }, cwd: '/tmp' },
+    { snapshotPath: tmp },
+  )
+  assert.strictEqual(r.decision.decision, 'block')
+  assert.strictEqual(r.decision.code, 'snapshot-invalid-providers')
+  assert.strictEqual(r.decision.field, 'cli_match')
+  assert.strictEqual(r.decision.provider, 'codex')
+})
+
+// R3-F1 / R7-F1: installed-hook test. Copy hook + dereferenced validator
+// lib to a temp ~/.claude/hooks-shaped dir; run the COPIED hook from cwd
+// outside the repo against a malformed snapshot. Verifies the install
+// copy mechanics work (hook can import its colocated lib at runtime).
+test('installed hook (outside-repo cwd) fail-closes on invalid snapshot', () => {
+  const tempBase = fs.mkdtempSync(path.join(os.tmpdir(), 'so-installed-hook-'))
+  tmpDirs.push(tempBase)
+  const installedHooksDir = path.join(tempBase, '.claude', 'hooks')
+  const installedLibDir = path.join(installedHooksDir, 'lib')
+  fs.mkdirSync(installedLibDir, { recursive: true })
+
+  // Copy hook + dereferenced validator (fs.copyFileSync dereferences the
+  // repo-side symlink, writing a regular file at the destination).
+  fs.copyFileSync(HOOK, path.join(installedHooksDir, 'second-opinion-gate.mjs'))
+  fs.copyFileSync(
+    path.join(REPO_ROOT, 'scripts/second-opinion/lib/registry-validator.mjs'),
+    path.join(installedLibDir, 'registry-validator.mjs'),
+  )
+
+  // Verify the copy is a regular file (not a symlink).
+  const stat = fs.lstatSync(path.join(installedLibDir, 'registry-validator.mjs'))
+  assert.ok(stat.isFile() && !stat.isSymbolicLink(),
+    `installed validator must be regular file, got isSymlink=${stat.isSymbolicLink()}`)
+
+  // Write malformed snapshot.
+  const snapPath = path.join(installedHooksDir, 'second-opinion-providers.json')
+  fs.writeFileSync(snapPath, JSON.stringify({
+    schema_version: 1, source_hash: 'dummy',
+    providers: [{
+      id: 'codex', binary: 'codex', cli_match: '[', prompt_max_chars: 1000,
+      agent_block_patterns: [], agent_allow_patterns: [],
+    }],
+  }), 'utf8')
+
+  // Run the INSTALLED hook from cwd outside the repo.
+  const outsideCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'so-outside-'))
+  tmpDirs.push(outsideCwd)
+  const r = spawnSync('node', [path.join(installedHooksDir, 'second-opinion-gate.mjs')], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'codex exec "hi"', run_in_background: true },
+      cwd: outsideCwd,
+    }),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    cwd: outsideCwd,
+    env: { ...process.env, SO_INSTALL_SNAPSHOT_PATH: snapPath },
+    encoding: 'utf8',
+  })
+
+  assert.strictEqual(r.status, 0, `hook exit should be 0; stderr=${r.stderr}`)
+  const decision = JSON.parse(r.stdout)
+  assert.strictEqual(decision.decision, 'block')
+  assert.strictEqual(decision.code, 'snapshot-invalid-providers')
+  assert.strictEqual(decision.field, 'cli_match')
+})
+
 // ---------------------------------------------------------------------------
 // Bash branch
 // ---------------------------------------------------------------------------

--- a/tests/test-second-opinion-install-snapshot.mjs
+++ b/tests/test-second-opinion-install-snapshot.mjs
@@ -165,6 +165,51 @@ test('readSnapshot on missing source_hash → snapshot-missing-source-hash', () 
   )
 })
 
+// I-NEW-B: snapshot providers[] validated against same contract as source
+// registry. Reader rejects malformed entries so hook fail-closes on read.
+test('readSnapshot on empty providers[] → snapshot-invalid-providers', () => {
+  const tmpPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'snap-empty-')), 'snap.json')
+  fs.writeFileSync(tmpPath, JSON.stringify({
+    schema_version: 1,
+    source_hash: 'dummy',
+    providers: [],
+  }), 'utf8')
+  assert.throws(() => readSnapshot(tmpPath),
+    (e) => e.code === 'snapshot-invalid-providers' && e.field === 'providers'
+  )
+})
+
+test('readSnapshot on malformed cli_match (invalid regex) → snapshot-invalid-providers', () => {
+  const tmpPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'snap-bad-regex-')), 'snap.json')
+  fs.writeFileSync(tmpPath, JSON.stringify({
+    schema_version: 1,
+    source_hash: 'dummy',
+    providers: [{
+      id: 'codex', binary: 'codex', cli_match: '[', prompt_max_chars: 1000,
+      agent_block_patterns: [], agent_allow_patterns: [],
+    }],
+  }), 'utf8')
+  assert.throws(() => readSnapshot(tmpPath),
+    (e) => e.code === 'snapshot-invalid-providers' && e.field === 'cli_match' &&
+           e.provider === 'codex' && typeof e.regexError === 'string'
+  )
+})
+
+test('readSnapshot on non-string binary → snapshot-invalid-providers', () => {
+  const tmpPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'snap-bad-binary-')), 'snap.json')
+  fs.writeFileSync(tmpPath, JSON.stringify({
+    schema_version: 1,
+    source_hash: 'dummy',
+    providers: [{
+      id: 'codex', binary: 123, cli_match: '^codex', prompt_max_chars: 1000,
+      agent_block_patterns: [], agent_allow_patterns: [],
+    }],
+  }), 'utf8')
+  assert.throws(() => readSnapshot(tmpPath),
+    (e) => e.code === 'snapshot-invalid-providers' && e.field === 'binary' && e.observed === 123
+  )
+})
+
 // ---------------------------------------------------------------------------
 // I-27a harness gate: matching source + snapshot → OK
 // ---------------------------------------------------------------------------

--- a/tests/test-second-opinion-preamble.mjs
+++ b/tests/test-second-opinion-preamble.mjs
@@ -365,9 +365,25 @@ test('readAndValidateOverride calls fs.readFileSync exactly once for override pa
 })
 
 // ---------------------------------------------------------------------------
-// Registry validator — N1 + N10 + Number.isInteger predicate
+// Registry validator — N1 + N10 + per-field predicates (id, prompt_max_chars,
+// cli_match, binary, agent_block_patterns, agent_allow_patterns).
 // ---------------------------------------------------------------------------
 console.log('\n## Registry validator')
+
+// Test helper: a minimal valid entry. Each per-field test overrides ONLY
+// the field it exercises so failures isolate to the field under test.
+function validEntry(overrides = {}) {
+  return {
+    id: 'p',
+    prompt_max_chars: 100,
+    cli_match: '^p\\b',
+    binary: 'p',
+    agent_block_patterns: [],
+    agent_allow_patterns: [],
+    ...overrides,
+  }
+}
+
 test('valid registry passes', () => {
   const reg = JSON.parse(fs.readFileSync(PROVIDERS_REGISTRY, 'utf8'))
   const result = validateProviderRegistry(reg)
@@ -386,8 +402,8 @@ test('N10: duplicate provider id → registry-invalid', () => {
   const reg = {
     schema_version: 1,
     providers: [
-      { id: 'codex', prompt_max_chars: 100 },
-      { id: 'codex', prompt_max_chars: 200 },
+      validEntry({ id: 'codex' }),
+      validEntry({ id: 'codex', prompt_max_chars: 200 }),
     ],
   }
   assert.throws(() => validateProviderRegistry(reg),
@@ -396,57 +412,140 @@ test('N10: duplicate provider id → registry-invalid', () => {
 })
 
 test('prompt_max_chars: 0 passes (legitimate "no prompt allowed")', () => {
-  const reg = {
-    schema_version: 1,
-    providers: [{ id: 'p', prompt_max_chars: 0 }],
-  }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: 0 })] }
   assert.doesNotThrow(() => validateProviderRegistry(reg))
 })
 
 test('prompt_max_chars: null → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: null }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: null })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars' && e.observed === null
   )
 })
 
 test('prompt_max_chars: undefined (missing) → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p' }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: undefined })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars'
   )
 })
 
 test('prompt_max_chars: -1 → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: -1 }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: -1 })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars' && e.observed === -1
   )
 })
 
 test('prompt_max_chars: "100" (string) → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: '100' }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: '100' })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars'
   )
 })
 
 test('prompt_max_chars: 1.5 (float) → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: 1.5 }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: 1.5 })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars'
   )
 })
 
 test('prompt_max_chars: NaN → registry-invalid', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: NaN }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: NaN })] }
   assert.throws(() => validateProviderRegistry(reg),
     (e) => e.code === 'registry-invalid' && e.field === 'prompt_max_chars'
   )
 })
 
 test('prompt_max_chars: 2147483647 (INT_MAX) passes', () => {
-  const reg = { schema_version: 1, providers: [{ id: 'p', prompt_max_chars: 2147483647 }] }
+  const reg = { schema_version: 1, providers: [validEntry({ prompt_max_chars: 2147483647 })] }
+  assert.doesNotThrow(() => validateProviderRegistry(reg))
+})
+
+// ---------------------------------------------------------------------------
+// New field validation (Issue #221): cli_match, binary,
+// agent_block_patterns, agent_allow_patterns.
+// ---------------------------------------------------------------------------
+
+test('cli_match: missing → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ cli_match: undefined })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'cli_match' && e.provider === 'p'
+  )
+})
+
+test('cli_match: empty string → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ cli_match: '' })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'cli_match' && e.observed === ''
+  )
+})
+
+test('cli_match: invalid regex ("[") → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ cli_match: '[' })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'cli_match' && typeof e.regexError === 'string'
+  )
+})
+
+test('binary: missing → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ binary: undefined })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'binary' && e.provider === 'p'
+  )
+})
+
+test('binary: empty string → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ binary: '' })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'binary'
+  )
+})
+
+test('binary: non-string (123) → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ binary: 123 })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'binary' && e.observed === 123
+  )
+})
+
+test('agent_block_patterns: non-array (string) → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ agent_block_patterns: 'foo' })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'agent_block_patterns'
+  )
+})
+
+test('agent_block_patterns: array with non-string entry → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ agent_block_patterns: ['ok', 42] })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'agent_block_patterns' && e.index === 1
+  )
+})
+
+test('agent_allow_patterns: non-array (null) → registry-invalid', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ agent_allow_patterns: null })] }
+  assert.throws(() => validateProviderRegistry(reg),
+    (e) => e.code === 'registry-invalid' && e.field === 'agent_allow_patterns'
+  )
+})
+
+test('agent_allow_patterns: empty array passes (no allowlist exceptions)', () => {
+  const reg = { schema_version: 1, providers: [validEntry({ agent_allow_patterns: [] })] }
+  assert.doesNotThrow(() => validateProviderRegistry(reg))
+})
+
+test('all-new-fields-valid entry passes', () => {
+  const reg = {
+    schema_version: 1,
+    providers: [validEntry({
+      cli_match: '^codex\\s+exec\\b',
+      binary: 'codex',
+      agent_block_patterns: ['codex:codex-rescue'],
+      agent_allow_patterns: ['codex:setup'],
+    })],
+  }
   assert.doesNotThrow(() => validateProviderRegistry(reg))
 })
 

--- a/tests/test-second-opinion-storage.mjs
+++ b/tests/test-second-opinion-storage.mjs
@@ -59,9 +59,18 @@ function makeTmpProject() {
  * Throws if exit code is unexpected.
  */
 function runHarness(args, { cwd, expectError = false } = {}) {
+  // Redirect SO_INSTALL_SNAPSHOT_PATH to a non-existent path so harness
+  // skips I-27a gate (dev mode). Storage tests are orthogonal to the
+  // freshness gate; a stale dev-box snapshot otherwise causes spurious
+  // registry-stale-at-gate failures.
+  const env = { ...process.env }
+  if (env.SO_INSTALL_SNAPSHOT_PATH === undefined) {
+    env.SO_INSTALL_SNAPSHOT_PATH = '/nonexistent/snapshot-for-storage-tests-dev-mode.json'
+  }
   const result = spawnSync('node', [HARNESS, ...args], {
     cwd: cwd || process.cwd(),
     stdio: ['ignore', 'pipe', 'pipe'],
+    env,
   })
   const stdout = result.stdout.toString()
   let parsed
@@ -191,6 +200,10 @@ console.log('\n## I-15 concurrent file-storage writes')
 test('rebuild-index recovers all entries after parallel writes', () => {
   const tmp = makeTmpProject()
   // Spawn 5 concurrent writes.
+  const env = { ...process.env }
+  if (env.SO_INSTALL_SNAPSHOT_PATH === undefined) {
+    env.SO_INSTALL_SNAPSHOT_PATH = '/nonexistent/snapshot-for-storage-tests-dev-mode.json'
+  }
   const procs = []
   for (let i = 0; i < 5; i++) {
     procs.push(spawnSync('node', [HARNESS,
@@ -200,7 +213,7 @@ test('rebuild-index recovers all entries after parallel writes', () => {
       '--storage', 'files',
       '--body', `parallel body ${i}`,
       '--summary', `parallel ${i}`,
-    ], { stdio: ['ignore', 'pipe', 'pipe'] }))
+    ], { stdio: ['ignore', 'pipe', 'pipe'], env }))
   }
   for (const p of procs) {
     assert.strictEqual(p.status, 0, `concurrent write failed: ${p.stderr.toString()}`)


### PR DESCRIPTION
## Summary

Fixes the launchd-scheduled routines `em-daily-mining`, `em-weekly-digest`, and `instruction-hygiene`, which were 100% broken since `install-launchd-routines.sh` shipped — every invocation produced `Unknown command: /<skill-name>` because the plists called `claude -p /<name>` as a slash command, but those names are SKILLs under `~/.claude/scheduled-tasks/`, not registered slash commands.

This change replaces the broken slash-command invocation with a parameterized wrapper (`em-skill-wrapper.sh`) that inlines `SKILL.md` content as the prompt to `claude -p`, with project-root hard-binding, install-time-pinned absolute binary, plist env defense for the SessionStart handoff guard, and sed-substitution safety.

## Failure mode (before)

`~/Library/Logs/episodic-memory/em-daily-mining.log` (every run since install):
```
Unknown command: /episodic-memory-daily-mining
Unknown command: /episodic-memory-daily-mining
```

`install-launchd-routines.sh:108` emitted `<string>/$1</string>` assuming SKILLs auto-resolve as slash commands. They don't — `~/.claude/scheduled-tasks/` is not a Claude command source.

## What's in this PR

**5 files, +653/−19:**

| File | Change |
|---|---|
| `scripts/em-skill-wrapper.sh.tmpl` | new (44 lines) — wrapper template with `@CLAUDE_BIN@` + `@PROJECT_DIR@` placeholders; `cd PROJECT_DIR` before exec; uses `--` separator before the prompt so SKILL.md's YAML frontmatter (`---`) doesn't trip claude's arg parser |
| `scripts/lib/render-input-validation.sh` | new (37 lines) — sourceable deny-list validator (rejects `\|`, `\\`, `&`, newline in render inputs) |
| `scripts/lib/render-input-validation-test.sh` | new (30 lines) — unit test, 1 positive + 8 negative cases all pass |
| `scripts/lib/launchd-routines-e2e-test.sh` | new (466 lines) — 15-test E2E suite covering wrapper-mechanism, plist contents, cwd-binding, PATH-poison, HOME-elsewhere, worktree caller, nested-cwd, validation-lib unit, dry-run, uninstall fail-open, rollback |
| `install-launchd-routines.sh` | modified — defers preflight to install branch (uninstall fail-open); fixes `gh` preflight from `command -v gh` to `command -v gh \|\| true` so `set -e` doesn't kill on absent `gh`; sources + invokes validator; renders wrapper with sed + sentinel-check; emits `/bin/bash <wrapper> <skill>` instead of `/<skill>`; adds `CLAUDE_SCHEDULED_TASK=1` to plist env (defense for `session-handoff-prompt.sh` env-var guard); `--uninstall` removes rendered wrapper |

## Review process (per Rule 18)

**Plan review:** 7 rounds of codex consensus on `scripts/second-opinion.mjs` harness.
- Trajectory: R1=4 → R2=3 → R3=6 → R4=3 → R5=3 → R6=3 → R7=**ACCEPT**
- Episodes archived in `.episodic-memory/episodes/` (`20260511-07*-launchd-routines-fix-r*` request/reply chain).

**Impl review:** 1 round, codex returned **ACCEPT-with-FU**. All 3 P2 follow-ups applied inline before push:
- positive cwd-binding stub-claude test (`T4a`)
- `command -v gh \|\| true` fix (production bug — `set -e` would kill the script when `gh` absent)
- validator docstring rewritten to reflect actual deny-list semantics (was claiming "strict allowlist")

**E2E:** 15/15 pass against the installed system.

```
T1   dry-run / no persistent writes                  PASS
T2   uninstall fail-open w/ stubbed bins             PASS
T3   install + wrapper content                       PASS
T4a  positive cwd-binding via stub Claude            PASS
T4   artifact-location, /tmp caller (negative)       PASS
T5   detached-worktree caller                        PASS
T6   HOME-elsewhere                                  PASS
T7   PATH-poison (binary pinning)                    PASS
T8   stub-Claude argv contract                       PASS
T9   validation-lib unit (1 pos + 8 neg)             PASS
T10  launchctl print all 3 wrapped                   PASS
T11  kickstart smoke, daily-mining                   PASS
T12  nested-cwd from <project>/scripts               PASS
T13  rollback (uninstall+reinstall)                  PASS
T14  plist content verification (3 plists)           PASS
```

## Dependency note

This branch is currently based on `bccb7fc` (commit 4 of #221 `fix/issue-221-snapshot-validator-extension`), not directly on `main`. The 4 #221 commits ahead of `main` will appear in this PR's "Files changed" tab even though they belong to #221.

**After #221 merges**, this PR can be rebased onto main with `git rebase main fix/launchd-routines-unknown-command` and the duplicate commits will drop out automatically (clean fast-forward).

If review priority is reversed, this PR's content can also be cherry-picked onto a fresh branch off `main` — the routine-fix touches zero files that #221 touches (`install-launchd-routines.sh` vs `install.mjs` etc.).

## Deferred follow-up

#226 — `scripts/lib/transcript-walker.mjs:178` lacks per-file try/catch, so one EACCES (e.g. root-owned `.jsonl` from a sudo'd claude run) aborts the entire walk. Surfaced by this PR's E2E because the routine finally ran far enough to expose it. Out of scope here; the wrapper-mechanism fix is independent and stable regardless.

## Test plan

- [x] `bash install-launchd-routines.sh --dry-run` — renders plists + wrapper without writing
- [x] `bash install-launchd-routines.sh` — installs cleanly; `launchctl print gui/$UID/com.charltonho.em-daily-mining` shows wrapper + `CLAUDE_SCHEDULED_TASK=1`
- [x] `bash scripts/lib/launchd-routines-e2e-test.sh` — 15/15 green
- [x] `launchctl kickstart -kp gui/$UID/com.charltonho.em-daily-mining` — log shows no "Unknown command", claude reaches SKILL execution
- [x] `bash install-launchd-routines.sh --uninstall` — removes all plists + rendered wrapper; repo template untouched
- [x] Uninstall fail-open verified with stubbed PATH (only `/tmp/stubs:/bin:/usr/bin`, no claude/node on PATH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
