### PR TITLE
feat(272): rank-5 FU day-1 sweep — tag-flag + F-8 dedup + F-4/F-5/C1/C2

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -144,20 +144,11 @@ plan_marker_exists_for_session() {
   return 1
 }
 
-# #268 fix F14 helper: any_plan_marker_exists — true if ANY plan marker
-# (legacy suffix-less OR any suffixed form) exists at either root. Used
-# for fail-closed-on-invalid-sid decisions.
-any_plan_marker_exists() {
-  [ -e "$PRIMARY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
-  [ -e "$LEGACY_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
-  local p
-  for p in "$PRIMARY_DIR"/.plan-approval-pending.*; do
-    [ -e "$p" ] && return 0
-  done
-  for p in "$LEGACY_DIR"/.plan-approval-pending.*; do
-    [ -e "$p" ] && return 0
-  done
-  return 1
+# any_plan_marker_exists is sourced from hooks/lib/marker-paths.sh. Local
+# wrapper threads REPO_ROOT through so call-sites read the same way. Rule 14
+# drift fix — single definition shared with plan-gate.sh.
+_any_plan_marker_exists_local() {
+  any_plan_marker_exists "$REPO_ROOT"
 }
 
 # #268 fix: composite predicate combining E13 + F14. Returns 0 (true) if
@@ -169,7 +160,7 @@ any_plan_marker_exists() {
 plan_pending_blocks_this_session() {
   local sid="$1"
   if ! validate_session_id "$sid"; then
-    any_plan_marker_exists && return 0
+    _any_plan_marker_exists_local && return 0
     return 1
   fi
   plan_marker_exists_for_session "$sid" && return 0

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -555,6 +555,17 @@ _classify_segment() {
   # so plan-marker helper detection (below) can reject command-local env
   # override attacks (`CLAUDE_CODE_SESSION_ID=B node plan-marker.mjs --rm …`).
   # Pattern is POSIX `name = [A-Za-z_][A-Za-z0-9_]*` (lowercase + digits + _).
+  #
+  # #272 F-4: walk only recognizes the LEADING `VAR=value` form. Sequential
+  # env mutation via `unset CLAUDE_CODE_SESSION_ID; node plan-marker.mjs …`
+  # OR `export CLAUDE_CODE_SESSION_ID=B; node plan-marker.mjs …` is not
+  # detected here — but both shapes hit `shell_keyword_or_group` /
+  # multi-command-segment paths upstream and the plan-marker helper itself
+  # fails closed (exit 8) when the resolved sid doesn't match its own
+  # session-id env var. Honest-agent threat: low (the helper is the
+  # authoritative defense, not the classifier). FU candidate: extend the
+  # tokenizer to track env-state across segments if a future repro shows
+  # a classifier-only bypass path.
   local idx=0
   local env_prefix_count=0
   while [ $idx -lt ${#TOKS[@]} ]; do

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -187,3 +187,25 @@ plan_marker_basename_matches() {
 plan_marker_basename_for_session() {
   printf '.plan-approval-pending.%s' "$1"
 }
+
+# any_plan_marker_exists <repo-root>
+# True if ANY plan-approval marker (legacy suffix-less OR any suffixed form)
+# exists at either primary or legacy marker dir under <repo-root>. Used by:
+#   - plan-gate.sh F14 fail-closed-on-invalid-sid decision
+#   - checkpoint-gate.sh probe-drift defense + plan_pending_blocks_this_session
+# Per-Rule-14 drift risk: previously duplicated across both gates with
+# identical body; centralized here so future surface additions (new plan
+# marker basenames, new root dirs) land in one place.
+any_plan_marker_exists() {
+  local root="$1"
+  [ -e "$root/$PRIMARY_MARKER_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  [ -e "$root/$LEGACY_MARKER_DIR/$PLAN_MARKER_LEGACY_BASENAME" ] && return 0
+  local p
+  for p in "$root/$PRIMARY_MARKER_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  for p in "$root/$LEGACY_MARKER_DIR"/.plan-approval-pending.*; do
+    [ -e "$p" ] && return 0
+  done
+  return 1
+}

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -75,19 +75,13 @@ if validate_session_id "$MY_SID"; then
   SUFFIXED_LEGACY="$REPO_ROOT/$LEGACY_MARKER_DIR/$(plan_marker_basename_for_session "$MY_SID")"
 fi
 
-# any_plan_marker_exists — true if ANY plan marker (legacy or any suffixed)
-# exists at either root. Used for F14 fail-closed-on-invalid-sid decision.
-any_plan_marker_exists() {
-  [ -e "$LEGACY_PRIMARY" ] && return 0
-  [ -e "$LEGACY_LEGACY" ] && return 0
-  local p
-  for p in "$REPO_ROOT/$PRIMARY_MARKER_DIR"/.plan-approval-pending.*; do
-    [ -e "$p" ] && return 0
-  done
-  for p in "$REPO_ROOT/$LEGACY_MARKER_DIR"/.plan-approval-pending.*; do
-    [ -e "$p" ] && return 0
-  done
-  return 1
+# any_plan_marker_exists is sourced from hooks/lib/marker-paths.sh. It takes
+# <repo-root> as a positional arg (was previously inlined here with implicit
+# REPO_ROOT capture). Rule 14 drift fix — single definition shared with
+# checkpoint-gate.sh. Local wrapper retained so existing call-sites read the
+# same way and don't need to thread REPO_ROOT each time.
+_any_plan_marker_exists_local() {
+  any_plan_marker_exists "$REPO_ROOT"
 }
 
 # Read-only tools — always allowed (planning needs them).
@@ -103,7 +97,7 @@ esac
 # stdin (Claude Code does this by default) or clear the marker via
 # plan-marker.mjs --rm.
 if ! $SID_VALID; then
-  if any_plan_marker_exists; then
+  if _any_plan_marker_exists_local; then
     jq -nc --arg path "$PLAN_PENDING_W" \
       '{decision: "block", reason: ("Plan approval pending; session_id missing/invalid in PreToolUse stdin — failing closed. Provide a valid session_id (PreToolUse JSON .session_id field) or clear the marker at " + $path + ". Hook: plan-gate.sh.")}'
     exit 0

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -63,7 +63,12 @@ function flag(name) {
 function flagAll(name) {
   const out = []
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === name && i + 1 < argv.length) out.push(argv[i + 1])
+    if (argv[i] === name && i + 1 < argv.length) {
+      const val = argv[i + 1]
+      if (val.startsWith('--')) continue
+      out.push(val)
+      i++
+    }
   }
   return out
 }
@@ -87,6 +92,7 @@ const commandInventoryRef = flag('--command-inventory-ref')
 const triggeredBy = flag('--triggered-by')
 const projectFlag = flag('--project')
 const tagsRaw = flag('--tags')
+const tagRepeats = flagAll('--tag')
 const scope = flag('--scope') || 'inherit'
 const dryRun = hasFlag('--dry-run')
 const patternId = flag('--pattern-id') || 'bp-001-implementation-workflow'
@@ -428,7 +434,7 @@ if (dryRun) {
 // Write episode (mirrors em-store.mjs primitives)
 // ---------------------------------------------------------------------------
 const project = projectFlag || path.basename(process.cwd())
-const inputTags = (tagsRaw ? tagsRaw.split(',') : []).map(t => t.trim().toLowerCase()).filter(Boolean)
+const inputTags = [...(tagsRaw ? tagsRaw.split(',') : []), ...tagRepeats].map(t => t.trim().toLowerCase()).filter(Boolean)
 const baseTags = ['workflow.lifecycle', 'review-request', `task:${task.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`]
 const tags = [...new Set([...baseTags, ...inputTags])].sort()
 

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -3,9 +3,13 @@
  * em-revise.mjs — Revise/supersede an existing decision.
  *
  * Usage:
- *   node em-revise.mjs --original <id> --project <name> --tags <t1,t2>
+ *   node em-revise.mjs --original <id> --project <name>
+ *                      (--tags <t1,t2> | --tag <t1> --tag <t2> | both)
  *                      --summary <text> (--body <text> | --body-file <path>)
  *                      [--scope inherit|local|global]
+ *
+ * Tag forms accepted (merged + deduplicated; mirrors em-store):
+ *   --tags a,b,c       --tag a --tag b       --tags a,b --tag c
  *
  * --scope defaults to "inherit" (write the revision to the same store as the
  * original). Pass "local" or "global" only to force a cross-scope revision.
@@ -39,9 +43,26 @@ function flag(name) {
   return argv[i + 1]
 }
 
+// flagAll(name) — collect every value of a repeated flag. Mirrors em-store's
+// helper; lets users pass `--tag a --tag b` in addition to `--tags a,b`.
+// Skips a position whose value starts with `--` (next flag, not a tag value).
+function flagAll(name) {
+  const out = []
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name && i + 1 < argv.length) {
+      const val = argv[i + 1]
+      if (val.startsWith('--')) continue
+      out.push(val)
+      i++
+    }
+  }
+  return out
+}
+
 const originalId = flag('--original')
 const project = flag('--project')
 const tagsRaw = flag('--tags')
+const tagRepeats = flagAll('--tag')
 const summary = flag('--summary')
 const bodyArg = flag('--body')
 const bodyFile = flag('--body-file')
@@ -69,7 +90,7 @@ if (bodyFile !== undefined) {
 if (!originalId || !summary || !body) {
   console.log(JSON.stringify({
     status: 'error',
-    message: 'Missing required args. Usage: --original <id> --project <name> --tags <t1,t2> --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global]'
+    message: 'Missing required args. Usage: --original <id> --project <name> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global]'
   }))
   process.exit(1)
 }
@@ -158,12 +179,17 @@ const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,
 const randSuffix = crypto.randomBytes(2).toString('hex')
 const id = `${ts}-${slug}-${randSuffix}`
 
-function normalizeTags(raw) {
-  if (!raw) return []
-  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+function normalizeTags(raw, repeats = []) {
+  let fromRaw = []
+  if (Array.isArray(raw)) {
+    fromRaw = raw
+  } else if (raw) {
+    fromRaw = raw.split(',')
+  }
+  const all = [...fromRaw, ...repeats]
     .map(t => t.trim().toLowerCase())
     .filter(Boolean)
-  return [...new Set(arr)].sort()
+  return [...new Set(all)].sort()
 }
 
 function updateTagsIndex(dataDir, episodeId, tags) {
@@ -181,7 +207,7 @@ function updateTagsIndex(dataDir, episodeId, tags) {
   fs.renameSync(tmpFile, tagsFile)
 }
 
-const tags = normalizeTags(tagsRaw)
+const tags = normalizeTags(tagsRaw, tagRepeats)
 const resolvedProject = origProject || path.basename(process.cwd())
 
 // Inherit original episode's tags (captured during first index pass above)

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -29,11 +29,17 @@ import { validateSessionId } from './lib/session-id.mjs'
 // ---------------------------------------------------------------------------
 // Load known patterns from _index.json
 // ---------------------------------------------------------------------------
-function loadPatternsIndex() {
+// #272 C2-minor: accept repoRoot (resolved from stdin .cwd) as the first
+// candidate. Previously this read `process.cwd()/patterns/_index.json`
+// which — after B2 bound cleanup to stdin .cwd — was the last remaining
+// caller-cwd dependency in this script. Worktree-cwd invocations no longer
+// silently fall through to the global HOME copy.
+function loadPatternsIndex(repoRoot) {
   const candidates = [
+    repoRoot ? path.join(repoRoot, 'patterns', '_index.json') : null,
     path.join(process.cwd(), 'patterns', '_index.json'),
     path.join(os.homedir(), '.episodic-memory', 'patterns', '_index.json')
-  ]
+  ].filter(Boolean)
   for (const p of candidates) {
     try {
       const data = JSON.parse(fs.readFileSync(p, 'utf8'))
@@ -77,17 +83,35 @@ function loadPatternsIndex() {
 // stdin. The hook target's cwd is the project the SessionEnd applies to;
 // using process.cwd() would bind cleanup to the caller, which is wrong
 // for linked-worktree / nested-cwd invocations.
+//
+// #272 C1-minor: skip the synchronous stdin read when stdin is a TTY. Hook
+// contract is "Claude Code always supplies stdin JSON," but a manual
+// interactive run (`node em-session-end-prompt.mjs` at a shell) would
+// otherwise block on fs.readFileSync(0) waiting for EOF. The TTY guard
+// makes the script safe to invoke ad-hoc for debugging while preserving
+// the hook contract.
+//
+// #272 F-5: if sessionEndSid is invalid/missing AFTER this read, the
+// per-session plan-marker cleanup (loop below) is skipped entirely. The
+// orphan-sweep at the NEXT session's SessionStart handles those leftovers
+// via mtime check (see em-recall.mjs orphan-sweep path). Audit trace:
+// SessionEnd → (skip) → SessionStart orphan-sweep → mtime-aged stale
+// markers cleaned. This is the documented fallback for the
+// invalid-sid-on-SessionEnd path; do not add eager cleanup here without
+// re-running plan v6 §F12 threat model (cross-session marker deletion).
 let sessionEndSid = null
 let sessionEndCwd = null
 try {
-  const stdinData = fs.readFileSync(0, 'utf8')
-  if (stdinData) {
-    const stdinJson = JSON.parse(stdinData)
-    if (stdinJson && typeof stdinJson.session_id === 'string') {
-      sessionEndSid = stdinJson.session_id
-    }
-    if (stdinJson && typeof stdinJson.cwd === 'string') {
-      sessionEndCwd = stdinJson.cwd
+  if (!process.stdin.isTTY) {
+    const stdinData = fs.readFileSync(0, 'utf8')
+    if (stdinData) {
+      const stdinJson = JSON.parse(stdinData)
+      if (stdinJson && typeof stdinJson.session_id === 'string') {
+        sessionEndSid = stdinJson.session_id
+      }
+      if (stdinJson && typeof stdinJson.cwd === 'string') {
+        sessionEndCwd = stdinJson.cwd
+      }
     }
   }
 } catch { /* best-effort; stdin missing/non-JSON → null sid + cwd */ }
@@ -118,7 +142,7 @@ for (const marker of ALL_MIGRATED_MARKERS) {
   }
 }
 
-const patterns = loadPatternsIndex()
+const patterns = loadPatternsIndex(repoRoot)
 
 const knownPatterns = patterns.map(p => ({
   pattern_id: p.pattern_id,

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -3,9 +3,15 @@
  * em-store.mjs — Create a new episodic memory entry.
  *
  * Usage:
- *   node em-store.mjs --project <name> --category <cat> --tags <t1,t2>
+ *   node em-store.mjs --project <name> --category <cat>
+ *                     (--tags <t1,t2> | --tag <t1> --tag <t2> | both)
  *                     --summary <text> (--body <text> | --body-file <path>)
  *                     [--scope local|global]
+ *
+ * Tag forms (any combination accepted; merged + deduplicated + sorted):
+ *   --tags a,b,c       — comma-separated single flag
+ *   --tag a --tag b    — repeated flag, one tag per occurrence
+ *   --tags a,b --tag c — mixed
  *
  * `--body-file` reads body content from a file (UTF-8, BOM stripped, exactly
  * one trailing newline stripped). Mutually exclusive with `--body`. Use it
@@ -37,9 +43,30 @@ function flag(name) {
   return argv[i + 1]
 }
 
+// flagAll(name) — collect every value of a repeated flag.
+// Used for --tag where users may pass `--tag a --tag b --tag c`. Returns []
+// when the flag is absent. Skips an occurrence whose value position would
+// fall outside argv (trailing `--tag`) OR whose value starts with `--` (the
+// next option, not a tag value). Single-dash values like `-foo` are accepted
+// because tags can legitimately contain leading hyphens; the `--` guard is
+// just to catch the missing-value-followed-by-next-flag shape.
+function flagAll(name) {
+  const out = []
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name && i + 1 < argv.length) {
+      const val = argv[i + 1]
+      if (val.startsWith('--')) continue
+      out.push(val)
+      i++
+    }
+  }
+  return out
+}
+
 const project = flag('--project')
 const category = flag('--category')
 const tagsRaw = flag('--tags')
+const tagRepeats = flagAll('--tag')
 const summary = flag('--summary')
 const bodyArg = flag('--body')
 const bodyFile = flag('--body-file')
@@ -48,7 +75,7 @@ const scope = flag('--scope') || 'global'
 
 const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']
 
-const USAGE = `--project <name> --category <${VALID_CATEGORIES.join('|')}> --tags <t1,t2> --summary <text> (--body <text> | --body-file <path>) [--scope local|global]`
+const USAGE = `--project <name> --category <${VALID_CATEGORIES.join('|')}> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope local|global]`
 
 if (bodyArg !== undefined && bodyFile !== undefined) {
   console.log(JSON.stringify({
@@ -96,12 +123,12 @@ const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,
 const randSuffix = crypto.randomBytes(2).toString('hex')
 const id = `${ts}-${slug}-${randSuffix}`
 
-function normalizeTags(raw) {
-  if (!raw) return []
-  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+function normalizeTags(raw, repeats = []) {
+  const fromComma = raw ? raw.split(',') : []
+  const all = [...fromComma, ...repeats]
     .map(t => t.trim().toLowerCase())
     .filter(Boolean)
-  return [...new Set(arr)].sort()
+  return [...new Set(all)].sort()
 }
 
 function updateTagsIndex(dataDir, episodeId, tags) {
@@ -119,7 +146,7 @@ function updateTagsIndex(dataDir, episodeId, tags) {
   fs.renameSync(tmpFile, tagsFile)
 }
 
-const tags = normalizeTags(tagsRaw)
+const tags = normalizeTags(tagsRaw, tagRepeats)
 
 const fmLines = [
   '---',

--- a/scripts/second-opinion.mjs
+++ b/scripts/second-opinion.mjs
@@ -53,6 +53,21 @@ function flag(name) {
   return argv[i + 1]
 }
 
+// flagAll(name) — collect every value of a repeated flag. Skips values that
+// start with -- (next flag, not a tag). Mirrors em-store/em-revise.
+function flagAll(name) {
+  const out = []
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name && i + 1 < argv.length) {
+      const val = argv[i + 1]
+      if (val.startsWith('--')) continue
+      out.push(val)
+      i++
+    }
+  }
+  return out
+}
+
 function hasFlag(name) {
   return argv.indexOf(name) !== -1
 }
@@ -219,7 +234,16 @@ async function cmdRequest() {
 
   // Write request via chosen storage.
   const summary = flag('--summary') || `second-opinion request (${provider})`
-  const tagsRaw = flag('--tags') || ''
+  // Merge --tags <a,b> + repeated --tag <x> into a single comma-separated
+  // string for downstream consumers (preamble composer, meta). Dedup +
+  // lowercase. Same shape as em-store/em-revise. Codex r1 same-class catch.
+  const _tagsRawFlag = flag('--tags') || ''
+  const _tagRepeats = flagAll('--tag')
+  const _mergedTags = [...new Set([
+    ..._tagsRawFlag.split(','),
+    ..._tagRepeats,
+  ].map(t => t.trim().toLowerCase()).filter(Boolean))].sort()
+  const tagsRaw = _mergedTags.join(',')
   const workArea = flag('--work-area') || ''
   const round = flag('--round') || '1'
   const meta = { summary, tags: tagsRaw, 'work-area': workArea, round, provider }

--- a/tests/test-em-store-tag-flags.mjs
+++ b/tests/test-em-store-tag-flags.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * test-em-store-tag-flags.mjs — Regression tests for --tag / --tags flag forms
+ * on em-store.mjs and em-revise.mjs.
+ *
+ * Bug context (workplan v62, #272 follow-up): the CLI's flag() helper returns
+ * the *first* occurrence of a repeated flag and silently drops subsequent
+ * `--tag X --tag Y` invocations. Users (and global lessons emitted via shell
+ * scripts) frequently expect repeated `--tag` to accumulate. Fix adds a
+ * flagAll() helper that collects every occurrence; this test pins the
+ * behavior.
+ *
+ * Cases:
+ *   - --tags a,b               → [a, b]
+ *   - --tag a --tag b          → [a, b]
+ *   - --tags a,b --tag c       → [a, b, c]
+ *   - --tag a --tag a          → [a]                (dedup)
+ *   - --tag A --tag b          → [a, b]             (lowercase normalization)
+ *   - --tag c --tag a --tag b  → [a, b, c]          (sorted output)
+ *   - em-revise --tag x --tag y inherits original tags + merges with repeats
+ *
+ * Usage: node tests/test-em-store-tag-flags.mjs
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+import assert from 'assert'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+const REVISE = path.join(REPO, 'scripts', 'em-revise.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function makeSandbox() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'em-tag-flags-test-')))
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  return {
+    root, home, cwd,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function runJSON(script, args, sandbox) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd: sandbox.cwd,
+    env: { ...process.env, HOME: sandbox.home },
+    encoding: 'utf8',
+  })
+  return { code: r.status, json: r.stdout ? JSON.parse(r.stdout.trim()) : null, stderr: r.stderr }
+}
+
+function readTags(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const m = raw.match(/^tags: \[(.*)\]$/m)
+  if (!m) throw new Error(`no tags frontmatter in ${filePath}`)
+  return m[1].split(',').map(s => s.trim()).filter(Boolean)
+}
+
+function storeAndReadTags(sandbox, tagArgs) {
+  const result = runJSON(STORE, [
+    '--project', 'test-tag-flags',
+    '--category', 'decision',
+    ...tagArgs,
+    '--summary', 'tag flag test',
+    '--body', 'body',
+    '--scope', 'global',
+  ], sandbox)
+  assert.strictEqual(result.code, 0, `em-store failed: ${result.stderr}\n${JSON.stringify(result.json)}`)
+  return readTags(result.json.file)
+}
+
+// ---------------------------------------------------------------------------
+// em-store cases
+// ---------------------------------------------------------------------------
+
+console.log('em-store --tag / --tags cases:')
+
+test('--tags comma form unchanged', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tags', 'a,b']), ['a', 'b'])
+  } finally { s.cleanup() }
+})
+
+test('--tag repeated form accumulates', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tag', 'a', '--tag', 'b']), ['a', 'b'])
+  } finally { s.cleanup() }
+})
+
+test('mixed --tags + --tag merges', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tags', 'a,b', '--tag', 'c']), ['a', 'b', 'c'])
+  } finally { s.cleanup() }
+})
+
+test('repeated --tag dedups identical values', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tag', 'a', '--tag', 'a']), ['a'])
+  } finally { s.cleanup() }
+})
+
+test('--tag lowercase-normalizes', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tag', 'A', '--tag', 'b']), ['a', 'b'])
+  } finally { s.cleanup() }
+})
+
+test('--tag output is sorted', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tag', 'c', '--tag', 'a', '--tag', 'b']), ['a', 'b', 'c'])
+  } finally { s.cleanup() }
+})
+
+test('no tag flags → empty tag set', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, []), [])
+  } finally { s.cleanup() }
+})
+
+test('trailing --tag with no value is ignored (no crash)', () => {
+  const s = makeSandbox()
+  try {
+    assert.deepStrictEqual(storeAndReadTags(s, ['--tag', 'a', '--tag']), ['a'])
+  } finally { s.cleanup() }
+})
+
+test('tags.json updated with all repeated tags', () => {
+  const s = makeSandbox()
+  try {
+    const r = runJSON(STORE, [
+      '--project', 'test-tag-flags',
+      '--category', 'decision',
+      '--tag', 'alpha', '--tag', 'beta', '--tag', 'gamma',
+      '--summary', 'tag-index test',
+      '--body', 'body',
+      '--scope', 'global',
+    ], s)
+    assert.strictEqual(r.code, 0)
+    const tagsIndex = JSON.parse(fs.readFileSync(path.join(s.home, '.episodic-memory', 'tags.json'), 'utf8'))
+    assert.ok(tagsIndex.alpha?.includes(r.json.id), 'alpha tag missing from index')
+    assert.ok(tagsIndex.beta?.includes(r.json.id), 'beta tag missing from index')
+    assert.ok(tagsIndex.gamma?.includes(r.json.id), 'gamma tag missing from index')
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// em-revise cases (same-class completeness)
+// ---------------------------------------------------------------------------
+
+console.log('em-revise --tag / --tags cases:')
+
+function seedOriginal(sandbox, tags) {
+  const r = runJSON(STORE, [
+    '--project', 'test-tag-flags',
+    '--category', 'decision',
+    ...tags.flatMap(t => ['--tag', t]),
+    '--summary', 'original',
+    '--body', 'original body',
+    '--scope', 'global',
+  ], sandbox)
+  assert.strictEqual(r.code, 0, `seed failed: ${r.stderr}`)
+  return r.json
+}
+
+test('em-revise --tag repeated merges with original tags', () => {
+  const s = makeSandbox()
+  try {
+    const orig = seedOriginal(s, ['x', 'y'])
+    const r = runJSON(REVISE, [
+      '--original', orig.id,
+      '--project', 'test-tag-flags',
+      '--tag', 'z', '--tag', 'w',
+      '--summary', 'revised',
+      '--body', 'revised body',
+      '--scope', 'global',
+    ], s)
+    assert.strictEqual(r.code, 0, `em-revise failed: ${r.stderr}`)
+    assert.deepStrictEqual(readTags(r.json.file), ['w', 'x', 'y', 'z'])
+  } finally { s.cleanup() }
+})
+
+test('em-revise mixed --tags + --tag merges with original tags', () => {
+  const s = makeSandbox()
+  try {
+    const orig = seedOriginal(s, ['x'])
+    const r = runJSON(REVISE, [
+      '--original', orig.id,
+      '--project', 'test-tag-flags',
+      '--tags', 'y,z', '--tag', 'q',
+      '--summary', 'revised',
+      '--body', 'revised body',
+      '--scope', 'global',
+    ], s)
+    assert.strictEqual(r.code, 0)
+    assert.deepStrictEqual(readTags(r.json.file), ['q', 'x', 'y', 'z'])
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log()
+console.log(`Tests: ${passed + failed}  passed: ${passed}  failed: ${failed}`)
+if (failed > 0) {
+  console.log()
+  console.log('Failures:')
+  for (const f of failures) console.log(`  ${f.name}\n    ${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary

Six follow-ups from PR #271 / #272 review chain, single PR per inline-FU heuristic (all items sub-3-LOC same-surface OR pure doc). Plus codex r1 ACCEPT-with-FU same-class extension to `em-review-request` + `second-opinion`.

| # | Item | Type | Files |
|---|---|---|---|
| 1 | `em-store` + `em-revise` repeated `--tag` flag | feat | `scripts/em-{store,revise}.mjs` + new `tests/test-em-store-tag-flags.mjs` |
| 2 | F-8 extract `any_plan_marker_exists` to shared helper | refactor (Rule 14) | `hooks/lib/marker-paths.sh`, `hooks/{plan,checkpoint}-gate.sh` |
| 3 | F-4 env_prefix_count edge comment | doc | `hooks/lib/command-classifier.sh` |
| 4 | F-5 SessionEnd-invalid-sid audit-trace comment | doc | `scripts/em-session-end-prompt.mjs` |
| 5 | C2-minor `loadPatternsIndex(repoRoot)` cwd-binding | fix | `scripts/em-session-end-prompt.mjs` |
| 6 | C1-minor TTY guard for SessionEnd stdin read | fix | `scripts/em-session-end-prompt.mjs` |
| 7 | Codex r1 same-class extension — repeated `--tag` on `em-review-request` + `second-opinion` | fix | `scripts/em-review-request.mjs`, `scripts/second-opinion.mjs` |

**Diff:** 10 files, +420/-57

## Review chain

| Layer | Verdict | Findings | Reply episode |
|---|---|---|---|
| Plan-tier second opinion | SKIPPED (Rule 6 light path) | n/a | n/a |
| Self-walk code review | 3 DEFER findings → issues #274/#275/#276 | 3 | n/a |
| **Codex code-tier r1** | **ACCEPT-with-FU** | 1 P2 same-class CLI gap (review-request + second-opinion) | `20260513-233740-...-6cfe` |

Codex r1 inline-FU resolved in commit 2 (extends to `em-review-request.mjs` + `second-opinion.mjs`).

## Tests run

| Test | Result |
|---|---|
| `tests/test-em-store-tag-flags.mjs` (NEW) | 11/11 ✓ |
| `tests/test-em-body-file.mjs` | 20/20 ✓ |
| `tests/test-em-revise-scope-inherit.mjs` | 18/18 ✓ |
| `tests/test-marker-paths.mjs` | 21/21 ✓ |
| `tests/test-marker-paths.sh` | 23/23 ✓ |
| `tests/test-command-classifier.sh` | 300/300 ✓ |
| `tests/test-checkpoint-gate.sh` | 145/145 ✓ |
| `tests/test-em-audit-compliance.mjs` | 7/7 ✓ |
| `tests/test-em-recall-session-start-early-exit.mjs` | 11/11 ✓ |
| `tests/test-install-hooks.sh` | 74 pass + 1 PRE-EXISTING fail (T1b8 — filed as #274) |

Smoke-tested `second-opinion --tag a --tag b --tags c,d` → meta `tags: "a,b,c,d"` (merged, sorted, deduped). ✓

## Test plan

- [x] Repeated `--tag a --tag b` accumulates
- [x] Mixed `--tags X,Y --tag Z` merges
- [x] Dedup + lowercase + sort
- [x] Trailing `--tag` with no value doesn't crash
- [x] `--tag --summary "x"` doesn't capture `--summary` as tag (value-skip guard)
- [x] em-revise inherits original tags + merges repeats
- [x] em-review-request + second-opinion same-class extension verified
- [x] F-8 dedup preserves identical behavior across both gates
- [x] TTY guard skips stdin read on interactive runs (manual smoke)
- [x] `loadPatternsIndex(repoRoot)` binds to stdin .cwd

## Follow-ups filed

- #274 — test-install-hooks.sh T1b8 stale managed-hooks count (pre-existing on main)
- #275 — plugins/episodic-memory/scripts drift from canonical (4+ commits behind)
- #276 — em-recall.mjs:421 loadPatternsIndex doesn't use already-resolved REPO_ROOT (NIT)

## Refs

- Closes parts of #272 (F-4, F-5, F-8, C1-minor, C2-minor)
- Codex r1 reply episode `20260513-233740-...-6cfe` (ACCEPT-with-FU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
