### PR TITLE
[codex] Add OpenCode and Pi Agent installer targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # episodic-memory
 
-A **shared memory layer for AI coding agents**. Different agentic AI platforms — Claude Code, Cursor, Codex, Windsurf — read and write to the *same* episodic store, so decisions, discoveries, and behavioral patterns persist across sessions *and* across tools.
+A **shared memory layer for AI coding agents**. Different agentic AI platforms — Claude Code, Cursor, Codex, OpenCode, Pi Agent, Windsurf — read and write to the *same* episodic store, so decisions, discoveries, and behavioral patterns persist across sessions *and* across tools.
 
-Works with: **Claude Code**, **Cursor**, **Codex (OpenAI)**, **Windsurf / Continue**
+Works with: **Claude Code**, **Cursor**, **Codex (OpenAI)**, **OpenCode**, **Pi Agent**, **Windsurf / Continue**
 
 The design principles guiding the system are documented in [PRINCIPLES.md](PRINCIPLES.md).
 
@@ -76,7 +76,7 @@ cd episodic-memory
 # Install for a specific tool in a target project
 node install.mjs --tool cursor --project /path/to/my-project
 
-# Install for all supported tools
+# Install for all bundled targets except OpenCode
 node install.mjs --tool all --project /path/to/my-project
 ```
 
@@ -93,8 +93,26 @@ The installer:
 |------|-----------------|------------------|
 | Claude Code | `SKILL.md` | `.claude/skills/episodic-memory/SKILL.md` |
 | Cursor | `cursor.mdc` | `.cursor/rules/episodic-memory.mdc` |
-| Codex | `codex-skill.md` | `.agents/skills/episodic-memory/` |
+| Codex | `SKILL.md` | `.agents/skills/episodic-memory/SKILL.md` |
+| OpenCode | `SKILL.md` | `.opencode/skills/episodic-memory/SKILL.md` |
+| Pi Agent | `SKILL.md` | `.agents/skills/episodic-memory/SKILL.md` |
 | Windsurf | `windsurf.md` | `.windsurfrules` (appended if exists) |
+
+OpenCode is explicit-only: run `node install.mjs --tool opencode --project <path>`. It is intentionally excluded from `--tool all` because current OpenCode discovery loads `.opencode/skills`, `.claude/skills`, and `.agents/skills`; a broad all-tools install can otherwise expose duplicate `episodic-memory` skills. This path contract is pinned to the current official OpenCode skill docs observed 2026-05-16: <https://opencode.ai/docs/skills>.
+
+Pi Agent shares the `.agents/skills/episodic-memory/SKILL.md` destination with Codex. `--tool all` includes Pi Agent by reusing that shared destination.
+
+Instruction-only support is deliberately modest for OpenCode and Pi Agent:
+
+| Capability | OpenCode | Pi Agent |
+|------------|----------|----------|
+| Manual recall/search/store/revise via scripts | MEDIUM when shell/script execution is available; otherwise WEAK/manual | MEDIUM when shell/script execution is available; otherwise WEAK/manual |
+| Proactive session-start recall | WEAK; depends on the agent loading/following the skill | WEAK; depends on the agent loading/following the skill |
+| Enforcement/hooks | Unsupported in this installer slice | Unsupported in this installer slice |
+| Live MCP tools | Deferred | Deferred |
+| Cross-tool typed requests | Deferred except manual existing-script use | Deferred except manual existing-script use |
+
+Future MCP support should be a thin wrapper around existing scripts (`recall`, `search`, `store`, `revise`) with no second store, no daemon, no polling, explicit activation, and reversible uninstall.
 
 ## Episode Categories
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -44,10 +44,16 @@ node ~/episodic-memory/install.mjs --tool claude-code --install-hooks --project 
 # For Codex
 node ~/episodic-memory/install.mjs --tool codex --project /path/to/my-project
 
+# For OpenCode (explicit-only; not included in --tool all)
+node ~/episodic-memory/install.mjs --tool opencode --project /path/to/my-project
+
+# For Pi Agent
+node ~/episodic-memory/install.mjs --tool pi-agent --project /path/to/my-project
+
 # For Windsurf
 node ~/episodic-memory/install.mjs --tool windsurf --project /path/to/my-project
 
-# For all tools at once
+# For all bundled targets except OpenCode
 node ~/episodic-memory/install.mjs --tool all --project /path/to/my-project
 ```
 
@@ -60,6 +66,57 @@ That's the only manual step. After this, your AI assistant reads the instruction
 3. Adds the right instruction file for your tool
 4. Updates `.gitignore` to exclude memory data
 5. With `--install-hooks` (Claude Code only): registers PreToolUse (checkpoint-gate, plan-gate, stop-gate), SessionStart (recall + BP-1 fallback sweep), and SessionEnd hooks. Re-running the installer warns when any installed hook has drifted from the source-of-truth copy.
+
+### Instruction-only skill adapters
+
+OpenCode and Pi Agent support is instruction-only in this installer slice. The installer writes skill files that tell the agent how to call the existing `~/.episodic-memory/scripts/*.mjs` commands; it does not install hooks, MCP servers, live dispatch, proactive session-start automation, or global tool config for these tools.
+
+OpenCode is explicit-only:
+
+```bash
+node ~/episodic-memory/install.mjs --tool opencode --project /path/to/my-project
+```
+
+It writes:
+
+```text
+<project>/.opencode/skills/episodic-memory/SKILL.md
+```
+
+OpenCode is intentionally excluded from `--tool all`. Current official OpenCode discovery loads all of these same-name skill locations, so a broad all-tools install can expose duplicate `episodic-memory` skills:
+
+| OpenCode discovery location | Scope |
+|-----------------------------|-------|
+| `.opencode/skills/<name>/SKILL.md` | project |
+| `~/.config/opencode/skills/<name>/SKILL.md` | global |
+| `.claude/skills/<name>/SKILL.md` | project Claude-compatible |
+| `~/.claude/skills/<name>/SKILL.md` | global Claude-compatible |
+| `.agents/skills/<name>/SKILL.md` | project agent-compatible |
+| `~/.agents/skills/<name>/SKILL.md` | global agent-compatible |
+
+Source pin: OpenCode skill discovery is based on the current official docs at <https://opencode.ai/docs/skills>, observed 2026-05-16; the page was last updated 2026-05-15. If OpenCode changes these paths, update this table, the installer scan, and tests together.
+
+Before writing the native OpenCode skill, the installer scans visible project ancestors through the actual git worktree root, global OpenCode/Claude/agent skill locations, and non-git ancestors through filesystem root. If another visible `episodic-memory` skill already exists, the OpenCode install warns and skips instead of knowingly creating a duplicate. This guard applies only when running `--tool opencode`; later `--tool codex`, `--tool pi-agent`, `--tool claude-code`, or `--tool all` runs can still create OpenCode-visible duplicates until a broader conflict resolver exists.
+
+Pi Agent uses the shared agent-compatible skill path:
+
+```text
+<project>/.agents/skills/episodic-memory/SKILL.md
+```
+
+This is the same destination Codex uses. `--tool all` includes Pi Agent by de-duplicating that shared `.agents` destination. Pi Agent same-name shadowing across other Pi-native, package, global, or settings-defined skill locations is not guarded in this installer slice.
+
+Capability tiers for these instruction-only adapters:
+
+| Capability | OpenCode | Pi Agent |
+|------------|----------|----------|
+| Manual recall/search/store/revise via scripts | MEDIUM when shell/script execution is available and allowed; otherwise WEAK/manual | MEDIUM when shell/script execution is available and allowed; otherwise WEAK/manual |
+| Proactive session-start recall | WEAK; depends on the agent loading/following the skill | WEAK; depends on the agent loading/following the skill |
+| Enforcement/hooks | Unsupported | Unsupported |
+| Live MCP tools | Deferred | Deferred |
+| Cross-tool typed requests | Deferred except manual existing-script use | Deferred except manual existing-script use |
+
+Future MCP support should be a follow-up RFC: thin wrappers around existing scripts (`recall`, `search`, `store`, `revise`) with no second store, no daemon, no polling, explicit activation, and reversible uninstall.
 
 ---
 

--- a/install.mjs
+++ b/install.mjs
@@ -18,6 +18,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -98,14 +99,16 @@ if (bootstrapLastPrompt) {
 }
 
 if (!tool) {
-  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|windsurf|all> [--project <path>] [--install-hooks] [--install-hooks-force]
+  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|opencode|pi-agent|windsurf|all> [--project <path>] [--install-hooks] [--install-hooks-force]
 
 Tools:
   claude-code  Install SKILL.md + plugin structure
   cursor       Install .cursor/rules/episodic-memory.mdc
   codex        Install skill to .agents/skills/episodic-memory/
+  opencode     Install skill to .opencode/skills/episodic-memory/ (explicit-only; excluded from all)
+  pi-agent     Install skill to .agents/skills/episodic-memory/ (shared with Codex)
   windsurf     Install .windsurfrules (or append to existing)
-  all          Install for all supported tools
+  all          Install for all supported tools except opencode (avoids duplicate OpenCode-visible skills)
 
 Hook flags (claude-code / Phase 3b):
   --install-hooks         Copy hooks/*.sh into ~/.claude/hooks/ and register
@@ -140,9 +143,9 @@ Pre-flight prompt-binding bootstrap:
   process.exit(1)
 }
 
-const VALID_TOOLS = ['claude-code', 'cursor', 'codex', 'windsurf', 'all']
+const VALID_TOOLS = ['claude-code', 'cursor', 'codex', 'opencode', 'pi-agent', 'windsurf', 'all']
 if (!VALID_TOOLS.includes(tool)) {
-  console.log(`Invalid tool "${tool}". Must be one of: ${VALID_TOOLS.join(', ')}`)
+  console.log(`Invalid tool "${tool}". Must be one of: ${VALID_TOOLS.join(', ')}. Note: opencode is explicit-only and is not included in all.`)
   process.exit(1)
 }
 
@@ -612,7 +615,91 @@ if (tool === 'claude-code' || tool === 'all') {
 // ---------------------------------------------------------------------------
 // 3. Install tool-specific instructions
 // ---------------------------------------------------------------------------
-const tools = tool === 'all' ? ['claude-code', 'cursor', 'codex', 'windsurf'] : [tool]
+const projectAbs = path.resolve(projectDir)
+const skillSource = path.join(REPO_INSTRUCTIONS, 'SKILL.md')
+
+function installOwnedFile({ src, dst, label }) {
+  const source = fs.readFileSync(src, 'utf8')
+  if (fs.existsSync(dst)) {
+    const existing = fs.readFileSync(dst, 'utf8')
+    if (existing === source) {
+      console.log(`${label} already current at ${dst}`)
+      return { status: 'current' }
+    }
+    console.log(`Skipped ${label} at ${dst}: existing file differs from repo source; leaving it untouched.`)
+    return { status: 'skipped-divergent' }
+  }
+
+  fs.mkdirSync(path.dirname(dst), { recursive: true })
+  fs.writeFileSync(dst, source)
+  console.log(`Installed ${label} to ${dst}`)
+  return { status: 'installed' }
+}
+
+function gitWorktreeRoot(cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+function ancestorChain(start, stop) {
+  const chain = []
+  let cur = path.resolve(start)
+  const stopResolved = stop ? path.resolve(stop) : null
+  while (true) {
+    chain.push(cur)
+    if (stopResolved && cur === stopResolved) break
+    const parent = path.dirname(cur)
+    if (parent === cur) break
+    cur = parent
+  }
+  return chain
+}
+
+function opencodeVisibleSkillPaths(projectRoot) {
+  const root = gitWorktreeRoot(projectRoot)
+  const dirs = ancestorChain(projectRoot, root)
+  const projectLocations = dirs.flatMap((dir) => [
+    path.join(dir, '.opencode', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join(dir, '.claude', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join(dir, '.agents', 'skills', 'episodic-memory', 'SKILL.md'),
+  ])
+  const home = os.homedir()
+  return [
+    ...projectLocations,
+    path.join(home, '.config', 'opencode', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join(home, '.claude', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join(home, '.agents', 'skills', 'episodic-memory', 'SKILL.md'),
+  ]
+}
+
+function installOpenCodeSkill(projectRoot) {
+  const dst = path.join(projectRoot, '.opencode', 'skills', 'episodic-memory', 'SKILL.md')
+  const intended = path.resolve(dst)
+  const duplicates = opencodeVisibleSkillPaths(projectRoot)
+    .map((p) => path.resolve(p))
+    .filter((p, idx, arr) => arr.indexOf(p) === idx)
+    .filter((p) => p !== intended && fs.existsSync(p))
+
+  if (duplicates.length > 0) {
+    console.log(`Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found at ${duplicates.join(', ')}. Run a future conflict-resolution flow before installing the native .opencode skill.`)
+    return { status: 'skipped-duplicate' }
+  }
+
+  return installOwnedFile({
+    src: skillSource,
+    dst,
+    label: 'OpenCode skill'
+  })
+}
+
+const tools = tool === 'all' ? ['claude-code', 'cursor', 'codex', 'pi-agent', 'windsurf'] : [tool]
 
 for (const t of tools) {
   switch (t) {
@@ -638,14 +725,26 @@ for (const t of tools) {
       break
     }
     case 'codex': {
-      // Install as a Codex skill in .agents/skills/
-      const skillDir = path.join(projectDir, '.agents', 'skills', 'episodic-memory')
-      fs.mkdirSync(skillDir, { recursive: true })
-      fs.copyFileSync(
-        path.join(REPO_INSTRUCTIONS, 'codex-skill.md'),
-        path.join(skillDir, 'episodic-memory.md')
-      )
-      console.log(`Installed Codex skill to ${skillDir}/episodic-memory.md`)
+      // Install as a Codex skill in .agents/skills/. Codex discovers skills
+      // by SKILL.md inside the skill directory; arbitrary markdown filenames
+      // in that directory are inert.
+      installOwnedFile({
+        src: skillSource,
+        dst: path.join(projectDir, '.agents', 'skills', 'episodic-memory', 'SKILL.md'),
+        label: 'Codex skill'
+      })
+      break
+    }
+    case 'opencode': {
+      installOpenCodeSkill(projectAbs)
+      break
+    }
+    case 'pi-agent': {
+      installOwnedFile({
+        src: skillSource,
+        dst: path.join(projectDir, '.agents', 'skills', 'episodic-memory', 'SKILL.md'),
+        label: 'Pi Agent skill'
+      })
       break
     }
     case 'windsurf': {

--- a/tests/test-install-opencode-pi-agent.mjs
+++ b/tests/test-install-opencode-pi-agent.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+/**
+ * test-install-opencode-pi-agent.mjs — OpenCode + Pi Agent install targets.
+ *
+ * OpenCode skill discovery is intentionally pinned to the current official
+ * docs observed on 2026-05-16:
+ * https://opencode.ai/docs/skills
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execSync, spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const INSTALL = path.join(REPO_ROOT, 'install.mjs')
+const SOURCE_SKILL = fs.readFileSync(path.join(REPO_ROOT, 'instructions', 'SKILL.md'), 'utf8')
+
+function tmpFixture(prefix = 'em-opencode-pi-') {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  const home = path.join(root, 'home')
+  const project = path.join(root, 'project')
+  const caller = path.join(root, 'caller')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(project, { recursive: true })
+  fs.mkdirSync(caller, { recursive: true })
+  return { root, home, project, caller }
+}
+
+function runInstall({ home, cwd, project, tool }) {
+  return spawnSync('node', [INSTALL, '--tool', tool, '--project', project], {
+    cwd,
+    env: { ...process.env, HOME: home },
+    encoding: 'utf8',
+    timeout: 30000
+  })
+}
+
+function git(cwd, args) {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+}
+
+function initRepo(repo) {
+  fs.mkdirSync(repo, { recursive: true })
+  git(repo, 'init -q -b main')
+  git(repo, 'config user.email test@example.com')
+  git(repo, 'config user.name test')
+  fs.writeFileSync(path.join(repo, 'README.md'), '# test\n')
+  git(repo, 'add README.md')
+  git(repo, 'commit -q -m init')
+}
+
+function writeSkill(file, body = SOURCE_SKILL) {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, body)
+}
+
+function assertOk(result) {
+  assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
+}
+
+const opencodeSkill = (project) =>
+  path.join(project, '.opencode', 'skills', 'episodic-memory', 'SKILL.md')
+const agentsSkill = (project) =>
+  path.join(project, '.agents', 'skills', 'episodic-memory', 'SKILL.md')
+const claudeSkill = (project) =>
+  path.join(project, '.claude', 'skills', 'episodic-memory', 'SKILL.md')
+
+test('install --tool opencode writes only the native OpenCode skill path', () => {
+  const f = tmpFixture()
+  try {
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'opencode' })
+    assertOk(r)
+    assert.equal(fs.readFileSync(opencodeSkill(f.project), 'utf8'), SOURCE_SKILL)
+    assert.equal(fs.existsSync(agentsSkill(f.project)), false, 'opencode install must not write .agents')
+    assert.equal(fs.existsSync(claudeSkill(f.project)), false, 'opencode install must not write .claude')
+    assert.equal(fs.existsSync(path.join(f.project, 'AGENTS.md')), false, 'opencode install must not write root AGENTS.md')
+    assert.equal(fs.existsSync(path.join(f.project, 'opencode.json')), false, 'opencode install must not write opencode.json')
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool opencode skips when direct .agents or .claude duplicate exists', () => {
+  for (const duplicatePath of [agentsSkill, claudeSkill]) {
+    const f = tmpFixture()
+    try {
+      writeSkill(duplicatePath(f.project), 'user-owned duplicate\n')
+      const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'opencode' })
+      assertOk(r)
+      assert.match(r.stdout, /Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found/)
+      assert.equal(fs.existsSync(opencodeSkill(f.project)), false)
+      assert.equal(fs.readFileSync(duplicatePath(f.project), 'utf8'), 'user-owned duplicate\n')
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true })
+    }
+  }
+})
+
+test('install --tool opencode scans git ancestors for .opencode/.agents/.claude duplicates', () => {
+  for (const duplicatePath of [opencodeSkill, agentsSkill, claudeSkill]) {
+    const f = tmpFixture()
+    const repo = path.join(f.root, 'repo')
+    const nested = path.join(repo, 'sub', 'dir')
+    try {
+      initRepo(repo)
+      fs.mkdirSync(nested, { recursive: true })
+      writeSkill(duplicatePath(repo), 'ancestor duplicate\n')
+      const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: nested, tool: 'opencode' })
+      assertOk(r)
+      assert.match(r.stdout, /Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found/)
+      assert.equal(fs.existsSync(opencodeSkill(nested)), false)
+      assert.equal(fs.readFileSync(duplicatePath(repo), 'utf8'), 'ancestor duplicate\n')
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true })
+    }
+  }
+})
+
+test('install --tool opencode stops duplicate scan at git worktree root', () => {
+  const f = tmpFixture()
+  const parent = path.join(f.root, 'parent')
+  const repo = path.join(parent, 'repo')
+  const nested = path.join(repo, 'sub', 'dir')
+  try {
+    writeSkill(path.join(parent, '.agents', 'skills', 'episodic-memory', 'SKILL.md'), 'above repo\n')
+    initRepo(repo)
+    fs.mkdirSync(nested, { recursive: true })
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: nested, tool: 'opencode' })
+    assertOk(r)
+    assert.doesNotMatch(r.stdout, /existing OpenCode-visible/)
+    assert.equal(fs.readFileSync(opencodeSkill(nested), 'utf8'), SOURCE_SKILL)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool opencode handles linked worktree roots, not canonical checkout roots', () => {
+  const f = tmpFixture()
+  const main = path.join(f.root, 'main')
+  const linked = path.join(f.root, 'linked')
+  const nested = path.join(linked, 'sub', 'dir')
+  try {
+    initRepo(main)
+    git(main, `worktree add -q -b feature ${linked}`)
+    fs.mkdirSync(nested, { recursive: true })
+
+    writeSkill(agentsSkill(main), 'canonical duplicate only\n')
+    let r = runInstall({ home: f.home, cwd: REPO_ROOT, project: nested, tool: 'opencode' })
+    assertOk(r)
+    assert.doesNotMatch(r.stdout, /existing OpenCode-visible/)
+    assert.equal(fs.readFileSync(opencodeSkill(nested), 'utf8'), SOURCE_SKILL)
+
+    fs.rmSync(opencodeSkill(nested), { force: true })
+    writeSkill(agentsSkill(linked), 'linked duplicate\n')
+    r = runInstall({ home: f.home, cwd: REPO_ROOT, project: nested, tool: 'opencode' })
+    assertOk(r)
+    assert.match(r.stdout, /Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found/)
+    assert.equal(fs.existsSync(opencodeSkill(nested)), false)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool opencode scans non-git ancestors to filesystem root', () => {
+  const f = tmpFixture()
+  const ancestor = path.join(f.root, 'plain')
+  const nested = path.join(ancestor, 'sub', 'dir')
+  try {
+    fs.mkdirSync(nested, { recursive: true })
+    writeSkill(agentsSkill(ancestor), 'plain ancestor duplicate\n')
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: nested, tool: 'opencode' })
+    assertOk(r)
+    assert.match(r.stdout, /Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found/)
+    assert.equal(fs.existsSync(opencodeSkill(nested)), false)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool opencode scans global OpenCode-visible skill locations', () => {
+  const globalDuplicates = [
+    path.join('.config', 'opencode', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join('.claude', 'skills', 'episodic-memory', 'SKILL.md'),
+    path.join('.agents', 'skills', 'episodic-memory', 'SKILL.md'),
+  ]
+  for (const rel of globalDuplicates) {
+    const f = tmpFixture()
+    try {
+      writeSkill(path.join(f.home, rel), 'global duplicate\n')
+      const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'opencode' })
+      assertOk(r)
+      assert.match(r.stdout, /Skipped OpenCode skill install: existing OpenCode-visible episodic-memory skill found/)
+      assert.equal(fs.existsSync(opencodeSkill(f.project)), false)
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true })
+    }
+  }
+})
+
+test('install --tool opencode rerun no-ops when only intended destination exists', () => {
+  const f = tmpFixture()
+  try {
+    assertOk(runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'opencode' }))
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'opencode' })
+    assertOk(r)
+    assert.match(r.stdout, /OpenCode skill already current/)
+    assert.doesNotMatch(r.stdout, /existing OpenCode-visible/)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool pi-agent shares the canonical .agents skill with Codex', () => {
+  const f = tmpFixture()
+  try {
+    let r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'pi-agent' })
+    assertOk(r)
+    assert.equal(fs.readFileSync(agentsSkill(f.project), 'utf8'), SOURCE_SKILL)
+
+    r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'codex' })
+    assertOk(r)
+    assert.match(r.stdout, /Codex skill already current/)
+    assert.equal(fs.readFileSync(agentsSkill(f.project), 'utf8'), SOURCE_SKILL)
+
+    fs.rmSync(agentsSkill(f.project), { force: true })
+    r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'codex' })
+    assertOk(r)
+    r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'pi-agent' })
+    assertOk(r)
+    assert.match(r.stdout, /Pi Agent skill already current/)
+    assert.equal(fs.readFileSync(agentsSkill(f.project), 'utf8'), SOURCE_SKILL)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('install --tool all includes pi-agent but excludes opencode', () => {
+  const f = tmpFixture()
+  try {
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'all' })
+    assertOk(r)
+    assert.equal(fs.existsSync(agentsSkill(f.project)), true, 'all should install shared .agents skill')
+    assert.equal(fs.existsSync(opencodeSkill(f.project)), false, 'all must not install native OpenCode skill')
+    assert.doesNotMatch(r.stdout, /Installed OpenCode skill/)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('skill installers skip divergent existing files', () => {
+  for (const [tool, fileFor] of [['opencode', opencodeSkill], ['pi-agent', agentsSkill]]) {
+    const f = tmpFixture()
+    try {
+      writeSkill(fileFor(f.project), 'user modified\n')
+      const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool })
+      assertOk(r)
+      assert.match(r.stdout, /existing file differs from repo source/)
+      assert.equal(fs.readFileSync(fileFor(f.project), 'utf8'), 'user modified\n')
+    } finally {
+      fs.rmSync(f.root, { recursive: true, force: true })
+    }
+  }
+})
+
+test('install --project writes under target project, not caller cwd', () => {
+  const f = tmpFixture()
+  try {
+    const r = runInstall({ home: f.home, cwd: f.caller, project: f.project, tool: 'pi-agent' })
+    assertOk(r)
+    assert.equal(fs.existsSync(agentsSkill(f.project)), true)
+    assert.equal(fs.existsSync(agentsSkill(f.caller)), false)
+    assert.equal(fs.existsSync(path.join(f.project, '.episodic-memory', 'episodes')), true)
+    assert.equal(fs.existsSync(path.join(f.caller, '.episodic-memory')), false)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})
+
+test('invalid tool output includes opencode/pi-agent and all exclusion note', () => {
+  const f = tmpFixture()
+  try {
+    const r = runInstall({ home: f.home, cwd: REPO_ROOT, project: f.project, tool: 'bogus' })
+    assert.notEqual(r.status, 0)
+    assert.match(r.stdout, /opencode/)
+    assert.match(r.stdout, /pi-agent/)
+    assert.match(r.stdout, /opencode is explicit-only and is not included in all/)
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Adds instruction-only installer support for OpenCode and Pi Agent.

- Adds explicit `opencode` and `pi-agent` install targets.
- Keeps OpenCode explicit-only and excluded from `--tool all` to avoid duplicate OpenCode-visible skills across `.opencode`, `.claude`, and `.agents` discovery locations.
- Installs Pi Agent through the shared `.agents/skills/episodic-memory/SKILL.md` destination used by Codex.
- Adds OpenCode duplicate detection across project ancestors, git worktree boundaries, linked worktrees, non-git ancestors, and global OpenCode-visible skill locations.
- Documents instruction-only capability tiers and the deferred MCP boundary.

## Validation

- `node tests/test-install-opencode-pi-agent.mjs`
- `node tests/test-install-bp1-wiring.mjs`
- `node tests/test-install-worktree-grant.mjs`
- `node --check install.mjs`

## Notes

OpenCode path behavior is pinned to the current official OpenCode skill docs observed 2026-05-16: https://opencode.ai/docs/skills.

Residual risks documented in the user manual: future tool-doc drift, Pi same-name shadowing outside this installer slice, legacy installs after OpenCode creating visible duplicates, and concurrent installer races.