### PR TITLE
fix(268): session-id-namespaced .plan-approval-pending marker

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -30,6 +30,27 @@ jobs:
       - name: Run plan-marker cross-session E2E tests (X1-X13)
         run: node tests/test-plan-marker-cross-session.mjs
 
+      - name: Run plan-marker classifier tests (E1-E5 + E5b + F-3 + F17/F18)
+        run: bash tests/test-plan-marker-classifier.sh
+
+      - name: Run checkpoints-migration regression (verifies F12 + legacy preserved)
+        run: node tests/test-checkpoints-migration.mjs
+
+      - name: Run em-recall session-start orphan-sweep regression
+        run: node tests/test-em-recall-session-start-early-exit.mjs
+
+      - name: Run em-strict-lstat regression
+        run: node tests/test-em-strict-lstat.mjs
+
+      - name: Run issue-146 plan-pending deferral regression
+        run: node tests/test-issue-146.mjs
+
+      - name: Run command-classifier full regression
+        run: bash tests/test-command-classifier.sh
+
+      - name: Run stop-gate regression
+        run: bash tests/test-stop-gate.sh
+
       - name: Run preflight-gate regression tests
         run: bash tests/test-preflight-gate.sh
 

--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -1,0 +1,37 @@
+name: Plan-marker enforcement validation
+
+# #268 fix F16: this workflow runs on EVERY PR/push (no `paths:` filter)
+# because the validator's job is to DETECT new unregistered enforcement
+# sites. A paths-filtered workflow can't catch sites added in files
+# outside the filter — the same class as plan v6's own call-site-closure
+# lesson, just moved to workflow triggering (codex r1 F5).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate plan-marker enforcement-site drift (D0 + D2)
+        run: node scripts/validate-plan-marker-sites.mjs
+
+      - name: Run plan-marker helper unit tests (H1-H13 + H3-bis)
+        run: node tests/test-plan-marker.mjs
+
+      - name: Run plan-marker cross-session E2E tests (X1-X13)
+        run: node tests/test-plan-marker-cross-session.mjs
+
+      - name: Run preflight-gate regression tests
+        run: bash tests/test-preflight-gate.sh
+
+      - name: Run preflight-prompt-helper regression tests
+        run: bash tests/test-preflight-prompt-helper.sh

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -46,14 +46,15 @@ set -e
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
+MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-# Source classifier + repo-root resolver + shared marker paths. Use
-# BASH_SOURCE for symlink safety.
+# Source classifier + repo-root resolver + shared marker paths + session-id.
+# Use BASH_SOURCE for symlink safety.
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 LIB_DIR="$HOOK_DIR/lib"
-if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ]; then
-  echo '{"decision": "block", "reason": "checkpoint-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh). Re-run install.mjs --install-hooks."}'
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ] || [ ! -f "$LIB_DIR/session-id.sh" ]; then
+  echo '{"decision": "block", "reason": "checkpoint-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh, session-id.sh). Re-run install.mjs --install-hooks."}'
   exit 0
 fi
 # shellcheck disable=SC1091
@@ -62,6 +63,8 @@ source "$LIB_DIR/repo-root.sh"
 source "$LIB_DIR/command-classifier.sh"
 # shellcheck disable=SC1091
 source "$LIB_DIR/marker-paths.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/session-id.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
 
@@ -102,7 +105,75 @@ marker_basename_for_target() {
       return 0
     fi
   done
+  # #268 fix E13: also accept any per-session plan-marker basename
+  # `.plan-approval-pending.<sid>` at either root. Strict validation via
+  # plan_marker_basename_matches (rejects path traversal / oversize / invalid chars).
+  local target_basename="${target##*/}"
+  local target_dir="${target%/*}"
+  case "$target_basename" in
+    .plan-approval-pending.*)
+      if plan_marker_basename_matches "$target_basename"; then
+        if [ "$target_dir" = "$PRIMARY_DIR" ] || [ "$target_dir" = "$LEGACY_DIR" ]; then
+          printf '%s' "$target_basename"
+          return 0
+        fi
+      fi
+      ;;
+  esac
   printf ''
+}
+
+# #268 fix E13: plan_marker_exists_for_session — is there a plan-approval
+# marker blocking THIS session? Returns 0 (true) on any of:
+#   - <root>/.checkpoints/.plan-approval-pending.<sid>          (own session, primary)
+#   - <root>/.claude/.plan-approval-pending.<sid>               (own session, legacy)
+#   - <root>/.checkpoints/.plan-approval-pending                (legacy suffix-less)
+#   - <root>/.claude/.plan-approval-pending                     (legacy suffix-less)
+# Cross-session suffixed markers (.plan-approval-pending.OTHER_SID) are
+# IGNORED — that's the #268 fix.
+plan_marker_exists_for_session() {
+  local sid="$1"
+  [ -e "$PRIMARY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  [ -e "$LEGACY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  if validate_session_id "$sid"; then
+    local basename
+    basename="$(plan_marker_basename_for_session "$sid")"
+    [ -e "$PRIMARY_DIR/$basename" ] && return 0
+    [ -e "$LEGACY_DIR/$basename" ] && return 0
+  fi
+  return 1
+}
+
+# #268 fix F14 helper: any_plan_marker_exists — true if ANY plan marker
+# (legacy suffix-less OR any suffixed form) exists at either root. Used
+# for fail-closed-on-invalid-sid decisions.
+any_plan_marker_exists() {
+  [ -e "$PRIMARY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  [ -e "$LEGACY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  local p
+  for p in "$PRIMARY_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  for p in "$LEGACY_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  return 1
+}
+
+# #268 fix: composite predicate combining E13 + F14. Returns 0 (true) if
+# THIS session is plan-blocked by either:
+#   (a) invalid/empty/missing sid AND any plan marker exists (F14
+#       fail-closed for probe-drift threat — per plan v6 §2)
+#   (b) valid sid AND plan_marker_exists_for_session true
+# Returns 1 (false) otherwise.
+plan_pending_blocks_this_session() {
+  local sid="$1"
+  if ! validate_session_id "$sid"; then
+    any_plan_marker_exists && return 0
+    return 1
+  fi
+  plan_marker_exists_for_session "$sid" && return 0
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -122,6 +193,10 @@ _marker_basename_in_set() {
     .last-user-prompt.json) return 0 ;;
     .last-user-prompt.*.json) return 0 ;;
     .so-runbook-shown.*) return 0 ;;
+    # #268 fix E7: per-session plan-marker `.plan-approval-pending.<sid>`.
+    # Loose glob here for set-membership routing; strict validation via
+    # plan_marker_basename_matches happens at marker_basename_for_target.
+    .plan-approval-pending.*) return 0 ;;
   esac
   return 1
 }
@@ -193,7 +268,7 @@ _escape_bash_glob() {
 _command_has_relative_marker_path() {
   local cmd_stripped
   cmd_stripped="$(_strip_shell_quotes "$1")"
-  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
+  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
 }
 
 # E2E-discovered absolute-non-canonical detection: for Bash commands where
@@ -210,7 +285,7 @@ _command_first_absolute_noncanonical_marker() {
   local cmd
   cmd="$(_strip_shell_quotes "$1")"
   local matches p basename
-  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
+  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
   [ -z "$matches" ] && return 0
   while IFS= read -r p; do
     [ -z "$p" ] && continue
@@ -372,10 +447,12 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     TARGET_BN="$(marker_basename_for_target "$TARGET")"
 
     # Cross-gate invariant: checkpoint marker writes are blocked while
-    # .plan-approval-pending exists (Codex ...3503 P1).
-    if marker_exists .plan-approval-pending; then
-      if [ "$TARGET_BN" = ".plan-approval-pending" ]; then
-        # Allow plan-marker removal — plan-gate.sh is what cares about this.
+    # the current session's plan-approval-pending exists (Codex ...3503 P1).
+    # #268 fix E14: session-aware via plan_pending_blocks_this_session +
+    # plan_marker_basename_matches for any-form plan-marker allowance.
+    if plan_pending_blocks_this_session "$MY_SID"; then
+      if plan_marker_basename_matches "$TARGET_BN"; then
+        # Allow plan-marker removal/touch — plan-gate.sh decides.
         exit 0
       fi
       _block_plan_pending
@@ -432,8 +509,8 @@ case "$TOOL_NAME" in
         fi
 
         TARGET_BN="$(marker_basename_for_target "$TARGET")"
-        # Cross-gate invariant
-        if marker_exists .plan-approval-pending && [ "$TARGET_BN" != ".plan-approval-pending" ]; then
+        # Cross-gate invariant (#268 fix E15)
+        if plan_pending_blocks_this_session "$MY_SID" && ! plan_marker_basename_matches "$TARGET_BN"; then
           _block_plan_pending
         fi
         case "$TARGET_BN" in
@@ -478,7 +555,9 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   # .claude/ until fallback is removed. Iteration over the shared
   # TASK_SIGNAL_MARKERS array keeps the cleanup set in lockstep with the
   # carve-out's marker set in em-recall.mjs.
-  if ! marker_exists .plan-approval-pending; then
+  # #268 fix E17: session-aware check — only cleanup if THIS session has
+  # no plan-pending. Other sessions' suffixed markers do not block cleanup.
+  if ! plan_pending_blocks_this_session "$MY_SID"; then
     for _m in "${CHECKPOINT_CLEANUP_MARKERS[@]}"; do
       rm -f "$PRIMARY_DIR/$_m" "$LEGACY_DIR/$_m" 2>/dev/null || true
     done

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -448,10 +448,15 @@ if [ "$TOOL_NAME" = "Bash" ]; then
 
     # Cross-gate invariant: checkpoint marker writes are blocked while
     # the current session's plan-approval-pending exists (Codex ...3503 P1).
-    # #268 fix E14: session-aware via plan_pending_blocks_this_session +
-    # plan_marker_basename_matches for any-form plan-marker allowance.
+    # #268 fix E14: session-aware via plan_pending_blocks_this_session.
+    # Codex code-tier r1 BLOCKER-B1: narrow plan-marker allowance to
+    # OWN-SESSION basename only (legacy literal OR own suffixed). Other-
+    # session suffixed markers MUST NOT be writable via direct Bash —
+    # without this narrowing, session A could `rm .plan-approval-pending.B`
+    # while plan-blocked on its own marker.
     if plan_pending_blocks_this_session "$MY_SID"; then
-      if plan_marker_basename_matches "$TARGET_BN"; then
+      own_session_basename="$(plan_marker_basename_for_session "$MY_SID")"
+      if [ "$TARGET_BN" = "$PLAN_MARKER_LEGACY_BASENAME" ] || [ "$TARGET_BN" = "$own_session_basename" ]; then
         # Allow plan-marker removal/touch — plan-gate.sh decides.
         exit 0
       fi
@@ -509,8 +514,13 @@ case "$TOOL_NAME" in
         fi
 
         TARGET_BN="$(marker_basename_for_target "$TARGET")"
-        # Cross-gate invariant (#268 fix E15)
-        if plan_pending_blocks_this_session "$MY_SID" && ! plan_marker_basename_matches "$TARGET_BN"; then
+        # Cross-gate invariant (#268 fix E15 + codex code-tier r1 B1 narrowing):
+        # block Write/Edit unless target is THIS session's own plan-marker
+        # basename (legacy literal OR own suffixed).
+        own_session_basename="$(plan_marker_basename_for_session "$MY_SID")"
+        if plan_pending_blocks_this_session "$MY_SID" \
+           && [ "$TARGET_BN" != "$PLAN_MARKER_LEGACY_BASENAME" ] \
+           && [ "$TARGET_BN" != "$own_session_basename" ]; then
           _block_plan_pending
         fi
         case "$TARGET_BN" in

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -525,6 +525,15 @@ _classify_segment() {
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
         return 0
         ;;
+      # #268 fix E1: per-session plan-marker via redirect. Same shape as
+      # the legacy literal case-arm above. Loose glob here; strict validation
+      # via plan_marker_basename_matches happens in checkpoint-gate.sh.
+      .plan-approval-pending.*)
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
       .so-runbook-shown.*)
         # Runbook UX-marker (second-opinion-gate). Same-class with the
         # other marker write surfaces; classifies as marker_write so the
@@ -542,10 +551,16 @@ _classify_segment() {
   done
 
   # ---- Strip leading env-assignment tokens (VAR=value) ----
+  # #268 fix F17/F18: also count how many env-prefix tokens were stripped
+  # so plan-marker helper detection (below) can reject command-local env
+  # override attacks (`CLAUDE_CODE_SESSION_ID=B node plan-marker.mjs --rm …`).
+  # Pattern is POSIX `name = [A-Za-z_][A-Za-z0-9_]*` (lowercase + digits + _).
   local idx=0
+  local env_prefix_count=0
   while [ $idx -lt ${#TOKS[@]} ]; do
     case "${TOKS[$idx]}" in
       [A-Za-z_]*=*)
+        env_prefix_count=$((env_prefix_count+1))
         idx=$((idx+1))
         ;;
       *)
@@ -595,6 +610,78 @@ _classify_segment() {
       ;;
   esac
 
+  # ---- #268 fix E5b: plan-marker.mjs helper invocation ----
+  # Recognize `node */plan-marker.mjs --touch|--rm --root <abs>` and emit
+  # marker_write with TARGET = canonical per-session marker path. This is
+  # the canonical Rule 8 approval invocation; plan-gate.sh must allow it
+  # while a plan-pending marker exists for this session.
+  #
+  # F17/F18 reject: any leading POSIX-name env assignment (env_prefix_count
+  # > 0) → emit unsafe_complex. Otherwise session A could write
+  #   CLAUDE_CODE_SESSION_ID=B node ~/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo
+  # and remove session B's marker while the classifier computes TARGET for
+  # session A. The shell command-local env assignment overrides
+  # process.env for the spawned `node` process; classifier and helper
+  # would target different markers (split-brain bypass).
+  if [ "$first" = "node" ]; then
+    local _next_idx=$((idx+1))
+    local _script_arg=""
+    if [ $_next_idx -lt ${#TOKS[@]} ]; then
+      _script_arg="${TOKS[$_next_idx]}"
+    fi
+    case "$_script_arg" in
+      */plan-marker.mjs)
+        # F17/F18: reject any leading env assignment.
+        if [ $env_prefix_count -gt 0 ]; then
+          printf '%s\t\t%s\n' "unsafe_complex" "plan_marker_env_override"
+          return 0
+        fi
+        # Parse --root <ARG> from remaining tokens
+        local _helper_root="" _has_touch=0 _has_rm=0
+        local _k=$((_next_idx+1))
+        while [ $_k -lt ${#TOKS[@]} ]; do
+          case "${TOKS[$_k]}" in
+            --root)
+              _k=$((_k+1))
+              if [ $_k -lt ${#TOKS[@]} ]; then
+                _helper_root="${TOKS[$_k]}"
+              fi
+              ;;
+            --touch) _has_touch=1 ;;
+            --rm)    _has_rm=1 ;;
+          esac
+          _k=$((_k+1))
+        done
+        # Resolve session-id from env (same source the helper will read).
+        local _env_sid="${CLAUDE_CODE_SESSION_ID:-}"
+        # Compose target. If --root or sid is missing, emit marker_write
+        # with empty TARGET; gate's existing equality check will fail and
+        # block — helper would also fail-closed anyway.
+        local _target=""
+        if [ -n "$_helper_root" ] && [ -n "$_env_sid" ]; then
+          _target="${_helper_root}/.checkpoints/.plan-approval-pending.${_env_sid}"
+        fi
+        local _reason="plan_marker_helper"
+        if [ $_has_touch -eq 1 ] && [ $_has_rm -eq 1 ]; then
+          # Mutex violation in args — helper will exit 6 anyway. Classify as
+          # unsafe_complex; gate blocks.
+          printf '%s\t\t%s\n' "unsafe_complex" "plan_marker_mutex_violation"
+          return 0
+        elif [ $_has_touch -eq 1 ]; then
+          _reason="plan_marker_touch"
+        elif [ $_has_rm -eq 1 ]; then
+          _reason="plan_marker_rm"
+        else
+          # Missing action — helper will exit 6. Classify as unsafe_complex.
+          printf '%s\t\t%s\n' "unsafe_complex" "plan_marker_missing_action"
+          return 0
+        fi
+        printf '%s\t%s\t%s\n' "marker_write" "$_target" "$_reason"
+        return 0
+        ;;
+    esac
+  fi
+
   case "$first" in
     bash|sh|zsh|dash|ksh)
       # Is there a -c flag?
@@ -638,6 +725,14 @@ _classify_segment() {
       # and re-opens the trust-based hole the gate exists to close.
       case "$tbase" in
         .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
+        # #268 fix E2: per-session plan-marker via rm. Loose glob; strict
+        # validation happens at checkpoint-gate.sh marker_basename_for_target.
+        .plan-approval-pending.*)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
@@ -688,6 +783,13 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
           return 0
           ;;
+        # #268 fix E3: per-session plan-marker via tee.
+        .plan-approval-pending.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
         .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
@@ -723,6 +825,13 @@ _classify_segment() {
       local tbase="$(basename "$t")"
       case "$tbase" in
         .pre-checkpoint-done|.post-checkpoint-done|.plan-approval-pending|.checkpoint-required|.post-checkpoint-required|.preflight-done|.last-user-prompt.json)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+        # #268 fix E4: per-session plan-marker via touch.
+        .plan-approval-pending.*)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
@@ -1308,6 +1417,13 @@ classify_path() {
   base="$(basename "$p")"
   case "$base" in
     .plan-approval-pending|.pre-checkpoint-done|.post-checkpoint-done)
+      local abs
+      abs="$(_resolve_marker_path "$p" "$repo_root")"
+      printf '%s\t%s\t%s\n' "marker_write" "$abs" "path_marker"
+      return 0
+      ;;
+    # #268 fix E5: per-session plan-marker via classify_path (Write/Edit).
+    .plan-approval-pending.*)
       local abs
       abs="$(_resolve_marker_path "$p" "$repo_root")"
       printf '%s\t%s\t%s\n' "marker_write" "$abs" "path_marker"

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -136,3 +136,54 @@ both_marker_paths() {
 ensure_primary_dir() {
   mkdir -p "$1/$PRIMARY_MARKER_DIR" 2>/dev/null
 }
+
+# ---------------------------------------------------------------------------
+# #268 fix — per-session .plan-approval-pending marker contract.
+#
+# Shell parity for scripts/lib/marker-paths.mjs PLAN_MARKER_*. Drift caught
+# by scripts/validate-plan-marker-sites.mjs Direction 0.
+# ---------------------------------------------------------------------------
+
+readonly PLAN_MARKER_LEGACY_BASENAME='.plan-approval-pending'
+readonly PLAN_MARKER_BASENAME_GLOB='.plan-approval-pending*'       # bash case glob (loose; for routing)
+readonly PLAN_MARKER_SUFFIX_CHARCLASS='A-Za-z0-9_-'
+readonly PLAN_MARKER_SUFFIX_MAXLEN=128
+readonly PLAN_MARKER_BASENAME_GREP_PATTERN='\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?'
+
+# plan_marker_basename_matches <basename>
+# Strict match. Accepts ONLY:
+#   .plan-approval-pending                          (legacy suffix-less)
+#   .plan-approval-pending.<sid>                    (sid matches char-class + length)
+# Rejects:
+#   .plan-approval-pending-extra                    (suffix without dot separator)
+#   .plan-approval-pending.                         (empty suffix)
+#   .plan-approval-pending./traversal               (slash in suffix)
+#   .plan-approval-pending..                        (dot in suffix)
+#   .plan-approval-pending.<129-char>               (oversize suffix)
+#
+# Used by checkpoint-gate's marker_basename_for_target equality refinement
+# and plan-gate's existence check (defense in depth — shell-case sites use
+# loose glob for routing, then this strict helper for validation).
+plan_marker_basename_matches() {
+  local basename="$1"
+  case "$basename" in
+    .plan-approval-pending) return 0 ;;
+    .plan-approval-pending.*)
+      local suffix="${basename#.plan-approval-pending.}"
+      [ -z "$suffix" ] && return 1
+      [ "${#suffix}" -gt "$PLAN_MARKER_SUFFIX_MAXLEN" ] && return 1
+      case "$suffix" in
+        *[!A-Za-z0-9_-]*) return 1 ;;
+      esac
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# plan_marker_basename_for_session <sid>
+# Compose the per-session marker basename. Caller MUST validate_session_id
+# (from hooks/lib/session-id.sh) BEFORE calling this; not re-validated here.
+plan_marker_basename_for_session() {
+  printf '.plan-approval-pending.%s' "$1"
+}

--- a/hooks/lib/session-id.sh
+++ b/hooks/lib/session-id.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# session-id.sh — Shared session-id validation (shell parity with
+# scripts/lib/session-id.mjs).
+#
+# Extracted for #268 fix. Sourced by hooks/plan-gate.sh,
+# hooks/checkpoint-gate.sh, and any future hook reading
+# .session_id from PreToolUse / SessionEnd / SessionStart stdin.
+#
+# Char-class: [A-Za-z0-9_-], length 1..128. No dots, no slashes.
+# Drift between this and session-id.mjs caught by
+# scripts/validate-plan-marker-sites.mjs Direction 0.
+
+readonly SESSION_ID_CHARCLASS='A-Za-z0-9_-'
+readonly SESSION_ID_MIN_LEN=1
+readonly SESSION_ID_MAX_LEN=128
+
+# validate_session_id <sid>
+# Returns 0 (true) iff sid matches /^[A-Za-z0-9_-]{1,128}$/.
+# Use BEFORE constructing per-session marker paths in any hook.
+validate_session_id() {
+  local sid="$1"
+  [ -z "$sid" ] && return 1
+  [ "${#sid}" -lt "$SESSION_ID_MIN_LEN" ] && return 1
+  [ "${#sid}" -gt "$SESSION_ID_MAX_LEN" ] && return 1
+  case "$sid" in
+    *[!A-Za-z0-9_-]*) return 1 ;;
+  esac
+  return 0
+}

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -1,46 +1,49 @@
 #!/usr/bin/env bash
 set -e
 
-# episodic-memory-hook-version: 2026-05-09.1
+# episodic-memory-hook-version: 2026-05-13.1
 # plan-gate.sh — PreToolUse hook
 #
-# Blocks write tools while .plan-approval-pending exists (at either root)
-# in the repo root. Read-only tools are always allowed (planning needs them).
+# Blocks write tools while a plan-approval marker exists for the current
+# session (per-session basename `.plan-approval-pending.<session_id>`) OR
+# while the legacy suffix-less `.plan-approval-pending` exists (burn-in
+# carry-forward). Read-only tools are always allowed.
+#
+# 2026-05-13 #268 fix: per-session namespaced markers.
+#   - Each session's plan-approval state lives at
+#       <root>/.checkpoints/.plan-approval-pending.<own-session-id>
+#   - One session's orphan no longer blocks unrelated sessions
+#   - Legacy suffix-less form still recognized for burn-in compat
+#   - F14 fail-CLOSED on missing/empty/invalid session_id IF any plan
+#     marker exists (runtime probe-drift threat is distinct from
+#     honest-agent forgery threat — see plan v6 §2)
 #
 # 2026-05-09 .checkpoints/ migration: marker WRITES go to
 # <repo-root>/.checkpoints/ via hooks/lib/marker-paths.sh; READS check
 # .checkpoints/ first then fall back to .claude/ until burn-in completes.
 # Marker REMOVAL is allowed at EITHER path during burn-in.
 #
-# Bash classification uses hooks/lib/command-classifier.sh (Session 1,
-# closes #86 PR-B). Replaces the prior regex-based marker-rm allowlist
-# with a quote/heredoc-aware classifier so quoted body text containing
-# `gh pr create` or `.plan-approval-pending` does not false-positive
-# (the `...a1e0` shape).
+# Bash classification uses hooks/lib/command-classifier.sh.
 #
-# Allowlist:
+# Allowlist (while a plan-marker exists):
 #   - Read-only tools (always)
-#   - Bash with classifier label `read_only` (#89: ls, cat, git status, etc.)
-#   - Bash that classifies as `marker_write` whose TARGET basename is
-#     .plan-approval-pending under either marker dir (deadlock prevention).
-#     Codex review ...3503: plan marker REMOVAL is the only plan-gate marker
-#     action allowed; checkpoint pre/post writes are NOT allowed by plan-gate.
-#
-# All other tool calls block while the marker exists.
+#   - Bash with classifier label `read_only`
+#   - Bash that classifies as `marker_write` whose TARGET basename
+#     matches plan_marker_basename_matches AND lives at primary or
+#     legacy marker dir (deadlock prevention — plan marker rm/touch).
 
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
+MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-# Source classifier + repo-root resolver + marker paths. Use BASH_SOURCE so
-# symlinked hook invocations resolve correctly (Codex ...3503: $(dirname
-# "$0") breaks under macOS without coreutils readlink -f).
+# Source classifier + repo-root resolver + marker paths + session-id.
+# Use BASH_SOURCE so symlinked hook invocations resolve correctly.
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 LIB_DIR="$HOOK_DIR/lib"
-if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ]; then
-  # Lib missing — fail loud rather than silently allowing
-  echo '{"decision": "block", "reason": "plan-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh). Re-run install.mjs --install-hooks."}'
+if [ ! -f "$LIB_DIR/command-classifier.sh" ] || [ ! -f "$LIB_DIR/repo-root.sh" ] || [ ! -f "$LIB_DIR/marker-paths.sh" ] || [ ! -f "$LIB_DIR/session-id.sh" ]; then
+  echo '{"decision": "block", "reason": "plan-gate.sh: hooks/lib/ not found alongside hook (need command-classifier.sh, repo-root.sh, marker-paths.sh, session-id.sh). Re-run install.mjs --install-hooks."}'
   exit 0
 fi
 # shellcheck disable=SC1091
@@ -49,24 +52,80 @@ source "$LIB_DIR/repo-root.sh"
 source "$LIB_DIR/command-classifier.sh"
 # shellcheck disable=SC1091
 source "$LIB_DIR/marker-paths.sh"
+# shellcheck disable=SC1091
+source "$LIB_DIR/session-id.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
 
-# Canonical write path (always primary). Used in the block-message reason
-# so the agent knows where to put a fresh marker if needed.
-PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
-PRIMARY_PATH="$REPO_ROOT/$PRIMARY_MARKER_DIR/.plan-approval-pending"
-LEGACY_PATH="$REPO_ROOT/$LEGACY_MARKER_DIR/.plan-approval-pending"
+# Path resolution for marker variants:
+#   LEGACY_PRIMARY: <root>/.checkpoints/.plan-approval-pending      (no sid)
+#   LEGACY_LEGACY:  <root>/.claude/.plan-approval-pending           (no sid, fallback root)
+#   SUFFIXED_PRIMARY (when sid valid): <root>/.checkpoints/.plan-approval-pending.<sid>
+#   SUFFIXED_LEGACY  (when sid valid): <root>/.claude/.plan-approval-pending.<sid>
+PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" "$PLAN_MARKER_LEGACY_BASENAME")"
+LEGACY_PRIMARY="$REPO_ROOT/$PRIMARY_MARKER_DIR/$PLAN_MARKER_LEGACY_BASENAME"
+LEGACY_LEGACY="$REPO_ROOT/$LEGACY_MARKER_DIR/$PLAN_MARKER_LEGACY_BASENAME"
 
-# Read-only tools — always allowed.
+SID_VALID=false
+SUFFIXED_PRIMARY=""
+SUFFIXED_LEGACY=""
+if validate_session_id "$MY_SID"; then
+  SID_VALID=true
+  SUFFIXED_PRIMARY="$REPO_ROOT/$PRIMARY_MARKER_DIR/$(plan_marker_basename_for_session "$MY_SID")"
+  SUFFIXED_LEGACY="$REPO_ROOT/$LEGACY_MARKER_DIR/$(plan_marker_basename_for_session "$MY_SID")"
+fi
+
+# any_plan_marker_exists — true if ANY plan marker (legacy or any suffixed)
+# exists at either root. Used for F14 fail-closed-on-invalid-sid decision.
+any_plan_marker_exists() {
+  [ -e "$LEGACY_PRIMARY" ] && return 0
+  [ -e "$LEGACY_LEGACY" ] && return 0
+  local p
+  for p in "$REPO_ROOT/$PRIMARY_MARKER_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  for p in "$REPO_ROOT/$LEGACY_MARKER_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  return 1
+}
+
+# Read-only tools — always allowed (planning needs them).
 case "$TOOL_NAME" in
   Read|Glob|Grep|Agent|WebFetch|WebSearch|AskUserQuestion|EnterPlanMode|ExitPlanMode|ListMcpResourcesTool|ReadMcpResourceTool|Skill|NotebookRead|ToolSearch|mcp__*)
     exit 0
     ;;
 esac
 
-# If no marker at either root, allow everything.
-if [ ! -e "$PRIMARY_PATH" ] && [ ! -e "$LEGACY_PATH" ]; then
+# F14 fail-closed: invalid/missing/empty session_id is a probe-drift threat
+# distinct from honest-agent forgery. If ANY plan marker exists, BLOCK with
+# a clear reason — the agent must either provide a valid session_id in
+# stdin (Claude Code does this by default) or clear the marker via
+# plan-marker.mjs --rm.
+if ! $SID_VALID; then
+  if any_plan_marker_exists; then
+    jq -nc --arg path "$PLAN_PENDING_W" \
+      '{decision: "block", reason: ("Plan approval pending; session_id missing/invalid in PreToolUse stdin — failing closed. Provide a valid session_id (PreToolUse JSON .session_id field) or clear the marker at " + $path + ". Hook: plan-gate.sh.")}'
+    exit 0
+  fi
+  # No plan marker exists → no plan to gate. Allow as today.
+  exit 0
+fi
+
+# SID_VALID: check own-session OR legacy.
+OWN_MARKER_EXISTS=false
+if [ -e "$SUFFIXED_PRIMARY" ] || [ -e "$SUFFIXED_LEGACY" ]; then
+  OWN_MARKER_EXISTS=true
+fi
+LEGACY_MARKER_EXISTS=false
+if [ -e "$LEGACY_PRIMARY" ] || [ -e "$LEGACY_LEGACY" ]; then
+  LEGACY_MARKER_EXISTS=true
+fi
+
+# No own marker AND no legacy marker → allow.
+# (Other sessions' suffixed markers `.plan-approval-pending.OTHER_SID`
+#  are intentionally ignored — that's the #268 fix.)
+if ! $OWN_MARKER_EXISTS && ! $LEGACY_MARKER_EXISTS; then
   exit 0
 fi
 
@@ -80,25 +139,22 @@ if [ "$TOOL_NAME" = "Bash" ]; then
 
   case "$LABEL" in
     read_only)
-      # #89 fix: read-only Bash should not be blocked while planning.
       exit 0
       ;;
     marker_write)
-      # Only allow exact removal/touch of the plan-approval marker at either
-      # root. Codex ...3503 P1: TARGET must equal one of the two marker
-      # paths, not any other marker. Path traversal / symlink / cwd≠repo
-      # blocked by the equality check against the resolved repo-root paths.
-      #
-      # Dual-root acceptance during burn-in: legacy `.claude/` rm targets
-      # are still allowed so cleanup of orphan markers works without flag
-      # changes.
-      if [ "$TARGET" = "$PRIMARY_PATH" ] || [ "$TARGET" = "$LEGACY_PATH" ]; then
-        exit 0
+      # Allow plan-marker rm/touch under primary or legacy marker dir.
+      # Use the strict matcher to reject path-traversal / invalid suffixes.
+      target_basename="${TARGET##*/}"
+      target_dir="${TARGET%/*}"
+      if plan_marker_basename_matches "$target_basename"; then
+        if [ "$target_dir" = "$REPO_ROOT/$PRIMARY_MARKER_DIR" ] || [ "$target_dir" = "$REPO_ROOT/$LEGACY_MARKER_DIR" ]; then
+          exit 0
+        fi
       fi
       ;;
   esac
 fi
 
-# Marker exists — block.
+# Marker exists (own session or legacy) — block.
 jq -nc --arg path "$PLAN_PENDING_W" \
   '{decision: "block", reason: ("Plan approval pending. Review the plan above and approve before implementation. To approve, say \"go\" or \"approved\". The " + $path + " marker will be removed and implementation will proceed.")}'

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -142,11 +142,15 @@ if [ "$TOOL_NAME" = "Bash" ]; then
       exit 0
       ;;
     marker_write)
-      # Allow plan-marker rm/touch under primary or legacy marker dir.
-      # Use the strict matcher to reject path-traversal / invalid suffixes.
+      # Allow plan-marker rm/touch under primary or legacy marker dir, but
+      # ONLY for THIS session's basename (legacy suffix-less OR
+      # `.plan-approval-pending.<MY_SID>`). Other-session suffixed forms
+      # are NOT allowed — that's the codex r1 BLOCKER-B1 fix: without this
+      # narrowing, session A could `rm` session B's marker via direct Bash.
       target_basename="${TARGET##*/}"
       target_dir="${TARGET%/*}"
-      if plan_marker_basename_matches "$target_basename"; then
+      own_session_basename="$(plan_marker_basename_for_session "$MY_SID")"
+      if [ "$target_basename" = "$PLAN_MARKER_LEGACY_BASENAME" ] || [ "$target_basename" = "$own_session_basename" ]; then
         if [ "$target_dir" = "$REPO_ROOT/$PRIMARY_MARKER_DIR" ] || [ "$target_dir" = "$REPO_ROOT/$LEGACY_MARKER_DIR" ]; then
           exit 0
         fi

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -23,6 +23,9 @@ import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 import {
   TASK_SIGNAL_MARKERS,
   BASELINE_NAME,
+  PRIMARY_MARKER_DIR,
+  LEGACY_MARKER_DIR,
+  PLAN_MARKER_LEGACY_BASENAME,
   primaryMarkerPath,
   legacyMarkerPath,
   resolveMarkerRead,
@@ -30,7 +33,10 @@ import {
   ensurePrimaryDir,
   bothMarkerPaths
 } from './lib/marker-paths.mjs'
-import { _maxMtimeAcrossRootsStrict } from './lib/stop-gate-helpers.mjs'
+import {
+  _maxMtimeAcrossRootsStrict,
+  _maxMtimeAcrossRootsForPlanMarkerStrict,
+} from './lib/stop-gate-helpers.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -161,6 +167,47 @@ function _maxMtimeAcrossRoots(repoRoot, basename) {
   return { mtime, hadSymlink, anyExisted }
 }
 
+// #268 fix E19: non-strict plan-marker variant for carve-out. Scans BOTH
+// legacy `.plan-approval-pending` AND any `.plan-approval-pending.<sid>`
+// at primary + legacy roots; returns max mtime across the set.
+//
+// Symmetric with _maxMtimeAcrossRoots (relaxed: lstat errors silently
+// skipped). Use this for carve-out (NON-fail-closed) sites; for stop-gate
+// fail-closed sites use _maxMtimeAcrossRootsForPlanMarkerStrict from
+// stop-gate-helpers.mjs.
+function _maxMtimeAcrossRootsForPlanMarker(repoRoot) {
+  let mtime = -Infinity
+  let hadSymlink = false
+  let anyExisted = false
+  for (const p of [
+    primaryMarkerPath(repoRoot, PLAN_MARKER_LEGACY_BASENAME),
+    legacyMarkerPath(repoRoot, PLAN_MARKER_LEGACY_BASENAME),
+  ]) {
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) { hadSymlink = true; continue }
+      anyExisted = true
+      if (st.mtimeMs > mtime) mtime = st.mtimeMs
+    } catch {}
+  }
+  const prefix = `${PLAN_MARKER_LEGACY_BASENAME}.`
+  for (const dir of [path.join(repoRoot, PRIMARY_MARKER_DIR), path.join(repoRoot, LEGACY_MARKER_DIR)]) {
+    let entries
+    try { entries = fs.readdirSync(dir) } catch { continue }
+    for (const name of entries) {
+      if (!name.startsWith(prefix)) continue
+      const p = path.join(dir, name)
+      try {
+        const st = fs.lstatSync(p)
+        if (st.isSymbolicLink()) { hadSymlink = true; continue }
+        anyExisted = true
+        if (st.mtimeMs > mtime) mtime = st.mtimeMs
+      } catch {}
+    }
+  }
+  return { mtime, hadSymlink, anyExisted }
+}
+
 function stopGateCarveOutApplies(repoRoot) {
   const base = _maxMtimeAcrossRoots(repoRoot, BASELINE_NAME)
   if (base.hadSymlink) return false
@@ -168,7 +215,10 @@ function stopGateCarveOutApplies(repoRoot) {
   const baselineMtime = base.mtime
 
   for (const name of TASK_SIGNAL_MARKERS) {
-    const m = _maxMtimeAcrossRoots(repoRoot, name)
+    // #268 fix E19: plan-marker member glob-expands suffixed forms.
+    const m = (name === PLAN_MARKER_LEGACY_BASENAME)
+      ? _maxMtimeAcrossRootsForPlanMarker(repoRoot)
+      : _maxMtimeAcrossRoots(repoRoot, name)
     // Symlink at either root → fail closed.
     if (m.hadSymlink) return false
     // Marker absent at both roots → no signal; skip.
@@ -211,7 +261,9 @@ if (gateFlag === 'stop') {
   // stop-gate stepping aside is the deadlock-break. The exemption fires
   // EVEN when other TASK_SIGNAL_MARKERS (.checkpoint-required,
   // .post-checkpoint-required) are also active — see test 5.13.
-  const planPending = _maxMtimeAcrossRootsStrict(REPO_ROOT, '.plan-approval-pending')
+  // #268 fix E19: plan-pending deferral fires for ANY plan-marker variant
+  // (legacy literal OR any suffixed) — own session or other.
+  const planPending = _maxMtimeAcrossRootsForPlanMarkerStrict(REPO_ROOT)
   const baseStrict = _maxMtimeAcrossRootsStrict(REPO_ROOT, BASELINE_NAME)
   if (
     planPending.anyExisted && !planPending.hadSymlink && !planPending.hadOtherError &&
@@ -585,6 +637,28 @@ if (sessionStartFlag) {
 
     if (priorBaselineMtime !== null) {
       for (const name of TASK_SIGNAL_MARKERS) {
+        // #268 fix E20: plan-marker member glob-expands suffixed forms.
+        // Sweep legacy `.plan-approval-pending` + every `.plan-approval-pending.<sid>`
+        // at both roots whose mtime <= prior baseline (stale orphan).
+        if (name === PLAN_MARKER_LEGACY_BASENAME) {
+          const prefix = `${PLAN_MARKER_LEGACY_BASENAME}.`
+          for (const dir of [path.join(REPO_ROOT, PRIMARY_MARKER_DIR), path.join(REPO_ROOT, LEGACY_MARKER_DIR)]) {
+            let entries = []
+            try { entries = fs.readdirSync(dir) } catch { continue }
+            for (const e of entries) {
+              if (e !== PLAN_MARKER_LEGACY_BASENAME && !e.startsWith(prefix)) continue
+              const p = path.join(dir, e)
+              try {
+                const st = fs.lstatSync(p)
+                if (st.isSymbolicLink()) continue
+                if (st.mtimeMs <= priorBaselineMtime) {
+                  fs.rmSync(p, { force: true })
+                }
+              } catch {}
+            }
+          }
+          continue
+        }
         for (const p of bothMarkerPaths(REPO_ROOT, name)) {
           try {
             const st = fs.lstatSync(p)

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -16,7 +16,15 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveRepoRoot } from './lib/local-dir.mjs'
-import { ALL_MIGRATED_MARKERS, bothMarkerPaths } from './lib/marker-paths.mjs'
+import {
+  ALL_MIGRATED_MARKERS,
+  PLAN_MARKER_LEGACY_BASENAME,
+  bothMarkerPaths,
+  planMarkerBasenameForSession,
+  primaryMarkerPath,
+  legacyMarkerPath,
+} from './lib/marker-paths.mjs'
+import { validateSessionId } from './lib/session-id.mjs'
 
 // ---------------------------------------------------------------------------
 // Load known patterns from _index.json
@@ -50,8 +58,49 @@ function loadPatternsIndex() {
 // (em-recall) and the hooks (hooks/lib/repo-root.sh) target — a worktree-cwd
 // would otherwise sweep an empty worktree-local marker dir while leaving
 // the real markers stranded at the main repo root. Closes #106.
+//
+// #268 fix F12 (codex r1 F1): plan-approval-pending cleanup is OWN-SESSION-ONLY.
+// SessionEnd hooks receive stdin JSON {session_id, ...}. We:
+//   1. Read stdin if available, extract session_id, validate.
+//   2. SKIP `.plan-approval-pending` (legacy literal) from the cleanup loop —
+//      legacy is read-only-during-burn-in per plan v6 F3 (cleared only by
+//      SessionStart orphan sweep with mtime check).
+//   3. If sid valid: also rm `.plan-approval-pending.<own-sid>` at both roots.
+//   4. If sid invalid/missing: skip plan-marker cleanup entirely.
+// Other ALL_MIGRATED_MARKERS members are unchanged (per-session by nature).
+//
+// This prevents the bug class where session B's SessionEnd would delete
+// session A's active `.plan-approval-pending.A` marker.
+
+// Read SessionEnd stdin (best-effort; non-blocking-safe via readFileSync(0)).
+let sessionEndSid = null
+try {
+  const stdinData = fs.readFileSync(0, 'utf8')
+  if (stdinData) {
+    const stdinJson = JSON.parse(stdinData)
+    if (stdinJson && typeof stdinJson.session_id === 'string') {
+      sessionEndSid = stdinJson.session_id
+    }
+  }
+} catch { /* best-effort; stdin missing/non-JSON → null sid */ }
+
 const repoRoot = resolveRepoRoot()
 for (const marker of ALL_MIGRATED_MARKERS) {
+  if (marker === PLAN_MARKER_LEGACY_BASENAME) {
+    // F12: never delete legacy plan-marker on SessionEnd.
+    if (validateSessionId(sessionEndSid)) {
+      // Own-session suffixed marker only.
+      const ownBasename = planMarkerBasenameForSession(sessionEndSid)
+      for (const p of [
+        primaryMarkerPath(repoRoot, ownBasename),
+        legacyMarkerPath(repoRoot, ownBasename),
+      ]) {
+        try { fs.unlinkSync(p) } catch {}
+      }
+    }
+    // sid invalid → skip plan-marker cleanup entirely; orphan-sweep handles it.
+    continue
+  }
   for (const p of bothMarkerPaths(repoRoot, marker)) {
     try { fs.unlinkSync(p) } catch {}
   }

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -73,7 +73,12 @@ function loadPatternsIndex() {
 // session A's active `.plan-approval-pending.A` marker.
 
 // Read SessionEnd stdin (best-effort; non-blocking-safe via readFileSync(0)).
+// Codex code-tier r1 BLOCKER-B2 fix: extract BOTH session_id AND cwd from
+// stdin. The hook target's cwd is the project the SessionEnd applies to;
+// using process.cwd() would bind cleanup to the caller, which is wrong
+// for linked-worktree / nested-cwd invocations.
 let sessionEndSid = null
+let sessionEndCwd = null
 try {
   const stdinData = fs.readFileSync(0, 'utf8')
   if (stdinData) {
@@ -81,10 +86,17 @@ try {
     if (stdinJson && typeof stdinJson.session_id === 'string') {
       sessionEndSid = stdinJson.session_id
     }
+    if (stdinJson && typeof stdinJson.cwd === 'string') {
+      sessionEndCwd = stdinJson.cwd
+    }
   }
-} catch { /* best-effort; stdin missing/non-JSON → null sid */ }
+} catch { /* best-effort; stdin missing/non-JSON → null sid + cwd */ }
 
-const repoRoot = resolveRepoRoot()
+// Pass stdin.cwd to resolveRepoRoot so cleanup binds to the hook target
+// project, not the caller cwd. Use `|| undefined` so null/empty falls
+// through to resolveRepoRoot's default-arg (process.cwd()) for manual
+// interactive runs without stdin.
+const repoRoot = resolveRepoRoot(sessionEndCwd || undefined)
 for (const marker of ALL_MIGRATED_MARKERS) {
   if (marker === PLAN_MARKER_LEGACY_BASENAME) {
     // F12: never delete legacy plan-marker on SessionEnd.

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -131,3 +131,123 @@ export function bothMarkerPaths(repoRoot, basename) {
 export function ensurePrimaryDir(repoRoot) {
   fs.mkdirSync(path.join(repoRoot, PRIMARY_MARKER_DIR), { recursive: true })
 }
+
+// ---------------------------------------------------------------------------
+// #268 fix — per-session .plan-approval-pending marker contract.
+//
+// Canonical (new):   .plan-approval-pending.<session_id>     (per-session)
+// Legacy (burn-in):  .plan-approval-pending                  (suffix-less)
+//
+// Both forms accepted by readers/gates during burn-in. Helper writes only
+// the suffixed form. SessionStart orphan-sweep clears both. SessionEnd
+// own-session-only deletes the suffixed form for the ending session.
+//
+// Shell parity: hooks/lib/marker-paths.sh PLAN_MARKER_*. Drift caught by
+// scripts/validate-plan-marker-sites.mjs Direction 0.
+// ---------------------------------------------------------------------------
+
+export const PLAN_MARKER_LEGACY_BASENAME = '.plan-approval-pending'
+export const PLAN_MARKER_BASENAME_TEMPLATE = '.plan-approval-pending.{sid}'
+export const PLAN_MARKER_BASENAME_RE = /^\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?$/
+
+/**
+ * Strict match for plan-marker basenames. Accepts ONLY:
+ *   .plan-approval-pending                          (legacy suffix-less)
+ *   .plan-approval-pending.<sid>                    (sid matches char-class + length)
+ * Rejects:
+ *   .plan-approval-pending-extra                    (suffix without dot separator)
+ *   .plan-approval-pending.                         (empty suffix)
+ *   .plan-approval-pending./traversal               (slash in suffix)
+ *   .plan-approval-pending..                        (dot in suffix)
+ *   .plan-approval-pending.<129-char>               (oversize suffix)
+ *
+ * Mirrors hooks/lib/marker-paths.sh plan_marker_basename_matches().
+ *
+ * @param {string} basename
+ * @returns {boolean}
+ */
+export function planMarkerBasenameMatches(basename) {
+  return typeof basename === 'string' && PLAN_MARKER_BASENAME_RE.test(basename)
+}
+
+/**
+ * Compose the per-session plan-marker basename for a given session id.
+ * Caller MUST validateSessionId(sid) first; this helper does not re-validate.
+ *
+ * @param {string} sid — valid session-id (matches SESSION_ID_RE)
+ * @returns {string} '.plan-approval-pending.<sid>'
+ */
+export function planMarkerBasenameForSession(sid) {
+  return PLAN_MARKER_BASENAME_TEMPLATE.replace('{sid}', sid)
+}
+
+// ---------------------------------------------------------------------------
+// Enforcement-site registry — single source of truth for the validator.
+//
+// Every place in the codebase that recognizes, gates, iterates, or otherwise
+// acts on `.plan-approval-pending` is registered here with:
+//   - file:    relative path from repo root
+//   - line:    target line number (validator reads ±20 lines for site span)
+//   - role:    human-readable description
+//   - kind:    semantic-test category (see Direction 1 in validator)
+//   - semantic_role: one of {read-own-session, read-any, sweep-stale,
+//                            remove-own-session, write-own-session, decoupled}
+//
+// Lifecycle: line numbers may drift after edits. The validator uses
+// `role` + content-shape regex as the canonical lookup, with line as a hint.
+// Any unregistered code reference to `.plan-approval-pending` outside test/
+// doc/comment context → CI fails via validate-plan-marker-sites.mjs D2.
+// ---------------------------------------------------------------------------
+
+export const PLAN_MARKER_ENFORCEMENT_SITES = [
+  // E1-E5: classifier basename allowlists (5 case-arms in command-classifier.sh).
+  // Each routes shell verb (rm/redirect/tee/touch) + classify_path through
+  // marker_write classification when target matches plan-marker basename.
+  { file: 'hooks/lib/command-classifier.sh', line: 516, role: 'rm-target basename allowlist', kind: 'shell-case', semantic_role: 'read-any' },
+  { file: 'hooks/lib/command-classifier.sh', line: 640, role: 'redirect-target basename allowlist', kind: 'shell-case', semantic_role: 'read-any' },
+  { file: 'hooks/lib/command-classifier.sh', line: 685, role: 'tee-target basename allowlist', kind: 'shell-case', semantic_role: 'read-any' },
+  { file: 'hooks/lib/command-classifier.sh', line: 725, role: 'touch-target basename allowlist', kind: 'shell-case', semantic_role: 'read-any' },
+  { file: 'hooks/lib/command-classifier.sh', line: 1310, role: 'classify_path marker_write basename', kind: 'shell-case', semantic_role: 'read-any' },
+
+  // E5b: classifier helper-invocation recognition (NEW in #268 fix commit 6).
+  // F17+F18 reject leading POSIX-name env assignment before classifying as marker_write.
+  { file: 'hooks/lib/command-classifier.sh', line: 0, role: 'plan-marker.mjs helper invocation classification (F13+F17+F18)', kind: 'shell-case-helper-invocation-strict', semantic_role: 'read-own-session' },
+
+  // E6-E9: checkpoint-gate.sh detector patterns/predicates (4 sites).
+  { file: 'hooks/checkpoint-gate.sh', line: 99, role: 'marker_basename_for_target exact-equality', kind: 'shell-equality', semantic_role: 'read-any' },
+  { file: 'hooks/checkpoint-gate.sh', line: 120, role: '_marker_basename_in_set closed set', kind: 'shell-case', semantic_role: 'read-any' },
+  { file: 'hooks/checkpoint-gate.sh', line: 196, role: '_command_has_relative_marker_path grep-E alternation', kind: 'grep-E-alternation', semantic_role: 'read-any' },
+  { file: 'hooks/checkpoint-gate.sh', line: 213, role: '_command_first_absolute_noncanonical grep-oE alternation', kind: 'grep-E-alternation', semantic_role: 'read-any' },
+
+  // E10: plan-gate.sh existence check + marker_write allowlist.
+  { file: 'hooks/plan-gate.sh', line: 57, role: 'PLAN_PENDING_W resolution + existence check + marker_write allowlist (session-aware after #268 fix)', kind: 'shell-equality', semantic_role: 'read-own-session' },
+
+  // E11: scripts/em-recall.mjs TASK_SIGNAL_MARKERS array literal (consumer).
+  { file: 'scripts/em-recall.mjs', line: 97, role: 'TASK_SIGNAL_MARKERS array literal (consumer)', kind: 'js-array', semantic_role: 'read-any' },
+
+  // E12: scripts/em-audit-compliance.mjs compliance regex.
+  { file: 'scripts/em-audit-compliance.mjs', line: 111, role: 'compliance audit regex (\\.plan-approval-pending\\b accepts both forms)', kind: 'js-regex', semantic_role: 'read-any' },
+
+  // E13: NEW plan_marker_exists_for_session helper definition (checkpoint-gate.sh).
+  { file: 'hooks/checkpoint-gate.sh', line: 82, role: 'plan_marker_exists_for_session helper definition (NEW in #268 fix)', kind: 'shell-function', semantic_role: 'read-own-session' },
+
+  // E14, E15, E17: cross-gate decision call-sites in checkpoint-gate.sh (3 sites).
+  // Swap `marker_exists .plan-approval-pending` → `plan_marker_exists_for_session "$MY_SID"`.
+  { file: 'hooks/checkpoint-gate.sh', line: 376, role: 'cross-gate plan-pending check (Bash marker_write branch)', kind: 'shell-predicate-call', semantic_role: 'read-own-session' },
+  { file: 'hooks/checkpoint-gate.sh', line: 436, role: 'cross-gate plan-pending check (Write/Edit branch)', kind: 'shell-predicate-call', semantic_role: 'read-own-session' },
+  { file: 'hooks/checkpoint-gate.sh', line: 481, role: 'push-gate plan-pending cleanup guard', kind: 'shell-predicate-call', semantic_role: 'read-own-session' },
+
+  // E16, E18: decoupled gate sites (DIFFERENT markers; validator asserts no coupling).
+  { file: 'hooks/checkpoint-gate.sh', line: 459, role: 'pre-checkpoint gate (.checkpoint-required — DIFFERENT marker)', kind: 'shell-decoupled', semantic_role: 'decoupled' },
+  { file: 'hooks/checkpoint-gate.sh', line: 497, role: 'pre→post arming gate (.checkpoint-required — DIFFERENT marker)', kind: 'shell-decoupled', semantic_role: 'decoupled' },
+
+  // E19-E20: em-recall.mjs iteration consumers.
+  { file: 'scripts/em-recall.mjs', line: 170, role: 'TASK_SIGNAL_MARKERS carve-out loop (glob-expands suffixed forms)', kind: 'js-array-iter', semantic_role: 'read-any' },
+  { file: 'scripts/em-recall.mjs', line: 587, role: 'TASK_SIGNAL_MARKERS orphan-clear sweep (glob-expands suffixed forms)', kind: 'js-array-iter', semantic_role: 'sweep-stale' },
+
+  // E21: em-session-end-prompt.mjs own-session-only delete (F12 — codex r1 F1 fold).
+  { file: 'scripts/em-session-end-prompt.mjs', line: 19, role: 'SessionEnd cleanup (own-session-only — F12)', kind: 'js-array-iter-own-session', semantic_role: 'remove-own-session' },
+
+  // E22: command-classifier.sh push-cleanup loop (DECOUPLED — plan-pending not in CHECKPOINT_CLEANUP_MARKERS).
+  { file: 'hooks/lib/command-classifier.sh', line: 482, role: 'push-cleanup loop over CHECKPOINT_CLEANUP_MARKERS (REFERENCE — plan-pending intentionally excluded)', kind: 'shell-loop-decoupled', semantic_role: 'decoupled' },
+]

--- a/scripts/lib/marker-root-validation.mjs
+++ b/scripts/lib/marker-root-validation.mjs
@@ -1,0 +1,73 @@
+/**
+ * marker-root-validation.mjs — Shared --root flag validation for marker
+ * helper scripts.
+ *
+ * Extracted from scripts/preflight-marker-write.mjs validateRoot() for
+ * reuse by scripts/plan-marker.mjs (#268 fix). Same semantics:
+ *
+ *   1. --root MUST be provided (no implicit cwd fallback)
+ *   2. --root MUST be absolute
+ *   3. canonicalize via canonicalize-path-tolerant.mjs (symlink-aware)
+ *   4. canonical path MUST exist as a directory
+ *   5. canonical path MUST have a repo signal (.git OR .checkpoints
+ *      OR .episodic-memory) — refusing without a signal prevents
+ *      writing markers into arbitrary user directories
+ *
+ * Throws RootValidationError on any failure with .code ∈ {4, 5}.
+ * Callers map .code to process.exit(code).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { canonicalizePathTolerant } from './canonicalize-path-tolerant.mjs'
+
+export const REPO_SIGNALS = ['.git', '.checkpoints', '.episodic-memory']
+
+export class RootValidationError extends Error {
+  constructor(code, message) {
+    super(message)
+    this.code = code
+    this.name = 'RootValidationError'
+  }
+}
+
+/**
+ * Validate --root argument. Returns canonical absolute path on success.
+ * Throws RootValidationError on failure.
+ *
+ * @param {string|null|undefined} rootArg — the --root flag value
+ * @returns {string} canonical absolute directory path
+ * @throws {RootValidationError} with .code 4 (missing) or 5 (invalid)
+ */
+export function validateRoot(rootArg) {
+  if (!rootArg) {
+    throw new RootValidationError(4, 'ROOT_REQUIRED: --root <abs> is mandatory; no cwd fallback')
+  }
+  if (!path.isAbsolute(rootArg)) {
+    throw new RootValidationError(5, `ROOT_INVALID: --root must be absolute, got: ${rootArg}`)
+  }
+
+  let canonical
+  try {
+    canonical = canonicalizePathTolerant(rootArg, process.cwd())
+  } catch (e) {
+    throw new RootValidationError(5, `ROOT_INVALID: canonicalization failed: ${e.message}`)
+  }
+
+  let stat
+  try {
+    stat = fs.statSync(canonical)
+  } catch (e) {
+    throw new RootValidationError(5, `ROOT_INVALID: ${canonical} does not exist (${e.code})`)
+  }
+  if (!stat.isDirectory()) {
+    throw new RootValidationError(5, `ROOT_INVALID: ${canonical} is not a directory`)
+  }
+
+  const hasSignal = REPO_SIGNALS.some((s) => fs.existsSync(path.join(canonical, s)))
+  if (!hasSignal) {
+    throw new RootValidationError(5, `ROOT_NOT_REPO: ${canonical} has none of [${REPO_SIGNALS.join(', ')}]`)
+  }
+
+  return canonical
+}

--- a/scripts/lib/session-id.mjs
+++ b/scripts/lib/session-id.mjs
@@ -1,0 +1,34 @@
+/**
+ * session-id.mjs — Shared session-id validation.
+ *
+ * Extracted from scripts/preflight-marker-write.mjs for reuse by
+ * scripts/plan-marker.mjs (#268 fix). Both helpers need identical
+ * session-id validation semantics; centralizing prevents drift.
+ *
+ * Char-class: [A-Za-z0-9_-], length 1..128. No dots (could collide
+ * with `.json` suffix in last-user-prompt files), no slashes (path
+ * traversal). Claude Code session IDs are UUIDs (hyphenated hex)
+ * which match this regex; other tools using other id shapes must
+ * conform.
+ *
+ * Shell parity: hooks/lib/session-id.sh validate_session_id() must
+ * mirror this regex. Drift caught by validate-plan-marker-sites.mjs
+ * Direction 0.
+ */
+
+export const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
+export const SESSION_ID_CHARCLASS = 'A-Za-z0-9_-'
+export const SESSION_ID_MIN_LEN = 1
+export const SESSION_ID_MAX_LEN = 128
+
+/**
+ * Returns true iff sid is a valid session-id (non-empty string matching
+ * the char-class + length bounds). Use this in helper scripts before
+ * constructing per-session marker paths.
+ *
+ * @param {unknown} sid
+ * @returns {boolean}
+ */
+export function validateSessionId(sid) {
+  return typeof sid === 'string' && SESSION_ID_RE.test(sid)
+}

--- a/scripts/lib/stop-gate-helpers.mjs
+++ b/scripts/lib/stop-gate-helpers.mjs
@@ -18,7 +18,14 @@
  */
 
 import fs from 'fs'
-import { primaryMarkerPath, legacyMarkerPath } from './marker-paths.mjs'
+import path from 'path'
+import {
+  PRIMARY_MARKER_DIR,
+  LEGACY_MARKER_DIR,
+  PLAN_MARKER_LEGACY_BASENAME,
+  primaryMarkerPath,
+  legacyMarkerPath,
+} from './marker-paths.mjs'
 
 export function _maxMtimeAcrossRootsStrict(repoRoot, basename) {
   let mtime = -Infinity
@@ -35,5 +42,64 @@ export function _maxMtimeAcrossRootsStrict(repoRoot, basename) {
       if (e && e.code !== 'ENOENT') hadOtherError = true
     }
   }
+  return { mtime, hadSymlink, anyExisted, hadOtherError }
+}
+
+// #268 fix E19/E20: strict-lstat helper for plan-marker that scans BOTH
+// legacy `.plan-approval-pending` AND any `.plan-approval-pending.<sid>`
+// at primary + legacy roots. Mtime is the MAX across the entire set —
+// stop-gate's plan-pending deferral fires if ANY plan-marker (own session
+// or other) is active mid-session.
+//
+// Same fail-closed semantics as the base strict helper:
+//   - hadSymlink on any matched symlink (caller fails closed)
+//   - hadOtherError on any non-ENOENT lstat / readdir error
+export function _maxMtimeAcrossRootsForPlanMarkerStrict(repoRoot) {
+  let mtime = -Infinity
+  let hadSymlink = false
+  let anyExisted = false
+  let hadOtherError = false
+
+  // Legacy literal at both roots (same as _maxMtimeAcrossRootsStrict for
+  // PLAN_MARKER_LEGACY_BASENAME).
+  for (const p of [
+    primaryMarkerPath(repoRoot, PLAN_MARKER_LEGACY_BASENAME),
+    legacyMarkerPath(repoRoot, PLAN_MARKER_LEGACY_BASENAME),
+  ]) {
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) { hadSymlink = true; continue }
+      anyExisted = true
+      if (st.mtimeMs > mtime) mtime = st.mtimeMs
+    } catch (e) {
+      if (e && e.code !== 'ENOENT') hadOtherError = true
+    }
+  }
+
+  // Glob-expand `.plan-approval-pending.<*>` at both roots.
+  const prefix = `${PLAN_MARKER_LEGACY_BASENAME}.`
+  for (const dir of [path.join(repoRoot, PRIMARY_MARKER_DIR), path.join(repoRoot, LEGACY_MARKER_DIR)]) {
+    let entries
+    try {
+      entries = fs.readdirSync(dir)
+    } catch (e) {
+      // ENOENT on the dir itself is fine (no markers); other → fail-closed.
+      if (e && e.code !== 'ENOENT') hadOtherError = true
+      continue
+    }
+    for (const name of entries) {
+      if (!name.startsWith(prefix)) continue
+      const p = path.join(dir, name)
+      try {
+        const st = fs.lstatSync(p)
+        if (st.isSymbolicLink()) { hadSymlink = true; continue }
+        anyExisted = true
+        if (st.mtimeMs > mtime) mtime = st.mtimeMs
+      } catch (e) {
+        if (e && e.code !== 'ENOENT') hadOtherError = true
+      }
+    }
+  }
+
   return { mtime, hadSymlink, anyExisted, hadOtherError }
 }

--- a/scripts/plan-marker.mjs
+++ b/scripts/plan-marker.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * plan-marker.mjs — Per-session .plan-approval-pending marker helper.
+ *
+ * Issue #268: cross-session .plan-approval-pending orphan markers block
+ * unrelated sessions. This helper writes / removes per-session markers
+ * `.plan-approval-pending.<session_id>` so each session's plan-gate state
+ * is filename-isolated.
+ *
+ * Modeled on scripts/preflight-marker-write.mjs (same canonicalization,
+ * same atomic temp+rename, same exit-code semantics). Shares the
+ * extracted libs:
+ *   - scripts/lib/session-id.mjs           SESSION_ID_RE + validateSessionId
+ *   - scripts/lib/marker-root-validation.mjs validateRoot + RootValidationError
+ *   - scripts/lib/marker-paths.mjs         primaryMarkerPath / legacyMarkerPath /
+ *                                          planMarkerBasenameForSession
+ *
+ * Usage:
+ *   node ~/.episodic-memory/scripts/plan-marker.mjs --touch --root <abs>
+ *   node ~/.episodic-memory/scripts/plan-marker.mjs --rm    --root <abs>
+ *
+ * Session-id source: process.env.CLAUDE_CODE_SESSION_ID (probed exposed
+ * to Bash subprocesses 2026-05-13). NO file-based source-of-truth (the
+ * `.current-session-id` file design from plan v1 was deleted after
+ * planner Class C1 caught the cross-session race).
+ *
+ * --touch:
+ *   1. Read CLAUDE_CODE_SESSION_ID; FAIL exit 8 if empty/unset/invalid
+ *   2. validateRoot(--root)
+ *   3. Atomic write empty file at <root>/.checkpoints/.plan-approval-pending.<sid>
+ *
+ * --rm (F3 narrowed semantics, per codex r1 F1 fold):
+ *   1. Same env + root validation
+ *   2. rm ONLY `.plan-approval-pending.<MY_SID>` at primary + legacy roots
+ *   3. NEVER touches bare suffix-less `.plan-approval-pending` — that's
+ *      reserved for burn-in compat from sessions still using the pre-v6
+ *      Rule 8 fallback. Legacy is read-only-during-burn-in; cleared only
+ *      by SessionStart orphan sweep (em-recall.mjs).
+ *
+ * Exit codes (matches preflight-marker-write convention):
+ *   0 — success; stdout is JSON {status:"ok", path|removed, sid}
+ *   3 — fs write/rename/unlink failed
+ *   4 — --root missing (no implicit cwd fallback)
+ *   5 — --root invalid (non-abs / non-existent / non-dir / no repo signal)
+ *   6 — --touch/--rm mutex violation (both set, or neither set, or unknown arg)
+ *   8 — CLAUDE_CODE_SESSION_ID missing/empty/invalid
+ */
+
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
+
+import {
+  ensurePrimaryDir,
+  primaryMarkerPath,
+  legacyMarkerPath,
+  planMarkerBasenameForSession,
+} from './lib/marker-paths.mjs'
+import { SESSION_ID_RE, validateSessionId } from './lib/session-id.mjs'
+import { validateRoot, RootValidationError } from './lib/marker-root-validation.mjs'
+
+function fail(code, message) {
+  process.stderr.write(`plan-marker: ${message}\n`)
+  process.exit(code)
+}
+
+function parseArgs(argv) {
+  const args = { root: null, touch: false, rm: false }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--root') {
+      args.root = argv[++i]
+    } else if (a === '--touch') {
+      args.touch = true
+    } else if (a === '--rm') {
+      args.rm = true
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        'Usage: plan-marker.mjs (--touch | --rm) --root <abs>\n' +
+        '  Session-id read from CLAUDE_CODE_SESSION_ID env var.\n' +
+        '  Exit codes: 0 ok / 3 fs / 4 root-missing / 5 root-invalid / 6 mutex / 8 sid-invalid\n'
+      )
+      process.exit(0)
+    } else {
+      fail(6, `unknown argument: ${a}`)
+    }
+  }
+  return args
+}
+
+function getSessionIdOrExit() {
+  const sid = process.env.CLAUDE_CODE_SESSION_ID
+  if (sid === undefined || sid === null || sid === '') {
+    fail(8, 'SESSION_ID_REQUIRED: CLAUDE_CODE_SESSION_ID env var missing or empty')
+  }
+  if (!validateSessionId(sid)) {
+    fail(8, `SESSION_ID_INVALID: must match ${SESSION_ID_RE.source}, got: ${JSON.stringify(sid)}`)
+  }
+  return sid
+}
+
+function validateRootOrExit(rootArg) {
+  try {
+    return validateRoot(rootArg)
+  } catch (e) {
+    if (e instanceof RootValidationError) fail(e.code, e.message)
+    throw e
+  }
+}
+
+function actionTouch(canonicalRoot, sid) {
+  ensurePrimaryDir(canonicalRoot)
+  const basename = planMarkerBasenameForSession(sid)
+  const finalPath = primaryMarkerPath(canonicalRoot, basename)
+
+  // Unique temp name in same dir → rename(2) atomic on same filesystem.
+  const hr = process.hrtime.bigint().toString()
+  const tempName = `.${basename}.${process.pid}.${hr}.tmp`
+  const tempPath = path.join(canonicalRoot, '.checkpoints', tempName)
+
+  let cleanupTemp = true
+  const onSig = (signal) => {
+    if (cleanupTemp) {
+      try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
+    }
+    process.exit(signal === 'SIGINT' ? 130 : 143)
+  }
+  process.on('SIGINT', () => onSig('SIGINT'))
+  process.on('SIGTERM', () => onSig('SIGTERM'))
+
+  try {
+    fs.writeFileSync(tempPath, '')
+    fs.renameSync(tempPath, finalPath)
+    cleanupTemp = false
+  } catch (e) {
+    try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
+    fail(3, `WRITE_FAILED: ${e.message}`)
+  }
+
+  process.stdout.write(JSON.stringify({ status: 'ok', path: finalPath, sid }) + '\n')
+  process.exit(0)
+}
+
+function actionRm(canonicalRoot, sid) {
+  // F3 narrowed: rm ONLY the SUFFIXED form at primary + legacy roots.
+  // Bare suffix-less `.plan-approval-pending` is never touched — its
+  // lifecycle is owned by SessionStart orphan-sweep during burn-in.
+  const basename = planMarkerBasenameForSession(sid)
+  const primary = primaryMarkerPath(canonicalRoot, basename)
+  const legacy = legacyMarkerPath(canonicalRoot, basename)
+  const removed = []
+
+  for (const p of [primary, legacy]) {
+    try {
+      fs.unlinkSync(p)
+      removed.push(p)
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        fail(3, `RM_FAILED: ${e.message} (${p})`)
+      }
+      // ENOENT is fine — idempotent rm.
+    }
+  }
+
+  process.stdout.write(JSON.stringify({ status: 'ok', removed, sid }) + '\n')
+  process.exit(0)
+}
+
+function main() {
+  const { root, touch, rm } = parseArgs(process.argv)
+
+  if (touch && rm) {
+    fail(6, 'MUTEX_VIOLATION: cannot specify both --touch and --rm')
+  }
+  if (!touch && !rm) {
+    fail(6, 'MISSING_ACTION: specify exactly one of --touch or --rm')
+  }
+
+  const sid = getSessionIdOrExit()
+  const canonicalRoot = validateRootOrExit(root)
+
+  if (touch) {
+    actionTouch(canonicalRoot, sid)
+  } else {
+    actionRm(canonicalRoot, sid)
+  }
+}
+
+main()

--- a/scripts/preflight-marker-write.mjs
+++ b/scripts/preflight-marker-write.mjs
@@ -60,7 +60,8 @@ import path from 'path'
 import process from 'process'
 
 import { ensurePrimaryDir, primaryMarkerPath } from './lib/marker-paths.mjs'
-import { canonicalizePathTolerant } from './lib/canonicalize-path-tolerant.mjs'
+import { SESSION_ID_RE } from './lib/session-id.mjs'
+import { validateRoot, RootValidationError } from './lib/marker-root-validation.mjs'
 
 // preflight target → fixed basename; last-prompt target → suffix template
 // where {sid} is substituted with the validated --session-id value.
@@ -69,11 +70,9 @@ const VALID_TARGETS = {
   'last-prompt': { kind: 'session', template: '.last-user-prompt.{sid}.json' }
 }
 
-// session_id format: alphanumeric, underscore, dash. No dots (could collide
-// with the `.json` suffix), no slashes (path traversal), length-capped.
-// Claude Code session IDs are UUIDs (hyphenated hex); this regex covers
-// them while rejecting anything that could escape the basename.
-const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
+// SESSION_ID_RE imported from ./lib/session-id.mjs (shared with plan-marker.mjs
+// per #268 fix). Char-class: [A-Za-z0-9_-], length 1..128. No dots (could
+// collide with the `.json` suffix), no slashes (path traversal).
 
 function fail(code, message) {
   process.stderr.write(`preflight-marker-write: ${message}\n`)
@@ -118,36 +117,15 @@ function resolveBasename(target, sessionId) {
   return spec.template.replace('{sid}', sessionId)
 }
 
-function validateRoot(rootArg) {
-  if (!rootArg) fail(4, 'ROOT_REQUIRED: --root <abs> is mandatory; no cwd fallback')
-  if (!path.isAbsolute(rootArg)) fail(5, `ROOT_INVALID: --root must be absolute, got: ${rootArg}`)
-
-  let canonical
+// validateRoot extracted to ./lib/marker-root-validation.mjs (#268 fix).
+// Helper wraps the throwing API so callers retain fail()-based exit semantics.
+function validateRootOrExit(rootArg) {
   try {
-    canonical = canonicalizePathTolerant(rootArg, process.cwd())
+    return validateRoot(rootArg)
   } catch (e) {
-    fail(5, `ROOT_INVALID: canonicalization failed: ${e.message}`)
+    if (e instanceof RootValidationError) fail(e.code, e.message)
+    throw e
   }
-
-  let stat
-  try {
-    stat = fs.statSync(canonical)
-  } catch (e) {
-    fail(5, `ROOT_INVALID: ${canonical} does not exist (${e.code})`)
-  }
-  if (!stat.isDirectory()) fail(5, `ROOT_INVALID: ${canonical} is not a directory`)
-
-  // Repo signal: must contain .git OR .checkpoints OR .episodic-memory.
-  // Any one is sufficient — the project may have any subset depending on
-  // initialization state. Refusing without a signal prevents writing markers
-  // into arbitrary user directories.
-  const signals = ['.git', '.checkpoints', '.episodic-memory']
-  const hasSignal = signals.some((s) => fs.existsSync(path.join(canonical, s)))
-  if (!hasSignal) {
-    fail(5, `ROOT_NOT_REPO: ${canonical} has none of [${signals.join(', ')}]`)
-  }
-
-  return canonical
 }
 
 function readStdinSync() {
@@ -165,7 +143,7 @@ function main() {
     fail(6, `TARGET_INVALID: ${target}; valid: ${Object.keys(VALID_TARGETS).join(', ')}`)
   }
 
-  const canonicalRoot = validateRoot(root)
+  const canonicalRoot = validateRootOrExit(root)
   const basename = resolveBasename(target, sessionId)
   const finalPath = primaryMarkerPath(canonicalRoot, basename)
 

--- a/scripts/validate-plan-marker-sites.mjs
+++ b/scripts/validate-plan-marker-sites.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * validate-plan-marker-sites.mjs — Plan-marker enforcement-site drift validator.
+ *
+ * #268 fix: detects when new code references `.plan-approval-pending` without
+ * being registered in PLAN_MARKER_ENFORCEMENT_SITES (scripts/lib/marker-paths.mjs).
+ * An unregistered reference is a potential drift: either the new code is a
+ * legitimate enforcement site that should be in the registry, or it's a
+ * comment/test/doc that should be excluded explicitly.
+ *
+ * Two directions implemented in this initial cut (per plan v6 §5.2):
+ *
+ *   D0 — Lib parity
+ *        scripts/lib/marker-paths.mjs and hooks/lib/marker-paths.sh must agree
+ *        on the per-session SID char-class + max length, and the legacy
+ *        basename. Drift FAILS the build.
+ *
+ *   D2 — Bidirectional drift
+ *        Grep the codebase for `.plan-approval-pending`. Every hit must be:
+ *          (a) inside a registered enforcement-site span (±20 lines), OR
+ *          (b) a comment line (`#` or `//` prefix), OR
+ *          (c) explicitly annotated `VALIDATOR-IGNORE: <rationale>`, OR
+ *          (d) in this validator's own file or the registry source, OR
+ *          (e) in a test file (tests/test-*), OR
+ *          (f) in a doc file (docs/, *.md, scratch/), OR
+ *          (g) in MEMORY.md-class files (~/.claude/projects/.../memory/).
+ *        Else → FAIL "unregistered enforcement site at <file>:<line>".
+ *
+ * D1 (per-kind site coverage), D3 (semantic input matrix), D4 (call-site closure),
+ * D5 (authority/effect closure) — deferred to follow-up FU. The above two
+ * directions already catch the most common drift class (new unregistered sites
+ * + lib/sh constant drift).
+ *
+ * Usage:
+ *   node scripts/validate-plan-marker-sites.mjs              # validate; exit 0/1
+ *   node scripts/validate-plan-marker-sites.mjs --json       # JSON output
+ *
+ * Exit codes:
+ *   0 — all checks pass
+ *   1 — drift detected (one or more failures); details on stderr
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+
+import {
+  PLAN_MARKER_LEGACY_BASENAME,
+  PLAN_MARKER_BASENAME_RE,
+  PLAN_MARKER_ENFORCEMENT_SITES,
+} from './lib/marker-paths.mjs'
+import {
+  SESSION_ID_CHARCLASS,
+  SESSION_ID_MAX_LEN,
+  SESSION_ID_MIN_LEN,
+} from './lib/session-id.mjs'
+
+const argv = process.argv.slice(2)
+const wantJson = argv.includes('--json')
+
+const failures = []
+let checks = 0
+
+function fail(msg) {
+  failures.push(msg)
+}
+
+function info(msg) {
+  if (!wantJson) process.stdout.write(msg + '\n')
+}
+
+// ---------------------------------------------------------------------------
+// D0 — Lib parity (.mjs vs .sh)
+// ---------------------------------------------------------------------------
+function checkLibParity() {
+  checks++
+  const shPath = path.join(REPO, 'hooks', 'lib', 'marker-paths.sh')
+  let shSource
+  try {
+    shSource = fs.readFileSync(shPath, 'utf8')
+  } catch (e) {
+    fail(`D0: cannot read ${shPath}: ${e.message}`)
+    return
+  }
+
+  // Extract from .sh source: readonly PLAN_MARKER_LEGACY_BASENAME='...'
+  // readonly PLAN_MARKER_SUFFIX_CHARCLASS='...'
+  // readonly PLAN_MARKER_SUFFIX_MAXLEN=...
+  const shLegacyMatch = shSource.match(/readonly\s+PLAN_MARKER_LEGACY_BASENAME=['"]([^'"]+)['"]/)
+  const shCharclassMatch = shSource.match(/readonly\s+PLAN_MARKER_SUFFIX_CHARCLASS=['"]([^'"]+)['"]/)
+  const shMaxlenMatch = shSource.match(/readonly\s+PLAN_MARKER_SUFFIX_MAXLEN=(\d+)/)
+
+  if (!shLegacyMatch) fail('D0: hooks/lib/marker-paths.sh missing PLAN_MARKER_LEGACY_BASENAME constant')
+  else if (shLegacyMatch[1] !== PLAN_MARKER_LEGACY_BASENAME) {
+    fail(`D0: legacy basename drift — .mjs="${PLAN_MARKER_LEGACY_BASENAME}" vs .sh="${shLegacyMatch[1]}"`)
+  }
+
+  if (!shCharclassMatch) fail('D0: hooks/lib/marker-paths.sh missing PLAN_MARKER_SUFFIX_CHARCLASS constant')
+  else if (shCharclassMatch[1] !== SESSION_ID_CHARCLASS) {
+    fail(`D0: charclass drift — .mjs="${SESSION_ID_CHARCLASS}" vs .sh="${shCharclassMatch[1]}"`)
+  }
+
+  if (!shMaxlenMatch) fail('D0: hooks/lib/marker-paths.sh missing PLAN_MARKER_SUFFIX_MAXLEN constant')
+  else if (parseInt(shMaxlenMatch[1], 10) !== SESSION_ID_MAX_LEN) {
+    fail(`D0: maxlen drift — .mjs=${SESSION_ID_MAX_LEN} vs .sh=${shMaxlenMatch[1]}`)
+  }
+
+  // Also assert the regex compiles to the expected canonical shape.
+  // PLAN_MARKER_BASENAME_RE must accept '.plan-approval-pending' AND
+  // '.plan-approval-pending.<any-valid-sid>'.
+  if (!PLAN_MARKER_BASENAME_RE.test('.plan-approval-pending')) {
+    fail('D0: PLAN_MARKER_BASENAME_RE rejects legacy literal — invariant broken')
+  }
+  if (!PLAN_MARKER_BASENAME_RE.test('.plan-approval-pending.abc-123')) {
+    fail('D0: PLAN_MARKER_BASENAME_RE rejects valid suffixed form')
+  }
+  if (PLAN_MARKER_BASENAME_RE.test('.plan-approval-pending.')) {
+    fail('D0: PLAN_MARKER_BASENAME_RE accepts empty-suffix (invariant broken)')
+  }
+  if (PLAN_MARKER_BASENAME_RE.test('.plan-approval-pending-extra')) {
+    fail('D0: PLAN_MARKER_BASENAME_RE accepts no-dot suffix (invariant broken)')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// D2 — Bidirectional drift detection
+// ---------------------------------------------------------------------------
+function checkBidirectionalDrift() {
+  checks++
+
+  // Files/directories where references are allowed (exclusion list).
+  // Patterns are matched against the relative path from REPO.
+  const EXCLUSION_PREFIXES = [
+    'tests/',           // test files
+    'docs/',            // doc files
+    'scratch/',         // scratch artifacts
+    '.episodic-memory/', // episode storage
+    '.git/',            // git internals
+    '.checkpoints/',    // live markers
+    '.claude/',         // local settings + worktrees
+    'node_modules/',
+    'patterns/',        // behavioral-pattern docs (markdown)
+  ]
+  const EXCLUSION_FILES = new Set([
+    'MEMORY.md',
+    'PRINCIPLES.md',
+    'README.md',
+    'CLAUDE.md',
+    'AGENTS.md',
+    '.gitignore',
+    // Validator self-exclusion (the JS + shell registry sources + validator itself).
+    'scripts/lib/marker-paths.mjs',
+    'hooks/lib/marker-paths.sh',
+    'scripts/validate-plan-marker-sites.mjs',
+  ])
+  // Any .md file (doc-class) is excluded regardless of path.
+  function isExcludedByExtension(file) {
+    return file.endsWith('.md')
+  }
+
+  // Registered site files — references inside these are OK regardless of line.
+  const REGISTERED_FILES = new Set(
+    PLAN_MARKER_ENFORCEMENT_SITES.map((s) => s.file)
+  )
+
+  // Build the union of registered + always-allowed file paths.
+  const ALLOWED_FILES = new Set([...REGISTERED_FILES, ...EXCLUSION_FILES])
+
+  // Run `git grep -n` to find all references to the literal basename.
+  // Use git to avoid traversing ignored directories.
+  let grepOutput
+  try {
+    grepOutput = execSync(
+      `git -C "${REPO}" grep -n -F '.plan-approval-pending'`,
+      { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
+    )
+  } catch (e) {
+    // Exit code 1 from grep = no matches. We expect MANY matches; if zero, that
+    // itself is suspicious (the basename should appear in every enforcement site).
+    if (e.status === 1) {
+      fail('D2: no `.plan-approval-pending` references found anywhere — registry should not be empty')
+      return
+    }
+    throw e
+  }
+
+  // Parse `file:line:content` records.
+  const unregistered = []
+  for (const line of grepOutput.split('\n')) {
+    if (!line) continue
+    const match = line.match(/^([^:]+):(\d+):(.*)$/)
+    if (!match) continue
+    const [, file, , content] = match
+
+    // Skip if file is in any allowed location.
+    if (ALLOWED_FILES.has(file)) continue
+    if (isExcludedByExtension(file)) continue
+    let inExcludedDir = false
+    for (const prefix of EXCLUSION_PREFIXES) {
+      if (file.startsWith(prefix)) { inExcludedDir = true; break }
+    }
+    if (inExcludedDir) continue
+
+    // Comment-line exclusion (heuristic — strip leading whitespace).
+    const stripped = content.replace(/^\s+/, '')
+    if (stripped.startsWith('#')) continue  // shell / Python / YAML comment
+    if (stripped.startsWith('//')) continue // JS line comment
+    if (stripped.startsWith('*')) continue  // JS block-comment continuation
+    // VALIDATOR-IGNORE annotation
+    if (/VALIDATOR-IGNORE/.test(content)) continue
+
+    // Unregistered reference.
+    unregistered.push(line)
+  }
+
+  if (unregistered.length > 0) {
+    fail(
+      `D2: ${unregistered.length} unregistered \`.plan-approval-pending\` reference(s) found ` +
+      `(must be added to PLAN_MARKER_ENFORCEMENT_SITES or annotated VALIDATOR-IGNORE):\n` +
+      unregistered.slice(0, 20).map(l => `  ${l}`).join('\n') +
+      (unregistered.length > 20 ? `\n  …+${unregistered.length - 20} more` : '')
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+checkLibParity()
+checkBidirectionalDrift()
+
+if (wantJson) {
+  process.stdout.write(JSON.stringify({
+    status: failures.length === 0 ? 'ok' : 'failed',
+    checks,
+    failures
+  }, null, 2) + '\n')
+} else {
+  if (failures.length === 0) {
+    info(`OK  validate-plan-marker-sites: ${checks} checks passed`)
+  } else {
+    info(`FAIL  ${failures.length} failure(s):`)
+    for (const f of failures) process.stderr.write(f + '\n')
+  }
+}
+
+process.exit(failures.length === 0 ? 0 : 1)

--- a/tests/test-checkpoints-migration.mjs
+++ b/tests/test-checkpoints-migration.mjs
@@ -219,39 +219,86 @@ test('removes stale legacy + primary markers below prior baseline', () => {
 
 console.log('\nSessionEnd cleanup sweeps BOTH roots for ALL_MIGRATED_MARKERS:')
 
-test('em-session-end-prompt removes 6 markers across both roots', () => {
+test('em-session-end-prompt removes non-plan markers; F12 preserves legacy + removes own-session plan-marker', () => {
+  // #268 fix F12 (codex r1 F1): SessionEnd no longer unconditionally removes
+  // .plan-approval-pending. Legacy is read-only-during-burn-in; only
+  // .plan-approval-pending.<own-sid> (provided via stdin .session_id) gets
+  // removed. Cross-session safety: B's SessionEnd does not delete A's marker.
   const root = setupRepo()
-  // Seed all 6 markers at BOTH roots.
-  const markers = [
+  const sid = 'session-test-A'
+
+  // Seed 5 non-plan migrated markers at BOTH roots.
+  const nonPlanMarkers = [
     '.checkpoint-required',
     '.post-checkpoint-required',
-    '.plan-approval-pending',
     '.pre-checkpoint-done',
     '.post-checkpoint-done',
     '.session-baseline'
   ]
   for (const dir of ['.checkpoints', '.claude']) {
     fs.mkdirSync(path.join(root, dir), { recursive: true })
-    for (const name of markers) {
+    for (const name of nonPlanMarkers) {
+      const p = path.join(root, dir, name)
+      fs.writeFileSync(p, 'x')
+      assertExists(p, `pre-condition: ${dir}/${name}`)
+    }
+    // Also seed legacy plan-marker and own-session suffixed plan-marker.
+    for (const name of ['.plan-approval-pending', `.plan-approval-pending.${sid}`]) {
       const p = path.join(root, dir, name)
       fs.writeFileSync(p, 'x')
       assertExists(p, `pre-condition: ${dir}/${name}`)
     }
   }
 
-  // em-session-end-prompt resolves the repo root via resolveRepoRoot —
-  // running from within the test repo's cwd resolves to that repo. HOME
-  // isolation matches runRecall.
+  // Run SessionEnd with stdin {session_id: <sid>} — F12 reads stdin.
   execSync(`node ${SESSION_END}`, {
     cwd: root,
-    stdio: ['ignore', 'pipe', 'ignore'],
+    input: JSON.stringify({ session_id: sid, hook_event_name: 'SessionEnd' }),
+    stdio: ['pipe', 'pipe', 'ignore'],
     env: { ...process.env, HOME: root }
   })
 
+  // 5 non-plan markers: removed at BOTH roots (unchanged behavior).
   for (const dir of ['.checkpoints', '.claude']) {
-    for (const name of markers) {
+    for (const name of nonPlanMarkers) {
       assertMissing(path.join(root, dir, name), `${dir}/${name} should be removed by SessionEnd sweep`)
     }
+  }
+  // F12: legacy plan-marker PRESERVED at BOTH roots (never removed by SessionEnd).
+  for (const dir of ['.checkpoints', '.claude']) {
+    assertExists(path.join(root, dir, '.plan-approval-pending'),
+      `F12: ${dir}/.plan-approval-pending must be PRESERVED (read-only-during-burn-in)`)
+  }
+  // F12: own-session suffixed plan-marker REMOVED at BOTH roots.
+  for (const dir of ['.checkpoints', '.claude']) {
+    assertMissing(path.join(root, dir, `.plan-approval-pending.${sid}`),
+      `F12: ${dir}/.plan-approval-pending.${sid} should be removed (own-session cleanup)`)
+  }
+})
+
+test('SessionEnd with invalid session_id leaves all plan-markers untouched', () => {
+  // F12: invalid sid → skip plan-marker cleanup entirely. Non-plan markers
+  // continue to clean up normally.
+  const root = setupRepo()
+  for (const dir of ['.checkpoints', '.claude']) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true })
+    fs.writeFileSync(path.join(root, dir, '.plan-approval-pending'), 'x')
+    fs.writeFileSync(path.join(root, dir, '.plan-approval-pending.session-A'), 'x')
+    fs.writeFileSync(path.join(root, dir, '.checkpoint-required'), 'x')
+  }
+  execSync(`node ${SESSION_END}`, {
+    cwd: root,
+    input: JSON.stringify({ session_id: '../evil', hook_event_name: 'SessionEnd' }),
+    stdio: ['pipe', 'pipe', 'ignore'],
+    env: { ...process.env, HOME: root }
+  })
+  for (const dir of ['.checkpoints', '.claude']) {
+    assertExists(path.join(root, dir, '.plan-approval-pending'),
+      `invalid sid: ${dir}/.plan-approval-pending preserved`)
+    assertExists(path.join(root, dir, '.plan-approval-pending.session-A'),
+      `invalid sid: ${dir}/.plan-approval-pending.session-A preserved (cross-session safety)`)
+    assertMissing(path.join(root, dir, '.checkpoint-required'),
+      `invalid sid: ${dir}/.checkpoint-required still removed (non-plan unchanged)`)
   }
 })
 

--- a/tests/test-plan-marker-classifier.sh
+++ b/tests/test-plan-marker-classifier.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# tests/test-plan-marker-classifier.sh — Classifier coverage for #268 fix.
+#
+# Verifies hooks/lib/command-classifier.sh handles:
+#   - E1-E5: per-session plan-marker case-arms in 4 verb handlers + classify_path
+#   - E5b: node */plan-marker.mjs --touch|--rm --root <abs> → marker_write
+#         with TARGET = canonical per-session marker path
+#   - F17/F18: leading POSIX-name env assignment on helper invocation →
+#             unsafe_complex (prevents command-local CLAUDE_CODE_SESSION_ID
+#             override cross-session attack)
+#   - F-3 architectural invariant: classifier reads CLAUDE_CODE_SESSION_ID
+#     from its own process env (the same env Claude Code injects into the
+#     spawned helper subprocess). Coverage requested by code-review F-3
+#     (negative-scenario-reviewer).
+#
+# Run: bash tests/test-plan-marker-classifier.sh
+
+set -u
+
+REPO="$(cd -P "$(dirname "$0")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO/hooks/lib/command-classifier.sh"
+# shellcheck disable=SC1091
+source "$REPO/hooks/lib/marker-paths.sh"
+# shellcheck disable=SC1091
+source "$REPO/hooks/lib/session-id.sh"
+
+export CLAUDE_CODE_SESSION_ID="test-sid-abc"
+
+passed=0
+failed=0
+
+run() {
+  local cmd="$1" expected_label="$2" expected_reason_grep="${3:-}" label_desc="$4"
+  local r
+  r="$(classify_command "$cmd" "$REPO" 2>&1)"
+  local label="${r%%	*}"
+  local rest="${r#*	}"
+  local reason="${rest#*	}"
+  if [ "$label" = "$expected_label" ]; then
+    if [ -z "$expected_reason_grep" ] || printf '%s' "$reason" | grep -qE "$expected_reason_grep"; then
+      echo "  ✓ $label_desc"
+      passed=$((passed+1))
+    else
+      echo "  ✗ $label_desc — label=$label OK but reason=$reason does not match /$expected_reason_grep/"
+      failed=$((failed+1))
+    fi
+  else
+    echo "  ✗ $label_desc — expected $expected_label, got $label ($reason)"
+    failed=$((failed+1))
+  fi
+}
+
+run_target_match() {
+  local cmd="$1" expected_target_grep="$2" label_desc="$3"
+  local r
+  r="$(classify_command "$cmd" "$REPO" 2>&1)"
+  local rest="${r#*	}"
+  local target="${rest%%	*}"
+  if printf '%s' "$target" | grep -qE "$expected_target_grep"; then
+    echo "  ✓ $label_desc (target=$target)"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $label_desc — target=$target does not match /$expected_target_grep/"
+    failed=$((failed+1))
+  fi
+}
+
+echo "--- E1-E5: case-arm extensions for suffixed form ---"
+run "rm /repo/.checkpoints/.plan-approval-pending.SID-abc" "marker_write" "rm_marker" "E2 rm suffixed"
+run "touch /repo/.checkpoints/.plan-approval-pending.SID-abc" "marker_write" "touch_marker" "E4 touch suffixed"
+run "echo x > /repo/.checkpoints/.plan-approval-pending.SID-abc" "marker_write" "redirect_to_marker" "E1 redirect suffixed"
+run "tee /repo/.checkpoints/.plan-approval-pending.SID-abc" "marker_write" "tee_marker" "E3 tee suffixed"
+
+echo ""
+echo "--- E5b: plan-marker.mjs helper invocation (F13) ---"
+run "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --touch --root /repo" "marker_write" "plan_marker_touch" "E5b helper --touch"
+run "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "marker_write" "plan_marker_rm" "E5b helper --rm"
+
+echo ""
+echo "--- F-3: classifier reads CLAUDE_CODE_SESSION_ID from env (target encodes sid) ---"
+# Classifier must compute TARGET = <root>/.checkpoints/.plan-approval-pending.<env_sid>.
+# This pins the architectural invariant that the classifier and the helper
+# read sid from the SAME source (process.env / inherited bash env).
+run_target_match \
+  "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" \
+  "/repo/\\.checkpoints/\\.plan-approval-pending\\.test-sid-abc" \
+  "F-3 TARGET encodes process.env CLAUDE_CODE_SESSION_ID"
+
+echo ""
+echo "--- F17/F18: env-prefix rejection ---"
+run "CLAUDE_CODE_SESSION_ID=B node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "unsafe_complex" "plan_marker_env_override" "F17 uppercase env-prefix"
+run "foo=bar node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "unsafe_complex" "plan_marker_env_override" "F18 lowercase env-prefix"
+run "Foo123=x node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "unsafe_complex" "plan_marker_env_override" "F18 mixed-case env-prefix"
+run "_x=y node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "unsafe_complex" "plan_marker_env_override" "F18 underscore env-prefix"
+run "ENV1=x ENV2=y node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "unsafe_complex" "plan_marker_env_override" "F17 multi env-prefix"
+
+echo ""
+echo "--- Mutex / missing action ---"
+run "node /scripts/plan-marker.mjs --touch --rm --root /repo" "unsafe_complex" "plan_marker_mutex" "mutex violation"
+run "node /scripts/plan-marker.mjs --root /repo" "unsafe_complex" "plan_marker_missing" "missing action"
+
+echo ""
+echo "--- Negative: non-marker node invocations classify normally ---"
+run "node /scripts/some-other.mjs --foo" "shared_write" "" "unrelated node script"
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+[ $failed -eq 0 ]

--- a/tests/test-plan-marker-cross-session.mjs
+++ b/tests/test-plan-marker-cross-session.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * test-plan-marker-cross-session.mjs — End-to-end cross-session isolation
+ * tests for #268 fix.
+ *
+ * Coverage (plan v6 §6.2):
+ *   X1   A's orphan; plan-gate stdin sid=B Write → ALLOW (the #268 fix)
+ *   X2   A's marker; plan-gate stdin sid=A Write → BLOCK (own plan still gates)
+ *   X3   Only legacy marker exists; any sid → BLOCK (burn-in compat)
+ *   X4   3 stale orphans + legacy; SessionStart orphan-sweep → all swept
+ *   X5   Worktree-cwd: helper --root <main-repo> from worktree cwd → file at
+ *        canonical main-repo, NOT worktree
+ *   X7   Concurrent A + B --touch — both markers exist (different basenames)
+ *   X8   CLAUDE_CODE_SESSION_ID="../evil" → helper exit 8 (no traversal)
+ *   X9   plan-gate stdin sid="../evil" + marker present → BLOCK (F14 fail-closed)
+ *   X10  A used legacy fallback; A --rm → legacy UNTOUCHED (F3)
+ *   X11  Session B SessionEnd → does NOT delete session A's active marker (F12)
+ *   X12  plan-gate allows `node plan-marker.mjs --rm` while marker exists (F13)
+ *   X13  classifier rejects env-prefix on helper invocation (F17/F18)
+ *
+ * Skipped here (covered elsewhere):
+ *   - X6 (re-resume) — orthogonal to namespacing; relies on Claude Code
+ *     resume semantics not modeled by this test.
+ *   - X13 / X13-bis subcases — already covered by /tmp/test-classifier-plan-marker.sh
+ *     smoke + covered indirectly by X12 + X13 here.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PLAN_GATE = path.join(REPO, 'hooks', 'plan-gate.sh')
+const HELPER = path.join(REPO, 'scripts', 'plan-marker.mjs')
+const EM_RECALL = path.join(REPO, 'scripts', 'em-recall.mjs')
+const SESSION_END = path.join(REPO, 'scripts', 'em-session-end-prompt.mjs')
+
+let passed = 0
+let failed = 0
+const cleanups = []
+process.on('exit', () => { for (const fn of cleanups) try { fn() } catch {} })
+
+function mkTmpRepo() {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-cross-test-'))
+  const real = fs.realpathSync(raw)
+  fs.mkdirSync(path.join(real, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(real, '.claude'), { recursive: true })
+  // Real git init so the resolver finds this as the repo root.
+  spawnSync('git', ['init', '-q'], { cwd: real })
+  // Stage the hook + libs the gate sources.
+  const hooksLib = path.join(real, 'hooks', 'lib')
+  fs.mkdirSync(hooksLib, { recursive: true })
+  fs.cpSync(path.join(REPO, 'hooks', 'plan-gate.sh'), path.join(real, 'hooks', 'plan-gate.sh'))
+  for (const lib of ['command-classifier.sh', 'repo-root.sh', 'marker-paths.sh', 'session-id.sh']) {
+    fs.cpSync(path.join(REPO, 'hooks', 'lib', lib), path.join(hooksLib, lib))
+  }
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  return real
+}
+
+function runPlanGate({ root, sid, toolName, toolInput }) {
+  const payload = JSON.stringify({
+    tool_name: toolName,
+    tool_input: toolInput,
+    cwd: root,
+    session_id: sid,
+  })
+  const r = spawnSync('bash', [path.join(root, 'hooks', 'plan-gate.sh')], {
+    input: payload,
+    encoding: 'utf8',
+  })
+  let decision = 'allow'
+  if (r.stdout && r.stdout.trim()) {
+    try { decision = JSON.parse(r.stdout).decision || 'unknown' }
+    catch { decision = 'unknown' }
+  }
+  return { decision, stdout: r.stdout, stderr: r.stderr, status: r.status }
+}
+
+function runHelper(root, sid, args) {
+  const env = { ...process.env, CLAUDE_CODE_SESSION_ID: sid }
+  if (sid === undefined) delete env.CLAUDE_CODE_SESSION_ID
+  return spawnSync('node', [HELPER, ...args, '--root', root], { encoding: 'utf8', env })
+}
+
+function check(cond, label) {
+  if (cond) { console.log(`  ✓ ${label}`); passed++ }
+  else { console.log(`  ✗ ${label}`); failed++ }
+}
+
+// ---------------- X1: A's orphan, session B Write → ALLOW (the #268 fix) ----
+{
+  const root = mkTmpRepo()
+  fs.writeFileSync(path.join(root, '.checkpoints', '.plan-approval-pending.session-A'), '')
+  const r = runPlanGate({ root, sid: 'session-B', toolName: 'Write', toolInput: { file_path: '/tmp/x' } })
+  check(r.decision === 'allow', `X1 cross-session orphan → ALLOW (the #268 fix; got ${r.decision})`)
+}
+
+// ---------------- X2: A's own marker, session A → BLOCK ---------------------
+{
+  const root = mkTmpRepo()
+  fs.writeFileSync(path.join(root, '.checkpoints', '.plan-approval-pending.session-A'), '')
+  const r = runPlanGate({ root, sid: 'session-A', toolName: 'Write', toolInput: { file_path: '/tmp/x' } })
+  check(r.decision === 'block', `X2 own marker → BLOCK (got ${r.decision})`)
+}
+
+// ---------------- X3: legacy only → BLOCK any sid (burn-in compat) -----------
+{
+  const root = mkTmpRepo()
+  fs.writeFileSync(path.join(root, '.checkpoints', '.plan-approval-pending'), '')
+  const r = runPlanGate({ root, sid: 'session-A', toolName: 'Write', toolInput: { file_path: '/tmp/x' } })
+  check(r.decision === 'block', `X3 legacy → BLOCK (got ${r.decision})`)
+}
+
+// ---------------- X4: orphan-sweep removes stale plan markers ----------------
+{
+  const root = mkTmpRepo()
+  const ck = path.join(root, '.checkpoints')
+  // 3 stale orphans + legacy + a session-baseline whose mtime is NEWER than them.
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.A'), '')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.B'), '')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.C'), '')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending'), '')
+  // Make all markers' mtime old (5 minutes ago).
+  const oldMs = Date.now() / 1000 - 300
+  for (const f of ['.plan-approval-pending.A', '.plan-approval-pending.B', '.plan-approval-pending.C', '.plan-approval-pending']) {
+    fs.utimesSync(path.join(ck, f), oldMs, oldMs)
+  }
+  // Baseline mtime is newer (now).
+  fs.writeFileSync(path.join(ck, '.session-baseline'), '')
+
+  // Run em-recall --session-start: it will write a NEW baseline and sweep orphans
+  // whose mtime <= prior baseline. The prior baseline mtime IS the "now" baseline
+  // we just wrote, so all 4 stale orphans (5 min ago) should sweep.
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--no-track', '--limit', '1'], {
+    cwd: root, encoding: 'utf8'
+  })
+  check(r.status === 0, `X4 em-recall --session-start exit 0 (got ${r.status})`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.A')), `X4: orphan A swept`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.B')), `X4: orphan B swept`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.C')), `X4: orphan C swept`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `X4: legacy orphan swept`)
+}
+
+// ---------------- X5: worktree-cwd helper writes at canonical root, not cwd --
+{
+  // Simulate worktree-cwd: caller cwd is OUTSIDE target root.
+  const target = mkTmpRepo()
+  const callerCwd = mkTmpRepo()
+  const r = spawnSync('node', [HELPER, '--touch', '--root', target], {
+    cwd: callerCwd,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_CODE_SESSION_ID: 'session-W' },
+  })
+  check(r.status === 0, `X5 helper exit 0 from caller_cwd != root (got ${r.status})`)
+  const targetMarker = path.join(target, '.checkpoints', '.plan-approval-pending.session-W')
+  const callerMarker = path.join(callerCwd, '.checkpoints', '.plan-approval-pending.session-W')
+  check(fs.existsSync(targetMarker), `X5: marker at TARGET ${targetMarker}`)
+  check(!fs.existsSync(callerMarker), `X5: NO marker at caller_cwd ${callerMarker}`)
+}
+
+// ---------------- X7: concurrent --touch A + B, both files exist -------------
+{
+  const root = mkTmpRepo()
+  const rA = runHelper(root, 'session-Conc-A', ['--touch'])
+  const rB = runHelper(root, 'session-Conc-B', ['--touch'])
+  check(rA.status === 0 && rB.status === 0, `X7 both helpers exit 0`)
+  check(fs.existsSync(path.join(root, '.checkpoints', '.plan-approval-pending.session-Conc-A')), `X7: A marker exists`)
+  check(fs.existsSync(path.join(root, '.checkpoints', '.plan-approval-pending.session-Conc-B')), `X7: B marker exists`)
+}
+
+// ---------------- X8: invalid env sid → exit 8 (path-traversal reject) -------
+{
+  const root = mkTmpRepo()
+  const r = runHelper(root, '../evil', ['--touch'])
+  check(r.status === 8, `X8 traversal env sid → exit 8 (got ${r.status})`)
+  check(!fs.existsSync(path.join(root, '.checkpoints', '.plan-approval-pending.../evil')), `X8: no traversal file written`)
+}
+
+// ---------------- X9: gate fail-closed on invalid stdin sid + marker --------
+{
+  const root = mkTmpRepo()
+  fs.writeFileSync(path.join(root, '.checkpoints', '.plan-approval-pending.session-A'), '')
+  const r = runPlanGate({ root, sid: '../evil', toolName: 'Write', toolInput: { file_path: '/tmp/x' } })
+  check(r.decision === 'block', `X9 invalid stdin sid + marker → BLOCK (F14; got ${r.decision})`)
+}
+
+// ---------------- X10: A used legacy fallback, A --rm — legacy UNTOUCHED -----
+{
+  const root = mkTmpRepo()
+  fs.writeFileSync(path.join(root, '.checkpoints', '.plan-approval-pending'), '')
+  const r = runHelper(root, 'session-A', ['--rm'])
+  check(r.status === 0, `X10 --rm exit 0`)
+  check(fs.existsSync(path.join(root, '.checkpoints', '.plan-approval-pending')),
+    `X10: legacy UNTOUCHED (F3 cross-session safety)`)
+}
+
+// ---------------- X11: B SessionEnd does NOT delete A's marker (F12) ---------
+{
+  const root = mkTmpRepo()
+  const markerA = path.join(root, '.checkpoints', '.plan-approval-pending.session-A')
+  const markerB = path.join(root, '.checkpoints', '.plan-approval-pending.session-B')
+  fs.writeFileSync(markerA, '')
+  fs.writeFileSync(markerB, '')
+  const r = spawnSync('node', [SESSION_END], {
+    input: JSON.stringify({ session_id: 'session-B', hook_event_name: 'SessionEnd' }),
+    cwd: root,
+    encoding: 'utf8',
+  })
+  check(r.status === 0, `X11 SessionEnd exit 0`)
+  check(fs.existsSync(markerA), `X11: A marker UNTOUCHED (F12)`)
+  check(!fs.existsSync(markerB), `X11: B marker removed (own-session)`)
+}
+
+// ---------------- X12: plan-gate allows helper while marker exists (F13) -----
+{
+  // E5b classifier maps `node */plan-marker.mjs --rm --root <abs>` → marker_write,
+  // and plan-gate allows marker_write of plan-marker basenames. Verify via the
+  // gate that the rm-via-helper invocation is allowed when own marker is present.
+  const root = mkTmpRepo()
+  const markerA = path.join(root, '.checkpoints', '.plan-approval-pending.session-A')
+  fs.writeFileSync(markerA, '')
+  const cmd = `node ${HELPER} --rm --root ${root}`
+  // Plan-gate receives the Bash command + caller's session_id.
+  const r = runPlanGate({
+    root, sid: 'session-A',
+    toolName: 'Bash',
+    toolInput: { command: cmd },
+  })
+  check(r.decision === 'allow', `X12 helper --rm via Bash classified marker_write → ALLOW (got ${r.decision})`)
+}
+
+// ---------------- X13: classifier rejects env-prefix on helper (F17) ---------
+{
+  const root = mkTmpRepo()
+  const markerA = path.join(root, '.checkpoints', '.plan-approval-pending.session-A')
+  const markerB = path.join(root, '.checkpoints', '.plan-approval-pending.session-B')
+  fs.writeFileSync(markerA, '')
+  fs.writeFileSync(markerB, '')
+  // Session A attempts to remove B's marker via command-local env override.
+  // Classifier should emit unsafe_complex → plan-gate falls through to block.
+  const cmd = `CLAUDE_CODE_SESSION_ID=session-B node ${HELPER} --rm --root ${root}`
+  const r = runPlanGate({
+    root, sid: 'session-A',
+    toolName: 'Bash',
+    toolInput: { command: cmd },
+  })
+  check(r.decision === 'block', `X13 env-prefix helper invocation → BLOCK (F17; got ${r.decision})`)
+  // Verify B's marker survives (no removal occurred).
+  check(fs.existsSync(markerB), `X13: B marker survives (helper didn't run)`)
+}
+
+console.log('')
+console.log(`Results: ${passed} passed, ${failed} failed`)
+process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-plan-marker-cross-session.mjs
+++ b/tests/test-plan-marker-cross-session.mjs
@@ -66,9 +66,15 @@ function runPlanGate({ root, sid, toolName, toolInput }) {
     cwd: root,
     session_id: sid,
   })
+  // Set CLAUDE_CODE_SESSION_ID in the gate's env to match stdin sid. In
+  // production Claude Code sets both the hook process env AND the spawned
+  // Bash subprocess env to the same session-id — the classifier reads the
+  // env, the gate reads stdin. Tests must mirror that invariant.
+  const env = { ...process.env, CLAUDE_CODE_SESSION_ID: sid }
   const r = spawnSync('bash', [path.join(root, 'hooks', 'plan-gate.sh')], {
     input: payload,
     encoding: 'utf8',
+    env,
   })
   let decision = 'allow'
   if (r.stdout && r.stdout.trim()) {
@@ -229,6 +235,53 @@ function check(cond, label) {
     toolInput: { command: cmd },
   })
   check(r.decision === 'allow', `X12 helper --rm via Bash classified marker_write → ALLOW (got ${r.decision})`)
+}
+
+// ---------------- X14: BLOCKER-B1 — direct Bash cannot rm other-session marker ----
+// Codex code-tier r1 finding: plan-gate marker_write allowance must narrow to
+// own-session basename only (legacy literal OR `.plan-approval-pending.<MY_SID>`).
+// Other-session suffixed markers MUST NOT be writable via direct Bash even
+// while own session is plan-blocked.
+{
+  const root = mkTmpRepo()
+  const markerA = path.join(root, '.checkpoints', '.plan-approval-pending.session-A')
+  const markerB = path.join(root, '.checkpoints', '.plan-approval-pending.session-B')
+  fs.writeFileSync(markerA, '')
+  fs.writeFileSync(markerB, '')
+  // Session A (plan-blocked by own marker) attempts to rm session B's marker.
+  const cmd = `rm ${markerB}`
+  const r = runPlanGate({
+    root, sid: 'session-A',
+    toolName: 'Bash',
+    toolInput: { command: cmd },
+  })
+  check(r.decision === 'block', `X14 cross-session rm via direct Bash → BLOCK (B1; got ${r.decision})`)
+}
+
+// ---------------- X15: BLOCKER-B2 — SessionEnd binds to stdin.cwd, not process.cwd ----
+// Codex code-tier r1 finding: em-session-end-prompt.mjs must use stdin .cwd
+// to resolve the hook target project, not process.cwd().
+{
+  const target = mkTmpRepo()
+  const callerCwd = mkTmpRepo()
+  const sid = 'session-Z'
+  // Seed own-session markers at BOTH target and caller.
+  fs.writeFileSync(path.join(target, '.checkpoints', `.plan-approval-pending.${sid}`), '')
+  fs.writeFileSync(path.join(callerCwd, '.checkpoints', `.plan-approval-pending.${sid}`), '')
+  const r = spawnSync('node', [SESSION_END], {
+    input: JSON.stringify({ session_id: sid, cwd: target, hook_event_name: 'SessionEnd' }),
+    cwd: callerCwd,  // process.cwd() will be CALLER, but stdin.cwd is TARGET
+    encoding: 'utf8',
+  })
+  check(r.status === 0, `X15 SessionEnd exit 0 (got ${r.status})`)
+  check(
+    !fs.existsSync(path.join(target, '.checkpoints', `.plan-approval-pending.${sid}`)),
+    `X15: TARGET marker removed (B2 fix: stdin.cwd binding)`
+  )
+  check(
+    fs.existsSync(path.join(callerCwd, '.checkpoints', `.plan-approval-pending.${sid}`)),
+    `X15: CALLER marker UNTOUCHED (cleanup correctly bound to stdin.cwd, not process.cwd)`
+  )
 }
 
 // ---------------- X13: classifier rejects env-prefix on helper (F17) ---------

--- a/tests/test-plan-marker.mjs
+++ b/tests/test-plan-marker.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * test-plan-marker.mjs — Unit tests for scripts/plan-marker.mjs.
+ *
+ * Coverage (plan v6 §6.1):
+ *   H1   --touch valid env + valid root → exit 0, file at expected path
+ *   H2   --rm valid env + valid root → exit 0, suffixed-only removed; legacy untouched
+ *   H3   --touch CLAUDE_CODE_SESSION_ID="" → exit 8
+ *   H3b  --touch CLAUDE_CODE_SESSION_ID UNSET → exit 8 (distinct from empty)
+ *   H4   --touch invalid sid (path traversal char) → exit 8
+ *   H5   --touch --root missing → exit 4
+ *   H6   --touch --root non-absolute → exit 5
+ *   H7   --touch --root non-existent → exit 5
+ *   H8   --touch --root no repo signal → exit 5
+ *   H9   --touch then --rm same sid — idempotent rm → exit 0
+ *   H10  --touch SIGINT mid-write — no partial .tmp left behind
+ *   H11  both --touch and --rm → exit 6
+ *   H12  neither --touch nor --rm → exit 6
+ *   H13  --rm with legacy `.plan-approval-pending` present, suffixed absent
+ *        → exit 0; legacy UNTOUCHED (F3 narrowing cross-session safety)
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const HELPER = path.join(REPO_ROOT, 'scripts', 'plan-marker.mjs')
+
+let passed = 0
+let failed = 0
+const cleanups = []
+
+process.on('exit', () => {
+  for (const fn of cleanups) try { fn() } catch { /* best-effort */ }
+})
+
+function mkTmpRepo() {
+  // Real filesystem dir with a .checkpoints/ signal so validateRoot accepts.
+  // macOS mktemp -d returns /var/folders/... — resolve via realpath so
+  // process.env.PWD-style equality holds when --root is canonicalized.
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-plan-marker-test-'))
+  const real = fs.realpathSync(raw)
+  fs.mkdirSync(path.join(real, '.checkpoints'), { recursive: true })
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  return real
+}
+
+function run(args, { sid = 'valid-sid-123', unsetSid = false } = {}) {
+  const env = { ...process.env }
+  if (unsetSid) {
+    delete env.CLAUDE_CODE_SESSION_ID
+  } else {
+    env.CLAUDE_CODE_SESSION_ID = sid
+  }
+  return spawnSync('node', [HELPER, ...args], { encoding: 'utf8', env })
+}
+
+function expect(cond, label) {
+  if (cond) {
+    console.log(`  ✓ ${label}`)
+    passed++
+  } else {
+    console.log(`  ✗ ${label}`)
+    failed++
+  }
+}
+
+// ---------- H1: --touch valid env + valid root → exit 0, file created ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--root', root])
+  const expected = path.join(root, '.checkpoints', '.plan-approval-pending.valid-sid-123')
+  expect(r.status === 0, `H1: --touch valid env+root → exit 0 (got ${r.status}; stderr=${r.stderr.trim()})`)
+  expect(fs.existsSync(expected), `H1: marker file written at ${expected}`)
+  const out = (() => { try { return JSON.parse(r.stdout) } catch { return null } })()
+  expect(out && out.status === 'ok' && out.path === expected, `H1: stdout JSON has status=ok + correct path`)
+}
+
+// ---------- H2: --rm valid → suffixed removed; legacy untouched ----------
+{
+  const root = mkTmpRepo()
+  const suffixed = path.join(root, '.checkpoints', '.plan-approval-pending.valid-sid-123')
+  const legacy = path.join(root, '.checkpoints', '.plan-approval-pending')
+  fs.writeFileSync(suffixed, '')
+  fs.writeFileSync(legacy, '')
+  const r = run(['--rm', '--root', root])
+  expect(r.status === 0, `H2: --rm exit 0 (got ${r.status})`)
+  expect(!fs.existsSync(suffixed), `H2: suffixed marker removed`)
+  expect(fs.existsSync(legacy), `H2: legacy marker UNTOUCHED (F3 narrowing)`)
+}
+
+// ---------- H3: --touch empty CLAUDE_CODE_SESSION_ID → exit 8 ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--root', root], { sid: '' })
+  expect(r.status === 8, `H3: empty SID → exit 8 (got ${r.status})`)
+  expect(/SESSION_ID_REQUIRED/.test(r.stderr), `H3: stderr has SESSION_ID_REQUIRED`)
+  expect(!fs.existsSync(path.join(root, '.checkpoints', '.plan-approval-pending.')), `H3: no empty-suffix file written`)
+}
+
+// ---------- H3b: --touch UNSET CLAUDE_CODE_SESSION_ID → exit 8 ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--root', root], { unsetSid: true })
+  expect(r.status === 8, `H3b: unset SID → exit 8 (got ${r.status})`)
+  expect(/SESSION_ID_REQUIRED/.test(r.stderr), `H3b: stderr has SESSION_ID_REQUIRED`)
+}
+
+// ---------- H4: --touch invalid sid (path-traversal char) → exit 8 ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--root', root], { sid: '../evil' })
+  expect(r.status === 8, `H4: traversal sid → exit 8 (got ${r.status})`)
+  expect(/SESSION_ID_INVALID/.test(r.stderr), `H4: stderr has SESSION_ID_INVALID`)
+}
+
+// ---------- H5: --root missing → exit 4 ----------
+{
+  const r = run(['--touch'])
+  expect(r.status === 4, `H5: missing --root → exit 4 (got ${r.status})`)
+  expect(/ROOT_REQUIRED/.test(r.stderr), `H5: stderr has ROOT_REQUIRED`)
+}
+
+// ---------- H6: --root non-absolute → exit 5 ----------
+{
+  const r = run(['--touch', '--root', 'relative/path'])
+  expect(r.status === 5, `H6: non-abs --root → exit 5 (got ${r.status})`)
+  expect(/ROOT_INVALID/.test(r.stderr), `H6: stderr has ROOT_INVALID`)
+}
+
+// ---------- H7: --root non-existent → exit 5 ----------
+{
+  const r = run(['--touch', '--root', '/nonexistent/path/xyz123'])
+  expect(r.status === 5, `H7: nonexistent --root → exit 5 (got ${r.status})`)
+}
+
+// ---------- H8: --root no repo signal → exit 5 ----------
+{
+  // Create a dir WITHOUT .git / .checkpoints / .episodic-memory
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-plan-marker-norepo-'))
+  const real = fs.realpathSync(raw)
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  const r = run(['--touch', '--root', real])
+  expect(r.status === 5, `H8: no-signal --root → exit 5 (got ${r.status})`)
+  expect(/ROOT_NOT_REPO/.test(r.stderr), `H8: stderr has ROOT_NOT_REPO`)
+}
+
+// ---------- H9: --touch then --rm same sid (idempotent rm) → exit 0 ----------
+{
+  const root = mkTmpRepo()
+  const r1 = run(['--touch', '--root', root])
+  expect(r1.status === 0, `H9: first --touch exit 0`)
+  const r2 = run(['--rm', '--root', root])
+  expect(r2.status === 0, `H9: --rm exit 0`)
+  const r3 = run(['--rm', '--root', root])
+  expect(r3.status === 0, `H9: second --rm (idempotent, no file) → exit 0`)
+}
+
+// ---------- H10: SIGINT during --touch → no partial .tmp file ----------
+{
+  // H10 is hard to test deterministically because the actionTouch path is
+  // synchronous (writeFileSync + renameSync) — SIGINT between these is
+  // unlikely to fire mid-rename. We test the post-hoc invariant: after a
+  // successful --touch, no .tmp file remains in .checkpoints/.
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--root', root])
+  expect(r.status === 0, `H10: --touch exit 0`)
+  const entries = fs.readdirSync(path.join(root, '.checkpoints'))
+  const tmps = entries.filter((e) => /\.tmp$/.test(e))
+  expect(tmps.length === 0, `H10: no .tmp files left (got ${tmps.join(',')})`)
+}
+
+// ---------- H11: both --touch and --rm → exit 6 ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--touch', '--rm', '--root', root])
+  expect(r.status === 6, `H11: --touch + --rm → exit 6 (got ${r.status})`)
+  expect(/MUTEX_VIOLATION/.test(r.stderr), `H11: stderr has MUTEX_VIOLATION`)
+}
+
+// ---------- H12: neither --touch nor --rm → exit 6 ----------
+{
+  const root = mkTmpRepo()
+  const r = run(['--root', root])
+  expect(r.status === 6, `H12: no action → exit 6 (got ${r.status})`)
+  expect(/MISSING_ACTION/.test(r.stderr), `H12: stderr has MISSING_ACTION`)
+}
+
+// ---------- H13: --rm with legacy present, suffixed absent → legacy UNTOUCHED ----------
+{
+  const root = mkTmpRepo()
+  const legacy = path.join(root, '.checkpoints', '.plan-approval-pending')
+  fs.writeFileSync(legacy, '')
+  // No suffixed marker exists for this sid.
+  const r = run(['--rm', '--root', root])
+  expect(r.status === 0, `H13: --rm exit 0 even with no suffixed (idempotent)`)
+  expect(fs.existsSync(legacy), `H13: legacy marker UNTOUCHED (F3 cross-session safety)`)
+  const out = (() => { try { return JSON.parse(r.stdout) } catch { return null } })()
+  expect(out && Array.isArray(out.removed) && out.removed.length === 0, `H13: stdout removed=[] (nothing removed)`)
+}
+
+console.log('')
+console.log(`Results: ${passed} passed, ${failed} failed`)
+process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -498,11 +498,18 @@ else
 fi
 
 # F4c: overwrite → file replaced atomically (different inode)
+# Platform-agnostic stat: macOS uses `stat -f %i`, Linux uses `stat -c %i`.
+# PR #271 CI catch: hardcoded `stat -f` failed on Ubuntu.
+if stat -f '%i' / >/dev/null 2>&1; then
+  STAT_INO=(stat -f %i)
+else
+  STAT_INO=(stat -c %i)
+fi
 TF="$(mktmp)"; stage_fixture "$TF"
 echo '{"v":1}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null
-ino1="$(stat -f '%i' "$TF/.checkpoints/.preflight-done")"
+ino1="$("${STAT_INO[@]}" "$TF/.checkpoints/.preflight-done")"
 echo '{"v":2}' | node "$TF/scripts/preflight-marker-write.mjs" --root "$TF" --target preflight >/dev/null
-ino2="$(stat -f '%i' "$TF/.checkpoints/.preflight-done")"
+ino2="$("${STAT_INO[@]}" "$TF/.checkpoints/.preflight-done")"
 v2="$(jq -r '.v' "$TF/.checkpoints/.preflight-done")"
 if [ "$ino1" != "$ino2" ] && [ "$v2" = "2" ]; then
   echo "  ✓ F4c overwrite is atomic (different inode after rename)"

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -45,6 +45,8 @@ stage_fixture() {
   cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$tmp/scripts/lib/"
   cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$tmp/scripts/lib/"
   cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/session-id.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-root-validation.mjs" "$tmp/scripts/lib/"
   cp "$REPO_ROOT/hooks/preflight-gate.sh" "$tmp/hooks/"
   cp "$REPO_ROOT/hooks/lib/command-classifier.sh" "$tmp/hooks/lib/"
   cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$tmp/hooks/lib/"

--- a/tests/test-preflight-prompt-helper.sh
+++ b/tests/test-preflight-prompt-helper.sh
@@ -38,6 +38,8 @@ stage_repo() {
   cp "$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs" "$target/scripts/lib/"
   cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$target/scripts/lib/"
   cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$target/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/session-id.mjs" "$target/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-root-validation.mjs" "$target/scripts/lib/"
   cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$target/hooks/lib/"
   # Make it git-detectable so resolve_repo_root returns this dir, not /.
   ( cd "$target" && git init -q && git config user.email t@t && git config user.name t )

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -306,7 +306,12 @@ mkdir -p "$L3_MAIN/.claude"
 touch "$L3_MAIN/.claude/.checkpoint-required"
 rm -f "$L3_MAIN/.claude/.post-checkpoint-done"
 input_with_cwd="$(printf '{"cwd":"%s","stop_hook_active":false}' "$L3_MAIN")"
-out="$(cd /private/tmp 2>/dev/null && echo "$input_with_cwd" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+# Use a platform-agnostic temp dir for "outside any project" cwd. `/private/tmp`
+# was macOS-specific; on Linux it doesn't exist and `cd` failed under set -e
+# (bash 5 errexit extends to assignment-with-cmdsubst). PR #271 CI catch.
+OUTSIDE_DIR="$(mktemp -d)"
+out="$(cd "$OUTSIDE_DIR" 2>/dev/null && echo "$input_with_cwd" | HOME="$L3_HOME" bash "$HOOK" 2>/dev/null)"
+rmdir "$OUTSIDE_DIR" 2>/dev/null || true
 if echo "$out" | grep -qE '"decision":[[:space:]]*"block"'; then
   pass "L3.8: hook from /private/tmp + input cwd→armed repo → blocks (Codex finding 1 regression)"
 else


### PR DESCRIPTION
## Summary
Closes #268. Cross-session `.plan-approval-pending` orphan markers no longer block unrelated sessions. Per-session namespacing via `.plan-approval-pending.<session_id>` filename + dedicated `scripts/plan-marker.mjs` helper.

- **Plan v6** (`scratch/rank1-268-plan-v6-final.md`) — consensus-accepted by negative-scenario-planner ×2 + codex plan-tier ×4 (r4 ACCEPT). 30 plan-tier findings closed.
- **Code-tier** — negative-scenario-reviewer HOLD with 3 blockers (test regression, CI gap, env-source invariant) → fixed in commit 10. Codex code-tier r1 HOLD with 2 BLOCKERs (cross-session marker mutation, SessionEnd cwd-binding) → fixed in commit 11. Codex r2 **ACCEPT-with-FU**.

## What changes

- New: `scripts/plan-marker.mjs` helper (`--touch | --rm --root <abs>`); shared libs `scripts/lib/session-id.mjs` + `marker-root-validation.mjs`; shell parity `hooks/lib/session-id.sh`.
- `hooks/plan-gate.sh` + `hooks/checkpoint-gate.sh` read `.session_id` from PreToolUse stdin; check own-session marker OR legacy literal; **fail closed** (F14) on invalid sid + any plan marker present; marker_write allowance narrowed to own-session basename + legacy literal (codex r1 B1).
- `hooks/lib/command-classifier.sh` — 5 case-arm extensions for suffixed form, NEW E5b case-arm recognizing `node */plan-marker.mjs --touch|--rm --root *` as `marker_write`; **rejects** leading POSIX-name env assignment (F17/F18) to block command-local SID override attacks.
- `scripts/em-recall.mjs` carve-out + orphan-clear sweep glob-expand `.plan-approval-pending.*`; `scripts/em-session-end-prompt.mjs` own-session-only delete reading stdin `.session_id` + `.cwd` (F12, codex r1 B2); legacy literal NEVER touched by helper `--rm` or SessionEnd (F3 read-only-during-burn-in).
- `scripts/validate-plan-marker-sites.mjs` (NEW) — D0 lib parity + D2 bidirectional drift detection.
- `.github/workflows/plan-marker-validate.yml` — runs on every PR/push (no `paths:` filter); pins validator + 12 test files.

## Architecture

- Agent reads `$CLAUDE_CODE_SESSION_ID` env; gates read PreToolUse stdin `.session_id`. No file-based source-of-truth (would be racy).
- Honest-agent threat model; SID forgery out-of-scope (consistent with `em-recall.mjs` lstat semantics). Runtime probe-drift IS in-scope — fail closed.

## Test plan
- [x] Plan-marker unit (`tests/test-plan-marker.mjs`): 32/32 H1-H13 + H3-bis
- [x] Cross-session E2E (`tests/test-plan-marker-cross-session.mjs`): 29/29 X1-X15
- [x] Classifier (`tests/test-plan-marker-classifier.sh`): 15/15 E1-E5 + E5b + F-3 + F17/F18 + mutex
- [x] Checkpoints-migration F12 update (`tests/test-checkpoints-migration.mjs`): 7/7
- [x] Issue-146 plan-pending deferral regression: 45/45
- [x] Stop-gate regression: 24/24
- [x] Command-classifier full regression: 300/300
- [x] em-recall session-start-early-exit regression: 11/11
- [x] em-strict-lstat regression: 5/5
- [x] Preflight-gate regression: 77/78 (F3e is pre-existing `/tmp/.checkpoints` test-isolation flake unrelated to this PR)
- [x] Preflight-prompt-helper regression: 12/12
- [x] Validator D0+D2: 2/2 checks

**Total: 580/581 (99.8%).** Only pre-existing flake outstanding.

## Review history

| Round | Layer | Verdict | Net findings |
|---|---|---|---|
| Planner v1 | negative-scenario-planner | HOLD | 12 blockers / 5 classes |
| Planner v2 | re-review | HOLD + new surface | 2 BLOCKER + 6 MAJOR/MINOR |
| Codex plan-tier r1 | second-opinion harness | HOLD | 4 BLOCKER + 1 MAJOR |
| Codex plan-tier r2 | r2 | HOLD | 1 BLOCKER (env override) |
| Codex plan-tier r3 | r3 | HOLD | 1 (regex char-class) |
| Codex plan-tier r4 | r4 | **ACCEPT** | — |
| Reviewer (impl) | negative-scenario-reviewer | HOLD | 3 BLOCKER + 5 MINOR/NIT |
| Codex code-tier r1 | second-opinion harness | HOLD | 2 BLOCKER (cross-session mutation, cwd-binding) |
| Codex code-tier r2 | r2 | **ACCEPT-with-FU** | — |

## Deferred FUs (post-PR issue to file)

- Reviewer F-4: `unset`/`export` between Bash segments edge (low-risk; honest-agent contained)
- Reviewer F-5: SessionEnd-invalid-sid → orphan-sweep audit-trace anchor
- Reviewer F-6: race / symlink / EROFS / `.tmp` orphan / locale axes
- Reviewer F-7: validator `.md` exclusion broadness
- Reviewer F-8: duplicated `any_plan_marker_exists` helper across two gate files
- Codex r1 minor: SessionEnd TTY-stdin blocking (hook-only contract)
- Codex r2 FU: `em-session-end-prompt.mjs:loadPatternsIndex()` reads `patterns/_index.json` from `process.cwd()` before HOME fallback

## Methodology notes

Per PR #265 lesson (multi-layer review catches distinct bug classes): each layer (planner / planner re-review / codex plan-tier / reviewer / codex code-tier) found classes the others missed. Convergence pattern across plan-tier: 12→8→5→1→1→0. Code-tier: 8→2→0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
