### PR TITLE
docs(rfc-006): withdraw — superseded by second-opinion harness shipped in PR #222

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -13,7 +13,7 @@ RFCs document proposed changes to the episodic-memory system. Every non-trivial 
 | RFC-003 | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | accepted | Charlton Ho |
 | RFC-004 | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | accepted | Charlton Ho |
 | RFC-005 | em-move — atomic episode relocation between scopes | draft | Charlton Ho |
-| RFC-006 | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | draft | Charlton Ho |
+| RFC-006 | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | withdrawn | Charlton Ho |
 
 ---
 

--- a/docs/rfcs/RFC-006-codex-review-adapter.md
+++ b/docs/rfcs/RFC-006-codex-review-adapter.md
@@ -600,6 +600,8 @@ runs in the foreground and returns the reply in the same invocation.
 | In-session trigger checklist (5-item gate) | Obsolete as designed — turn-end auto-dispatch is now gated by `hooks/second-opinion-gate.mjs` PreToolUse hook, a different mechanism with different semantics |
 | `em-watch-codex.mjs` extension for `local-reviewer` tag | Obsolete — no fallback request stream to watch |
 | Update to `memory/reference_codex_review_flow.md` | DONE under PR #222; see `memory/reference_second_opinion_harness.md` (the v9.4 toolkit + per-session pin in MEMORY.md) |
+| `--type codex-review` mode on `scripts/em-review-request.mjs` (PR-1 scope) | Obsolete-by-supersession — never shipped; the harness covers the in-session request shape via `scripts/second-opinion.mjs request --provider codex --body-file <plan> --summary <slug>`. No `--type` flag is needed because provider selection IS the request type. Verified: `grep -n "\-\-type" scripts/em-review-request.mjs` returns no matches. |
+| `claude mcp add codex` setup in `docs/USER_MANUAL.md` (PR-4 scope) | Obsolete-by-supersession — never shipped to USER_MANUAL. The codex MCP wire-up is no longer the trigger path: the Claude Code PreToolUse hook (`hooks/second-opinion-gate.mjs`) routes direct codex invocations through the harness instead, fail-closed on missing/malformed install snapshot. Verified: `grep -rn "claude mcp add codex" docs/` matches only this RFC. |
 
 ### Residual items kept as informal harness follow-ons (NOT RFC-tracked)
 

--- a/docs/rfcs/RFC-006-codex-review-adapter.md
+++ b/docs/rfcs/RFC-006-codex-review-adapter.md
@@ -2,13 +2,20 @@
 rfc_id: RFC-006
 slug: codex-review-adapter
 title: "Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback"
-status: draft
+status: withdrawn
 champion: Charlton Ho
 created: 2026-05-06
-last_modified: 2026-05-06
+last_modified: 2026-05-14
 supersedes: ~
 superseded_by: ~
 ---
+
+> **Status:** WITHDRAWN on 2026-05-14. The in-session use case is covered by the
+> second-opinion harness shipped via PR #222 (`e3c8dc9`). The adapter/queue/claim
+> architecture proposed below was never realized; the residual provider-hardening
+> items are tracked as informal harness follow-ons, not under this RFC.
+> See [Withdrawal note](#withdrawal-note) at the bottom for the full disposition.
+
 
 # RFC-006 — Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback
 
@@ -560,7 +567,104 @@ Per the project's review-rigor toolkit discipline #17, every fix introduces new 
 
 ## Withdrawal note
 
-> Populate only if status changes to `withdrawn`.
+**Withdrawn on 2026-05-14** by Charlton Ho. Status went `draft` → `withdrawn` (no
+intermediate `accepted` / `implemented` states).
+
+### What changed between draft (2026-05-06) and withdrawal (2026-05-14)
+
+The second-opinion harness shipped via [PR #222](https://github.com/lantisprime/episodic-memory/pull/222)
+(commit `e3c8dc9`, 2026-05-10) covers the in-session review use case that
+motivated this RFC, via a different architecture than the one proposed here.
+The harness is a synchronous CLI (`scripts/second-opinion.mjs`) with pluggable
+providers (`codex`, `claude-subagent`, `gemini`, `stub`) and storage backends
+(`files`, `episodic`), composed preambles, an install-snapshot freshness gate
+(I-27a), preamble-tamper detection (I-27b), and a `--consensus` loop with
+verdict parsing. The Claude Code PreToolUse hook
+(`hooks/second-opinion-gate.mjs`) routes direct codex invocations through the
+harness, fail-closed on missing/malformed snapshot.
+
+This design intentionally skips the queue-based architecture proposed below:
+no typed-request inbox, no separate adapter process, no `--once` consumer, no
+cross-lane claim primitive. In-session reviews are synchronous; the harness
+runs in the foreground and returns the reply in the same invocation.
+
+### Disposition of RFC-006's in-scope items
+
+| RFC-006 item | Disposition under harness |
+|---|---|
+| `requests/codex-review.json` typed-request registry entry | Obsolete — harness uses synchronous CLI, not a queue |
+| `scripts/em-claim.mjs` O_EXCL claim primitive | Obsolete — single-lane synchronous; no cross-lane race to arbitrate |
+| `adapters/codex/` directory + manifest | Obsolete — provider lives at `scripts/second-opinion/providers/codex.mjs`, not as a separate adapter |
+| `em-dispatch-codex --once --dry-run` entrypoint | Obsolete — harness `--dispatch` runs synchronously; `--dry-run` not needed for in-session use |
+| Schema fields `review_chain_id`, `review_round`, `fallback_from` (request body); `source`, `inspected.*` (reply body) | Partially obsolete — `--consensus --max-rounds` covers within-invocation rounds; cross-invocation chain identity is unused. Reply `source` distinction is moot in single-provider invocations. |
+| In-session trigger checklist (5-item gate) | Obsolete as designed — turn-end auto-dispatch is now gated by `hooks/second-opinion-gate.mjs` PreToolUse hook, a different mechanism with different semantics |
+| `em-watch-codex.mjs` extension for `local-reviewer` tag | Obsolete — no fallback request stream to watch |
+| Update to `memory/reference_codex_review_flow.md` | DONE under PR #222; see `memory/reference_second_opinion_harness.md` (the v9.4 toolkit + per-session pin in MEMORY.md) |
+
+### Residual items kept as informal harness follow-ons (NOT RFC-tracked)
+
+These four items from RFC-006's scope retain real value but don't share an
+architectural premise — they're independent provider-hardening enhancements
+against `scripts/second-opinion/providers/codex.mjs` (and peers). They will be
+filed as GitHub issues when picked up, not under a new RFC.
+
+1. **Runtime context validation (cwd binding + `git rev-parse` cross-check).**
+   The harness composes from arbitrary `--project <absolute>`; the codex
+   provider should `spawn` with `cwd: <project>` and verify
+   `worktree/branch/head` match the request context before invoking. Fail-
+   closed on mismatch with a `review-context-mismatch` event.
+2. **Failure classification ladder (auth / quota / network / binary-missing /
+   unknown).** Currently the harness bubbles raw `spawn` errors. The
+   classification design from §"Failure classification and fallback" above
+   is portable to the codex provider as-is — multi-signal ladder, fail-closed
+   to `unknown` on ambiguity.
+3. **Stderr redaction module.** Raw codex stderr can leak API tokens, email
+   addresses, $HOME paths, stack-trace addresses. The redaction recipe from
+   §"Stderr redaction" above is portable as a small module reused by all
+   providers.
+4. **Local-agent fallback path (`source: local-fallback`).** When codex is
+   unreachable (auth expired, quota exhausted, binary missing), the harness
+   should optionally fall back to invoking the local
+   `.claude/agents/negative-scenario-reviewer.md` subagent and tag the reply
+   `source: local-fallback`. Opt-in via a harness flag (`--fallback local`),
+   off by default.
+
+### Why not re-issue as RFC-006-v2 "Codex provider hardening"?
+
+The four residual items don't share an architectural premise — they're
+independent provider enhancements. Bundling them under one RFC adds ceremony
+without coherence; the substrate (harness contract, provider plugin
+interface, episode envelope) is already established and stable. Each
+enhancement is a self-contained PR or pair of PRs.
+
+If the queue-driven / async / cron-driven review use case ever emerges (e.g.,
+CI bot reviews, post-merge automated audits), draft a fresh RFC at that time.
+The harness's storage and provider plugin contracts will absorb that surface
+cleanly — the typed-request envelope from this RFC is still the right shape
+for a queue-driven design, but the surrounding architecture would be
+re-derived against the harness as substrate, not built parallel to it as
+proposed here.
+
+### Open questions — resolution under withdrawal
+
+- **OQ-1** (20-line trigger threshold): N/A — no auto-trigger; user invokes
+  harness explicitly.
+- **OQ-2** (quota backoff policy): folds into residual item 2 (failure
+  classification).
+- **OQ-3** (UUID vs content-hash for `review_chain_id`): N/A — chain identity
+  is unused.
+- **OQ-4** (TTL ↔ timeout coupling): N/A — no claim primitive.
+- **OQ-5** (`local-fallback` reply counting toward `review_round`): folds into
+  residual item 4 (fallback semantics).
+- **OQ-6** (`em-claim` filename collisions with episode parsers): N/A — no
+  claim primitive.
+- **OQ-7** (recovery + release via generation counter): N/A — no claim primitive.
+
+### Index updates accompanying this withdrawal
+
+- `docs/rfcs/_index.json` — status flipped `draft` → `withdrawn`
+- `docs/rfcs/README.md` — status column updated
+- Workplan v64 → v65 (em-revise) — rank-9 marked closed
 
 ---
 

--- a/docs/rfcs/_index.json
+++ b/docs/rfcs/_index.json
@@ -46,7 +46,7 @@
       "id": "RFC-006",
       "slug": "codex-review-adapter",
       "title": "Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback",
-      "status": "draft",
+      "status": "withdrawn",
       "champion": "Charlton Ho",
       "file": "RFC-006-codex-review-adapter.md"
     }


### PR DESCRIPTION
## Summary

- Withdraw RFC-006 (codex-review-adapter): in-session use case is covered by the second-opinion harness shipped in PR #222 (`e3c8dc9`); the queue + adapter + claim-primitive architecture proposed in RFC-006 was never built.
- Update `docs/rfcs/RFC-006-codex-review-adapter.md` frontmatter (`status: draft` → `withdrawn`), add banner + Withdrawal note enumerating: 8 obsolete in-scope items, 4 residual provider-hardening items kept as informal follow-ons (NOT RFC-tracked), all 7 open questions resolved or N/A.
- Sync `docs/rfcs/_index.json` and `docs/rfcs/README.md` table.

## Disposition of RFC-006 in-scope items

**Obsolete under harness (8):** typed-request registry entry, `em-claim.mjs` O_EXCL primitive, `adapters/codex/` directory, `em-dispatch-codex --once`, `review_chain_id`/`review_round`/`fallback_from` schema fields, in-session 5-item trigger checklist, `em-watch-codex` local-reviewer extension, `reference_codex_review_flow.md` update (DONE under PR #222 via `reference_second_opinion_harness.md`).

**Retained as informal harness follow-ons (4):** runtime context validation (cwd + `git rev-parse` cross-check), failure classification ladder, stderr redaction module, local-agent fallback path. Tracked under workplan v65 rank-11.

## Why not move the file to `docs/rfcs/archived/`?

`docs/rfcs/README.md` says withdrawn RFCs live in `rfcs/archived/`, but `scripts/em-rfc-validate.mjs:87` scans `rfcsDir` non-recursively — moving would orphan the registry entry. The convention vs tooling gap is tracked under workplan v65 rank-12.

## Test plan

- [x] `node scripts/em-rfc-validate.mjs` reports 6/6/6 consistent
- [x] Frontmatter, _index.json, and README table all agree on `status: withdrawn`
- [x] No code touched; no test suites impacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
