### PR TITLE
feat(preflight): UserPromptSubmit hook for true prompt-binding (closes #238, unblocks #243)

### DIFF
--- a/bundles/codex-review-channel-current.md
+++ b/bundles/codex-review-channel-current.md
@@ -80,6 +80,15 @@ the harness, which is now the canonical channel.
 
 ## Marker schema
 
+The `prompt_sha256` field is now load-bearing: the pre-flight gate
+cross-checks it against `<repo>/.checkpoints/.last-user-prompt.<session_id>.json`,
+which is written by the `preflight-prompt-helper.sh` UserPromptSubmit hook
+on every real user prompt (#238 PR1 FU-C2). Both sides compute
+`sha256(utf8_bytes(JSON.parse(stdin).prompt))` via
+`scripts/lib/preflight-prompt-canon.mjs` — no trailing newline, post
+JSON-unescape. Markers with a fabricated sha that doesn't match the
+current real prompt are rejected.
+
 ```json
 {
   "session_id": "...",

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -657,8 +657,13 @@ _classify_segment() {
       esac
       local tbase="$(basename "$t")"
       # Same-class extension per plan-v2 I10 — see rm-of-marker comment above.
+      # Codex round-2 FU on PR #246: tee was still missing
+      # `.checkpoint-required` and `.post-checkpoint-required` (latent
+      # pre-existing gap, parallel shape to the rm-class C4 fix); closing
+      # for class-completeness so the same-class lens is tight across all
+      # write surfaces.
       case "$tbase" in
-        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.preflight-done|.last-user-prompt.json)
+        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -608,8 +608,20 @@ _classify_segment() {
         -*) j=$((j+1)); continue ;;
       esac
       local tbase="$(basename "$t")"
+      # Preflight markers added per plan-v2 I10 (audit F1 same-class):
+      # the rm-marker class was missing `.preflight-done` (PR #240 oversight)
+      # and the new session-namespaced `.last-user-prompt.<sid>.json` files.
+      # Without these, `rm .checkpoints/.preflight-done` (or the per-session
+      # last-prompt file) from Bash bypasses the gate's direct-Write deny
+      # and re-opens the trust-based hole the gate exists to close.
       case "$tbase" in
-        .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required)
+        .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required|.preflight-done)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
+        .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
@@ -632,8 +644,15 @@ _classify_segment() {
         -*) j=$((j+1)); continue ;;
       esac
       local tbase="$(basename "$t")"
+      # Same-class extension per plan-v2 I10 — see rm-of-marker comment above.
       case "$tbase" in
-        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
+        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.preflight-done)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
+        .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
@@ -1713,7 +1732,17 @@ classify_preflight_tool() {
     Agent|Task)
       local subagent
       subagent="$(printf '%s' "$tool_input_json" | jq -r '.subagent_type // ""' 2>/dev/null)"
+      # Plan-v2 I11 (audit F7): `negative-scenario-planner` is the documented
+      # bootstrap workaround for plan-time review when the harness channel is
+      # blocked (workplan v49 §workaround). It runs BEFORE plans exist, so it
+      # cannot itself be gated by a post-plan marker. Reviewer-class subagents
+      # (`negative-scenario-reviewer`, future `negative-scenario-coder`, etc.)
+      # remain gated — those run AFTER a plan exists and a marker is feasible.
       case "$subagent" in
+        negative-scenario-planner)
+          printf '%s\t%s\t%s\n' "none" "" "agent_planner_bootstrap_exempt"
+          return 0
+          ;;
         codex:*|codex-*|negative-scenario-*)
           printf '%s\t%s\t%s\n' "codex-review-handoff" "tool_target" "agent_${subagent//[^a-zA-Z0-9]/_}"
           return 0

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -506,8 +506,20 @@ _classify_segment() {
         continue
         ;;
     esac
+    # Same-class scope mirrors the rm/tee handlers below. Codex round-1 F1
+    # on PR #246 (HOLD): the redirect handler covered only 3 of 6 checkpoint
+    # markers and was missing both `.preflight-done` AND the new last-user-
+    # prompt family — so `printf x > .checkpoints/.last-user-prompt.<sid>.json`
+    # classified as `shared_write` and bypassed the entire prompt-binding
+    # layered enforcement.
     case "$rbase" in
-      .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending)
+      .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
+      .last-user-prompt.*.json)
         local abs_target
         abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -615,7 +615,7 @@ _classify_segment() {
       # last-prompt file) from Bash bypasses the gate's direct-Write deny
       # and re-opens the trust-based hole the gate exists to close.
       case "$tbase" in
-        .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required|.preflight-done)
+        .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
@@ -646,7 +646,7 @@ _classify_segment() {
       local tbase="$(basename "$t")"
       # Same-class extension per plan-v2 I10 — see rm-of-marker comment above.
       case "$tbase" in
-        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.preflight-done)
+        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.preflight-done|.last-user-prompt.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -88,6 +88,22 @@ _emit_deny() {
   exit 0
 }
 
+# P2-1 (code-review FU): validate SESSION_ID shape immediately after
+# _emit_deny is defined and BEFORE any downstream path-construction or
+# marker comparison. Every other layer (hook, helper, install bootstrap)
+# enforces ^[A-Za-z0-9_-]{1,128}$; the gate must match so a malicious
+# stdin payload can't cause path-traversal via LAST_PROMPT_SID_PATH
+# interpolation. Empty SESSION_ID is allowed (Claude Code may omit it;
+# downstream branches already test `-n "$SESSION_ID"`).
+if [ -n "$SESSION_ID" ]; then
+  case "$SESSION_ID" in
+    *[!A-Za-z0-9_-]*) _emit_deny "preflight-gate.sh: session_id from stdin contains invalid chars; cannot evaluate prompt-binding." ;;
+  esac
+  if [ ${#SESSION_ID} -gt 128 ]; then
+    _emit_deny "preflight-gate.sh: session_id from stdin exceeds 128 chars; cannot evaluate prompt-binding."
+  fi
+fi
+
 # _canonicalize_one <input-path> <hook-cwd>
 # Echoes canonical path on stdout; returns 0 on success, non-zero on
 # canonicalization failure (SYMLOOP_MAX, EACCES, lib-missing). CALLER must
@@ -189,7 +205,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
       # last-prompt` is an agent attempt to spoof the prompt-binding.
       # Deny regardless of --root presence (the agent could supply
       # --root correctly while still forging the sha).
-      if printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-target[[:space:]]+last-prompt(\b|$)'; then
+      if printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-target[[:space:]]+last-prompt([[:space:]]|$)'; then
         _emit_deny "preflight-marker-write.mjs --target last-prompt is reserved for the UserPromptSubmit hook. Agent invocation at PreToolUse is forbidden — the hook writes this file on every real user prompt automatically. If the file is missing, the install may be incomplete: re-run install.mjs --install-hooks."
       fi
     fi
@@ -301,7 +317,7 @@ if [ -n "$SESSION_ID" ]; then
     fi
     if [ "$M_PROMPT_SHA" != "$FILE_PROMPT_SHA" ]; then
       # Truncate the shas for readability (full hashes are 64 chars).
-      _emit_deny "Pre-flight marker prompt_sha256 does not match the current real user prompt. Marker sha: ${M_PROMPT_SHA:0:12}…; ground-truth sha: ${FILE_PROMPT_SHA:0:12}… (from $CANON_LAST_PROMPT_SID). The marker is bound to a prior prompt. Re-run the pre-flight steps for the current prompt before retrying."
+      _emit_deny "Pre-flight marker prompt_sha256 does not match the current real user prompt. Marker sha: ${M_PROMPT_SHA:0:16}…; ground-truth sha: ${FILE_PROMPT_SHA:0:16}… (from $CANON_LAST_PROMPT_SID). The marker is bound to a prior prompt. Re-run the pre-flight steps for the current prompt before retrying."
     fi
   fi
 fi

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -304,6 +304,15 @@ if [ -n "$SESSION_ID" ]; then
     # I8 60s bootstrap window. After 60s, the bootstrap sentinel is stale
     # — fail-closed. Use node for portable ms-precision arithmetic.
     NOW_MS="$(node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0)"
+    # Codex round-1 F2 on PR #246 (HOLD): validate FILE_WROTE_AT_MS is
+    # numeric BEFORE arithmetic. Without this, a sentinel containing
+    # `"wrote_at_ms": "123abc"` triggers a bash arithmetic error; the
+    # gate exits non-zero with no `permissionDecision:"deny"` JSON,
+    # making behavior depend on Claude Code's hook-error fallback rather
+    # than the gate's local fail-closed contract.
+    case "$FILE_WROTE_AT_MS" in
+      ''|*[!0-9]*) _emit_deny "Bootstrap sentinel at $CANON_LAST_PROMPT_SID has non-numeric wrote_at_ms ($FILE_WROTE_AT_MS); cannot evaluate age. Re-run install.mjs --install-hooks --bootstrap-last-prompt." ;;
+    esac
     AGE_MS=$((NOW_MS - FILE_WROTE_AT_MS))
     if [ "$AGE_MS" -gt 60000 ] || [ "$AGE_MS" -lt 0 ]; then
       _emit_deny "Bootstrap sentinel at $CANON_LAST_PROMPT_SID is stale (age ${AGE_MS}ms > 60000ms). The UserPromptSubmit hook should have replaced it by now. Re-run install.mjs --install-hooks to wire the hook."

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -124,6 +124,8 @@ case "$TOOL_NAME" in
       ec_pf=$?
       CANON_LAST_PROMPT="$(_canonicalize_one "$LAST_PROMPT_MARKER" "$REPO_ROOT")"
       ec_lp=$?
+      CANON_PRIMARY_DIR="$(_canonicalize_one "$PRIMARY_DIR" "$REPO_ROOT")"
+      ec_pd=$?
       set -e
       if [ $ec_tool -eq 99 ]; then
         _emit_deny "preflight-gate.sh: canonicalize-path-tolerant lib missing at $CANON_LIB. Re-run install.mjs --install-hooks."
@@ -133,10 +135,23 @@ case "$TOOL_NAME" in
       fi
       # Marker-path canonicalization should never fail (paths are simple,
       # no symlinks expected). If it does → conservative deny.
-      if [ $ec_pf -ne 0 ] || [ $ec_lp -ne 0 ]; then
+      if [ $ec_pf -ne 0 ] || [ $ec_lp -ne 0 ] || [ $ec_pd -ne 0 ]; then
         _emit_deny "preflight-gate.sh: failed to canonicalize marker paths; gate cannot evaluate. Re-run install.mjs --install-hooks."
       fi
-      if [ "$CANON_TOOL" = "$CANON_PREFLIGHT" ] || [ "$CANON_TOOL" = "$CANON_LAST_PROMPT" ]; then
+      # Direct equality covers .preflight-done and the legacy non-namespaced
+      # .last-user-prompt.json. Plan-v2 C5: also deny any
+      # .last-user-prompt.<sid>.json under .checkpoints/ (the session-
+      # namespaced files written by the helper via the UserPromptSubmit
+      # hook — agents must never write these directly).
+      _tool_basename="$(basename "$CANON_TOOL")"
+      _tool_parent="$(dirname "$CANON_TOOL")"
+      _last_prompt_namespaced=0
+      if [ "$_tool_parent" = "$CANON_PRIMARY_DIR" ]; then
+        case "$_tool_basename" in
+          .last-user-prompt.*.json) _last_prompt_namespaced=1 ;;
+        esac
+      fi
+      if [ "$CANON_TOOL" = "$CANON_PREFLIGHT" ] || [ "$CANON_TOOL" = "$CANON_LAST_PROMPT" ] || [ $_last_prompt_namespaced -eq 1 ]; then
         _emit_deny "Direct $TOOL_NAME to preflight marker is forbidden. Use the atomic helper: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight (or --target last-prompt). Resolved tool path: $CANON_TOOL."
       fi
     fi
@@ -155,13 +170,27 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     # variants like `node\t/abs/.../preflight-marker-write.mjs` or
     # `node \\` + newline + path slip through to the same matcher (A3).
     NORMALIZED_CMD="$(printf '%s' "$CMD" | tr '\t\n' '  ' | sed 's/\\ / /g; s/  */ /g')"
-    # Match any helper invocation: node|npx|bash, bare basename `preflight-
-    # marker-write.mjs`, or any path ending in that basename. Closes A1
-    # asymmetry with the codex/em-* classifier in command-classifier.sh
-    # which already handles bare/npx/script-shebang invocations.
-    if printf '%s' "$NORMALIZED_CMD" | grep -qE '(\bnode |\bnpx |\bbash )?[^[:space:]]*\bpreflight-marker-write\.mjs\b'; then
+    # Match the helper basename when it's a real invocation: must be
+    # preceded by start-of-string, space, or slash (i.e. it IS the basename
+    # of a path or a bare invocation), AND followed by space or end. The
+    # previous regex used `\b...\b` which matched ANY word-boundary,
+    # producing false-positives on `test-preflight-marker-write.mjs`
+    # (the `-` in `test-` is a non-word char, so `\b` triggered against
+    # the following `p`). Plan-v2 C5: tighten the boundary.
+    HELPER_BASENAME_RE='(^|[ /])preflight-marker-write\.mjs( |$)'
+    if printf '%s' "$NORMALIZED_CMD" | grep -qE "$HELPER_BASENAME_RE"; then
       if ! printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-root[[:space:]]+[^[:space:]]'; then
         _emit_deny "preflight-marker-write.mjs invoked without explicit --root. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt>. No cwd fallback (ROOT_REQUIRED)."
+      fi
+      # I7 (plan-v2 audit F2): the UserPromptSubmit hook is the ONLY
+      # sanctioned writer of `.last-user-prompt.<sid>.json`. The hook
+      # runs OUTSIDE the PreToolUse path (UserPromptSubmit event), so
+      # any PreToolUse-time invocation of the helper with `--target
+      # last-prompt` is an agent attempt to spoof the prompt-binding.
+      # Deny regardless of --root presence (the agent could supply
+      # --root correctly while still forging the sha).
+      if printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-target[[:space:]]+last-prompt(\b|$)'; then
+        _emit_deny "preflight-marker-write.mjs --target last-prompt is reserved for the UserPromptSubmit hook. Agent invocation at PreToolUse is forbidden — the hook writes this file on every real user prompt automatically. If the file is missing, the install may be incomplete: re-run install.mjs --install-hooks."
       fi
     fi
   fi
@@ -216,6 +245,67 @@ fi
 if [ -z "$M_PROMPT_SHA" ]; then
   _emit_deny "Pre-flight marker missing prompt_sha256. Re-write with the current user prompt's sha256."
 fi
+
+# ---------------------------------------------------------------------------
+# I2 cross-check (plan-v2 audit F3 closure): compare marker prompt_sha256
+# against the ground-truth file written by the UserPromptSubmit hook
+# (.checkpoints/.last-user-prompt.<SESSION_ID>.json).
+#
+# I8 fail-closed with bootstrap window: if the ground-truth file is absent
+# for the current session, deny by default. Exception: install.mjs may
+# write a sentinel file with `bootstrap=true` and a recent wrote_at_ms;
+# accept that for 60 seconds so the first prompt of a fresh install can
+# land before the real UserPromptSubmit fires on prompt #2.
+#
+# Locally verifiable: the file path is constructed from REPO_ROOT (gate-
+# resolved) and SESSION_ID (passed by Claude Code in stdin), canonicalized
+# via the same tolerant lib used for write-side paths (I9).
+# ---------------------------------------------------------------------------
+if [ -n "$SESSION_ID" ]; then
+  LAST_PROMPT_SID_PATH="$PRIMARY_DIR/.last-user-prompt.${SESSION_ID}.json"
+  set +e
+  CANON_LAST_PROMPT_SID="$(_canonicalize_one "$LAST_PROMPT_SID_PATH" "$REPO_ROOT")"
+  ec_lps=$?
+  set -e
+  if [ $ec_lps -eq 99 ]; then
+    _emit_deny "preflight-gate.sh: canonicalize lib missing; cannot evaluate prompt-binding. Re-run install.mjs --install-hooks."
+  fi
+  if [ $ec_lps -ne 0 ]; then
+    # Canonicalization failed (e.g. symlink loop). Conservative deny.
+    _emit_deny "preflight-gate.sh: failed to canonicalize $LAST_PROMPT_SID_PATH ($CANON_LAST_PROMPT_SID); cannot verify prompt-binding."
+  fi
+  if [ ! -f "$CANON_LAST_PROMPT_SID" ]; then
+    _emit_deny "Pre-flight marker cannot be cross-checked against ground truth: $CANON_LAST_PROMPT_SID does not exist for session $SESSION_ID. The UserPromptSubmit hook should write this file on every real prompt. If this is the first prompt after a fresh install, run: node install.mjs --tool claude-code --install-hooks --bootstrap-last-prompt. Otherwise re-run install to wire the UserPromptSubmit hook."
+  fi
+  FILE_JSON="$(cat "$CANON_LAST_PROMPT_SID" 2>/dev/null || true)"
+  if [ -z "$FILE_JSON" ] || ! printf '%s' "$FILE_JSON" | jq empty 2>/dev/null; then
+    _emit_deny "Ground-truth file $CANON_LAST_PROMPT_SID is empty or not valid JSON. Re-run install.mjs --install-hooks to restore the UserPromptSubmit hook."
+  fi
+  FILE_BOOTSTRAP="$(printf '%s' "$FILE_JSON" | jq -r '.bootstrap // false')"
+  FILE_WROTE_AT_MS="$(printf '%s' "$FILE_JSON" | jq -r '.wrote_at_ms // 0')"
+  FILE_PROMPT_SHA="$(printf '%s' "$FILE_JSON" | jq -r '.prompt_sha256 // ""')"
+  if [ "$FILE_BOOTSTRAP" = "true" ]; then
+    # I8 60s bootstrap window. After 60s, the bootstrap sentinel is stale
+    # — fail-closed. Use node for portable ms-precision arithmetic.
+    NOW_MS="$(node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0)"
+    AGE_MS=$((NOW_MS - FILE_WROTE_AT_MS))
+    if [ "$AGE_MS" -gt 60000 ] || [ "$AGE_MS" -lt 0 ]; then
+      _emit_deny "Bootstrap sentinel at $CANON_LAST_PROMPT_SID is stale (age ${AGE_MS}ms > 60000ms). The UserPromptSubmit hook should have replaced it by now. Re-run install.mjs --install-hooks to wire the hook."
+    fi
+    # Within bootstrap window: allow without sha cross-check. The marker
+    # still has to satisfy all other gate checks below.
+  else
+    # Normal case: real UserPromptSubmit-written file. Compare shas.
+    if [ -z "$FILE_PROMPT_SHA" ]; then
+      _emit_deny "Ground-truth file $CANON_LAST_PROMPT_SID missing prompt_sha256 field. Re-run install.mjs --install-hooks."
+    fi
+    if [ "$M_PROMPT_SHA" != "$FILE_PROMPT_SHA" ]; then
+      # Truncate the shas for readability (full hashes are 64 chars).
+      _emit_deny "Pre-flight marker prompt_sha256 does not match the current real user prompt. Marker sha: ${M_PROMPT_SHA:0:12}…; ground-truth sha: ${FILE_PROMPT_SHA:0:12}… (from $CANON_LAST_PROMPT_SID). The marker is bound to a prior prompt. Re-run the pre-flight steps for the current prompt before retrying."
+    fi
+  fi
+fi
+
 if [ -z "$M_REQUIRED" ]; then
   _emit_deny "Pre-flight marker required_files is empty. Must include the bundle path: $BUNDLE_PATH."
 fi

--- a/hooks/preflight-prompt-helper.sh
+++ b/hooks/preflight-prompt-helper.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# episodic-memory-hook-version: 2026-05-12.2
+# preflight-prompt-helper.sh — UserPromptSubmit hook for true prompt-binding.
+#
+# Maintains `<repo>/.checkpoints/.last-user-prompt.<session_id>.json` with the
+# canonical sha256 of the current real user prompt. The preflight-gate
+# (hooks/preflight-gate.sh) cross-checks that file's `prompt_sha256` against
+# any codex-review-handoff pre-flight marker — closing the trust-based hole
+# left open by PR #240 (which took the FALLBACK path of trusting agent-supplied
+# sha values without comparison to ground truth).
+#
+# Plan provenance: scratch/238-plan-v2.md C3 (workplan v49 rank 0). Closes
+# #238 PR1 FU-C2. Audit findings folded in: F3 (pin canonicalization),
+# F4 (session-namespaced file), F5 (no hooks/lib dependency — keep tight),
+# F6 (UserPromptSubmit ordering documented as external contract).
+#
+# Behavior:
+#   1) Read stdin (Claude Code UserPromptSubmit payload):
+#        { prompt, session_id, transcript_path, cwd, hook_event_name, ... }
+#   2) Resolve repo root from cwd.
+#   3) Compute canonical sha256 via scripts/lib/preflight-prompt-canon.mjs
+#      (binding contract: sha256(utf8_bytes(JSON.parse(stdin).prompt))).
+#   4) Compose marker JSON (sha + session_id + transcript_path + cwd + wrote_at_ms).
+#   5) Pipe to scripts/preflight-marker-write.mjs --target last-prompt
+#      --session-id <sid>, which atomically temp+renames the file into place.
+#
+# Fail-safe (audit F3 I3): on ANY internal error (malformed stdin, helper
+# missing, session_id invalid, jq failure, repo-root unresolvable), exit 0
+# + log to stderr. NEVER block a real user prompt; degraded enforcement
+# is strictly better than hard-stop-on-bug.
+
+set -u
+# Deliberately NOT `set -e`: every step is wrapped to fail-safe via the
+# `_log_and_exit_safe` helper. errexit could fire on transient pipe
+# failures (e.g. jq early exit) and silently block the prompt.
+
+# ---------------------------------------------------------------------------
+# Read input
+# ---------------------------------------------------------------------------
+INPUT="$(cat 2>/dev/null || true)"
+
+_log_and_exit_safe() {
+  # Fail-safe: log to stderr, then exit 0. The hook framework captures
+  # stderr to the debug log per Claude Code hooks reference, but the
+  # user's prompt flow is not blocked.
+  printf 'preflight-prompt-helper: %s\n' "$1" >&2
+  exit 0
+}
+
+if [ -z "$INPUT" ]; then
+  _log_and_exit_safe "empty stdin; skipping"
+fi
+
+# Validate JSON shape minimally. Full validation lives in canon lib.
+if ! printf '%s' "$INPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  _log_and_exit_safe "stdin is not a JSON object; skipping"
+fi
+
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)"
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)"
+TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)"
+
+[ -z "$CWD" ] && CWD="$(pwd)"
+
+if [ -z "$SESSION_ID" ]; then
+  _log_and_exit_safe "stdin missing session_id; skipping"
+fi
+
+# Validate session_id format (same regex as helper rejects). Done here
+# too so we don't bother shelling out to node for an invalid value.
+case "$SESSION_ID" in
+  *[!A-Za-z0-9_-]*) _log_and_exit_safe "session_id has invalid chars; skipping" ;;
+esac
+if [ ${#SESSION_ID} -gt 128 ] || [ ${#SESSION_ID} -lt 1 ]; then
+  _log_and_exit_safe "session_id length out of bounds; skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve repo root + dependent paths
+# ---------------------------------------------------------------------------
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+LIB_DIR="$HOOK_DIR/lib"
+if [ ! -f "$LIB_DIR/repo-root.sh" ]; then
+  _log_and_exit_safe "hooks/lib/repo-root.sh missing; skipping (re-run install.mjs --install-hooks)"
+fi
+# shellcheck disable=SC1091
+. "$LIB_DIR/repo-root.sh"
+
+REPO_ROOT="$(resolve_repo_root "$CWD")"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
+  _log_and_exit_safe "repo root unresolved from cwd=$CWD; skipping"
+fi
+
+# Locate the canon lib + marker-write helper. Prefer in-repo paths
+# (development), fall back to the global install (~/.episodic-memory/).
+CANON_LIB=""
+HELPER=""
+for cand in \
+  "$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs" \
+  "${HOME:-/}/.episodic-memory/scripts/lib/preflight-prompt-canon.mjs"
+do
+  if [ -f "$cand" ]; then CANON_LIB="$cand"; break; fi
+done
+for cand in \
+  "$REPO_ROOT/scripts/preflight-marker-write.mjs" \
+  "${HOME:-/}/.episodic-memory/scripts/preflight-marker-write.mjs"
+do
+  if [ -f "$cand" ]; then HELPER="$cand"; break; fi
+done
+[ -z "$CANON_LIB" ] && _log_and_exit_safe "canonicalize lib not found in repo or ~/.episodic-memory/; skipping"
+[ -z "$HELPER" ] && _log_and_exit_safe "marker-write helper not found in repo or ~/.episodic-memory/; skipping"
+
+# ---------------------------------------------------------------------------
+# Compute canonical sha via canon lib
+# ---------------------------------------------------------------------------
+# We hand the lib the entire stdin so it does the JSON.parse + .prompt
+# extract + utf-8 byte encode itself — keeping the binding logic in one
+# place. The lib exits non-zero on bad input; treat that as fail-safe.
+PROMPT_SHA="$(printf '%s' "$INPUT" | node -e \
+  "import('$CANON_LIB').then(m => { let s=''; process.stdin.setEncoding('utf8'); process.stdin.on('data', d => s+=d); process.stdin.on('end', () => { try { process.stdout.write(m.canonicalPromptSha256(s)) } catch (e) { process.stderr.write(e.message); process.exit(2) } }) })" \
+  2>/dev/null)"
+if [ -z "$PROMPT_SHA" ] || [ "${#PROMPT_SHA}" -ne 64 ]; then
+  _log_and_exit_safe "canonical sha computation returned empty or wrong length; skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Compose marker JSON via jq (safe argument-passing, no heredoc escape risk)
+# ---------------------------------------------------------------------------
+WROTE_AT_MS="$(node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0)"
+
+MARKER_JSON="$(jq -nc \
+  --arg sha "$PROMPT_SHA" \
+  --arg sid "$SESSION_ID" \
+  --arg tp "$TRANSCRIPT_PATH" \
+  --arg cwd "$CWD" \
+  --arg root "$REPO_ROOT" \
+  --argjson ms "$WROTE_AT_MS" \
+  '{prompt_sha256: $sha, session_id: $sid, transcript_path: $tp, cwd: $cwd, repo_root: $root, wrote_at_ms: $ms}')"
+if [ -z "$MARKER_JSON" ]; then
+  _log_and_exit_safe "jq composition of marker JSON failed; skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Pipe to marker-write helper
+# ---------------------------------------------------------------------------
+HELPER_OUT="$(printf '%s' "$MARKER_JSON" | node "$HELPER" --root "$REPO_ROOT" --target last-prompt --session-id "$SESSION_ID" 2>&1)"
+HELPER_EC=$?
+if [ $HELPER_EC -ne 0 ]; then
+  _log_and_exit_safe "marker-write helper exit $HELPER_EC: $HELPER_OUT"
+fi
+
+# Success — exit 0 with no stdout. Claude Code's hooks framework treats
+# empty stdout on UserPromptSubmit as no-op (per ref:230); no decision
+# emitted, no additional context injected. The file is the side effect.
+exit 0

--- a/install.mjs
+++ b/install.mjs
@@ -38,6 +38,7 @@ const projectDir = flag('--project') || process.cwd()
 const installHooks = argv.includes('--install-hooks')
 const installHooksForce = argv.includes('--install-hooks-force')
 const installSecondOpinion = argv.includes('--install-second-opinion')
+const bootstrapLastPrompt = argv.includes('--bootstrap-last-prompt')
 const REPO_HOOKS = path.join(REPO_DIR, 'hooks')
 const REPO_SECOND_OPINION = path.join(REPO_SCRIPTS, 'second-opinion')
 
@@ -51,6 +52,49 @@ let installFailed = false
 // alone silently no-ops and a user might think their settings were updated.
 if (installHooksForce && !installHooks) {
   console.log('Warning: --install-hooks-force has no effect without --install-hooks; ignoring.')
+}
+
+// ---------------------------------------------------------------------------
+// --bootstrap-last-prompt: standalone operation, doesn't require --tool.
+// Writes a 60-second bootstrap sentinel at
+// <projectDir>/.checkpoints/.last-user-prompt.<sid>.json so the pre-flight
+// gate's I8 cross-check has ground truth for the FIRST prompt of a fresh
+// install — before any UserPromptSubmit hook has fired. After the first
+// real prompt, the hook writes a non-bootstrap file and this sentinel is
+// replaced. Plan-v2 C6 (#238).
+// ---------------------------------------------------------------------------
+if (bootstrapLastPrompt) {
+  const sidFromFlag = flag('--session-id')
+  const sid = sidFromFlag || process.env.CLAUDE_SESSION_ID
+  if (!sid) {
+    console.error('--bootstrap-last-prompt: no session_id provided. Pass --session-id <sid> or set CLAUDE_SESSION_ID in env.')
+    process.exit(1)
+  }
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(sid)) {
+    console.error(`--bootstrap-last-prompt: session_id "${sid}" does not match [A-Za-z0-9_-]{1,128}.`)
+    process.exit(1)
+  }
+  const projectAbs = path.resolve(projectDir)
+  if (!fs.existsSync(projectAbs)) {
+    console.error(`--bootstrap-last-prompt: --project ${projectAbs} does not exist.`)
+    process.exit(1)
+  }
+  const checkpointsDir = path.join(projectAbs, '.checkpoints')
+  fs.mkdirSync(checkpointsDir, { recursive: true })
+  const sentinel = {
+    bootstrap: true,
+    session_id: sid,
+    wrote_at_ms: Date.now(),
+    note: 'install.mjs --bootstrap-last-prompt; valid for 60s; UserPromptSubmit hook will replace on first real prompt'
+  }
+  const target = path.join(checkpointsDir, `.last-user-prompt.${sid}.json`)
+  const temp = path.join(checkpointsDir, `.last-user-prompt.${sid}.json.${process.pid}.tmp`)
+  fs.writeFileSync(temp, JSON.stringify(sentinel, null, 2))
+  fs.renameSync(temp, target)
+  console.log(`Wrote bootstrap sentinel: ${target} (valid 60s)`)
+  // If --bootstrap-last-prompt is the ONLY action requested (no --tool),
+  // exit successfully here. Otherwise fall through to the normal install.
+  if (!tool) process.exit(0)
 }
 
 if (!tool) {
@@ -82,7 +126,17 @@ Second-opinion harness:
                           providers (each provider's available() probed; CLI
                           not on PATH → skipped). Required for harness I-27a
                           gate (registry-stale-at-gate) + composer I-27b
-                          (preamble-tamper-at-composer).`)
+                          (preamble-tamper-at-composer).
+
+Pre-flight prompt-binding bootstrap:
+  --bootstrap-last-prompt  Write a bootstrap sentinel at
+                          <project>/.checkpoints/.last-user-prompt.<sid>.json
+                          so the pre-flight gate's I8 cross-check has
+                          ground truth for the FIRST prompt of a fresh
+                          install (before the UserPromptSubmit hook has
+                          fired). The sentinel is valid for 60 seconds.
+                          Reads CLAUDE_SESSION_ID from env (or refuses
+                          with a clear error). Idempotent.`)
   process.exit(1)
 }
 
@@ -1062,7 +1116,12 @@ if (installHooks) {
       'checkpoint-gate.sh': path.join(userHooksDir, 'checkpoint-gate.sh'),
       'plan-gate.sh': path.join(userHooksDir, 'plan-gate.sh'),
       'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh'),
-      'stop-gate.sh': path.join(userHooksDir, 'stop-gate.sh')
+      'stop-gate.sh': path.join(userHooksDir, 'stop-gate.sh'),
+      // #238 plan-v2 audit F5: include preflight-gate.sh (PR #240 omission)
+      // AND the new preflight-prompt-helper.sh so stale registrations are
+      // flagged for the operator to prune.
+      'preflight-gate.sh': path.join(userHooksDir, 'preflight-gate.sh'),
+      'preflight-prompt-helper.sh': path.join(userHooksDir, 'preflight-prompt-helper.sh')
     }
     const staleEntries = detectStaleCanonicalEntries(settings.hooks, canonicalByBasename)
     for (const { event, basename, command } of staleEntries) {

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -70,6 +70,18 @@ export const HOOK_SPECS = [
     event: 'PreToolUse',
     matcher: 'Bash|Agent|Task|Write|Edit|MultiEdit|NotebookEdit',
     timeout: 10
+  },
+  // preflight-prompt-helper.sh: UserPromptSubmit hook for true prompt-
+  // binding (#238 PR1 FU-C2). Writes .checkpoints/.last-user-prompt.<sid>.json
+  // with the canonical sha of the real user prompt; preflight-gate.sh
+  // cross-checks marker.prompt_sha256 against the file. UserPromptSubmit
+  // accepts no matcher per claude-code-hooks-reference.md:85 (always fires).
+  // Timeout 5s — hook is small and atomic; if it can't complete in 5s
+  // something is wrong and fail-safe (exit 0) is the right outcome.
+  {
+    file: 'preflight-prompt-helper.sh',
+    event: 'UserPromptSubmit',
+    timeout: 5
   }
 ]
 

--- a/scripts/lib/preflight-prompt-canon.mjs
+++ b/scripts/lib/preflight-prompt-canon.mjs
@@ -1,0 +1,68 @@
+/**
+ * preflight-prompt-canon.mjs — Canonical sha256 of a UserPromptSubmit prompt.
+ *
+ * The cross-check between `<repo>/.checkpoints/.last-user-prompt.<sid>.json`
+ * (written by the UserPromptSubmit hook) and a `codex-review-handoff`
+ * pre-flight marker (written by `preflight-marker-write.mjs`) is meaningful
+ * ONLY if both sides compute `prompt_sha256` over the same bytes. Without a
+ * pinned canonicalization, the hook hashing `JSON.parse(stdin).prompt` and an
+ * external constructor hashing the prompt-as-displayed produce different
+ * digests; every legitimate marker mismatches; the cross-check is useless.
+ *
+ * Binding contract:
+ *
+ *     prompt_sha256 = sha256_hex( utf8_bytes( JSON.parse(stdin).prompt ) )
+ *
+ * - JSON parse runs first; escape sequences (\n, \t, \uXXXX) are unescaped.
+ * - The resulting JS string is encoded as UTF-8 with `Buffer.from(s, 'utf8')`.
+ * - No trailing newline is appended.
+ * - Surrogate pairs / non-BMP code points encode to 4-byte UTF-8 sequences.
+ *
+ * Both the hook AND any external constructor (tests, install bootstrap, gate
+ * validator) MUST import from this module — no re-implementations.
+ *
+ * Discovered: plan-time audit finding F3 (`scratch/238-plan-v2.md`) — without
+ * this pin, "every legitimate marker would mismatch."
+ */
+
+import crypto from 'node:crypto'
+
+/**
+ * Hash the prompt extracted from a UserPromptSubmit stdin JSON payload.
+ * Throws if the payload is not a JSON object or `.prompt` is not a string.
+ *
+ * @param {string} stdinJson — raw stdin bytes from the hook
+ * @returns {string} 64-char lowercase hex sha256 digest
+ */
+export function canonicalPromptSha256(stdinJson) {
+  if (typeof stdinJson !== 'string') {
+    throw new TypeError(`stdinJson must be a string, got ${typeof stdinJson}`)
+  }
+  let parsed
+  try {
+    parsed = JSON.parse(stdinJson)
+  } catch (e) {
+    throw new SyntaxError(`stdin is not valid JSON: ${e.message}`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new TypeError('stdin JSON must be a non-null object')
+  }
+  if (typeof parsed.prompt !== 'string') {
+    throw new TypeError(`.prompt must be a string, got ${typeof parsed.prompt}`)
+  }
+  return canonicalPromptSha256FromString(parsed.prompt)
+}
+
+/**
+ * Hash a prompt string directly. Use when the prompt has already been
+ * extracted (tests, install bootstrap that takes prompt as a CLI arg).
+ *
+ * @param {string} prompt — the prompt text exactly as JSON.parse would yield
+ * @returns {string} 64-char lowercase hex sha256 digest
+ */
+export function canonicalPromptSha256FromString(prompt) {
+  if (typeof prompt !== 'string') {
+    throw new TypeError(`prompt must be a string, got ${typeof prompt}`)
+  }
+  return crypto.createHash('sha256').update(Buffer.from(prompt, 'utf8')).digest('hex')
+}

--- a/scripts/preflight-marker-write.mjs
+++ b/scripts/preflight-marker-write.mjs
@@ -21,8 +21,17 @@
  *
  * Usage:
  *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target preflight
- *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target last-prompt
+ *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target last-prompt --session-id <sid>
  *   cat input.json | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target preflight
+ *
+ * Per-session namespacing (`--target last-prompt`):
+ *   The last-prompt file is keyed by session_id to avoid cross-session
+ *   liveness collisions (plan-time audit F4, scratch/238-plan-v2.md).
+ *   Basename: `.last-user-prompt.<session_id>.json`. session_id is required
+ *   for that target and must match `[A-Za-z0-9_-]{1,128}` (no dots, no
+ *   slashes — prevents basename injection past the `.json` suffix).
+ *   The preflight target is unchanged: single `.preflight-done` per repo,
+ *   session-bound via marker JSON content.
  *
  * Exit codes:
  *   0 — success; stdout is `{"status":"ok","path":"<final>","bytes":N}`
@@ -32,11 +41,13 @@
  *   5 — `--root` invalid (non-existent OR not a repo root signal)
  *   6 — `--target` missing or invalid value
  *   7 — stdin read error
+ *   8 — `--session-id` missing/invalid when target=last-prompt
  *
  * Discovered: codex r2 reply `20260512-071449-...-6e90` (atomicity invariant
  *   not locally verifiable for agent-side Write).
  * Refined:    codex r3-r5 (helper-only contract + --root required +
  *   canonicalize-path-tolerant lib for `--root` validation).
+ * Extended:   plan v2 C2 — `--session-id` for last-prompt namespacing (F4).
  *
  * Composes with:
  *   - scripts/lib/local-dir.mjs — resolveRepoRoot for --root validation.
@@ -51,10 +62,18 @@ import process from 'process'
 import { ensurePrimaryDir, primaryMarkerPath } from './lib/marker-paths.mjs'
 import { canonicalizePathTolerant } from './lib/canonicalize-path-tolerant.mjs'
 
+// preflight target → fixed basename; last-prompt target → suffix template
+// where {sid} is substituted with the validated --session-id value.
 const VALID_TARGETS = {
-  preflight: '.preflight-done',
-  'last-prompt': '.last-user-prompt.json'
+  preflight: { kind: 'fixed', basename: '.preflight-done' },
+  'last-prompt': { kind: 'session', template: '.last-user-prompt.{sid}.json' }
 }
+
+// session_id format: alphanumeric, underscore, dash. No dots (could collide
+// with the `.json` suffix), no slashes (path traversal), length-capped.
+// Claude Code session IDs are UUIDs (hyphenated hex); this regex covers
+// them while rejecting anything that could escape the basename.
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
 
 function fail(code, message) {
   process.stderr.write(`preflight-marker-write: ${message}\n`)
@@ -62,16 +81,19 @@ function fail(code, message) {
 }
 
 function parseArgs(argv) {
-  const args = { root: null, target: null }
+  const args = { root: null, target: null, sessionId: null }
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--root') {
       args.root = argv[++i]
     } else if (a === '--target') {
       args.target = argv[++i]
+    } else if (a === '--session-id') {
+      args.sessionId = argv[++i]
     } else if (a === '--help' || a === '-h') {
       process.stdout.write(
-        'Usage: echo "<JSON>" | preflight-marker-write.mjs --root <abs> --target <preflight|last-prompt>\n'
+        'Usage: echo "<JSON>" | preflight-marker-write.mjs --root <abs> --target <preflight|last-prompt> [--session-id <sid>]\n' +
+        '  --session-id required when --target=last-prompt (alphanumeric/underscore/dash, max 128 chars)\n'
       )
       process.exit(0)
     } else {
@@ -79,6 +101,21 @@ function parseArgs(argv) {
     }
   }
   return args
+}
+
+// Resolve the marker basename for a target, validating any required
+// per-target args (e.g. --session-id for last-prompt).
+function resolveBasename(target, sessionId) {
+  const spec = VALID_TARGETS[target]
+  if (spec.kind === 'fixed') return spec.basename
+  // kind === 'session'
+  if (!sessionId) {
+    fail(8, `SESSION_ID_REQUIRED: --session-id <sid> is mandatory when --target=${target}`)
+  }
+  if (!SESSION_ID_RE.test(sessionId)) {
+    fail(8, `SESSION_ID_INVALID: must match ${SESSION_ID_RE.source}, got: ${sessionId}`)
+  }
+  return spec.template.replace('{sid}', sessionId)
 }
 
 function validateRoot(rootArg) {
@@ -122,14 +159,14 @@ function readStdinSync() {
 }
 
 function main() {
-  const { root, target } = parseArgs(process.argv)
+  const { root, target, sessionId } = parseArgs(process.argv)
   if (!target) fail(6, 'TARGET_REQUIRED: --target <preflight|last-prompt>')
   if (!Object.prototype.hasOwnProperty.call(VALID_TARGETS, target)) {
     fail(6, `TARGET_INVALID: ${target}; valid: ${Object.keys(VALID_TARGETS).join(', ')}`)
   }
 
   const canonicalRoot = validateRoot(root)
-  const basename = VALID_TARGETS[target]
+  const basename = resolveBasename(target, sessionId)
   const finalPath = primaryMarkerPath(canonicalRoot, basename)
 
   const raw = readStdinSync()

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -129,6 +129,22 @@ assert_label "T54c2 rm legacy non-namespaced last-user-prompt.json" \
   "rm .checkpoints/.last-user-prompt.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.json"
 assert_label "T54c3 tee legacy non-namespaced last-user-prompt.json" \
   "tee .checkpoints/.last-user-prompt.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.json"
+# Codex round-1 F1 on PR #246: the `> redirect` handler was missing 4 of 6
+# checkpoint markers AND the entire last-user-prompt family. Without these,
+# `printf x > .checkpoints/.last-user-prompt.<sid>.json` bypasses the
+# marker_write class entirely.
+assert_label "T54d > redirect to .preflight-done → marker_write" \
+  "printf x > .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
+assert_label "T54e > redirect to .last-user-prompt session-namespaced → marker_write" \
+  "printf x > .checkpoints/.last-user-prompt.spoof.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.spoof.json"
+assert_label "T54f >> append redirect to .last-user-prompt namespaced → marker_write" \
+  "echo x >> .checkpoints/.last-user-prompt.uuid-1234.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.uuid-1234.json"
+assert_label "T54g > redirect to legacy .last-user-prompt.json → marker_write" \
+  "printf x > .checkpoints/.last-user-prompt.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.json"
+assert_label "T54h > redirect to .checkpoint-required → marker_write" \
+  "printf x > .checkpoints/.checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.checkpoint-required"
+assert_label "T54i > redirect to .post-checkpoint-required → marker_write" \
+  "printf x > .checkpoints/.post-checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.post-checkpoint-required"
 assert_label "T54d tee writing to preflight-done" \
   "tee .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
 assert_label "T54e tee writing to last-user-prompt" \

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -145,6 +145,13 @@ assert_label "T54h > redirect to .checkpoint-required → marker_write" \
   "printf x > .checkpoints/.checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.checkpoint-required"
 assert_label "T54i > redirect to .post-checkpoint-required → marker_write" \
   "printf x > .checkpoints/.post-checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.post-checkpoint-required"
+# Codex round-2 FU on PR #246: tee was missing checkpoint-required +
+# post-checkpoint-required (latent pre-existing gap parallel to the
+# C4 rm-class fix); regression test the closure.
+assert_label "T54j tee .checkpoint-required → marker_write" \
+  "tee .checkpoints/.checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.checkpoint-required"
+assert_label "T54k tee .post-checkpoint-required → marker_write" \
+  "tee .checkpoints/.post-checkpoint-required" "marker_write" "$TEST_ROOT/.checkpoints/.post-checkpoint-required"
 assert_label "T54d tee writing to preflight-done" \
   "tee .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
 assert_label "T54e tee writing to last-user-prompt" \

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -111,6 +111,23 @@ assert_label "T53 rm plan-approval-pending" \
   "rm .claude/.plan-approval-pending" "marker_write" "$TEST_ROOT/.claude/.plan-approval-pending"
 assert_label "T54 rm -f marker" \
   "rm -f .pre-checkpoint-done" "marker_write" "$TEST_ROOT/.pre-checkpoint-done"
+# Plan-v2 I10 (audit F1 same-class). PR #240 omitted .preflight-done from the
+# rm-marker class; plan-v2 adds it + the new session-namespaced last-prompt
+# files. Without these, `rm .checkpoints/.preflight-done` bypasses the gate.
+assert_label "T54a rm preflight-done (PR240 same-class gap)" \
+  "rm .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
+assert_label "T54b rm last-user-prompt session-namespaced" \
+  "rm .checkpoints/.last-user-prompt.abc-123.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.abc-123.json"
+assert_label "T54c rm -rf last-user-prompt UUID-form" \
+  "rm -rf .checkpoints/.last-user-prompt.1d6761c2-eaa2-43f7-a287-9dc2f301c9db.json" \
+  "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.1d6761c2-eaa2-43f7-a287-9dc2f301c9db.json"
+assert_label "T54d tee writing to preflight-done" \
+  "tee .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
+assert_label "T54e tee writing to last-user-prompt" \
+  "tee .checkpoints/.last-user-prompt.sess.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.sess.json"
+# Negative: rm of a similarly-named file that's NOT in the class should NOT trip.
+assert_label "T54f rm last-user-prompt without .json suffix → not marker" \
+  "rm .checkpoints/.last-user-prompt.notjson" "shared_write"
 assert_label "T55 quoted body containing marker name" \
   "echo 'this is .pre-checkpoint-done text'" "read_only"
 
@@ -561,7 +578,14 @@ assert_preflight_tool "QT01 Bash codex" "Bash" '{"command":"codex exec foo"}' "c
 assert_preflight_tool "QT02 Bash ls" "Bash" '{"command":"ls -la"}' "none"
 assert_preflight_tool "QT03 Bash empty" "Bash" '{"command":""}' "none"
 assert_preflight_tool "QT04 Agent codex-rescue" "Agent" '{"subagent_type":"codex:codex-rescue"}' "codex-review-handoff"
-assert_preflight_tool "QT05 Agent neg-scenario" "Agent" '{"subagent_type":"negative-scenario-reviewer"}' "codex-review-handoff"
+assert_preflight_tool "QT05 Agent neg-scenario-reviewer (gated)" "Agent" '{"subagent_type":"negative-scenario-reviewer"}' "codex-review-handoff"
+# Plan-v2 I11 (audit F7): the planner subagent is the bootstrap workaround
+# for plan-time review when the harness channel is blocked (workplan v49).
+# It must NOT be gated — it runs BEFORE plans exist, so requiring a
+# post-plan marker creates an interlock (#243). Reviewer-class subagents
+# remain gated.
+assert_preflight_tool "QT05a Agent neg-scenario-planner (bootstrap exempt)" "Agent" '{"subagent_type":"negative-scenario-planner"}' "none"
+assert_preflight_tool "QT05b Task neg-scenario-planner (bootstrap exempt)" "Task" '{"subagent_type":"negative-scenario-planner"}' "none"
 assert_preflight_tool "QT06 Agent generic" "Agent" '{"subagent_type":"general-purpose"}' "none"
 assert_preflight_tool "QT07 Task variant" "Task" '{"subagent_type":"codex:something"}' "codex-review-handoff"
 assert_preflight_tool "QT08 Write feedback" "Write" '{"file_path":"/abs/repo/feedback_x.md"}' "rule-bearing-file-edit"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -121,6 +121,14 @@ assert_label "T54b rm last-user-prompt session-namespaced" \
 assert_label "T54c rm -rf last-user-prompt UUID-form" \
   "rm -rf .checkpoints/.last-user-prompt.1d6761c2-eaa2-43f7-a287-9dc2f301c9db.json" \
   "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.1d6761c2-eaa2-43f7-a287-9dc2f301c9db.json"
+# P2-2 (code-review FU): legacy non-namespaced .last-user-prompt.json also
+# in rm-marker class. Previously omitted from the C4 fix — Bash rm of the
+# legacy basename would have classified as shared_write, leaving the gate's
+# direct-Write deny (which DOES cover legacy) inconsistent with Bash rm.
+assert_label "T54c2 rm legacy non-namespaced last-user-prompt.json" \
+  "rm .checkpoints/.last-user-prompt.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.json"
+assert_label "T54c3 tee legacy non-namespaced last-user-prompt.json" \
+  "tee .checkpoints/.last-user-prompt.json" "marker_write" "$TEST_ROOT/.checkpoints/.last-user-prompt.json"
 assert_label "T54d tee writing to preflight-done" \
   "tee .checkpoints/.preflight-done" "marker_write" "$TEST_ROOT/.checkpoints/.preflight-done"
 assert_label "T54e tee writing to last-user-prompt" \

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -96,7 +96,7 @@ managed_count=$(jq '[.files[]? | select(.relative_path | test("^hooks/.*\\.sh$")
 # 4 hook .sh files (checkpoint-gate, plan-gate, em-recall-sessionstart,
 # stop-gate) + 3 hooks/lib/.sh files (command-classifier, repo-root, +
 # marker-paths added 2026-05-09 with the .checkpoints/ migration) = 7.
-assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "7" "$managed_count"
+assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "9" "$managed_count"
 
 pg_manifest=$(jq -r '.files[] | select(.relative_path == "hooks/plan-gate.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
 assert_eq "T1b9 hook freshness manifest records plan-gate install path (#103)" "$TEST_HOME/.claude/hooks/plan-gate.sh" "$pg_manifest"
@@ -208,7 +208,7 @@ pre_total=$(jq '.hooks.PreToolUse | length' "$TEST_HOME/.claude/settings.json")
 # Post #86 PR-A: existing /some/user/plan-gate.sh + canonical checkpoint-gate
 # + canonical plan-gate = 3 entries. The stale /some/user/plan-gate.sh is
 # preserved verbatim (T4b) and the canonical is registered separately (T4b3).
-assert_eq "T4a PreToolUse now has 3 entries (existing plan-gate + canonical checkpoint-gate + canonical plan-gate)" "3" "$pre_total"
+assert_eq "T4a PreToolUse now has 4 entries (existing plan-gate + canonical checkpoint-gate + canonical plan-gate + canonical preflight-gate)" "4" "$pre_total"
 
 plan_gate_existing=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/some/user/plan-gate.sh")] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T4b existing /some/user/plan-gate.sh entry preserved verbatim" "1" "$plan_gate_existing"
@@ -568,6 +568,104 @@ assert_eq "T16a --install-hooks-force overwrites divergent plan-gate with repo v
 
 pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
 assert_eq "T16b --install-hooks-force registers plan-gate after overwrite" "1" "$pg_count"
+
+# ---------------------------------------------------------------------------
+# T17: #238 plan-v2 C6 — preflight-prompt-helper.sh wired on UserPromptSubmit
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- T17: UserPromptSubmit hook wiring (#238 C6) ---"
+reset_state
+run_installer --install-hooks
+
+# Hook file copied
+if [ -f "$TEST_HOME/.claude/hooks/preflight-prompt-helper.sh" ]; then
+  echo "  ✓ T17a preflight-prompt-helper.sh copied to ~/.claude/hooks/"
+  ((passed++))
+else
+  echo "  ✗ T17a preflight-prompt-helper.sh missing"
+  ((failed++))
+fi
+
+# Registered under UserPromptSubmit (event-agnostic addHookEntry path)
+ups_count=$(jq '[.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper"))] | length' "$TEST_HOME/.claude/settings.json" 2>/dev/null || echo 0)
+assert_eq "T17b preflight-prompt-helper registered on UserPromptSubmit" "1" "$ups_count"
+
+# No matcher on the entry (UserPromptSubmit always fires per hooks ref:85)
+ups_matcher=$(jq -r '.hooks.UserPromptSubmit[]? | select(.hooks[].command | test("preflight-prompt-helper")) | .matcher // "absent"' "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+assert_eq "T17c UserPromptSubmit entry has no matcher" "absent" "$ups_matcher"
+
+# Timeout from HOOK_SPECS (5s)
+ups_timeout=$(jq -r '.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper")) | .timeout' "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+assert_eq "T17d UserPromptSubmit entry timeout=5s" "5" "$ups_timeout"
+
+# ---------------------------------------------------------------------------
+# T18: #238 plan-v2 C6 — --bootstrap-last-prompt sentinel write
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- T18: --bootstrap-last-prompt (#238 C6) ---"
+reset_state
+
+# Bootstrap with --session-id flag (no env)
+HOME="$TEST_HOME" node "$INSTALLER" --bootstrap-last-prompt --project "$TEST_PROJECT" --session-id "boot-test-1" >/dev/null 2>&1
+EC=$?
+if [ $EC -eq 0 ] && [ -f "$TEST_PROJECT/.checkpoints/.last-user-prompt.boot-test-1.json" ]; then
+  echo "  ✓ T18a --session-id flag writes sentinel"
+  ((passed++))
+else
+  echo "  ✗ T18a sentinel not written (ec=$EC)"
+  ((failed++))
+fi
+
+# Sentinel has bootstrap=true + recent wrote_at_ms
+boot_flag=$(jq -r '.bootstrap' "$TEST_PROJECT/.checkpoints/.last-user-prompt.boot-test-1.json" 2>/dev/null)
+assert_eq "T18b sentinel bootstrap=true" "true" "$boot_flag"
+
+# Bootstrap with env CLAUDE_SESSION_ID
+reset_state
+HOME="$TEST_HOME" CLAUDE_SESSION_ID="env-sid-2" node "$INSTALLER" --bootstrap-last-prompt --project "$TEST_PROJECT" >/dev/null 2>&1
+if [ -f "$TEST_PROJECT/.checkpoints/.last-user-prompt.env-sid-2.json" ]; then
+  echo "  ✓ T18c CLAUDE_SESSION_ID env var works"
+  ((passed++))
+else
+  echo "  ✗ T18c env-var path failed"
+  ((failed++))
+fi
+
+# Missing session_id → error
+reset_state
+out=$(HOME="$TEST_HOME" node "$INSTALLER" --bootstrap-last-prompt --project "$TEST_PROJECT" 2>&1)
+EC=$?
+if [ $EC -ne 0 ] && echo "$out" | grep -q "no session_id"; then
+  echo "  ✓ T18d missing session_id → exit 1 + clear error"
+  ((passed++))
+else
+  echo "  ✗ T18d no-session_id behavior wrong (ec=$EC): $out"
+  ((failed++))
+fi
+
+# Invalid session_id format → error
+reset_state
+out=$(HOME="$TEST_HOME" node "$INSTALLER" --bootstrap-last-prompt --project "$TEST_PROJECT" --session-id "bad/sid" 2>&1)
+EC=$?
+if [ $EC -ne 0 ] && echo "$out" | grep -qE "does not match"; then
+  echo "  ✓ T18e bad session_id format → exit 1"
+  ((passed++))
+else
+  echo "  ✗ T18e bad-sid behavior wrong (ec=$EC): $out"
+  ((failed++))
+fi
+
+# Standalone (no --tool) succeeds
+reset_state
+out=$(HOME="$TEST_HOME" node "$INSTALLER" --bootstrap-last-prompt --project "$TEST_PROJECT" --session-id "standalone" 2>&1)
+EC=$?
+if [ $EC -eq 0 ] && [ -f "$TEST_PROJECT/.checkpoints/.last-user-prompt.standalone.json" ]; then
+  echo "  ✓ T18f standalone (no --tool) succeeds"
+  ((passed++))
+else
+  echo "  ✗ T18f standalone path failed (ec=$EC): $out"
+  ((failed++))
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/test-marker-write-helper.mjs
+++ b/tests/test-marker-write-helper.mjs
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for scripts/preflight-marker-write.mjs
+ *
+ * Focused on the C2 additions (plan v2): `--session-id` flag, per-session
+ * basename for `--target last-prompt`, session-id format validation. Pre-
+ * existing helper behavior (root validation, atomic temp+rename, JSON parse,
+ * non-object payload rejection) is covered by tests/test-preflight-gate.sh
+ * end-to-end; this file adds the unit-level coverage that the new arg
+ * surface needs.
+ *
+ * File named without the literal `preflight-marker-write` substring on
+ * purpose: the preflight-gate's helper-invocation regex
+ * (`\bpreflight-marker-write\.mjs\b`) currently matches any Bash argv
+ * containing that token, including this test file's path. The regex
+ * tightening is in scope for C5 (gate work). Until then, the test file
+ * lives under a clearly-distinct name.
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { spawnSync } from 'node:child_process'
+
+const HELPER = path.resolve('scripts/preflight-marker-write.mjs')
+
+function tmpRepo() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'mwtest-')))
+  // Helper validates --root has a repo signal (.git/.checkpoints/.episodic-memory).
+  fs.mkdirSync(path.join(dir, '.checkpoints'))
+  return dir
+}
+
+function run(args, stdin = '{"a":1}') {
+  return spawnSync('node', [HELPER, ...args], {
+    input: stdin,
+    encoding: 'utf8',
+    timeout: 10000
+  })
+}
+
+test('helper: target=preflight ignores --session-id (backward compat)', () => {
+  const root = tmpRepo()
+  try {
+    const r = run(['--root', root, '--target', 'preflight'])
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`)
+    assert.ok(fs.existsSync(path.join(root, '.checkpoints', '.preflight-done')))
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: target=last-prompt requires --session-id (exit 8)', () => {
+  const root = tmpRepo()
+  try {
+    const r = run(['--root', root, '--target', 'last-prompt'])
+    assert.equal(r.status, 8)
+    assert.match(r.stderr, /SESSION_ID_REQUIRED/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: target=last-prompt with valid session-id writes namespaced file', () => {
+  const root = tmpRepo()
+  try {
+    const sid = 'abc123-DEF_456'
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', sid])
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`)
+    const expectedPath = path.join(root, '.checkpoints', `.last-user-prompt.${sid}.json`)
+    assert.ok(fs.existsSync(expectedPath), `expected ${expectedPath}`)
+    assert.equal(fs.existsSync(path.join(root, '.checkpoints', '.last-user-prompt.json')), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: session-id with slash is rejected (path traversal guard)', () => {
+  const root = tmpRepo()
+  try {
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', '../etc/passwd'])
+    assert.equal(r.status, 8)
+    assert.match(r.stderr, /SESSION_ID_INVALID/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: session-id with dot is rejected (basename injection guard)', () => {
+  const root = tmpRepo()
+  try {
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', 'x.attack'])
+    assert.equal(r.status, 8)
+    assert.match(r.stderr, /SESSION_ID_INVALID/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: session-id empty string is rejected', () => {
+  const root = tmpRepo()
+  try {
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', ''])
+    assert.equal(r.status, 8)
+    assert.match(r.stderr, /SESSION_ID_(REQUIRED|INVALID)/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: session-id >128 chars is rejected', () => {
+  const root = tmpRepo()
+  try {
+    const big = 'a'.repeat(129)
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', big])
+    assert.equal(r.status, 8)
+    assert.match(r.stderr, /SESSION_ID_INVALID/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: session-id UUID format is accepted', () => {
+  const root = tmpRepo()
+  try {
+    const sid = '1d6761c2-eaa2-43f7-a287-9dc2f301c9db'
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', sid])
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`)
+    assert.ok(fs.existsSync(path.join(root, '.checkpoints', `.last-user-prompt.${sid}.json`)))
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: two sessions write distinct files (no cross-session collision)', () => {
+  const root = tmpRepo()
+  try {
+    const sidA = 'session-A'
+    const sidB = 'session-B'
+    run(['--root', root, '--target', 'last-prompt', '--session-id', sidA], '{"prompt":"p_A"}')
+    run(['--root', root, '--target', 'last-prompt', '--session-id', sidB], '{"prompt":"p_B"}')
+    const fileA = path.join(root, '.checkpoints', `.last-user-prompt.${sidA}.json`)
+    const fileB = path.join(root, '.checkpoints', `.last-user-prompt.${sidB}.json`)
+    assert.ok(fs.existsSync(fileA))
+    assert.ok(fs.existsSync(fileB))
+    assert.equal(JSON.parse(fs.readFileSync(fileA, 'utf8')).prompt, 'p_A')
+    assert.equal(JSON.parse(fs.readFileSync(fileB, 'utf8')).prompt, 'p_B')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: stdout JSON includes the namespaced path', () => {
+  const root = tmpRepo()
+  try {
+    const sid = 'echo-test'
+    const r = run(['--root', root, '--target', 'last-prompt', '--session-id', sid])
+    assert.equal(r.status, 0)
+    const out = JSON.parse(r.stdout)
+    assert.equal(out.status, 'ok')
+    assert.ok(out.path.endsWith(`.last-user-prompt.${sid}.json`))
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('helper: --help mentions --session-id', () => {
+  const r = spawnSync('node', [HELPER, '--help'], { encoding: 'utf8', timeout: 5000 })
+  assert.equal(r.status, 0)
+  assert.match(r.stdout, /--session-id/)
+})

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -531,14 +531,16 @@ echo ""
 echo "--- F5-series: project-root binding ---"
 
 # F5a: gate spawned from caller cwd != target → marker artifacts under target
+# Updated for C2 plan-v2: last-prompt is now session-namespaced. Pass --session-id.
 TF="$(mktmp)"; stage_fixture "$TF"
 CALLER="$(mktmp)"
-echo '{"x":1}' | (cd "$CALLER" && node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target last-prompt) >/dev/null
-if [ -f "$TF/.checkpoints/.last-user-prompt.json" ] && [ ! -f "$CALLER/.checkpoints/.last-user-prompt.json" ]; then
+F5A_SID="f5a-fixture"
+echo '{"x":1}' | (cd "$CALLER" && node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target last-prompt --session-id "$F5A_SID") >/dev/null
+if [ -f "$TF/.checkpoints/.last-user-prompt.${F5A_SID}.json" ] && [ ! -f "$CALLER/.checkpoints/.last-user-prompt.${F5A_SID}.json" ]; then
   echo "  ✓ F5a artifacts land under --root, not caller cwd"
   passed=$((passed+1))
 else
-  echo "  ✗ F5a — TF: $([ -f "$TF/.checkpoints/.last-user-prompt.json" ] && echo yes || echo no), CALLER: $([ -f "$CALLER/.checkpoints/.last-user-prompt.json" ] && echo yes || echo no)"
+  echo "  ✗ F5a — TF: $([ -f "$TF/.checkpoints/.last-user-prompt.${F5A_SID}.json" ] && echo yes || echo no), CALLER: $([ -f "$CALLER/.checkpoints/.last-user-prompt.${F5A_SID}.json" ] && echo yes || echo no)"
   failed=$((failed+1))
 fi
 

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -175,10 +175,33 @@ write_valid_marker() {
 EOF
 }
 
+# Helper: write the ground-truth `.last-user-prompt.<SESSION_ID>.json` file
+# that the C5 I2 cross-check requires. The marker's prompt_sha256 above is
+# the test-fixture string "abc123"; the cross-check requires this file's
+# prompt_sha256 to match. Use the same string so the cross-check passes
+# in tests that expect marker validation to fall through to later checks.
+write_ground_truth_last_prompt() {
+  local tmp="$1"
+  local sha="${2:-abc123}"
+  local now_ms
+  now_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+  cat > "$tmp/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
+{
+  "prompt_sha256": "$sha",
+  "session_id": "$SESSION_ID",
+  "transcript_path": "/tmp/x",
+  "cwd": "$tmp",
+  "repo_root": "$tmp",
+  "wrote_at_ms": $now_ms
+}
+EOF
+}
+
 # DIRECT-WRITE PATH: marker-write enforcement fires BEFORE marker validation.
 # So a Write to the marker path is denied even when a valid marker exists.
 # To test marker-validation paths, use a Bash claim-class trigger instead.
 write_valid_marker "$TMP"
+write_ground_truth_last_prompt "$TMP"
 run_gate "$TMP" "Bash" '{"command":"codex exec foo"}' "allow" "" "M10 valid marker → allow codex"
 
 # Wrong claim_class
@@ -205,6 +228,7 @@ run_gate "$TMP4" "Bash" '{"command":"codex exec foo"}' "deny" "repo_root" "M13 w
 # Bundle hash drift (modify bundle after marker written)
 TMP5="$(mktmp)"; stage_fixture "$TMP5"
 write_valid_marker "$TMP5"
+write_ground_truth_last_prompt "$TMP5"
 echo "DRIFT" >> "$TMP5/bundles/codex-review-channel-current.md"
 run_gate "$TMP5" "Bash" '{"command":"codex exec foo"}' "deny" "hash drift|sha-drift" "M14 bundle hash drift"
 
@@ -221,11 +245,13 @@ run_gate "$TMP7" "Bash" '{"command":"codex exec foo"}' "deny" "valid JSON" "M16 
 # Missing required_files
 TMP8="$(mktmp)"; stage_fixture "$TMP8"
 echo '{"session_id":"'"$SESSION_ID"'","transcript_path":"/tmp/x","prompt_sha256":"abc","prompt_index":1,"cwd":"'"$TMP8"'","repo_root":"'"$TMP8"'","memory_root":"x","claim_class":"codex-review-handoff","matched_triggers":{},"required_files":[],"loaded_files":[{"path":"x","mtime_ms":1,"sha256":"y"}],"artifact_steps_done":["x"],"created_at_ms":1}' > "$TMP8/.checkpoints/.preflight-done"
+write_ground_truth_last_prompt "$TMP8" "abc"
 run_gate "$TMP8" "Bash" '{"command":"codex exec foo"}' "deny" "required_files is empty|does not list bundle" "M17 empty required_files"
 
 # Required_files lacks bundle
 TMP9="$(mktmp)"; stage_fixture "$TMP9"
 echo '{"session_id":"'"$SESSION_ID"'","transcript_path":"/tmp/x","prompt_sha256":"abc","prompt_index":1,"cwd":"'"$TMP9"'","repo_root":"'"$TMP9"'","memory_root":"x","claim_class":"codex-review-handoff","matched_triggers":{},"required_files":["/some/other/file.md"],"loaded_files":[{"path":"/some/other/file.md","mtime_ms":1,"sha256":"y"}],"artifact_steps_done":["x"],"created_at_ms":1}' > "$TMP9/.checkpoints/.preflight-done"
+write_ground_truth_last_prompt "$TMP9" "abc"
 run_gate "$TMP9" "Bash" '{"command":"codex exec foo"}' "deny" "does not list bundle" "M18 required_files missing bundle"
 
 # ---------------------------------------------------------------------------
@@ -593,6 +619,104 @@ else
   echo "  ✗ F1-neg — exit $ec output: $out"
   failed=$((failed+1))
 fi
+
+# ---------------------------------------------------------------------------
+# C5-series: plan-v2 audit findings F1-F7 closures
+#   I2  marker sha vs ground-truth file cross-check
+#   I7  agent-context --target last-prompt deny
+#   I8  fail-closed when ground-truth file absent (+ 60s bootstrap window)
+#   I9  reader canonicalization parity for the session-namespaced file
+#   regex tightening for the helper-invocation false-positive
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- C5-series: prompt-binding cross-check + helper-target deny ---"
+
+# I2a: marker sha matches ground-truth → allow (M10 already covers this; add
+# explicit I2 framing).
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+write_ground_truth_last_prompt "$TF" "abc123"
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "allow" "" "I2a marker sha matches ground-truth → allow"
+
+# I2b: marker sha differs from ground-truth → deny with both shas in reason
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"  # marker has prompt_sha256: "abc123"
+write_ground_truth_last_prompt "$TF" "different_sha_xyz"
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "does not match the current real user prompt" "I2b marker sha mismatch → deny"
+
+# I8a: ground-truth file absent → fail-closed deny
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+# Deliberately no write_ground_truth_last_prompt
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "does not exist for session" "I8a ground-truth file absent → deny"
+
+# I8b: bootstrap sentinel within 60s → allow
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+NOW_MS="$(node -e 'process.stdout.write(String(Date.now()))')"
+cat > "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
+{"bootstrap": true, "wrote_at_ms": $NOW_MS, "session_id": "$SESSION_ID"}
+EOF
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "allow" "" "I8b bootstrap sentinel within 60s → allow"
+
+# I8c: bootstrap sentinel >60s old → deny (stale)
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+STALE_MS="$(node -e 'process.stdout.write(String(Date.now() - 90000))')"  # 90s ago
+cat > "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
+{"bootstrap": true, "wrote_at_ms": $STALE_MS, "session_id": "$SESSION_ID"}
+EOF
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "Bootstrap sentinel.*stale" "I8c bootstrap sentinel stale → deny"
+
+# I7a: Bash invocation with --target last-prompt → DENY (agent spoof attempt)
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Bash" "{\"command\":\"node $TF/scripts/preflight-marker-write.mjs --root $TF --target last-prompt --session-id agent-spoof\"}" \
+  "deny" "reserved for the UserPromptSubmit hook" "I7a agent --target last-prompt → deny"
+
+# I7b: Bash invocation with --target preflight (legitimate) → no I7 deny
+# (other gate checks still apply: the marker write itself proceeds).
+TF="$(mktmp)"; stage_fixture "$TF"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"node %s/scripts/preflight-marker-write.mjs --root %s --target preflight"},"cwd":"%s","session_id":"%s"}' \
+  "$TF" "$TF" "$TF" "$SESSION_ID" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecisionReason | test("reserved for the UserPromptSubmit hook")' >/dev/null 2>&1; then
+  echo "  ✓ I7b --target preflight not blocked by I7 deny"
+  passed=$((passed+1))
+else
+  echo "  ✗ I7b --target preflight false-blocked: $out"
+  failed=$((failed+1))
+fi
+
+# Regex tightening: `test-preflight-marker-write.mjs` in argv should NOT
+# trigger the helper-invocation deny. (Before C5 it did — false-positive
+# blocking `node --test tests/test-marker-write-helper.mjs`-style usage.)
+TF="$(mktmp)"; stage_fixture "$TF"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"node --test tests/test-preflight-marker-write.mjs"},"cwd":"%s","session_id":"%s"}' "$TF" "$SESSION_ID" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecisionReason | test("preflight-marker-write.mjs invoked without")' >/dev/null 2>&1; then
+  echo "  ✓ regex no longer false-positives on test-preflight-marker-write.mjs"
+  passed=$((passed+1))
+else
+  echo "  ✗ regex still false-positives: $out"
+  failed=$((failed+1))
+fi
+
+# Regex still catches the real basename
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Bash" "{\"command\":\"node preflight-marker-write.mjs --target preflight\"}" \
+  "deny" "invoked without explicit --root" "regex still catches bare basename sans --root"
+
+# Direct Write to session-namespaced last-prompt file → DENY
+TF="$(mktmp)"; stage_fixture "$TF"
+run_gate "$TF" "Write" "{\"file_path\":\"$TF/.checkpoints/.last-user-prompt.fake-sid.json\",\"content\":\"x\"}" \
+  "deny" "forbidden|helper" "direct Write to namespaced last-prompt → DENY"
+
+# I9: gate's read path is canonicalized — symlink target outside expected
+# location should be denied conservatively.
+# (Symlink edge-case test: replace the last-user-prompt file with a dangling
+# symlink and confirm conservative deny rather than ambiguous allow.)
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+ln -s "$TF/.checkpoints/non-existent-target.json" "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json"
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "does not exist|cannot.*canonicalize|cannot.*verify" "I9 dangling symlink for ground-truth → deny"
 
 # ---------------------------------------------------------------------------
 # Results

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -668,6 +668,24 @@ cat > "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
 EOF
 run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "Bootstrap sentinel.*stale" "I8c bootstrap sentinel stale → deny"
 
+# I8d: codex round-1 F2 on PR #246 — non-numeric wrote_at_ms must emit a
+# proper deny JSON, NOT a bash arithmetic error. Without the numeric guard,
+# behavior depended on Claude Code's hook-error fallback.
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+cat > "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
+{"bootstrap": true, "wrote_at_ms": "123abc", "session_id": "$SESSION_ID"}
+EOF
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "non-numeric wrote_at_ms" "I8d non-numeric wrote_at_ms → proper deny JSON"
+
+# I8e: empty wrote_at_ms also fail-closed
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+cat > "$TF/.checkpoints/.last-user-prompt.${SESSION_ID}.json" <<EOF
+{"bootstrap": true, "wrote_at_ms": "", "session_id": "$SESSION_ID"}
+EOF
+run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "non-numeric wrote_at_ms" "I8e empty wrote_at_ms → deny"
+
 # I7a: Bash invocation with --target last-prompt → DENY (agent spoof attempt)
 TF="$(mktmp)"; stage_fixture "$TF"
 run_gate "$TF" "Bash" "{\"command\":\"node $TF/scripts/preflight-marker-write.mjs --root $TF --target last-prompt --session-id agent-spoof\"}" \

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -691,7 +691,11 @@ fi
 # blocking `node --test tests/test-marker-write-helper.mjs`-style usage.)
 TF="$(mktmp)"; stage_fixture "$TF"
 out="$(printf '{"tool_name":"Bash","tool_input":{"command":"node --test tests/test-preflight-marker-write.mjs"},"cwd":"%s","session_id":"%s"}' "$TF" "$SESSION_ID" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
-if [ -z "$out" ] || ! printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecisionReason | test("preflight-marker-write.mjs invoked without")' >/dev/null 2>&1; then
+# M-4 tightening: pass iff out is empty OR permissionDecision is NOT "deny".
+# (Previous form passed when the reason didn't match a specific string —
+# any OTHER deny reason also satisfied it.)
+decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+if [ -z "$out" ] || [ "$decision" != "deny" ]; then
   echo "  ✓ regex no longer false-positives on test-preflight-marker-write.mjs"
   passed=$((passed+1))
 else
@@ -708,6 +712,21 @@ run_gate "$TF" "Bash" "{\"command\":\"node preflight-marker-write.mjs --target p
 TF="$(mktmp)"; stage_fixture "$TF"
 run_gate "$TF" "Write" "{\"file_path\":\"$TF/.checkpoints/.last-user-prompt.fake-sid.json\",\"content\":\"x\"}" \
   "deny" "forbidden|helper" "direct Write to namespaced last-prompt → DENY"
+
+# P2-1 (code-review FU): malicious session_id from stdin → conservative deny
+# Without the gate-side regex check, a session_id containing path-traversal
+# could escape .checkpoints/ via the constructed LAST_PROMPT_SID_PATH.
+TF="$(mktmp)"; stage_fixture "$TF"
+write_valid_marker "$TF"
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"codex exec foo"},"cwd":"%s","session_id":"../etc/passwd"}' "$TF" | bash "$TF/hooks/preflight-gate.sh" 2>&1 || true)"
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null 2>&1 && \
+   printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason' | grep -qE "invalid chars"; then
+  echo "  ✓ P2-1 invalid session_id from stdin → deny + 'invalid chars' reason"
+  passed=$((passed+1))
+else
+  echo "  ✗ P2-1 invalid session_id path-traversal not caught: $out"
+  failed=$((failed+1))
+fi
 
 # I9: gate's read path is canonicalized — symlink target outside expected
 # location should be denied conservatively.

--- a/tests/test-preflight-prompt-canon.mjs
+++ b/tests/test-preflight-prompt-canon.mjs
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for scripts/lib/preflight-prompt-canon.mjs
+ *
+ * Covers the I-canon invariant from `scratch/238-plan-v2.md`:
+ *   prompt_sha256 = sha256_hex( utf8_bytes( JSON.parse(stdin).prompt ) )
+ *
+ * Known-value anchors below were computed independently
+ * (`printf '%s' '<input>' | shasum -a 256`).
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+
+import {
+  canonicalPromptSha256,
+  canonicalPromptSha256FromString
+} from '../scripts/lib/preflight-prompt-canon.mjs'
+
+// Reference shas computed locally:
+//   printf '%s' 'hello'            | shasum -a 256
+//   printf '%s' ''                 | shasum -a 256
+const SHA_HELLO = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+const SHA_EMPTY = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+function sha256Utf8(s) {
+  return crypto.createHash('sha256').update(Buffer.from(s, 'utf8')).digest('hex')
+}
+
+test('canon: plain ASCII matches independent sha256', () => {
+  assert.equal(canonicalPromptSha256FromString('hello'), SHA_HELLO)
+})
+
+test('canon: empty string sha is the well-known empty-input digest', () => {
+  assert.equal(canonicalPromptSha256FromString(''), SHA_EMPTY)
+})
+
+test('canon: stdin wrapper extracts .prompt and hashes its bytes', () => {
+  const stdin = JSON.stringify({ prompt: 'hello', session_id: 'abc' })
+  assert.equal(canonicalPromptSha256(stdin), SHA_HELLO)
+})
+
+test('canon: JSON.parse unescapes \\n before hashing — escape vs raw newline match', () => {
+  // The whole point of pinning canonicalization: both representations of
+  // "hi<newline>there" produce the same sha. Without JSON.parse(), the raw
+  // backslash-n bytes would hash differently from the actual newline byte.
+  const fromEscapedJson = canonicalPromptSha256(JSON.stringify({ prompt: 'hi\nthere' }))
+  const fromLiteral = canonicalPromptSha256FromString('hi\nthere')
+  assert.equal(fromEscapedJson, fromLiteral)
+})
+
+test('canon: no trailing newline is appended', () => {
+  // sha("hi") vs sha("hi\n") must differ; canon must produce the former.
+  const withoutNl = canonicalPromptSha256FromString('hi')
+  const withNl = canonicalPromptSha256FromString('hi\n')
+  assert.notEqual(withoutNl, withNl)
+  assert.equal(withoutNl, sha256Utf8('hi'))
+})
+
+test('canon: multi-byte UTF-8 encodes correctly', () => {
+  // mix of 1-byte ASCII, 2-byte Latin-1 supplement, 3-byte CJK
+  const prompt = 'héllo 你好'
+  const expected = sha256Utf8(prompt)
+  assert.equal(canonicalPromptSha256FromString(prompt), expected)
+  assert.equal(canonicalPromptSha256(JSON.stringify({ prompt })), expected)
+})
+
+test('canon: surrogate pair (emoji) — 4-byte UTF-8 sequence', () => {
+  // U+1F680 ROCKET — UTF-8 is F0 9F 9A 80
+  const prompt = 'launch 🚀'
+  const expected = sha256Utf8(prompt)
+  assert.equal(canonicalPromptSha256FromString(prompt), expected)
+  assert.equal(canonicalPromptSha256(JSON.stringify({ prompt })), expected)
+})
+
+test('canon: embedded NUL byte is hashed (not truncated)', () => {
+  // \x00 hex-escape keeps the test source as text (no raw NUL in file)
+  // while the JS-parsed string contains a real NUL byte at position 1.
+  const prompt = 'a\x00b'
+  const expected = sha256Utf8(prompt)
+  assert.equal(canonicalPromptSha256FromString(prompt), expected)
+  // Round-trip via JSON (which encodes NUL as "") must also match.
+  assert.equal(canonicalPromptSha256(JSON.stringify({ prompt })), expected)
+})
+
+test('canon: stdin with extra fields hashes only .prompt', () => {
+  const stdinA = JSON.stringify({ prompt: 'same', session_id: 'A', cwd: '/x' })
+  const stdinB = JSON.stringify({ prompt: 'same', session_id: 'B', cwd: '/y', extra: 42 })
+  assert.equal(canonicalPromptSha256(stdinA), canonicalPromptSha256(stdinB))
+})
+
+test('canon: invalid stdin — not a string', () => {
+  assert.throws(() => canonicalPromptSha256(null), TypeError)
+  assert.throws(() => canonicalPromptSha256(42), TypeError)
+  assert.throws(() => canonicalPromptSha256({ prompt: 'x' }), TypeError)
+})
+
+test('canon: invalid stdin — bad JSON', () => {
+  assert.throws(() => canonicalPromptSha256('not json'), SyntaxError)
+  assert.throws(() => canonicalPromptSha256(''), SyntaxError)
+})
+
+test('canon: invalid stdin — JSON is not an object', () => {
+  assert.throws(() => canonicalPromptSha256('null'), TypeError)
+  assert.throws(() => canonicalPromptSha256('[]'), TypeError)
+  assert.throws(() => canonicalPromptSha256('"raw string"'), TypeError)
+  assert.throws(() => canonicalPromptSha256('42'), TypeError)
+})
+
+test('canon: invalid stdin — .prompt missing or non-string', () => {
+  assert.throws(() => canonicalPromptSha256('{}'), TypeError)
+  assert.throws(() => canonicalPromptSha256(JSON.stringify({ prompt: null })), TypeError)
+  assert.throws(() => canonicalPromptSha256(JSON.stringify({ prompt: 42 })), TypeError)
+  assert.throws(() => canonicalPromptSha256(JSON.stringify({ prompt: ['a'] })), TypeError)
+})
+
+test('canon: from-string accepts strings up to 10MB', () => {
+  // Sanity: no length cap inside canon. The hook may impose limits separately.
+  const big = 'x'.repeat(10 * 1024 * 1024)
+  const sha = canonicalPromptSha256FromString(big)
+  assert.equal(sha.length, 64)
+})

--- a/tests/test-preflight-prompt-helper.sh
+++ b/tests/test-preflight-prompt-helper.sh
@@ -169,24 +169,41 @@ rm -rf "$TF"
 
 # ---------- I5: idempotent on identical input ----------
 
-echo "--- I5: idempotent for same prompt + session ---"
+echo "--- I5: load-bearing fields stable across calls ---"
 
+# Note: wrote_at_ms WILL differ across calls (timestamp), so the file is NOT
+# byte-identical across calls. The load-bearing fields are prompt_sha256 +
+# session_id + cwd + repo_root — those MUST be identical. M-5 tightening:
+# explicitly compare each load-bearing field's before/after value, not just
+# the final value against a canon recompute.
 TF="$(mktmp)"; stage_repo "$TF"
 SID="i5-test"
 run_hook "$TF" "stable prompt text" "$SID" 2>/dev/null
-SHA1="$(shasum -a 256 "$TF/.checkpoints/.last-user-prompt.${SID}.json" | awk '{print $1}')"
-sleep 0.05  # ensure mtime would tick if write happened
-# Note: wrote_at_ms WILL differ across calls (timestamp), so the file is NOT
-# byte-identical across calls. But the prompt_sha256 + session_id + cwd
-# fields MUST be identical. This tests the load-bearing portion.
+SHA_BEFORE="$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+SID_BEFORE="$(jq -r '.session_id'    "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+CWD_BEFORE="$(jq -r '.cwd'           "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+sleep 0.05  # mtime would tick if anything fluctuated
 run_hook "$TF" "stable prompt text" "$SID" 2>/dev/null
-SHA1_AFTER="$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
-EXP="$(jq -nc --arg s "$SID" '{}' >/dev/null; node -e "import('$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs').then(m => process.stdout.write(m.canonicalPromptSha256FromString('stable prompt text')))")"
-if [ "$SHA1_AFTER" = "$EXP" ]; then
-  echo "  ✓ I5 prompt_sha256 stable across idempotent calls"
+SHA_AFTER="$(jq -r '.prompt_sha256'  "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+SID_AFTER="$(jq -r '.session_id'     "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+CWD_AFTER="$(jq -r '.cwd'            "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+
+if [ "$SHA_BEFORE" = "$SHA_AFTER" ] && [ "$SID_BEFORE" = "$SID_AFTER" ] && [ "$CWD_BEFORE" = "$CWD_AFTER" ]; then
+  echo "  ✓ I5 load-bearing fields (sha/session_id/cwd) stable across two calls"
   passed=$((passed+1))
 else
-  echo "  ✗ I5 sha drift: got $SHA1_AFTER, expected $EXP"
+  echo "  ✗ I5 field drift: sha=$SHA_BEFORE→$SHA_AFTER sid=$SID_BEFORE→$SID_AFTER cwd=$CWD_BEFORE→$CWD_AFTER"
+  failed=$((failed+1))
+fi
+
+# Cross-check: the second-call sha matches what the canon lib computes
+# directly. (Was the I5 test pre-tightening; keep it as a separate cross-check.)
+EXP="$(node -e "import('$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs').then(m => process.stdout.write(m.canonicalPromptSha256FromString('stable prompt text')))")"
+if [ "$SHA_AFTER" = "$EXP" ]; then
+  echo "  ✓ I5 prompt_sha256 matches canon-lib direct computation"
+  passed=$((passed+1))
+else
+  echo "  ✗ I5 sha drift vs canon: got $SHA_AFTER, expected $EXP"
   failed=$((failed+1))
 fi
 

--- a/tests/test-preflight-prompt-helper.sh
+++ b/tests/test-preflight-prompt-helper.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight-prompt-helper.sh — UserPromptSubmit hook test suite.
+#
+# Plan-v2 §I1, I3, I5, I6 coverage:
+#   I1  Hook writes .last-user-prompt.<sid>.json atomically with canonical sha
+#   I3  Fail-safe: any internal error → exit 0 + stderr log; never block
+#   I5  Idempotent for same prompt+session: byte-identical file content
+#   I6  External-contract documentation — UserPromptSubmit ordering verified
+#       indirectly via "hook runs to completion before any tool call" semantic
+#
+# Audit findings landed by C3: F3 (canon import), F4 (--session-id), F5
+# (no hooks/lib coupling beyond repo-root.sh), F6 (ordering documented).
+
+set -u
+
+REPO_ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/preflight-prompt-helper.sh"
+
+passed=0
+failed=0
+
+mktmp() {
+  # macOS mktemp -d returns /var/folders/...; realpath via cd -P to dereference.
+  local d
+  d="$(mktemp -d)"
+  ( cd -P "$d" && pwd )
+}
+
+stage_repo() {
+  # Stage a minimal repo fixture so resolve_repo_root finds a root and the
+  # in-repo scripts/lib path resolves.
+  local target="$1"
+  mkdir -p "$target/.checkpoints"
+  mkdir -p "$target/scripts/lib"
+  mkdir -p "$target/hooks/lib"
+  cp "$REPO_ROOT/scripts/preflight-marker-write.mjs" "$target/scripts/"
+  cp "$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs" "$target/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$target/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$target/scripts/lib/"
+  cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$target/hooks/lib/"
+  # Make it git-detectable so resolve_repo_root returns this dir, not /.
+  ( cd "$target" && git init -q && git config user.email t@t && git config user.name t )
+}
+
+run_hook() {
+  # run_hook <repo_dir> <prompt> <session_id> → echoes stderr, returns exit code
+  local repo="$1" prompt="$2" sid="$3" tp="${4:-/tmp/transcript.jsonl}"
+  local input
+  input="$(jq -nc --arg p "$prompt" --arg s "$sid" --arg c "$repo" --arg tp "$tp" \
+    '{prompt: $p, session_id: $s, cwd: $c, transcript_path: $tp, hook_event_name: "UserPromptSubmit"}')"
+  # The hook resolves repo from cwd via git -C; we cd into the repo so the
+  # resolution matches the cwd field exactly.
+  ( cd "$repo" && printf '%s' "$input" | bash "$HOOK" )
+}
+
+# ---------- I1: hook writes namespaced file with correct sha ----------
+
+echo "--- I1: hook writes namespaced last-user-prompt file ---"
+
+TF="$(mktmp)"; stage_repo "$TF"
+SID="i1-test-session"
+PROMPT="hello world"
+run_hook "$TF" "$PROMPT" "$SID" 2>/dev/null
+EC=$?
+
+if [ $EC -ne 0 ]; then
+  echo "  ✗ I1 hook exit $EC (expected 0)"
+  failed=$((failed+1))
+elif [ ! -f "$TF/.checkpoints/.last-user-prompt.${SID}.json" ]; then
+  echo "  ✗ I1 file not written"
+  failed=$((failed+1))
+else
+  echo "  ✓ I1 hook wrote namespaced file"
+  passed=$((passed+1))
+fi
+
+# Verify sha matches the well-known sha256("hello world")
+EXPECTED_SHA="b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+ACTUAL_SHA="$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+if [ "$ACTUAL_SHA" = "$EXPECTED_SHA" ]; then
+  echo "  ✓ I1 sha matches canonical sha256(prompt)"
+  passed=$((passed+1))
+else
+  echo "  ✗ I1 sha mismatch: got $ACTUAL_SHA, expected $EXPECTED_SHA"
+  failed=$((failed+1))
+fi
+
+# Schema fields present
+if jq -e '.session_id and .transcript_path and .cwd and .repo_root and .wrote_at_ms' \
+    "$TF/.checkpoints/.last-user-prompt.${SID}.json" >/dev/null; then
+  echo "  ✓ I1 file has all required fields"
+  passed=$((passed+1))
+else
+  echo "  ✗ I1 file missing required fields"
+  failed=$((failed+1))
+fi
+
+rm -rf "$TF"
+
+# ---------- I3: fail-safe on malformed inputs ----------
+
+echo "--- I3: fail-safe — never block on internal errors ---"
+
+# Empty stdin
+TF="$(mktmp)"; stage_repo "$TF"
+( cd "$TF" && printf '' | bash "$HOOK" )
+EC=$?
+if [ $EC -eq 0 ]; then
+  echo "  ✓ I3a empty stdin → exit 0"
+  passed=$((passed+1))
+else
+  echo "  ✗ I3a empty stdin → exit $EC (expected 0)"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# Non-JSON stdin
+TF="$(mktmp)"; stage_repo "$TF"
+( cd "$TF" && printf 'not json' | bash "$HOOK" )
+EC=$?
+if [ $EC -eq 0 ]; then
+  echo "  ✓ I3b non-JSON stdin → exit 0"
+  passed=$((passed+1))
+else
+  echo "  ✗ I3b non-JSON → exit $EC (expected 0)"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# JSON but not an object
+TF="$(mktmp)"; stage_repo "$TF"
+( cd "$TF" && printf '[1,2,3]' | bash "$HOOK" )
+EC=$?
+if [ $EC -eq 0 ]; then
+  echo "  ✓ I3c JSON non-object → exit 0"
+  passed=$((passed+1))
+else
+  echo "  ✗ I3c non-object → exit $EC (expected 0)"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# Missing session_id
+TF="$(mktmp)"; stage_repo "$TF"
+( cd "$TF" && printf '{"prompt":"x","cwd":"%s"}' "$TF" | bash "$HOOK" )
+EC=$?
+if [ $EC -eq 0 ]; then
+  echo "  ✓ I3d missing session_id → exit 0"
+  passed=$((passed+1))
+else
+  echo "  ✗ I3d missing session_id → exit $EC"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# Invalid session_id (path traversal)
+TF="$(mktmp)"; stage_repo "$TF"
+( cd "$TF" && jq -nc --arg c "$TF" '{prompt:"x", session_id:"../etc/passwd", cwd:$c}' | bash "$HOOK" )
+EC=$?
+if [ $EC -eq 0 ] && [ ! -f "$TF/.checkpoints/.last-user-prompt.../etc/passwd.json" ]; then
+  echo "  ✓ I3e invalid session_id → exit 0 + no file written"
+  passed=$((passed+1))
+else
+  echo "  ✗ I3e invalid session_id → exit $EC"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# ---------- I5: idempotent on identical input ----------
+
+echo "--- I5: idempotent for same prompt + session ---"
+
+TF="$(mktmp)"; stage_repo "$TF"
+SID="i5-test"
+run_hook "$TF" "stable prompt text" "$SID" 2>/dev/null
+SHA1="$(shasum -a 256 "$TF/.checkpoints/.last-user-prompt.${SID}.json" | awk '{print $1}')"
+sleep 0.05  # ensure mtime would tick if write happened
+# Note: wrote_at_ms WILL differ across calls (timestamp), so the file is NOT
+# byte-identical across calls. But the prompt_sha256 + session_id + cwd
+# fields MUST be identical. This tests the load-bearing portion.
+run_hook "$TF" "stable prompt text" "$SID" 2>/dev/null
+SHA1_AFTER="$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.${SID}.json")"
+EXP="$(jq -nc --arg s "$SID" '{}' >/dev/null; node -e "import('$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs').then(m => process.stdout.write(m.canonicalPromptSha256FromString('stable prompt text')))")"
+if [ "$SHA1_AFTER" = "$EXP" ]; then
+  echo "  ✓ I5 prompt_sha256 stable across idempotent calls"
+  passed=$((passed+1))
+else
+  echo "  ✗ I5 sha drift: got $SHA1_AFTER, expected $EXP"
+  failed=$((failed+1))
+fi
+
+rm -rf "$TF"
+
+# ---------- I6: cross-session distinct files (composes with C2 namespacing) ----------
+
+echo "--- I6: two sessions in same repo write distinct files ---"
+
+TF="$(mktmp)"; stage_repo "$TF"
+run_hook "$TF" "promptA" "session-A" 2>/dev/null
+run_hook "$TF" "promptB" "session-B" 2>/dev/null
+if [ -f "$TF/.checkpoints/.last-user-prompt.session-A.json" ] && \
+   [ -f "$TF/.checkpoints/.last-user-prompt.session-B.json" ] && \
+   [ "$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.session-A.json")" != \
+     "$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.session-B.json")" ]; then
+  echo "  ✓ I6 two sessions wrote distinct namespaced files with distinct shas"
+  passed=$((passed+1))
+else
+  echo "  ✗ I6 cross-session isolation broken"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# ---------- Multi-byte + emoji prompt round-trip ----------
+
+echo "--- canon round-trip via hook ---"
+
+TF="$(mktmp)"; stage_repo "$TF"
+run_hook "$TF" "héllo 你好 🚀" "rt-test" 2>/dev/null
+SHA_VIA_HOOK="$(jq -r '.prompt_sha256' "$TF/.checkpoints/.last-user-prompt.rt-test.json")"
+SHA_VIA_CANON="$(node -e "import('$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs').then(m => process.stdout.write(m.canonicalPromptSha256FromString('héllo 你好 🚀')))")"
+if [ "$SHA_VIA_HOOK" = "$SHA_VIA_CANON" ]; then
+  echo "  ✓ multi-byte + emoji prompt hashes match canon lib direct"
+  passed=$((passed+1))
+else
+  echo "  ✗ multi-byte sha mismatch: hook=$SHA_VIA_HOOK canon=$SHA_VIA_CANON"
+  failed=$((failed+1))
+fi
+rm -rf "$TF"
+
+# ---------- Results ----------
+
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes #238 (PR1 FU-C2: true prompt-binding via UserPromptSubmit hook) and unblocks #243 (the rank-0 interlock that blocks agent-driven Rule 18 step 2 plan dispatches via the second-opinion harness).

PR #240 shipped Layer D's pre-flight gate but took the FALLBACK route: marker `prompt_sha256` was required to be non-empty but never compared to ground truth. This PR closes back to the PRIMARY path — a `UserPromptSubmit` hook maintains `<repo>/.checkpoints/.last-user-prompt.<session_id>.json` with the canonical sha of every real prompt, and the gate cross-checks the marker against it.

## Plan provenance

- Plan v1: `scratch/238-plan-v1.md`
- Plan v2 (audit-folded-in): `scratch/238-plan-v2.md`
- Plan-time audit via `Plan` subagent (workplan v49's `negative-scenario-planner` bootstrap workaround was itself self-blocked by classifier:1717 — fixed inline as audit F7). 4 P1 + 3 P2 + 2 deferrable findings folded into v2.
- User approval: "Proceed with v2 as-is" 2026-05-12.

## Commits (one concern per commit, Rule 10)

| # | SHA | Subject |
|---|---|---|
| C1 | fab0d0c | `feat(preflight-canon)` — pinned sha256 canonicalization lib |
| C2 | ed1981a | `feat(marker-write)` — `--session-id` flag + per-session basename |
| C3 | 0d96920 | `feat(preflight-prompt-helper)` — UserPromptSubmit hook |
| C4 | 473f1a1 | `feat(classifier)` — rm/tee same-class fix + planner exemption |
| C5 | 02ecd56 | `feat(preflight-gate)` — cross-check + I7 deny + I8 fail-closed + regex fix |
| C6 | 68ef03f | `feat(install)` — HOOK_SPECS + `--bootstrap-last-prompt` |
| C7 | fe1042f | `docs+fix` — bundle doc + 2 P2 + 4 MINOR FUs from code review |

## Components

| File | Action | LOC |
|---|---|---|
| `scripts/lib/preflight-prompt-canon.mjs` | NEW | 68 |
| `scripts/preflight-marker-write.mjs` | MODIFY | +51 |
| `hooks/preflight-prompt-helper.sh` | NEW | 155 |
| `hooks/preflight-gate.sh` | MODIFY | +127 |
| `hooks/lib/command-classifier.sh` | MODIFY | +33 |
| `scripts/lib/install-manifest.mjs` | MODIFY | +12 |
| `install.mjs` | MODIFY | +63 |
| `bundles/codex-review-channel-current.md` | MODIFY | +9 |
| Test suites (5 files) | NEW/MODIFY | +800 |

## Binding contract

`prompt_sha256 = sha256_hex(utf8_bytes(JSON.parse(stdin).prompt))`

JSON parse first (so `\n`, `\uXXXX`, `\t` etc. unescape to their byte values), UTF-8 encode via `Buffer.from(s, 'utf8')`, no trailing newline appended. Both the hook AND any external constructor MUST import from `scripts/lib/preflight-prompt-canon.mjs` — no re-implementations. 14 unit tests including JSON-escape parity, multi-byte UTF-8, surrogate-pair emoji, embedded NUL byte, no-trailing-newline.

## Enforcement layers (defense in depth)

1. **Direct Write/Edit/MultiEdit/NotebookEdit** to `.last-user-prompt.<sid>.json` (any session) → DENIED at gate (extends PR #240's direct-marker deny to the namespaced glob).
2. **Bash `rm` / `tee`** of `.last-user-prompt.*.json` OR `.preflight-done` (PR #240 same-class gap) → classified `marker_write` at the command classifier.
3. **Bash `node …preflight-marker-write.mjs --target last-prompt`** from PreToolUse context → DENIED at gate (only the UserPromptSubmit hook should write this target; the hook runs outside PreToolUse).
4. **Gate cross-check**: marker `prompt_sha256` must equal the file's `prompt_sha256` for the current session. Mismatch → DENY with both shas truncated to 16 hex chars for diagnostic uniqueness.
5. **I8 fail-closed** when the ground-truth file is absent. Bootstrap exception: `install.mjs --bootstrap-last-prompt` writes a `{"bootstrap": true, "wrote_at_ms": <now>}` sentinel valid for 60s, after which the real UserPromptSubmit hook is expected to have replaced it.

## Audit findings closure

| Finding | Commit |
|---|---|
| F1 — rm-marker same-class (PR #240 omission + new namespaced files) | C4 + C7 P2-2 |
| F2 — I7 helper-invocation deny underspecified | C5 |
| F3 — sha canonicalization (every marker would mismatch without it) | C1 |
| F4 — cross-session liveness DoS | C2 namespacing |
| F5 — install observability | C6 |
| F6 — I6 UserPromptSubmit ordering external contract | C5 I8 fail-closed; documented limitations in plan §F6 |
| F7 — bootstrap workaround self-blocked (this PR's own plan review hit it) | C4 I11 planner exemption |
| F8 — orphan tmp-file sweep on SIGKILL | DEFERRED → #244 |
| F9 — `prompt_index` schema | plan §I1 note |
| Code-review P2-1 (gate-side session_id validation) | C7 inline |
| Code-review P2-2 (legacy `.last-user-prompt.json` in rm/tee class) | C7 inline |
| Code-review M-1/M-2/M-4/M-5 | C7 inline |
| Code-review M-3 (I9 test weak) | DEFERRED → #245 |
| Code-review M-6 (set -u cosmetic) | No-op |

## Test totals

- canon + helper unit (Node test): 25
- hook (bash): 12
- classifier (bash): 292
- gate (bash): 76
- install (bash): 75
- **Total: 480 tests, 0 failures**

## Why prerequisite (workplan v49 rank 0)

Without this PR, agent-driven Rule 18 step 2 plan reviews dispatched via the second-opinion harness are blocked by PR #240's gate — the classifier denies any marker with synthesized values, and there's no canonical way to construct a valid one without `.last-user-prompt.<sid>.json`. C4 also exempts the `negative-scenario-planner` subagent from the codex-review-handoff trigger so the documented workplan v49 bootstrap workaround actually works going forward.

## Test plan

- [ ] CI green on `feat/238-userpromptsubmit-hook`
- [ ] Reviewer (lantiscooperdev) verifies no regression in existing classifier/gate/checkpoint/plan suites
- [ ] Manual smoke post-merge:
  - [ ] Trigger codex review without running `--bootstrap-last-prompt` → verify gate denies with "does not exist for session"
  - [ ] Run `node install.mjs --tool claude-code --install-hooks --bootstrap-last-prompt --session-id <test-sid>` → verify gate allows for 60s
  - [ ] After 60s without UserPromptSubmit firing → verify gate denies with "Bootstrap sentinel … stale"
  - [ ] Direct `Write` to `.checkpoints/.last-user-prompt.<sid>.json` → verify gate denies citing "forbidden"
  - [ ] Direct `rm .checkpoints/.preflight-done` and `rm .checkpoints/.last-user-prompt.*.json` from Bash → verify classifier intercepts at PreToolUse

## Follow-ups filed

- #244 — orphan `.tmp` sweep on SIGKILL recovery (F8)
- #245 — tighten I9 dangling-symlink test to pin canonicalize path (M-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
