### PR TITLE
fix: resolve preflight memory-root drift

### DIFF
--- a/hooks/preflight-prompt-helper.sh
+++ b/hooks/preflight-prompt-helper.sh
@@ -191,13 +191,29 @@ MEMORY_ROOT=""
 CONFIG_FILE="$REPO_ROOT/.episodic-memory/config.json"
 if [ -f "$CONFIG_FILE" ]; then
   MEMORY_ROOT="$(jq -r '.claude_memory_root // ""' "$CONFIG_FILE" 2>/dev/null)"
+  if [ -n "$MEMORY_ROOT" ] && [ ! -d "$MEMORY_ROOT" ]; then
+    MEMORY_ROOT=""
+  fi
+fi
+if [ -z "$MEMORY_ROOT" ]; then
+  # Keep this bounded and deterministic: derive candidates only from the
+  # resolved repo root, mirroring session-handoff-prompt.sh. The observed
+  # Claude project path on this machine has existed in both canonical
+  # `charltondho` and drifted `charltond-ho` forms; pick the first candidate
+  # that actually contains memory markdown, not merely an empty directory.
+  SANITIZED="$(printf '%s' "$REPO_ROOT" | sed 's|/|-|g; s|\.|-|g')"
+  CANONICAL_MEM="${HOME:-/}/.claude/projects/${SANITIZED}/memory"
+  VARIANT_SANITIZED="$(printf '%s' "$SANITIZED" | sed 's|charltondho|charltond-ho|')"
+  VARIANT_MEM="${HOME:-/}/.claude/projects/${VARIANT_SANITIZED}/memory"
+  for cand in "$CANONICAL_MEM" "$VARIANT_MEM"; do
+    if [ -d "$cand" ] && ls "$cand"/*.md >/dev/null 2>&1; then
+      MEMORY_ROOT="$cand"
+      break
+    fi
+  done
 fi
 if [ -z "$MEMORY_ROOT" ] || [ ! -d "$MEMORY_ROOT" ]; then
-  SANITIZED="$(printf '%s' "$REPO_ROOT" | sed 's|/|-|g')"
-  MEMORY_ROOT="${HOME:-/}/.claude/projects/${SANITIZED}/memory"
-fi
-if [ ! -d "$MEMORY_ROOT" ]; then
-  _log_and_exit_safe_post_lp "memory_root not resolvable from config or HOME; rolling back last-prompt marker so gate denies cleanly"
+  _log_and_exit_safe_post_lp "memory_root not resolvable from config or bounded HOME candidates; rolling back last-prompt marker so gate denies cleanly"
 fi
 
 # Extract component basenames from the bundle's json:bundle-manifest block.

--- a/tests/test-preflight-prompt-helper.sh
+++ b/tests/test-preflight-prompt-helper.sh
@@ -28,6 +28,22 @@ mktmp() {
   ( cd -P "$d" && pwd )
 }
 
+write_review_components() {
+  local target="$1"
+  mkdir -p "$target"
+  for f in \
+    reference_codex_review_flow.md \
+    feedback_codex_cli_episode_messaging.md \
+    feedback_subagent_cli_episode_messaging.md \
+    feedback_canonical_agent_dispatch_trigger.md \
+    feedback_codex_review_request_preamble.md \
+    feedback_second_opinion_harness_runbook.md \
+    reference_second_opinion_harness.md
+  do
+    printf 'stub content for %s\n' "$f" > "$target/$f"
+  done
+}
+
 stage_repo() {
   # Stage a minimal repo fixture so resolve_repo_root finds a root and the
   # in-repo scripts/lib path resolves.
@@ -51,17 +67,7 @@ stage_repo() {
   # Stage the 7 review-channel components at the local memory_root +
   # a config.json that points the hook there. Stub content per file —
   # the gate validates loaded sha against disk, not against bundle-recorded.
-  for f in \
-    reference_codex_review_flow.md \
-    feedback_codex_cli_episode_messaging.md \
-    feedback_subagent_cli_episode_messaging.md \
-    feedback_canonical_agent_dispatch_trigger.md \
-    feedback_codex_review_request_preamble.md \
-    feedback_second_opinion_harness_runbook.md \
-    reference_second_opinion_harness.md
-  do
-    printf 'stub content for %s\n' "$f" > "$target/.episodic-memory/memory/$f"
-  done
+  write_review_components "$target/.episodic-memory/memory"
   jq -nc --arg p "$target/.episodic-memory/memory" '{claude_memory_root: $p}' > "$target/.episodic-memory/config.json"
   # Make it git-detectable so resolve_repo_root returns this dir, not /.
   ( cd "$target" && git init -q && git config user.email t@t && git config user.name t )
@@ -221,6 +227,62 @@ else
 fi
 
 rm -rf "$TF"
+
+# ---------- I2c: memory_root fallback handles observed Claude path variant ----------
+
+echo "--- I2c: memory_root fallback chooses non-empty bounded variant ---"
+
+BASE="$(mktmp)"
+TF="$BASE/Users/charltondho/Developer/projects/episodic-memory"
+mkdir -p "$TF"
+stage_repo "$TF"
+rm -rf "$TF/.episodic-memory"
+
+HOME_FIXTURE="$BASE/home"
+SANITIZED="$(printf '%s' "$TF" | sed 's|/|-|g; s|\.|-|g')"
+VARIANT_SANITIZED="$(printf '%s' "$SANITIZED" | sed 's|charltondho|charltond-ho|')"
+CANONICAL_MEM="$HOME_FIXTURE/.claude/projects/$SANITIZED/memory"
+VARIANT_MEM="$HOME_FIXTURE/.claude/projects/$VARIANT_SANITIZED/memory"
+mkdir -p "$CANONICAL_MEM/session_summaries"
+write_review_components "$VARIANT_MEM"
+
+SID="i2c-test-session"
+PROMPT="review handoff prompt from variant memory root"
+INPUT="$(jq -nc --arg p "$PROMPT" --arg s "$SID" --arg c "$TF" \
+  '{prompt: $p, session_id: $s, cwd: $c, transcript_path: "/tmp/transcript.jsonl", hook_event_name: "UserPromptSubmit"}')"
+( cd "$TF" && printf '%s' "$INPUT" | HOME="$HOME_FIXTURE" bash "$HOOK" ) 2>/dev/null
+EC=$?
+
+if [ $EC -ne 0 ]; then
+  echo "  ✗ I2c hook exit $EC (expected 0)"
+  failed=$((failed+1))
+elif [ ! -f "$TF/.checkpoints/.preflight-done.${SID}" ]; then
+  echo "  ✗ I2c preflight marker not written via variant memory root"
+  failed=$((failed+1))
+else
+  echo "  ✓ I2c hook wrote preflight marker via variant memory root"
+  passed=$((passed+1))
+fi
+
+MARKER_MEM="$(jq -r '.memory_root // ""' "$TF/.checkpoints/.preflight-done.${SID}" 2>/dev/null || true)"
+if [ "$MARKER_MEM" = "$VARIANT_MEM" ]; then
+  echo "  ✓ I2c marker records the non-empty variant memory root"
+  passed=$((passed+1))
+else
+  echo "  ✗ I2c memory_root=$MARKER_MEM (expected $VARIANT_MEM)"
+  failed=$((failed+1))
+fi
+
+GATE_OUT="$(HOME="$HOME_FIXTURE" run_gate "$TF" "$SID" 2>&1 || true)"
+if [ -z "$GATE_OUT" ]; then
+  echo "  ✓ I2c gate accepts marker built from variant memory root"
+  passed=$((passed+1))
+else
+  echo "  ✗ I2c gate denied variant-root marker: $GATE_OUT"
+  failed=$((failed+1))
+fi
+
+rm -rf "$BASE"
 
 # ---------- I2b (PR #291 A1): bundle missing → roll back last-prompt ----------
 


### PR DESCRIPTION
## Summary

- Fixes the post-PR #291 production regression where `preflight-prompt-helper.sh` resolved the canonical Claude memory path even when the actual review-channel files lived under the observed `charltond-ho` path variant.
- Mirrors the bounded candidate strategy already used by `session-handoff-prompt.sh`: valid config override first, then canonical sanitized path if it contains markdown, then the known `charltond-ho` variant if it contains markdown.
- Adds regression coverage for an empty canonical memory dir plus populated variant memory dir.

## Root Cause

PR #291 did fix the reviewed helper-invocation bypass, but the hook-owned marker write still failed in production because the helper could not find bundle components:

```text
looked: ~/.claude/projects/-Users-charltondho-Developer-projects-episodic-memory/memory/reference_codex_review_flow.md
actual: ~/.claude/projects/-Users-charltond-ho-Developer-projects-episodic-memory/memory/reference_codex_review_flow.md
```

The helper rolled back `.last-user-prompt.<sid>.json` and never wrote `.preflight-done.<sid>`, leaving `preflight-gate.sh` to fall back to stale legacy markers and deny Codex handoffs.

## Verification

```text
bash tests/test-preflight-prompt-helper.sh -> 24 passed, 0 failed
bash tests/test-preflight-gate.sh          -> 107 passed, 0 failed
bash tests/test-command-classifier.sh      -> 301 passed, 0 failed
```

Live smoke against this machine's actual Claude memory layout:

```text
UserPromptSubmit helper wrote .preflight-done.codexdiag-20260516-3
marker memory_root = ~/.claude/projects/-Users-charltond-ho-Developer-projects-episodic-memory/memory
preflight-gate allowed codex exec for that session
```

Local active hook was force-installed after verification so the current Claude Code environment is already using the patched helper.