### PR TITLE
chore: env-prefix review discipline + autoMode drift validator

### DIFF
--- a/.github/workflows/automode-drift.yml
+++ b/.github/workflows/automode-drift.yml
@@ -1,0 +1,34 @@
+name: autoMode drift check
+
+# Lightweight gate against the merge-vs-replace gotcha — see
+# memory/feedback_automode_replace_not_merge.md + lesson
+# 20260516-000611-custom-automode-rules-in-claude-code-set-7e62.
+#
+# The check authority is the developer's local `claude` CLI, not CI.
+# In CI, the claude CLI is typically absent — the validator exits 0
+# with "skip: claude CLI not available", which documents the check
+# without false-failing the workflow. Local developers should run
+# `node scripts/check-automode-defaults.mjs` before committing
+# settings.json edits.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/check-automode-defaults.mjs'
+      - '.github/workflows/automode-drift.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/check-automode-defaults.mjs'
+      - '.github/workflows/automode-drift.yml'
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run autoMode drift check (skips if claude CLI absent)
+        run: node scripts/check-automode-defaults.mjs

--- a/instructions/AGENTS.md
+++ b/instructions/AGENTS.md
@@ -74,3 +74,9 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 - Routine edits, test runs, file reads
 - Credentials or sensitive data
 - Information already in project documentation
+
+## Command Invocation Hygiene
+
+**Env-prefix wrapper escape** (specific instance of safety-check bypass). Don't invoke commands with leading environment-variable assignments where the var name hints at gate-bypass intent — names containing `BYPASS_*`, `SKIP_*`, `DISABLE_*`, `ALLOW_*`, `OVERRIDE_*`, `UNSAFE_*`, or known internal gate prefixes. The wrapping invocation looks innocuous to a permission check while the env var carries the bypass payload (documented cross-session attack class; tracked in episodes tagged `pr-271`). Reject the entire form; don't tokenize allowed vs. disallowed vars.
+
+Does NOT cover routine framework / runtime env vars on their normal commands — `NODE_ENV=production npm start`, `DEBUG=1 ./run.sh`, `CI=true pytest`, `PYTHONPATH=. python script.py`, `LOG_LEVEL=debug ./service` are fine.

--- a/instructions/codex-skill.md
+++ b/instructions/codex-skill.md
@@ -54,3 +54,9 @@ Review session for 0-3 significant events, store them, then proceed with normal 
 ## Maintenance
 
 Rebuild index if corrupted: `node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all`
+
+## Command Invocation Hygiene
+
+**Env-prefix wrapper escape** (specific instance of safety-check bypass). Don't invoke commands with leading environment-variable assignments where the var name hints at gate-bypass intent — names containing `BYPASS_*`, `SKIP_*`, `DISABLE_*`, `ALLOW_*`, `OVERRIDE_*`, `UNSAFE_*`, or known internal gate prefixes. The wrapping invocation looks innocuous to a permission check while the env var carries the bypass payload (documented cross-session attack class; tracked in episodes tagged `pr-271`). Reject the entire form; don't tokenize allowed vs. disallowed vars.
+
+Does NOT cover routine framework / runtime env vars on their normal commands — `NODE_ENV=production npm start`, `DEBUG=1 ./run.sh`, `CI=true pytest`, `PYTHONPATH=. python script.py`, `LOG_LEVEL=debug ./service` are fine.

--- a/instructions/cursor.mdc
+++ b/instructions/cursor.mdc
@@ -91,3 +91,9 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 - Routine edits, file reads, test runs
 - Credentials or sensitive data
 - Information already in .cursorrules or project docs
+
+## Command Invocation Hygiene
+
+**Env-prefix wrapper escape** (specific instance of safety-check bypass). Don't invoke commands with leading environment-variable assignments where the var name hints at gate-bypass intent — names containing `BYPASS_*`, `SKIP_*`, `DISABLE_*`, `ALLOW_*`, `OVERRIDE_*`, `UNSAFE_*`, or known internal gate prefixes. The wrapping invocation looks innocuous to a permission check while the env var carries the bypass payload (documented cross-session attack class; tracked in episodes tagged `pr-271`). Reject the entire form; don't tokenize allowed vs. disallowed vars.
+
+Does NOT cover routine framework / runtime env vars on their normal commands — `NODE_ENV=production npm start`, `DEBUG=1 ./run.sh`, `CI=true pytest`, `PYTHONPATH=. python script.py`, `LOG_LEVEL=debug ./service` are fine.

--- a/instructions/windsurf.md
+++ b/instructions/windsurf.md
@@ -74,3 +74,9 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 - Routine edits, test runs, file reads
 - Credentials or sensitive data
 - Information already in project documentation
+
+## Command Invocation Hygiene
+
+**Env-prefix wrapper escape** (specific instance of safety-check bypass). Don't invoke commands with leading environment-variable assignments where the var name hints at gate-bypass intent — names containing `BYPASS_*`, `SKIP_*`, `DISABLE_*`, `ALLOW_*`, `OVERRIDE_*`, `UNSAFE_*`, or known internal gate prefixes. The wrapping invocation looks innocuous to a permission check while the env var carries the bypass payload (documented cross-session attack class; tracked in episodes tagged `pr-271`). Reject the entire form; don't tokenize allowed vs. disallowed vars.
+
+Does NOT cover routine framework / runtime env vars on their normal commands — `NODE_ENV=production npm start`, `DEBUG=1 ./run.sh`, `CI=true pytest`, `PYTHONPATH=. python script.py`, `LOG_LEVEL=debug ./service` are fine.

--- a/scripts/check-automode-defaults.mjs
+++ b/scripts/check-automode-defaults.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// check-automode-defaults.mjs
+//
+// Diff Claude Code's autoMode defaults against the effective config.
+// Fails (or warns, with --warn) if the effective config has fewer entries
+// than the defaults — signal that custom rules silently replaced stock
+// protections.
+//
+// Background: custom autoMode.{allow,soft_deny,hard_deny,environment}
+// arrays in settings.json REPLACE defaults per-key, not merge per-entry.
+// Adding one custom hard_deny rule without re-including stock defaults
+// silently disables Data Exfiltration + Safety-Check Bypass protections.
+//
+// Lesson: 20260516-000611-custom-automode-rules-in-claude-code-set-7e62
+
+import { execFileSync } from 'node:child_process'
+
+const KEYS = ['allow', 'soft_deny', 'hard_deny', 'environment']
+
+function readJsonFromClaude(subcommand) {
+  try {
+    const out = execFileSync('claude', ['auto-mode', subcommand], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return JSON.parse(out)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return null  // claude CLI not installed; skip gracefully
+    }
+    throw new Error(`claude auto-mode ${subcommand} failed: ${err.message}`)
+  }
+}
+
+function main() {
+  const argv = process.argv.slice(2)
+  const warnOnly = argv.includes('--warn')
+
+  const defaults = readJsonFromClaude('defaults')
+  const effective = readJsonFromClaude('config')
+
+  if (!defaults || !effective) {
+    console.log('skip: claude CLI not available')
+    process.exit(0)
+  }
+
+  const issues = []
+  for (const key of KEYS) {
+    const defaultEntries = defaults[key] || []
+    const effectiveEntries = effective[key] || []
+    const effectiveSet = new Set(effectiveEntries)
+    const missing = defaultEntries.filter(d => !effectiveSet.has(d))
+    // Predicate: ANY default missing from effective config = drift.
+    // Count alone (effCount < defCount) is insufficient — equal-count
+    // SUBSTITUTION (default replaced by a different rule) would false-pass.
+    // Codex r1 finding P1.1 (20260516-002119-...-e1a5).
+    if (missing.length > 0) {
+      issues.push({
+        key,
+        defaults_count: defaultEntries.length,
+        effective_count: effectiveEntries.length,
+        missing,
+      })
+    }
+  }
+
+  if (issues.length === 0) {
+    console.log('ok: all autoMode defaults present in effective config')
+    process.exit(0)
+  }
+
+  console.log(JSON.stringify({ status: 'drift', issues }, null, 2))
+  console.error('')
+  console.error(`autoMode defaults dropped from effective config — ${issues.length} key(s) affected.`)
+  console.error('Custom autoMode rules REPLACE defaults per-key, not merge.')
+  console.error('Fix: include stock defaults verbatim alongside custom rules in settings.json.')
+  console.error('Lesson: 20260516-000611-custom-automode-rules-in-claude-code-set-7e62')
+
+  process.exit(warnOnly ? 0 : 1)
+}
+
+main()

--- a/scripts/second-opinion/preambles/fragments/env-prefix-discipline-v1.md
+++ b/scripts/second-opinion/preambles/fragments/env-prefix-discipline-v1.md
@@ -1,0 +1,43 @@
+# Env-prefix wrapper escape discipline (review axis)
+
+When reviewing a diff, FLAG any command invocation in code, tests, hooks, CI, or scripts that uses a leading environment-variable assignment whose name hints at gate-bypass intent.
+
+## Suspicious name patterns
+
+- `BYPASS_*` — `BYPASS_GATE=1`, `BYPASS_CHECK=true`
+- `SKIP_*` — `SKIP_CLASSIFIER=1`, `SKIP_PREFLIGHT=true`
+- `DISABLE_*` — `DISABLE_CHECK=1`, `DISABLE_HOOK=true`
+- `ALLOW_*` — `ALLOW_UNSAFE=1`, `ALLOW_OVERRIDE=true`
+- `OVERRIDE_*` — `OVERRIDE_PERMISSION=1`
+- `UNSAFE_*` — `UNSAFE_MODE=1`
+- Known internal gate prefixes for the project under review (e.g. project-specific allowlist-disable vars)
+
+## Why this matters
+
+The wrapping invocation looks innocuous to a permission check (the command itself is allowlisted) while the env var carries the bypass payload. Same env var read by both the classifier and the spawned helper = cross-session attack vector. Documented in episodes tagged `pr-271`.
+
+## What's NOT this rule
+
+Routine framework / runtime env vars on their normal commands:
+
+- `NODE_ENV=production npm start`
+- `DEBUG=1 ./run.sh`
+- `CI=true pytest`
+- `PYTHONPATH=. python script.py`
+- `LOG_LEVEL=debug ./service`
+
+These pass through unflagged.
+
+## Verdict guidance
+
+If you find a suspicious env-prefix invocation in the diff:
+
+1. ACCEPT-with-FU — sub-3-LOC fix to remove the env-prefix and route through tool flags or config files instead
+2. REJECT — if the env-prefix is load-bearing and the author justifies it, request stronger comment + test demonstrating the legitimate use, OR file as a follow-up issue requiring redesign
+3. Do NOT tokenize "allowed vs. disallowed vars" — reject the form, not the var name
+
+## Related discipline
+
+- Stock `Safety-Check Bypass` auto-mode `hard_deny` rule (Claude Code) — env-prefix is a specific instance
+- Custom user-level `Env-prefix wrapper escape` rule added 2026-05-16
+- `hooks/lib/command-classifier.sh:_PREFLIGHT_WRAPPERS_RE` — local hook-tier defense, repo-scoped

--- a/scripts/second-opinion/preambles/index.json
+++ b/scripts/second-opinion/preambles/index.json
@@ -1,14 +1,15 @@
 {
   "schema_version": 1,
   "default_per_provider": {
-    "codex": ["review-ladder-v9.4"],
-    "claude-subagent": ["claude-subagent-loader-ref"],
-    "gemini": ["gemini-ladder-v1"],
+    "codex": ["review-ladder-v9.4", "env-prefix-discipline-v1"],
+    "claude-subagent": ["claude-subagent-loader-ref", "env-prefix-discipline-v1"],
+    "gemini": ["gemini-ladder-v1", "env-prefix-discipline-v1"],
     "stub": ["review-ladder-v9.4"]
   },
   "fragments": [
     {"id": "review-ladder-v9.4", "path": "fragments/review-ladder-v9.4.md"},
     {"id": "claude-subagent-loader-ref", "path": "fragments/claude-subagent-loader-ref.md"},
-    {"id": "gemini-ladder-v1", "path": "fragments/gemini-ladder-v1.md"}
+    {"id": "gemini-ladder-v1", "path": "fragments/gemini-ladder-v1.md"},
+    {"id": "env-prefix-discipline-v1", "path": "fragments/env-prefix-discipline-v1.md"}
   ]
 }

--- a/tests/test-second-opinion-preamble.mjs
+++ b/tests/test-second-opinion-preamble.mjs
@@ -100,30 +100,33 @@ console.log('# test-second-opinion-preamble')
 // I-24: default preamble lands verbatim
 // ---------------------------------------------------------------------------
 console.log('\n## I-24 default preamble lands verbatim')
-test('default preamble for codex matches review-ladder-v9.4 fragment', () => {
+test('default preamble for codex includes review-ladder + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'codex', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['review-ladder-v9.4'])
+  assert.deepStrictEqual(result.fragmentIds, ['review-ladder-v9.4', 'env-prefix-discipline-v1'])
 
   const reg = loadRegistry()
-  const expectedFragment = readFragment(reg.fragments.find((f) => f.id === 'review-ladder-v9.4'))
-  assert.strictEqual(result.preambleBody, expectedFragment,
-    'composed body must equal fragment file content byte-for-byte')
+  const ladder = readFragment(reg.fragments.find((f) => f.id === 'review-ladder-v9.4'))
+  const envPrefix = readFragment(reg.fragments.find((f) => f.id === 'env-prefix-discipline-v1'))
+  assert.ok(result.preambleBody.includes(ladder),
+    'composed body must include review-ladder fragment content')
+  assert.ok(result.preambleBody.includes(envPrefix),
+    'composed body must include env-prefix-discipline fragment content')
 })
 
-test('default preamble for claude-subagent matches claude-subagent-loader-ref', () => {
+test('default preamble for claude-subagent includes loader-ref + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'claude-subagent', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['claude-subagent-loader-ref'])
+  assert.deepStrictEqual(result.fragmentIds, ['claude-subagent-loader-ref', 'env-prefix-discipline-v1'])
 })
 
-test('default preamble for gemini matches gemini-ladder-v1', () => {
+test('default preamble for gemini includes ladder-v1 + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'gemini', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['gemini-ladder-v1'])
+  assert.deepStrictEqual(result.fragmentIds, ['gemini-ladder-v1', 'env-prefix-discipline-v1'])
 })
 
 test('unknown provider with no default → no-default-preamble-for-provider', () => {


### PR DESCRIPTION
## Summary

- Propagates the env-prefix wrapper-escape attack class (closed in PR #271 at the local hook layer) to user-level `autoMode.hard_deny` and across per-tool instruction surfaces (cursor.mdc, AGENTS.md, windsurf.md, codex-skill.md).
- Adds reviewer-facing fragment (`env-prefix-discipline-v1.md`) so codex/claude-subagent/gemini apply env-prefix as a review axis via the second-opinion harness preamble.
- Adds `scripts/check-automode-defaults.mjs` autoMode drift validator using `missing.length > 0` predicate (catches equal-count default substitution — codex r1 P1.1 fix).
- Wires validator into `.github/workflows/automode-drift.yml` (CI skip is acceptable; primary enforcement is local-dev per FU #280).

## Discovery

Custom Claude Code `autoMode.{allow,soft_deny,hard_deny,environment}` arrays REPLACE stock defaults per-key, not merge per-entry. Adding one custom rule silently dropped the 2 stock `hard_deny` defaults (`Data Exfiltration`, `Safety-Check Bypass`). Lesson logged as global episode `20260516-000611-custom-automode-rules-in-claude-code-set-7e62`. Validator catches regressions.

## Review chain (formal consensus via second-opinion harness)

| Round | Verdict | Reply episode | Stop reason |
|---|---|---|---|
| 1 | REJECT (4 P1 + 1 P2) | `20260516-002119-...-e1a5` | findings |
| 2 | ACCEPT-with-FU (prose only; no fenced JSON) | `20260516-002741-...-aba8` | — |
| 3 | **ACCEPT-with-FU (harness-validated)** | `20260516-003243-...-07d9` | `verdict-accept-with-fu` |

Round 3 was a verdict-structure-only re-emit triggered when the user noted my consensus claim was based on prose mental-tracing rather than the artifact (`consensus.mjs` requires a fenced `json:second-opinion-summary` block). Round 3 harness output:

```json
{"consensus": "reached", "final_verdict": "ACCEPT-with-FU", "success": true,
 "fu_appendix": [{"id":"FU-1","severity":"P3","status":"DEFERRED-AS-FU"},
                 {"id":"FU-2","severity":"P2","status":"DEFERRED-AS-FU"}]}
```

## Followups

- #280 (P3): wire validator into local install / pre-commit (not CI)
- #281 (P2): add `tests/test-automode-drift.mjs` regression test for missing-array predicate

## Test plan

- [x] `node tests/test-second-opinion-preamble.mjs` — 43 passed, 0 failed
- [x] `node scripts/check-automode-defaults.mjs` — `ok: all autoMode defaults present in effective config`
- [x] Codex stub repro (r3 reply): equal-count substitution correctly exits 1
- [x] Install snapshot regenerated via `node install.mjs --tool claude-code --install-second-opinion`
- [ ] Bot review by `lantiscooperdev` (auto-runs after PR create per Rule 17)
- [ ] User approval in GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
