### PR TITLE
docs: reflect snapshot-validator extension (PR #227) + launchd routines (PR #228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,15 @@ Bootstrap (writes the install snapshot consumed by validators + the Claude Code 
 node install.mjs --tool claude-code --install-second-opinion
 ```
 
-The PreToolUse hook (`hooks/second-opinion-gate.mjs`) blocks direct provider invocations (Bash + Agent variants) so reviews route through the harness; fail-closed on missing/malformed snapshot.
+The PreToolUse hook (`hooks/second-opinion-gate.mjs`) blocks direct provider invocations (Bash + Agent variants) so reviews route through the harness. Fail-closed cases:
+
+- Missing or malformed snapshot (parse error, missing `source_hash`).
+- Invalid providers — empty `providers[]`, duplicate `id`, missing/non-compilable `cli_match` regex, missing `binary`, or non-array `agent_block_patterns` / `agent_allow_patterns`. Hook blocks with reason `snapshot-invalid-providers`.
+- Validator lib unloadable (orphan hook without `~/.claude/hooks/lib/registry-validator.mjs`). Hook blocks with reason `snapshot-validator-load-failed`.
+
+The shared `validateProviderRegistry` (`scripts/second-opinion/lib/registry-validator.mjs`) runs at install (Gate 1 + Gate 2), `readSnapshot`, and the hook — one contract, three enforcement points (PR #221 / #227).
+
+`--install-second-opinion` is atomic across five failure paths. Gate 1 hard-stops before any file copy if the source registry is invalid. Beyond Gate 1, any failure — runtime-copy throw, validator-lib throw, Gate 2 throw, or `writeSnapshot` throw — renames any pre-existing `~/.claude/hooks/second-opinion-providers.json` to `second-opinion-providers.json.stale.<unix-ms>` so the hook keeps fail-closing rather than reading a stale snapshot against newly-updated source. Re-run the install command to recover.
 
 ### Codex Watcher
 
@@ -468,6 +476,28 @@ node ~/.episodic-memory/scripts/em-audit-compliance.mjs \
 node ~/.episodic-memory/scripts/em-mine-transcripts.mjs \
   [--since <ISO>] [--slug <substr>] [--output <path>] [--dry-run]
 ```
+
+### Scheduled Routines (launchd, macOS)
+
+Bootstrap (`install-launchd-routines.sh`) installs four LaunchAgent plists so the recurring chores run without manual invocation:
+
+| Plist label | Schedule | What runs |
+|---|---|---|
+| `com.charltonho.em-daily-mining` | daily 19:30 | `episodic-memory-daily-mining` SKILL — mines today's transcripts into a staging file under `.claude/scratch/` |
+| `com.charltonho.em-weekly-digest` | Sunday 09:00 | `episodic-memory-weekly-digest` SKILL — writes the weekly digest episode |
+| `com.charltonho.instruction-hygiene` | Sunday 11:00 | `instruction-hygiene-maintenance` SKILL — lesson-set audit |
+| `com.charltonho.em-backup-sync` | daily 23:00 | `em-backup-sync-wrapper.sh` — pushes the em-backup repo to remote |
+
+The three SKILL-driven jobs invoke through a rendered wrapper (`~/.claude/scheduled-tasks/em-skill-wrapper.sh`) that reads the SKILL.md body and passes it to `claude -p --`. The `--` separator is required because SKILL.md begins with YAML frontmatter (`---`) — without it, the arg parser treats the body as a long-option flag (PR #228).
+
+```bash
+bash install-launchd-routines.sh --dry-run     # preview, no writes
+bash install-launchd-routines.sh               # install (no smoke test)
+bash install-launchd-routines.sh --smoke       # install + kickstart daily-mining
+bash install-launchd-routines.sh --uninstall   # bootout + delete plists (logs preserved)
+```
+
+Logs land at `~/Library/Logs/episodic-memory/<job>.log`. Each plist sets `CLAUDE_SCHEDULED_TASK=1` so the SessionStart handoff prompt self-suppresses; `WorkingDirectory` and the wrapper both pin the project root so cwd-sensitive resolvers don't drift under launchd.
 
 ### Review Request (Workflow Lifecycle Event)
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -16,6 +16,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 7: Recording Project Context](#scenario-7-recording-project-context)
 - [Scenario 8: Switching Between Tools](#scenario-8-switching-between-tools)
 - [Scenario 8b: Running a Second-Opinion Review on a Plan or Diff](#scenario-8b-running-a-second-opinion-review-on-a-plan-or-diff)
+- [Scenario 8c: Running Routines on a Schedule (macOS)](#scenario-8c-running-routines-on-a-schedule-macos)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
@@ -317,6 +318,33 @@ The `--rebuttal-cb` is a script that takes the reviewer's verdict and decides wh
 **Providers available:** `codex` (OpenAI Codex CLI), `claude-subagent` (a separate Claude Code session), `gemini` (Google's CLI), and `stub` for testing harness behavior without spending tokens.
 
 **When to use it:** Rule 18 step 2 (any non-trivial implementation needs a second-opinion review on the plan before approval), PR-level reviews before merge, or any time you want a sanity check from a different model family on a load-bearing decision.
+
+---
+
+## Scenario 8c: Running Routines on a Schedule (macOS)
+
+**What happens:** Some episodic-memory chores benefit from running on a recurring schedule rather than waiting for your next session — nightly transcript mining (so today's lessons don't pile up), Sunday digest, weekly hygiene check, and daily backup sync. macOS `launchd` can drive these for you so you never have to remember.
+
+This is the one corner of the project where you run a script yourself: a one-shot install. After that, the routines fire on their own and write logs you can read later.
+
+```bash
+# From the project root
+bash install-launchd-routines.sh --dry-run     # preview, no writes
+bash install-launchd-routines.sh               # install
+bash install-launchd-routines.sh --smoke       # install + kickstart daily-mining for a smoke test
+bash install-launchd-routines.sh --uninstall   # remove everything (logs preserved)
+```
+
+After install:
+
+- **Daily 19:30** — mines the day's transcripts into a staging file you'll review next session.
+- **Sunday 09:00** — writes the weekly digest episode (so Monday you wake up to a summary).
+- **Sunday 11:00** — runs the instruction-hygiene audit against your behavioral rules.
+- **Daily 23:00** — pushes your em-backup repo to remote.
+
+Logs live at `~/Library/Logs/episodic-memory/`. If something looks off (digest didn't run, mining looks empty), `tail ~/Library/Logs/episodic-memory/em-daily-mining.log` is the first stop; `launchctl print gui/$(id -u)/com.charltonho.em-daily-mining` shows whether the job is loaded and when it last ran.
+
+**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — every scheduled task has a manual equivalent (`node scripts/em-mine-transcripts.mjs`, `em-search --tag weekly-digest`, etc.).
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -344,7 +344,7 @@ After install:
 
 Logs live at `~/Library/Logs/episodic-memory/`. If something looks off (digest didn't run, mining looks empty), `tail ~/Library/Logs/episodic-memory/em-daily-mining.log` is the first stop; `launchctl print gui/$(id -u)/com.charltonho.em-daily-mining` shows whether the job is loaded and when it last ran.
 
-**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — every scheduled task has a manual equivalent (`node scripts/em-mine-transcripts.mjs`, `em-search --tag weekly-digest`, etc.).
+**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — the mining job has a direct CLI equivalent (`node scripts/em-mine-transcripts.mjs`), and the digest / hygiene jobs run their SKILLs, so you can trigger those by asking your AI assistant to run the weekly-digest / instruction-hygiene routine when you want one.
 
 ---
 


### PR DESCRIPTION
## Summary

Bring README + USER_MANUAL up to date with two PRs that shipped to `main` without doc updates: PR #227 (snapshot-validator extension + install quarantine, closing #221) and PR #228 (launchd wrapper-mechanism for SKILL-driven routines).

Last doc refresh was PR #225 (`26fc875`, reflected PR #222 harness). Between then and now: `486b950` (PR #228) and `43430f6` (PR #227). Both shipped without touching `*.md`.

## Changes

### README.md

- **§Second-Opinion Review Harness**: expanded "fail-closed on missing/malformed snapshot" into an explicit enumeration of the three block reasons (parse/`source_hash` family, `snapshot-invalid-providers`, `snapshot-validator-load-failed`). Added the shared-validator invariant statement (`scripts/second-opinion/lib/registry-validator.mjs` runs at install Gate 1 + Gate 2, `readSnapshot`, and the hook). Added a paragraph on `--install-second-opinion` atomicity across the five failure paths and the `.stale.<unix-ms>` quarantine path.
- **New §Scheduled Routines (launchd, macOS)**: covers all four LaunchAgent plists (`em-daily-mining` @ 19:30, `em-weekly-digest` @ Sunday 09:00, `instruction-hygiene` @ Sunday 11:00, `em-backup-sync` @ 23:00), the `em-skill-wrapper.sh` wrapper-mechanism with the `--` separator rationale (YAML frontmatter collision avoidance), install/uninstall/dry-run/smoke flags, and the log path at `~/Library/Logs/episodic-memory/`.

### docs/USER_MANUAL.md

- **TOC**: added Scenario 8c entry.
- **New Scenario 8c**: user-facing walkthrough — one-shot install, plain-English description of the four jobs, log inspection commands, and an opt-out path for non-macOS users.

## Diff stat

```
README.md           | 32 +++++++++++++++++++++++++++++++-
docs/USER_MANUAL.md | 28 ++++++++++++++++++++++++++++
2 files changed, 59 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `grep -E "snapshot-invalid-providers|snapshot-validator-load-failed|stale\.<unix-ms>|com\.charltonho\.|em-skill-wrapper|install-launchd-routines"` — 13 hits in README, 5 in USER_MANUAL (all new terms cited).
- [x] Every claim cross-referenced against shipped code: `hooks/second-opinion-gate.mjs`, `scripts/second-opinion/lib/registry-validator.mjs`, `install.mjs`, `install-launchd-routines.sh`, `scripts/em-skill-wrapper.sh.tmpl`.
- [x] Prose-only PR; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
