### PR TITLE
feat(preflight-gate): Layer D narrow PR1 — codex-review-handoff enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ node_modules/
 .claude/.plan-approval-pending
 .claude/.session-baseline
 .claude/settings.local.json
+.claude/settings.local.json.bak.*
+# .claude/settings.json is per-user (contains hardcoded SessionStart hook
+# paths and per-developer permissions allowlists). The helper allowlist for
+# the preflight gate is documented in bundles/codex-review-channel-current.md.
+.claude/settings.json
+.claude/settings.json.bak.*
 
 # Per-session scratch (mining staging, codex requests/replies, etc.)
 .claude/scratch/

--- a/bundles/codex-review-channel-current.md
+++ b/bundles/codex-review-channel-current.md
@@ -1,0 +1,171 @@
+# Codex review channel — current canonical bundle
+
+**Bundle version:** 1
+**Generated:** 2026-05-12 (manual; regenerate when component sha256 drifts)
+**Claim class:** `codex-review-handoff`
+**Gated by:** `hooks/preflight-gate.sh`
+
+This bundle declares the canonical reading list an agent MUST load before
+issuing any codex review handoff (em-store / em-revise / em-violation with
+codex-review tags, `codex exec|review`, second-opinion harness, or
+Agent dispatch with `codex:*|negative-scenario-*` subagent_type).
+
+The pre-flight gate requires the agent's `.checkpoints/.preflight-done`
+marker to:
+
+1. List THIS bundle file in `required_files`.
+2. Include each component listed below in `loaded_files` with the current
+   sha256 + mtime_ms from disk.
+3. Declare `claim_class = "codex-review-handoff"`.
+4. Bind to the current `session_id` + `prompt_sha256`.
+
+## Per-user settings allowlist
+
+The helper script `scripts/preflight-marker-write.mjs` is invoked via `Bash`.
+To avoid Claude Code's permission prompt on each invocation, add this to
+`.claude/settings.json` or `.claude/settings.local.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(node */scripts/preflight-marker-write.mjs --root *)",
+      "Bash(node */preflight-marker-write.mjs --root *)"
+    ]
+  }
+}
+```
+
+Note: `.claude/settings.json` is gitignored in this repo (per-user file with
+machine-specific paths). Each developer adds the allowlist locally. The
+gate enforces helper-only writes regardless of allowlist state — the
+allowlist only controls Claude Code's prompt UI.
+
+## How to load (agent recipe)
+
+```bash
+# 1. Resolve memory_root (Cause 7 — see Plan §"Memory-root validation"):
+#    Either read .episodic-memory/config.json:claude_memory_root OR compute
+#    ~/.claude/projects/<sanitized-cwd>/memory.
+
+# 2. For each component below, Read the file from <memory_root>/<basename>.
+
+# 3. Compute current sha256 + mtime_ms for each loaded file.
+
+# 4. Construct marker JSON (see schema below) and write atomically:
+echo '<JSON>' | node $REPO_ROOT/scripts/preflight-marker-write.mjs \
+  --root $REPO_ROOT --target preflight
+```
+
+## Components (7 files)
+
+The basenames + the **bundle-recorded** sha256 are listed below. The pre-flight
+gate validates against ACTUAL disk sha256 at gate time, not these recorded
+values — a recorded-vs-disk mismatch here is a bundle-staleness issue
+(regenerate this file), not a security issue.
+
+| # | Basename | Role | Recorded sha256 (2026-05-12) |
+|---|---|---|---|
+| 1 | `reference_codex_review_flow.md` | Canonical 5-step flow (manual fallback) | `341cd798d4646a146beb7e06e50c2cc3f6b68e9fb4168fe74b0330bcaa895eeb` |
+| 2 | `feedback_codex_cli_episode_messaging.md` | Foreground-only rule + auto-background mitigation | `e39f9117c14c8264aba5c6c7e44622eec82a6a32c590bcb0e5f3df7b9beb800d` |
+| 3 | `feedback_subagent_cli_episode_messaging.md` | Both halves go through episodes | `8830b3e6245c4a32cffd1e907ee922fba44e7f919376e0ef5e586e77fcdb3b1f` |
+| 4 | `feedback_canonical_agent_dispatch_trigger.md` | Trigger-phrase set | `a5f40e8f218b074fc8dd37551e998a0e0e7340076f3ff2bc77296db62bc60ec4` |
+| 5 | `feedback_codex_review_request_preamble.md` | Canonical 7-section preamble (review-ladder) | `cf41fef47178932c299ab4cc30cb6342867cdaed1a4a055f32d5b433e9ec98b3` |
+| 6 | `feedback_second_opinion_harness_runbook.md` | Operator runbook (timeout, HOLD discipline) | `a33a5ea246a712f4ccf37590a6a0e911495b4a1d10b4b5b8b793c87dd2acff1c` |
+| 7 | `reference_second_opinion_harness.md` | Harness design reference (canonical channel) | `860372ea1f92cc6cb434c0a419a93913b76ad4d53a0084db53a02dd7ccbc08b5` |
+
+Components 6 and 7 added in this PR1 bundle (codex r1 FU-3) — without them,
+stale "manual 5-step recipe" knowledge could pass the gate while bypassing
+the harness, which is now the canonical channel.
+
+## Marker schema
+
+```json
+{
+  "session_id": "...",
+  "transcript_path": "...",
+  "prompt_sha256": "...",
+  "prompt_index": 42,
+  "cwd": "...",
+  "repo_root": "...",
+  "memory_root": "...",
+  "claim_class": "codex-review-handoff",
+  "matched_triggers": {
+    "tool_target": ["Bash:em-store --tags codex-review", "Bash:codex exec"],
+    "prompt_phrase": ["second opinion"]
+  },
+  "required_files": [
+    "<repo>/bundles/codex-review-channel-current.md",
+    "<memory_root>/reference_codex_review_flow.md",
+    "<memory_root>/feedback_codex_cli_episode_messaging.md",
+    "<memory_root>/feedback_subagent_cli_episode_messaging.md",
+    "<memory_root>/feedback_canonical_agent_dispatch_trigger.md",
+    "<memory_root>/feedback_codex_review_request_preamble.md",
+    "<memory_root>/feedback_second_opinion_harness_runbook.md",
+    "<memory_root>/reference_second_opinion_harness.md"
+  ],
+  "loaded_files": [
+    {"path": "<abs-path>", "mtime_ms": 1746735000000, "sha256": "..."}
+  ],
+  "artifact_steps_done": ["memory-pre-pass", "channel-discipline-note", "work-area-tags"],
+  "created_at_ms": 1746735000000
+}
+```
+
+## Machine-readable component manifest
+
+The block below is the source of truth for bundle composition. Tooling MAY
+parse this JSON to enumerate components programmatically. Keep prose table
+above in sync.
+
+```json:bundle-manifest
+{
+  "version": 1,
+  "generated_at_ms": 1747022400000,
+  "components": [
+    {
+      "basename": "reference_codex_review_flow.md",
+      "sha256": "341cd798d4646a146beb7e06e50c2cc3f6b68e9fb4168fe74b0330bcaa895eeb",
+      "role": "canonical-5-step-flow"
+    },
+    {
+      "basename": "feedback_codex_cli_episode_messaging.md",
+      "sha256": "e39f9117c14c8264aba5c6c7e44622eec82a6a32c590bcb0e5f3df7b9beb800d",
+      "role": "foreground-only-rule"
+    },
+    {
+      "basename": "feedback_subagent_cli_episode_messaging.md",
+      "sha256": "8830b3e6245c4a32cffd1e907ee922fba44e7f919376e0ef5e586e77fcdb3b1f",
+      "role": "episode-messaging-contract"
+    },
+    {
+      "basename": "feedback_canonical_agent_dispatch_trigger.md",
+      "sha256": "a5f40e8f218b074fc8dd37551e998a0e0e7340076f3ff2bc77296db62bc60ec4",
+      "role": "trigger-phrase-set"
+    },
+    {
+      "basename": "feedback_codex_review_request_preamble.md",
+      "sha256": "cf41fef47178932c299ab4cc30cb6342867cdaed1a4a055f32d5b433e9ec98b3",
+      "role": "canonical-preamble"
+    },
+    {
+      "basename": "feedback_second_opinion_harness_runbook.md",
+      "sha256": "a33a5ea246a712f4ccf37590a6a0e911495b4a1d10b4b5b8b793c87dd2acff1c",
+      "role": "operator-runbook"
+    },
+    {
+      "basename": "reference_second_opinion_harness.md",
+      "sha256": "860372ea1f92cc6cb434c0a419a93913b76ad4d53a0084db53a02dd7ccbc08b5",
+      "role": "harness-design-reference"
+    }
+  ]
+}
+```
+
+## Codex consensus chain (provenance)
+
+This bundle composition was negotiated across 5 codex review rounds 2026-05-12:
+
+- r1 ACCEPT-with-FU `20260512-070738-...-ed24` — codex caught that runbook + harness ref were missing (FU-3).
+- r2-r4 HOLD chain on canonicalization + atomicity contracts.
+- r5 ACCEPT `20260512-072545-...-dbf6` — bundle composition + helper-only contract converged.

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1512,6 +1512,50 @@ _classify_preflight_segment() {
     return 0
   fi
 
+  # Special-case: env -S "<command-string>" or env --split-string "<cmd>"
+  # treats the argument as a command vector to execute (GNU coreutils env
+  # `-S/--split-string` semantics). Codex r5 finding `...729a`. Detect
+  # before generic unwrap consumes -S as a regular arg-taking flag.
+  if [ $n -ge 3 ] && [ "${T[0]}" = "env" ]; then
+    local _envk=1
+    while [ $_envk -lt $n ]; do
+      local _envt="${T[$_envk]}"
+      case "$_envt" in
+        -S|--split-string)
+          local _envinner="${T[$((_envk+1))]:-}"
+          if [ -n "$_envinner" ]; then
+            classify_preflight_command "$_envinner" "$_repo_root"
+            return 0
+          fi
+          break
+          ;;
+        --split-string=*)
+          local _envinner="${_envt#*=}"
+          if [ -n "$_envinner" ]; then
+            classify_preflight_command "$_envinner" "$_repo_root"
+            return 0
+          fi
+          break
+          ;;
+        # `-S` may appear inside a short-opt cluster: -vS, -iS, etc.
+        -*S*)
+          case "$_envt" in
+            --*) _envk=$((_envk+1)); continue ;;
+          esac
+          local _envinner="${T[$((_envk+1))]:-}"
+          if [ -n "$_envinner" ]; then
+            classify_preflight_command "$_envinner" "$_repo_root"
+            return 0
+          fi
+          break
+          ;;
+        -*) _envk=$((_envk+1)) ;;
+        *=*) _envk=$((_envk+1)) ;;
+        *) break ;;
+      esac
+    done
+  fi
+
   local i
   i="$(_preflight_unwrap_index 0 "${T[@]}")"
   if [ $i -ge $n ]; then

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1228,7 +1228,13 @@ classify_path() {
 
 # Wrapper-utility prefixes that may precede the real command verb. Same set
 # the existing classifier handles for bash -c / env / sudo / nohup / timeout.
-_PREFLIGHT_WRAPPERS_RE='^(env|command|sudo|doas|nohup|timeout|stdbuf|nice|chrt|ionice|setsid|exec)$'
+_PREFLIGHT_WRAPPERS_RE='^(env|command|sudo|doas|nohup|timeout|stdbuf|nice|chrt|ionice|setsid|exec|systemd-run|flatpak-spawn)$'
+
+# Two-word command runners: verb + fixed subcommand consume index; rest of
+# loop unwraps wrapper flags. Codex r3 finding `...bd73`. Patterns:
+#   uv run CMD | poetry run CMD | pixi run CMD | direnv exec DIR CMD
+#   nix develop -c CMD | nix shell -c CMD
+_PREFLIGHT_RUNNERS_RE='^(uv|poetry|pixi|direnv|nix)$'
 
 # Tag-name fragments that, when found in --tag/--tags/--summary args, mark
 # an em-* invocation as a codex-review handoff.
@@ -1249,35 +1255,128 @@ _preflight_unwrap_index() {
   local n=${#T[@]}
   while [ $i -lt $n ]; do
     local t="${T[$i]}"
+    local wrapper=""
+
+    # Two-word runner detection (uv run, poetry run, pixi run, direnv exec,
+    # nix develop -c, nix shell -c). Codex r3 finding `...bd73`.
+    if [[ "$t" =~ $_PREFLIGHT_RUNNERS_RE ]] && [ $((i+1)) -lt $n ]; then
+      local sub="${T[$((i+1))]}"
+      case "$t" in
+        uv|poetry|pixi)
+          if [ "$sub" = "run" ]; then
+            wrapper="$t-run"
+            i=$((i+2))
+          fi
+          ;;
+        direnv)
+          if [ "$sub" = "exec" ]; then
+            wrapper="direnv-exec"
+            i=$((i+2))
+            # direnv exec DIR CMD — consume DIR positional.
+            if [ $i -lt $n ]; then i=$((i+1)); fi
+          fi
+          ;;
+        nix)
+          if [ "$sub" = "develop" ] || [ "$sub" = "shell" ]; then
+            wrapper="nix-$sub"
+            i=$((i+2))
+            # nix develop|shell -c CMD — find -c, then advance past it
+            # so CMD becomes the verb. If no -c found, this isn't the
+            # bypass shape; let the outer loop break naturally.
+            while [ $i -lt $n ]; do
+              local nt="${T[$i]}"
+              if [ "$nt" = "-c" ]; then
+                i=$((i+1))
+                break
+              fi
+              case "$nt" in
+                -*) i=$((i+1)) ;;
+                *)  break ;;
+              esac
+            done
+          fi
+          ;;
+      esac
+      if [ -n "$wrapper" ]; then
+        # Skip remaining wrapper flags (rare but possible after the
+        # subcommand).
+        while [ $i -lt $n ]; do
+          local w="${T[$i]}"
+          case "$w" in
+            *=*) i=$((i+1)) ;;
+            -*)  i=$((i+1)) ;;
+            *)   break ;;
+          esac
+        done
+        continue
+      fi
+    fi
+
     if [[ "$t" =~ $_PREFLIGHT_WRAPPERS_RE ]]; then
-      local wrapper="$t"
+      wrapper="$t"
       i=$((i+1))
       # Per-wrapper short-opt set that takes an ARGUMENT in the next token.
-      # P1 fix from codex PR-level review round 2 (`...cbc2`): without per-
-      # wrapper arg-arity, `sudo -u root codex exec foo` consumed `root` as
-      # the positional verb and matched none.
+      # P1 fix from codex PR-level review round 2 (`...cbc2`).
       local arg_re=''
+      # Per-wrapper LONG-opt set that takes an ARGUMENT in the next token
+      # (when in `--key value` form, not `--key=value`). Codex r3 finding
+      # `...bd73` rejected the deferral.
+      local long_arg_re=''
       case "$wrapper" in
-        sudo|doas)  arg_re='^-[ugCDHRTpAB]$' ;;
-        timeout)    arg_re='^-[ks]$' ;;
-        nice)       arg_re='^-n$' ;;
-        ionice)     arg_re='^-[cnpt]$' ;;
-        env)        arg_re='^-[uS]$' ;;
-        stdbuf)     arg_re='^-[ioe]$' ;;
-        exec)       arg_re='^-a$' ;;
-        chrt)       arg_re='^-[pP]$' ;;
-        nohup|command|setsid|stdbuf) arg_re='' ;;
+        sudo|doas)
+          arg_re='^-[ugCDHRTpAB]$'
+          long_arg_re='^--(user|group|close-from|host|prompt|runas-uid|runas-gid|chdir|chroot)$'
+          ;;
+        timeout)
+          arg_re='^-[ks]$'
+          long_arg_re='^--(kill-after|signal)$'
+          ;;
+        nice)
+          arg_re='^-n$'
+          long_arg_re='^--adjustment$'
+          ;;
+        ionice)
+          arg_re='^-[cnpt]$'
+          long_arg_re='^--(class|classdata|pid|pgrp|uid)$'
+          ;;
+        env)
+          arg_re='^-[uS]$'
+          long_arg_re='^--(unset|split-string|chdir)$'
+          ;;
+        stdbuf)
+          arg_re='^-[ioe]$'
+          long_arg_re='^--(input|output|error)$'
+          ;;
+        exec)
+          arg_re='^-a$'
+          long_arg_re='^--argv0$'
+          ;;
+        chrt)
+          arg_re='^-[pP]$'
+          long_arg_re='^--(pid|sched-runtime|sched-deadline|sched-period)$'
+          ;;
+        systemd-run)
+          arg_re='^-[uGtMpES]$'
+          long_arg_re='^--(unit|user|machine|property|setenv|description|slice|on-active|on-boot|on-startup|on-unit-active|on-unit-inactive|on-calendar|service-type|exec-directory|state-directory|cache-directory|logs-directory|configuration-directory|working-directory|gid|uid|nice)$'
+          ;;
+        flatpak-spawn)
+          arg_re=''
+          long_arg_re='^--(env|directory|forward-fd)$'
+          ;;
       esac
-      # Skip env-style assignments, short options, and per-wrapper option
-      # arguments. Long-opt `--key value` form residual gap (filed if seen);
-      # `--key=value` form is already handled (contains `=`).
       while [ $i -lt $n ]; do
         local w="${T[$i]}"
         case "$w" in
           *=*) i=$((i+1)) ;;
+          --*)
+            if [ -n "$long_arg_re" ] && [[ "$w" =~ $long_arg_re ]]; then
+              i=$((i+2))
+            else
+              i=$((i+1))
+            fi
+            ;;
           -*)
             if [ -n "$arg_re" ] && [[ "$w" =~ $arg_re ]]; then
-              # Consume flag + its argument.
               i=$((i+2))
             else
               i=$((i+1))
@@ -1286,14 +1385,12 @@ _preflight_unwrap_index() {
           *)   break ;;
         esac
       done
-      # Wrappers that take a single positional argument BEFORE the command
-      # to wrap. `timeout DURATION CMD` — DURATION is positional, distinct
-      # from `-k DURATION` and `-s SIGNAL` (already consumed via arg_re).
+      # Wrappers with a positional BEFORE the command to wrap.
       case "$wrapper" in
         timeout)
-          if [ $i -lt $n ]; then
-            i=$((i+1))
-          fi
+          # `timeout DURATION CMD` — DURATION is positional, distinct from
+          # `-k DURATION` and `-s SIGNAL` (consumed via arg_re/long_arg_re).
+          if [ $i -lt $n ]; then i=$((i+1)); fi
           ;;
       esac
     else

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1331,24 +1331,86 @@ classify_preflight_command() {
     return 0
   fi
 
-  # Collect token texts in order
-  local -a T=()
+  # Walk segments separated by control operators (; && || | & NL). Per
+  # segment, run the classifier inner; if ANY segment matches a preflight
+  # claim class, the whole command does. P1 fix for bash-chain bypass
+  # (`echo ok; codex exec foo`, `true && codex exec`, etc.) caught by codex
+  # PR-level review 2026-05-12.
+  local -a SEG=()
   local line
+  local matched_class="" matched_trigger="" matched_detail=""
+  _classify_seg_and_check() {
+    if [ ${#SEG[@]} -eq 0 ]; then return 0; fi
+    local seg_result
+    seg_result="$(_classify_preflight_segment "$_repo_root" "${SEG[@]}")"
+    local seg_class="${seg_result%%	*}"
+    if [ "$seg_class" != "none" ] && [ -z "$matched_class" ]; then
+      matched_class="$seg_class"
+      local rest="${seg_result#*	}"
+      matched_trigger="${rest%%	*}"
+      matched_detail="${rest#*	}"
+    fi
+  }
   while IFS= read -r line; do
     case "$line" in
-      "T "*) T+=("${line:2}") ;;
+      "T "*) SEG+=("${line:2}") ;;
+      "O &&"|"O ||"|"O ;"|"O ;;"|"O |"|"O |&"|"O &"|"O NL")
+        _classify_seg_and_check
+        SEG=()
+        ;;
     esac
   done <<< "$stream"
+  _classify_seg_and_check
+
+  if [ -n "$matched_class" ]; then
+    printf '%s\t%s\t%s\n' "$matched_class" "$matched_trigger" "$matched_detail"
+    return 0
+  fi
+  printf '%s\t%s\t%s\n' "none" "" "no_match"
+  return 0
+}
+
+# _classify_preflight_segment <repo-root> <token1> <token2> ...
+# Per-segment classifier. Returns claim-class<TAB>trigger<TAB>detail.
+# Extracted from classify_preflight_command's body so segments separated by
+# control operators each get classified.
+_classify_preflight_segment() {
+  local _repo_root="$1"
+  shift
+  local -a T=("$@")
+  local n=${#T[@]}
+  if [ $n -eq 0 ]; then
+    printf '%s\t%s\t%s\n' "none" "" "empty_segment"
+    return 0
+  fi
 
   local i
   i="$(_preflight_unwrap_index 0 "${T[@]}")"
-  local n=${#T[@]}
   if [ $i -ge $n ]; then
     printf '%s\t%s\t%s\n' "none" "" "empty_after_unwrap"
     return 0
   fi
 
   local verb="${T[$i]}"
+
+  # Strip leading subshell-open / brace-group / parenthesis tokens. The
+  # tokenizer emits `(` / `{` as standalone T tokens; we treat them as
+  # transparent for verb detection. P1 fix for `( codex exec foo )` bypass.
+  while [ $i -lt $n ]; do
+    case "${T[$i]}" in
+      '('|'{')
+        i=$((i+1))
+        # Re-run unwrap after stripping the open paren/brace.
+        i="$(_preflight_unwrap_index $i "${T[@]}")"
+        verb="${T[$i]:-}"
+        ;;
+      *) break ;;
+    esac
+  done
+  if [ -z "$verb" ]; then
+    printf '%s\t%s\t%s\n' "none" "" "empty_after_subshell_strip"
+    return 0
+  fi
 
   # Direct codex CLI
   if [ "$verb" = "codex" ]; then
@@ -1362,11 +1424,6 @@ classify_preflight_command() {
   fi
 
   # Shell wrapper with -c <cmd>: recurse into the inner command string.
-  # bash/sh/zsh/dash/ash/ksh + -c <CMD> executes CMD; verb of CMD is what
-  # matters. Distinct from env/sudo (which already had wrapper-unwrap).
-  # F4 fix: also recognize short-opt clusters containing `c` like `-lc`,
-  # `-il`, `-ci` — bash treats them as `-l` + `-c` etc. with the command
-  # arg following the cluster.
   case "$verb" in
     bash|sh|zsh|dash|ash|ksh)
       local k=$((i+1))
@@ -1374,11 +1431,8 @@ classify_preflight_command() {
         local kt="${T[$k]}"
         case "$kt" in
           -c|-*c*)
-            # -c exactly OR short-opt cluster containing 'c' (excluding
-            # long opts like --color). Long opts handled by the catch-all
-            # below.
             case "$kt" in
-              --*) k=$((k+1)); continue ;;  # long opts: skip
+              --*) k=$((k+1)); continue ;;
             esac
             local inner="${T[$((k+1))]:-}"
             if [ -n "$inner" ]; then
@@ -1397,7 +1451,6 @@ classify_preflight_command() {
   # node|npx invocation of em-* or second-opinion script
   case "$verb" in
     node|npx)
-      # Find the script arg (next non-flag token)
       local j=$((i+1))
       while [ $j -lt $n ]; do
         local t="${T[$j]}"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1209,3 +1209,304 @@ classify_path() {
   printf '%s\t\t%s\n' "shared_write" "path_default"
   return 0
 }
+
+# ---------------------------------------------------------------------------
+# Layer D pre-flight classifier siblings (PR1 enforces codex-review-handoff
+# only; other claim classes registered for shape but not enforced).
+#
+# Output format: claim-class<TAB>trigger<TAB>match-detail
+#   claim-class:   codex-review-handoff | rule-bearing-file-edit |
+#                  adversarial-code-review | plan-time-matrix |
+#                  scratch-files | wrap-up-discipline | none
+#   trigger:       tool_target | prompt_phrase | (empty for none)
+#   match-detail:  short identifier of the rule that fired
+#
+# Sibling to classify_command / classify_path; reuses _tokenize internally.
+#
+# Codex consensus chain: r1 ACCEPT-with-FU `...ed24` → r5 ACCEPT `...dbf6`.
+# ---------------------------------------------------------------------------
+
+# Wrapper-utility prefixes that may precede the real command verb. Same set
+# the existing classifier handles for bash -c / env / sudo / nohup / timeout.
+_PREFLIGHT_WRAPPERS_RE='^(env|command|sudo|doas|nohup|timeout|stdbuf|nice|chrt|ionice|setsid|exec)$'
+
+# Tag-name fragments that, when found in --tag/--tags/--summary args, mark
+# an em-* invocation as a codex-review handoff.
+_PREFLIGHT_REVIEW_TAG_RE='codex|review|second-opinion|plan-review|code-review|cross-tool-review|meta-review'
+
+# em-* CLI verbs that route review traffic. Bare names AND `node */<name>.mjs`
+# AND `npx <name>` AND plugin-script forms all classified.
+_PREFLIGHT_EM_VERBS_RE='^(em-store|em-revise|em-violation)(\.mjs)?$'
+
+# _preflight_unwrap_index — emit (to stdout) the index past wrapper-utility
+# prefix tokens. Args: $1 = start_index; $2..$N = all tokens.
+# Bash 3.2-compatible (no namerefs); same calling convention as existing
+# _classify_git in this file.
+_preflight_unwrap_index() {
+  local i=$1
+  shift
+  local -a T=("$@")
+  local n=${#T[@]}
+  while [ $i -lt $n ]; do
+    local t="${T[$i]}"
+    if [[ "$t" =~ $_PREFLIGHT_WRAPPERS_RE ]]; then
+      local wrapper="$t"
+      i=$((i+1))
+      # Skip env-style assignments and short options.
+      while [ $i -lt $n ]; do
+        local w="${T[$i]}"
+        case "$w" in
+          *=*) i=$((i+1)) ;;
+          -*)  i=$((i+1)) ;;
+          *)   break ;;
+        esac
+      done
+      # Wrappers that take a single positional argument BEFORE the command
+      # to wrap (timeout DURATION, nice may use -n, but bare `nice CMD` is
+      # also valid → no extra positional). Conservative list:
+      case "$wrapper" in
+        timeout)
+          # `timeout DURATION CMD` — skip one non-flag positional (DURATION).
+          if [ $i -lt $n ]; then
+            i=$((i+1))
+          fi
+          ;;
+      esac
+    else
+      break
+    fi
+  done
+  printf '%d' "$i"
+}
+
+# _preflight_scan_em_args — return 0 if em-* invocation has review-handoff
+# signals in --tag/--tags/--summary args; 1 otherwise.
+# Args: $1 = start_index; $2..$N = tokens.
+_preflight_scan_em_args() {
+  local i=$1
+  shift
+  local -a T=("$@")
+  local n=${#T[@]}
+  while [ $i -lt $n ]; do
+    local t="${T[$i]}"
+    case "$t" in
+      --tag|--tags|--summary)
+        local v="${T[$((i+1))]:-}"
+        if [[ "$v" =~ $_PREFLIGHT_REVIEW_TAG_RE ]]; then
+          return 0
+        fi
+        i=$((i+2))
+        ;;
+      --tag=*|--tags=*|--summary=*)
+        local v="${t#*=}"
+        if [[ "$v" =~ $_PREFLIGHT_REVIEW_TAG_RE ]]; then
+          return 0
+        fi
+        i=$((i+1))
+        ;;
+      *) i=$((i+1)) ;;
+    esac
+  done
+  return 1
+}
+
+# classify_preflight_command "$cmd" "$repo_root"
+classify_preflight_command() {
+  local cmd="$1"
+  # repo_root currently unused but kept for API parity + future trigger expansion.
+  local _repo_root="${2:-$(pwd)}"
+  local stream
+  stream="$(_tokenize "$cmd")"
+
+  # Unsafe (command substitution / unbalanced quotes) → conservatively
+  # treat as codex-review-handoff if literal `codex exec` or em-store appears
+  # anywhere in the raw command, otherwise none. The gate's policy is
+  # "fail closed on ambiguity."
+  if printf '%s\n' "$stream" | grep -q '^E '; then
+    if printf '%s\n' "$cmd" | grep -qE '\b(codex[[:space:]]+(exec|review)|em-(store|revise|violation))\b'; then
+      printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "unsafe_complex_with_review_literal"
+      return 0
+    fi
+    printf '%s\t%s\t%s\n' "none" "" "unsafe_complex_no_review_literal"
+    return 0
+  fi
+
+  # Collect token texts in order
+  local -a T=()
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "T "*) T+=("${line:2}") ;;
+    esac
+  done <<< "$stream"
+
+  local i
+  i="$(_preflight_unwrap_index 0 "${T[@]}")"
+  local n=${#T[@]}
+  if [ $i -ge $n ]; then
+    printf '%s\t%s\t%s\n' "none" "" "empty_after_unwrap"
+    return 0
+  fi
+
+  local verb="${T[$i]}"
+
+  # Direct codex CLI
+  if [ "$verb" = "codex" ]; then
+    local sub="${T[$((i+1))]:-}"
+    case "$sub" in
+      exec|review)
+        printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "codex_${sub}"
+        return 0
+        ;;
+    esac
+  fi
+
+  # Shell wrapper with -c <cmd>: recurse into the inner command string.
+  # bash/sh/zsh/dash/ash/ksh + -c <CMD> executes CMD; verb of CMD is what
+  # matters. Distinct from env/sudo (which already had wrapper-unwrap).
+  # F4 fix: also recognize short-opt clusters containing `c` like `-lc`,
+  # `-il`, `-ci` — bash treats them as `-l` + `-c` etc. with the command
+  # arg following the cluster.
+  case "$verb" in
+    bash|sh|zsh|dash|ash|ksh)
+      local k=$((i+1))
+      while [ $k -lt $n ]; do
+        local kt="${T[$k]}"
+        case "$kt" in
+          -c|-*c*)
+            # -c exactly OR short-opt cluster containing 'c' (excluding
+            # long opts like --color). Long opts handled by the catch-all
+            # below.
+            case "$kt" in
+              --*) k=$((k+1)); continue ;;  # long opts: skip
+            esac
+            local inner="${T[$((k+1))]:-}"
+            if [ -n "$inner" ]; then
+              classify_preflight_command "$inner" "$_repo_root"
+              return 0
+            fi
+            break
+            ;;
+          -*) k=$((k+1)) ;;
+          *)  break ;;
+        esac
+      done
+      ;;
+  esac
+
+  # node|npx invocation of em-* or second-opinion script
+  case "$verb" in
+    node|npx)
+      # Find the script arg (next non-flag token)
+      local j=$((i+1))
+      while [ $j -lt $n ]; do
+        local t="${T[$j]}"
+        case "$t" in
+          -*) j=$((j+1)) ;;
+          *)  break ;;
+        esac
+      done
+      if [ $j -lt $n ]; then
+        local script_basename
+        script_basename="$(basename "${T[$j]}")"
+        if [[ "$script_basename" =~ $_PREFLIGHT_EM_VERBS_RE ]]; then
+          if _preflight_scan_em_args $((j+1)) "${T[@]}"; then
+            printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "em_via_node_${script_basename%.mjs}"
+            return 0
+          fi
+        fi
+        if [[ "$script_basename" == "second-opinion.mjs" ]]; then
+          printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "second_opinion_harness"
+          return 0
+        fi
+      fi
+      ;;
+  esac
+
+  # Bare em-* verb (PATH-resolved)
+  local verb_basename
+  verb_basename="$(basename "$verb")"
+  if [[ "$verb_basename" =~ $_PREFLIGHT_EM_VERBS_RE ]]; then
+    if _preflight_scan_em_args $((i+1)) "${T[@]}"; then
+      printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "em_bare_${verb_basename%.mjs}"
+      return 0
+    fi
+  fi
+
+  printf '%s\t%s\t%s\n' "none" "" "no_match"
+  return 0
+}
+
+# Rule-bearing path patterns. Edits to these files trigger
+# rule-bearing-file-edit claim class. PR1 registers shape only; enforcement
+# requires pairing with codex-review-handoff (see plan §"Three material
+# revisions"). Patterns are basename or path-suffix matches against the
+# realpath of the target file.
+_PREFLIGHT_RULE_BEARING_PATTERNS=(
+  '/MEMORY.md$'
+  '/feedback_[^/]*\.md$'
+  '/reference_[^/]*\.md$'
+  '/bundles/[^/]*\.md$'
+  '/.claude/hooks/'
+  '/.claude/settings(\.local)?\.json$'
+  '/docs/rfcs/'
+  '/.episodic-memory/episodes/'
+)
+
+# classify_preflight_path "$path" "$repo_root"
+classify_preflight_path() {
+  local p="$1"
+  local _repo_root="${2:-$(pwd)}"
+  local pat
+  for pat in "${_PREFLIGHT_RULE_BEARING_PATTERNS[@]}"; do
+    if [[ "$p" =~ $pat ]]; then
+      printf '%s\t%s\t%s\n' "rule-bearing-file-edit" "tool_target" "path_${pat//[^a-zA-Z0-9]/_}"
+      return 0
+    fi
+  done
+  printf '%s\t%s\t%s\n' "none" "" "path_no_match"
+  return 0
+}
+
+# classify_preflight_tool "$tool_name" "$tool_input_json" "$repo_root"
+# Top-level dispatch. tool_input_json passed as a single JSON string.
+classify_preflight_tool() {
+  local tool_name="$1"
+  local tool_input_json="$2"
+  local repo_root="${3:-$(pwd)}"
+
+  case "$tool_name" in
+    Bash)
+      local cmd
+      cmd="$(printf '%s' "$tool_input_json" | jq -r '.command // ""' 2>/dev/null)"
+      if [ -z "$cmd" ]; then
+        printf '%s\t%s\t%s\n' "none" "" "bash_empty_command"
+        return 0
+      fi
+      classify_preflight_command "$cmd" "$repo_root"
+      ;;
+    Agent|Task)
+      local subagent
+      subagent="$(printf '%s' "$tool_input_json" | jq -r '.subagent_type // ""' 2>/dev/null)"
+      case "$subagent" in
+        codex:*|codex-*|negative-scenario-*)
+          printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "agent_${subagent//[^a-zA-Z0-9]/_}"
+          return 0
+          ;;
+      esac
+      printf '%s\t%s\t%s\n' "none" "" "agent_no_match"
+      ;;
+    Write|Edit|MultiEdit|NotebookEdit)
+      local p
+      p="$(printf '%s' "$tool_input_json" | jq -r '.file_path // .path // .notebook_path // ""' 2>/dev/null)"
+      if [ -z "$p" ]; then
+        printf '%s\t%s\t%s\n' "none" "" "write_empty_path"
+        return 0
+      fi
+      classify_preflight_path "$p" "$repo_root"
+      ;;
+    *)
+      printf '%s\t%s\t%s\n' "none" "" "tool_not_gated"
+      ;;
+  esac
+}

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1252,21 +1252,45 @@ _preflight_unwrap_index() {
     if [[ "$t" =~ $_PREFLIGHT_WRAPPERS_RE ]]; then
       local wrapper="$t"
       i=$((i+1))
-      # Skip env-style assignments and short options.
+      # Per-wrapper short-opt set that takes an ARGUMENT in the next token.
+      # P1 fix from codex PR-level review round 2 (`...cbc2`): without per-
+      # wrapper arg-arity, `sudo -u root codex exec foo` consumed `root` as
+      # the positional verb and matched none.
+      local arg_re=''
+      case "$wrapper" in
+        sudo|doas)  arg_re='^-[ugCDHRTpAB]$' ;;
+        timeout)    arg_re='^-[ks]$' ;;
+        nice)       arg_re='^-n$' ;;
+        ionice)     arg_re='^-[cnpt]$' ;;
+        env)        arg_re='^-[uS]$' ;;
+        stdbuf)     arg_re='^-[ioe]$' ;;
+        exec)       arg_re='^-a$' ;;
+        chrt)       arg_re='^-[pP]$' ;;
+        nohup|command|setsid|stdbuf) arg_re='' ;;
+      esac
+      # Skip env-style assignments, short options, and per-wrapper option
+      # arguments. Long-opt `--key value` form residual gap (filed if seen);
+      # `--key=value` form is already handled (contains `=`).
       while [ $i -lt $n ]; do
         local w="${T[$i]}"
         case "$w" in
           *=*) i=$((i+1)) ;;
-          -*)  i=$((i+1)) ;;
+          -*)
+            if [ -n "$arg_re" ] && [[ "$w" =~ $arg_re ]]; then
+              # Consume flag + its argument.
+              i=$((i+2))
+            else
+              i=$((i+1))
+            fi
+            ;;
           *)   break ;;
         esac
       done
       # Wrappers that take a single positional argument BEFORE the command
-      # to wrap (timeout DURATION, nice may use -n, but bare `nice CMD` is
-      # also valid → no extra positional). Conservative list:
+      # to wrap. `timeout DURATION CMD` — DURATION is positional, distinct
+      # from `-k DURATION` and `-s SIGNAL` (already consumed via arg_re).
       case "$wrapper" in
         timeout)
-          # `timeout DURATION CMD` — skip one non-flag positional (DURATION).
           if [ $i -lt $n ]; then
             i=$((i+1))
           fi

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1356,8 +1356,15 @@ _preflight_unwrap_index() {
           long_arg_re='^--(pid|sched-runtime|sched-deadline|sched-period)$'
           ;;
         systemd-run)
-          arg_re='^-[uGtMpES]$'
-          long_arg_re='^--(unit|user|machine|property|setenv|description|slice|on-active|on-boot|on-startup|on-unit-active|on-unit-inactive|on-calendar|service-type|exec-directory|state-directory|cache-directory|logs-directory|configuration-directory|working-directory|gid|uid|nice)$'
+          # Only short opts that ACTUALLY take an argument:
+          #   -u (--unit), -M (--machine), -p (--property), -E (--setenv).
+          # NOT: -G (--collect, boolean), -t (--pty, boolean), -S (--shell, boolean).
+          arg_re='^-[uMpE]$'
+          # Long opts that take an argument. Booleans intentionally excluded:
+          # --user, --system, --scope, --pty, --tty, --quiet, --no-block,
+          # --no-ask-password, --collect, --remain-after-exit, --send-sighup,
+          # --pipe, --shell, --wait. Codex r4 finding `...fa74`.
+          long_arg_re='^--(unit|machine|property|setenv|description|slice|on-active|on-boot|on-startup|on-unit-active|on-unit-inactive|on-calendar|service-type|exec-directory|state-directory|cache-directory|logs-directory|configuration-directory|working-directory|gid|uid|nice)$'
           ;;
         flatpak-spawn)
           arg_re=''

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -e
+
+# episodic-memory-hook-version: 2026-05-12.1
+# preflight-gate.sh — Layer D narrow PreToolUse gate.
+#
+# Closes the bp-010 cluster: codex/Agent/em-store review handoffs (and
+# rule-bearing-file edits) must produce a structured memory pre-flight
+# marker BEFORE the tool call lands.
+#
+# Architecture (codex consensus chain `...ed24` → `...dbf6`, 5 rounds):
+#   1) classify_preflight_tool returns claim-class for the proposed call.
+#      `none` → exit 0 (allow).
+#   2) Else: validate `<repo>/.checkpoints/.preflight-done` exists, is JSON,
+#      matches current session/prompt, declares this claim-class, lists
+#      required_files, hashes match disk, artifact_steps_done present.
+#   3) Marker-write enforcement: deny direct Write/Edit/MultiEdit to the
+#      final preflight marker path (helper-only contract). Path matching
+#      uses canonicalize-path-tolerant for symlink-safety (F2h-n).
+#   4) Helper-invocation enforcement: deny `Bash node *preflight-marker-write.mjs`
+#      missing `--root` (defense-in-depth even if allowlist permits).
+#
+# Output: hookSpecificOutput.permissionDecision per Claude Code spec.
+# Reason strings are ACTIONABLE: name marker path + bundle + missing field.
+#
+# Read/Grep/Test/Agent are exempt at the tool-name level (same carve-out as
+# checkpoint-gate.sh). Agent dispatches with codex/negative-scenario subtype
+# are gated by classify_preflight_tool emitting codex-review-handoff.
+#
+# Composes with:
+#   - hooks/lib/command-classifier.sh   classify_preflight_tool
+#   - hooks/lib/marker-paths.sh         primary/legacy paths
+#   - hooks/lib/repo-root.sh            resolve_repo_root
+#   - scripts/lib/canonicalize-path-tolerant.mjs  symlink-safe match (via node -e)
+
+INPUT="$(cat)"
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
+TOOL_INPUT_JSON="$(echo "$INPUT" | jq -c '.tool_input // {}')"
+CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
+[ -z "$CWD" ] && CWD="$(pwd)"
+SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // ""')"
+TRANSCRIPT_PATH="$(echo "$INPUT" | jq -r '.transcript_path // ""')"
+
+# Source helpers. Same pattern as checkpoint-gate.sh; symlink-safe via BASH_SOURCE.
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+LIB_DIR="$HOOK_DIR/lib"
+for f in command-classifier.sh repo-root.sh marker-paths.sh; do
+  if [ ! -f "$LIB_DIR/$f" ]; then
+    jq -nc --arg f "$f" \
+      '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: ("preflight-gate.sh: hooks/lib/" + $f + " not found. Re-run install.mjs --install-hooks.")}}'
+    exit 0
+  fi
+done
+# shellcheck disable=SC1091
+source "$LIB_DIR/repo-root.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/command-classifier.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/marker-paths.sh"
+
+REPO_ROOT="$(resolve_repo_root "$CWD")"
+PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"
+PREFLIGHT_MARKER="$PRIMARY_DIR/.preflight-done"
+LAST_PROMPT_MARKER="$PRIMARY_DIR/.last-user-prompt.json"
+HELPER_PATH="$REPO_ROOT/scripts/preflight-marker-write.mjs"
+CANON_LIB="$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs"
+BUNDLE_PATH="$REPO_ROOT/bundles/codex-review-channel-current.md"
+
+# ---------------------------------------------------------------------------
+# Tool-level read-only carve-out (mirror checkpoint-gate.sh).
+# Note: Agent IS gated here because classify_preflight_tool inspects
+# subagent_type for codex:* / negative-scenario-* patterns. Pure read tools
+# stay exempt.
+# ---------------------------------------------------------------------------
+case "$TOOL_NAME" in
+  Read|Glob|Grep|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
+    exit 0
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_emit_deny() {
+  local reason="$1"
+  jq -nc --arg r "$reason" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'
+  exit 0
+}
+
+# _canonicalize_one <input-path> <hook-cwd>
+# Echoes canonical path on stdout; returns 0 on success, non-zero on
+# canonicalization failure (SYMLOOP_MAX, EACCES, lib-missing). CALLER must
+# check exit status and call _emit_deny — never call _emit_deny from inside
+# this function because it runs inside a $() subshell and exit would only
+# kill the subshell, not the gate process.
+_canonicalize_one() {
+  local input="$1" hookcwd="$2"
+  if [ ! -f "$CANON_LIB" ]; then
+    return 99   # signals "lib missing"
+  fi
+  # Use top-level await via async IIFE so import-rejection propagates as
+  # a non-zero exit deterministically.
+  node -e "(async () => { try { const m = await import('$CANON_LIB'); process.stdout.write(m.canonicalizePathTolerant(process.argv[1], process.argv[2])) } catch (e) { process.stderr.write(e.message || String(e)); process.exit(2) } })()" "$input" "$hookcwd" 2>&1
+  return $?
+}
+
+# ---------------------------------------------------------------------------
+# Marker-write enforcement (FU-4 + F2 canonicalization).
+# Deny direct Write/Edit/MultiEdit/NotebookEdit to .preflight-done /
+# .last-user-prompt.json regardless of marker state — helper is the only
+# sanctioned writer.
+# ---------------------------------------------------------------------------
+case "$TOOL_NAME" in
+  Write|Edit|MultiEdit|NotebookEdit)
+    TOOL_PATH="$(printf '%s' "$TOOL_INPUT_JSON" | jq -r '.file_path // .path // .notebook_path // ""')"
+    if [ -n "$TOOL_PATH" ]; then
+      # Disable errexit around command-substitution exit-code capture; bash
+      # 3.2's errexit can fire on assignment when the subshell exits non-zero.
+      set +e
+      CANON_TOOL="$(_canonicalize_one "$TOOL_PATH" "$CWD")"
+      ec_tool=$?
+      CANON_PREFLIGHT="$(_canonicalize_one "$PREFLIGHT_MARKER" "$REPO_ROOT")"
+      ec_pf=$?
+      CANON_LAST_PROMPT="$(_canonicalize_one "$LAST_PROMPT_MARKER" "$REPO_ROOT")"
+      ec_lp=$?
+      set -e
+      if [ $ec_tool -eq 99 ]; then
+        _emit_deny "preflight-gate.sh: canonicalize-path-tolerant lib missing at $CANON_LIB. Re-run install.mjs --install-hooks."
+      fi
+      if [ $ec_tool -ne 0 ]; then
+        _emit_deny "preflight-gate.sh: path canonicalization failed for '$TOOL_PATH': $CANON_TOOL — refusing to evaluate $TOOL_NAME. Use: node $HELPER_PATH --root $REPO_ROOT --target preflight"
+      fi
+      # Marker-path canonicalization should never fail (paths are simple,
+      # no symlinks expected). If it does → conservative deny.
+      if [ $ec_pf -ne 0 ] || [ $ec_lp -ne 0 ]; then
+        _emit_deny "preflight-gate.sh: failed to canonicalize marker paths; gate cannot evaluate. Re-run install.mjs --install-hooks."
+      fi
+      if [ "$CANON_TOOL" = "$CANON_PREFLIGHT" ] || [ "$CANON_TOOL" = "$CANON_LAST_PROMPT" ]; then
+        _emit_deny "Direct $TOOL_NAME to preflight marker is forbidden. Use the atomic helper: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight (or --target last-prompt). Resolved tool path: $CANON_TOOL."
+      fi
+    fi
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Helper-invocation enforcement (FU-3): Bash invoking the helper without
+# explicit --root is denied at gate layer (defense in depth even when the
+# settings.json allowlist permits).
+# ---------------------------------------------------------------------------
+if [ "$TOOL_NAME" = "Bash" ]; then
+  CMD="$(printf '%s' "$TOOL_INPUT_JSON" | jq -r '.command // ""')"
+  if [ -n "$CMD" ]; then
+    # Normalize whitespace (tabs / multi-space / line continuations) so
+    # variants like `node\t/abs/.../preflight-marker-write.mjs` or
+    # `node \\` + newline + path slip through to the same matcher (A3).
+    NORMALIZED_CMD="$(printf '%s' "$CMD" | tr '\t\n' '  ' | sed 's/\\ / /g; s/  */ /g')"
+    # Match any helper invocation: node|npx|bash, bare basename `preflight-
+    # marker-write.mjs`, or any path ending in that basename. Closes A1
+    # asymmetry with the codex/em-* classifier in command-classifier.sh
+    # which already handles bare/npx/script-shebang invocations.
+    if printf '%s' "$NORMALIZED_CMD" | grep -qE '(\bnode |\bnpx |\bbash )?[^[:space:]]*\bpreflight-marker-write\.mjs\b'; then
+      if ! printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-root[[:space:]]+[^[:space:]]'; then
+        _emit_deny "preflight-marker-write.mjs invoked without explicit --root. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt>. No cwd fallback (ROOT_REQUIRED)."
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Claim-class classification + marker validation.
+# ---------------------------------------------------------------------------
+CLASS_RESULT="$(classify_preflight_tool "$TOOL_NAME" "$TOOL_INPUT_JSON" "$REPO_ROOT")"
+CLAIM_CLASS="${CLASS_RESULT%%	*}"
+
+# v1 enforcement: only codex-review-handoff is enforced. Other classes
+# (rule-bearing-file-edit, plan-time-matrix, scratch-files,
+# wrap-up-discipline, adversarial-code-review) registered for shape but
+# allowed pass-through in PR1. PR2+ will enable them.
+if [ "$CLAIM_CLASS" != "codex-review-handoff" ]; then
+  exit 0
+fi
+
+# Marker existence
+if [ ! -f "$PREFLIGHT_MARKER" ]; then
+  _emit_deny "Pre-flight marker required for codex-review-handoff. Write to $PREFLIGHT_MARKER via: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight. Required JSON fields: session_id, transcript_path, prompt_sha256, prompt_index, cwd, repo_root, memory_root, claim_class=\"codex-review-handoff\", matched_triggers, required_files (must include $BUNDLE_PATH), loaded_files (with sha256+mtime_ms per file), artifact_steps_done. Bundle: $BUNDLE_PATH."
+fi
+
+# JSON parse
+MARKER_JSON="$(cat "$PREFLIGHT_MARKER" 2>/dev/null || true)"
+if [ -z "$MARKER_JSON" ]; then
+  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER is empty. Write a valid JSON marker via the helper. May indicate a write-in-progress race; retry."
+fi
+if ! printf '%s' "$MARKER_JSON" | jq empty 2>/dev/null; then
+  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER is not valid JSON. Re-write via $HELPER_PATH (which validates JSON.parse before writing)."
+fi
+
+# Field-by-field validation
+M_CLAIM="$(printf '%s' "$MARKER_JSON" | jq -r '.claim_class // ""')"
+M_SESSION="$(printf '%s' "$MARKER_JSON" | jq -r '.session_id // ""')"
+M_REPO_ROOT="$(printf '%s' "$MARKER_JSON" | jq -r '.repo_root // ""')"
+M_PROMPT_SHA="$(printf '%s' "$MARKER_JSON" | jq -r '.prompt_sha256 // ""')"
+M_REQUIRED="$(printf '%s' "$MARKER_JSON" | jq -r '.required_files // [] | join(",")')"
+M_LOADED_COUNT="$(printf '%s' "$MARKER_JSON" | jq -r '.loaded_files // [] | length')"
+M_STEPS="$(printf '%s' "$MARKER_JSON" | jq -r '.artifact_steps_done // [] | join(",")')"
+
+if [ "$M_CLAIM" != "codex-review-handoff" ]; then
+  _emit_deny "Pre-flight marker claim_class is '$M_CLAIM'; required: 'codex-review-handoff'. Re-write the marker."
+fi
+if [ "$M_REPO_ROOT" != "$REPO_ROOT" ]; then
+  _emit_deny "Pre-flight marker repo_root is '$M_REPO_ROOT'; gate-resolved repo_root is '$REPO_ROOT'. Re-write with the correct repo_root."
+fi
+if [ -n "$SESSION_ID" ] && [ "$M_SESSION" != "$SESSION_ID" ]; then
+  _emit_deny "Pre-flight marker session_id '$M_SESSION' does not match current session '$SESSION_ID'. Stale-session marker; re-write."
+fi
+if [ -z "$M_PROMPT_SHA" ]; then
+  _emit_deny "Pre-flight marker missing prompt_sha256. Re-write with the current user prompt's sha256."
+fi
+if [ -z "$M_REQUIRED" ]; then
+  _emit_deny "Pre-flight marker required_files is empty. Must include the bundle path: $BUNDLE_PATH."
+fi
+# Exact-match via jq (not grep) — `.md` regex metachars in BUNDLE_PATH
+# could otherwise match unintended substrings. C1 fix.
+if ! printf '%s' "$MARKER_JSON" | jq -e --arg b "$BUNDLE_PATH" '(.required_files // []) | index($b) != null' >/dev/null 2>&1; then
+  _emit_deny "Pre-flight marker required_files does not list bundle: $BUNDLE_PATH. Re-write with bundle in required_files."
+fi
+if [ "$M_LOADED_COUNT" = "0" ]; then
+  _emit_deny "Pre-flight marker loaded_files is empty. Must list each required_file with its current sha256 + mtime_ms."
+fi
+if [ -z "$M_STEPS" ]; then
+  _emit_deny "Pre-flight marker artifact_steps_done is empty. Must include at least: memory-pre-pass, channel-discipline-note, work-area-tags."
+fi
+
+# Cross-check: every required_file must appear in loaded_files with
+# sha256 matching disk, and disk file must exist.
+MISMATCH="$(printf '%s' "$MARKER_JSON" | jq -r '
+  (.required_files // []) as $req |
+  (.loaded_files // []) as $loaded |
+  $req | map(. as $rf |
+    ($loaded[] | select(.path == $rf)) // {missing: $rf}
+  ) | map(select(.missing != null) | "missing-loaded:" + .missing) | join("\n")
+')"
+if [ -n "$MISMATCH" ]; then
+  _emit_deny "Pre-flight marker required_files have no loaded_files entries: $MISMATCH. Re-load and re-write."
+fi
+
+# Hash-match each loaded_file vs disk.
+HASH_MISMATCH="$(printf '%s' "$MARKER_JSON" | jq -r '.loaded_files // [] | map([.path, .sha256] | @tsv) | .[]' | while IFS=$'\t' read -r path expected_sha; do
+  if [ ! -f "$path" ]; then
+    printf 'missing-on-disk:%s\n' "$path"
+    continue
+  fi
+  actual_sha="$(shasum -a 256 "$path" 2>/dev/null | awk '{print $1}')"
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    printf 'sha-drift:%s\n' "$path"
+  fi
+done)"
+if [ -n "$HASH_MISMATCH" ]; then
+  _emit_deny "Pre-flight marker bundle component hash drift detected: $HASH_MISMATCH. Re-read each component, recompute sha256, re-write the marker."
+fi
+
+# All validations passed — allow.
+exit 0

--- a/scripts/lib/canonicalize-path-tolerant.mjs
+++ b/scripts/lib/canonicalize-path-tolerant.mjs
@@ -1,0 +1,121 @@
+/**
+ * canonicalize-path-tolerant.mjs — POSIX-style path canonicalization that
+ * dereferences symlinks for components that exist and tolerates a missing
+ * leaf (or any component past the first ENOENT).
+ *
+ * Why exist:
+ *   `fs.realpathSync(p)` is all-or-nothing — throws ENOENT if any component
+ *   is missing. Falling back to `path.resolve(p)` is INCORRECT for security-
+ *   sensitive comparisons because `path.resolve` does NOT follow symlinks,
+ *   so a Write to `<repo>/sym` (where `sym -> .checkpoints/.preflight-done`,
+ *   target absent) would canonicalize to `<repo>/sym` and miss the marker
+ *   match. The Write would then create the marker at the symlink target,
+ *   bypassing the gate's helper-only contract.
+ *
+ *   This lib walks path components left-to-right, calls `fs.lstatSync` on
+ *   each, dereferences symlinks via `fs.readlinkSync`, and stops resolution
+ *   at the first ENOENT — appending the literal remainder. That matches
+ *   POSIX `realpath -m` semantics ("missing tolerant") which Node lacks.
+ *
+ * Used by:
+ *   - hooks/preflight-gate.sh — via `node -e` invocation for marker-write
+ *     denial path canonicalization.
+ *   - scripts/preflight-marker-write.mjs — for `--root` validation (rejects
+ *     if `--root` resolves to anywhere outside the declared project).
+ *
+ * Discovered: codex r4 reply `20260512-072212-...-0fc1` (dangling-symlink
+ *   bypass). Closed: codex r5 ACCEPT `20260512-072545-...-dbf6`.
+ *
+ * Threat model:
+ *   - Single symlink to absent marker → DENY (F2h)
+ *   - Multi-hop chain → DENY (F2i)
+ *   - Symlink in middle of path → DENY (F2j)
+ *   - Symlink loop → throw, gate emits conservative DENY (F2k)
+ *   - Relative-target symlink → resolved against symlink's parent dir (F2l)
+ *   - Absolute-target symlink → resolved verbatim (F2m)
+ *   - Symlink to unrelated path → ALLOW (F2n)
+ *
+ * Bound:
+ *   MAX_HOPS=40 (POSIX SYMLOOP_MAX is typically 40 on Linux/macOS).
+ *
+ * NOT in scope: Windows path semantics. POSIX-only by project convention.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+export const MAX_HOPS = 40
+
+/**
+ * Canonicalize an input path with symlink dereference + missing-leaf tolerance.
+ *
+ * @param {string} inputPath - the path to canonicalize (absolute or relative)
+ * @param {string} hookCwd - the cwd to resolve relative inputs against
+ * @returns {string} - canonical absolute path with symlinks resolved as far as
+ *                     possible; literal remainder past first ENOENT
+ * @throws {Error} - on SYMLOOP_MAX exceeded; gate should emit conservative DENY
+ */
+export function canonicalizePathTolerant(inputPath, hookCwd) {
+  if (typeof inputPath !== 'string' || inputPath.length === 0) {
+    throw new Error('canonicalizePathTolerant: inputPath must be non-empty string')
+  }
+  if (typeof hookCwd !== 'string' || !path.isAbsolute(hookCwd)) {
+    throw new Error('canonicalizePathTolerant: hookCwd must be absolute path')
+  }
+  return resolveInner(inputPath, hookCwd, 0)
+}
+
+function resolveInner(inputPath, hookCwd, hopsSoFar) {
+  let abs = path.isAbsolute(inputPath)
+    ? inputPath
+    : path.resolve(hookCwd, inputPath)
+  abs = path.normalize(abs)
+
+  // POSIX-only; root is '/'. Split, drop empties from leading '/'.
+  const parts = abs.split(path.sep).filter(Boolean)
+  let resolved = path.sep
+  let hops = hopsSoFar
+
+  for (let i = 0; i < parts.length; i++) {
+    const candidate = path.join(resolved, parts[i])
+    let stat
+    try {
+      stat = fs.lstatSync(candidate)
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        // First missing component — append literal remainder. POSIX
+        // `realpath -m` semantics: nonexistent components are kept verbatim,
+        // no further resolution attempted.
+        const remainder = parts.slice(i)
+        return path.normalize(path.join(resolved, ...remainder))
+      }
+      // Other errors (EACCES, ENOTDIR mid-path, etc.) propagate. Gate
+      // should treat as conservative DENY.
+      throw e
+    }
+
+    if (stat.isSymbolicLink()) {
+      hops++
+      if (hops > MAX_HOPS) {
+        throw new Error(
+          `canonicalizePathTolerant: SYMLOOP_MAX (${MAX_HOPS}) exceeded resolving ${inputPath}`
+        )
+      }
+      const target = fs.readlinkSync(candidate)
+      // Relative target resolves against symlink's parent dir; absolute
+      // target replaces the path-so-far entirely.
+      const targetAbs = path.isAbsolute(target)
+        ? target
+        : path.resolve(path.dirname(candidate), target)
+      // Replace [0..i] with target, keep [i+1..] as remainder, recurse.
+      const remainder = parts.slice(i + 1)
+      const newAbs = path.normalize(path.join(targetAbs, ...remainder))
+      return resolveInner(newAbs, hookCwd, hops)
+    }
+
+    // Regular file or dir component — extend resolved.
+    resolved = candidate
+  }
+
+  return path.normalize(resolved)
+}

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -61,6 +61,15 @@ export const HOOK_SPECS = [
     file: 'stop-gate.sh',
     event: 'SubagentStop',
     timeout: 5
+  },
+  // preflight-gate.sh: Layer D narrow PR1 (codex consensus chain
+  // ...ed24 → ...dbf6, 2026-05-12). PreToolUse on Bash/Agent/Write/Edit/
+  // MultiEdit/NotebookEdit. Read-only tools exempt at gate level.
+  {
+    file: 'preflight-gate.sh',
+    event: 'PreToolUse',
+    matcher: 'Bash|Agent|Task|Write|Edit|MultiEdit|NotebookEdit',
+    timeout: 10
   }
 ]
 

--- a/scripts/preflight-marker-write.mjs
+++ b/scripts/preflight-marker-write.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * preflight-marker-write.mjs — Atomic writer for Layer D pre-flight markers.
+ *
+ * Why exist:
+ *   The pre-flight gate (`hooks/preflight-gate.sh`) requires a structured JSON
+ *   marker at `<root>/.checkpoints/.preflight-done` (and a sibling
+ *   `.last-user-prompt.json` for turn-id derivation). Both files MUST be
+ *   written atomically — partial writes during a tight reader loop would
+ *   make the gate intermittently-pass / intermittently-fail.
+ *
+ *   Claude Code's `Write` tool is NOT a POSIX `rename(2)` API. To make the
+ *   atomicity contract locally verifiable, this helper:
+ *     1) reads JSON from stdin, validates parse,
+ *     2) writes to a unique-named temp file in the SAME directory as final,
+ *     3) `fs.renameSync(temp, final)` — atomic on same filesystem,
+ *     4) on any failure: best-effort `unlinkSync(temp)` and exit non-zero.
+ *
+ *   Gate enforces helper-only writes by denying direct `Write`/`Edit`/
+ *   `MultiEdit` to the final marker basename.
+ *
+ * Usage:
+ *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target preflight
+ *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target last-prompt
+ *   cat input.json | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target preflight
+ *
+ * Exit codes:
+ *   0 — success; stdout is `{"status":"ok","path":"<final>","bytes":N}`
+ *   2 — JSON parse failed
+ *   3 — fs write/rename failed
+ *   4 — `--root` missing (no implicit cwd fallback)
+ *   5 — `--root` invalid (non-existent OR not a repo root signal)
+ *   6 — `--target` missing or invalid value
+ *   7 — stdin read error
+ *
+ * Discovered: codex r2 reply `20260512-071449-...-6e90` (atomicity invariant
+ *   not locally verifiable for agent-side Write).
+ * Refined:    codex r3-r5 (helper-only contract + --root required +
+ *   canonicalize-path-tolerant lib for `--root` validation).
+ *
+ * Composes with:
+ *   - scripts/lib/local-dir.mjs — resolveRepoRoot for --root validation.
+ *   - scripts/lib/marker-paths.mjs — primaryMarkerPath, ensurePrimaryDir.
+ *   - scripts/lib/canonicalize-path-tolerant.mjs — symlink-aware --root check.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
+
+import { ensurePrimaryDir, primaryMarkerPath } from './lib/marker-paths.mjs'
+import { canonicalizePathTolerant } from './lib/canonicalize-path-tolerant.mjs'
+
+const VALID_TARGETS = {
+  preflight: '.preflight-done',
+  'last-prompt': '.last-user-prompt.json'
+}
+
+function fail(code, message) {
+  process.stderr.write(`preflight-marker-write: ${message}\n`)
+  process.exit(code)
+}
+
+function parseArgs(argv) {
+  const args = { root: null, target: null }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--root') {
+      args.root = argv[++i]
+    } else if (a === '--target') {
+      args.target = argv[++i]
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        'Usage: echo "<JSON>" | preflight-marker-write.mjs --root <abs> --target <preflight|last-prompt>\n'
+      )
+      process.exit(0)
+    } else {
+      fail(6, `unknown argument: ${a}`)
+    }
+  }
+  return args
+}
+
+function validateRoot(rootArg) {
+  if (!rootArg) fail(4, 'ROOT_REQUIRED: --root <abs> is mandatory; no cwd fallback')
+  if (!path.isAbsolute(rootArg)) fail(5, `ROOT_INVALID: --root must be absolute, got: ${rootArg}`)
+
+  let canonical
+  try {
+    canonical = canonicalizePathTolerant(rootArg, process.cwd())
+  } catch (e) {
+    fail(5, `ROOT_INVALID: canonicalization failed: ${e.message}`)
+  }
+
+  let stat
+  try {
+    stat = fs.statSync(canonical)
+  } catch (e) {
+    fail(5, `ROOT_INVALID: ${canonical} does not exist (${e.code})`)
+  }
+  if (!stat.isDirectory()) fail(5, `ROOT_INVALID: ${canonical} is not a directory`)
+
+  // Repo signal: must contain .git OR .checkpoints OR .episodic-memory.
+  // Any one is sufficient — the project may have any subset depending on
+  // initialization state. Refusing without a signal prevents writing markers
+  // into arbitrary user directories.
+  const signals = ['.git', '.checkpoints', '.episodic-memory']
+  const hasSignal = signals.some((s) => fs.existsSync(path.join(canonical, s)))
+  if (!hasSignal) {
+    fail(5, `ROOT_NOT_REPO: ${canonical} has none of [${signals.join(', ')}]`)
+  }
+
+  return canonical
+}
+
+function readStdinSync() {
+  try {
+    return fs.readFileSync(0, 'utf8')
+  } catch (e) {
+    fail(7, `stdin read failed: ${e.message}`)
+  }
+}
+
+function main() {
+  const { root, target } = parseArgs(process.argv)
+  if (!target) fail(6, 'TARGET_REQUIRED: --target <preflight|last-prompt>')
+  if (!Object.prototype.hasOwnProperty.call(VALID_TARGETS, target)) {
+    fail(6, `TARGET_INVALID: ${target}; valid: ${Object.keys(VALID_TARGETS).join(', ')}`)
+  }
+
+  const canonicalRoot = validateRoot(root)
+  const basename = VALID_TARGETS[target]
+  const finalPath = primaryMarkerPath(canonicalRoot, basename)
+
+  const raw = readStdinSync()
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (e) {
+    fail(2, `JSON parse failed: ${e.message}`)
+  }
+  // B1: reject non-object payloads (null, [], 42, "string"). Markers are
+  // structured records; `null`/`[]` would parse but produce semantically
+  // invalid markers the gate then has to reject downstream.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail(2, `JSON payload must be a non-null object; got ${parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed}`)
+  }
+  const serialized = JSON.stringify(parsed, null, 2)
+  const bytes = Buffer.byteLength(serialized, 'utf8')
+
+  ensurePrimaryDir(canonicalRoot)
+
+  // Unique temp name in same dir as final → rename(2) atomic on same FS.
+  const hr = process.hrtime.bigint().toString()
+  const tempName = `.${basename}.${process.pid}.${hr}.tmp`
+  const tempPath = path.join(canonicalRoot, '.checkpoints', tempName)
+
+  let cleanupTemp = true
+  process.on('SIGINT', () => {
+    if (cleanupTemp) try { fs.unlinkSync(tempPath) } catch { /* ignore */ }
+    process.exit(130)
+  })
+  process.on('SIGTERM', () => {
+    if (cleanupTemp) try { fs.unlinkSync(tempPath) } catch { /* ignore */ }
+    process.exit(143)
+  })
+
+  try {
+    fs.writeFileSync(tempPath, serialized)
+    fs.renameSync(tempPath, finalPath)
+    cleanupTemp = false
+  } catch (e) {
+    try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
+    fail(3, `WRITE_FAILED: ${e.message}`)
+  }
+
+  process.stdout.write(JSON.stringify({ status: 'ok', path: finalPath, bytes }) + '\n')
+  process.exit(0)
+}
+
+main()

--- a/tests/test-canonicalize-path-tolerant.mjs
+++ b/tests/test-canonicalize-path-tolerant.mjs
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for scripts/lib/canonicalize-path-tolerant.mjs
+ *
+ * Covers the F2h-n bypass classes from codex r4-r5 plus base correctness.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+import { canonicalizePathTolerant, MAX_HOPS } from '../scripts/lib/canonicalize-path-tolerant.mjs'
+
+function tmpDir() {
+  // Canonicalize via realpathSync so macOS /var → /private/var and similar
+  // platform-prefix symlinks don't surprise the assertions. Each test needs
+  // a fully-resolved tmp root because the lib under test dereferences
+  // symlinks (which is the entire point).
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'canonpath-')))
+}
+
+test('absolute existing path returns itself', () => {
+  const dir = tmpDir()
+  try {
+    const file = path.join(dir, 'real.txt')
+    fs.writeFileSync(file, '')
+    assert.equal(canonicalizePathTolerant(file, dir), file)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('relative path resolves against hookCwd', () => {
+  const dir = tmpDir()
+  try {
+    const file = path.join(dir, 'real.txt')
+    fs.writeFileSync(file, '')
+    assert.equal(canonicalizePathTolerant('real.txt', dir), file)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('missing leaf is preserved literally', () => {
+  const dir = tmpDir()
+  try {
+    const missing = path.join(dir, '.checkpoints', '.preflight-done')
+    // .checkpoints/ does not exist; missing component fall-through preserves it
+    assert.equal(canonicalizePathTolerant(missing, dir), missing)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('missing intermediate component is preserved', () => {
+  const dir = tmpDir()
+  try {
+    const p = path.join(dir, 'nope', 'deeper', 'leaf')
+    assert.equal(canonicalizePathTolerant(p, dir), p)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2h: dangling symlink to absent target dereferences to target', () => {
+  const dir = tmpDir()
+  try {
+    const checkpointsAbs = path.join(dir, '.checkpoints', '.preflight-done')
+    const symPath = path.join(dir, 'sym')
+    // Symlink target doesn't exist on disk
+    fs.symlinkSync(path.join('.checkpoints', '.preflight-done'), symPath)
+    const out = canonicalizePathTolerant(symPath, dir)
+    assert.equal(out, checkpointsAbs, 'dangling symlink must dereference to target')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2i: multi-hop chain dereferences fully', () => {
+  const dir = tmpDir()
+  try {
+    const checkpointsAbs = path.join(dir, '.checkpoints', '.preflight-done')
+    const a = path.join(dir, 'a')
+    const b = path.join(dir, 'b')
+    fs.symlinkSync('b', a)
+    fs.symlinkSync(path.join('.checkpoints', '.preflight-done'), b)
+    const out = canonicalizePathTolerant(a, dir)
+    assert.equal(out, checkpointsAbs)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2j: symlink in middle of path resolves intermediate', () => {
+  const dir = tmpDir()
+  try {
+    fs.mkdirSync(path.join(dir, '.checkpoints'))
+    fs.symlinkSync('.checkpoints', path.join(dir, 'cp_alias'))
+    const input = path.join(dir, 'cp_alias', '.preflight-done')
+    const expected = path.join(dir, '.checkpoints', '.preflight-done')
+    assert.equal(canonicalizePathTolerant(input, dir), expected)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2k: symlink loop throws SYMLOOP_MAX', () => {
+  const dir = tmpDir()
+  try {
+    fs.symlinkSync('loop2', path.join(dir, 'loop1'))
+    fs.symlinkSync('loop1', path.join(dir, 'loop2'))
+    assert.throws(
+      () => canonicalizePathTolerant(path.join(dir, 'loop1'), dir),
+      /SYMLOOP_MAX/
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2l: relative-target symlink resolves against symlink parent', () => {
+  const dir = tmpDir()
+  try {
+    fs.mkdirSync(path.join(dir, '.checkpoints'))
+    // Symlink at .checkpoints/dangle -> ./.preflight-done; target absent
+    fs.symlinkSync('./.preflight-done', path.join(dir, '.checkpoints', 'dangle'))
+    const input = path.join(dir, '.checkpoints', 'dangle')
+    const expected = path.join(dir, '.checkpoints', '.preflight-done')
+    assert.equal(canonicalizePathTolerant(input, dir), expected)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2m: absolute-target symlink resolves verbatim', () => {
+  const dir = tmpDir()
+  try {
+    const target = path.join(dir, '.checkpoints', '.preflight-done')
+    fs.symlinkSync(target, path.join(dir, 'abs_sym'))
+    const out = canonicalizePathTolerant(path.join(dir, 'abs_sym'), dir)
+    assert.equal(out, target)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F2n: symlink to unrelated path resolves to that path (not marker)', () => {
+  const dir = tmpDir()
+  try {
+    const otherTmp = tmpDir()
+    try {
+      const otherFile = path.join(otherTmp, 'scratch.txt')
+      fs.writeFileSync(otherFile, '')
+      fs.symlinkSync(otherFile, path.join(dir, 'scratch_sym'))
+      const out = canonicalizePathTolerant(path.join(dir, 'scratch_sym'), dir)
+      assert.equal(out, otherFile)
+    } finally {
+      fs.rmSync(otherTmp, { recursive: true, force: true })
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('throws on empty inputPath', () => {
+  const dir = tmpDir()
+  try {
+    assert.throws(() => canonicalizePathTolerant('', dir), /non-empty string/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('throws on relative hookCwd', () => {
+  assert.throws(
+    () => canonicalizePathTolerant('foo', 'relative/cwd'),
+    /absolute path/
+  )
+})
+
+test('handles . and .. in input path', () => {
+  const dir = tmpDir()
+  try {
+    fs.mkdirSync(path.join(dir, 'sub'))
+    const input = path.join(dir, 'sub', '..', 'sub', '.', 'foo.txt')
+    const expected = path.join(dir, 'sub', 'foo.txt')
+    assert.equal(canonicalizePathTolerant(input, dir), expected)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('MAX_HOPS exported as 40', () => {
+  assert.equal(MAX_HOPS, 40)
+})
+
+test('F1 boundary: chain of MAX_HOPS-1 symlinks succeeds', () => {
+  // Build a 39-link chain: link0 -> link1 -> ... -> link38 -> target.
+  // Total 39 lstat hops, under MAX_HOPS=40.
+  const dir = tmpDir()
+  try {
+    const target = path.join(dir, 'target.txt')
+    fs.writeFileSync(target, '')
+    let prev = 'target.txt'
+    for (let i = MAX_HOPS - 2; i >= 0; i--) {
+      const linkName = `link${i}`
+      fs.symlinkSync(prev, path.join(dir, linkName))
+      prev = linkName
+    }
+    const out = canonicalizePathTolerant(path.join(dir, 'link0'), dir)
+    assert.equal(out, target, 'just-under-budget chain should resolve')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F1 boundary: chain of MAX_HOPS+1 symlinks throws SYMLOOP_MAX', () => {
+  // Build a 41-link chain (one over budget).
+  const dir = tmpDir()
+  try {
+    const target = path.join(dir, 'target.txt')
+    fs.writeFileSync(target, '')
+    let prev = 'target.txt'
+    for (let i = MAX_HOPS; i >= 0; i--) {
+      const linkName = `link${i}`
+      fs.symlinkSync(prev, path.join(dir, linkName))
+      prev = linkName
+    }
+    assert.throws(
+      () => canonicalizePathTolerant(path.join(dir, 'link0'), dir),
+      /SYMLOOP_MAX/
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -497,6 +497,17 @@ assert_preflight_cmd "Q61 systemd-run with arg-taking" \
   'systemd-run --unit myapp --user codex exec foo' "codex-review-handoff"
 assert_preflight_cmd "Q62 systemd-run -G boolean" \
   'systemd-run -G codex exec foo' "codex-review-handoff"
+# Q63-Q65: env -S/--split-string command-vector recursion (codex r5 finding `...729a`)
+assert_preflight_cmd "Q63 env -S codex" \
+  'env -S "codex exec foo"' "codex-review-handoff"
+assert_preflight_cmd "Q64 env --split-string codex" \
+  'env --split-string "codex review --plan"' "codex-review-handoff"
+assert_preflight_cmd "Q65 env -vS codex" \
+  'env -vS "codex exec foo"' "codex-review-handoff"
+assert_preflight_cmd "Q66 env -S non-codex" \
+  'env -S "ls -la"' "none"
+assert_preflight_cmd "Q67 env --split-string=codex equals" \
+  'env --split-string=codex\ exec\ foo true' "codex-review-handoff"
 
 echo ""
 echo "--- classify_preflight_path ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -432,6 +432,27 @@ assert_preflight_cmd "Q31 multi-segment with chain at end" \
   'ls; echo ok && codex exec foo' "codex-review-handoff"
 assert_preflight_cmd "Q32 benign chain — no codex" \
   'echo ok; ls; pwd' "none"
+# Q33-Q40: wrapper option-argument bypass class (codex round 2 finding `...cbc2`)
+assert_preflight_cmd "Q33 sudo -u root" \
+  'sudo -u root codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q34 sudo -g group" \
+  'sudo -g admin codex review' "codex-review-handoff"
+assert_preflight_cmd "Q35 timeout -k 5s 30s" \
+  'timeout -k 5s 30s codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q36 timeout -s SIGTERM 30s" \
+  'timeout -s SIGTERM 30s codex review' "codex-review-handoff"
+assert_preflight_cmd "Q37 nice -n 10" \
+  'nice -n 10 codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q38 ionice -c 3" \
+  'ionice -c 3 codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q39 env -u VAR" \
+  'env -u BAD codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q40 stdbuf -o L" \
+  'stdbuf -o L codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q41 stacked wrappers" \
+  'sudo -u root timeout -k 5s 30s nice -n 10 codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q42 sudo --user=root long-opt-equals" \
+  'sudo --user=root codex exec foo' "codex-review-handoff"
 
 echo ""
 echo "--- classify_preflight_path ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -486,6 +486,17 @@ assert_preflight_cmd "Q56 direnv exec ." \
 # Q57: stacked runner + classic wrapper
 assert_preflight_cmd "Q57 sudo + uv run codex" \
   'sudo -u root uv run codex exec foo' "codex-review-handoff"
+# Q58-Q62: systemd-run boolean flags (codex round 4 finding `...fa74`)
+assert_preflight_cmd "Q58 systemd-run --user only" \
+  'systemd-run --user codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q59 systemd-run --scope --user" \
+  'systemd-run --scope --user codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q60 systemd-run --pty --user" \
+  'systemd-run --pty --user codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q61 systemd-run with arg-taking" \
+  'systemd-run --unit myapp --user codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q62 systemd-run -G boolean" \
+  'systemd-run -G codex exec foo' "codex-review-handoff"
 
 echo ""
 echo "--- classify_preflight_path ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -453,6 +453,39 @@ assert_preflight_cmd "Q41 stacked wrappers" \
   'sudo -u root timeout -k 5s 30s nice -n 10 codex exec foo' "codex-review-handoff"
 assert_preflight_cmd "Q42 sudo --user=root long-opt-equals" \
   'sudo --user=root codex exec foo' "codex-review-handoff"
+# Q43-Q50: long-opt --key value form (codex round 3 finding `...bd73`)
+assert_preflight_cmd "Q43 sudo --user root space" \
+  'sudo --user root codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q44 timeout --kill-after 5s 30s" \
+  'timeout --kill-after 5s 30s codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q45 stdbuf --output L" \
+  'stdbuf --output L codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q46 env --unset BAD" \
+  'env --unset BAD codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q47 nice --adjustment 10" \
+  'nice --adjustment 10 codex exec foo' "codex-review-handoff"
+# Q48-Q55: modern command runners (codex round 3 finding `...bd73`)
+assert_preflight_cmd "Q48 systemd-run --user --scope" \
+  'systemd-run --user --scope codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q49 systemd-run -u name" \
+  'systemd-run -u myunit codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q50 flatpak-spawn --host" \
+  'flatpak-spawn --host codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q51 uv run" \
+  'uv run codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q52 poetry run" \
+  'poetry run codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q53 pixi run" \
+  'pixi run codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q54 nix develop -c" \
+  'nix develop -c codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q55 nix shell -c" \
+  'nix shell -c codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q56 direnv exec ." \
+  'direnv exec . codex exec foo' "codex-review-handoff"
+# Q57: stacked runner + classic wrapper
+assert_preflight_cmd "Q57 sudo + uv run codex" \
+  'sudo -u root uv run codex exec foo' "codex-review-handoff"
 
 echo ""
 echo "--- classify_preflight_path ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -355,6 +355,131 @@ assert_path "P02 plan-approval-pending" ".claude/.plan-approval-pending" "marker
 assert_path "P03 ordinary file" "src/foo.mjs" "shared_write"
 assert_path "P04 absolute marker" "$TEST_ROOT/.claude/.post-checkpoint-done" "marker_write"
 
+# ---------------------------------------------------------------------------
+# Layer D pre-flight classifier siblings — Q-series tests.
+# Codex consensus chain: r1 ACCEPT-with-FU `...ed24` → r5 ACCEPT `...dbf6`.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- classify_preflight_command ---"
+assert_preflight_cmd() {
+  local desc="$1"
+  local cmd="$2"
+  local expected_class="$3"
+  local result class
+  result="$(classify_preflight_command "$cmd" "$TEST_ROOT")"
+  class="${result%%	*}"
+  if [ "$class" = "$expected_class" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc — got $class, expected $expected_class"
+    failed=$((failed+1))
+  fi
+}
+assert_preflight_cmd "Q01 codex exec" 'codex exec "review"' "codex-review-handoff"
+assert_preflight_cmd "Q02 codex review" 'codex review --plan' "codex-review-handoff"
+assert_preflight_cmd "Q03 sudo wrap codex" 'sudo codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q04 env wrap codex" 'env A=1 codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q05 timeout wrap codex" 'timeout 60s codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q06 nohup wrap codex" 'nohup codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q07 multi-wrap" 'env X=y timeout 30s sudo codex review' "codex-review-handoff"
+assert_preflight_cmd "Q08 quoted-string echo no-fp" 'echo "codex exec foo"' "none"
+assert_preflight_cmd "Q09 bash -c codex" 'bash -c "codex exec foo"' "codex-review-handoff"
+assert_preflight_cmd "Q10 sh -c codex" 'sh -c "codex review --bar"' "codex-review-handoff"
+assert_preflight_cmd "Q11 zsh -c em-store" 'zsh -c "em-store --tag codex-review --body x"' "codex-review-handoff"
+assert_preflight_cmd "Q11a bash -lc codex" 'bash -lc "codex exec foo"' "codex-review-handoff"
+assert_preflight_cmd "Q11b bash -il then -c" 'bash -il -c "codex review"' "codex-review-handoff"
+assert_preflight_cmd "Q11c bash -ci codex" 'bash -ci "codex exec"' "codex-review-handoff"
+assert_preflight_cmd "Q11d bash --color" 'bash --color=auto -c "ls"' "none"
+assert_preflight_cmd "Q12 node em-store w/codex tag" \
+  'node scripts/em-store.mjs --tag codex-review --summary x' "codex-review-handoff"
+assert_preflight_cmd "Q13 node em-store no review tag" \
+  'node scripts/em-store.mjs --tag random --summary x' "none"
+assert_preflight_cmd "Q14 node em-revise w/code-review tag" \
+  'node scripts/em-revise.mjs --tag code-review-round-2 --body y' "codex-review-handoff"
+assert_preflight_cmd "Q15 node em-violation w/review-bp tag" \
+  'node scripts/em-violation.mjs --tags codex,review-pattern' "codex-review-handoff"
+assert_preflight_cmd "Q16 second-opinion harness" \
+  'node scripts/second-opinion.mjs request --provider codex --dispatch' "codex-review-handoff"
+assert_preflight_cmd "Q17 bare em-store w/review tag" \
+  'em-store --tag plan-review --body z' "codex-review-handoff"
+assert_preflight_cmd "Q18 bare em-store no review tag" \
+  'em-store --tag random --body z' "none"
+assert_preflight_cmd "Q19 ls" 'ls -la' "none"
+assert_preflight_cmd "Q20 git status" 'git status' "none"
+assert_preflight_cmd "Q21 npx em-store w/codex tag" \
+  'npx em-store --tag codex-review --body x' "codex-review-handoff"
+assert_preflight_cmd "Q22 absolute path em-store" \
+  'node /abs/repo/scripts/em-store.mjs --summary "codex review request"' "codex-review-handoff"
+assert_preflight_cmd "Q23 unsafe + codex literal" \
+  'eval $(cat /etc/x); codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q24 unsafe no codex literal" \
+  'eval $(cat /etc/x); ls -la' "none"
+assert_preflight_cmd "Q25 --tags=codex equals form" \
+  'em-store --tags=codex-reply,round-3 --body z' "codex-review-handoff"
+
+echo ""
+echo "--- classify_preflight_path ---"
+assert_preflight_path() {
+  local desc="$1"
+  local p="$2"
+  local expected_class="$3"
+  local result class
+  result="$(classify_preflight_path "$p" "$TEST_ROOT")"
+  class="${result%%	*}"
+  if [ "$class" = "$expected_class" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc — got $class, expected $expected_class"
+    failed=$((failed+1))
+  fi
+}
+assert_preflight_path "QP01 MEMORY.md" "/abs/repo/MEMORY.md" "rule-bearing-file-edit"
+assert_preflight_path "QP02 feedback_*.md" "/abs/repo/feedback_x.md" "rule-bearing-file-edit"
+assert_preflight_path "QP03 reference_*.md" "/abs/repo/reference_y.md" "rule-bearing-file-edit"
+assert_preflight_path "QP04 bundles" "/abs/repo/bundles/codex-channel.md" "rule-bearing-file-edit"
+assert_preflight_path "QP05 hooks" "/abs/repo/.claude/hooks/foo.sh" "rule-bearing-file-edit"
+assert_preflight_path "QP06 settings.json" "/abs/repo/.claude/settings.json" "rule-bearing-file-edit"
+assert_preflight_path "QP07 settings.local.json" "/abs/repo/.claude/settings.local.json" "rule-bearing-file-edit"
+assert_preflight_path "QP08 RFC dir" "/abs/repo/docs/rfcs/RFC-007-foo.md" "rule-bearing-file-edit"
+assert_preflight_path "QP09 episode file" "/abs/repo/.episodic-memory/episodes/x.md" "rule-bearing-file-edit"
+assert_preflight_path "QP10 random script" "/abs/repo/scripts/em-search.mjs" "none"
+assert_preflight_path "QP11 random source" "/abs/repo/src/foo.mjs" "none"
+assert_preflight_path "QP12 README" "/abs/repo/README.md" "none"
+
+echo ""
+echo "--- classify_preflight_tool ---"
+assert_preflight_tool() {
+  local desc="$1"
+  local tool_name="$2"
+  local tool_input_json="$3"
+  local expected_class="$4"
+  local result class
+  result="$(classify_preflight_tool "$tool_name" "$tool_input_json" "$TEST_ROOT")"
+  class="${result%%	*}"
+  if [ "$class" = "$expected_class" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc — got $class, expected $expected_class"
+    failed=$((failed+1))
+  fi
+}
+assert_preflight_tool "QT01 Bash codex" "Bash" '{"command":"codex exec foo"}' "codex-review-handoff"
+assert_preflight_tool "QT02 Bash ls" "Bash" '{"command":"ls -la"}' "none"
+assert_preflight_tool "QT03 Bash empty" "Bash" '{"command":""}' "none"
+assert_preflight_tool "QT04 Agent codex-rescue" "Agent" '{"subagent_type":"codex:codex-rescue"}' "codex-review-handoff"
+assert_preflight_tool "QT05 Agent neg-scenario" "Agent" '{"subagent_type":"negative-scenario-reviewer"}' "codex-review-handoff"
+assert_preflight_tool "QT06 Agent generic" "Agent" '{"subagent_type":"general-purpose"}' "none"
+assert_preflight_tool "QT07 Task variant" "Task" '{"subagent_type":"codex:something"}' "codex-review-handoff"
+assert_preflight_tool "QT08 Write feedback" "Write" '{"file_path":"/abs/repo/feedback_x.md"}' "rule-bearing-file-edit"
+assert_preflight_tool "QT09 Edit MEMORY.md" "Edit" '{"file_path":"/abs/repo/MEMORY.md"}' "rule-bearing-file-edit"
+assert_preflight_tool "QT10 MultiEdit hook" "MultiEdit" '{"file_path":"/abs/repo/.claude/hooks/foo.sh"}' "rule-bearing-file-edit"
+assert_preflight_tool "QT11 Write src file" "Write" '{"file_path":"/abs/repo/src/foo.mjs"}' "none"
+assert_preflight_tool "QT12 Read ungated" "Read" '{"file_path":"/anything"}' "none"
+assert_preflight_tool "QT13 Grep ungated" "Grep" '{"pattern":"foo"}' "none"
+
 echo ""
 echo "=================================================="
 echo "Results: $passed passed, $failed failed"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -417,6 +417,21 @@ assert_preflight_cmd "Q24 unsafe no codex literal" \
   'eval $(cat /etc/x); ls -la' "none"
 assert_preflight_cmd "Q25 --tags=codex equals form" \
   'em-store --tags=codex-reply,round-3 --body z' "codex-review-handoff"
+# Q26-Q30: bash chain bypass class (codex PR-level review 2026-05-12 finding)
+assert_preflight_cmd "Q26 ; chain after benign verb" \
+  'echo ok; codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q27 && chain" \
+  'true && codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q28 || chain" \
+  'false || codex review --plan' "codex-review-handoff"
+assert_preflight_cmd "Q29 subshell parens" \
+  '( codex exec foo )' "codex-review-handoff"
+assert_preflight_cmd "Q30 chain with em-store" \
+  'cd /tmp && node scripts/em-store.mjs --tag codex-review --body x' "codex-review-handoff"
+assert_preflight_cmd "Q31 multi-segment with chain at end" \
+  'ls; echo ok && codex exec foo' "codex-review-handoff"
+assert_preflight_cmd "Q32 benign chain — no codex" \
+  'echo ok; ls; pwd' "none"
 
 echo ""
 echo "--- classify_preflight_path ---"

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -1,0 +1,602 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight-gate.sh — Layer D pre-flight gate test suite.
+#
+# Codex consensus chain: r1 ACCEPT-with-FU `...ed24` → r5 ACCEPT `...dbf6`.
+# All 9 locally-verifiable invariants per discipline #18:
+#
+#   I1  Helper produces atomic marker writes              (F4a-c)
+#   I2  No partial-write observation                      (F4f-g)
+#   I3  Direct Write/Edit/MultiEdit to marker denied      (F2a-n + F4d-e)
+#   I4  Marker artifacts land under --root, not caller    (F3b-c, F5)
+#   I5  Sibling-gate behavior unchanged                   (separate file)
+#   I6  Bundle component drift triggers reject            (M-series)
+#   I7  Stale prompt rejection                            (M-series)
+#   I8  Helper requires explicit --root                   (F3a, F3f-g)
+#   I9  Helper imports resolve from staged tmp project    (F1)
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/preflight-gate.sh"
+HELPER="$REPO_ROOT/scripts/preflight-marker-write.mjs"
+GATE_INPUT_TMPL='{"tool_name":"%s","tool_input":%s,"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}'
+
+passed=0
+failed=0
+SESSION_ID="test-session-$$"
+
+# ---------------------------------------------------------------------------
+# Common helpers
+# ---------------------------------------------------------------------------
+
+# stage_fixture <tmp-root>
+# Creates a minimal tmp project that can host the gate + helper.
+# Stages: scripts/{preflight-marker-write.mjs,lib/{canonicalize-path-tolerant,local-dir,marker-paths}.mjs}
+# Stages: hooks/{preflight-gate.sh,lib/{command-classifier,repo-root,marker-paths}.sh}
+# Creates: .git (so resolveRepoRoot works), .checkpoints/, bundles/ (empty or seeded).
+stage_fixture() {
+  local tmp="$1"
+  mkdir -p "$tmp/scripts/lib" "$tmp/hooks/lib" "$tmp/.checkpoints" "$tmp/bundles"
+  # Real git init so resolve_repo_root walks up correctly from nested cwds.
+  # A fake `.git` dir doesn't satisfy `git rev-parse --git-common-dir`.
+  (cd "$tmp" && git init -q 2>/dev/null) || true
+  cp "$REPO_ROOT/scripts/preflight-marker-write.mjs" "$tmp/scripts/"
+  cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/hooks/preflight-gate.sh" "$tmp/hooks/"
+  cp "$REPO_ROOT/hooks/lib/command-classifier.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/marker-paths.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/bundles/codex-review-channel-current.md" "$tmp/bundles/"
+}
+
+# run_gate <tmp-root> <tool-name> <tool-input-json> <expect-class: allow|deny> [reason-grep]
+run_gate() {
+  local tmp="$1" tool="$2" input="$3" expect="$4" reason_grep="${5:-}"
+  local desc="$6"
+  local payload
+  payload="$(printf "$GATE_INPUT_TMPL" "$tool" "$input" "$tmp" "$SESSION_ID")"
+  local out
+  out="$(printf '%s' "$payload" | bash "$tmp/hooks/preflight-gate.sh" 2>&1 || true)"
+
+  if [ "$expect" = "allow" ]; then
+    if [ -z "$out" ]; then
+      echo "  ✓ $desc"
+      passed=$((passed+1))
+    else
+      echo "  ✗ $desc — expected allow (no output) but got: $out"
+      failed=$((failed+1))
+    fi
+  elif [ "$expect" = "deny" ]; then
+    local decision
+    decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+    if [ "$decision" = "deny" ]; then
+      if [ -n "$reason_grep" ]; then
+        local reason
+        reason="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""')"
+        if printf '%s' "$reason" | grep -qE "$reason_grep"; then
+          echo "  ✓ $desc"
+          passed=$((passed+1))
+        else
+          echo "  ✗ $desc — denied but reason missing /$reason_grep/: $reason"
+          failed=$((failed+1))
+        fi
+      else
+        echo "  ✓ $desc"
+        passed=$((passed+1))
+      fi
+    else
+      echo "  ✗ $desc — expected deny but got: $out"
+      failed=$((failed+1))
+    fi
+  fi
+}
+
+cleanup_dirs=()
+on_exit() {
+  for d in "${cleanup_dirs[@]}"; do
+    rm -rf "$d" 2>/dev/null || true
+  done
+}
+trap on_exit EXIT
+
+mktmp() {
+  local d
+  d="$(mktemp -d)"
+  d="$(cd "$d" && pwd -P)"  # macOS /var → /private/var
+  cleanup_dirs+=("$d")
+  echo "$d"
+}
+
+# ---------------------------------------------------------------------------
+# A-series: allow cases (read-only tools / ungated commands)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- A-series: allow cases ---"
+TMP="$(mktmp)"; stage_fixture "$TMP"
+
+run_gate "$TMP" "Bash" '{"command":"ls -la"}' "allow" "" "A01 Bash ls"
+run_gate "$TMP" "Bash" '{"command":"git status"}' "allow" "" "A02 Bash git status"
+run_gate "$TMP" "Read" '{"file_path":"/anything"}' "allow" "" "A03 Read tool"
+run_gate "$TMP" "Grep" '{"pattern":"foo"}' "allow" "" "A04 Grep tool"
+run_gate "$TMP" "Glob" '{"pattern":"*.mjs"}' "allow" "" "A05 Glob tool"
+run_gate "$TMP" "Bash" '{"command":"echo \"codex exec foo\""}' "allow" "" "A06 echo with codex string (no FP)"
+run_gate "$TMP" "Bash" '{"command":"node scripts/em-store.mjs --tag random --body x"}' "allow" "" "A07 em-store no review tag"
+run_gate "$TMP" "Agent" '{"subagent_type":"general-purpose","description":"x","prompt":"y"}' "allow" "" "A08 Agent generic"
+
+# ---------------------------------------------------------------------------
+# M-series: marker-required (codex-review-handoff without marker → DENY)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- M-series: marker-required ---"
+
+run_gate "$TMP" "Bash" '{"command":"codex exec foo"}' "deny" "Pre-flight marker required" "M01 codex exec no marker"
+run_gate "$TMP" "Bash" '{"command":"codex review --plan"}' "deny" "Pre-flight marker required" "M02 codex review no marker"
+run_gate "$TMP" "Bash" '{"command":"sudo codex exec foo"}' "deny" "Pre-flight marker required" "M03 sudo codex no marker"
+run_gate "$TMP" "Bash" '{"command":"env A=1 timeout 30s codex exec foo"}' "deny" "Pre-flight marker required" "M04 env+timeout codex no marker"
+run_gate "$TMP" "Bash" '{"command":"bash -c \"codex exec foo\""}' "deny" "Pre-flight marker required" "M05 bash -c codex no marker"
+run_gate "$TMP" "Bash" '{"command":"node scripts/em-store.mjs --tag codex-review --body x"}' "deny" "Pre-flight marker required" "M06 em-store codex-review tag no marker"
+run_gate "$TMP" "Bash" '{"command":"node scripts/second-opinion.mjs request --provider codex --dispatch"}' "deny" "Pre-flight marker required" "M07 harness no marker"
+run_gate "$TMP" "Agent" '{"subagent_type":"codex:codex-rescue","description":"x","prompt":"y"}' "deny" "Pre-flight marker required" "M08 Agent codex no marker"
+run_gate "$TMP" "Agent" '{"subagent_type":"negative-scenario-reviewer","description":"x","prompt":"y"}' "deny" "Pre-flight marker required" "M09 Agent neg-scenario no marker"
+
+# ---------------------------------------------------------------------------
+# Marker validation — write a valid marker, then mutate fields
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- M-series: marker field validation ---"
+
+# Helper: write a valid marker for $TMP given current fixture's bundle.
+write_valid_marker() {
+  local tmp="$1"
+  local bundle="$tmp/bundles/codex-review-channel-current.md"
+  local bundle_sha
+  bundle_sha="$(shasum -a 256 "$bundle" | awk '{print $1}')"
+  local bundle_mtime
+  bundle_mtime="$(node -e "process.stdout.write(String(require('fs').statSync(process.argv[1]).mtimeMs))" "$bundle")"
+  cat > "$tmp/.checkpoints/.preflight-done" <<EOF
+{
+  "session_id": "$SESSION_ID",
+  "transcript_path": "/tmp/x",
+  "prompt_sha256": "abc123",
+  "prompt_index": 1,
+  "cwd": "$tmp",
+  "repo_root": "$tmp",
+  "memory_root": "$tmp/memory",
+  "claim_class": "codex-review-handoff",
+  "matched_triggers": {"tool_target": ["Bash:codex exec"]},
+  "required_files": ["$bundle"],
+  "loaded_files": [{"path": "$bundle", "mtime_ms": $bundle_mtime, "sha256": "$bundle_sha"}],
+  "artifact_steps_done": ["memory-pre-pass"],
+  "created_at_ms": 1747022400000
+}
+EOF
+}
+
+# DIRECT-WRITE PATH: marker-write enforcement fires BEFORE marker validation.
+# So a Write to the marker path is denied even when a valid marker exists.
+# To test marker-validation paths, use a Bash claim-class trigger instead.
+write_valid_marker "$TMP"
+run_gate "$TMP" "Bash" '{"command":"codex exec foo"}' "allow" "" "M10 valid marker → allow codex"
+
+# Wrong claim_class
+TMP2="$(mktmp)"; stage_fixture "$TMP2"
+write_valid_marker "$TMP2"
+sed -i.bak 's/"codex-review-handoff"/"plan-time-matrix"/' "$TMP2/.checkpoints/.preflight-done"
+rm "$TMP2/.checkpoints/.preflight-done.bak"
+run_gate "$TMP2" "Bash" '{"command":"codex exec foo"}' "deny" "claim_class is" "M11 wrong claim_class"
+
+# Wrong session_id
+TMP3="$(mktmp)"; stage_fixture "$TMP3"
+write_valid_marker "$TMP3"
+sed -i.bak "s/$SESSION_ID/different-session/" "$TMP3/.checkpoints/.preflight-done"
+rm "$TMP3/.checkpoints/.preflight-done.bak"
+run_gate "$TMP3" "Bash" '{"command":"codex exec foo"}' "deny" "session_id" "M12 wrong session_id"
+
+# Wrong repo_root
+TMP4="$(mktmp)"; stage_fixture "$TMP4"
+write_valid_marker "$TMP4"
+sed -i.bak "s|\"repo_root\": \"$TMP4\"|\"repo_root\": \"/totally/different\"|" "$TMP4/.checkpoints/.preflight-done"
+rm "$TMP4/.checkpoints/.preflight-done.bak"
+run_gate "$TMP4" "Bash" '{"command":"codex exec foo"}' "deny" "repo_root" "M13 wrong repo_root"
+
+# Bundle hash drift (modify bundle after marker written)
+TMP5="$(mktmp)"; stage_fixture "$TMP5"
+write_valid_marker "$TMP5"
+echo "DRIFT" >> "$TMP5/bundles/codex-review-channel-current.md"
+run_gate "$TMP5" "Bash" '{"command":"codex exec foo"}' "deny" "hash drift|sha-drift" "M14 bundle hash drift"
+
+# Empty marker
+TMP6="$(mktmp)"; stage_fixture "$TMP6"
+: > "$TMP6/.checkpoints/.preflight-done"
+run_gate "$TMP6" "Bash" '{"command":"codex exec foo"}' "deny" "empty|valid JSON|required" "M15 empty marker"
+
+# Invalid JSON
+TMP7="$(mktmp)"; stage_fixture "$TMP7"
+echo "{ malformed" > "$TMP7/.checkpoints/.preflight-done"
+run_gate "$TMP7" "Bash" '{"command":"codex exec foo"}' "deny" "valid JSON" "M16 malformed JSON marker"
+
+# Missing required_files
+TMP8="$(mktmp)"; stage_fixture "$TMP8"
+echo '{"session_id":"'"$SESSION_ID"'","transcript_path":"/tmp/x","prompt_sha256":"abc","prompt_index":1,"cwd":"'"$TMP8"'","repo_root":"'"$TMP8"'","memory_root":"x","claim_class":"codex-review-handoff","matched_triggers":{},"required_files":[],"loaded_files":[{"path":"x","mtime_ms":1,"sha256":"y"}],"artifact_steps_done":["x"],"created_at_ms":1}' > "$TMP8/.checkpoints/.preflight-done"
+run_gate "$TMP8" "Bash" '{"command":"codex exec foo"}' "deny" "required_files is empty|does not list bundle" "M17 empty required_files"
+
+# Required_files lacks bundle
+TMP9="$(mktmp)"; stage_fixture "$TMP9"
+echo '{"session_id":"'"$SESSION_ID"'","transcript_path":"/tmp/x","prompt_sha256":"abc","prompt_index":1,"cwd":"'"$TMP9"'","repo_root":"'"$TMP9"'","memory_root":"x","claim_class":"codex-review-handoff","matched_triggers":{},"required_files":["/some/other/file.md"],"loaded_files":[{"path":"/some/other/file.md","mtime_ms":1,"sha256":"y"}],"artifact_steps_done":["x"],"created_at_ms":1}' > "$TMP9/.checkpoints/.preflight-done"
+run_gate "$TMP9" "Bash" '{"command":"codex exec foo"}' "deny" "does not list bundle" "M18 required_files missing bundle"
+
+# ---------------------------------------------------------------------------
+# F2-series: marker-write canonicalization
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- F2-series: direct marker-write enforcement ---"
+
+# F2a: absolute path Write to .preflight-done → DENY
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/.checkpoints/.preflight-done\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2a abs path Write marker"
+
+# F2b: repo-relative — gate input cwd = repo, path is repo-relative
+TF="$(mktmp)"; stage_fixture "$TF"
+payload="$(printf "$GATE_INPUT_TMPL" "Write" '{"file_path":".checkpoints/.preflight-done","content":"x"}' "$TF" "$SESSION_ID")"
+out="$(printf '%s' "$payload" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+if [ "$decision" = "deny" ]; then echo "  ✓ F2b repo-relative Write marker"; passed=$((passed+1)); else echo "  ✗ F2b — got: $out"; failed=$((failed+1)); fi
+
+# F2c: nested cwd, ../.checkpoints/.preflight-done
+TF="$(mktmp)"; stage_fixture "$TF"
+mkdir -p "$TF/scripts"
+payload="$(printf "$GATE_INPUT_TMPL" "Write" '{"file_path":"../.checkpoints/.preflight-done","content":"x"}' "$TF/scripts" "$SESSION_ID")"
+out="$(printf '%s' "$payload" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+if [ "$decision" = "deny" ]; then echo "  ✓ F2c nested-cwd Write marker"; passed=$((passed+1)); else echo "  ✗ F2c — got: $out"; failed=$((failed+1)); fi
+
+# F2d: ./ form
+TF="$(mktmp)"; stage_fixture "$TF"
+payload="$(printf "$GATE_INPUT_TMPL" "Write" '{"file_path":"./.checkpoints/.preflight-done","content":"x"}' "$TF" "$SESSION_ID")"
+out="$(printf '%s' "$payload" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+if [ "$decision" = "deny" ]; then echo "  ✓ F2d ./ form Write marker"; passed=$((passed+1)); else echo "  ✗ F2d — got: $out"; failed=$((failed+1)); fi
+
+# F2e: symlink to marker
+TF="$(mktmp)"; stage_fixture "$TF"
+ln -s "$TF/.checkpoints/.preflight-done" "$TF/sym"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/sym\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2e symlink Write marker"
+
+# F2f: unrelated file matching basename → ALLOW
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Write" '{"file_path":"/tmp/.preflight-done","content":"x"}' "allow" "" "F2f unrelated /tmp file"
+
+# F2g: same basename in unrelated subdir → ALLOW
+TF="$(mktmp)"; stage_fixture "$TF"
+mkdir -p "$TF/scratch"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/scratch/.preflight-done\",\"content\":\"x\"}" "allow" "" "F2g same basename diff parent"
+
+# F2h: dangling symlink to absent marker (the codex r4 bypass)
+TF="$(mktmp)"; stage_fixture "$TF"
+rm -f "$TF/.checkpoints/.preflight-done"
+ln -s ".checkpoints/.preflight-done" "$TF/dangling"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/dangling\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2h dangling symlink → DENY"
+
+# F2i: multi-hop chain
+TF="$(mktmp)"; stage_fixture "$TF"
+ln -s "b" "$TF/a"
+ln -s ".checkpoints/.preflight-done" "$TF/b"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/a\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2i multi-hop symlink"
+
+# F2j: symlink in middle of path
+TF="$(mktmp)"; stage_fixture "$TF"
+rm -rf "$TF/.checkpoints"; mkdir -p "$TF/.checkpoints"
+ln -s ".checkpoints" "$TF/cp_alias"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/cp_alias/.preflight-done\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2j middle-path symlink"
+
+# F2k: symlink loop
+TF="$(mktmp)"; stage_fixture "$TF"
+ln -s "loop2" "$TF/loop1"
+ln -s "loop1" "$TF/loop2"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/loop1\",\"content\":\"x\"}" "deny" "canonicalization failed|SYMLOOP" "F2k symlink loop conservative-deny"
+
+# F2l: relative-target symlink in .checkpoints
+TF="$(mktmp)"; stage_fixture "$TF"
+mkdir -p "$TF/.checkpoints"
+ln -s "./.preflight-done" "$TF/.checkpoints/dangle"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/.checkpoints/dangle\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2l relative-target symlink"
+
+# F2m: absolute-target symlink
+TF="$(mktmp)"; stage_fixture "$TF"
+ln -s "$TF/.checkpoints/.preflight-done" "$TF/abs_sym"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/abs_sym\",\"content\":\"x\"}" "deny" "forbidden|helper" "F2m absolute-target symlink"
+
+# F2n: symlink to unrelated path → ALLOW
+TF="$(mktmp)"; stage_fixture "$TF"
+OTHER="$(mktmp)"
+echo '' > "$OTHER/scratch.txt"
+ln -s "$OTHER/scratch.txt" "$TF/scratch_sym"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/scratch_sym\",\"content\":\"x\"}" "allow" "" "F2n symlink to unrelated"
+
+# Edit + MultiEdit equivalents
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Edit" "{\"file_path\":\"$TF/.checkpoints/.preflight-done\",\"old_string\":\"a\",\"new_string\":\"b\"}" "deny" "forbidden|helper" "F4d Edit marker → DENY"
+run_gate "$TF" "MultiEdit" "{\"file_path\":\"$TF/.checkpoints/.preflight-done\",\"edits\":[]}" "deny" "forbidden|helper" "F4e MultiEdit marker → DENY"
+
+# Same for .last-user-prompt.json
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/.checkpoints/.last-user-prompt.json\",\"content\":\"x\"}" "deny" "forbidden|helper" "F4d2 Write last-prompt → DENY"
+
+# ---------------------------------------------------------------------------
+# F3-series: helper-invocation enforcement
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- F3-series: helper invocation enforcement ---"
+
+TF="$(mktmp)"; stage_fixture "$TF"
+# F3-gate: Bash invoking helper without --root → DENY at gate
+run_gate "$TF" "Bash" "{\"command\":\"node $TF/scripts/preflight-marker-write.mjs --target preflight\"}" "deny" "ROOT_REQUIRED|--root" "F3-gate helper sans --root → DENY"
+# F3-gate: Bash invoking helper WITH --root → not blocked by gate (helper itself runs)
+run_gate "$TF" "Bash" "{\"command\":\"node $TF/scripts/preflight-marker-write.mjs --root $TF --target preflight\"}" "allow" "" "F3-gate helper with --root → allowed by gate"
+# A1: bare/npx/script-shebang invocation also denied without --root
+run_gate "$TF" "Bash" '{"command":"./scripts/preflight-marker-write.mjs --target preflight"}' "deny" "ROOT_REQUIRED|--root" "A1a bare script invocation sans --root → DENY"
+run_gate "$TF" "Bash" '{"command":"npx preflight-marker-write.mjs --target preflight"}' "deny" "ROOT_REQUIRED|--root" "A1b npx invocation sans --root → DENY"
+# A3: tab/multi-space variants
+run_gate "$TF" "Bash" "{\"command\":\"node\\tscripts/preflight-marker-write.mjs   --target preflight\"}" "deny" "ROOT_REQUIRED|--root" "A3 tab+multi-space sans --root → DENY"
+
+# F3a: helper directly (out of gate) without --root → exit 4
+set +e
+out="$(echo '{}' | node "$TF/scripts/preflight-marker-write.mjs" --target preflight 2>&1)"
+ec=$?
+set -e
+if printf '%s' "$out" | grep -qE "ROOT_REQUIRED" && [ "$ec" = "4" ]; then
+  echo "  ✓ F3a helper without --root → exit 4 ROOT_REQUIRED"
+  passed=$((passed+1))
+else
+  echo "  ✗ F3a — got exit $ec, output: $out"
+  failed=$((failed+1))
+fi
+
+# F3b: helper from caller cwd != target → marker lands under target
+TF="$(mktmp)"; stage_fixture "$TF"
+CALLER="$(mktmp)"
+out="$(cd "$CALLER" && echo '{"x":1}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+if [ -f "$TF/.checkpoints/.preflight-done" ] && [ ! -f "$CALLER/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ F3b caller-cwd != target — marker lands under target"
+  passed=$((passed+1))
+else
+  echo "  ✗ F3b — TF marker exists: $([ -f "$TF/.checkpoints/.preflight-done" ] && echo yes || echo no), CALLER marker exists: $([ -f "$CALLER/.checkpoints/.preflight-done" ] && echo yes || echo no)"
+  failed=$((failed+1))
+fi
+
+# F3d: --root non-existent → exit 5
+set +e
+out="$(echo '{}' | node "$REPO_ROOT/scripts/preflight-marker-write.mjs" --root /nonexistent/path --target preflight 2>&1)"
+ec=$?
+set -e
+if printf '%s' "$out" | grep -qE "ROOT_INVALID" && [ "$ec" = "5" ]; then
+  echo "  ✓ F3d --root nonexistent → exit 5"
+  passed=$((passed+1))
+else
+  echo "  ✗ F3d — got exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# F3e: --root without repo signals → exit 5
+set +e
+out="$(echo '{}' | node "$REPO_ROOT/scripts/preflight-marker-write.mjs" --root /tmp --target preflight 2>&1)"
+ec=$?
+set -e
+if printf '%s' "$out" | grep -qE "ROOT_NOT_REPO" && [ "$ec" = "5" ]; then
+  echo "  ✓ F3e --root without repo signal → exit 5 ROOT_NOT_REPO"
+  passed=$((passed+1))
+else
+  echo "  ✗ F3e — got exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# ---------------------------------------------------------------------------
+# F4-series: atomicity + race
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- F4-series: helper atomicity ---"
+
+# F4a: helper writes valid JSON → success
+TF="$(mktmp)"; stage_fixture "$TF"
+out="$(echo '{"key":"value"}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+if [ "$ec" = "0" ] && [ -f "$TF/.checkpoints/.preflight-done" ]; then
+  parsed_key="$(jq -r '.key' "$TF/.checkpoints/.preflight-done")"
+  if [ "$parsed_key" = "value" ]; then
+    echo "  ✓ F4a helper writes valid JSON"
+    passed=$((passed+1))
+  else
+    echo "  ✗ F4a — file content wrong"
+    failed=$((failed+1))
+  fi
+else
+  echo "  ✗ F4a — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# B1: non-object JSON (null / array / scalar) → exit 2, no marker
+TF="$(mktmp)"; stage_fixture "$TF"
+set +e
+out="$(echo 'null' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "2" ] && [ ! -f "$TF/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ B1a JSON null rejected → exit 2, no marker"
+  passed=$((passed+1))
+else
+  echo "  ✗ B1a — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+TF="$(mktmp)"; stage_fixture "$TF"
+set +e
+out="$(echo '[]' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "2" ] && [ ! -f "$TF/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ B1b JSON array rejected → exit 2, no marker"
+  passed=$((passed+1))
+else
+  echo "  ✗ B1b — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+TF="$(mktmp)"; stage_fixture "$TF"
+set +e
+out="$(echo '42' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "2" ] && [ ! -f "$TF/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ B1c JSON scalar rejected → exit 2, no marker"
+  passed=$((passed+1))
+else
+  echo "  ✗ B1c — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# F4b: malformed JSON → exit 2, no marker file written
+TF="$(mktmp)"; stage_fixture "$TF"
+set +e
+out="$(echo '{ bad' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "2" ] && [ ! -f "$TF/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ F4b malformed JSON → exit 2, no marker"
+  passed=$((passed+1))
+else
+  echo "  ✗ F4b — exit $ec, marker exists: $([ -f "$TF/.checkpoints/.preflight-done" ] && echo yes || echo no)"
+  failed=$((failed+1))
+fi
+
+# F4c: overwrite → file replaced atomically (different inode)
+TF="$(mktmp)"; stage_fixture "$TF"
+echo '{"v":1}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null
+ino1="$(stat -f '%i' "$TF/.checkpoints/.preflight-done")"
+echo '{"v":2}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null
+ino2="$(stat -f '%i' "$TF/.checkpoints/.preflight-done")"
+v2="$(jq -r '.v' "$TF/.checkpoints/.preflight-done")"
+if [ "$ino1" != "$ino2" ] && [ "$v2" = "2" ]; then
+  echo "  ✓ F4c overwrite is atomic (different inode after rename)"
+  passed=$((passed+1))
+else
+  echo "  ✗ F4c — ino1=$ino1 ino2=$ino2 v2=$v2"
+  failed=$((failed+1))
+fi
+
+# F4f: concurrent writers — last-writer-wins, no partial files leftover
+TF="$(mktmp)"; stage_fixture "$TF"
+for i in 1 2 3 4 5; do
+  echo "{\"writer\":$i}" | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null &
+done
+wait
+final_writer="$(jq -r '.writer' "$TF/.checkpoints/.preflight-done" 2>/dev/null)"
+temp_count="$(ls "$TF/.checkpoints/" | grep -c '\.tmp$' || true)"
+if [ -n "$final_writer" ] && [ "$temp_count" = "0" ]; then
+  echo "  ✓ F4f concurrent writers — winner=$final_writer, no temps leftover"
+  passed=$((passed+1))
+else
+  echo "  ✗ F4f — final_writer=$final_writer temp_count=$temp_count"
+  failed=$((failed+1))
+fi
+
+# F4g: reader-during-write race — every read parseable as JSON
+TF="$(mktmp)"; stage_fixture "$TF"
+echo '{"v":0}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null
+# Spawn 20 writers and 50 readers concurrently
+for i in $(seq 1 20); do
+  echo "{\"v\":$i}" | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null &
+done
+read_failures=0
+for i in $(seq 1 50); do
+  if [ -f "$TF/.checkpoints/.preflight-done" ]; then
+    if ! jq empty "$TF/.checkpoints/.preflight-done" 2>/dev/null; then
+      read_failures=$((read_failures+1))
+    fi
+  fi
+done
+wait
+if [ "$read_failures" = "0" ]; then
+  echo "  ✓ F4g reader-during-write — 50 reads, 0 parse failures"
+  passed=$((passed+1))
+else
+  echo "  ✗ F4g — $read_failures parse failures during race"
+  failed=$((failed+1))
+fi
+
+# ---------------------------------------------------------------------------
+# F5-series: project-root binding (per #20 axis 9)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- F5-series: project-root binding ---"
+
+# F5a: gate spawned from caller cwd != target → marker artifacts under target
+TF="$(mktmp)"; stage_fixture "$TF"
+CALLER="$(mktmp)"
+echo '{"x":1}' | (cd "$CALLER" && node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target last-prompt) >/dev/null
+if [ -f "$TF/.checkpoints/.last-user-prompt.json" ] && [ ! -f "$CALLER/.checkpoints/.last-user-prompt.json" ]; then
+  echo "  ✓ F5a artifacts land under --root, not caller cwd"
+  passed=$((passed+1))
+else
+  echo "  ✗ F5a — TF: $([ -f "$TF/.checkpoints/.last-user-prompt.json" ] && echo yes || echo no), CALLER: $([ -f "$CALLER/.checkpoints/.last-user-prompt.json" ] && echo yes || echo no)"
+  failed=$((failed+1))
+fi
+
+# F5b: helper output JSON's project_root field (well, helper outputs path) →
+# ensure the path is under --root
+TF="$(mktmp)"; stage_fixture "$TF"
+out="$(echo '{}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight)"
+out_path="$(printf '%s' "$out" | jq -r '.path')"
+case "$out_path" in
+  "$TF/"*)
+    echo "  ✓ F5b helper output path under --root"
+    passed=$((passed+1))
+    ;;
+  *)
+    echo "  ✗ F5b — out_path=$out_path not under TF=$TF"
+    failed=$((failed+1))
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# F1: transitive-import drift (per lesson `...3260`)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- F1: transitive-import staging ---"
+
+# Staged tmp project must include all 3 lib files for helper to import
+# without ERR_MODULE_NOT_FOUND
+TF="$(mktmp)"; stage_fixture "$TF"
+out="$(echo '{}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+if [ "$ec" = "0" ]; then
+  echo "  ✓ F1 helper runs in staged tmp (transitive imports resolved)"
+  passed=$((passed+1))
+else
+  echo "  ✗ F1 — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# Negative: deliberately remove canonicalize-path-tolerant.mjs to confirm
+# the test would catch drift.
+rm "$TF/scripts/lib/canonicalize-path-tolerant.mjs"
+set +e
+out="$(echo '{}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight 2>&1)"
+ec=$?
+set -e
+if printf '%s' "$out" | grep -qE "ERR_MODULE_NOT_FOUND|Cannot find module"; then
+  echo "  ✓ F1-neg removing lib triggers ERR_MODULE_NOT_FOUND (test would catch drift)"
+  passed=$((passed+1))
+else
+  echo "  ✗ F1-neg — exit $ec output: $out"
+  failed=$((failed+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+exit $((failed > 0 ? 1 : 0))

--- a/tests/test-preflight-non-worsening.sh
+++ b/tests/test-preflight-non-worsening.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight-non-worsening.sh — assert that adding the new
+# `.checkpoints/.preflight-done` and `.checkpoints/.last-user-prompt.json`
+# marker files does NOT change the decision behavior of the existing four
+# sibling gates (checkpoint-gate, plan-gate, stop-gate, second-opinion-gate).
+#
+# Closes lesson `20260512-053535-...-d20c` (out-of-scope ≠ doesn't break;
+# plans must assert non-worsening) and FU-2 of codex r1.
+#
+# For each sibling gate: pick one deterministic input, run gate against
+# the fixture in two states:
+#   (a) fixture has NONE of the new preflight files
+#   (b) fixture has BOTH preflight files seeded with arbitrary content
+# Assert the gate's stdout + exit are byte-for-byte identical.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+passed=0
+failed=0
+SESSION_ID="non-worsening-$$"
+
+cleanup_dirs=()
+on_exit() { for d in "${cleanup_dirs[@]}"; do rm -rf "$d" 2>/dev/null || true; done; }
+trap on_exit EXIT
+
+mktmp() {
+  local d
+  d="$(mktemp -d)"
+  d="$(cd "$d" && pwd -P)"
+  cleanup_dirs+=("$d")
+  echo "$d"
+}
+
+# Stage a minimal repo with all 5 hooks + their lib deps + git init.
+stage_full_fixture() {
+  local tmp="$1"
+  mkdir -p "$tmp/scripts/lib" "$tmp/hooks/lib" "$tmp/.checkpoints"
+  (cd "$tmp" && git init -q 2>/dev/null) || true
+  cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/hooks/lib/command-classifier.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/marker-paths.sh" "$tmp/hooks/lib/"
+  for h in checkpoint-gate.sh plan-gate.sh stop-gate.sh; do
+    cp "$REPO_ROOT/hooks/$h" "$tmp/hooks/"
+  done
+  # second-opinion-gate.mjs depends on its lib; copy whole dir.
+  if [ -d "$REPO_ROOT/hooks/second-opinion-gate.mjs" ] || [ -f "$REPO_ROOT/hooks/second-opinion-gate.mjs" ]; then
+    cp "$REPO_ROOT/hooks/second-opinion-gate.mjs" "$tmp/hooks/"
+  fi
+}
+
+# Add the two preflight files with arbitrary content.
+add_preflight_files() {
+  local tmp="$1"
+  echo '{"placeholder":true}' > "$tmp/.checkpoints/.preflight-done"
+  echo '{"placeholder":true}' > "$tmp/.checkpoints/.last-user-prompt.json"
+}
+
+# run_and_capture <gate-cmd> <input>  → echo "$exit\n$stdout"
+run_and_capture() {
+  local gate="$1" input="$2"
+  local out ec
+  set +e
+  out="$(printf '%s' "$input" | bash -c "$gate" 2>&1)"
+  ec=$?
+  set -e
+  printf '%d\n%s' "$ec" "$out"
+}
+
+# Compare two captures; both must be identical.
+assert_unchanged() {
+  local desc="$1" before="$2" after="$3"
+  if [ "$before" = "$after" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc"
+    echo "    BEFORE: $before"
+    echo "    AFTER:  $after"
+    failed=$((failed+1))
+  fi
+}
+
+echo ""
+echo "--- N1: checkpoint-gate.sh — benign read-only Bash unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+INPUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}' "$TMP" "$SESSION_ID")"
+GATE="bash $TMP/hooks/checkpoint-gate.sh"
+BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+add_preflight_files "$TMP"
+AFTER="$(run_and_capture "$GATE" "$INPUT")"
+assert_unchanged "N1 checkpoint-gate ls Bash" "$BEFORE" "$AFTER"
+
+echo ""
+echo "--- N2: checkpoint-gate.sh — with .checkpoint-required (block) unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+touch "$TMP/.checkpoints/.checkpoint-required"
+INPUT="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s/foo.txt","content":"x"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}' "$TMP" "$TMP" "$SESSION_ID")"
+GATE="bash $TMP/hooks/checkpoint-gate.sh"
+BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+add_preflight_files "$TMP"
+AFTER="$(run_and_capture "$GATE" "$INPUT")"
+assert_unchanged "N2 checkpoint-gate blocked Write w/.checkpoint-required" "$BEFORE" "$AFTER"
+
+echo ""
+echo "--- N3: plan-gate.sh — benign Bash unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+INPUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"ls"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}' "$TMP" "$SESSION_ID")"
+GATE="bash $TMP/hooks/plan-gate.sh"
+BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+add_preflight_files "$TMP"
+AFTER="$(run_and_capture "$GATE" "$INPUT")"
+assert_unchanged "N3 plan-gate ls Bash" "$BEFORE" "$AFTER"
+
+echo ""
+echo "--- N4: plan-gate.sh — with .plan-approval-pending (block) unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+touch "$TMP/.checkpoints/.plan-approval-pending"
+INPUT="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s/foo.txt","content":"x"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}' "$TMP" "$TMP" "$SESSION_ID")"
+GATE="bash $TMP/hooks/plan-gate.sh"
+BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+add_preflight_files "$TMP"
+AFTER="$(run_and_capture "$GATE" "$INPUT")"
+assert_unchanged "N4 plan-gate blocked Write w/.plan-approval-pending" "$BEFORE" "$AFTER"
+
+echo ""
+echo "--- N5: stop-gate.sh — without checkpoint-required unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+INPUT="$(printf '{"hook_event_name":"Stop","cwd":"%s","session_id":"%s","transcript_path":"/tmp/x","stop_hook_active":false}' "$TMP" "$SESSION_ID")"
+GATE="bash $TMP/hooks/stop-gate.sh"
+BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+add_preflight_files "$TMP"
+AFTER="$(run_and_capture "$GATE" "$INPUT")"
+assert_unchanged "N5 stop-gate clean state" "$BEFORE" "$AFTER"
+
+echo ""
+echo "--- N6: second-opinion-gate.mjs — benign Bash unchanged ---"
+TMP="$(mktmp)"; stage_full_fixture "$TMP"
+if [ -f "$TMP/hooks/second-opinion-gate.mjs" ]; then
+  INPUT="$(printf '{"tool_name":"Bash","tool_input":{"command":"ls"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}' "$TMP" "$SESSION_ID")"
+  GATE="node $TMP/hooks/second-opinion-gate.mjs"
+  BEFORE="$(run_and_capture "$GATE" "$INPUT")"
+  add_preflight_files "$TMP"
+  AFTER="$(run_and_capture "$GATE" "$INPUT")"
+  assert_unchanged "N6 second-opinion-gate ls Bash" "$BEFORE" "$AFTER"
+else
+  echo "  (skip) N6 — second-opinion-gate.mjs not present in fixture"
+fi
+
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+exit $((failed > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

Implements **Layer D narrow pre-flight gate PR1** (rank 1c in workplan v46). Closes the bp-010 cluster: codex/Agent/em-store review handoffs now require a structured memory pre-flight marker before the tool call lands.

- **5 rounds of codex consensus** (r1 ACCEPT-with-FU → r2 HOLD atomicity → r3 HOLD spec gaps → r4 HOLD dangling-symlink bypass → r5 ACCEPT) — each round caught a real bug; never drift.
- **327 tests pass** + 9/9 codex-mandated E2E temp-dir repro.
- **Code review:** `Agent(negative-scenario-reviewer)` ACCEPT-with-FU; 0 BLOCKERs.

## Components added

| File | LOC | Role |
|---|---|---|
| `scripts/lib/canonicalize-path-tolerant.mjs` | 121 | POSIX path canonicalization with missing-leaf tolerance + symlink dereference; MAX_HOPS=40 |
| `scripts/preflight-marker-write.mjs` | 181 | Atomic temp+rename helper; requires explicit `--root`; validates root has `.git`/`.checkpoints`/`.episodic-memory` signal |
| `hooks/preflight-gate.sh` | 263 | PreToolUse gate; classifier-driven; canonicalize marker-path comparison; helper-only enforcement |
| `bundles/codex-review-channel-current.md` | 171 | 7-component manifest; sha256 + role per component; marker schema; machine-readable JSON block |

## Components modified

| File | LOC added | Change |
|---|---|---|
| `hooks/lib/command-classifier.sh` | +301 | `classify_preflight_*` siblings + wrapper-utility unwrap (env/sudo/timeout/nohup) + bash -c/-lc/-ci recursion |
| `tests/test-command-classifier.sh` | +125 | 54 new Q-series tests for preflight classifier |
| `scripts/lib/install-manifest.mjs` | +9 | `HOOK_SPECS` entry for preflight-gate.sh on PreToolUse |
| `.gitignore` | +6 | `.claude/settings.json` is per-user (hardcoded paths) |

## Tests

| Suite | New | Existing | Total |
|---|---|---|---|
| canonicalize-path-tolerant unit | 17 | — | 17 |
| command-classifier | 54 | 186 | 240 |
| preflight-gate | 64 | — | 64 |
| preflight-non-worsening | 6 | — | 6 |
| **Total** | **141** | **186** | **327** |

E2E codex-mandated repro (caller cwd ≠ target project root):
- Marker landed under TARGET ✓
- Marker did NOT leak to CALLER ✓
- Last-prompt landed under TARGET ✓
- Last-prompt did NOT leak to CALLER ✓
- Nested-cwd write replaced TARGET marker (atomic, new inode) ✓
- Helper without --root from non-git caller → exit 4 `ROOT_REQUIRED` ✓
- Gate allows helper invocation with `--root` ✓
- Gate denies helper invocation without `--root` ✓

## Codex consensus chain (5 rounds, ~23 minutes)

| Round | Reply | Verdict | Class |
|---|---|---|---|
| r1 | `20260512-070738-...-ed24` | ACCEPT-with-FU | 5 FUs absorbed inline |
| r2 | `20260512-071449-...-6e90` | HOLD | atomicity contract not locally verifiable (Write ≠ rename) |
| r3 | `20260512-071818-...-6f25` | HOLD | wrong import + missing canonicalization + ambiguous helper invocation |
| r4 | `20260512-072212-...-0fc1` | HOLD | dangling-symlink bypass (`realpathSync` ENOENT-fallback) |
| r5 | `20260512-072545-...-dbf6` | **ACCEPT** | component-wise tolerant canonicalization closes blocker |

## Code review (negative-scenario-reviewer)

ACCEPT-with-FU. 0 BLOCKERs. 4 MAJOR (defense-in-depth gaps, none exploitable), 6 MINOR, 3 NIT.

**Inline-FU dispositions** (sub-3-LOC same-surface):
- B1: helper rejects non-object JSON
- C1: bundle membership via `jq -e index` (avoids grep `.md` regex leak)
- A1: helper-invocation regex extended (npx/bare/script forms)
- A3: whitespace normalization (tabs / multi-space)
- F4: bash `-lc` / `-il` / `-ci` short-opt recursion in classifier
- F1: MAX_HOPS=40 boundary tests (just-under + over)

**Filed as issues** (architectural / cross-file):
- #236 — A2 Bash redirection writes to marker bypass helper-only contract
- #237 — B2 orphan temp-file sweep
- #238 — C2 implement true prompt-binding via `UserPromptSubmit` hook
- #239 — bundle: C3 enumerate `artifact_steps_done`, D2 `mcp__*` policy, E1 worktree fixture

## v1 enforcement scope

PR1 enforces `codex-review-handoff` only. Other claim classes registered for shape but pass-through: `rule-bearing-file-edit`, `adversarial-code-review`, `plan-time-matrix`, `scratch-files`, `wrap-up-discipline`. PR2+ enables them.

## Plan provenance

- Final plan episode: `.episodic-memory/episodes/20260508-123531-layer-d-narrow-pre-flight-gate-final-pla-23f3.md`
- Workplan rank 1c (v46): `20260512-053617-workplan-2026-05-12-v46-232-regression-c-5f0f`

## Test plan

- [ ] CI green
- [ ] Reviewer (`lantiscooperdev`) verifies no regressions in existing classifier / checkpoint-gate / plan-gate / stop-gate / second-opinion-gate suites
- [ ] Manual smoke (post-merge): trigger codex review without marker → verify gate emits actionable block reason
- [ ] Manual smoke (post-merge): write marker via helper, dispatch codex review → verify gate allows
- [ ] Manual smoke (post-merge): direct `Write` to `.checkpoints/.preflight-done` → verify gate denies + reason names helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
