### PR TITLE
feat(279): per-session preflight marker + env-prefix structural defense

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -188,6 +188,10 @@ _marker_basename_in_set() {
     # Loose glob here for set-membership routing; strict validation via
     # plan_marker_basename_matches happens at marker_basename_for_target.
     .plan-approval-pending.*) return 0 ;;
+    # #279 fix: per-session preflight-marker `.preflight-done.<sid>`.
+    # Sibling of plan-approval-pending; loose glob, strict validation
+    # via preflight_marker_basename_matches happens at gate layer.
+    .preflight-done.*) return 0 ;;
   esac
   return 1
 }
@@ -259,7 +263,7 @@ _escape_bash_glob() {
 _command_has_relative_marker_path() {
   local cmd_stripped
   cmd_stripped="$(_strip_shell_quotes "$1")"
-  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
+  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
 }
 
 # E2E-discovered absolute-non-canonical detection: for Bash commands where
@@ -276,7 +280,7 @@ _command_first_absolute_noncanonical_marker() {
   local cmd
   cmd="$(_strip_shell_quotes "$1")"
   local matches p basename
-  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
+  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
   [ -z "$matches" ] && return 0
   while IFS= read -r p; do
     [ -z "$p" ] && continue

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -464,14 +464,20 @@ _is_in_space_list() {
 #   <command> := <env-prefix>* <executable> <helper-script-path> <helper-flags>*
 #
 # Echoes one of:
-#   OK\t<idx>\t<basename>             — grammar satisfied; idx is the index
-#                                       of the executable token in TOKS
+#   OK\t<idx>\t<basename>             — grammar satisfied (env-prefix walk +
+#                                       executable + helper-script-path
+#                                       basename all verified); idx is the
+#                                       index of the executable token in TOKS
 #   DENY\tenv-prefix\t<name>          — non-allowlist env-prefix at position
 #   DENY\twrapper\t<basename>         — non-node basename at exec position
 #   DENY\tenv-prefix-invalid\t<tok>   — token shape rejected (POSIX-name re)
-#   DENY\ttokenize\t<reason>          — tokenizer emitted E
+#   DENY\ttokenize\t<reason>          — tokenizer emitted E or O (control op)
 #   DENY\tno-exec\t                   — no executable token after env-prefix
 #                                       walk (env-only command)
+#   DENY\tno-helper\t                 — executable present but no helper-script
+#                                       token follows
+#   DENY\twrong-helper\t<basename>    — T[idx+1] basename is not
+#                                       preflight-marker-write.mjs (codex PR-r1 P3)
 #
 # Caller (preflight-gate.sh) parses the result, formats user-facing reason.
 # Returns 0 always; failure expressed in echoed verdict.
@@ -537,6 +543,25 @@ _check_helper_invocation_grammar() {
   local exec_base="${exec_tok##*/}"
   if ! _is_in_space_list "$exec_base" "$_NODE_BINARY_BASENAME_ALLOWLIST"; then
     printf 'DENY\twrapper\t%s\n' "$exec_base"
+    return 0
+  fi
+
+  # Step 4 (codex PR-r1 P3): verify T[idx+1] is the preflight-marker-write
+  # helper. The outer gate regex already matched the helper basename in the
+  # command string; this is defense in depth that ALSO catches injected
+  # alternate scripts like `node /tmp/other.mjs ; node helper.mjs ...` (the
+  # tokenizer emits an O control operator for `;` and we deny earlier; but
+  # for `node /tmp/other.mjs preflight-marker-write.mjs ...` no operator
+  # fires and the outer regex still matches). Tightens grammar claim.
+  local helper_idx=$((idx+1))
+  if [ $helper_idx -ge ${#TOKS[@]} ]; then
+    printf 'DENY\tno-helper\t\n'
+    return 0
+  fi
+  local helper_tok="${TOKS[$helper_idx]}"
+  local helper_base="${helper_tok##*/}"
+  if [ "$helper_base" != "preflight-marker-write.mjs" ]; then
+    printf 'DENY\twrong-helper\t%s\n' "$helper_base"
     return 0
   fi
 

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -534,6 +534,15 @@ _classify_segment() {
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
         return 0
         ;;
+      # #279 fix: per-session preflight-marker via redirect. Sibling of the
+      # .plan-approval-pending.* arm. Loose glob; strict validation via
+      # preflight_marker_basename_matches at gate layer.
+      .preflight-done.*)
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
       .so-runbook-shown.*)
         # Runbook UX-marker (second-opinion-gate). Same-class with the
         # other marker write surfaces; classifies as marker_write so the
@@ -749,6 +758,13 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
           return 0
           ;;
+        # #279 fix: per-session preflight-marker via rm. Sibling shape.
+        .preflight-done.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
         .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
@@ -801,6 +817,13 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
           return 0
           ;;
+        # #279 fix: per-session preflight-marker via tee.
+        .preflight-done.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
         .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
@@ -843,6 +866,13 @@ _classify_segment() {
           ;;
         # #268 fix E4: per-session plan-marker via touch.
         .plan-approval-pending.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+        # #279 fix: per-session preflight-marker via touch.
+        .preflight-done.*)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -423,6 +423,128 @@ _tokenize() {
 }
 
 # ---------------------------------------------------------------------------
+# #279 Stream 2: env-prefix wrapper defense — structural grammar for
+# preflight-marker-write.mjs helper invocations.
+#
+# Replaces regex-based helper-invocation detection (preflight-gate.sh) with
+# two whitelists that collectively eliminate the entire env-wrapper,
+# sudo-wrapper, npx-wrapper, path-spelled-anything class.
+#
+# _ROUTINE_ENV_ALLOWLIST — env-prefix names permitted before the helper.
+#   Sourced from env-prefix-discipline-v1.md "What's NOT this rule" section
+#   (routine framework / runtime env vars on their normal commands).
+#   Drift-validated by validate-plan-marker-sites.mjs.
+#
+# _NODE_BINARY_BASENAME_ALLOWLIST — token basenames permitted at the
+#   executable position. The gate enforces TOKEN-FORM identity (basename
+#   match), not RUNTIME identity. A binary literally named `node` that is
+#   actually a shell wrapper WILL pass this check — that class is out of
+#   scope for this gate (mitigated by file-system permissions + the Bash
+#   allowlist, not by this hook). Same-command shell shadowing (function
+#   defs, aliases, source, eval) is also out of scope (deep shell-injection;
+#   honest-agent threat model PR #271).
+# ---------------------------------------------------------------------------
+
+readonly _ROUTINE_ENV_ALLOWLIST="NODE_ENV DEBUG CI PYTHONPATH LOG_LEVEL"
+readonly _NODE_BINARY_BASENAME_ALLOWLIST="node"
+
+# _is_in_space_list <needle> <space-separated-list>
+# True iff <needle> appears as a whole token in <space-separated-list>.
+_is_in_space_list() {
+  local needle="$1" list="$2" t
+  for t in $list; do
+    [ "$t" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# _check_helper_invocation_grammar <cmd>
+#
+# Walks the tokenized command checking the v7 plan command-form grammar:
+#   <command> := <env-prefix>* <executable> <helper-script-path> <helper-flags>*
+#
+# Echoes one of:
+#   OK\t<idx>\t<basename>             — grammar satisfied; idx is the index
+#                                       of the executable token in TOKS
+#   DENY\tenv-prefix\t<name>          — non-allowlist env-prefix at position
+#   DENY\twrapper\t<basename>         — non-node basename at exec position
+#   DENY\tenv-prefix-invalid\t<tok>   — token shape rejected (POSIX-name re)
+#   DENY\ttokenize\t<reason>          — tokenizer emitted E
+#   DENY\tno-exec\t                   — no executable token after env-prefix
+#                                       walk (env-only command)
+#
+# Caller (preflight-gate.sh) parses the result, formats user-facing reason.
+# Returns 0 always; failure expressed in echoed verdict.
+_check_helper_invocation_grammar() {
+  local cmd="$1"
+  local -a TOKS=()
+  local line tok_text
+  while IFS= read -r line; do
+    case "$line" in
+      "T "*)
+        TOKS+=("${line:2}")
+        ;;
+      "E "*)
+        printf 'DENY\ttokenize\t%s\n' "${line:2}"
+        return 0
+        ;;
+      "O "*)
+        # Control operator at top level — multi-command segment, not a
+        # simple helper invocation. Fail-closed deny: structural rule
+        # requires single-segment command.
+        printf 'DENY\ttokenize\t%s\n' "control_operator_${line:2}"
+        return 0
+        ;;
+      *) ;;
+    esac
+  done < <(_tokenize "$cmd")
+
+  local idx=0
+  # Step 2: walk env-prefix tokens
+  while [ $idx -lt ${#TOKS[@]} ]; do
+    local t="${TOKS[$idx]}"
+    case "$t" in
+      [A-Za-z_]*=*)
+        # POSIX env-prefix shape. Extract name (before first =) and validate.
+        local ename="${t%%=*}"
+        case "$ename" in
+          *[!A-Za-z0-9_]*)
+            # Should not happen (case-glob requires [A-Za-z_] prefix),
+            # but be defensive.
+            printf 'DENY\tenv-prefix-invalid\t%s\n' "$t"
+            return 0
+            ;;
+        esac
+        if ! _is_in_space_list "$ename" "$_ROUTINE_ENV_ALLOWLIST"; then
+          printf 'DENY\tenv-prefix\t%s\n' "$ename"
+          return 0
+        fi
+        idx=$((idx+1))
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [ $idx -ge ${#TOKS[@]} ]; then
+    printf 'DENY\tno-exec\t\n'
+    return 0
+  fi
+
+  # Step 3: executable token basename whitelist
+  local exec_tok="${TOKS[$idx]}"
+  local exec_base="${exec_tok##*/}"
+  if ! _is_in_space_list "$exec_base" "$_NODE_BINARY_BASENAME_ALLOWLIST"; then
+    printf 'DENY\twrapper\t%s\n' "$exec_base"
+    return 0
+  fi
+
+  printf 'OK\t%d\t%s\n' "$idx" "$exec_base"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Per-segment classifier
 # ---------------------------------------------------------------------------
 # Reads tokens (T-records and redirect O-records) from stdin for ONE segment,

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -209,3 +209,70 @@ any_plan_marker_exists() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# #279 fix — per-session .preflight-done marker contract.
+#
+# Shell parity for scripts/lib/marker-paths.mjs PREFLIGHT_MARKER_*. Sibling
+# of PLAN_MARKER_* (#268 / PR #271). Drift caught by
+# scripts/validate-plan-marker-sites.mjs.
+# ---------------------------------------------------------------------------
+
+readonly PREFLIGHT_MARKER_LEGACY_BASENAME='.preflight-done'
+readonly PREFLIGHT_MARKER_BASENAME_GLOB='.preflight-done*'             # bash case glob (loose; for routing)
+readonly PREFLIGHT_MARKER_SUFFIX_CHARCLASS='A-Za-z0-9_-'
+readonly PREFLIGHT_MARKER_SUFFIX_MAXLEN=128
+readonly PREFLIGHT_MARKER_BASENAME_GREP_PATTERN='\.preflight-done(\.[A-Za-z0-9_-]{1,128})?'
+
+# preflight_marker_basename_matches <basename>
+# Strict match. Accepts ONLY:
+#   .preflight-done                                 (legacy suffix-less)
+#   .preflight-done.<sid>                           (sid matches char-class + length)
+# Rejects:
+#   .preflight-done-extra                           (suffix without dot separator)
+#   .preflight-done.                                (empty suffix)
+#   .preflight-done./traversal                      (slash in suffix)
+#   .preflight-done..                               (dot in suffix)
+#   .preflight-done.<129-char>                      (oversize suffix)
+preflight_marker_basename_matches() {
+  local basename="$1"
+  case "$basename" in
+    .preflight-done) return 0 ;;
+    .preflight-done.*)
+      local suffix="${basename#.preflight-done.}"
+      [ -z "$suffix" ] && return 1
+      [ "${#suffix}" -gt "$PREFLIGHT_MARKER_SUFFIX_MAXLEN" ] && return 1
+      case "$suffix" in
+        *[!A-Za-z0-9_-]*) return 1 ;;
+      esac
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# preflight_marker_basename_for_session <sid>
+# Compose the per-session marker basename. Caller MUST validate_session_id
+# BEFORE calling this; not re-validated here.
+preflight_marker_basename_for_session() {
+  printf '.preflight-done.%s' "$1"
+}
+
+# any_preflight_marker_exists <repo-root>
+# True if ANY preflight-done marker (legacy OR any suffixed form) exists at
+# either primary or legacy marker dir under <repo-root>. Used by:
+#   - preflight-gate.sh existence check (session-aware after #279 fix)
+#   - SessionStart orphan-sweep
+any_preflight_marker_exists() {
+  local root="$1"
+  [ -e "$root/$PRIMARY_MARKER_DIR/$PREFLIGHT_MARKER_LEGACY_BASENAME" ] && return 0
+  [ -e "$root/$LEGACY_MARKER_DIR/$PREFLIGHT_MARKER_LEGACY_BASENAME" ] && return 0
+  local p
+  for p in "$root/$PRIMARY_MARKER_DIR"/.preflight-done.*; do
+    [ -e "$p" ] && return 0
+  done
+  for p in "$root/$LEGACY_MARKER_DIR"/.preflight-done.*; do
+    [ -e "$p" ] && return 0
+  done
+  return 1
+}

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -214,8 +214,9 @@ any_plan_marker_exists() {
 # #279 fix — per-session .preflight-done marker contract.
 #
 # Shell parity for scripts/lib/marker-paths.mjs PREFLIGHT_MARKER_*. Sibling
-# of PLAN_MARKER_* (#268 / PR #271). Drift caught by
-# scripts/validate-plan-marker-sites.mjs.
+# of PLAN_MARKER_* (#268 / PR #271). Drift detection extension to
+# scripts/validate-plan-marker-sites.mjs for PREFLIGHT_* constants is FU —
+# see issue #283 (validator currently covers PLAN_MARKER_* only).
 # ---------------------------------------------------------------------------
 
 readonly PREFLIGHT_MARKER_LEGACY_BASENAME='.preflight-done'

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -251,6 +251,12 @@ if [ "$TOOL_NAME" = "Bash" ]; then
           no-exec)
             _emit_deny "Helper invocation has no executable token after env-prefix walk. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
             ;;
+          no-helper)
+            _emit_deny "Helper invocation: executable token (node) present but no helper-script-path token follows. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          wrong-helper)
+            _emit_deny "Helper invocation: token after 'node' has basename '$GRAMMAR_DETAIL'; expected 'preflight-marker-write.mjs'. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
           *)
             _emit_deny "Helper invocation grammar denied ($GRAMMAR_KIND): $GRAMMAR_DETAIL"
             ;;

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -60,7 +60,11 @@ source "$LIB_DIR/marker-paths.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
 PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"
-PREFLIGHT_MARKER="$PRIMARY_DIR/.preflight-done"
+# #279 fix: prefer per-session marker, fall back to legacy during burn-in.
+# Resolution happens AFTER SESSION_ID is validated (below); the actual marker
+# path used by claim-class validation is set as PREFLIGHT_MARKER_RESOLVED.
+PREFLIGHT_MARKER_LEGACY="$PRIMARY_DIR/.preflight-done"
+PREFLIGHT_MARKER_SID=""   # set after SESSION_ID validation if present
 LAST_PROMPT_MARKER="$PRIMARY_DIR/.last-user-prompt.json"
 HELPER_PATH="$REPO_ROOT/scripts/preflight-marker-write.mjs"
 CANON_LIB="$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs"
@@ -102,6 +106,8 @@ if [ -n "$SESSION_ID" ]; then
   if [ ${#SESSION_ID} -gt 128 ]; then
     _emit_deny "preflight-gate.sh: session_id from stdin exceeds 128 chars; cannot evaluate prompt-binding."
   fi
+  # #279 fix: SESSION_ID has been validated, safe to interpolate into path.
+  PREFLIGHT_MARKER_SID="$PRIMARY_DIR/.preflight-done.${SESSION_ID}"
 fi
 
 # _canonicalize_one <input-path> <hook-cwd>
@@ -136,7 +142,7 @@ case "$TOOL_NAME" in
       set +e
       CANON_TOOL="$(_canonicalize_one "$TOOL_PATH" "$CWD")"
       ec_tool=$?
-      CANON_PREFLIGHT="$(_canonicalize_one "$PREFLIGHT_MARKER" "$REPO_ROOT")"
+      CANON_PREFLIGHT="$(_canonicalize_one "$PREFLIGHT_MARKER_LEGACY" "$REPO_ROOT")"
       ec_pf=$?
       CANON_LAST_PROMPT="$(_canonicalize_one "$LAST_PROMPT_MARKER" "$REPO_ROOT")"
       ec_lp=$?
@@ -159,16 +165,30 @@ case "$TOOL_NAME" in
       # .last-user-prompt.<sid>.json under .checkpoints/ (the session-
       # namespaced files written by the helper via the UserPromptSubmit
       # hook — agents must never write these directly).
+      # #279 fix: also deny .preflight-done.<sid> (the new per-session
+      # marker form) regardless of which session — helper-only contract.
       _tool_basename="$(basename "$CANON_TOOL")"
       _tool_parent="$(dirname "$CANON_TOOL")"
       _last_prompt_namespaced=0
+      _preflight_namespaced=0
       if [ "$_tool_parent" = "$CANON_PRIMARY_DIR" ]; then
         case "$_tool_basename" in
           .last-user-prompt.*.json) _last_prompt_namespaced=1 ;;
+          .preflight-done.*)
+            # Validate suffix shape ([A-Za-z0-9_-]{1,128}) so .preflight-done.bak
+            # / .preflight-done. / .preflight-done./traversal don't slip.
+            _suffix="${_tool_basename#.preflight-done.}"
+            if [ -n "$_suffix" ] && [ ${#_suffix} -le 128 ]; then
+              case "$_suffix" in
+                *[!A-Za-z0-9_-]*) : ;;
+                *) _preflight_namespaced=1 ;;
+              esac
+            fi
+            ;;
         esac
       fi
-      if [ "$CANON_TOOL" = "$CANON_PREFLIGHT" ] || [ "$CANON_TOOL" = "$CANON_LAST_PROMPT" ] || [ $_last_prompt_namespaced -eq 1 ]; then
-        _emit_deny "Direct $TOOL_NAME to preflight marker is forbidden. Use the atomic helper: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight (or --target last-prompt). Resolved tool path: $CANON_TOOL."
+      if [ "$CANON_TOOL" = "$CANON_PREFLIGHT" ] || [ "$CANON_TOOL" = "$CANON_LAST_PROMPT" ] || [ $_last_prompt_namespaced -eq 1 ] || [ $_preflight_namespaced -eq 1 ]; then
+        _emit_deny "Direct $TOOL_NAME to preflight marker is forbidden. Use the atomic helper: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight --session-id $SESSION_ID (or --target last-prompt). Resolved tool path: $CANON_TOOL."
       fi
     fi
     ;;
@@ -196,7 +216,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     HELPER_BASENAME_RE='(^|[ /])preflight-marker-write\.mjs( |$)'
     if printf '%s' "$NORMALIZED_CMD" | grep -qE "$HELPER_BASENAME_RE"; then
       if ! printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-root[[:space:]]+[^[:space:]]'; then
-        _emit_deny "preflight-marker-write.mjs invoked without explicit --root. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt>. No cwd fallback (ROOT_REQUIRED)."
+        _emit_deny "preflight-marker-write.mjs invoked without explicit --root. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>. No cwd fallback (ROOT_REQUIRED)."
       fi
       # I7 (plan-v2 audit F2): the UserPromptSubmit hook is the ONLY
       # sanctioned writer of `.last-user-prompt.<sid>.json`. The hook
@@ -226,18 +246,34 @@ if [ "$CLAIM_CLASS" != "codex-review-handoff" ]; then
   exit 0
 fi
 
-# Marker existence
-if [ ! -f "$PREFLIGHT_MARKER" ]; then
-  _emit_deny "Pre-flight marker required for codex-review-handoff. Write to $PREFLIGHT_MARKER via: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight. Required JSON fields: session_id, transcript_path, prompt_sha256, prompt_index, cwd, repo_root, memory_root, claim_class=\"codex-review-handoff\", matched_triggers, required_files (must include $BUNDLE_PATH), loaded_files (with sha256+mtime_ms per file), artifact_steps_done. Bundle: $BUNDLE_PATH."
+# #279 fix: prefer per-session marker `.preflight-done.<SESSION_ID>`, fall
+# back to legacy `.preflight-done` during burn-in. Resolution is purely a
+# local file existence check; the cross-session-stomp bug occurs only on
+# the legacy filename, so reading the suffixed form deterministically
+# returns THIS session's marker even when sibling sessions ran.
+PREFLIGHT_MARKER_RESOLVED=""
+if [ -n "$PREFLIGHT_MARKER_SID" ] && [ -f "$PREFLIGHT_MARKER_SID" ]; then
+  PREFLIGHT_MARKER_RESOLVED="$PREFLIGHT_MARKER_SID"
+elif [ -f "$PREFLIGHT_MARKER_LEGACY" ]; then
+  PREFLIGHT_MARKER_RESOLVED="$PREFLIGHT_MARKER_LEGACY"
+fi
+
+# Marker existence — name both candidate paths so callers know where to write.
+if [ -z "$PREFLIGHT_MARKER_RESOLVED" ]; then
+  if [ -n "$PREFLIGHT_MARKER_SID" ]; then
+    _emit_deny "Pre-flight marker required for codex-review-handoff. Write to $PREFLIGHT_MARKER_SID via: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight --session-id $SESSION_ID. Required JSON fields: session_id, transcript_path, prompt_sha256, prompt_index, cwd, repo_root, memory_root, claim_class=\"codex-review-handoff\", matched_triggers, required_files (must include $BUNDLE_PATH), loaded_files (with sha256+mtime_ms per file), artifact_steps_done. Bundle: $BUNDLE_PATH."
+  else
+    _emit_deny "Pre-flight marker required for codex-review-handoff. Write to $PREFLIGHT_MARKER_LEGACY via: echo '<JSON>' | node $HELPER_PATH --root $REPO_ROOT --target preflight --session-id <sid>. (stdin missing session_id — gate cannot derive per-session path; legacy path used.) Required JSON fields: session_id, transcript_path, prompt_sha256, prompt_index, cwd, repo_root, memory_root, claim_class=\"codex-review-handoff\", matched_triggers, required_files (must include $BUNDLE_PATH), loaded_files (with sha256+mtime_ms per file), artifact_steps_done. Bundle: $BUNDLE_PATH."
+  fi
 fi
 
 # JSON parse
-MARKER_JSON="$(cat "$PREFLIGHT_MARKER" 2>/dev/null || true)"
+MARKER_JSON="$(cat "$PREFLIGHT_MARKER_RESOLVED" 2>/dev/null || true)"
 if [ -z "$MARKER_JSON" ]; then
-  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER is empty. Write a valid JSON marker via the helper. May indicate a write-in-progress race; retry."
+  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER_RESOLVED is empty. Write a valid JSON marker via the helper. May indicate a write-in-progress race; retry."
 fi
 if ! printf '%s' "$MARKER_JSON" | jq empty 2>/dev/null; then
-  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER is not valid JSON. Re-write via $HELPER_PATH (which validates JSON.parse before writing)."
+  _emit_deny "Pre-flight marker $PREFLIGHT_MARKER_RESOLVED is not valid JSON. Re-write via $HELPER_PATH (which validates JSON.parse before writing)."
 fi
 
 # Field-by-field validation

--- a/hooks/preflight-gate.sh
+++ b/hooks/preflight-gate.sh
@@ -195,9 +195,23 @@ case "$TOOL_NAME" in
 esac
 
 # ---------------------------------------------------------------------------
-# Helper-invocation enforcement (FU-3): Bash invoking the helper without
-# explicit --root is denied at gate layer (defense in depth even when the
-# settings.json allowlist permits).
+# Helper-invocation enforcement (FU-3 + #279 Stream 2): Bash invoking the
+# helper must satisfy the v7 structural command-form grammar:
+#   <command> := <env-prefix>* <executable> <helper-script-path> <helper-flags>*
+# where:
+#   <env-prefix> name ∈ _ROUTINE_ENV_ALLOWLIST (NODE_ENV, DEBUG, CI, ...)
+#   <executable> basename ∈ _NODE_BINARY_BASENAME_ALLOWLIST (node)
+#
+# Replaces the prior regex-based detection of env wrappers / sudo wrappers /
+# path-spelled variants with two structural whitelists. Catches the entire
+# wrapper class (env, sudo, npx, nohup, time, bash, python, ...) via the
+# single executable-basename check.
+#
+# Defense layers BEYOND this gate:
+#   - Bash allowlist (settings.json) — first line of defense
+#   - command-classifier.sh wrapper_utility list — classify_command rejects
+#   - file-system permissions on /usr/bin/env etc.
+# This gate is one of many; not the only defense.
 # ---------------------------------------------------------------------------
 if [ "$TOOL_NAME" = "Bash" ]; then
   CMD="$(printf '%s' "$TOOL_INPUT_JSON" | jq -r '.command // ""')"
@@ -210,21 +224,47 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     # preceded by start-of-string, space, or slash (i.e. it IS the basename
     # of a path or a bare invocation), AND followed by space or end. The
     # previous regex used `\b...\b` which matched ANY word-boundary,
-    # producing false-positives on `test-preflight-marker-write.mjs`
-    # (the `-` in `test-` is a non-word char, so `\b` triggered against
-    # the following `p`). Plan-v2 C5: tighten the boundary.
+    # producing false-positives on `test-preflight-marker-write.mjs`.
     HELPER_BASENAME_RE='(^|[ /])preflight-marker-write\.mjs( |$)'
     if printf '%s' "$NORMALIZED_CMD" | grep -qE "$HELPER_BASENAME_RE"; then
+      # #279 Stream 2: structural command-form check.
+      # _check_helper_invocation_grammar is sourced from command-classifier.sh.
+      GRAMMAR_RESULT="$(_check_helper_invocation_grammar "$CMD")"
+      GRAMMAR_VERDICT="${GRAMMAR_RESULT%%	*}"
+      if [ "$GRAMMAR_VERDICT" = "DENY" ]; then
+        GRAMMAR_REST="${GRAMMAR_RESULT#*	}"
+        GRAMMAR_KIND="${GRAMMAR_REST%%	*}"
+        GRAMMAR_DETAIL="${GRAMMAR_REST#*	}"
+        case "$GRAMMAR_KIND" in
+          env-prefix)
+            _emit_deny "Helper invocation env-prefix wrapper ($GRAMMAR_DETAIL=...) not in routine allowlist. Only routine framework env vars permitted before helper: NODE_ENV, DEBUG, CI, PYTHONPATH, LOG_LEVEL. Per env-prefix-discipline-v1.md. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          env-prefix-invalid)
+            _emit_deny "Helper invocation env-prefix token has invalid POSIX-name shape: $GRAMMAR_DETAIL. Names must match [A-Za-z_][A-Za-z0-9_]*. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          wrapper)
+            _emit_deny "Helper must be invoked via a token whose basename is 'node'. Got basename '$GRAMMAR_DETAIL'. Wrappers (env, sudo, npx, nohup, time, exec, bash, python, etc.) not permitted at executable position. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          tokenize)
+            _emit_deny "Helper invocation could not be safely tokenized ($GRAMMAR_DETAIL). Use a simple form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          no-exec)
+            _emit_deny "Helper invocation has no executable token after env-prefix walk. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>."
+            ;;
+          *)
+            _emit_deny "Helper invocation grammar denied ($GRAMMAR_KIND): $GRAMMAR_DETAIL"
+            ;;
+        esac
+      fi
+      # Grammar passed (T[idx]=node). Still enforce existing --root and
+      # --target last-prompt rules on the helper flags.
       if ! printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-root[[:space:]]+[^[:space:]]'; then
         _emit_deny "preflight-marker-write.mjs invoked without explicit --root. Required form: node $HELPER_PATH --root $REPO_ROOT --target <preflight|last-prompt> --session-id <sid>. No cwd fallback (ROOT_REQUIRED)."
       fi
-      # I7 (plan-v2 audit F2): the UserPromptSubmit hook is the ONLY
-      # sanctioned writer of `.last-user-prompt.<sid>.json`. The hook
-      # runs OUTSIDE the PreToolUse path (UserPromptSubmit event), so
-      # any PreToolUse-time invocation of the helper with `--target
-      # last-prompt` is an agent attempt to spoof the prompt-binding.
-      # Deny regardless of --root presence (the agent could supply
-      # --root correctly while still forging the sha).
+      # I7 (plan-v2 audit F2): UserPromptSubmit hook is the ONLY sanctioned
+      # writer of `.last-user-prompt.<sid>.json`. PreToolUse-time invocation
+      # of the helper with `--target last-prompt` is an agent attempt to
+      # spoof the prompt-binding.
       if printf '%s' "$NORMALIZED_CMD" | grep -qE '\-\-target[[:space:]]+last-prompt([[:space:]]|$)'; then
         _emit_deny "preflight-marker-write.mjs --target last-prompt is reserved for the UserPromptSubmit hook. Agent invocation at PreToolUse is forbidden — the hook writes this file on every real user prompt automatically. If the file is missing, the install may be incomplete: re-run install.mjs --install-hooks."
       fi

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -182,6 +182,57 @@ export function planMarkerBasenameForSession(sid) {
 }
 
 // ---------------------------------------------------------------------------
+// #279 fix — per-session .preflight-done marker contract.
+//
+// Canonical (new):   .preflight-done.<session_id>     (per-session)
+// Legacy (burn-in):  .preflight-done                  (suffix-less)
+//
+// Sibling of PLAN_MARKER_* (#268 / PR #271). Both forms accepted by
+// readers/gates during burn-in. Helper writes only the suffixed form when
+// --session-id is provided to --target preflight. SessionStart orphan-sweep
+// clears both. SessionEnd own-session-only deletes the suffixed form for
+// the ending session.
+//
+// Shell parity: hooks/lib/marker-paths.sh PREFLIGHT_MARKER_*. Drift caught
+// by scripts/validate-plan-marker-sites.mjs (Direction 0, registry-driven).
+// ---------------------------------------------------------------------------
+
+export const PREFLIGHT_MARKER_LEGACY_BASENAME = '.preflight-done'
+export const PREFLIGHT_MARKER_BASENAME_TEMPLATE = '.preflight-done.{sid}'
+export const PREFLIGHT_MARKER_BASENAME_RE = /^\.preflight-done(\.[A-Za-z0-9_-]{1,128})?$/
+
+/**
+ * Strict match for preflight-marker basenames. Accepts ONLY:
+ *   .preflight-done                                 (legacy suffix-less)
+ *   .preflight-done.<sid>                           (sid matches char-class + length)
+ * Rejects:
+ *   .preflight-done-extra                           (suffix without dot separator)
+ *   .preflight-done.                                (empty suffix)
+ *   .preflight-done./traversal                      (slash in suffix)
+ *   .preflight-done..                               (dot in suffix)
+ *   .preflight-done.<129-char>                      (oversize suffix)
+ *
+ * Mirrors hooks/lib/marker-paths.sh preflight_marker_basename_matches().
+ *
+ * @param {string} basename
+ * @returns {boolean}
+ */
+export function preflightMarkerBasenameMatches(basename) {
+  return typeof basename === 'string' && PREFLIGHT_MARKER_BASENAME_RE.test(basename)
+}
+
+/**
+ * Compose the per-session preflight-marker basename for a given session id.
+ * Caller MUST validateSessionId(sid) first; this helper does not re-validate.
+ *
+ * @param {string} sid — valid session-id (matches SESSION_ID_RE)
+ * @returns {string} '.preflight-done.<sid>'
+ */
+export function preflightMarkerBasenameForSession(sid) {
+  return PREFLIGHT_MARKER_BASENAME_TEMPLATE.replace('{sid}', sid)
+}
+
+// ---------------------------------------------------------------------------
 // Enforcement-site registry — single source of truth for the validator.
 //
 // Every place in the codebase that recognizes, gates, iterates, or otherwise

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -189,12 +189,16 @@ export function planMarkerBasenameForSession(sid) {
 //
 // Sibling of PLAN_MARKER_* (#268 / PR #271). Both forms accepted by
 // readers/gates during burn-in. Helper writes only the suffixed form when
-// --session-id is provided to --target preflight. SessionStart orphan-sweep
-// clears both. SessionEnd own-session-only deletes the suffixed form for
-// the ending session.
+// --session-id is provided to --target preflight.
 //
-// Shell parity: hooks/lib/marker-paths.sh PREFLIGHT_MARKER_*. Drift caught
-// by scripts/validate-plan-marker-sites.mjs (Direction 0, registry-driven).
+// SessionStart orphan-sweep / SessionEnd own-session-only cleanup of the
+// per-session form are FU — see issue #283 (`any_preflight_marker_exists`
+// is defined for future wiring; not yet called by lifecycle hooks).
+//
+// Shell parity: hooks/lib/marker-paths.sh PREFLIGHT_MARKER_*. Drift
+// detection extension to validate-plan-marker-sites.mjs for PREFLIGHT_*
+// constants is FU — see issue #283 (validator currently covers
+// PLAN_MARKER_* only).
 // ---------------------------------------------------------------------------
 
 export const PREFLIGHT_MARKER_LEGACY_BASENAME = '.preflight-done'

--- a/scripts/preflight-marker-write.mjs
+++ b/scripts/preflight-marker-write.mjs
@@ -24,14 +24,22 @@
  *   echo '<JSON>'  | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target last-prompt --session-id <sid>
  *   cat input.json | node /abs/path/preflight-marker-write.mjs --root /abs/repo --target preflight
  *
- * Per-session namespacing (`--target last-prompt`):
- *   The last-prompt file is keyed by session_id to avoid cross-session
- *   liveness collisions (plan-time audit F4, scratch/238-plan-v2.md).
- *   Basename: `.last-user-prompt.<session_id>.json`. session_id is required
- *   for that target and must match `[A-Za-z0-9_-]{1,128}` (no dots, no
- *   slashes — prevents basename injection past the `.json` suffix).
- *   The preflight target is unchanged: single `.preflight-done` per repo,
- *   session-bound via marker JSON content.
+ * Per-session namespacing (`--target last-prompt` AND `--target preflight`):
+ *   Both files are keyed by session_id to avoid cross-session liveness
+ *   collisions. last-prompt: plan-time audit F4, scratch/238-plan-v2.md.
+ *   preflight: #279 fix mirroring PR #271's plan-approval-pending pattern.
+ *
+ *   - last-prompt basename: `.last-user-prompt.<session_id>.json`
+ *                           (session-id REQUIRED)
+ *   - preflight   basename: `.preflight-done.<session_id>` (new in #279)
+ *                           or `.preflight-done` legacy form during burn-in.
+ *                           (session-id OPTIONAL: writes legacy filename
+ *                            when absent so existing callers keep working;
+ *                            gate prefers per-session form when present.)
+ *
+ *   session_id must match `[A-Za-z0-9_-]{1,128}` when given (no dots —
+ *   could collide with `.json` suffix on last-prompt — no slashes —
+ *   path traversal).
  *
  * Exit codes:
  *   0 — success; stdout is `{"status":"ok","path":"<final>","bytes":N}`
@@ -41,7 +49,7 @@
  *   5 — `--root` invalid (non-existent OR not a repo root signal)
  *   6 — `--target` missing or invalid value
  *   7 — stdin read error
- *   8 — `--session-id` missing/invalid when target=last-prompt
+ *   8 — `--session-id` missing when target=last-prompt; or invalid format for either target
  *
  * Discovered: codex r2 reply `20260512-071449-...-6e90` (atomicity invariant
  *   not locally verifiable for agent-side Write).
@@ -63,10 +71,12 @@ import { ensurePrimaryDir, primaryMarkerPath } from './lib/marker-paths.mjs'
 import { SESSION_ID_RE } from './lib/session-id.mjs'
 import { validateRoot, RootValidationError } from './lib/marker-root-validation.mjs'
 
-// preflight target → fixed basename; last-prompt target → suffix template
-// where {sid} is substituted with the validated --session-id value.
+// #279 burn-in: --target preflight accepts both forms.
+//   With    --session-id <sid> → writes .preflight-done.<sid>  (new, canonical)
+//   Without --session-id        → writes .preflight-done       (legacy)
+// last-prompt is always session-keyed (--session-id required).
 const VALID_TARGETS = {
-  preflight: { kind: 'fixed', basename: '.preflight-done' },
+  preflight: { kind: 'session-optional', legacyBasename: '.preflight-done', template: '.preflight-done.{sid}' },
   'last-prompt': { kind: 'session', template: '.last-user-prompt.{sid}.json' }
 }
 
@@ -92,7 +102,8 @@ function parseArgs(argv) {
     } else if (a === '--help' || a === '-h') {
       process.stdout.write(
         'Usage: echo "<JSON>" | preflight-marker-write.mjs --root <abs> --target <preflight|last-prompt> [--session-id <sid>]\n' +
-        '  --session-id required when --target=last-prompt (alphanumeric/underscore/dash, max 128 chars)\n'
+        '  --session-id required for --target=last-prompt; optional for --target=preflight (burn-in #279).\n' +
+        '  Format: alphanumeric/underscore/dash, max 128 chars.\n'
       )
       process.exit(0)
     } else {
@@ -102,12 +113,20 @@ function parseArgs(argv) {
   return args
 }
 
-// Resolve the marker basename for a target, validating any required
-// per-target args (e.g. --session-id for last-prompt).
+// Resolve the marker basename for a target.
+//   kind=session           — --session-id required; substitutes into template.
+//   kind=session-optional  — --session-id optional; legacy basename if absent,
+//                             else substituted template (#279 burn-in).
 function resolveBasename(target, sessionId) {
   const spec = VALID_TARGETS[target]
-  if (spec.kind === 'fixed') return spec.basename
-  // kind === 'session'
+  if (spec.kind === 'session-optional') {
+    if (!sessionId) return spec.legacyBasename
+    if (!SESSION_ID_RE.test(sessionId)) {
+      fail(8, `SESSION_ID_INVALID: must match ${SESSION_ID_RE.source}, got: ${sessionId}`)
+    }
+    return spec.template.replace('{sid}', sessionId)
+  }
+  // kind === 'session' — --session-id is mandatory
   if (!sessionId) {
     fail(8, `SESSION_ID_REQUIRED: --session-id <sid> is mandatory when --target=${target}`)
   }

--- a/tests/test-preflight-gate-sid-parser.sh
+++ b/tests/test-preflight-gate-sid-parser.sh
@@ -185,6 +185,13 @@ run_gate_grammar "$TF" "--session-id A $HELPER --root $TF --target preflight" "d
 run_gate_grammar "$TF" "/usr/bin/node/ $HELPER $COMMON_FLAGS" "deny" "basename ''" \
   "B19 trailing-slash token → empty basename → deny (codex r9 FU)"
 
+# B20: wrong-helper basename (per codex PR-r1 P3). Grammar verifies T[idx+1]
+# basename matches preflight-marker-write.mjs; injected alternate scripts
+# deny. Even though the outer gate regex matched the helper basename
+# somewhere in argv, the grammar walk enforces position.
+run_gate_grammar "$TF" "node /tmp/other.mjs $HELPER --root $TF --target preflight --session-id $SESSION_ID" "deny" "expected 'preflight-marker-write.mjs'" \
+  "B20 wrong-helper at T[idx+1] → grammar deny (codex PR-r1 P3)"
+
 echo ""
 echo "=================================================="
 echo "Results: $passed passed, $failed failed"

--- a/tests/test-preflight-gate-sid-parser.sh
+++ b/tests/test-preflight-gate-sid-parser.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight-gate-sid-parser.sh — #279 Stream 2 grammar tests.
+#
+# Tests the structural command-form grammar enforced at the preflight-gate's
+# helper-invocation branch:
+#
+#   <command> := <env-prefix>* <executable> <helper-script-path> <helper-flags>*
+#   <env-prefix> name ∈ _ROUTINE_ENV_ALLOWLIST  (NODE_ENV, DEBUG, CI, PYTHONPATH, LOG_LEVEL)
+#   <executable> basename ∈ _NODE_BINARY_BASENAME_ALLOWLIST  (node)
+#
+# Class A (8 accept) proves the allow combinatorial.
+# Class B (19 deny) proves each rule branch fires across variant classes.
+# Class C (sid-form: --session-id A vs --session-id=A vs duplicate vs missing
+#   etc.) lives in test-preflight-gate.sh M/N-series — not re-tested here.
+#
+# Codex r9 plan-tier ACCEPT-with-FU; B19 added per the inline FU.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE_INPUT_TMPL='{"tool_name":"Bash","tool_input":{"command":"%s"},"cwd":"%s","session_id":"%s","transcript_path":"/tmp/x"}'
+
+passed=0
+failed=0
+SESSION_ID="test-session-$$"
+
+# Stage a minimal tmp project. Mirrors test-preflight-gate.sh stage_fixture.
+mktmp() { mktemp -d -t emt279.XXXXXX; }
+
+stage_fixture() {
+  local tmp="$1"
+  mkdir -p "$tmp/scripts/lib" "$tmp/hooks/lib" "$tmp/.checkpoints" "$tmp/bundles"
+  (cd "$tmp" && git init -q 2>/dev/null) || true
+  cp "$REPO_ROOT/scripts/preflight-marker-write.mjs" "$tmp/scripts/"
+  cp "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/local-dir.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-paths.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/session-id.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/scripts/lib/marker-root-validation.mjs" "$tmp/scripts/lib/"
+  cp "$REPO_ROOT/hooks/preflight-gate.sh" "$tmp/hooks/"
+  cp "$REPO_ROOT/hooks/lib/command-classifier.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/repo-root.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/hooks/lib/marker-paths.sh" "$tmp/hooks/lib/"
+  cp "$REPO_ROOT/bundles/codex-review-channel-current.md" "$tmp/bundles/"
+}
+
+cleanup_dirs=()
+on_exit() { local d; for d in "${cleanup_dirs[@]+${cleanup_dirs[@]}}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap on_exit EXIT
+_track() { cleanup_dirs+=("$1"); }
+
+# run_gate_grammar <tmp> <cmd> <expect:allow|deny> <reason_grep> <desc>
+# Runs the helper-invocation portion of the gate. <cmd> should contain the
+# helper basename so the helper-invocation branch fires.
+run_gate_grammar() {
+  local tmp="$1" cmd="$2" expect="$3" reason_grep="$4" desc="$5"
+  local cmd_escaped
+  cmd_escaped="$(printf '%s' "$cmd" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  local payload
+  payload="$(printf "$GATE_INPUT_TMPL" "$cmd_escaped" "$tmp" "$SESSION_ID")"
+  local out
+  out="$(printf '%s' "$payload" | bash "$tmp/hooks/preflight-gate.sh" 2>&1 || true)"
+
+  if [ "$expect" = "allow" ]; then
+    # Allow path: gate emits no JSON OR emits non-deny.
+    local decision
+    decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+    if [ -z "$out" ] || [ "$decision" != "deny" ]; then
+      echo "  ✓ $desc"
+      passed=$((passed+1))
+    else
+      echo "  ✗ $desc — expected allow but denied: $out"
+      failed=$((failed+1))
+    fi
+  else
+    local decision reason
+    decision="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")"
+    reason="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null || echo "")"
+    if [ "$decision" = "deny" ] && printf '%s' "$reason" | grep -qE "$reason_grep"; then
+      echo "  ✓ $desc"
+      passed=$((passed+1))
+    else
+      echo "  ✗ $desc — got decision='$decision' reason='$reason' (expected deny matching /$reason_grep/)"
+      failed=$((failed+1))
+    fi
+  fi
+}
+
+TF="$(mktmp)"; _track "$TF"; stage_fixture "$TF"
+HELPER="$TF/scripts/preflight-marker-write.mjs"
+COMMON_FLAGS="--root $TF --target preflight --session-id $SESSION_ID"
+
+echo "--- Class A: ACCEPT (proves the allow combinatorial) ---"
+
+# A1: bare node invocation, no env-prefix
+run_gate_grammar "$TF" "node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A1 bare node invocation, no env-prefix"
+
+# A2: path-spelled node
+run_gate_grammar "$TF" "/usr/bin/node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A2 /usr/bin/node path-spelled"
+
+# A3: different node install path
+run_gate_grammar "$TF" "/usr/local/bin/node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A3 /usr/local/bin/node path"
+
+# A4: relative path node
+run_gate_grammar "$TF" "./node_modules/.bin/node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A4 ./node_modules/.bin/node relative path"
+
+# A5: single allowlist env-prefix
+run_gate_grammar "$TF" "NODE_ENV=production node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A5 NODE_ENV=production allowlist env-prefix"
+
+# A6: multiple allowlist env-prefixes
+run_gate_grammar "$TF" "NODE_ENV=production DEBUG=1 node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A6 NODE_ENV + DEBUG (multiple allowlist)"
+
+# A7: three allowlist env-prefixes
+run_gate_grammar "$TF" "CI=true PYTHONPATH=. LOG_LEVEL=debug node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A7 CI + PYTHONPATH + LOG_LEVEL (full multi)"
+
+# A8: allowlist env-prefix + path-spelled node
+run_gate_grammar "$TF" "DEBUG=1 /usr/bin/node $HELPER $COMMON_FLAGS" "allow" "" \
+  "A8 DEBUG=1 + /usr/bin/node (combined)"
+
+echo ""
+echo "--- Class B: DENY (one row per rule branch, not per variant) ---"
+
+# B1-B4: env wrapper (all variants collapse to basename=env)
+run_gate_grammar "$TF" "env node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B1 env wrapper → basename=env deny"
+run_gate_grammar "$TF" "/usr/bin/env node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B2 /usr/bin/env path-spelled → same rule"
+run_gate_grammar "$TF" "/bin/env -i node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B3 /bin/env -i variant → same rule"
+run_gate_grammar "$TF" "./env node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B4 ./env relative-path → same rule"
+
+# B5-B10: non-env wrappers (all collapse to wrapper deny)
+run_gate_grammar "$TF" "sudo node $HELPER $COMMON_FLAGS" "deny" "basename 'sudo'" \
+  "B5 sudo wrapper"
+run_gate_grammar "$TF" "npx node $HELPER $COMMON_FLAGS" "deny" "basename 'npx'" \
+  "B6 npx shim wrapper"
+run_gate_grammar "$TF" "nohup node $HELPER $COMMON_FLAGS" "deny" "basename 'nohup'" \
+  "B7 nohup wrapper"
+run_gate_grammar "$TF" "time node $HELPER $COMMON_FLAGS" "deny" "basename 'time'" \
+  "B8 time wrapper"
+run_gate_grammar "$TF" "python $HELPER $COMMON_FLAGS" "deny" "basename 'python'" \
+  "B9 wrong interpreter (python)"
+run_gate_grammar "$TF" "bash $HELPER $COMMON_FLAGS" "deny" "basename 'bash'" \
+  "B10 shell wrapper (bash)"
+
+# B11-B13: non-allowlist env-prefix
+run_gate_grammar "$TF" "SKIP_PREFLIGHT=1 node $HELPER $COMMON_FLAGS" "deny" "SKIP_PREFLIGHT" \
+  "B11 SKIP_PREFLIGHT=1 non-allowlist"
+run_gate_grammar "$TF" "BYPASS_GATE=1 node $HELPER $COMMON_FLAGS" "deny" "BYPASS_GATE" \
+  "B12 BYPASS_GATE=1 non-allowlist"
+run_gate_grammar "$TF" "SESSION_ID=A node $HELPER $COMMON_FLAGS" "deny" "SESSION_ID" \
+  "B13 SESSION_ID=A non-allowlist (form-rejection)"
+
+# B14-B16: benign-prefix walk → then non-allow at next position
+run_gate_grammar "$TF" "NODE_ENV=production env SKIP_PREFLIGHT=1 node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B14 benign-prefix walk → T[p]=env (NOT step 2)"
+run_gate_grammar "$TF" "NODE_ENV=production /usr/bin/env node $HELPER $COMMON_FLAGS" "deny" "basename 'env'" \
+  "B15 benign-prefix walk → path-env"
+run_gate_grammar "$TF" "NODE_ENV=production sudo node $HELPER $COMMON_FLAGS" "deny" "basename 'sudo'" \
+  "B16 benign-prefix walk → non-env wrapper"
+
+# B17: benign-prefix walk → suspicious-prefix
+run_gate_grammar "$TF" "NODE_ENV=production SKIP_PREFLIGHT=1 node $HELPER $COMMON_FLAGS" "deny" "SKIP_PREFLIGHT" \
+  "B17 benign-prefix walk → suspicious-prefix (step 2 deny)"
+
+# B18: T[p] is a flag, not an executable
+# In practice the grammar walk would see `--session-id` as T[idx] and treat
+# basename as `--session-id` which is not 'node'. The helper-basename regex
+# also fires here. Reasonable verdict: wrapper deny on the flag's basename.
+run_gate_grammar "$TF" "--session-id A $HELPER --root $TF --target preflight" "deny" "basename '--session-id'|invalid POSIX-name" \
+  "B18 T[p]=--session-id (flag at exec position)"
+
+# B19: trailing-slash token (per codex r9 P3 FU). _tokenize emits the path
+# as-is; `${path##*/}` yields empty string for trailing slash → not in
+# allowlist → deny.
+run_gate_grammar "$TF" "/usr/bin/node/ $HELPER $COMMON_FLAGS" "deny" "basename ''" \
+  "B19 trailing-slash token → empty basename → deny (codex r9 FU)"
+
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+exit $((failed > 0 ? 1 : 0))

--- a/tests/test-preflight-gate.sh
+++ b/tests/test-preflight-gate.sh
@@ -765,6 +765,120 @@ ln -s "$TF/.checkpoints/non-existent-target.json" "$TF/.checkpoints/.last-user-p
 run_gate "$TF" "Bash" '{"command":"codex exec foo"}' "deny" "does not exist|cannot.*canonicalize|cannot.*verify" "I9 dangling symlink for ground-truth → deny"
 
 # ---------------------------------------------------------------------------
+# N-series: #279 per-session preflight marker (cross-session stomp fix)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- N-series: per-session .preflight-done.<sid> (#279) ---"
+
+# Helper: write a valid marker at the per-session path for $TMP.
+write_valid_marker_for_session() {
+  local tmp="$1" sid="$2"
+  local bundle="$tmp/bundles/codex-review-channel-current.md"
+  local bundle_sha
+  bundle_sha="$(shasum -a 256 "$bundle" | awk '{print $1}')"
+  local bundle_mtime
+  bundle_mtime="$(node -e "process.stdout.write(String(require('fs').statSync(process.argv[1]).mtimeMs))" "$bundle")"
+  cat > "$tmp/.checkpoints/.preflight-done.${sid}" <<EOF
+{
+  "session_id": "$sid",
+  "transcript_path": "/tmp/x",
+  "prompt_sha256": "abc123",
+  "prompt_index": 1,
+  "cwd": "$tmp",
+  "repo_root": "$tmp",
+  "memory_root": "$tmp/memory",
+  "claim_class": "codex-review-handoff",
+  "matched_triggers": {"tool_target": ["Bash:codex exec"]},
+  "required_files": ["$bundle"],
+  "loaded_files": [{"path": "$bundle", "mtime_ms": $bundle_mtime, "sha256": "$bundle_sha"}],
+  "artifact_steps_done": ["memory-pre-pass"],
+  "created_at_ms": 1747022400000
+}
+EOF
+}
+
+# N1: gate reads `.preflight-done.<sid>` when present (no legacy fallback needed)
+TFN1="$(mktmp)"; stage_fixture "$TFN1"
+write_valid_marker_for_session "$TFN1" "$SESSION_ID"
+write_ground_truth_last_prompt "$TFN1"
+run_gate "$TFN1" "Bash" '{"command":"codex exec foo"}' "allow" "" "N1 session-keyed marker → allow codex"
+
+# N2: gate PREFERS session-keyed over legacy when both exist
+TFN2="$(mktmp)"; stage_fixture "$TFN2"
+write_valid_marker "$TFN2"                    # legacy .preflight-done
+write_valid_marker_for_session "$TFN2" "$SESSION_ID"  # session-keyed
+write_ground_truth_last_prompt "$TFN2"
+# Mutate legacy to have wrong claim_class — if gate reads legacy, this denies;
+# if gate reads session-keyed (correct), allow.
+sed -i.bak 's/"codex-review-handoff"/"plan-time-matrix"/' "$TFN2/.checkpoints/.preflight-done"
+rm "$TFN2/.checkpoints/.preflight-done.bak"
+run_gate "$TFN2" "Bash" '{"command":"codex exec foo"}' "allow" "" "N2 session-keyed PREFERRED over legacy"
+
+# N3: gate falls back to legacy when session-keyed missing (burn-in)
+TFN3="$(mktmp)"; stage_fixture "$TFN3"
+write_valid_marker "$TFN3"                    # legacy only
+write_ground_truth_last_prompt "$TFN3"
+run_gate "$TFN3" "Bash" '{"command":"codex exec foo"}' "allow" "" "N3 legacy fallback when session-keyed absent"
+
+# N4: direct Write to .preflight-done.<sid> denied (helper-only contract)
+TFN4="$(mktmp)"; stage_fixture "$TFN4"
+run_gate "$TFN4" "Write" "{\"file_path\":\"$TFN4/.checkpoints/.preflight-done.${SESSION_ID}\",\"content\":\"x\"}" \
+  "deny" "forbidden|helper" "N4 direct Write to .preflight-done.<sid> → DENY"
+
+# N5: cross-session stomp protection — markers for two sessions, gate reads OWN
+# This IS the #279 bug fix. Pre-#279: both sessions stomped legacy .preflight-done.
+# Post-#279: each session has its own .preflight-done.<sid>; gate reads stdin sid.
+TFN5="$(mktmp)"; stage_fixture "$TFN5"
+OTHER_SID="other-session-$$"
+write_valid_marker_for_session "$TFN5" "$SESSION_ID"
+write_valid_marker_for_session "$TFN5" "$OTHER_SID"
+write_ground_truth_last_prompt "$TFN5"
+# Gate runs with $SESSION_ID; should pick up THIS session's marker, not other.
+run_gate "$TFN5" "Bash" '{"command":"codex exec foo"}' "allow" "" "N5 cross-session: gate reads OWN session marker (#279 fix)"
+
+# N6: helper writes to session-keyed path when --session-id given
+TFN6="$(mktmp)"; stage_fixture "$TFN6"
+set +e
+out="$(echo '{"v":1}' | node "$TFN6/scripts/preflight-marker-write.mjs" --root "$TFN6" --target preflight --session-id "$SESSION_ID" 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "0" ] && [ -f "$TFN6/.checkpoints/.preflight-done.${SESSION_ID}" ] && [ ! -f "$TFN6/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ N6 helper --session-id writes .preflight-done.<sid>, not legacy"
+  passed=$((passed+1))
+else
+  echo "  ✗ N6 — exit $ec, session-keyed exists: $([ -f "$TFN6/.checkpoints/.preflight-done.${SESSION_ID}" ] && echo yes || echo no), legacy exists: $([ -f "$TFN6/.checkpoints/.preflight-done" ] && echo yes || echo no), output: $out"
+  failed=$((failed+1))
+fi
+
+# N7: helper without --session-id writes legacy filename (burn-in compat)
+TFN7="$(mktmp)"; stage_fixture "$TFN7"
+set +e
+out="$(echo '{"v":1}' | node "$TFN7/scripts/preflight-marker-write.mjs" --root "$TFN7" --target preflight 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "0" ] && [ -f "$TFN7/.checkpoints/.preflight-done" ]; then
+  echo "  ✓ N7 helper without --session-id writes legacy .preflight-done (burn-in)"
+  passed=$((passed+1))
+else
+  echo "  ✗ N7 — exit $ec, output: $out"
+  failed=$((failed+1))
+fi
+
+# N8: helper with invalid --session-id (path traversal) rejected
+TFN8="$(mktmp)"; stage_fixture "$TFN8"
+set +e
+out="$(echo '{"v":1}' | node "$TFN8/scripts/preflight-marker-write.mjs" --root "$TFN8" --target preflight --session-id "../etc/passwd" 2>&1)"
+ec=$?
+set -e
+if [ "$ec" = "8" ] && printf '%s' "$out" | grep -qE "SESSION_ID_INVALID"; then
+  echo "  ✓ N8 helper rejects invalid --session-id (path traversal) → exit 8"
+  passed=$((passed+1))
+else
+  echo "  ✗ N8 — exit $ec, output: $out"
+  failed=$((failed+1))
+fi
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- **Stream 1** (`c0685cb`): per-session `.preflight-done.<sid>` marker namespacing closes the #279 cross-session stomp bug. Mirrors PR #271's plan-marker pattern for the sibling marker.
- **Stream 2** (`1219635`): tokenize-based 2-whitelist structural grammar replaces regex-based helper-invocation enforcement. Eliminates the entire env-wrapper / sudo-wrapper / path-spelled-anything class via `_ROUTINE_ENV_ALLOWLIST` + `_NODE_BINARY_BASENAME_ALLOWLIST`.
- **Docstring fix** (`2dfbf50`): retracted overclaimed validator/lifecycle coverage per code-review F1/F2; consolidated 5 follow-up findings into #283.

## Plan-tier provenance

- 9-round codex plan-tier chain converged ACCEPT-with-FU at round 9 (`20260516-014225-reply-codex-to-20260516-014039-279-plan--fa42`).
- Sole FU (B19 trailing-slash deny test row) folded inline.
- Implementation diff reviewed by `negative-scenario-reviewer` subagent → ACCEPT-with-FU (5 findings, 0 P1, 1 P2, 2 P3, 2 NIT). All filed as #283.

## Surface changed

| File | Direction |
|---|---|
| `scripts/lib/marker-paths.mjs` | +`PREFLIGHT_MARKER_*` constants + helpers |
| `hooks/lib/marker-paths.sh` | shell parity for above |
| `scripts/preflight-marker-write.mjs` | `--target preflight` accepts optional `--session-id` |
| `hooks/preflight-gate.sh` | gate prefers `.preflight-done.<sid>`; helper-invocation uses structural grammar |
| `hooks/lib/command-classifier.sh` | `.preflight-done.<sid>` marker-write recognition (rm/tee/touch/redirect); `_check_helper_invocation_grammar()` function |
| `hooks/checkpoint-gate.sh` | basename allowlist + regex alternations extended |
| `tests/test-preflight-gate.sh` | +8 N-series tests (including N5 cross-session stomp protection) |
| `tests/test-preflight-gate-sid-parser.sh` | NEW — 27 Class A/B grammar tests |

## Out of scope (documented in plan v7)

- Same-command shell shadowing (function defs, aliases, source, eval) — deep shell-injection class; honest-agent threat model boundary per PR #271.
- Runtime identity of `node`-named binary that is actually a shell wrapper — mitigated by Bash allowlist + file-system permissions.
- PATH-based resolution attacks — same scope rationale.

## Test plan

- [x] `bash tests/test-preflight-gate.sh` → 86/86 pass (includes 8 new N-series)
- [x] `bash tests/test-preflight-gate-sid-parser.sh` → 27/27 pass
- [x] `bash tests/test-command-classifier.sh` → 300/300 pass (no regressions)
- [x] `bash tests/test-checkpoint-gate.sh` → 145/145 pass (no regressions)
- [x] **N5 cross-session stomp protection** — the actual #279 repro: writes markers for two distinct session-ids in the same `.checkpoints/`, gate dispatched with `SESSION_ID_A` reads `.preflight-done.<sid-a>`, ignores `<sid-b>`.
- [x] Empirically tokenized 13 wrapper/edge variants (`env`, `sudo`, `npx`, `nohup`, `time`, `script`, `gosu`, `chronic`, `setsid`, `unshare`, `taskset`, `bash -c`, `$(...)`) — all DENY via `_check_helper_invocation_grammar`.

Closes #279
Follow-ups: #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
