### PR TITLE
fix(claude-subagent): propagate CLAUDE_SCHEDULED_TASK=1 to child env (#232)

### DIFF
--- a/scripts/second-opinion/providers/claude-subagent.mjs
+++ b/scripts/second-opinion/providers/claude-subagent.mjs
@@ -56,11 +56,17 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
   // version; safest portable pattern is `claude -p <prompt>` for
   // single-shot non-interactive runs. For subagent dispatch specifically,
   // use the `--agent` or task-tool surface; v1 keeps it simple as `-p`.
+  //
+  // CLAUDE_SCHEDULED_TASK=1 (issue #232): the child `claude` invocation
+  // must skip the operator's SessionStart hook. Without this override the
+  // hook's blocking directive prepends to the child's first turn and
+  // hijacks the review prompt. Same env-propagation class as #224.
   const result = spawnSync(binary, ['-p', prompt], {
     cwd: projectRoot,
     shell: false,
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout,
+    env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' },
   })
 
   return {

--- a/tests/test-claude-subagent-env-propagation.mjs
+++ b/tests/test-claude-subagent-env-propagation.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * test-claude-subagent-env-propagation.mjs — Issue #232 regression test.
+ *
+ * Invariants (from plan):
+ *   I-232a: dispatch() forces CLAUDE_SCHEDULED_TASK=1 into child env
+ *           regardless of parent state.
+ *   I-232b: dispatch() preserves inherited env (PATH/HOME/auth).
+ *   I-232c: child runs with PWD === projectRoot even when caller cwd
+ *           differs; no side-effect dirs leak under caller cwd.
+ *
+ * Strategy: install a `claude` shim in a test-controlled PATH dir, point
+ * dispatch at a different `projectRoot`, run it from a third `callerDir`,
+ * and verify the shim's stdout matches the invariants.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PROVIDER_PATH = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers', 'claude-subagent.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+async function asyncTest(name, fn) {
+  try {
+    await fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+console.log('# test-claude-subagent-env-propagation (issue #232)')
+
+await asyncTest('dispatch propagates CLAUDE_SCHEDULED_TASK=1 + cwd binding + no side-effect leaks', async () => {
+  // Step 1: mkdtemp three dirs; realpath each immediately (macOS /var ↔
+  // /private/var neutralization).
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-232-bin-')))
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-232-proj-')))
+  const callerDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-232-caller-')))
+
+  // Step 3: save originals so finally can restore.
+  const originalPath = process.env.PATH
+  const originalScheduled = process.env.CLAUDE_SCHEDULED_TASK
+  const originalCwd = process.cwd()
+
+  try {
+    // Step 2: write narrow shim. 3 echoes only — no full `env` dump
+    // (avoids secret leak in CI failure logs per codex round-1).
+    const shimPath = path.join(binDir, 'claude')
+    fs.writeFileSync(
+      shimPath,
+      '#!/bin/sh\n' +
+      'echo "CLAUDE_SCHEDULED_TASK=${CLAUDE_SCHEDULED_TASK}"\n' +
+      'echo "PWD=$(pwd)"\n' +
+      'echo "PATH=${PATH}"\n',
+      { mode: 0o755 }
+    )
+
+    // Step 1 (cont): chdir to callerDir so caller cwd ≠ projectRoot.
+    process.chdir(callerDir)
+
+    // Step 4: regression-state parent env. binDir on PATH so the child
+    // `claude` resolves to the shim; CLAUDE_SCHEDULED_TASK explicitly
+    // unset so the test starts from the bug's actual parent-env shape.
+    process.env.PATH = binDir + path.delimiter + originalPath
+    delete process.env.CLAUDE_SCHEDULED_TASK
+
+    // Step 5: pre-condition negative spawn. Direct spawn of the shim
+    // (no dispatch) must show CLAUDE_SCHEDULED_TASK is empty in the
+    // parent env. Guards against any layer leaking the var and making
+    // this test a vacuous pass.
+    const preCheck = spawnSync('claude', [], {
+      env: process.env,
+      cwd: callerDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    assert.strictEqual(preCheck.status, 0,
+      `pre-check shim failed: ${preCheck.stderr?.toString()}`)
+    assert.match(preCheck.stdout.toString(), /^CLAUDE_SCHEDULED_TASK=\s*$/m,
+      `pre-condition vacuous-pass guard: expected empty CLAUDE_SCHEDULED_TASK in parent env, ` +
+      `got stdout=${JSON.stringify(preCheck.stdout.toString())}`)
+
+    // Step 6: import provider + dispatch.
+    const mod = await import(`${pathToFileURL(PROVIDER_PATH).href}?cb=${Date.now()}`)
+    const result = mod.dispatch({ prompt: 'x', projectRoot: projectDir })
+    assert.strictEqual(result.exitCode, 0,
+      `dispatch exit code: expected 0, got ${result.exitCode} stderr=${result.stderr}`)
+
+    // Step 7: I-232a — env override.
+    assert.match(result.stdout, /^CLAUDE_SCHEDULED_TASK=1$/m,
+      `I-232a: expected CLAUDE_SCHEDULED_TASK=1 in child env, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // Step 8: I-232c — cwd binding via realpath comparison (macOS
+    // /var vs /private/var divergence per codex round 2).
+    const pwdMatch = result.stdout.match(/^PWD=(.+)$/m)
+    assert.ok(pwdMatch, `I-232c: expected PWD=<value> line in stdout`)
+    const childPwdReal = fs.realpathSync(pwdMatch[1])
+    const projectDirReal = fs.realpathSync(projectDir)
+    assert.strictEqual(childPwdReal, projectDirReal,
+      `I-232c: child PWD must equal projectRoot (realpath). ` +
+      `child=${childPwdReal} expected=${projectDirReal}`)
+
+    // Step 9: I-232b — PATH propagation.
+    assert.match(result.stdout, new RegExp(`^PATH=.*${escapeRegex(binDir)}`, 'm'),
+      `I-232b: expected binDir on child PATH, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // Step 10: side-effect leak. No artifact dirs under callerDir.
+    const leakNames = ['.review-store', '.episodic-memory', '.checkpoints']
+    const callerContents = fs.readdirSync(callerDir)
+    const leaked = callerContents.filter((n) => leakNames.includes(n))
+    assert.deepStrictEqual(leaked, [],
+      `I-232c: expected no side-effect dirs under callerDir, found ${JSON.stringify(leaked)}`)
+  } finally {
+    // Step 11: restore env, cwd, fixtures.
+    process.chdir(originalCwd)
+    process.env.PATH = originalPath
+    if (originalScheduled === undefined) {
+      delete process.env.CLAUDE_SCHEDULED_TASK
+    } else {
+      process.env.CLAUDE_SCHEDULED_TASK = originalScheduled
+    }
+    try { fs.rmSync(binDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(projectDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(callerDir, { recursive: true, force: true }) } catch {}
+  }
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Fix: `scripts/second-opinion/providers/claude-subagent.mjs` now passes `env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' }` to `spawnSync`, so child `claude` invocations skip the operator's SessionStart hook and don't get hijacked by a blocking discipline-load directive.
- Test: new `tests/test-claude-subagent-env-propagation.mjs` (151 LOC, zero deps) uses a PATH-shadowed shim to verify I-232a (env override), I-232b (PATH propagation), and I-232c (cwd binding via realpath compare; no `.review-store`/`.episodic-memory`/`.checkpoints` leak under caller cwd).
- Regression class: same env-propagation shape as #224, but scoped to the harness's own provider.

Closes #232.

## Context

Surfaced today after PR #229's two-phase SessionStart hook extension. The new hook always emits a Phase 2 discipline-load directive even when no `session_handoff.md` exists. That made any non-interactive `claude` spawn lacking `CLAUDE_SCHEDULED_TASK=1` get blocked, where previously dormant projects silently passed. Codex's impl review of PR #229 ACCEPTed the hook because its probe matrix scoped to the hook itself — not its consumers. User caught it post-merge with the right question: "has this impact when there is a session installed via routines or agents?"

## Review trail

- **Plan review (3 rounds)** — `scratch/plan-issue-232.md`
  - Round 1: HOLD — test missing cwd-binding invariant; full-env dump risked secret leak in failure logs.
  - Round 2: HOLD — raw `PWD === projectRoot` non-portable on macOS (`/var` ↔ `/private/var`).
  - Round 3: **ACCEPT.** All 4 invariants verified locally verifiable; cwd-binding repro executed.
- **Diff code review** — codex via harness, **ACCEPT-with-FU**. Both findings sub-3-LOC same-surface → applied inline (mode-bit revert; `pathToFileURL` for dynamic import).
- **Live E2E probe** — `--provider claude-subagent` dispatch returned a real review of trivial `add(a, b)` content (not a SessionStart blocking directive), confirming the hijack is closed in the real-CLI path.

## Test plan

- [x] `node tests/test-claude-subagent-env-propagation.mjs` → 1 passed, 0 failed.
- [x] Negative scenario: temporary revert of fix → 1 failed on I-232a (exactly the regression shape) → re-applied fix → green again.
- [x] `node tests/test-second-opinion-providers.mjs` → 16 passed, 0 failed (no sibling regression).
- [x] Live E2E: `node scripts/second-opinion.mjs request --provider claude-subagent --dispatch …` returned a real review reply, not the SessionStart directive.
- [x] Install snapshot refreshed (`node install.mjs --tool claude-code --install-second-opinion`) — new `source_hash: 757dec0a…`.

## Out of scope

- #224 broader class (Claude Code's internal Agent tool subagent dispatch) — tracked under workplan rank 1j.
- Hook itself — workplan v45 explicitly says no revert; two-phase behavior is intentional for session-start discipline-load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
