### PR TITLE
fix(transcript-walker): per-file try/catch (closes #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,15 @@ Bootstrap (writes the install snapshot consumed by validators + the Claude Code 
 node install.mjs --tool claude-code --install-second-opinion
 ```
 
-The PreToolUse hook (`hooks/second-opinion-gate.mjs`) blocks direct provider invocations (Bash + Agent variants) so reviews route through the harness; fail-closed on missing/malformed snapshot.
+The PreToolUse hook (`hooks/second-opinion-gate.mjs`) blocks direct provider invocations (Bash + Agent variants) so reviews route through the harness. Fail-closed cases:
+
+- Missing or malformed snapshot (parse error, missing `source_hash`).
+- Invalid providers — empty `providers[]`, duplicate `id`, missing/non-compilable `cli_match` regex, missing `binary`, or non-array `agent_block_patterns` / `agent_allow_patterns`. Hook blocks with reason `snapshot-invalid-providers`.
+- Validator lib unloadable (orphan hook without `~/.claude/hooks/lib/registry-validator.mjs`). Hook blocks with reason `snapshot-validator-load-failed`.
+
+The shared `validateProviderRegistry` (`scripts/second-opinion/lib/registry-validator.mjs`) runs at install (Gate 1 + Gate 2), `readSnapshot`, and the hook — one contract, three enforcement points (PR #221 / #227).
+
+`--install-second-opinion` is atomic across five failure paths. Gate 1 hard-stops before any file copy if the source registry is invalid. Beyond Gate 1, any failure — runtime-copy throw, validator-lib throw, Gate 2 throw, or `writeSnapshot` throw — renames any pre-existing `~/.claude/hooks/second-opinion-providers.json` to `second-opinion-providers.json.stale.<unix-ms>` so the hook keeps fail-closing rather than reading a stale snapshot against newly-updated source. Re-run the install command to recover.
 
 ### Codex Watcher
 
@@ -468,6 +476,28 @@ node ~/.episodic-memory/scripts/em-audit-compliance.mjs \
 node ~/.episodic-memory/scripts/em-mine-transcripts.mjs \
   [--since <ISO>] [--slug <substr>] [--output <path>] [--dry-run]
 ```
+
+### Scheduled Routines (launchd, macOS)
+
+Bootstrap (`install-launchd-routines.sh`) installs four LaunchAgent plists so the recurring chores run without manual invocation:
+
+| Plist label | Schedule | What runs |
+|---|---|---|
+| `com.charltonho.em-daily-mining` | daily 19:30 | `episodic-memory-daily-mining` SKILL — mines today's transcripts into a staging file under `.claude/scratch/` |
+| `com.charltonho.em-weekly-digest` | Sunday 09:00 | `episodic-memory-weekly-digest` SKILL — writes the weekly digest episode |
+| `com.charltonho.instruction-hygiene` | Sunday 11:00 | `instruction-hygiene-maintenance` SKILL — lesson-set audit |
+| `com.charltonho.em-backup-sync` | daily 23:00 | `em-backup-sync-wrapper.sh` — pushes the em-backup repo to remote |
+
+The three SKILL-driven jobs invoke through a rendered wrapper (`~/.claude/scheduled-tasks/em-skill-wrapper.sh`) that reads the SKILL.md body and passes it to `claude -p --`. The `--` separator is required because SKILL.md begins with YAML frontmatter (`---`) — without it, the arg parser treats the body as a long-option flag (PR #228).
+
+```bash
+bash install-launchd-routines.sh --dry-run     # preview, no writes
+bash install-launchd-routines.sh               # install (no smoke test)
+bash install-launchd-routines.sh --smoke       # install + kickstart daily-mining
+bash install-launchd-routines.sh --uninstall   # bootout + delete plists (logs preserved)
+```
+
+Logs land at `~/Library/Logs/episodic-memory/<job>.log`. Each plist sets `CLAUDE_SCHEDULED_TASK=1` so the SessionStart handoff prompt self-suppresses; `WorkingDirectory` and the wrapper both pin the project root so cwd-sensitive resolvers don't drift under launchd.
 
 ### Review Request (Workflow Lifecycle Event)
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -16,6 +16,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 7: Recording Project Context](#scenario-7-recording-project-context)
 - [Scenario 8: Switching Between Tools](#scenario-8-switching-between-tools)
 - [Scenario 8b: Running a Second-Opinion Review on a Plan or Diff](#scenario-8b-running-a-second-opinion-review-on-a-plan-or-diff)
+- [Scenario 8c: Running Routines on a Schedule (macOS)](#scenario-8c-running-routines-on-a-schedule-macos)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
@@ -317,6 +318,33 @@ The `--rebuttal-cb` is a script that takes the reviewer's verdict and decides wh
 **Providers available:** `codex` (OpenAI Codex CLI), `claude-subagent` (a separate Claude Code session), `gemini` (Google's CLI), and `stub` for testing harness behavior without spending tokens.
 
 **When to use it:** Rule 18 step 2 (any non-trivial implementation needs a second-opinion review on the plan before approval), PR-level reviews before merge, or any time you want a sanity check from a different model family on a load-bearing decision.
+
+---
+
+## Scenario 8c: Running Routines on a Schedule (macOS)
+
+**What happens:** Some episodic-memory chores benefit from running on a recurring schedule rather than waiting for your next session — nightly transcript mining (so today's lessons don't pile up), Sunday digest, weekly hygiene check, and daily backup sync. macOS `launchd` can drive these for you so you never have to remember.
+
+This is the one corner of the project where you run a script yourself: a one-shot install. After that, the routines fire on their own and write logs you can read later.
+
+```bash
+# From the project root
+bash install-launchd-routines.sh --dry-run     # preview, no writes
+bash install-launchd-routines.sh               # install
+bash install-launchd-routines.sh --smoke       # install + kickstart daily-mining for a smoke test
+bash install-launchd-routines.sh --uninstall   # remove everything (logs preserved)
+```
+
+After install:
+
+- **Daily 19:30** — mines the day's transcripts into a staging file you'll review next session.
+- **Sunday 09:00** — writes the weekly digest episode (so Monday you wake up to a summary).
+- **Sunday 11:00** — runs the instruction-hygiene audit against your behavioral rules.
+- **Daily 23:00** — pushes your em-backup repo to remote.
+
+Logs live at `~/Library/Logs/episodic-memory/`. If something looks off (digest didn't run, mining looks empty), `tail ~/Library/Logs/episodic-memory/em-daily-mining.log` is the first stop; `launchctl print gui/$(id -u)/com.charltonho.em-daily-mining` shows whether the job is loaded and when it last ran.
+
+**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — every scheduled task has a manual equivalent (`node scripts/em-mine-transcripts.mjs`, `em-search --tag weekly-digest`, etc.).
 
 ---
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -344,7 +344,7 @@ After install:
 
 Logs live at `~/Library/Logs/episodic-memory/`. If something looks off (digest didn't run, mining looks empty), `tail ~/Library/Logs/episodic-memory/em-daily-mining.log` is the first stop; `launchctl print gui/$(id -u)/com.charltonho.em-daily-mining` shows whether the job is loaded and when it last ran.
 
-**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — every scheduled task has a manual equivalent (`node scripts/em-mine-transcripts.mjs`, `em-search --tag weekly-digest`, etc.).
+**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — the mining job has a direct CLI equivalent (`node scripts/em-mine-transcripts.mjs`), and the digest / hygiene jobs run their SKILLs, so you can trigger those by asking your AI assistant to run the weekly-digest / instruction-hygiene routine when you want one.
 
 ---
 

--- a/scripts/lib/transcript-walker.mjs
+++ b/scripts/lib/transcript-walker.mjs
@@ -201,8 +201,12 @@ export async function* walkTranscripts({ slugFilter, excludeWorktrees, since } =
         }
       }
     } catch (err) {
+      // NOTE: records yielded before the error are NOT rolled back. For
+      // EACCES-on-open (the #226 case) no records are yielded; for mid-read
+      // errors (EIO, truncation) consumers see records up to the failure
+      // point. "stopped reading" — not "atomic skip."
       process.stderr.write(
-        `transcript-walker: skipping ${t.file} (${err.code || err.name || 'error'}: ${err.message})\n`
+        `transcript-walker: stopped reading ${t.file} (${err.code || err.name || 'error'}: ${err.message})\n`
       )
       continue
     }

--- a/scripts/lib/transcript-walker.mjs
+++ b/scripts/lib/transcript-walker.mjs
@@ -175,29 +175,36 @@ export async function* walkTranscripts({ slugFilter, excludeWorktrees, since } =
   // events (rare, but accurate).
   const transcripts = listTranscripts({ slugFilter, excludeWorktrees })
   for (const t of transcripts) {
-    const stream = fs.createReadStream(t.file, { encoding: 'utf8' })
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
-    for await (const line of rl) {
-      if (!line.trim()) continue
-      let rec
-      try { rec = JSON.parse(line) } catch { continue }
-      const { role, toolName } = classify(rec)
-      if (role === 'skip') continue
-      if (sinceMs && rec.timestamp) {
-        const recMs = new Date(rec.timestamp).getTime()
-        if (Number.isFinite(recMs) && recMs < sinceMs) continue
+    try {
+      const stream = fs.createReadStream(t.file, { encoding: 'utf8' })
+      const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
+      for await (const line of rl) {
+        if (!line.trim()) continue
+        let rec
+        try { rec = JSON.parse(line) } catch { continue }
+        const { role, toolName } = classify(rec)
+        if (role === 'skip') continue
+        if (sinceMs && rec.timestamp) {
+          const recMs = new Date(rec.timestamp).getTime()
+          if (Number.isFinite(recMs) && recMs < sinceMs) continue
+        }
+        const text = extractText(rec)
+        yield {
+          sessionId: t.sessionId,
+          slug: t.slug,
+          file: t.file,
+          ts: rec.timestamp || null,
+          role,
+          toolName,
+          text,
+          raw: rec,
+        }
       }
-      const text = extractText(rec)
-      yield {
-        sessionId: t.sessionId,
-        slug: t.slug,
-        file: t.file,
-        ts: rec.timestamp || null,
-        role,
-        toolName,
-        text,
-        raw: rec,
-      }
+    } catch (err) {
+      process.stderr.write(
+        `transcript-walker: skipping ${t.file} (${err.code || err.name || 'error'}: ${err.message})\n`
+      )
+      continue
     }
   }
 }

--- a/tests/test-transcript-walker.mjs
+++ b/tests/test-transcript-walker.mjs
@@ -188,60 +188,65 @@ fs.utimesSync(readablePath, later, later)
 
 const brokenFiles = new Set()
 const origCreateReadStream = fs.createReadStream
-fs.createReadStream = function patchedCreateReadStream(file, opts) {
-  if (brokenFiles.has(file)) {
-    const err = Object.assign(new Error('mocked permission denied'), { code: 'EACCES' })
-    return new Readable({
-      read() { process.nextTick(() => this.destroy(err)) }
-    })
-  }
-  return origCreateReadStream.call(fs, file, opts)
-}
-
 const origStderrWrite = process.stderr.write.bind(process.stderr)
 let capturedStderr = ''
-process.stderr.write = (chunk, ...rest) => {
-  capturedStderr += typeof chunk === 'string' ? chunk : chunk.toString()
-  return true
+
+// try/finally guards against future top-level failures between patch and
+// restore leaking the monkey-patches into the cleanup section or subsequent
+// test runs (codex code-review FU-1 on cdec66f).
+try {
+  fs.createReadStream = function patchedCreateReadStream(file, opts) {
+    if (brokenFiles.has(file)) {
+      const err = Object.assign(new Error('mocked permission denied'), { code: 'EACCES' })
+      return new Readable({
+        read() { process.nextTick(() => this.destroy(err)) }
+      })
+    }
+    return origCreateReadStream.call(fs, file, opts)
+  }
+
+  process.stderr.write = (chunk, ...rest) => {
+    capturedStderr += typeof chunk === 'string' ? chunk : chunk.toString()
+    return true
+  }
+
+  await tap('#226: walker continues past unreadable file (unreadable-first ordering)', async () => {
+    brokenFiles.clear()
+    brokenFiles.add(unreadablePath)
+    capturedStderr = ''
+    const recs = []
+    for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
+    assert.ok(
+      recs.some((r) => r.sessionId === sidRead),
+      'expected at least one record from readable file after unreadable file was skipped'
+    )
+    assert.ok(
+      !recs.some((r) => r.sessionId === sidUnread),
+      'no records should be attributed to the unreadable file'
+    )
+    assert.match(
+      capturedStderr,
+      new RegExp(`transcript-walker: stopped reading ${unreadablePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+      'stderr should warn about the stopped-reading unreadable file'
+    )
+    assert.match(capturedStderr, /EACCES/, 'stderr should include the error code')
+  })
+
+  await tap('#226: walker handles all-N-unreadable case (zero records, N warnings, no throw)', async () => {
+    brokenFiles.clear()
+    brokenFiles.add(unreadablePath)
+    brokenFiles.add(readablePath)
+    capturedStderr = ''
+    const recs = []
+    for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
+    assert.equal(recs.length, 0, 'expected zero records when all files in slug are unreadable')
+    const warningLines = capturedStderr.split('\n').filter((l) => l.includes('transcript-walker: stopped reading'))
+    assert.equal(warningLines.length, 2, `expected 2 stopped-reading warnings, got ${warningLines.length}: ${capturedStderr}`)
+  })
+} finally {
+  fs.createReadStream = origCreateReadStream
+  process.stderr.write = origStderrWrite
 }
-
-await tap('#226: walker continues past unreadable file (unreadable-first ordering)', async () => {
-  brokenFiles.clear()
-  brokenFiles.add(unreadablePath)
-  capturedStderr = ''
-  const recs = []
-  for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
-  assert.ok(
-    recs.some((r) => r.sessionId === sidRead),
-    'expected at least one record from readable file after unreadable file was skipped'
-  )
-  assert.ok(
-    !recs.some((r) => r.sessionId === sidUnread),
-    'no records should be attributed to the unreadable file'
-  )
-  assert.match(
-    capturedStderr,
-    new RegExp(`transcript-walker: skipping ${unreadablePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-    'stderr should warn about the skipped unreadable file'
-  )
-  assert.match(capturedStderr, /EACCES/, 'stderr should include the error code')
-})
-
-await tap('#226: walker handles all-N-unreadable case (zero records, N warnings, no throw)', async () => {
-  brokenFiles.clear()
-  brokenFiles.add(unreadablePath)
-  brokenFiles.add(readablePath)
-  capturedStderr = ''
-  const recs = []
-  for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
-  assert.equal(recs.length, 0, 'expected zero records when all files in slug are unreadable')
-  const warningLines = capturedStderr.split('\n').filter((l) => l.includes('transcript-walker: skipping'))
-  assert.equal(warningLines.length, 2, `expected 2 skip warnings, got ${warningLines.length}: ${capturedStderr}`)
-})
-
-// Restore patches before cleanup
-fs.createReadStream = origCreateReadStream
-process.stderr.write = origStderrWrite
 
 // --- cleanup ---------------------------------------------------------------
 fs.rmSync(TMP, { recursive: true, force: true })

--- a/tests/test-transcript-walker.mjs
+++ b/tests/test-transcript-walker.mjs
@@ -156,6 +156,93 @@ await tap('sessionSnapshot summarizes a session', async () => {
   assert.equal(snap.cwd, '/Users/test/foo')
 })
 
+// --- #226 regression: per-file fault tolerance under EACCES ---------------
+// Issue #226: one unreadable .jsonl was aborting the entire walk. The fix
+// wraps the per-file stream consumption in try/catch and continues.
+// Determinism: monkey-patch fs.createReadStream to return a stream that
+// emits 'error' on first read (mirrors real EACCES async-error path).
+// Ordering: unreadable BEFORE readable to prove continue-after-error.
+
+const { Readable } = await import('node:stream')
+const slug3 = '-Users-test-projects-eacces-fixture'
+const sidUnread = '33333333-3333-3333-3333-333333333333'
+const sidRead = '44444444-4444-4444-4444-444444444444'
+fs.mkdirSync(path.join(projectsDir, slug3), { recursive: true })
+
+const unreadablePath = path.join(projectsDir, slug3, sidUnread + '.jsonl')
+const readablePath = path.join(projectsDir, slug3, sidRead + '.jsonl')
+
+const readableSession = [
+  { type: 'queue-operation', operation: 'enqueue', timestamp: '2026-05-03T10:00:00Z', sessionId: sidRead, content: 'readable record' },
+  { type: 'assistant', timestamp: '2026-05-03T10:00:01Z', sessionId: sidRead, cwd: '/Users/test/eacces', message: { content: [{ type: 'text', text: 'continued past the unreadable file' }] } },
+]
+// File contents don't matter for unreadablePath because createReadStream is
+// monkey-patched for it; but listTranscripts.statSync requires it to exist.
+fs.writeFileSync(unreadablePath, 'this content is never read because createReadStream is mocked\n')
+fs.writeFileSync(readablePath, readableSession.map((r) => JSON.stringify(r)).join('\n') + '\n')
+// Enforce walk order: unreadable mtime < readable mtime (listTranscripts sorts ascending)
+const earlier = new Date('2026-05-03T09:00:00Z')
+const later = new Date('2026-05-03T11:00:00Z')
+fs.utimesSync(unreadablePath, earlier, earlier)
+fs.utimesSync(readablePath, later, later)
+
+const brokenFiles = new Set()
+const origCreateReadStream = fs.createReadStream
+fs.createReadStream = function patchedCreateReadStream(file, opts) {
+  if (brokenFiles.has(file)) {
+    const err = Object.assign(new Error('mocked permission denied'), { code: 'EACCES' })
+    return new Readable({
+      read() { process.nextTick(() => this.destroy(err)) }
+    })
+  }
+  return origCreateReadStream.call(fs, file, opts)
+}
+
+const origStderrWrite = process.stderr.write.bind(process.stderr)
+let capturedStderr = ''
+process.stderr.write = (chunk, ...rest) => {
+  capturedStderr += typeof chunk === 'string' ? chunk : chunk.toString()
+  return true
+}
+
+await tap('#226: walker continues past unreadable file (unreadable-first ordering)', async () => {
+  brokenFiles.clear()
+  brokenFiles.add(unreadablePath)
+  capturedStderr = ''
+  const recs = []
+  for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
+  assert.ok(
+    recs.some((r) => r.sessionId === sidRead),
+    'expected at least one record from readable file after unreadable file was skipped'
+  )
+  assert.ok(
+    !recs.some((r) => r.sessionId === sidUnread),
+    'no records should be attributed to the unreadable file'
+  )
+  assert.match(
+    capturedStderr,
+    new RegExp(`transcript-walker: skipping ${unreadablePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+    'stderr should warn about the skipped unreadable file'
+  )
+  assert.match(capturedStderr, /EACCES/, 'stderr should include the error code')
+})
+
+await tap('#226: walker handles all-N-unreadable case (zero records, N warnings, no throw)', async () => {
+  brokenFiles.clear()
+  brokenFiles.add(unreadablePath)
+  brokenFiles.add(readablePath)
+  capturedStderr = ''
+  const recs = []
+  for await (const r of walker.walkTranscripts({ slugFilter: 'eacces-fixture' })) recs.push(r)
+  assert.equal(recs.length, 0, 'expected zero records when all files in slug are unreadable')
+  const warningLines = capturedStderr.split('\n').filter((l) => l.includes('transcript-walker: skipping'))
+  assert.equal(warningLines.length, 2, `expected 2 skip warnings, got ${warningLines.length}: ${capturedStderr}`)
+})
+
+// Restore patches before cleanup
+fs.createReadStream = origCreateReadStream
+process.stderr.write = origStderrWrite
+
 // --- cleanup ---------------------------------------------------------------
 fs.rmSync(TMP, { recursive: true, force: true })
 


### PR DESCRIPTION
## Summary

- Fixes #226 — one unreadable `.jsonl` (root-owned, mode 600 from a sudo'd `claude` invocation) was aborting the entire mining/audit walk via uncaught EACCES.
- Wraps `walkTranscripts()` per-file body in try/catch around the `for await` consumption; on error, writes `stopped reading <file>` warning to stderr and continues.
- Wording is "stopped reading" not "skipping" — pre-error yielded records (mid-read errors like EIO) are not rolled back; the new wording is honest about that.
- Tests use `fs.createReadStream` monkey-patch (deterministic, platform-stable — avoids chmod flakiness under root). Two cases: unreadable-FIRST + readable-second; all-N-unreadable.
- Manual smoke (`scratch/smoke-issue-226.sh`, gitignored) verifies `em-mine-transcripts --output` from a non-repo cwd + `em-audit-compliance` shared-consumer tolerance with `chmod 000` transcript.

## Commits

- `cdec66f` — initial fix (code + 2 new tests)
- `955cc5b` — folded codex code-review FUs (try/finally test isolation + partial-yield wording honesty)

## Codex review trail (consensus reached)

- Plan R1 (HOLD, 3 findings): `20260511-125925-…-a625` → all folded
- Plan R2 (ACCEPT-with-FU): `20260511-130406-…-8c0c` → chmod-for-subprocess clarification folded into final plan
- Code R1 (ACCEPT-with-FU): `20260511-131454-…-4c90` → 2 FUs folded inline in commit `955cc5b`
- Code R2 (**ACCEPT, no findings**): `20260511-132030-…-e8df`

## Test plan

- [x] `node tests/test-transcript-walker.mjs` → 13/13 (11 existing + 2 new)
- [x] `bash scratch/smoke-issue-226.sh` → all checks pass (em-mine-transcripts + em-audit-compliance)
- [ ] Reviewer to approve in UI (Rule 17 user-approval gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
