### PR TITLE
feat(hook-deadlock): rank-1 — stop-gate active-plan exemption + wrong-root marker BLOCK

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -54,8 +54,34 @@ fallback-removal commit.
 
 **Edit here as the canonical source**, but local edits to `~/.claude/hooks/*.sh` are also fine in the meantime — PR-B's installer will diff them against the repo source rather than silently overwriting. If you choose to edit the installed copy directly, expect to either re-apply that edit here on next sync or use `--install-hooks-force` to overwrite when you're done.
 
+## macOS `com.apple.provenance` xattr — recovery from undeletable marker
+
+On macOS Sequoia (Darwin 25+) with App Management or an EDR agent, files written by Claude Code's Write tool inherit `com.apple.provenance` and can become **undeletable** — `sudo rm` returns `EPERM` ("Operation not permitted") even with full disk access. If a marker file (`.plan-approval-pending`, `.checkpoint-required`, `.pre-checkpoint-done`, etc.) gets stuck in this state, the gate hooks fire on every turn-end with no escape from inside the agent.
+
+**Escape hatch** (run from a terminal, NOT from the agent):
+
+```sh
+# Temporarily disable the hooks so the gate doesn't fire while you triage:
+sudo mv ~/.claude/hooks/checkpoint-gate.sh /tmp/
+sudo mv ~/.claude/hooks/plan-gate.sh       /tmp/
+sudo mv ~/.claude/hooks/stop-gate.sh       /tmp/
+
+# Resolve the marker situation (move the offending marker to /tmp/, or
+# wait for the xattr to age out, or contact your IT for an EDR override).
+
+# Restore the hooks:
+sudo mv /tmp/checkpoint-gate.sh ~/.claude/hooks/
+sudo mv /tmp/plan-gate.sh       ~/.claude/hooks/
+sudo mv /tmp/stop-gate.sh       ~/.claude/hooks/
+```
+
+`sudo mv` of the hook scripts themselves works because the parent `~/.claude/hooks/` directory typically doesn't carry the provenance protection — only files written by Claude Code's Write tool do. The marker file itself remains stuck; once the hooks are absent, the gates don't fire, and Claude Code can resume work. The stuck marker can be cleaned up when the xattr ages out (usually 24-48 hours) or via IT-level provenance override.
+
+**Long-term fix** tracked at #178 F3 — Claude Code harness change to strip `com.apple.provenance` post-write on marker files in `.checkpoints/`. Out of scope for this repo. Cross-link to writer-side worktree audit: `feedback_project_root_binding_audit.md`.
+
 ## Related
 
 - RFC-002 Phase 3b spec: `docs/rfcs/RFC-002-learning-loop.md`
 - Tracking issue: #59
 - plan-gate canonicalization: #86 (PR-A: tool-name allowlist + canonicalize; PR-B: strict Bash command allowlist)
+- Hook-deadlock cluster: #178, #191, #202 (rank-1 plan v7 — wrong-root marker write detection + stop-gate active-plan exemption)

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -168,6 +168,22 @@ _strip_shell_quotes() {
   printf '%s' "$s"
 }
 
+# PR-review round-2 P1 (codex episode ...5b9e): `${var//pattern/}` in
+# bash is pattern substitution, NOT literal substitution. Glob meta chars
+# (`*`, `?`, `[`) in the pattern are active. When the extracted absolute
+# path `$p` contains a literal `*` (e.g. `/tmp/emglob*/.checkpoints/X`),
+# `${cmd//\.${p}/}` over-matches and the occurrence-scoped check is
+# defeated. Escape glob meta chars in `$p` before using it as a pattern.
+# Backslash escape is not required because _strip_shell_quotes already
+# removed backslashes from the input.
+_escape_bash_glob() {
+  local s="$1"
+  s="${s//\*/\\*}"
+  s="${s//\?/\\?}"
+  s="${s//\[/\\[}"
+  printf '%s' "$s"
+}
+
 # Codex round-4 F12 + round-5 F15 + code-review A1: relative-marker-reference
 # detection. Matches `.checkpoints/<marker>` or `.claude/<marker>` as a
 # RELATIVE path (no leading `/`). (^|[^/])(\./)* handles bare, ./, ././, ../.
@@ -204,7 +220,13 @@ _command_first_absolute_noncanonical_marker() {
     # false-negative where `echo ./tmp/.checkpoints/X >/dev/null; touch
     # /tmp/.checkpoints/X` would have skipped the check because
     # `./tmp/.checkpoints/X` exists somewhere in the command.
-    local cmd_filtered="${cmd//\.${p}/}"
+    #
+    # PR-review round-2 P1: `${var//pattern/}` interprets glob meta chars
+    # in the pattern. Escape `*`/`?`/`[` in `$p` so the substitution is
+    # truly literal-equivalent (codex episode ...5b9e).
+    local p_escaped
+    p_escaped="$(_escape_bash_glob "$p")"
+    local cmd_filtered="${cmd//\.${p_escaped}/}"
     if [[ "$cmd_filtered" != *"$p"* ]]; then
       continue
     fi

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -197,13 +197,15 @@ _command_first_absolute_noncanonical_marker() {
   [ -z "$matches" ] && return 0
   while IFS= read -r p; do
     [ -z "$p" ] && continue
-    # If the extracted path appears as `.<p>` in the command, that's a
-    # relative-form reference (./<p> or part of ../<p>) — already handled
-    # by _command_has_relative_marker_path. Skip to avoid false-positive
-    # blocking of canonical writes from MAIN cwd (e.g.
-    # `echo x > ./.checkpoints/<marker>` with cwd == REPO_ROOT). Uses
-    # `grep -F` for literal substring match.
-    if printf '%s' "$cmd" | grep -qF ".${p}"; then
+    # PR-review P1: occurrence-scoped relative-vs-absolute disambiguation.
+    # Strip all literal `.${p}` occurrences from cmd, then check if $p
+    # still appears. If it does, there's at least one NON-relative
+    # occurrence (a genuine absolute reference). Avoids the global-filter
+    # false-negative where `echo ./tmp/.checkpoints/X >/dev/null; touch
+    # /tmp/.checkpoints/X` would have skipped the check because
+    # `./tmp/.checkpoints/X` exists somewhere in the command.
+    local cmd_filtered="${cmd//\.${p}/}"
+    if [[ "$cmd_filtered" != *"$p"* ]]; then
       continue
     fi
     basename="${p##*/}"

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -105,6 +105,117 @@ marker_basename_for_target() {
   printf ''
 }
 
+# ---------------------------------------------------------------------------
+# Wrong-root marker write detection (#191 B2 / #202 / #178 cluster).
+# Hook-deadlock cluster plan v7 — codex 7-round review, ACCEPT-with-FU.
+# ---------------------------------------------------------------------------
+#
+# Closed marker set (8 basenames) — mirrors classifier emit-site cases at
+# command-classifier.sh lines 516, 522, 630, 636, 666, 672. Used for
+# wrong-root detection only; NOT for marker_basename_for_target's narrower
+# 3-marker allowlist (intentionally narrower — only 3 markers are valid
+# gate-action targets here; the other 5 are handled by other gates/hooks).
+_marker_basename_in_set() {
+  case "${1##*/}" in
+    .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending| \
+    .checkpoint-required|.post-checkpoint-required|.preflight-done| \
+    .last-user-prompt.json) return 0 ;;
+    .last-user-prompt.*.json) return 0 ;;
+  esac
+  return 1
+}
+
+# Codex round-4 F13: lexical `./` segment normalization (pure string manip;
+# no symlink resolution — kept lexical for defense in depth + simplicity).
+# Strips leading `./`, mid-path `/./`. `../` lexical normalization is FU
+# (see scratch/rank1-plan-v7.md FU list F13b); if a TARGET contains `../`,
+# this helper passes it through and the equality check fails closed (block).
+_normalize_path_lexical() {
+  local p="$1"
+  while [ "${p#*/./}" != "$p" ]; do
+    p="${p%%/./*}/${p#*/./}"
+  done
+  case "$p" in
+    ./*) p="${p#./}" ;;
+  esac
+  printf '%s' "$p"
+}
+
+# Returns 0 iff (lexically-normalized) target equals canonical PRIMARY or
+# LEGACY path for its own basename. Decoupled from marker_basename_for_target's
+# narrower 3-marker scope (codex round-2 F7).
+_is_canonical_marker_path() {
+  local target basename norm
+  norm="$(_normalize_path_lexical "$1")"
+  basename="${norm##*/}"
+  [ "$norm" = "$PRIMARY_DIR/$basename" ] && return 0
+  [ "$norm" = "$LEGACY_DIR/$basename" ] && return 0
+  return 1
+}
+
+# Codex round-4 F12 + round-5 F15: relative-marker-reference detection.
+# Matches `.checkpoints/<marker>` or `.claude/<marker>` as a RELATIVE
+# path (no leading `/`). (^|[^/])(\./)* handles bare, ./, ././, ../ forms.
+# Returns 0 iff a relative marker path is referenced.
+_command_has_relative_marker_path() {
+  local cmd="$1"
+  printf '%s' "$cmd" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)'
+}
+
+# E2E-discovered absolute-non-canonical detection: for Bash commands where
+# the classifier returns shared_write (touch/mv/cp/install/dd of=) on an
+# ABSOLUTE marker path NOT under canonical PRIMARY/LEGACY. The
+# marker_write-branch check covers absolute paths classified AS marker_write
+# (redirect/rm/tee); this catches the shared_write-classified-but-targets-
+# marker case. Echoes the first offending path on match (exit 0); empty on
+# no match (exit 1).
+_command_first_absolute_noncanonical_marker() {
+  local cmd="$1"
+  local matches p basename
+  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)' 2>/dev/null || true)
+  [ -z "$matches" ] && return 1
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    basename="${p##*/}"
+    if [ "$p" != "$PRIMARY_DIR/$basename" ] && [ "$p" != "$LEGACY_DIR/$basename" ]; then
+      printf '%s' "$p"
+      return 0
+    fi
+  done <<< "$matches"
+  return 1
+}
+
+# Emit wrong-root BLOCK decision for absolute-path attempts (Write/Edit or
+# Bash with absolute paths). Reason names BOTH the attempted path AND the
+# canonical path the agent should use.
+_block_wrong_root_marker() {
+  local attempted="$1" basename="${1##*/}"
+  local canonical="$PRIMARY_DIR/$basename"
+  jq -nc --arg attempted "$attempted" --arg canonical "$canonical" --arg basename "$basename" \
+    '{decision: "block", reason: ("Marker write to non-canonical path. You wrote " + $attempted + " but " + $basename + " must live under the main repo at " + $canonical + ". In a git worktree, hooks resolve markers against the main repo root via git-common-dir — write the marker at the canonical absolute path instead. Hook: checkpoint-gate.sh.")}'
+  exit 0
+}
+
+# Emit wrong-root BLOCK decision for Bash relative-marker attempts from
+# non-canonical cwd. Reason includes the verbatim command excerpt and the
+# canonical primary marker dir.
+_block_relative_marker_in_worktree() {
+  local cmd_excerpt="$1"
+  jq -nc --arg cmd "$cmd_excerpt" --arg primary "$PRIMARY_DIR" \
+    '{decision: "block", reason: ("Relative marker reference from worktree cwd. The classifier resolves relative paths against the main repo root, but the shell executes them under the worktree cwd. Command was: " + $cmd + ". Re-issue with an absolute path under " + $primary + " (or cd to the main repo first). Hook: checkpoint-gate.sh.")}'
+  exit 0
+}
+
+# Composite predicate: wrong-root iff (basename in closed set) AND (NOT
+# canonical primary/legacy path). Decoupled from marker_basename_for_target's
+# narrower allowlist (codex round-2 F7).
+_is_wrong_root_marker_write() {
+  local target="$1"
+  _marker_basename_in_set "$target" || return 1
+  _is_canonical_marker_path "$target" && return 1
+  return 0
+}
+
 # Read-only tools — always allowed
 case "$TOOL_NAME" in
   Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
@@ -148,6 +259,30 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     exit 0
   fi
 
+  # Codex round-4 F12 + round-5 F15 + round-6 F18: verb-agnostic relative-
+  # marker precheck. Runs for ALL non-read_only Bash when CWD != REPO_ROOT
+  # (linked worktree OR nested cwd inside main repo). Catches touch/mv/cp/
+  # install/dd-of/cat>>/heredoc-> + redirect/rm/tee. Classifier resolves
+  # relative redirect targets against REPO_ROOT, but shell executes under
+  # tool cwd — without this precheck, the gate "allows" a write whose
+  # artifact lands at the wrong root.
+  if [ "$CWD" != "$REPO_ROOT" ] && _command_has_relative_marker_path "$COMMAND"; then
+    _block_relative_marker_in_worktree "$COMMAND"
+  fi
+
+  # E2E-discovered: when CWD != REPO_ROOT and the command has an ABSOLUTE
+  # non-canonical marker path (typically worktree-absolute like
+  # `touch $WT_DIR/.checkpoints/X`), classifier returns shared_write so the
+  # marker_write branch never fires. Check explicitly here so the
+  # wrong-root block reason is emitted instead of falling through to the
+  # generic pre-gate reason.
+  if [ "$CWD" != "$REPO_ROOT" ]; then
+    NONCANON_ABS="$(_command_first_absolute_noncanonical_marker "$COMMAND")"
+    if [ -n "$NONCANON_ABS" ]; then
+      _block_wrong_root_marker "$NONCANON_ABS"
+    fi
+  fi
+
   # marker_write deadlock-prevention allowlist. Only allow when the gate's
   # state expects that specific marker write. All other marker_write Bash
   # falls through to the pre-gate as a normal write.
@@ -156,6 +291,14 @@ if [ "$TOOL_NAME" = "Bash" ]; then
   # either .checkpoints/.X (new canonical) or .claude/.X (legacy fallback,
   # tolerated during burn-in for backward compat).
   if [ "$LABEL" = "marker_write" ]; then
+    # Codex round-1 F1 + round-2 F7: absolute-path wrong-root BLOCK before
+    # marker_basename_for_target's narrower allowlist evaluation. Catches
+    # `Bash echo x > <wt>/.checkpoints/.pre-checkpoint-done` shape where
+    # classifier-reported TARGET ≠ shell-resolved artifact location.
+    if _is_wrong_root_marker_write "$TARGET"; then
+      _block_wrong_root_marker "$TARGET"
+    fi
+
     TARGET_BN="$(marker_basename_for_target "$TARGET")"
 
     # Cross-gate invariant: checkpoint marker writes are blocked while
@@ -200,6 +343,24 @@ case "$TOOL_NAME" in
       REST="${RESULT#*	}"
       TARGET="${REST%%	*}"
       if [ "$LABEL" = "marker_write" ]; then
+        # Codex round-1 F1 + round-2 F7: absolute-path wrong-root BLOCK
+        # before marker_basename_for_target. Same predicate as Bash branch.
+        # Note: classify_path at command-classifier.sh:1232 only emits
+        # marker_write for 3 checkpoint markers — so this branch's effective
+        # wrong-root surface is narrower than Bash's 8 markers. The other 5
+        # markers (.checkpoint-required, .post-checkpoint-required,
+        # .preflight-done, .last-user-prompt.*) reach Write/Edit via
+        # preflight-gate.sh's helper-only enforcement at
+        # preflight-gate.sh:170-209, not via this branch. classify_path
+        # 3→8 marker expansion tracked as FU per scratch/rank1-plan-v7.md F9.
+        #
+        # Relative-marker precheck (Bash side) is NOT mirrored here:
+        # Claude Code's Write/Edit tool requires absolute file_path, so the
+        # worktree-relative attack surface doesn't apply.
+        if _is_wrong_root_marker_write "$TARGET"; then
+          _block_wrong_root_marker "$TARGET"
+        fi
+
         TARGET_BN="$(marker_basename_for_target "$TARGET")"
         # Cross-gate invariant
         if marker_exists .plan-approval-pending && [ "$TARGET_BN" != ".plan-approval-pending" ]; then

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -153,13 +153,30 @@ _is_canonical_marker_path() {
   return 1
 }
 
-# Codex round-4 F12 + round-5 F15: relative-marker-reference detection.
-# Matches `.checkpoints/<marker>` or `.claude/<marker>` as a RELATIVE
-# path (no leading `/`). (^|[^/])(\./)* handles bare, ./, ././, ../ forms.
+# Code-review A1: strip shell quote/escape characters before regex match.
+# Bash quoting that breaks the contiguous `.checkpoints/<marker>` substring
+# (e.g. `touch ".checkpoints"/.pre-checkpoint-done`) evades the raw regex
+# while the actual tool still writes to the unquoted path. Quote-stripping
+# preserves the path's effective shape for detection purposes; it's a
+# defense-in-depth lexer, not a full bash parser (eval/$() expansion is
+# out of scope — classify_command labels those `unsafe_complex`).
+_strip_shell_quotes() {
+  local s="$1"
+  s="${s//\"/}"
+  s="${s//\'/}"
+  s="${s//\\/}"
+  printf '%s' "$s"
+}
+
+# Codex round-4 F12 + round-5 F15 + code-review A1: relative-marker-reference
+# detection. Matches `.checkpoints/<marker>` or `.claude/<marker>` as a
+# RELATIVE path (no leading `/`). (^|[^/])(\./)* handles bare, ./, ././, ../.
+# Runs on the quote-stripped command so quote-broken bypasses are caught.
 # Returns 0 iff a relative marker path is referenced.
 _command_has_relative_marker_path() {
-  local cmd="$1"
-  printf '%s' "$cmd" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)'
+  local cmd_stripped
+  cmd_stripped="$(_strip_shell_quotes "$1")"
+  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)'
 }
 
 # E2E-discovered absolute-non-canonical detection: for Bash commands where
@@ -170,19 +187,32 @@ _command_has_relative_marker_path() {
 # marker case. Echoes the first offending path on match (exit 0); empty on
 # no match (exit 1).
 _command_first_absolute_noncanonical_marker() {
-  local cmd="$1"
+  # Empty output = no wrong-root marker found; non-empty = the offending
+  # path. Function always returns 0 so `x="$(...)"` under `set -e` never
+  # triggers script exit on the no-match case (caller uses `[ -n "$x" ]`).
+  local cmd
+  cmd="$(_strip_shell_quotes "$1")"
   local matches p basename
   matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)' 2>/dev/null || true)
-  [ -z "$matches" ] && return 1
+  [ -z "$matches" ] && return 0
   while IFS= read -r p; do
     [ -z "$p" ] && continue
+    # If the extracted path appears as `.<p>` in the command, that's a
+    # relative-form reference (./<p> or part of ../<p>) — already handled
+    # by _command_has_relative_marker_path. Skip to avoid false-positive
+    # blocking of canonical writes from MAIN cwd (e.g.
+    # `echo x > ./.checkpoints/<marker>` with cwd == REPO_ROOT). Uses
+    # `grep -F` for literal substring match.
+    if printf '%s' "$cmd" | grep -qF ".${p}"; then
+      continue
+    fi
     basename="${p##*/}"
     if [ "$p" != "$PRIMARY_DIR/$basename" ] && [ "$p" != "$LEGACY_DIR/$basename" ]; then
       printf '%s' "$p"
       return 0
     fi
   done <<< "$matches"
-  return 1
+  return 0
 }
 
 # Emit wrong-root BLOCK decision for absolute-path attempts (Write/Edit or
@@ -270,17 +300,19 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     _block_relative_marker_in_worktree "$COMMAND"
   fi
 
-  # E2E-discovered: when CWD != REPO_ROOT and the command has an ABSOLUTE
-  # non-canonical marker path (typically worktree-absolute like
-  # `touch $WT_DIR/.checkpoints/X`), classifier returns shared_write so the
-  # marker_write branch never fires. Check explicitly here so the
-  # wrong-root block reason is emitted instead of falling through to the
-  # generic pre-gate reason.
-  if [ "$CWD" != "$REPO_ROOT" ]; then
-    NONCANON_ABS="$(_command_first_absolute_noncanonical_marker "$COMMAND")"
-    if [ -n "$NONCANON_ABS" ]; then
-      _block_wrong_root_marker "$NONCANON_ABS"
-    fi
+  # Code-review A2: drop the `CWD != REPO_ROOT` guard so this check ALSO
+  # fires from MAIN cwd. The predicate itself filters non-canonical paths
+  # by exact-equality vs $PRIMARY_DIR/$basename / $LEGACY_DIR/$basename,
+  # so it cannot false-positive on canonical absolute paths.
+  #
+  # Catches: ABSOLUTE non-canonical marker paths in Bash commands from
+  # any cwd, e.g. `touch /tmp/.checkpoints/X` from main cwd OR
+  # `touch $WT_DIR/.checkpoints/X` from worktree cwd. Classifier returns
+  # shared_write for touch/mv/cp/install/dd-of with empty TARGET, so the
+  # marker_write branch can't see them; this precheck fills that gap.
+  NONCANON_ABS="$(_command_first_absolute_noncanonical_marker "$COMMAND")"
+  if [ -n "$NONCANON_ABS" ]; then
+    _block_wrong_root_marker "$NONCANON_ABS"
   fi
 
   # marker_write deadlock-prevention allowlist. Only allow when the gate's

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -30,6 +30,7 @@ import {
   ensurePrimaryDir,
   bothMarkerPaths
 } from './lib/marker-paths.mjs'
+import { _maxMtimeAcrossRootsStrict } from './lib/stop-gate-helpers.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -184,6 +185,32 @@ if (gateFlag === 'stop') {
   // hooks/checkpoint-gate.sh + hooks/plan-gate.sh that use repo-root.sh.
   // Closes #106's worktree-orphan class for this gate.
   //
+  // #178 F1: defer stop-gate when plan is ACTIVELY pending at EITHER root.
+  // The plan-gate blocks Write/Bash while .plan-approval-pending exists at
+  // either root, creating an unrecoverable triangle when stop-gate ALSO
+  // blocks. The exemption narrows to ACTIVE plan-pending only (mtime >
+  // baseline) — orphan plan-pending falls through to the existing carve-out.
+  //
+  // Strict-lstat semantics via _maxMtimeAcrossRootsStrict (codex round-3 F11
+  // + round-6 F17): ENOENT skips (marker absent at this root, fine); any
+  // other lstat error (EACCES, ENOTDIR, EIO, ELOOP) → hadOtherError → fail
+  // closed. Symlink at EITHER root → fail closed (same-class with carve-out
+  // symmetric defense).
+  //
+  // Dual-root semantics (codex round-2 F8): plan-pending and baseline are
+  // BOTH evaluated across primary and legacy. resolveMarkerRead's primary-
+  // first ordering would have recreated the deadlock when primary is stale
+  // and legacy is active during burn-in.
+  const planPending = _maxMtimeAcrossRootsStrict(REPO_ROOT, '.plan-approval-pending')
+  const baseStrict = _maxMtimeAcrossRootsStrict(REPO_ROOT, BASELINE_NAME)
+  if (
+    planPending.anyExisted && !planPending.hadSymlink && !planPending.hadOtherError &&
+    baseStrict.anyExisted && !baseStrict.hadSymlink && !baseStrict.hadOtherError &&
+    planPending.mtime > baseStrict.mtime
+  ) {
+    process.exit(0)
+  }
+
   // Dual-root .checkpoints/ migration: PRE_REQ existence is checked at
   // EITHER root (resolveMarkerRead returns the path of whichever exists,
   // primary preferred). POST_DONE non-empty check uses the resolved path.

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -201,6 +201,16 @@ if (gateFlag === 'stop') {
   // BOTH evaluated across primary and legacy. resolveMarkerRead's primary-
   // first ordering would have recreated the deadlock when primary is stale
   // and legacy is active during burn-in.
+  //
+  // Code-review B1: this exemption INTENTIONALLY supersedes the
+  // stopGateCarveOutApplies() check below for the active-plan-pending case.
+  // If plan-pending is mid-session active, the agent is in plan-review
+  // (no writes happening), and the checkpoint-gate + plan-gate + stop-gate
+  // triangle would otherwise be unrecoverable. Plan-gate provides the
+  // writer-side defense via its independent .plan-approval-pending check;
+  // stop-gate stepping aside is the deadlock-break. The exemption fires
+  // EVEN when other TASK_SIGNAL_MARKERS (.checkpoint-required,
+  // .post-checkpoint-required) are also active — see test 5.13.
   const planPending = _maxMtimeAcrossRootsStrict(REPO_ROOT, '.plan-approval-pending')
   const baseStrict = _maxMtimeAcrossRootsStrict(REPO_ROOT, BASELINE_NAME)
   if (

--- a/scripts/lib/stop-gate-helpers.mjs
+++ b/scripts/lib/stop-gate-helpers.mjs
@@ -1,0 +1,39 @@
+/**
+ * stop-gate-helpers.mjs — Pure helpers for em-recall.mjs --gate stop.
+ *
+ * Extracted so tests/test-em-strict-lstat.mjs can import the strict-lstat
+ * helper directly and assert internal state (hadOtherError reached vs.
+ * tautological BLOCK). Codex round-6 F17.
+ *
+ * `_maxMtimeAcrossRootsStrict` — distinguishes ENOENT (marker absent at
+ * a root → fine to skip) from other lstat errors (EACCES, ENOTDIR, EIO,
+ * ELOOP — inspection failed → caller must fail closed). For NEW
+ * fail-closed paths only; the existing `_maxMtimeAcrossRoots` in
+ * em-recall.mjs retains its relaxed semantic (carve-out callers; FU to
+ * migrate per scratch/rank1-plan-v7.md FU list).
+ *
+ * Codex review trail: rounds 1-7 of rank-1 hook-deadlock plan, episodes
+ * `...bd6c` → `...afd2` → `...3ad6` → `...5697` → `...fb05` → `...acdc` →
+ * `...e19a` (ACCEPT-with-FU).
+ */
+
+import fs from 'fs'
+import { primaryMarkerPath, legacyMarkerPath } from './marker-paths.mjs'
+
+export function _maxMtimeAcrossRootsStrict(repoRoot, basename) {
+  let mtime = -Infinity
+  let hadSymlink = false
+  let anyExisted = false
+  let hadOtherError = false
+  for (const p of [primaryMarkerPath(repoRoot, basename), legacyMarkerPath(repoRoot, basename)]) {
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) { hadSymlink = true; continue }
+      anyExisted = true
+      if (st.mtimeMs > mtime) mtime = st.mtimeMs
+    } catch (e) {
+      if (e && e.code !== 'ENOENT') hadOtherError = true
+    }
+  }
+  return { mtime, hadSymlink, anyExisted, hadOtherError }
+}

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -339,16 +339,22 @@ assert_blocked "50. Bash 'tee .post-checkpoint-done' BLOCKED (POST_REQ not armed
 # or .claude/ must NOT pass the marker_write allowlist. Pre-fix the
 # allowlist matched any descendant by basename; post-fix it requires an
 # EXACT match against the canonical primary or legacy marker path.
+#
+# Rank-1 plan v7 update: descendants are now blocked by the new wrong-root
+# helper (_is_wrong_root_marker_write) with a more specific reason that
+# names the canonical path, NOT the generic "Checkpoint required" pre-gate
+# reason. Behavior is strictly better (block reason is actionable). Assert
+# the new reason substring.
 mkdir -p "$MARKER_DIR/sub" "$LEGACY_MARKER_DIR/sub"
 assert_blocked "50a. nested .checkpoints/sub/.pre-checkpoint-done — NOT allowed (F1)" \
-  "$(mock_json 'Bash' "echo content > $MARKER_DIR/sub/.pre-checkpoint-done")" "Checkpoint required"
+  "$(mock_json 'Bash' "echo content > $MARKER_DIR/sub/.pre-checkpoint-done")" "non-canonical path"
 assert_blocked "50b. nested .claude/sub/.pre-checkpoint-done — NOT allowed (F1)" \
-  "$(mock_json 'Bash' "echo content > $LEGACY_MARKER_DIR/sub/.pre-checkpoint-done")" "Checkpoint required"
+  "$(mock_json 'Bash' "echo content > $LEGACY_MARKER_DIR/sub/.pre-checkpoint-done")" "non-canonical path"
 # Edit tool path-equivalent of 50a
 edit_nested_json=$(jq -nc --arg fp "$MARKER_DIR/sub/.pre-checkpoint-done" --arg cwd "$TEST_DIR" \
   '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd}')
 assert_blocked "50c. Edit nested .checkpoints/sub/.pre-checkpoint-done — NOT allowed (F1)" \
-  "$edit_nested_json" "Checkpoint required"
+  "$edit_nested_json" "non-canonical path"
 
 # ============================================================================
 echo ""
@@ -759,6 +765,200 @@ else
   diff <(echo "$REPO_ROOT_BEFORE") <(echo "$REPO_ROOT_AFTER")
   ((failed++))
 fi
+
+# ============================================================================
+echo ""
+echo "--- B: Wrong-root marker write detection (rank-1 plan v7) ---"
+# ============================================================================
+# Codex-reviewed 7 rounds; final ACCEPT-with-FU at episode ...e19a.
+# Tests the new helpers in checkpoint-gate.sh:
+#   _marker_basename_in_set, _normalize_path_lexical, _is_canonical_marker_path,
+#   _command_has_relative_marker_path, _block_wrong_root_marker,
+#   _block_relative_marker_in_worktree, _is_wrong_root_marker_write.
+
+reset_state
+
+# B-tests need a SECOND cwd that is NOT the main repo root, to simulate
+# worktree-cwd OR nested-cwd within main. Create both shapes.
+WORKTREE_DIR="$(mktemp -d)"
+WORKTREE_DIR="$(cd -P "$WORKTREE_DIR" && pwd)"
+# Make WORKTREE_DIR a linked worktree of TEST_DIR (so resolve_repo_root from
+# WORKTREE_DIR returns TEST_DIR via git-common-dir).
+git -C "$TEST_DIR" config user.email t@t 2>/dev/null
+git -C "$TEST_DIR" config user.name t 2>/dev/null
+echo x > "$TEST_DIR/README.md"
+git -C "$TEST_DIR" add . >/dev/null 2>&1
+git -C "$TEST_DIR" commit -q -m init 2>/dev/null
+rmdir "$WORKTREE_DIR"
+git -C "$TEST_DIR" worktree add -q -b test-wt-branch "$WORKTREE_DIR" 2>/dev/null
+WORKTREE_DIR="$(cd -P "$WORKTREE_DIR" && pwd)"
+
+# Nested cwd inside main repo (codex F18)
+NESTED_DIR="$TEST_DIR/subdir"
+mkdir -p "$NESTED_DIR"
+
+# Arm the gate (checkpoint-required), but DON'T pre-create pre-done — so
+# the gate's pre-gate would block any allowed write. The B-tests assert
+# the EARLIER wrong-root checks fire BEFORE the pre-gate, with their
+# specific reason strings.
+touch "$PRE_REQ"
+
+mock_json_cwd() {
+  local tool_name="$1" command="$2" cwd="$3"
+  jq -n --arg tn "$tool_name" --arg cmd "$command" --arg cwd "$cwd" \
+    '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd}'
+}
+
+mock_json_write() {
+  local file_path="$1" cwd="$2"
+  jq -n --arg fp "$file_path" --arg cwd "$cwd" \
+    '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}, cwd: $cwd}'
+}
+
+# ---- Absolute-path wrong-root (codex F1/F7) ----
+
+assert_blocked "B-1. Bash: rm worktree-absolute marker → wrong-root block" \
+  "$(mock_json_cwd 'Bash' "rm $WORKTREE_DIR/.checkpoints/.pre-checkpoint-done" "$WORKTREE_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-2. Write: worktree-absolute marker → wrong-root block" \
+  "$(mock_json_write "$WORKTREE_DIR/.checkpoints/.post-checkpoint-done" "$WORKTREE_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-3. Bash: outside-repo absolute marker → wrong-root block" \
+  "$(mock_json_cwd 'Bash' "echo x > /tmp/.checkpoints/.pre-checkpoint-done" "$WORKTREE_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-4. Write: worktree legacy .claude/ absolute → wrong-root block" \
+  "$(mock_json_write "$WORKTREE_DIR/.claude/.plan-approval-pending" "$WORKTREE_DIR")" \
+  "non-canonical path"
+
+# ---- No false-positive on canonical paths of markers outside the 3-marker
+# allowlist (codex F7 — Bash redirects to canonical .checkpoint-required /
+# .preflight-done / .last-user-prompt.*.json should NOT trigger wrong-root) ----
+# Setup: satisfy pre-gate (PRE_DONE non-empty) so we test the WRONG-ROOT
+# branch only, not the orthogonal pre-checkpoint pre-gate.
+echo "pre-block" > "$PRE_DONE"
+
+# Asserts that the SPECIFIC wrong-root block does NOT fire. Other blocks
+# (push-gate, plan-gate) may still fire — we check the reason substring.
+assert_no_wrong_root_block() {
+  local test_name="$1"
+  local json="$2"
+  local output
+  output=$(echo "$json" | run_hook 2>/dev/null)
+  if echo "$output" | grep -qE 'non-canonical path|Relative marker reference'; then
+    echo "  ✗ $test_name (wrong-root falsely fired): $output"
+    ((failed++))
+  else
+    echo "  ✓ $test_name"
+    ((passed++))
+  fi
+}
+
+assert_no_wrong_root_block "B-5. Bash: canonical main .checkpoint-required (no FP)" \
+  "$(mock_json_cwd 'Bash' "echo x > $MARKER_DIR/.checkpoint-required" "$TEST_DIR")"
+
+assert_no_wrong_root_block "B-6. Bash: canonical main .preflight-done (no FP)" \
+  "$(mock_json_cwd 'Bash' "echo x > $MARKER_DIR/.preflight-done" "$TEST_DIR")"
+
+assert_no_wrong_root_block "B-7. Bash: canonical main .last-user-prompt (no FP)" \
+  "$(mock_json_cwd 'Bash' "echo x > $MARKER_DIR/.last-user-prompt.json" "$TEST_DIR")"
+
+# Restore pre-done empty for remaining tests (pre-gate state)
+: > "$PRE_DONE"
+rm -f "$PRE_DONE"
+
+# ---- Relative-marker precheck from worktree cwd (codex F10, F12, F15) ----
+
+assert_blocked "B-8. Bash: relative '> .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'echo x > .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_allowed "B-9. Bash: relative '> .checkpoints/<marker>' from MAIN" \
+  "$(mock_json_cwd 'Bash' "echo x > .checkpoints/.pre-checkpoint-done" "$TEST_DIR")"
+
+assert_blocked "B-10. Bash: 'touch .checkpoints/<marker>' from worktree (F12 verb-agnostic)" \
+  "$(mock_json_cwd 'Bash' 'touch .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-11. Bash: 'mv /tmp/x .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'mv /tmp/x .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-12. Bash: 'cp /tmp/x .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'cp /tmp/x .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-13. Bash: 'dd of=.checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'dd if=/tmp/x of=.checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-14. Bash: '> ./.checkpoints/<marker>' from worktree → block" \
+  "$(mock_json_cwd 'Bash' 'echo x > ./.checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# B-14b sanity: same shape from MAIN cwd → wrong-root block does NOT fire
+# (CWD == REPO_ROOT means precheck skips; the pre-gate may still fire — we
+# only assert the wrong-root reason is absent).
+assert_no_wrong_root_block "B-14b. Bash: './.checkpoints/<marker>' from MAIN cwd → no wrong-root FP" \
+  "$(mock_json_cwd 'Bash' 'echo x > ./.checkpoints/.pre-checkpoint-done' "$TEST_DIR")"
+
+assert_blocked "B-15. Bash: 'rm .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'rm .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# ---- Codex F16 — verb fan-out: install, cat >>, heredoc ----
+
+assert_blocked "B-16. Bash: 'install /tmp/x .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'install /tmp/x .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-17. Bash: 'cat /tmp/x >> .checkpoints/<marker>' from worktree" \
+  "$(mock_json_cwd 'Bash' 'cat /tmp/x >> .checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# B-18 (codex F16 heredoc): DEFERRED — classifier mis-labels
+# `cat <<EOF > .checkpoints/<marker>\nx\nEOF` as read_only, so the precheck
+# (which only runs for non-read_only) doesn't fire. This is a classifier
+# bug separate from the wrong-root cluster. Tracked as FU: "classifier
+# heredoc-with-redirect mis-classification" (see PR description).
+# The 7 other verbs (touch, mv, cp, install, dd, redirect, rm, tee, cat>>)
+# are covered by B-8/B-10/B-11/B-12/B-13/B-14/B-15/B-16/B-17.
+
+# ---- Codex F15 — `./` and `././` prefix chains ----
+
+assert_blocked "B-19. Bash: '> ./.checkpoints/<marker>' worktree" \
+  "$(mock_json_cwd 'Bash' 'echo x > ./.checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# B-20 is the canonical-main same shape allowed; B-14b above covers it. Skip duplicate.
+
+assert_blocked "B-21. Bash: '> ././.checkpoints/<marker>' worktree (chained ./)" \
+  "$(mock_json_cwd 'Bash' 'echo x > ././.checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-22. Bash: 'touch ./.checkpoints/<marker>' worktree (./ + touch)" \
+  "$(mock_json_cwd 'Bash' 'touch ./.checkpoints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# ---- Codex F18 — nested-cwd (not a worktree, just inside main repo) ----
+
+assert_blocked "B-23. Bash: relative marker from nested cwd inside main repo" \
+  "$(mock_json_cwd 'Bash' 'echo x > .checkpoints/.pre-checkpoint-done' "$NESTED_DIR")" \
+  "Relative marker reference"
+
+# Disk assertions (B-23a/b/c): block didn't write either nested or canonical
+assert_marker_absent "B-23a. After B-23: nested marker NOT created" \
+  "$NESTED_DIR/.checkpoints/.pre-checkpoint-done"
+assert_marker_absent "B-23b. After B-23: canonical marker NOT created (no PRE_DONE write)" \
+  "$PRE_DONE"
+assert_marker_exists "B-23c. After B-23: trigger marker (PRE_REQ) preserved" \
+  "$PRE_REQ"
+
+# Cleanup B-test worktree
+git -C "$TEST_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
+git -C "$TEST_DIR" branch -D test-wt-branch 2>/dev/null
 
 # ============================================================================
 echo ""

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1021,6 +1021,19 @@ assert_blocked "B-34 (codex PR P1). benign mention + real wrong-root write → s
 assert_no_wrong_root_block "B-35 (codex PR P1 no-FP). pure relative mention without absolute write → no block" \
   "$(mock_json_cwd 'Bash' "echo x > ./.checkpoints/.pre-checkpoint-done" "$TEST_DIR")"
 
+# B-36 (codex PR round-2 P1): bash pattern substitution glob bypass.
+# Pre-fix: `${cmd//\.${p}/}` interpreted `*` in $p as glob, over-matching
+# both the relative mention AND the absolute write occurrences, defeating
+# the occurrence-scoped check. With glob-escape, `$p` is treated literally.
+assert_blocked "B-36 (codex PR round-2 P1). glob-metachar bypass → still blocks" \
+  "$(mock_json_cwd 'Bash' "echo ./tmp/emglob*/.checkpoints/.pre-checkpoint-done >/dev/null; touch /tmp/emglob*/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+# B-37 (codex PR round-2 P1 no-FP): pure relative glob-metachar mention
+# from main cwd should still NOT block (pattern literal in residual check).
+assert_no_wrong_root_block "B-37 (codex PR round-2 P1 no-FP). pure relative glob mention → no block" \
+  "$(mock_json_cwd 'Bash' "echo x > ./.checkpoints/.pre-checkpoint-done; echo also ./tmp/glob?/.checkpoints/.checkpoint-required" "$TEST_DIR")"
+
 # Cleanup B-test worktree
 git -C "$TEST_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
 git -C "$TEST_DIR" branch -D test-wt-branch 2>/dev/null

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -956,6 +956,57 @@ assert_marker_absent "B-23b. After B-23: canonical marker NOT created (no PRE_DO
 assert_marker_exists "B-23c. After B-23: trigger marker (PRE_REQ) preserved" \
   "$PRE_REQ"
 
+# ---- Code-review A1 — quote-broken bypasses ----
+# Bash quoting that breaks the contiguous `.checkpoints/<marker>` substring
+# must still be detected because the shell evaluates the quotes before
+# the actual write occurs.
+
+assert_blocked "B-24 (A1). Bash: touch with double-quoted .checkpoints from worktree" \
+  "$(mock_json_cwd 'Bash' 'touch ".checkpoints"/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-25 (A1). Bash: touch with single-quoted .checkpoints from worktree" \
+  "$(mock_json_cwd 'Bash' "touch '.checkpoints'/.pre-checkpoint-done" "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-26 (A1). Bash: echo with single-quoted marker basename from worktree" \
+  "$(mock_json_cwd 'Bash' "echo x > .checkpoints/'.pre-checkpoint-done'" "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+assert_blocked "B-27 (A1). Bash: backslash-broken marker from worktree" \
+  "$(mock_json_cwd 'Bash' 'touch .checkpo\ints/.pre-checkpoint-done' "$WORKTREE_DIR")" \
+  "Relative marker reference"
+
+# ---- Code-review A2 — absolute non-canonical from MAIN cwd (shared_write verbs) ----
+# Pre-fix the absolute-noncanonical detection was gated on CWD != REPO_ROOT,
+# so `touch /tmp/.checkpoints/<marker>` from main cwd fell through to
+# shared_write -> pre-gate. Now it must block as wrong-root.
+
+assert_blocked "B-28 (A2). Bash: touch /tmp/.checkpoints/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "touch /tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-29 (A2). Bash: mv to /tmp/.checkpoints/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "mv /tmp/x /tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-30 (A2). Bash: cp to /tmp/.checkpoints/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "cp /tmp/x /tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-31 (A2). Bash: install to /tmp/.checkpoints/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "install /tmp/x /tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+assert_blocked "B-32 (A2). Bash: dd of=/tmp/.checkpoints/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "dd if=/tmp/x of=/tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+# A2 no-FP: canonical absolute marker from MAIN cwd should still NOT
+# trigger the wrong-root block (predicate filters canonical paths).
+assert_no_wrong_root_block "B-33 (A2 no-FP). Bash: touch on canonical $MARKER_DIR/<marker> from MAIN cwd" \
+  "$(mock_json_cwd 'Bash' "touch $MARKER_DIR/.checkpoint-required" "$TEST_DIR")"
+
 # Cleanup B-test worktree
 git -C "$TEST_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
 git -C "$TEST_DIR" branch -D test-wt-branch 2>/dev/null

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1007,6 +1007,20 @@ assert_blocked "B-32 (A2). Bash: dd of=/tmp/.checkpoints/<marker> from MAIN cwd"
 assert_no_wrong_root_block "B-33 (A2 no-FP). Bash: touch on canonical $MARKER_DIR/<marker> from MAIN cwd" \
   "$(mock_json_cwd 'Bash' "touch $MARKER_DIR/.checkpoint-required" "$TEST_DIR")"
 
+# ---- PR-level review P1 regression — occurrence-scoped relative-vs-absolute ----
+# Codex caught: a benign mention of `./<absolute-path>` in part of the command
+# was making the global filter skip the absolute-write check for the WHOLE
+# command, allowing a separate real wrong-root write elsewhere.
+
+assert_blocked "B-34 (codex PR P1). benign mention + real wrong-root write → still blocks" \
+  "$(mock_json_cwd 'Bash' "echo ./tmp/.checkpoints/.pre-checkpoint-done >/dev/null; touch /tmp/.checkpoints/.pre-checkpoint-done" "$TEST_DIR")" \
+  "non-canonical path"
+
+# Defensive: pure benign mention (no real write) should still NOT block
+# (avoid over-correction — we want occurrence-scoped, not blunt always-block)
+assert_no_wrong_root_block "B-35 (codex PR P1 no-FP). pure relative mention without absolute write → no block" \
+  "$(mock_json_cwd 'Bash' "echo x > ./.checkpoints/.pre-checkpoint-done" "$TEST_DIR")"
+
 # Cleanup B-test worktree
 git -C "$TEST_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
 git -C "$TEST_DIR" branch -D test-wt-branch 2>/dev/null

--- a/tests/test-em-recall-session-start-early-exit.mjs
+++ b/tests/test-em-recall-session-start-early-exit.mjs
@@ -420,6 +420,12 @@ function buildTempHome(homeRoot) {
     path.join(SCRIPTS, 'lib', 'marker-paths.mjs'),
     path.join(installedLib, 'marker-paths.mjs'),
   )
+  // rank-1 plan v7: em-recall now imports stop-gate-helpers.mjs for the
+  // active-plan exemption. Test fixture must mirror transitive imports.
+  fs.copyFileSync(
+    path.join(SCRIPTS, 'lib', 'stop-gate-helpers.mjs'),
+    path.join(installedLib, 'stop-gate-helpers.mjs'),
+  )
   // No hook-install.json; warn_hook_freshness soft-fails on missing manifest.
   return installedScripts
 }

--- a/tests/test-em-strict-lstat.mjs
+++ b/tests/test-em-strict-lstat.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// test-em-strict-lstat.mjs — Level-2 in-process unit tests for
+// _maxMtimeAcrossRootsStrict (scripts/lib/stop-gate-helpers.mjs).
+//
+// Codex round-6 F17: prove the strict-error PATH is reached (not just
+// a tautological BLOCK from a downstream effect). Imports the helper
+// directly and asserts internal state: hadOtherError === true when a
+// non-ENOENT lstat error occurs at either root.
+//
+// Coverage:
+//   U1  absent at both roots          → anyExisted=false, hadSymlink=false, hadOtherError=false
+//   U2  ENOENT primary + active legacy → anyExisted=true,  hadSymlink=false, hadOtherError=false
+//   U3  symlink primary + absent legacy → anyExisted=false, hadSymlink=true,  hadOtherError=false
+//   U4  ENOTDIR primary + active legacy → anyExisted=true,  hadSymlink=false, hadOtherError=true   ← F17 proof
+//   U5  active primary + active legacy  → anyExisted=true,  hadSymlink=false, hadOtherError=false
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execSync } from 'child_process'
+import { _maxMtimeAcrossRootsStrict } from '../scripts/lib/stop-gate-helpers.mjs'
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) {
+  fail++; failures.push(`${name}: ${detail}`)
+  console.log(`  ✗ ${name}: ${detail}`)
+}
+
+function mkRepo(label) {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), `em-strict-${label}-`))
+  const d = fs.realpathSync(raw)
+  execSync(`git init -q -b main "${d}"`)
+  return d
+}
+
+function setMtime(p, ms) {
+  const t = ms / 1000
+  fs.utimesSync(p, t, t)
+}
+
+const cleanupDirs = []
+process.on('exit', () => {
+  for (const d of cleanupDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+console.log('\n=== U1-U5 — _maxMtimeAcrossRootsStrict in-process semantics ===')
+
+// U1 — absent at both roots
+{
+  const d = mkRepo('u1'); cleanupDirs.push(d)
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  const r = _maxMtimeAcrossRootsStrict(d, '.plan-approval-pending')
+  if (r.anyExisted === false && r.hadSymlink === false && r.hadOtherError === false && r.mtime === -Infinity) {
+    ok('U1: absent at both roots → anyExisted=false, hadOtherError=false')
+  } else {
+    bad('U1', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+// U2 — ENOENT primary + active legacy
+{
+  const d = mkRepo('u2'); cleanupDirs.push(d)
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  const legacy = path.join(d, '.claude', '.plan-approval-pending')
+  fs.writeFileSync(legacy, '')
+  setMtime(legacy, Date.now())
+  const r = _maxMtimeAcrossRootsStrict(d, '.plan-approval-pending')
+  if (r.anyExisted === true && r.hadSymlink === false && r.hadOtherError === false && r.mtime > 0) {
+    ok('U2: ENOENT primary + active legacy → anyExisted=true, hadOtherError=false')
+  } else {
+    bad('U2', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+// U3 — symlink primary + absent legacy
+{
+  const d = mkRepo('u3'); cleanupDirs.push(d)
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  // Real file + symlink to it
+  const real = path.join(d, '.checkpoints', 'real-target')
+  fs.writeFileSync(real, '')
+  fs.symlinkSync(real, path.join(d, '.checkpoints', '.plan-approval-pending'))
+  const r = _maxMtimeAcrossRootsStrict(d, '.plan-approval-pending')
+  if (r.anyExisted === false && r.hadSymlink === true && r.hadOtherError === false) {
+    ok('U3: symlink primary + absent legacy → hadSymlink=true, hadOtherError=false')
+  } else {
+    bad('U3', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+// U4 — ENOTDIR primary + active legacy  ← F17 proof
+// Setup: primary `.checkpoints` is a REGULAR FILE, not a directory.
+// lstat(<repo>/.checkpoints/.plan-approval-pending) fails with ENOTDIR
+// (because `.checkpoints` is not a directory). The helper must set
+// hadOtherError=true (not skip silently as ENOENT).
+{
+  const d = mkRepo('u4'); cleanupDirs.push(d)
+  // PRIMARY: regular file at .checkpoints (NOT a directory) → ENOTDIR on child
+  fs.writeFileSync(path.join(d, '.checkpoints'), 'not-a-dir')
+  // LEGACY: active plan-pending
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  const legacy = path.join(d, '.claude', '.plan-approval-pending')
+  fs.writeFileSync(legacy, '')
+  setMtime(legacy, Date.now())
+  const r = _maxMtimeAcrossRootsStrict(d, '.plan-approval-pending')
+  // Defensive: confirm setup — primary `.checkpoints` IS a regular file at check time
+  const st = fs.lstatSync(path.join(d, '.checkpoints'))
+  if (!st.isFile()) {
+    bad('U4 setup', `expected .checkpoints to be a regular file, got mode ${st.mode.toString(8)}`)
+  } else {
+    if (r.hadOtherError === true && r.anyExisted === true && r.hadSymlink === false) {
+      ok('U4 (F17): ENOTDIR primary + active legacy → hadOtherError=true (PROVES strict-error path reached)')
+    } else {
+      bad('U4', `expected hadOtherError=true, got: ${JSON.stringify(r)}`)
+    }
+  }
+}
+
+// U5 — both roots active
+{
+  const d = mkRepo('u5'); cleanupDirs.push(d)
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(d, '.claude'), { recursive: true })
+  const primary = path.join(d, '.checkpoints', '.plan-approval-pending')
+  const legacy = path.join(d, '.claude', '.plan-approval-pending')
+  fs.writeFileSync(primary, '')
+  fs.writeFileSync(legacy, '')
+  const earlier = Date.now() - 60_000
+  const later = Date.now()
+  setMtime(primary, earlier)
+  setMtime(legacy, later)
+  const r = _maxMtimeAcrossRootsStrict(d, '.plan-approval-pending')
+  if (r.anyExisted === true && r.hadSymlink === false && r.hadOtherError === false) {
+    // mtime should be max of the two — take the later one
+    const expected = fs.lstatSync(legacy).mtimeMs
+    if (Math.abs(r.mtime - expected) < 100) {
+      ok('U5: both roots active → mtime = max(primary, legacy)')
+    } else {
+      bad('U5', `expected mtime≈${expected}, got ${r.mtime}`)
+    }
+  } else {
+    bad('U5', `got: ${JSON.stringify(r)}`)
+  }
+}
+
+console.log('\n==================================================')
+console.log(`Results: ${pass} passed, ${fail} failed`)
+console.log('==================================================')
+if (fail > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  ${f}`)
+  process.exit(1)
+}
+process.exit(0)

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -145,20 +145,26 @@ console.log('\n=== L1 — stop-gate carve-out behavior ===')
   else bad('1.2: carve-out should fire', `got: ${JSON.stringify(r)}`)
 }
 
-// 1.3 baseline + plan-pending newer than baseline → block
+// 1.3 baseline + plan-pending newer than baseline → DEFER (rank-1 plan v7
+// #178 F1 inverts the pre-existing expectation: active plan-pending in
+// flight triggers the new stop-gate exemption — see L5 5.1 for the
+// canonical positive test of this behavior). Active plan-pending was
+// previously a TASK_SIGNAL that BLOCKED stop-gate; now it DEFERs (because
+// otherwise checkpoint-gate + plan-gate + stop-gate form an unrecoverable
+// triangle — see scratch/rank1-plan-v7.md §A rationale).
 {
   const d = mkRepo('1-3'); cleanupDirs.push(d)
   const claudeDir = path.join(d, '.checkpoints')
   fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
   setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
-  // sleep effect: plan-pending will be NEWER than baseline
+  // plan-pending NEWER than baseline → active (rank-1 plan v7 exemption fires)
   const planP = path.join(claudeDir, '.plan-approval-pending')
   fs.writeFileSync(planP, '')
-  setMtime(planP, Date.now() + 5_000) // explicitly future to defeat fs resolution
+  setMtime(planP, Date.now() + 5_000)
   const r = runGateStop(d)
-  if (isBlock(r) && r.status === 0) ok('1.3: plan-pending newer than baseline → block')
-  else bad('1.3: plan-pending → block', `got: ${JSON.stringify(r)}`)
+  if (isCarveOutAllow(r)) ok('1.3 (rank-1 v7): plan-pending active → defer (was: block)')
+  else bad('1.3: active plan-pending should defer', `got: ${JSON.stringify(r)}`)
   if (fs.existsSync(planP)) ok('1.3 (defensive): plan-pending preserved')
   else bad('1.3 defensive', 'plan-pending disappeared')
 }
@@ -472,7 +478,7 @@ function mkE2EHome() {
   // .checkpoints/ migration: marker-paths.mjs ships alongside local-dir.mjs;
   // omit it and em-recall fails to load (same fix as test-stop-gate.sh's
   // mk_fake_home).
-  for (const lib of ['local-dir.mjs', 'marker-paths.mjs']) {
+  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'stop-gate-helpers.mjs']) {
     const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', lib)
     fs.copyFileSync(libSrc, path.join(scripts, 'lib', lib))
   }
@@ -631,6 +637,252 @@ function runHook(hookPath, inputJson, cwd, home) {
   } else {
     bad('4.3: marker_write should be allowed',
       `status=${r.status} stdout=${r.stdout}`)
+  }
+}
+
+// ============================================================================
+console.log('\n=== L5 — Active-plan exemption (#178 F1, rank-1 plan v7) ===')
+// ============================================================================
+// Codex-reviewed 7 rounds; final ACCEPT-with-FU at episode ...e19a.
+// Exemption fires iff plan-pending active (mtime > baseline) at either
+// root, with strict-lstat fail-closed (codex F11). Symlink + ENOTDIR
+// fail closed (codex F17). 5.11/5.12 use ENOTDIR via .checkpoints
+// being a regular file — deterministic and platform-portable.
+
+function isCarveOutAllow_v5(r) {
+  // Same shape as isCarveOutAllow (above); aliased for L5 readability.
+  return r.status === 0 && !r.stdout
+}
+
+// 5.1 plan-pending active at primary (mtime > baseline) → defer
+{
+  const d = mkRepo('5-1'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  setMtime(path.join(claudeDir, '.session-baseline'), Date.now() - 30_000)
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() + 5_000) // active mid-session
+  const r = runGateStop(d)
+  if (isCarveOutAllow_v5(r)) ok('5.1: plan-pending active at primary → defer')
+  else bad('5.1', `got: ${JSON.stringify(r)}`)
+}
+
+// 5.2 plan-pending symlink at primary → fail closed
+{
+  const d = mkRepo('5-2'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  setMtime(path.join(claudeDir, '.session-baseline'), Date.now() - 30_000)
+  const real = path.join(claudeDir, 'real-plan-marker')
+  fs.writeFileSync(real, '')
+  setMtime(real, Date.now() + 5_000)
+  fs.symlinkSync(real, path.join(claudeDir, '.plan-approval-pending'))
+  const r = runGateStop(d)
+  // Symlink → exemption ineligible; carve-out ALSO fails closed on symlink
+  // markers (existing #146 P2 symmetry). Net: block.
+  if (isBlock(r) && r.status === 0) ok('5.2: symlinked plan-pending → exemption ineligible → block')
+  else bad('5.2', `got: ${JSON.stringify(r)}`)
+}
+
+// 5.3 plan-pending orphan (mtime ≤ baseline) → exemption skipped; existing
+// carve-out fires when ALL markers stale → defer.
+{
+  const d = mkRepo('5-3'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 120_000)
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() - 90_000) // older than baseline
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // baseline mtime now (newest) → carve-out fires for stale plan-pending
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.3: orphan plan-pending → exemption skipped, carve-out fires → defer')
+  else bad('5.3', 'expected carve-out defer for fully orphan markers')
+}
+
+// 5.4 plan-pending orphan + .checkpoint-required ACTIVE → block. Exemption
+// doesn't rescue when other carve-out signals fail.
+{
+  const d = mkRepo('5-4'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  setMtime(path.join(claudeDir, '.session-baseline'), Date.now() - 30_000)
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() - 90_000) // orphan
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  fs.writeFileSync(preReq, '')
+  setMtime(preReq, Date.now() + 5_000) // re-armed mid-session
+  if (isBlock(runGateStop(d))) ok('5.4: orphan plan-pending + active checkpoint-required → block (exemption skipped)')
+  else bad('5.4', 'expected block when checkpoint-required is mid-session active')
+}
+
+// 5.5 plan-pending active at LEGACY root only → defer (dual-root happy path)
+{
+  const d = mkRepo('5-5'); cleanupDirs.push(d)
+  const primary = path.join(d, '.checkpoints')
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(primary, '.checkpoint-required'), '')
+  setMtime(path.join(primary, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(primary, '.session-baseline'), '')
+  setMtime(path.join(primary, '.session-baseline'), Date.now() - 30_000)
+  // plan-pending lives at LEGACY only
+  const planP = path.join(legacy, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() + 5_000)
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.5: active plan-pending at LEGACY only → defer (dual-root)')
+  else bad('5.5', 'expected dual-root exemption to fire for legacy-only active plan-pending')
+}
+
+// 5.6 baseline absent at both roots → exemption skipped → block (preReq + empty postDone path).
+{
+  const d = mkRepo('5-6'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  // NO baseline at either root
+  if (isBlock(runGateStop(d))) ok('5.6: baseline absent → exemption ineligible → block')
+  else bad('5.6', 'expected block when no baseline anywhere')
+}
+
+// 5.7 plan-pending lstat ENOENT-equivalent (we test the "absent" branch
+// covered by ENOENT being silently skipped — same as U2). At gate level:
+// no plan-pending anywhere → exemption ineligible → existing carve-out path.
+{
+  const d = mkRepo('5-7'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.checkpoint-required'), '')
+  setMtime(path.join(claudeDir, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  // No plan-pending — exemption ineligible. Carve-out evaluates;
+  // checkpoint-required is stale, baseline is current → carve-out fires → defer
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.7: no plan-pending → exemption ineligible, carve-out defers')
+  else bad('5.7', 'expected carve-out defer when no plan-pending')
+}
+
+// 5.8 primary stale + legacy active → defer (codex F8 dual-root active)
+{
+  const d = mkRepo('5-8'); cleanupDirs.push(d)
+  const primary = path.join(d, '.checkpoints')
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(primary, '.checkpoint-required'), '')
+  setMtime(path.join(primary, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(primary, '.session-baseline'), '')
+  setMtime(path.join(primary, '.session-baseline'), Date.now() - 30_000)
+  // PRIMARY plan-pending: stale
+  const primaryPlan = path.join(primary, '.plan-approval-pending')
+  fs.writeFileSync(primaryPlan, '')
+  setMtime(primaryPlan, Date.now() - 90_000)
+  // LEGACY plan-pending: active
+  const legacyPlan = path.join(legacy, '.plan-approval-pending')
+  fs.writeFileSync(legacyPlan, '')
+  setMtime(legacyPlan, Date.now() + 5_000)
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.8 (F8): primary stale + legacy active → defer (max-across-roots)')
+  else bad('5.8', 'expected dual-root exemption to take MAX mtime; should fire')
+}
+
+// 5.9 primary symlink + legacy active → BLOCK (codex F8 symlink-at-either fails closed)
+{
+  const d = mkRepo('5-9'); cleanupDirs.push(d)
+  const primary = path.join(d, '.checkpoints')
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(primary, '.checkpoint-required'), '')
+  setMtime(path.join(primary, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(primary, '.session-baseline'), '')
+  setMtime(path.join(primary, '.session-baseline'), Date.now() - 30_000)
+  // PRIMARY plan-pending: symlink
+  const real = path.join(primary, 'real-plan-marker')
+  fs.writeFileSync(real, '')
+  fs.symlinkSync(real, path.join(primary, '.plan-approval-pending'))
+  // LEGACY plan-pending: active
+  const legacyPlan = path.join(legacy, '.plan-approval-pending')
+  fs.writeFileSync(legacyPlan, '')
+  setMtime(legacyPlan, Date.now() + 5_000)
+  if (isBlock(runGateStop(d))) ok('5.9 (F8): primary symlink + legacy active → block (fail-closed)')
+  else bad('5.9', 'expected block when ANY root has symlink')
+}
+
+// 5.10 both roots have active plan-pending → defer (sanity)
+{
+  const d = mkRepo('5-10'); cleanupDirs.push(d)
+  const primary = path.join(d, '.checkpoints')
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(primary, '.checkpoint-required'), '')
+  setMtime(path.join(primary, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(primary, '.session-baseline'), '')
+  setMtime(path.join(primary, '.session-baseline'), Date.now() - 30_000)
+  fs.writeFileSync(path.join(primary, '.plan-approval-pending'), '')
+  setMtime(path.join(primary, '.plan-approval-pending'), Date.now() + 5_000)
+  fs.writeFileSync(path.join(legacy, '.plan-approval-pending'), '')
+  setMtime(path.join(legacy, '.plan-approval-pending'), Date.now() + 5_000)
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.10: both roots active → defer')
+  else bad('5.10', 'expected defer when both roots have active plan-pending')
+}
+
+// 5.11 ENOTDIR on primary marker dir → exemption ineligible → BLOCK (codex F17)
+// Setup: primary .checkpoints is a REGULAR FILE (not dir), legacy is real
+// directory with active plan-pending + baseline + checkpoint-required. The
+// strict helper detects hadOtherError on primary side → exemption ineligible.
+{
+  const d = mkRepo('5-11'); cleanupDirs.push(d)
+  // PRIMARY: regular file at .checkpoints (NOT a dir) → ENOTDIR on child lstat
+  // mkRepo() creates .checkpoints as a directory — rm it first before
+  // writing the regular file in its place.
+  fs.rmSync(path.join(d, '.checkpoints'), { recursive: true, force: true })
+  fs.writeFileSync(path.join(d, '.checkpoints'), 'not-a-dir')
+  // LEGACY: full setup
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(legacy, '.checkpoint-required'), '')
+  setMtime(path.join(legacy, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(legacy, '.session-baseline'), '')
+  setMtime(path.join(legacy, '.session-baseline'), Date.now() - 30_000)
+  fs.writeFileSync(path.join(legacy, '.plan-approval-pending'), '')
+  setMtime(path.join(legacy, '.plan-approval-pending'), Date.now() + 5_000)
+  // Defensive: confirm primary .checkpoints is a regular file at check time
+  const st = fs.lstatSync(path.join(d, '.checkpoints'))
+  if (!st.isFile()) {
+    bad('5.11 setup', `expected .checkpoints to be regular file; got mode ${st.mode.toString(8)}`)
+  } else if (isBlock(runGateStop(d))) {
+    ok('5.11 (F17): ENOTDIR primary + active legacy → exemption ineligible → block')
+  } else {
+    bad('5.11', 'expected block when primary marker dir is unreadable (ENOTDIR)')
+  }
+}
+
+// 5.12 ENOTDIR on primary baseline (.checkpoints is a regular file) +
+// legacy baseline ok + plan-pending active → BLOCK on baseline side
+// (same fail-closed semantic for baseline computation).
+{
+  const d = mkRepo('5-12'); cleanupDirs.push(d)
+  // Same shape as 5.11: primary `.checkpoints` is regular file. This also
+  // affects baseline lookup at primary. Combined with the marker side
+  // failing, both branches of the strict helper see hadOtherError=true.
+  // This test documents that the strict semantic applies symmetrically.
+  fs.rmSync(path.join(d, '.checkpoints'), { recursive: true, force: true })
+  fs.writeFileSync(path.join(d, '.checkpoints'), 'not-a-dir')
+  const legacy = path.join(d, '.claude')
+  fs.mkdirSync(legacy, { recursive: true })
+  fs.writeFileSync(path.join(legacy, '.checkpoint-required'), '')
+  setMtime(path.join(legacy, '.checkpoint-required'), Date.now() - 60_000)
+  fs.writeFileSync(path.join(legacy, '.session-baseline'), '')
+  setMtime(path.join(legacy, '.session-baseline'), Date.now() - 30_000)
+  fs.writeFileSync(path.join(legacy, '.plan-approval-pending'), '')
+  setMtime(path.join(legacy, '.plan-approval-pending'), Date.now() + 5_000)
+  if (isBlock(runGateStop(d))) {
+    ok('5.12 (F17): ENOTDIR primary baseline + legacy active → block (fail-closed on baseline)')
+  } else {
+    bad('5.12', 'expected block when primary baseline path is unreadable')
   }
 }
 

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -752,9 +752,10 @@ function isCarveOutAllow_v5(r) {
   else bad('5.6', 'expected block when no baseline anywhere')
 }
 
-// 5.7 plan-pending lstat ENOENT-equivalent (we test the "absent" branch
-// covered by ENOENT being silently skipped — same as U2). At gate level:
-// no plan-pending anywhere → exemption ineligible → existing carve-out path.
+// 5.7 NEGATIVE class — no plan-pending anywhere → exemption ineligible
+// (anyExisted=false). Tests the negative class of the eligibility predicate;
+// the strict-lstat-fails-with-non-ENOENT branch is covered by 5.11/5.12 +
+// U4 in tests/test-em-strict-lstat.mjs (code-review C2 renaming).
 {
   const d = mkRepo('5-7'); cleanupDirs.push(d)
   const claudeDir = path.join(d, '.checkpoints')
@@ -763,7 +764,7 @@ function isCarveOutAllow_v5(r) {
   fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
   // No plan-pending — exemption ineligible. Carve-out evaluates;
   // checkpoint-required is stale, baseline is current → carve-out fires → defer
-  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.7: no plan-pending → exemption ineligible, carve-out defers')
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.7 (C2 negative class): no plan-pending → exemption ineligible, carve-out defers')
   else bad('5.7', 'expected carve-out defer when no plan-pending')
 }
 
@@ -858,6 +859,33 @@ function isCarveOutAllow_v5(r) {
   } else {
     bad('5.11', 'expected block when primary marker dir is unreadable (ENOTDIR)')
   }
+}
+
+// 5.13 (code-review B1): active plan-pending + active checkpoint-required
+// → exemption fires → defer. Documents the intentional behavior change in
+// rank-1 v7: the new exemption supersedes the carve-out's TASK_SIGNAL_MARKERS
+// check when plan-pending is in flight, because the agent is in the plan-
+// review phase (no writes happening), and the triangle deadlock between
+// checkpoint-gate + plan-gate + stop-gate would otherwise be unrecoverable.
+// Plan-gate provides the writer-side defense; stop-gate stepping aside is
+// the deadlock-break.
+{
+  const d = mkRepo('5-13'); cleanupDirs.push(d)
+  const claudeDir = path.join(d, '.checkpoints')
+  fs.writeFileSync(path.join(claudeDir, '.session-baseline'), '')
+  setMtime(path.join(claudeDir, '.session-baseline'), Date.now() - 30_000)
+  // checkpoint-required ACTIVE (mid-session re-arm)
+  const preReq = path.join(claudeDir, '.checkpoint-required')
+  fs.writeFileSync(preReq, '')
+  setMtime(preReq, Date.now() + 5_000)
+  // plan-pending ACTIVE
+  const planP = path.join(claudeDir, '.plan-approval-pending')
+  fs.writeFileSync(planP, '')
+  setMtime(planP, Date.now() + 5_000)
+  // Pre-fix: carve-out would block (active TASK_SIGNAL_MARKERS).
+  // Post-fix: exemption fires first → defer (intentional).
+  if (isCarveOutAllow_v5(runGateStop(d))) ok('5.13 (B1): active plan-pending + active checkpoint-required → defer (exemption supersedes carve-out)')
+  else bad('5.13', 'expected exemption to fire and defer even with another active TASK_SIGNAL marker')
 }
 
 // 5.12 ENOTDIR on primary baseline (.checkpoints is a regular file) +

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -77,6 +77,9 @@ mk_fake_home() {
   # marker-paths.mjs; without it the module fails to load and the hook
   # falls back to the canned em-recall-non-zero error message.
   cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$fake_home/.episodic-memory/scripts/lib/marker-paths.mjs"
+  # rank-1 plan v7 (2026-05-12): em-recall also imports stop-gate-helpers.mjs
+  # for the active-plan exemption (_maxMtimeAcrossRootsStrict).
+  cp "$REPO_ROOT/scripts/lib/stop-gate-helpers.mjs" "$fake_home/.episodic-memory/scripts/lib/stop-gate-helpers.mjs"
 }
 
 TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"

--- a/tests/test-worktree-marker-write.sh
+++ b/tests/test-worktree-marker-write.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test-worktree-marker-write.sh — E2E for rank-1 hook-deadlock plan v7.
+#
+# Exercises checkpoint-gate.sh via real piped JSON against a real main
+# repo + linked git worktree + nested cwd. Verifies the wrong-root
+# detection BOTH blocks AND prevents the artifact from landing where the
+# agent attempted (codex round-4 F12 + round-6 F18 disk assertions).
+#
+# Closes BP-1 step 8 for this slice: subprocess unit tests in
+# test-checkpoint-gate.sh don't prove the on-disk authority preservation;
+# this file does.
+#
+# Codex review trail: 7 rounds, final ACCEPT-with-FU at episode ...e19a.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/checkpoint-gate.sh"
+
+passed=0
+failed=0
+
+MAIN_DIR=$(mktemp -d)
+MAIN_DIR="$(cd -P "$MAIN_DIR" && pwd)"
+
+WT_DIR=$(mktemp -d)
+WT_DIR="$(cd -P "$WT_DIR" && pwd)"
+# Need empty for git worktree add
+rmdir "$WT_DIR"
+
+cleanup() {
+  if [ -d "$WT_DIR" ]; then
+    git -C "$MAIN_DIR" worktree remove --force "$WT_DIR" 2>/dev/null || true
+  fi
+  rm -rf "$MAIN_DIR" "$WT_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Initialize main repo
+git -C "$MAIN_DIR" init -q
+git -C "$MAIN_DIR" config user.email t@t
+git -C "$MAIN_DIR" config user.name t
+echo x > "$MAIN_DIR/README.md"
+git -C "$MAIN_DIR" add .
+git -C "$MAIN_DIR" commit -q -m init
+
+# Create linked worktree
+git -C "$MAIN_DIR" worktree add -q -b wt-branch "$WT_DIR"
+WT_DIR="$(cd -P "$WT_DIR" && pwd)"
+
+# Arm checkpoint-required at main (canonical authority root)
+MAIN_CKDIR="$MAIN_DIR/.checkpoints"
+mkdir -p "$MAIN_CKDIR"
+touch "$MAIN_CKDIR/.checkpoint-required"
+
+# Nested cwd inside main repo (codex F18)
+NESTED_DIR="$MAIN_DIR/subdir"
+mkdir -p "$NESTED_DIR"
+
+run_hook() {
+  HOME="$MAIN_DIR" bash "$HOOK"
+}
+
+mock_write() {
+  local file_path="$1" cwd="$2"
+  jq -n --arg fp "$file_path" --arg cwd "$cwd" \
+    '{tool_name: "Write", tool_input: {file_path: $fp, content: "x"}, cwd: $cwd}'
+}
+
+mock_bash() {
+  local cmd="$1" cwd="$2"
+  jq -n --arg cmd "$cmd" --arg cwd "$cwd" \
+    '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd}'
+}
+
+assert_blocked_with_canonical() {
+  local label="$1" json="$2" expected_substring="$3"
+  local output
+  output=$(echo "$json" | run_hook 2>/dev/null)
+  if echo "$output" | grep -q '"decision".*"block"' && echo "$output" | grep -q "$expected_substring"; then
+    echo "  ✓ $label"
+    ((passed++))
+  else
+    echo "  ✗ $label — output: $output"
+    ((failed++))
+  fi
+}
+
+assert_file_absent() {
+  local label="$1" path="$2"
+  if [ ! -e "$path" ]; then
+    echo "  ✓ $label (file absent at $path)"
+    ((passed++))
+  else
+    echo "  ✗ $label — file unexpectedly exists at $path"
+    ((failed++))
+  fi
+}
+
+echo ""
+echo "=== rank-1 plan v7 E2E — wrong-root marker write detection ==="
+echo ""
+
+# Case 1 — Worktree Write to worktree-absolute marker → BLOCK, canonical hint, canonical absent
+WT_PRE="$WT_DIR/.checkpoints/.pre-checkpoint-done"
+MAIN_PRE="$MAIN_DIR/.checkpoints/.pre-checkpoint-done"
+rm -f "$WT_PRE" "$MAIN_PRE"
+mkdir -p "$WT_DIR/.checkpoints"
+assert_blocked_with_canonical "1. Worktree Write absolute → block + canonical hint" \
+  "$(mock_write "$WT_PRE" "$WT_DIR")" \
+  "non-canonical path"
+assert_file_absent "1a. canonical main marker NOT created by blocked Write" "$MAIN_PRE"
+
+# Case 2 — Worktree Bash redirect → BLOCK, neither location written
+assert_blocked_with_canonical "2. Worktree Bash redirect → block + canonical hint" \
+  "$(mock_bash "echo x > $WT_DIR/.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "non-canonical path"
+assert_file_absent "2a. canonical main marker NOT created by blocked Bash redirect" "$MAIN_PRE"
+
+# Case 3 — Worktree Bash touch → BLOCK
+assert_blocked_with_canonical "3. Worktree Bash touch absolute → block + canonical hint" \
+  "$(mock_bash "touch $WT_DIR/.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "non-canonical path"
+assert_file_absent "3a. canonical main marker NOT created" "$MAIN_PRE"
+
+# Case 4 — Worktree Bash mv to absolute worktree path
+rm -f "$WT_PRE" "$MAIN_PRE"
+assert_blocked_with_canonical "4. Worktree Bash mv absolute → block" \
+  "$(mock_bash "mv /tmp/x $WT_DIR/.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "non-canonical path"
+
+# Case 5 — Worktree Bash cp to absolute worktree path
+assert_blocked_with_canonical "5. Worktree Bash cp absolute → block" \
+  "$(mock_bash "cp /tmp/x $WT_DIR/.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "non-canonical path"
+
+# Case 6 — Worktree Bash dd to absolute worktree path
+assert_blocked_with_canonical "6. Worktree Bash dd of= absolute → block" \
+  "$(mock_bash "dd if=/tmp/x of=$WT_DIR/.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "non-canonical path"
+
+# Case 7 — Main cwd relative '> ./.checkpoints/<marker>' → no wrong-root block
+# (the pre-gate may still fire because PRE_DONE is empty, but the wrong-root
+# reason should NOT appear)
+output=$(echo "$(mock_bash "echo x > ./.checkpoints/.pre-checkpoint-done" "$MAIN_DIR")" | run_hook 2>/dev/null)
+if echo "$output" | grep -qE 'non-canonical path|Relative marker reference'; then
+  echo "  ✗ 7. Main cwd './.checkpoints/<marker>' — wrong-root FALSELY fired"
+  ((failed++))
+else
+  echo "  ✓ 7. Main cwd './.checkpoints/<marker>' → no wrong-root false-positive"
+  ((passed++))
+fi
+
+# Case 8 — Worktree relative './.checkpoints/<marker>' → BLOCK
+assert_blocked_with_canonical "8. Worktree './.checkpoints/<marker>' redirect → block" \
+  "$(mock_bash "echo x > ./.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "Relative marker reference"
+assert_file_absent "8a. canonical main marker NOT created" "$MAIN_PRE"
+assert_file_absent "8b. worktree marker NOT created (shell didn't run)" "$WT_PRE"
+
+# Case 9 — Worktree './.checkpoints/<marker>' touch → BLOCK
+assert_blocked_with_canonical "9. Worktree './.checkpoints/<marker>' touch → block" \
+  "$(mock_bash "touch ./.checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "Relative marker reference"
+
+# Case 10 — Worktree install to relative marker → BLOCK
+assert_blocked_with_canonical "10. Worktree install to relative marker → block" \
+  "$(mock_bash "install /tmp/x .checkpoints/.pre-checkpoint-done" "$WT_DIR")" \
+  "Relative marker reference"
+
+# Case 11 — Worktree heredoc DEFERRED — classifier mis-labels as read_only
+# (filed as FU; precheck doesn't fire for read_only-classified commands).
+
+# Case 12 — Nested cwd inside main repo + relative marker write → BLOCK (codex F18)
+assert_blocked_with_canonical "12. Nested cwd inside main repo + relative marker → block" \
+  "$(mock_bash "echo x > .checkpoints/.pre-checkpoint-done" "$NESTED_DIR")" \
+  "Relative marker reference"
+assert_file_absent "12a. nested marker NOT created by blocked Bash" "$NESTED_DIR/.checkpoints/.pre-checkpoint-done"
+assert_file_absent "12b. canonical main marker NOT created" "$MAIN_PRE"
+
+echo ""
+echo "=== Result ==="
+echo "Passed: $passed"
+echo "Failed: $failed"
+
+if [ $failed -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Rank-1 P0 SAFETY hook-deadlock cluster fix. Closes #178 F1 (triangle deadlock), #191 B2 (worktree-relative marker writes), #202 (worktree path canonicalization), plus 7 of #146's deferred sub-cases. Workplan v51 rank-1 item.

## Changes

### A. stop-gate active-plan exemption (`scripts/em-recall.mjs` + new `scripts/lib/stop-gate-helpers.mjs`)
Defer stop-gate when `.plan-approval-pending` is **active** (mtime > baseline) at either root, with strict-lstat fail-closed semantics. Closes the unrecoverable triangle where checkpoint-gate + plan-gate + stop-gate would otherwise wedge each other while a plan is in flight. New helper `_maxMtimeAcrossRootsStrict` distinguishes ENOENT (skip) from non-ENOENT lstat errors (fail-closed). **Intentional**: supersedes the existing carve-out's TASK_SIGNAL check while plan is active — plan-gate provides the writer-side defense independently.

### B. Wrong-root marker write BLOCK (`hooks/checkpoint-gate.sh`)
Block marker writes to non-canonical paths with an actionable "use $CANONICAL" reason instead of falling through to the generic pre-gate. Two paths cover the surface:

- **Bash precheck** (verb-agnostic, any cwd): catches relative marker references (`.checkpoints/<m>`, `./<m>`, `././<m>`, `../<m>`) AND absolute non-canonical paths (`/tmp/.checkpoints/<m>`, worktree-absolute) for all writing verbs (touch/mv/cp/install/dd-of/cat>>/rm/tee/redirect). Operates on quote-stripped command text to defeat quote-broken bypasses (`touch ".checkpoints"/X`). Uses occurrence-scoped relative-vs-absolute disambiguation with glob-meta-char escaping.
- **Bash marker_write + Write/Edit branches**: canonical-equality check via `_is_canonical_marker_path` (with `./` lexical normalization).

Authority preserved: gate state machine never accepts non-canonical paths.

### C. Tests (~510 LOC, 213 cases across 4 files)
- `tests/test-em-strict-lstat.mjs` (NEW): U1-U5 in-process unit tests; U4 deterministically exercises `hadOtherError` via ENOTDIR.
- `tests/test-issue-146.mjs` L5 (NEW): 5.1-5.13 covering active/orphan/symlink/dual-root/baseline-absent/ENOTDIR/exemption-supersedes scenarios.
- `tests/test-checkpoint-gate.sh` B-1..B-37 (NEW): absolute, relative (`./`, `././`, `../`), verb-agnostic (touch/mv/cp/install/dd/cat>>), nested-cwd, quote-broken (`"`, `'`, `\`), occurrence-scoped (benign mention + real wrong-root write), glob-metachar bypass.
- `tests/test-worktree-marker-write.sh` (NEW): 12 E2E cases with real git worktree + disk assertions.

### D. Provenance xattr doc (`hooks/README.md`)
macOS `com.apple.provenance` recovery + `sudo mv hooks/*.sh /tmp/` escape hatch (#178 F3 mitigation).

## Review trail

**Plan-time codex** (7 rounds, episodes `...bd6c` → `...afd2` → `...3ad6` → `...5697` → `...fb05` → `...acdc` → `...e19a`): structural classifier-rewrite flaw → decoupled predicate → dual-root + strict-lstat → verb-agnostic same-class → `./.checkpoints` regex bypass → nested-cwd test fan-out → ACCEPT-with-FU.

**Step-6 code review** (`negative-scenario-reviewer`): ACCEPT-with-FU with 2 MAJOR + 3 MINOR + 1 NIT; A1/A2/B1/C2 fixed inline (commit `76b8a8b`); C1 + C3 deferred to FU.

**PR-level codex** (3 rounds, episodes `...1912` → `...5b9e` → `...a2ff`): occurrence-scoped filter false-negative (R1, fixed in `1affae5`) → bash pattern-substitution glob bypass (R2, fixed in `ade7869`) → ACCEPT-with-FU (R3, no findings).

## Test plan

- [x] `bash tests/test-checkpoint-gate.sh` → 145/145
- [x] `bash tests/test-worktree-marker-write.sh` → 18/18
- [x] `node tests/test-issue-146.mjs` → 45/45
- [x] `node tests/test-em-strict-lstat.mjs` → 5/5
- [x] `bash tests/test-stop-gate.sh` → 24/24
- [x] `node tests/test-em-recall-session-start-early-exit.mjs` → 11/11
- [x] Adjacent suites: green (test-marker-paths.mjs/.sh, test-em-repo-root-worktree.mjs, test-checkpoints-migration.mjs, test-command-classifier.sh, test-plan-gate.sh, test-preflight-gate.sh)
- [ ] Manual: in a fresh worktree, present a plan + verify turn ends cleanly (triangle deadlock no longer occurs)
- [ ] Manual: from worktree cwd, attempt `touch .checkpoints/X` → BLOCK with canonical hint

Pre-existing failure unrelated to this slice: `tests/test-migration-cutover.mjs` (HOOK_SPECS count drift from preflight-gate additions — tracked as FU).

## Follow-ups (file at merge per Rule 18 step 9)

1. **F6**: plan-pending mtime-bump (Claude Code harness or post-Write hook)
2. **F9**: `classify_path` 3→8 marker expansion (broadens Write/Edit wrong-root coverage)
3. **F13b**: `../` lexical normalization in `_normalize_path_lexical`
4. **Carve-out → strict-lstat migration**: existing `_maxMtimeAcrossRoots` callers
5. **Rule 14 marker-set sync validator (step-6 C1)**: closed marker set drift across 4 sites
6. **Classifier heredoc-with-redirect mis-classification** (B-18 deferred): `cat <<EOF > X` returns `read_only`
7. **Step-6 C3**: scope absolute-noncanonical regex to write-verb argument positions
8. **Pre-existing**: `tests/test-migration-cutover.mjs` HOOK_SPECS count drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
