### PR TITLE
feat(runbook-gate): hook-enforce second-opinion runbook injection per session

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -121,6 +121,7 @@ _marker_basename_in_set() {
     .checkpoint-required|.post-checkpoint-required|.preflight-done| \
     .last-user-prompt.json) return 0 ;;
     .last-user-prompt.*.json) return 0 ;;
+    .so-runbook-shown.*) return 0 ;;
   esac
   return 1
 }
@@ -192,7 +193,7 @@ _escape_bash_glob() {
 _command_has_relative_marker_path() {
   local cmd_stripped
   cmd_stripped="$(_strip_shell_quotes "$1")"
-  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)'
+  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
 }
 
 # E2E-discovered absolute-non-canonical detection: for Bash commands where
@@ -209,7 +210,7 @@ _command_first_absolute_noncanonical_marker() {
   local cmd
   cmd="$(_strip_shell_quotes "$1")"
   local matches p basename
-  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json)' 2>/dev/null || true)
+  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
   [ -z "$matches" ] && return 0
   while IFS= read -r p; do
     [ -z "$p" ] && continue
@@ -354,6 +355,19 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     if _is_wrong_root_marker_write "$TARGET"; then
       _block_wrong_root_marker "$TARGET"
     fi
+
+    # Runbook UX-marker exemption (second-opinion-gate). EXACT-BASENAME
+    # scoped via case, evaluated AFTER wrong-root check (canonical-root
+    # binding already verified above) and BEFORE cross-gate plan-pending
+    # invariant. The runbook UX-marker has no gate-lifecycle dependency
+    # (it tracks "model has seen the runbook this session" — orthogonal
+    # to checkpoint/plan lifecycle), so it must work under
+    # .plan-approval-pending AND .checkpoint-required.
+    case "${TARGET##*/}" in
+      .so-runbook-shown.*)
+        exit 0
+        ;;
+    esac
 
     TARGET_BN="$(marker_basename_for_target "$TARGET")"
 

--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -109,6 +109,31 @@ warn_hook_freshness() {
 
 warn_hook_freshness
 
+# ─── second-opinion runbook UX-marker cleanup ────────────────────────────
+# Glob-clear all `.checkpoints/.so-runbook-shown.*` files at canonical repo
+# root so the next session re-injects the runbook on the first harness
+# invocation. Bound to canonical root (not $CWD) via repo-root.sh so
+# linked-worktree session starts converge on the same place the gate writes.
+#
+# Codex r4 Q1: contained-subshell sourcing so any internal failure in
+# repo-root.sh (or missing lib on partial install) falls back to $CWD
+# without aborting SessionStart under `set -e`.
+CANONICAL_ROOT="$(
+  bash -c '
+    LIB_DIR="$1/lib"
+    LIB="$LIB_DIR/repo-root.sh"
+    [ -f "$LIB" ] || { printf "%s" "$2"; exit 0; }
+    # shellcheck disable=SC1090
+    . "$LIB" 2>/dev/null || { printf "%s" "$2"; exit 0; }
+    resolve_repo_root "$2" 2>/dev/null || printf "%s" "$2"
+  ' _ "$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" "$CWD"
+)"
+[ -z "$CANONICAL_ROOT" ] && CANONICAL_ROOT="$CWD"
+if [ -d "$CANONICAL_ROOT/.checkpoints" ]; then
+  # shellcheck disable=SC2086
+  rm -f "$CANONICAL_ROOT"/.checkpoints/.so-runbook-shown.* 2>/dev/null || true
+fi
+
 # Soft-fail if em-recall isn't installed — sessions without episodic-memory
 # should still start cleanly.
 if [ ! -f "$EM_RECALL" ]; then

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -525,6 +525,16 @@ _classify_segment() {
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
         return 0
         ;;
+      .so-runbook-shown.*)
+        # Runbook UX-marker (second-opinion-gate). Same-class with the
+        # other marker write surfaces; classifies as marker_write so the
+        # touch/rm/tee/redirect paths share the wrong-root detection +
+        # exemption flow in checkpoint-gate.sh.
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
       *)
         has_nonmarker_redirect=1
         ;;
@@ -639,6 +649,15 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
           return 0
           ;;
+        .so-runbook-shown.*)
+          # Runbook UX-marker (second-opinion-gate). Same-class with other
+          # marker rm surfaces. SessionStart cleanup uses rm at canonical
+          # root; this classification keeps the touch/rm pair symmetric.
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
       esac
       j=$((j+1))
     done
@@ -675,9 +694,62 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
           return 0
           ;;
+        .so-runbook-shown.*)
+          # Runbook UX-marker (second-opinion-gate). Same-class with other
+          # marker tee surfaces. Kept symmetric with rm/touch/redirect.
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
       esac
       break
     done
+  fi
+
+  # ---- touch with marker ----
+  # Same-class with rm/tee/redirect handlers. Recognizes the full closed
+  # marker set so touch becomes a first-class marker_write path, not a
+  # silent fall-through to shared_write (which would block the touch under
+  # an active .checkpoint-required pre-gate). Codex r1 P1: hooks/runbooks
+  # touch must classify as marker_write so the exemption case fires.
+  if [ "$first" = "touch" ]; then
+    local j=$((idx+1))
+    while [ $j -lt ${#TOKS[@]} ]; do
+      local t="${TOKS[$j]}"
+      case "$t" in
+        -*) j=$((j+1)); continue ;;
+      esac
+      local tbase="$(basename "$t")"
+      case "$tbase" in
+        .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+        .last-user-prompt.*.json)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+        .so-runbook-shown.*)
+          # Runbook UX-marker (second-opinion-gate). Model writes this
+          # marker after Read of the runbook contents; classification as
+          # marker_write routes the write through checkpoint-gate's
+          # exemption case (canonical-root check + plan-pending bypass).
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+      esac
+      j=$((j+1))
+    done
+    # touch of non-marker → shared_write (matches rm semantics)
+    printf '%s\t\t%s\n' "shared_write" "touch_non_marker"
+    return 0
   fi
 
   # ---- git ----

--- a/hooks/lib/local-dir.mjs
+++ b/hooks/lib/local-dir.mjs
@@ -1,0 +1,1 @@
+../../scripts/lib/local-dir.mjs

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -23,6 +23,20 @@
 #   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
 #   .session-baseline              | BASELINE only
 #
+# Adjacent UX-marker classes (NOT in any of the above sets):
+#
+#   .so-runbook-shown.<sha8>       | UX-marker only — tracks "model has been
+#                                    shown the second-opinion harness runbook
+#                                    this session." Excluded from TASK_SIGNAL
+#                                    (would break stop-gate carve-out per
+#                                    20260512-...d4fc) AND from CHECKPOINT_CLEANUP
+#                                    (push-gate shouldn't clear it; session
+#                                    lifecycle via SessionStart glob is the
+#                                    only cleanup path). Recognized by the
+#                                    classifier marker_write handlers (touch/
+#                                    rm/tee/redirect) and by checkpoint-gate's
+#                                    runbook exemption case.
+#
 # Set semantics:
 #   TASK_SIGNAL_MARKERS         3 markers — em-recall stop-gate carve-out
 #                               class (mid-session mtime > baseline = task

--- a/hooks/runbooks/second-opinion-harness.md
+++ b/hooks/runbooks/second-opinion-harness.md
@@ -1,0 +1,118 @@
+# Second-opinion harness — operator runbook
+
+The harness exists. Use it. But the harness is invoked via the Bash tool, and the Bash tool has its own gotchas. This file is the single-page operator checklist so I stop burning sessions rediscovering the same lessons.
+
+This file is shipped via `install.mjs --install-second-opinion` to `~/.claude/hooks/runbooks/second-opinion-harness.md` and is the source the `second-opinion-gate.mjs` PreToolUse hook injects into context on the first harness invocation per session. Mirror of `feedback_second_opinion_harness_runbook.md` in episodic memory.
+
+## ⚠️ Self-trigger checklist — the THREE moments I keep getting wrong
+
+Read this before every harness invocation AND every HOLD reply. These are the recurring violations that cost user time:
+
+| Moment | The habit that fires | The rule | Self-check before emit |
+|---|---|---|---|
+| **Dispatching the harness** | Reaching for `run_in_background: true` because the harness takes minutes | **Foreground Bash, `timeout: 600000`. NEVER `run_in_background`.** No exceptions for "long-running." | Am I about to set `run_in_background: true`? STOP. Foreground + timeout 600000. |
+| **Codex returns HOLD** | Pausing to ask user "want me to fix and re-review, or pause?" — feels deferential, IS the failure mode | **Iterate to round 2 immediately.** User authorized the review = user authorized convergence. | Am I about to write "your call" / "want me to run round 2?" → STOP. Build the rebuttal table, dispatch round 2. The ONE exception: REJECT-class architectural redesign. HOLD with concrete findings = iterate. |
+| **Disposing a HOLD finding I disagree with** | Filing it as DEFER-issue unilaterally citing scope/discipline #19 without sending the pushback back to codex | **Round-trip the disagreement.** Discipline #19 applies to contract-cross-reference oscillation ONLY, NOT to concrete code findings. If codex recommended a specific code change, you owe codex the Verdict/Evidence/Required-action rebuttal — not a unilateral DEFER. | Is this finding a concrete code recommendation? Then DEFER without round-trip is a violation. Send it back via round-2 body. |
+
+**Self-test:** Before sending a HOLD reply to the user, re-read the table. If any column 2 description matches what I'm about to do, STOP and apply column 4 instead.
+
+## The canonical invocation (memorize the shape)
+
+```bash
+node scripts/second-opinion.mjs request \
+  --provider codex \
+  --project /Users/charltondho/Developer/projects/episodic-memory \
+  --storage episodic \
+  --body-file scratch/<review-body>.md \
+  --summary "<short summary>" \
+  --dispatch
+```
+
+Bash tool call MUST include `timeout: 600000` (10 minutes).
+
+**Defaults I get wrong:**
+
+- `--project .` works but absolute path is what every past successful session used. Use the absolute path.
+- `--storage` defaults to `episodic`, which is what you want for cross-tool message-bus dogfooding. Don't pass `--storage files` unless you have a specific reason.
+- Bash tool default timeout is 120000ms (2 min). Codex review of a 5K+ char prompt routinely takes 3–8 min. **The 2-min default SIGTERMs codex silently.**
+
+## Failure mode → diagnosis cheat sheet
+
+| Symptom | Likely cause | Verify |
+|---|---|---|
+| `em-store failed (exit 1):` with empty stderr | Bash timeout SIGTERM'd codex → empty stdout → em-store rejected `--body ""` | Check past-session transcript for working invocation; compare timeouts |
+| Harness exits but no reply episode | Reply episode write failed AFTER dispatch (rare; usually still the timeout class) | Re-check Bash `timeout` and codex CLI auth |
+| `provider-dispatch-failed` | Codex CLI binary not on PATH / auth issue | `which codex` then `codex exec --help` |
+| `registry-stale-at-gate` | Source registry diverged from installed snapshot | `node install.mjs --tool claude-code --install-second-opinion` |
+| `runbook-injection-required` | First harness call this session — runbook gate; runbook is now in context | Retry the command; marker auto-binds to current sha |
+| `runbook-load-failed` | Runbook missing/empty/missing-sentinel at install path | Re-run `node install.mjs --tool claude-code --install-second-opinion` |
+
+## HOLD is not the end of the review
+
+When codex returns `Verdict: HOLD`, that is NOT the close-out. Per `feedback_three_state_review_verdict.md`: HOLD's closeout phrasing is mandatory — "revise + re-request review on findings 1-N plus any new integration surface introduced by the fixes." That re-review is round 2 of the same logical review cycle, not a fresh review.
+
+**Rule of thumb:**
+
+- ACCEPT → done.
+- ACCEPT-with-FU → done; file the FUs as issues.
+- HOLD → fix the findings, run round 2 with the fix referenced, expect ACCEPT.
+- REJECT → architectural redesign needed; pause and consult user.
+
+If round 2 returns HOLD again with NEW findings, that's when the cap engages.
+
+## Round 2 (post-HOLD) request body — template
+
+```markdown
+# PR #X — Round 2 (post-HOLD fix)
+
+## Round 1 verdict
+Episode `<r1-reply-id>` — HOLD with N finding(s).
+
+## Round 1 findings + my disposition
+**Finding:** <quote>
+**Verdict:** ACCEPT / ACCEPT-WITH-MODIFICATION / REJECT / DEFER / NEEDS-EVIDENCE
+**Evidence:** <artifact>
+**Required action:** <concrete>
+**Confidence:** HIGH / MED / LOW
+
+## Fix landed
+Commit `<sha>` on branch `<name>`, pushed to origin.
+
+## Second-order review per discipline #17
+[Table: what the fix introduced, scope/persistence/rollback/negative-test for each new surface.]
+
+## Convergence request
+Please re-review and emit closeout verdict.
+```
+
+## Trigger phrases I keep missing
+
+When the prompt mentions any of:
+
+- "second opinion"
+- "codex review"
+- "cross-tool review"
+- "review the plan / diff / PR"
+- Rule 6 light path on a feature plan
+- Rule 18 step 2 (mandatory plan review) or step 6 (mandatory code review)
+- The user says "request a codex review" or "ask codex" or "run a second opinion"
+
+→ Use this harness. Bash `timeout: 600000`. After HOLD, run round 2 to converge.
+
+## Anti-patterns this memory exists to prevent
+
+- ❌ Invoking the harness via Bash without `timeout: 600000`.
+- ❌ Debugging em-store / provider source / preamble composer before checking past-session transcripts.
+- ❌ "Let me dispatch codex directly via the provider module" when the harness fails. The harness IS the canonical path. Diagnose it; don't bypass it.
+- ❌ Treating HOLD as the close-out because of the "cap at 1 round" pin.
+- ❌ Asking the user "want me to run round 2?" — iterate without between-round confirmation; the user authorized the review.
+
+## Composes with
+
+- `reference_second_opinion_harness.md` — design reference (what the harness IS).
+- `reference_codex_review_flow.md` — manual 5-step fallback.
+- `feedback_three_state_review_verdict.md` — HOLD/ACCEPT/REJECT discipline #16.
+- `feedback_reach_consensus_with_codex.md` — iterate without pausing.
+- `feedback_implementer_second_order_review.md` — discipline #17 (run on the fix surface in round 2).
+- `feedback_verify_by_artifact.md` — when in doubt, the artifact is past-session transcripts at `~/.claude/projects/<project-path>/*.jsonl`.
+- `feedback_codex_review_episodes_both_halves.md` — both request and reply MUST be em-store episodes; harness's `--storage episodic` handles this.

--- a/hooks/second-opinion-gate.mjs
+++ b/hooks/second-opinion-gate.mjs
@@ -2,7 +2,23 @@
 /**
  * second-opinion-gate.mjs — Claude Code PreToolUse hook for second-opinion harness.
  *
- * Block-class matrix per v3 §Hook block-class matrix:
+ * Two responsibilities, ordered:
+ *
+ *   1. RUNBOOK GATE (codex r2 P1 — runbook injection):
+ *      For Bash tool calls matching `node ... second-opinion.mjs ... request`,
+ *      block on the FIRST invocation per session with the runbook quickref
+ *      inlined in the reason field. Marker `.checkpoints/.so-runbook-shown.<sha8>`
+ *      at canonical repo root tracks "runbook has been shown this session";
+ *      sha8 binds to runbook content so in-session edits force re-inject.
+ *      Runs BEFORE validator/snapshot load so a missing/bad snapshot cannot
+ *      preempt the runbook block.
+ *
+ *   2. DIRECT-PROVIDER BLOCK (existing v1 behavior):
+ *      Block direct provider CLI calls (codex/etc.) that bypass the harness.
+ *      Reads installed provider snapshot at ~/.claude/hooks/second-opinion-providers.json
+ *      and applies cli_match / agent_block_patterns from the snapshot.
+ *
+ * Block-class matrix per v3 §Hook block-class matrix (existing flow):
  *
  * Bash branch (tool_name == "Bash"):
  *   For each provider in install snapshot, if tool_input.command matches
@@ -19,54 +35,45 @@
  *   provider.agent_block_patterns AND NOT in provider.agent_allow_patterns
  *   → block.
  *
- * Fail-closed cases (block on snapshot problems — any direct provider call
- * could be the bypass):
- *   - Snapshot file missing  → block.
- *   - Snapshot JSON parse fails → block.
- *   - Snapshot missing source_hash → block.
+ * Fail-closed cases (block on snapshot/runbook problems):
+ *   - Runbook gate: runbook file missing/empty/too-short/no-sentinel → block.
+ *   - Snapshot file missing/parse-failed/missing-source-hash → block.
  *
  * Hook contract (Claude Code spec):
  *   - stdin = JSON: {tool_name, tool_input, cwd, ...}
  *   - exit 0 + stdout JSON {decision: "block", reason: "..."} → block
  *   - exit 0 + no stdout → allow
- *
- * Out-of-scope bypass classes (documented in commit; users can add gates):
- *   - Shell aliases / functions resolving to provider CLI
- *   - eval indirection
- *   - Wrapper scripts (npm scripts, project-local shell scripts)
- *   - Background provider runs spawned outside Claude Code
- *   - Provider invocations via SSH / remote tools
  */
 
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import crypto from 'node:crypto'
+
+// resolveRepoRoot is dynamically imported inside checkRunbookGate so a
+// missing local-dir.mjs (orphan/partial install) cannot preempt the gate
+// at module load. Fallback resolver below handles the case where the
+// installed lib is missing.
 
 const SNAPSHOT_PATH = process.env.SO_INSTALL_SNAPSHOT_PATH ||
   path.join(os.homedir(), '.claude', 'hooks', 'second-opinion-providers.json')
 
-// Dynamic import of validator so the hook can emit a structured block
-// decision if the colocated ./lib/registry-validator.mjs is missing or
-// malformed (partial install / orphan hook). A static import would crash
-// the hook at module-load with empty stdout — ambiguous fail-open class.
-// F4 from post-implementation code review.
-let validateProviderRegistry
-try {
-  const mod = await import(new URL('./lib/registry-validator.mjs', import.meta.url).href)
-  validateProviderRegistry = mod.validateProviderRegistry
-} catch (e) {
-  // Emit a fail-closed block decision and exit. Same envelope shape as
-  // every other block path so Claude Code can parse the JSON.
-  console.log(JSON.stringify({
-    decision: 'block',
-    code: 'snapshot-validator-load-failed',
-    reason: `second-opinion-gate: cannot load validator at ./lib/registry-validator.mjs ` +
-      `(detail: ${e.message}). Run: node install.mjs --install-second-opinion to ` +
-      `reinstall the colocated validator lib.`,
-    detail: e.message,
-  }))
-  process.exit(0)
-}
+const RUNBOOK_PATH = process.env.SO_RUNBOOK_PATH ||
+  path.join(os.homedir(), '.claude', 'hooks', 'runbooks', 'second-opinion-harness.md')
+
+const QUICKREF_PATH = process.env.SO_QUICKREF_PATH ||
+  path.join(os.homedir(), '.claude', 'hooks', 'runbooks', 'second-opinion-harness.quickref.md')
+
+// Sentinel substring required to be present in the full runbook. The
+// canonical runbook's load-bearing section is "## ⚠️ Self-trigger checklist";
+// the substring drops the emoji to avoid regex/encoding fragility.
+const RUNBOOK_SENTINEL = 'Self-trigger checklist'
+const MIN_RUNBOOK_BYTES = 256
+const MIN_QUICKREF_BYTES = 64
+
+// ---------------------------------------------------------------------------
+// Pure helpers — no side effects at module load.
+// ---------------------------------------------------------------------------
 
 function emitBlock(reason, extra = {}) {
   console.log(JSON.stringify({ decision: 'block', reason, ...extra }))
@@ -79,27 +86,133 @@ function emitAllow() {
 }
 
 function readStdinSync() {
-  // Claude Code provides stdin as a finite JSON blob, not a stream.
   let data = ''
   try {
     data = fs.readFileSync(0, 'utf8')
   } catch (e) {
-    // No stdin — Claude Code always provides one; treat as fail-open
-    // (test/CLI invocation without stdin should not block real tools).
     return null
   }
   if (!data.trim()) return null
   try {
     return JSON.parse(data)
   } catch (e) {
-    // Malformed input — Claude Code internal contract violation.
-    // Fail-open per the spec for unknown inputs (don't block on parse error
-    // of stdin we can't trust the schema of).
     return null
   }
 }
 
-function loadSnapshot() {
+/**
+ * Occurrence-scoped harness detection. Strips shell quote/escape chars (mirrors
+ * `_strip_shell_quotes` in checkpoint-gate.sh:163), then matches the literal
+ * `second-opinion.mjs ... request` substring. Accepts splice patterns
+ * (&& / ; / env-prefix), quoted script names, and absolute paths. Known
+ * false-positive: `echo "node second-opinion.mjs request"` — acceptable
+ * trade-off per plan v4 (asymmetric cost: false-positive = one extra prompt
+ * round; false-negative = runbook never loaded).
+ */
+function isHarnessRequest(command) {
+  if (!command) return false
+  const stripped = command.replace(/["'\\]/g, '')
+  return /\bsecond-opinion\.mjs\s+request\b/.test(stripped) ||
+         /\bsecond-opinion\.mjs\b[^|;&]*\brequest\b/.test(stripped)
+}
+
+function computeSha8(content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8)
+}
+
+function loadAndValidateRunbook() {
+  if (!fs.existsSync(RUNBOOK_PATH)) {
+    return { error: 'runbook-missing', detail: RUNBOOK_PATH }
+  }
+  if (!fs.existsSync(QUICKREF_PATH)) {
+    return { error: 'quickref-missing', detail: QUICKREF_PATH }
+  }
+  let runbook, quickref
+  try {
+    runbook = fs.readFileSync(RUNBOOK_PATH, 'utf8')
+    quickref = fs.readFileSync(QUICKREF_PATH, 'utf8')
+  } catch (e) {
+    return { error: 'runbook-read-failed', detail: e.message }
+  }
+  if (runbook.trim().length < MIN_RUNBOOK_BYTES) {
+    return { error: 'runbook-too-short' }
+  }
+  if (!runbook.includes(RUNBOOK_SENTINEL)) {
+    return { error: 'runbook-missing-sentinel' }
+  }
+  if (quickref.trim().length < MIN_QUICKREF_BYTES) {
+    return { error: 'quickref-too-short' }
+  }
+  return { ok: true, runbook, quickref, sha8: computeSha8(runbook) }
+}
+
+async function checkRunbookGate(input) {
+  const cwd = input.cwd || process.cwd()
+  let canonicalRoot = cwd
+  const localDirUrl = new URL('./lib/local-dir.mjs', import.meta.url).href
+  try {
+    const mod = await import(localDirUrl)
+    canonicalRoot = mod.resolveRepoRoot(cwd)
+  } catch (e) {
+    // PR-level review P1: distinguish missing DIRECT target from transitive
+    // ERR_MODULE_NOT_FOUND (broken inner import). Only direct-target ENOENT
+    // is the "orphan install" case that gets the CWD-fallback degradation.
+    // Any other failure mode (transitive missing, syntax error, runtime
+    // error) indicates installed-lib corruption → fail closed.
+    const isDirectMissing = e.code === 'ERR_MODULE_NOT_FOUND' &&
+      typeof e.url === 'string' &&
+      e.url === localDirUrl
+    if (isDirectMissing) {
+      canonicalRoot = cwd
+    } else {
+      emitBlock(
+        `second-opinion runbook gate: local-dir.mjs failed to load ` +
+        `(${e.code || e.name}: ${e.message}). The installed lib at ` +
+        `~/.claude/hooks/lib/local-dir.mjs appears corrupted (transitive ` +
+        `missing dep or syntax/runtime error, NOT just a missing direct ` +
+        `target). Run: node install.mjs --tool claude-code --install-second-opinion to reinstall.`,
+        { code: 'runbook-canonicalize-failed', detail: e.message }
+      )
+    }
+  }
+  const loaded = loadAndValidateRunbook()
+  if (loaded.error) {
+    emitBlock(
+      `second-opinion runbook gate: ${loaded.error}` +
+      (loaded.detail ? ` (${loaded.detail})` : '') +
+      `. Run: node install.mjs --tool claude-code --install-second-opinion to install/refresh the runbook.`,
+      { code: 'runbook-load-failed', detail: loaded.error }
+    )
+  }
+  const markerPath = path.join(
+    canonicalRoot, '.checkpoints', `.so-runbook-shown.${loaded.sha8}`
+  )
+  if (fs.existsSync(markerPath)) emitAllow()
+
+  // Marker absent → block with quickref inlined. Marker is NOT self-written
+  // by the hook (codex r2 / r3 design): the model must Read the full runbook
+  // and `touch <markerPath>` to acknowledge. The touch passes through
+  // command-classifier's touch handler → marker_write → checkpoint-gate's
+  // runbook exemption case (canonical-root check + plan-pending bypass).
+  emitBlock(
+    `${loaded.quickref}\n\n` +
+    `=== Full runbook ===\n${RUNBOOK_PATH}\n` +
+    `After reading the full runbook, run: touch ${markerPath} — then retry your original command. ` +
+    `Marker resets at next SessionStart.`,
+    {
+      code: 'runbook-injection-required',
+      runbook_sha: loaded.sha8,
+      runbook_path: RUNBOOK_PATH,
+      marker_path: markerPath,
+    }
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Provider snapshot helpers — only called for non-harness flow.
+// ---------------------------------------------------------------------------
+
+function loadSnapshot(validateProviderRegistry) {
   if (!fs.existsSync(SNAPSHOT_PATH)) {
     return { error: 'snapshot-not-installed' }
   }
@@ -117,9 +230,6 @@ function loadSnapshot() {
   if (!parsed.source_hash) {
     return { error: 'snapshot-missing-source-hash' }
   }
-  // I-NEW-B: validate providers[] shape so the hook fail-closes on bad
-  // registry rather than silently skipping providers with bad regex via
-  // compileCliMatch's null-return fallback.
   try {
     validateProviderRegistry({ schema_version: 1, providers: parsed.providers })
   } catch (e) {
@@ -134,9 +244,6 @@ function loadSnapshot() {
 }
 
 function isWorktreeCwd(cwd) {
-  // Linked worktree: <cwd>/.git is a FILE (containing gitdir: ...), not a dir.
-  // Main repo: <cwd>/.git is a directory.
-  // Non-git: <cwd>/.git doesn't exist.
   const gitPath = path.join(cwd, '.git')
   if (!fs.existsSync(gitPath)) return false
   try {
@@ -162,7 +269,6 @@ function checkBashBranch(toolInput, cwd, snapshot) {
     const cliRe = compileCliMatch(provider.cli_match || '')
     if (!cliRe || !cliRe.test(command)) continue
 
-    // Block class 1: run_in_background
     if (runInBackground) {
       return {
         block: true,
@@ -171,7 +277,6 @@ function checkBashBranch(toolInput, cwd, snapshot) {
       }
     }
 
-    // Block class 2: command length > prompt_max_chars
     if (provider.prompt_max_chars > 0 && command.length > provider.prompt_max_chars) {
       return {
         block: true,
@@ -180,7 +285,6 @@ function checkBashBranch(toolInput, cwd, snapshot) {
       }
     }
 
-    // Block class 3: cwd is worktree + no --allow-worktree
     if (isWorktreeCwd(cwd) && !command.includes('--allow-worktree')) {
       return {
         block: true,
@@ -190,8 +294,6 @@ function checkBashBranch(toolInput, cwd, snapshot) {
     }
   }
 
-  // Block class 4: em-store --scope local from worktree (PR #218 class).
-  // Independent of provider match; applies to any em-store call.
   if (/\bem-store\b/.test(command) && /--scope\s+local/.test(command) && isWorktreeCwd(cwd)) {
     return {
       block: true,
@@ -226,49 +328,69 @@ function checkAgentBranch(toolInput, snapshot) {
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Main — stdin FIRST, runbook gate FIRST, validator LAZY.
 // ---------------------------------------------------------------------------
-const input = readStdinSync()
-if (!input) {
-  // No / unparseable stdin. Allow (Claude Code spec: hooks should not block
-  // on malformed inputs; the actual tool dispatcher handles its own validation).
+
+async function main() {
+  const input = readStdinSync()
+  if (!input) emitAllow()
+
+  const toolName = input.tool_name || ''
+  const toolInput = input.tool_input || {}
+  const cwd = input.cwd || process.cwd()
+
+  // ─── Runbook gate fires BEFORE validator/snapshot work. ───────────────
+  // Codex r2 P1: validator import failure / snapshot errors MUST NOT
+  // preempt the runbook block on harness invocations.
+  if (toolName === 'Bash' && isHarnessRequest(toolInput.command || '')) {
+    await checkRunbookGate(input)
+    return
+  }
+
+  // ─── Lazy validator load for non-harness flow. ────────────────────────
+  let validateProviderRegistry
+  try {
+    const mod = await import(new URL('./lib/registry-validator.mjs', import.meta.url).href)
+    validateProviderRegistry = mod.validateProviderRegistry
+  } catch (e) {
+    emitBlock(
+      `second-opinion-gate: cannot load validator at ./lib/registry-validator.mjs ` +
+      `(detail: ${e.message}). Run: node install.mjs --tool claude-code --install-second-opinion ` +
+      `to reinstall the colocated validator lib.`,
+      { code: 'snapshot-validator-load-failed', detail: e.message }
+    )
+  }
+
+  const snap = loadSnapshot(validateProviderRegistry)
+  if (snap.error) {
+    const extra = { code: snap.error }
+    if (snap.field) extra.field = snap.field
+    if (snap.provider) extra.provider = snap.provider
+    if (snap.detail) extra.detail = snap.detail
+    const detailSuffix = snap.field
+      ? ` (field: ${snap.field}${snap.provider ? `, provider: ${snap.provider}` : ''})`
+      : ''
+    emitBlock(
+      `second-opinion-gate: ${snap.error}${detailSuffix}. ` +
+      `Run: node install.mjs --tool claude-code --install-second-opinion to install/refresh the registry. ` +
+      `(Direct provider calls cannot be safely gated without a valid install snapshot.)`,
+      extra
+    )
+  }
+
+  if (toolName === 'Bash') {
+    const decision = checkBashBranch(toolInput, cwd, snap.snapshot)
+    if (decision.block) emitBlock(decision.reason)
+    emitAllow()
+  }
+
+  if (toolName === 'Agent' || toolName === 'Task') {
+    const decision = checkAgentBranch(toolInput, snap.snapshot)
+    if (decision.block) emitBlock(decision.reason)
+    emitAllow()
+  }
+
   emitAllow()
 }
 
-const snap = loadSnapshot()
-if (snap.error) {
-  const extra = { code: snap.error }
-  if (snap.field) extra.field = snap.field
-  if (snap.provider) extra.provider = snap.provider
-  if (snap.detail) extra.detail = snap.detail
-  const detailSuffix = snap.field
-    ? ` (field: ${snap.field}${snap.provider ? `, provider: ${snap.provider}` : ''})`
-    : ''
-  emitBlock(
-    `second-opinion-gate: ${snap.error}${detailSuffix}. ` +
-    `Run: node install.mjs --install-second-opinion to install/refresh the registry. ` +
-    `(Direct provider calls cannot be safely gated without a valid install snapshot.)`,
-    extra
-  )
-}
-
-const snapshot = snap.snapshot
-const toolName = input.tool_name || ''
-const toolInput = input.tool_input || {}
-const cwd = input.cwd || process.cwd()
-
-if (toolName === 'Bash') {
-  const decision = checkBashBranch(toolInput, cwd, snapshot)
-  if (decision.block) emitBlock(decision.reason)
-  emitAllow()
-}
-
-if (toolName === 'Agent' || toolName === 'Task') {
-  // Claude Code's Agent tool may report as 'Task' depending on version.
-  const decision = checkAgentBranch(toolInput, snapshot)
-  if (decision.block) emitBlock(decision.reason)
-  emitAllow()
-}
-
-// Other tools: allow.
-emitAllow()
+main()

--- a/install.mjs
+++ b/install.mjs
@@ -1176,44 +1176,194 @@ if (installHooks) {
 if (installSecondOpinion) {
   const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
   const userHooksLibDir = path.join(userHooksDir, 'lib')
-  try {
-    // Copy hooks/second-opinion-gate.mjs to ~/.claude/hooks/.
-    fs.mkdirSync(userHooksDir, { recursive: true })
-    const repoGateSrc = path.join(REPO_HOOKS, 'second-opinion-gate.mjs')
-    const userGateDst = path.join(userHooksDir, 'second-opinion-gate.mjs')
-    if (fs.existsSync(repoGateSrc)) {
-      fs.copyFileSync(repoGateSrc, userGateDst)
-      fs.chmodSync(userGateDst, 0o755)
-      console.log(`Installed second-opinion gate hook: ${userGateDst}`)
-    } else {
-      console.log(`Warning: ${repoGateSrc} not found; hook gate not installed.`)
-      installFailed = true
+  const userRunbooksDir = path.join(userHooksDir, 'runbooks')
+
+  // ─── Codex r1 P1-3: pre-flight source existence + quickref derivation. ───
+  // Validate ALL sources upfront so a missing/bad source doesn't leave a
+  // partial install. Quickref derivation is the most failure-prone step
+  // (section sentinel must be present + size-bounded); run it first so
+  // we fail fast before any copy is attempted.
+  const repoGateSrc       = path.join(REPO_HOOKS, 'second-opinion-gate.mjs')
+  const repoValidatorSrc  = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
+  const repoLocalDirSrc   = path.join(REPO_DIR, 'scripts', 'lib', 'local-dir.mjs')
+  const repoRunbookSrc    = path.join(REPO_HOOKS, 'runbooks', 'second-opinion-harness.md')
+
+  const userGateDst       = path.join(userHooksDir, 'second-opinion-gate.mjs')
+  const userValidatorDst  = path.join(userHooksLibDir, 'registry-validator.mjs')
+  const userLocalDirDst   = path.join(userHooksLibDir, 'local-dir.mjs')
+  const userRunbookDst    = path.join(userRunbooksDir, 'second-opinion-harness.md')
+  const userQuickrefDst   = path.join(userRunbooksDir, 'second-opinion-harness.quickref.md')
+
+  // deriveQuickref: extract the "Self-trigger checklist" section from the
+  // full runbook. Fail-closed if the section is missing or out of range.
+  // Codex r4: section rename/removal in canonical runbook → install throws.
+  function deriveQuickref(fullRunbookPath) {
+    if (!fs.existsSync(fullRunbookPath)) {
+      throw new Error(`runbook source not found at ${fullRunbookPath}`)
     }
-  } catch (e) {
-    console.error(`Failed to copy second-opinion gate hook: ${e.message}`)
+    const body = fs.readFileSync(fullRunbookPath, 'utf8')
+    // Locate header line (emoji-tolerant), then scan forward for the next
+    // `## ` heading. Avoids multiline-mode `$` ambiguity.
+    const headerRe = /^## [^\n]*Self-trigger checklist[^\n]*\n/m
+    const headerMatch = body.match(headerRe)
+    if (!headerMatch) {
+      throw new Error(
+        `quickref-derivation-failed: section "Self-trigger checklist" not found in ${fullRunbookPath}. ` +
+        `Either restore the section in the runbook or update the install script's headerRe.`
+      )
+    }
+    const startIdx = headerMatch.index
+    const afterHeader = startIdx + headerMatch[0].length
+    const nextHeader = body.indexOf('\n## ', afterHeader)
+    const endIdx = nextHeader === -1 ? body.length : nextHeader
+    const section = body.substring(startIdx, endIdx).trim()
+    if (section.length < 64) {
+      throw new Error(`quickref-derivation-failed: section too short (${section.length} chars)`)
+    }
+    if (section.length > 2048) {
+      throw new Error(
+        `quickref-derivation-failed: section too long (${section.length} chars > 2048 cap); ` +
+        `distill before installing or update the cap in install.mjs:deriveQuickref.`
+      )
+    }
+    return section + '\n'
+  }
+
+  // Pre-flight all source existence checks.
+  const preflightMissing = []
+  for (const src of [repoGateSrc, repoValidatorSrc, repoLocalDirSrc, repoRunbookSrc]) {
+    if (!fs.existsSync(src)) preflightMissing.push(src)
+  }
+  if (preflightMissing.length > 0) {
+    console.error('second-opinion install pre-flight failed; missing sources:')
+    for (const m of preflightMissing) console.error(`  ${m}`)
     installFailed = true
   }
 
-  try {
-    // Copy registry-validator.mjs alongside the hook so the installed hook can
-    // import './lib/registry-validator.mjs' (single source of truth — in-tree
-    // hook tests resolve through the hooks/lib/ symlink; installed hook reads
-    // this dereferenced copy).
-    fs.mkdirSync(userHooksLibDir, { recursive: true })
-    const repoValidatorSrc = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
-    const userValidatorDst = path.join(userHooksLibDir, 'registry-validator.mjs')
-    if (fs.existsSync(repoValidatorSrc)) {
-      // fs.copyFileSync dereferences symlinks by default — destination is a
-      // regular file with the validator source's content.
-      fs.copyFileSync(repoValidatorSrc, userValidatorDst)
-      console.log(`Installed second-opinion validator lib: ${userValidatorDst}`)
-    } else {
-      console.log(`Warning: ${repoValidatorSrc} not found; validator lib not installed.`)
+  let derivedQuickref = null
+  if (!installFailed) {
+    try {
+      derivedQuickref = deriveQuickref(repoRunbookSrc)
+      console.log(`Derived quickref: ${derivedQuickref.length} chars`)
+    } catch (e) {
+      console.error(`Quickref derivation failed: ${e.message}`)
       installFailed = true
     }
-  } catch (e) {
-    console.error(`Failed to copy second-opinion validator lib: ${e.message}`)
-    installFailed = true
+  }
+
+  // Codex post-impl review F1 (HOLD P1): make runtime install atomic via
+  // rollback. Each successful copy is recorded; on failure, all copies are
+  // reverted by quarantining (rename to .stale.<ts>) so the install never
+  // leaves a half-updated runtime that disagrees with the snapshot below.
+  const runtimeInstalled = []  // array of {dest, prevQuarantine?} entries
+
+  function safeCopy(label, src, dst, mode = null) {
+    if (installFailed) return
+    let prevQuarantine = null
+    let entryPushed = false
+    try {
+      const dir = path.dirname(dst)
+      fs.mkdirSync(dir, { recursive: true })
+      // If dst already exists, move it aside so rollback can restore.
+      if (fs.existsSync(dst)) {
+        prevQuarantine = `${dst}.preinstall.${Date.now()}`
+        fs.renameSync(dst, prevQuarantine)
+        // PR-level review P1: record rollback metadata IMMEDIATELY after
+        // quarantine so a later copy/chmod failure restores prevQuarantine.
+        // Without this push, a first-copy failure leaves the rollback array
+        // empty and rollbackRuntime() is a no-op while the original file
+        // sits quarantined unrecoverably.
+        runtimeInstalled.push({ dest: dst, prevQuarantine })
+        entryPushed = true
+      }
+      fs.copyFileSync(src, dst)
+      if (mode !== null) fs.chmodSync(dst, mode)
+      if (!entryPushed) {
+        runtimeInstalled.push({ dest: dst, prevQuarantine })
+      }
+      console.log(`Installed ${label}: ${dst}`)
+    } catch (e) {
+      console.error(`Failed to install ${label}: ${e.message}`)
+      // If we quarantined but didn't push (shouldn't happen now), still
+      // attempt direct restore here so the caller's rollbackRuntime can
+      // proceed. The post-fix push above means this catch is mostly safety net.
+      if (prevQuarantine && !entryPushed) {
+        try {
+          if (!fs.existsSync(dst)) fs.renameSync(prevQuarantine, dst)
+        } catch {}
+      }
+      installFailed = true
+    }
+  }
+
+  function safeWrite(label, dst, content) {
+    if (installFailed) return
+    let prevQuarantine = null
+    let entryPushed = false
+    try {
+      const dir = path.dirname(dst)
+      fs.mkdirSync(dir, { recursive: true })
+      if (fs.existsSync(dst)) {
+        prevQuarantine = `${dst}.preinstall.${Date.now()}`
+        fs.renameSync(dst, prevQuarantine)
+        runtimeInstalled.push({ dest: dst, prevQuarantine })
+        entryPushed = true
+      }
+      fs.writeFileSync(dst, content)
+      if (!entryPushed) {
+        runtimeInstalled.push({ dest: dst, prevQuarantine })
+      }
+      console.log(`Installed ${label}: ${dst}`)
+    } catch (e) {
+      console.error(`Failed to install ${label}: ${e.message}`)
+      if (prevQuarantine && !entryPushed) {
+        try {
+          if (!fs.existsSync(dst)) fs.renameSync(prevQuarantine, dst)
+        } catch {}
+      }
+      installFailed = true
+    }
+  }
+
+  function rollbackRuntime() {
+    if (runtimeInstalled.length === 0) return
+    console.error('Rolling back runtime install due to failure...')
+    // Reverse order — last-installed quarantined first.
+    for (let i = runtimeInstalled.length - 1; i >= 0; i--) {
+      const { dest, prevQuarantine } = runtimeInstalled[i]
+      try {
+        if (fs.existsSync(dest)) {
+          const failQuarantine = `${dest}.rollback.${Date.now()}`
+          fs.renameSync(dest, failQuarantine)
+          console.error(`  Quarantined: ${dest} -> ${failQuarantine}`)
+        }
+        if (prevQuarantine && fs.existsSync(prevQuarantine)) {
+          fs.renameSync(prevQuarantine, dest)
+          console.error(`  Restored:    ${prevQuarantine} -> ${dest}`)
+        }
+      } catch (re) {
+        console.error(`  Rollback failed for ${dest}: ${re.message}`)
+      }
+    }
+  }
+
+  safeCopy('second-opinion gate hook', repoGateSrc, userGateDst, 0o755)
+  safeCopy('second-opinion validator lib', repoValidatorSrc, userValidatorDst)
+  safeCopy('second-opinion local-dir lib', repoLocalDirSrc, userLocalDirDst)
+  safeCopy('runbook', repoRunbookSrc, userRunbookDst)
+  if (!installFailed && derivedQuickref) {
+    safeWrite(`quickref (${derivedQuickref.length} chars)`, userQuickrefDst, derivedQuickref)
+  }
+
+  if (installFailed) {
+    rollbackRuntime()
+  } else {
+    // Clean up pre-install quarantines (success path — old files no longer needed).
+    for (const { prevQuarantine } of runtimeInstalled) {
+      if (prevQuarantine && fs.existsSync(prevQuarantine)) {
+        try { fs.unlinkSync(prevQuarantine) } catch {}
+      }
+    }
   }
 
   // Unified quarantine: if ANY snapshot-refresh step fails after the global
@@ -1239,7 +1389,20 @@ if (installSecondOpinion) {
     }
   }
 
+  // Codex post-impl review F1: skip snapshot refresh entirely if runtime
+  // install failed. Quarantine pre-existing snapshot so the gate
+  // fail-closes on a partial runtime rather than reading a stale-valid
+  // snapshot against the rolled-back runtime files.
   try {
+    if (installFailed) {
+      const { snapshotPath } = await import(
+        new URL('./scripts/second-opinion/lib/install-snapshot.mjs', import.meta.url).href
+      )
+      snapshotPathFn = snapshotPath
+      quarantineExistingSnapshot()
+      throw new Error('runtime install failed — snapshot refresh skipped, runtime rolled back, pre-existing snapshot quarantined')
+    }
+
     const { computeSourceHash } = await import(
       new URL('./scripts/second-opinion/lib/source-hash.mjs', import.meta.url).href
     )

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -22,6 +22,16 @@
  *   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
  *   .session-baseline              | BASELINE only
  *
+ * Adjacent UX-marker classes (NOT in any of the above sets):
+ *
+ *   .so-runbook-shown.<sha8>       | UX-marker only — tracks "model has been
+ *                                    shown the second-opinion harness runbook
+ *                                    this session." Excluded from TASK_SIGNAL
+ *                                    AND CHECKPOINT_CLEANUP. SessionStart glob
+ *                                    is the only cleanup path. Recognized by
+ *                                    classifier marker_write handlers and by
+ *                                    checkpoint-gate's runbook exemption case.
+ *
  * Set semantics:
  *   TASK_SIGNAL_MARKERS         3 markers — em-recall stop-gate carve-out
  *                               class (mid-session mtime > baseline = task

--- a/tests/test-runbook-marker-checkpoint-gate.sh
+++ b/tests/test-runbook-marker-checkpoint-gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# test-runbook-marker-checkpoint-gate.sh — checkpoint-gate integration
+# for .so-runbook-shown.* exemption (plan v4.1 #3, codex r2 P1).
+#
+# Verifies:
+#   - touch of runbook marker at canonical root passes the marker_write
+#     branch (exit 0) even with .plan-approval-pending active
+#   - touch of runbook marker passes with .checkpoint-required active
+#   - wrong-root touch (absolute non-canonical) → block via
+#     _block_wrong_root_marker (wrong-root check fires BEFORE exemption)
+#   - registry assertion: .so-runbook-shown.* basename NOT in
+#     TASK_SIGNAL_MARKERS or CHECKPOINT_CLEANUP_MARKERS
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/checkpoint-gate.sh"
+
+PASS=0
+FAIL=0
+FAILED=()
+
+# run_gate <tool_name> <command-json-value> <cwd> → returns: exit_code, stdout
+run_gate() {
+  local tool_name="$1" command="$2" cwd="$3"
+  printf '{"tool_name":"%s","tool_input":{"command":%s},"cwd":"%s","session_id":"test"}' \
+    "$tool_name" "$(printf '%s' "$command" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" "$cwd" | \
+    bash "$HOOK" 2>&1
+}
+
+assert_allow() {
+  local name="$1" cwd="$2" cmd="$3"
+  local out
+  out="$(run_gate Bash "$cmd" "$cwd" 2>&1)" || true
+  if [ -z "$out" ]; then
+    PASS=$((PASS+1))
+    printf '  ✓ %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED+=("$name: expected empty stdout (allow), got: $out")
+    printf '  ✗ %s — got: %s\n' "$name" "$out"
+  fi
+}
+
+assert_block() {
+  local name="$1" cwd="$2" cmd="$3" expected_substring="$4"
+  local out
+  out="$(run_gate Bash "$cmd" "$cwd" 2>&1)" || true
+  if [[ "$out" == *"$expected_substring"* ]]; then
+    PASS=$((PASS+1))
+    printf '  ✓ %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED+=("$name: expected substring=$expected_substring got=$out")
+    printf '  ✗ %s — expected "%s", got: %s\n' "$name" "$expected_substring" "$out"
+  fi
+}
+
+# Fixture: tmp git repo with .checkpoints/
+# realpath on TMP because macOS mktemp returns /var/folders/... which is a
+# symlink to /private/var/folders/...; the hook canonicalizes via cd -P so
+# tests must use the resolved form to avoid wrong-root false-positives.
+TMP="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TMP"' EXIT
+git init -q "$TMP"
+mkdir -p "$TMP/.checkpoints"
+
+echo "# Checkpoint-gate × runbook marker"
+
+# Baseline — no markers armed: touch runbook marker → allow
+assert_allow \
+  "no markers armed: touch runbook marker → allow" \
+  "$TMP" \
+  "touch $TMP/.checkpoints/.so-runbook-shown.deadbeef"
+
+# Arm .plan-approval-pending, then touch runbook marker — exemption should fire
+echo "plan pending" > "$TMP/.checkpoints/.plan-approval-pending"
+assert_allow \
+  "plan-pending armed: touch runbook marker → allow (exemption)" \
+  "$TMP" \
+  "touch $TMP/.checkpoints/.so-runbook-shown.deadbeef"
+
+# Same scenario — touch a non-runbook marker should be blocked by plan-pending
+assert_block \
+  "plan-pending armed: touch .pre-checkpoint-done → block (cross-gate)" \
+  "$TMP" \
+  "touch $TMP/.checkpoints/.pre-checkpoint-done" \
+  "plan-approval-pending"
+
+rm -f "$TMP/.checkpoints/.plan-approval-pending"
+
+# Arm .checkpoint-required, touch runbook marker → allow (exemption)
+echo "ckpt required" > "$TMP/.checkpoints/.checkpoint-required"
+assert_allow \
+  "checkpoint-required armed: touch runbook marker → allow (exemption)" \
+  "$TMP" \
+  "touch $TMP/.checkpoints/.so-runbook-shown.deadbeef"
+rm -f "$TMP/.checkpoints/.checkpoint-required"
+
+# Wrong-root: touch runbook marker at non-canonical absolute path → block
+assert_block \
+  "wrong-root absolute path: touch runbook marker at /tmp/elsewhere → block" \
+  "$TMP" \
+  "touch /tmp/elsewhere/.checkpoints/.so-runbook-shown.deadbeef" \
+  "non-canonical"
+
+# Marker registry classification — assert .so-runbook-shown.* NOT in TASK_SIGNAL
+echo ""
+echo "# Marker registry classification"
+
+REGISTRY_CHECK="$(node -e "
+import('$REPO_ROOT/scripts/lib/marker-paths.mjs').then(m => {
+  const isTaskSignal = m.TASK_SIGNAL_MARKERS.some(n => n.includes('so-runbook-shown'))
+  const isCheckpointCleanup = m.CHECKPOINT_CLEANUP_MARKERS.some(n => n.includes('so-runbook-shown'))
+  if (isTaskSignal) { console.log('FAIL_TASK_SIGNAL'); process.exit(1) }
+  if (isCheckpointCleanup) { console.log('FAIL_CLEANUP'); process.exit(1) }
+  console.log('OK')
+}).catch(e => { console.log('ERR:' + e.message); process.exit(1) })
+")"
+
+if [ "$REGISTRY_CHECK" = "OK" ]; then
+  PASS=$((PASS+1))
+  printf '  ✓ .so-runbook-shown.* NOT in TASK_SIGNAL_MARKERS or CHECKPOINT_CLEANUP_MARKERS\n'
+else
+  FAIL=$((FAIL+1))
+  FAILED+=("registry classification: $REGISTRY_CHECK")
+  printf '  ✗ registry classification failed: %s\n' "$REGISTRY_CHECK"
+fi
+
+echo ""
+echo "$PASS/$((PASS+FAIL)) pass"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for f in "${FAILED[@]}"; do
+    echo "  ✗ $f"
+  done
+  exit 1
+fi

--- a/tests/test-runbook-marker-classifier.sh
+++ b/tests/test-runbook-marker-classifier.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test-runbook-marker-classifier.sh — classifier integration for .so-runbook-shown.*
+#
+# Verifies:
+#   - touch/rm/tee/redirect of .so-runbook-shown.<sha> → marker_write classification
+#   - kind suffix matches the operation (touch_marker, rm_marker, tee_marker, redirect_to_marker)
+#   - touch of non-marker → shared_write (regression — touch handler must
+#     not over-promote)
+#   - non-runbook markers continue to classify correctly (no regression on
+#     the existing same-class set)
+
+set -euo pipefail
+
+LIB_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../hooks/lib" && pwd)"
+# shellcheck disable=SC1091
+source "$LIB_DIR/command-classifier.sh"
+
+PASS=0
+FAIL=0
+FAILED=()
+
+# assert_classify <cmd> <expected-label> <expected-kind-substring>
+assert_classify() {
+  local cmd="$1" expected_label="$2" expected_kind="$3" name="$4"
+  local result label rest kind
+  result="$(classify_command "$cmd" "/tmp/fake-repo")"
+  label="${result%%	*}"
+  rest="${result#*	}"
+  kind="${rest##*	}"
+  if [ "$label" = "$expected_label" ] && [[ "$kind" == *"$expected_kind"* ]]; then
+    PASS=$((PASS+1))
+    printf '  ✓ %s\n' "$name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED+=("$name: expected=$expected_label/$expected_kind got=$label/$kind")
+    printf '  ✗ %s (expected %s/%s, got %s/%s)\n' \
+      "$name" "$expected_label" "$expected_kind" "$label" "$kind"
+  fi
+}
+
+echo "# Runbook marker classification"
+
+# touch handler — new in plan v4.1
+assert_classify \
+  "touch /tmp/fake-repo/.checkpoints/.so-runbook-shown.deadbeef" \
+  "marker_write" "touch_marker" \
+  "touch runbook marker → marker_write touch_marker"
+
+assert_classify \
+  "touch /tmp/fake-repo/.checkpoints/.so-runbook-shown.abc12345" \
+  "marker_write" "touch_marker" \
+  "touch runbook marker (different sha) → marker_write touch_marker"
+
+# touch of non-marker — regression guard
+assert_classify \
+  "touch /tmp/some/other/file.txt" \
+  "shared_write" "touch_non_marker" \
+  "touch non-marker → shared_write touch_non_marker"
+
+# Same-class additions to existing handlers
+assert_classify \
+  "rm /tmp/fake-repo/.checkpoints/.so-runbook-shown.deadbeef" \
+  "marker_write" "rm_marker" \
+  "rm runbook marker → marker_write rm_marker"
+
+assert_classify \
+  ": > /tmp/fake-repo/.checkpoints/.so-runbook-shown.deadbeef" \
+  "marker_write" "redirect_to_marker" \
+  "redirect to runbook marker → marker_write redirect_to_marker"
+
+assert_classify \
+  "tee /tmp/fake-repo/.checkpoints/.so-runbook-shown.deadbeef" \
+  "marker_write" "tee_marker" \
+  "tee runbook marker → marker_write tee_marker"
+
+# Regression — existing markers still classify as marker_write
+assert_classify \
+  "touch /tmp/fake-repo/.checkpoints/.pre-checkpoint-done" \
+  "marker_write" "touch_marker" \
+  "touch .pre-checkpoint-done → marker_write touch_marker (existing marker)"
+
+assert_classify \
+  "rm /tmp/fake-repo/.checkpoints/.plan-approval-pending" \
+  "marker_write" "rm_marker" \
+  "rm .plan-approval-pending → marker_write rm_marker (existing marker)"
+
+echo ""
+echo "$PASS/$((PASS+FAIL)) pass"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for f in "${FAILED[@]}"; do
+    echo "  ✗ $f"
+  done
+  exit 1
+fi

--- a/tests/test-second-opinion-gate-runbook.mjs
+++ b/tests/test-second-opinion-gate-runbook.mjs
@@ -1,0 +1,556 @@
+#!/usr/bin/env node
+/**
+ * test-second-opinion-gate-runbook.mjs — Tests for the runbook-injection
+ * branch of hooks/second-opinion-gate.mjs (codex r4 ACCEPT plan v4.1).
+ *
+ * Coverage:
+ *   Gate flow (P1-2 ordering):
+ *     - Runbook gate fires BEFORE validator/snapshot load on harness Bash
+ *     - Non-harness Bash falls through to existing snapshot flow
+ *     - Missing snapshot doesn't preempt runbook block on harness call
+ *
+ *   Detection (occurrence-scoped):
+ *     - Canonical harness invocation → block
+ *     - Quoted/single-quoted/splice variants → block
+ *     - `--help` / `info` subcommand → allow
+ *     - Non-harness `node` calls (em-search, em-store) → allow
+ *
+ *   Runbook validation (fail-closed):
+ *     - Missing runbook → block with runbook-load-failed
+ *     - Missing quickref → block with runbook-load-failed
+ *     - Too-short runbook → block
+ *     - Missing sentinel → block
+ *
+ *   Marker semantics:
+ *     - Marker absent → block with sha8 + marker_path
+ *     - Marker present at canonical → allow
+ *     - Sha drift (marker for old sha, runbook updated) → block
+ *     - Linked worktree cwd → marker_path is at CANONICAL root, not worktree
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const HOOK = path.join(REPO_ROOT, 'hooks', 'second-opinion-gate.mjs')
+const RUNBOOK_SRC = path.join(REPO_ROOT, 'hooks', 'runbooks', 'second-opinion-harness.md')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+const tmpDirs = []
+process.on('exit', () => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+function makeTmpProject() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'so-runbook-test-'))
+  tmpDirs.push(tmp)
+  execFileSync('git', ['init', '-q', tmp], { stdio: ['ignore', 'pipe', 'ignore'] })
+  fs.mkdirSync(path.join(tmp, '.checkpoints'), { recursive: true })
+  return tmp
+}
+
+function makeTmpRunbookDir() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'so-runbook-runtime-'))
+  tmpDirs.push(tmp)
+  return tmp
+}
+
+function installRunbook(runbookDir, runbookContent, quickrefContent) {
+  const rbPath = path.join(runbookDir, 'second-opinion-harness.md')
+  const qrPath = path.join(runbookDir, 'second-opinion-harness.quickref.md')
+  fs.writeFileSync(rbPath, runbookContent)
+  fs.writeFileSync(qrPath, quickrefContent)
+  return { rbPath, qrPath }
+}
+
+function computeSha8(content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8)
+}
+
+function runHook({ toolName, toolInput, cwd, env = {} }) {
+  const input = JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd })
+  const result = spawnSync('node', [HOOK], {
+    input,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    timeout: 5000,
+  })
+  if (result.status !== 0) {
+    throw new Error(`Hook exited non-zero (${result.status}); stderr: ${result.stderr}`)
+  }
+  const stdout = result.stdout.trim()
+  if (!stdout) return { allow: true }
+  return { allow: false, decision: JSON.parse(stdout) }
+}
+
+// Validate runbook content for fixtures. Must be ≥ 256 chars and contain
+// "Self-trigger checklist" sentinel.
+function validRunbookContent() {
+  return [
+    '# Test runbook',
+    '',
+    '## ⚠️ Self-trigger checklist — test fixture',
+    '',
+    'Padding to reach 256 chars: ' + 'x'.repeat(300),
+    '',
+    '## Other section',
+    'lorem ipsum',
+  ].join('\n')
+}
+
+function validQuickrefContent() {
+  return '## Self-trigger checklist (quickref)\nThis is a quickref body padded for size.\n' + 'x'.repeat(80)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+console.log('# Gate detection — positive cases')
+
+test('canonical harness invocation → block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request --provider codex --dispatch' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.decision, 'block')
+  assert.strictEqual(r.decision.code, 'runbook-injection-required')
+  assert.ok(r.decision.runbook_sha, 'runbook_sha present')
+  assert.ok(r.decision.marker_path.includes('.so-runbook-shown.'))
+})
+
+test('absolute-path harness invocation → block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node /abs/path/scripts/second-opinion.mjs request --provider codex' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-injection-required')
+})
+
+test('quoted-script harness → block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node "scripts/second-opinion.mjs" request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false, 'quoted form must block')
+})
+
+test('splice &&: harness via && → block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'true && node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false, '&& splice must block')
+})
+
+test('env-prefix: FOO=bar node ... request → block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'FOO=bar node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false, 'env-prefix must block')
+})
+
+console.log('\n# Gate detection — negative cases')
+
+test('harness --help → allow', () => {
+  const project = makeTmpProject()
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs --help' },
+    cwd: project,
+  })
+  // Allow because no `request` subcommand. May still be blocked by snapshot
+  // gate (missing snapshot in test env) — we accept either pure allow OR
+  // snapshot block, but NOT runbook-injection-required.
+  if (!r.allow) {
+    assert.notStrictEqual(r.decision.code, 'runbook-injection-required')
+  }
+})
+
+test('em-search node call → not runbook-blocked', () => {
+  const project = makeTmpProject()
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/em-search.mjs --category lesson' },
+    cwd: project,
+  })
+  if (!r.allow) {
+    assert.notStrictEqual(r.decision.code, 'runbook-injection-required')
+  }
+})
+
+console.log('\n# Runbook validation — fail-closed cases')
+
+test('missing runbook → block runbook-load-failed', () => {
+  const project = makeTmpProject()
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: '/nonexistent/runbook.md',
+      SO_QUICKREF_PATH: '/nonexistent/quickref.md',
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-load-failed')
+})
+
+test('missing quickref → block runbook-load-failed', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  fs.writeFileSync(path.join(rbDir, 'second-opinion-harness.md'), validRunbookContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-load-failed')
+})
+
+test('too-short runbook → block runbook-load-failed', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, '## ⚠️ Self-trigger checklist\nshort', validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-load-failed')
+})
+
+test('runbook missing sentinel → block runbook-load-failed', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  const noSentinel = '# Heading\n' + 'x'.repeat(400)  // long enough but lacks sentinel
+  installRunbook(rbDir, noSentinel, validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-load-failed')
+})
+
+console.log('\n# Marker semantics')
+
+test('marker absent → block, marker_path is canonical', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-injection-required')
+  const sha = computeSha8(validRunbookContent())
+  assert.strictEqual(r.decision.runbook_sha, sha)
+  assert.ok(r.decision.marker_path.startsWith(project), `marker_path under project: ${r.decision.marker_path}`)
+  assert.ok(r.decision.marker_path.endsWith(`.so-runbook-shown.${sha}`))
+})
+
+test('marker present → allow', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  const content = validRunbookContent()
+  installRunbook(rbDir, content, validQuickrefContent())
+  const sha = computeSha8(content)
+  fs.writeFileSync(path.join(project, '.checkpoints', `.so-runbook-shown.${sha}`), '')
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, true)
+})
+
+test('sha drift → re-block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  const oldContent = validRunbookContent()
+  installRunbook(rbDir, oldContent, validQuickrefContent())
+  // Plant a marker for the OLD sha
+  const oldSha = computeSha8(oldContent)
+  fs.writeFileSync(path.join(project, '.checkpoints', `.so-runbook-shown.${oldSha}`), '')
+  // Now mutate the runbook
+  const newContent = oldContent + '\n## extra section\n' + 'y'.repeat(50)
+  fs.writeFileSync(path.join(rbDir, 'second-opinion-harness.md'), newContent)
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false, 'sha drift must re-block')
+  const newSha = computeSha8(newContent)
+  assert.strictEqual(r.decision.runbook_sha, newSha)
+  assert.notStrictEqual(r.decision.runbook_sha, oldSha)
+})
+
+console.log('\n# Gate ordering (P1-2): runbook fires before snapshot')
+
+test('missing snapshot does NOT preempt runbook block', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+      SO_INSTALL_SNAPSHOT_PATH: '/nonexistent/snap.json',
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'runbook-injection-required',
+    `expected runbook-injection-required, got ${r.decision.code}`)
+})
+
+console.log('\n# local-dir.mjs failure modes (codex post-impl P1 #2)')
+
+test('malformed local-dir.mjs → block runbook-canonicalize-failed (not silent fallback)', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+
+  // Create a tmp installed-hook tree with a SYNTAX-BROKEN local-dir.mjs.
+  const orphan = fs.mkdtempSync(path.join(os.tmpdir(), 'so-orphan-lib-'))
+  tmpDirs.push(orphan)
+  const orphanHooks = path.join(orphan, '.claude', 'hooks')
+  const orphanLib = path.join(orphanHooks, 'lib')
+  fs.mkdirSync(orphanLib, { recursive: true })
+  // Copy the hook so its import.meta.url resolves to <orphan>/.claude/hooks/...
+  fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  // Write a syntactically broken local-dir.mjs
+  fs.writeFileSync(path.join(orphanLib, 'local-dir.mjs'), 'export function resolveRepoRoot( {{{ INVALID')
+
+  const r = spawnSync('node', [path.join(orphanHooks, 'second-opinion-gate.mjs')], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/second-opinion.mjs request' },
+      cwd: project,
+    }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+    timeout: 5000,
+  })
+  assert.strictEqual(r.status, 0, `hook should exit 0; stderr=${r.stderr}`)
+  const decision = JSON.parse(r.stdout)
+  assert.strictEqual(decision.decision, 'block')
+  assert.strictEqual(decision.code, 'runbook-canonicalize-failed',
+    `expected runbook-canonicalize-failed for malformed lib, got ${decision.code}`)
+})
+
+test('transitive ERR_MODULE_NOT_FOUND in local-dir.mjs → block (PR-level P1-1)', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+
+  const orphan = fs.mkdtempSync(path.join(os.tmpdir(), 'so-transitive-lib-'))
+  tmpDirs.push(orphan)
+  const orphanHooks = path.join(orphan, '.claude', 'hooks')
+  const orphanLib = path.join(orphanHooks, 'lib')
+  fs.mkdirSync(orphanLib, { recursive: true })
+  fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  // local-dir.mjs exists but imports a missing transitive dep
+  fs.writeFileSync(path.join(orphanLib, 'local-dir.mjs'),
+    "import './nonexistent-dep.mjs'\nexport function resolveRepoRoot(cwd) { return cwd }\n")
+
+  const r = spawnSync('node', [path.join(orphanHooks, 'second-opinion-gate.mjs')], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/second-opinion.mjs request' },
+      cwd: project,
+    }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+    timeout: 5000,
+  })
+  assert.strictEqual(r.status, 0, `hook should exit 0; stderr=${r.stderr}`)
+  const decision = JSON.parse(r.stdout)
+  assert.strictEqual(decision.decision, 'block')
+  // Transitive ERR_MODULE_NOT_FOUND must fail closed (not silent fallback).
+  assert.strictEqual(decision.code, 'runbook-canonicalize-failed',
+    `expected runbook-canonicalize-failed for transitive missing dep, got ${decision.code}`)
+})
+
+test('missing local-dir.mjs → cwd fallback (silent, plan v4.1 accepted)', () => {
+  const project = makeTmpProject()
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+
+  const orphan = fs.mkdtempSync(path.join(os.tmpdir(), 'so-missing-lib-'))
+  tmpDirs.push(orphan)
+  const orphanHooks = path.join(orphan, '.claude', 'hooks')
+  fs.mkdirSync(orphanHooks, { recursive: true })
+  fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  // Deliberately do NOT create lib/local-dir.mjs
+
+  const r = spawnSync('node', [path.join(orphanHooks, 'second-opinion-gate.mjs')], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'node scripts/second-opinion.mjs request' },
+      cwd: project,
+    }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+    timeout: 5000,
+  })
+  assert.strictEqual(r.status, 0, `hook should exit 0; stderr=${r.stderr}`)
+  const decision = JSON.parse(r.stdout)
+  // Should block with runbook-injection-required (gate still works), not with
+  // runbook-canonicalize-failed (which is reserved for malformed-lib).
+  assert.strictEqual(decision.code, 'runbook-injection-required',
+    `expected runbook-injection-required (cwd fallback), got ${decision.code}`)
+})
+
+console.log('\n# Worktree canonical-root binding')
+
+test('linked-worktree cwd → marker_path is canonical, not worktree', () => {
+  const main = makeTmpProject()
+  // Need a commit so worktree add works
+  execFileSync('git', ['-C', main, 'commit', '--allow-empty', '-q', '-m', 'init'], {
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+  })
+  const wt = path.join(path.dirname(main), `wt-${path.basename(main)}`)
+  tmpDirs.push(wt)
+  execFileSync('git', ['-C', main, 'worktree', 'add', '-q', '-b', 'wtbr', wt], { stdio: ['ignore', 'pipe', 'pipe'] })
+  fs.mkdirSync(path.join(wt, '.checkpoints'), { recursive: true })
+  const rbDir = makeTmpRunbookDir()
+  installRunbook(rbDir, validRunbookContent(), validQuickrefContent())
+  const r = runHook({
+    toolName: 'Bash',
+    toolInput: { command: 'node scripts/second-opinion.mjs request' },
+    cwd: wt,
+    env: {
+      SO_RUNBOOK_PATH: path.join(rbDir, 'second-opinion-harness.md'),
+      SO_QUICKREF_PATH: path.join(rbDir, 'second-opinion-harness.quickref.md'),
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  // canonical root = main (linked worktree's common-dir is main's .git).
+  // realpath both sides — macOS /var/folders is a symlink to /private/var/folders.
+  const mainReal = fs.realpathSync(main)
+  const wtReal = fs.realpathSync(wt)
+  const markerReal = fs.realpathSync(path.dirname(r.decision.marker_path))
+  assert.ok(markerReal.startsWith(mainReal),
+    `marker_path canonical (${markerReal}) should be under main repo (${mainReal})`)
+  assert.ok(!markerReal.startsWith(wtReal) || markerReal === mainReal + '/.checkpoints',
+    `marker_path must not be at worktree (${wtReal}): ${markerReal}`)
+})
+
+// ---------------------------------------------------------------------------
+
+console.log(`\n${passed}/${passed + failed} pass`)
+if (failed > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  ✗ ${f.name}\n    ${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

- Adds a PreToolUse hook gate that injects the second-opinion harness runbook into model context on the first harness invocation per session — replacing documentation-tier reminders (which fail under task-end momentum per MEMORY.md "Rule 18 / bp-001 — Only Hooks Work") with hook-tier enforcement.
- Marker is sha8-bound to runbook content so in-session edits force re-injection; SessionStart glob-clears the marker.
- Touch of marker (the model's acknowledgement) classifies as `marker_write` via new `touch` handler in `command-classifier.sh` and bypasses cross-gate plan-pending invariants via exact-basename exemption in `checkpoint-gate.sh`.

## Why

Repeat violations across recent sessions: missing `timeout: 600000` on harness `Bash` invocations, `--storage files` instead of `episodic`, HOLD-without-round-2, etc. Each one cost a user correction round. Documentation memory exists (`feedback_second_opinion_harness_runbook.md`) but isn't reliably in context when the harness is invoked. This PR makes the runbook a hook-enforced precondition.

## Review chain

| Stage | Verdict | Episode |
|---|---|---|
| 8-axis (negative-scenario-planner) | HOLD → closed | inline |
| Plan review r1 → r4 | r4 ACCEPT | `…6e69` |
| Code review r1 → r2 | r2 ACCEPT | `…9957` |
| PR-level review r1 → r2 | r2 ACCEPT-with-FU | `…6566` |

Two FUs filed:
- #263 — long-session re-injection threshold (plan-tier Class F DEFER)
- #264 — tighten rollback regression test for exact post-rename-failure path (PR-level FU)

## Test plan

- [ ] CI passes (existing 465 regression tests)
- [ ] New tests pass (33 added):
  - [ ] `node tests/test-second-opinion-gate-runbook.mjs` (19)
  - [ ] `bash tests/test-runbook-marker-classifier.sh` (8)
  - [ ] `bash tests/test-runbook-marker-checkpoint-gate.sh` (6)
- [ ] Locally, run `node install.mjs --tool claude-code --install-second-opinion`; verify quickref derived + installed at `~/.claude/hooks/runbooks/second-opinion-harness.quickref.md`
- [ ] Trigger harness call after install; verify block with `code:"runbook-injection-required"` on first call, allow after `touch` of the named marker
- [ ] Trigger SessionStart; verify marker glob-cleared at canonical root

## Files changed

```
hooks/checkpoint-gate.sh                       |  18 ++-
hooks/em-recall-sessionstart.sh                |  25 ++++
hooks/lib/command-classifier.sh                |  72 ++++++++++
hooks/lib/local-dir.mjs                        |   1 + (symlink)
hooks/lib/marker-paths.sh                      |  14 ++
hooks/runbooks/second-opinion-harness.md       | 137 +++ (new)
hooks/second-opinion-gate.mjs                  | 302 +++++++++++++++++++++++++++++++--------
install.mjs                                    | 207 +++++++++++++++++++++++++--
scripts/lib/marker-paths.mjs                   |  10 ++
tests/test-runbook-marker-checkpoint-gate.sh   | 144 ++++++++++++++++++ (new)
tests/test-runbook-marker-classifier.sh        |  98 ++++++++++++++ (new)
tests/test-second-opinion-gate-runbook.mjs     | 379 +++++++++++++++++++++++++++++++++++++++++++ (new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
