### PR TITLE
fix(cluster): multi-step write atomicity — closes #286 #287 #288

### DIFF
--- a/docs/rfcs/RFC-004-bp1-auto-pilot.contract.json
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.contract.json
@@ -60,7 +60,9 @@
         "terminal_at",
         "decided_class",
         "pre_episode_id",
-        "rfc_detected_episode_id"
+        "rfc_detected_episode_id",
+        "classified_episode_id",
+        "route_episode_id"
       ]
     }
   },

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -1188,9 +1188,10 @@ function recordClassifierDispatchPre(args) {
       // current args; if not, recoverable-canonical-drift error.
       // -------------------------------------------------------------------
       if (run.state === 'classifier-dispatch-pending') {
-        if (!run.pre_episode_id) {
+        if (!run.pre_episode_id || typeof run.pre_episode_id !== 'string'
+            || !EPISODE_ID_RE.test(run.pre_episode_id)) {
           process.stderr.write(
-            'error: recoverable-no-parent: state=classifier-dispatch-pending but pre_episode_id is null\n',
+            `error: recoverable-no-parent: state=classifier-dispatch-pending but pre_episode_id=${JSON.stringify(run.pre_episode_id)} (null or malformed)\n`,
           )
           exitCode = 5
           return
@@ -1203,10 +1204,12 @@ function recordClassifierDispatchPre(args) {
           },
         )
         if (lookup.status !== 'match' || lookup.episodeId !== run.pre_episode_id) {
+          const ids = lookup.status === 'field-mismatch'
+            ? ` [${lookup.candidates.map(c => c.episodeId).join(', ')}]` : ''
           process.stderr.write(
             `error: recoverable-canonical-drift: state=classifier-dispatch-pending ` +
             `pre_episode_id=${run.pre_episode_id} does not match args ` +
-            `(lookup.status=${lookup.status})\n`,
+            `(lookup.status=${lookup.status})${ids}\n`,
           )
           exitCode = 5
           return
@@ -1396,6 +1399,34 @@ function validateClassifierOutput(obj) {
   return { ok: true }
 }
 
+// Phase B route-episode spec. Single source-of-truth for the routeFields
+// predicate AND the fresh-emit writeBp1Episode call: customFm is what
+// orphan-attach uses to disambiguate signed episodes on disk, AND what
+// the writer persists. The two CANNOT drift.
+// targetState is derived from decided_class, NOT read from run.state — so
+// Phase B's resume branches can compare run.state against targetState and
+// reject inconsistent state/decided_class pairs (closes F2).
+function deriveRouteSpec(decidedClass, runId) {
+  if (decidedClass === 'trivial') {
+    return {
+      targetState: 'planning',
+      customFm: { source_class: 'trivial' },
+      tags: ['bp1-planning'],
+      summary: `BP-1 planning (source: trivial): ${runId}`,
+      body: `# bp1-planning — ${runId}\n\nsource_class: \`trivial\`\n`,
+      filenameSuffix: 'planning',
+    }
+  }
+  return {
+    targetState: 'needs-human',
+    customFm: { reason: 'risky-class', decided_class: decidedClass },
+    tags: ['bp1-needs-human'],
+    summary: `BP-1 needs-human (risky-class ${decidedClass}): ${runId}`,
+    body: `# bp1-needs-human — ${runId}\n\nreason: \`risky-class\`\ndecided_class: \`${decidedClass}\`\n`,
+    filenameSuffix: 'needs-human',
+  }
+}
+
 function recordClassification(args) {
   if (!args.project) { usage(); return 2 }
   if (!args.runId) {
@@ -1568,9 +1599,10 @@ function recordClassification(args) {
           return
         }
         if (backfill.status === 'field-mismatch') {
+          const ids = backfill.candidates.map(c => c.episodeId).join(', ')
           process.stderr.write(
             `error: recoverable-canonical-drift: state=${run.state} but classified_episode_id null; ` +
-            `${backfill.candidates.length} signed candidate(s) do not match current args\n`,
+            `${backfill.candidates.length} signed candidate(s) [${ids}] do not match current args\n`,
           )
           phaseAExit = 5
           return
@@ -1680,6 +1712,11 @@ function recordClassification(args) {
   // ---------------------------------------------------------------------
   // Phase B: emit route (planning|needs-human) + persist state/route_episode_id
   // ---------------------------------------------------------------------
+  // Single source-of-truth for the route episode: customFm IS the predicate.
+  // Closes F1 (orphan-attach predicate-completeness) and F2 (state-vs-
+  // targetState consistency) — both Phase B parallel branches now inherit
+  // Phase A's invariant-discipline.
+  const routeSpec = deriveRouteSpec(decidedClass, args.runId)
   let nextState = null
   let routeEpisodeId = null
   let phaseBExit = 0
@@ -1691,49 +1728,69 @@ function recordClassification(args) {
         return
       }
 
-      const targetState = run.decided_class === 'trivial' ? 'planning' : 'needs-human'
-      const routeFields = { parent_episode: run.classified_episode_id }
+      const targetState = routeSpec.targetState
+      // routeFields predicate = parent + customFm. Identical to what
+      // fresh-emit writes, so orphan-attach can never silently accept a
+      // stale signed route episode with mismatched contents.
+      const routeFields = { parent_episode: run.classified_episode_id, ...routeSpec.customFm }
+
+      // F2: state-vs-targetState consistency. If a past run advanced state
+      // to the *wrong* route relative to current decided_class (which
+      // shouldn't happen under any legal trajectory, but is detectable),
+      // refuse rather than silently re-route.
+      if ((run.state === 'planning' || run.state === 'needs-human')
+          && run.state !== targetState) {
+        process.stderr.write(
+          `error: state-violation (Phase B): run.state=${run.state} but ` +
+          `decided_class=${run.decided_class} implies targetState=${targetState}\n`,
+        )
+        phaseBExit = 5
+        return
+      }
 
       // Idempotent past-Phase-B no-op: state advanced + route_episode_id set.
-      if ((run.state === 'planning' || run.state === 'needs-human') && run.route_episode_id) {
+      if (run.state === targetState && run.route_episode_id) {
         const verify = findSignedStateEpisode(
-          projectRoot, args.runId, run.state, key32B, routeFields,
+          projectRoot, args.runId, targetState, key32B, routeFields,
         )
         if (verify.status !== 'match' || verify.episodeId !== run.route_episode_id) {
+          const ids = verify.status === 'field-mismatch'
+            ? ` [${verify.candidates.map(c => c.episodeId).join(', ')}]` : ''
           process.stderr.write(
-            `error: recoverable-canonical-drift: state=${run.state} ` +
-            `route_episode_id=${run.route_episode_id} does not match expected parent ` +
-            `(verify.status=${verify.status})\n`,
+            `error: recoverable-canonical-drift: state=${targetState} ` +
+            `route_episode_id=${run.route_episode_id} does not match args ` +
+            `(verify.status=${verify.status})${ids}\n`,
           )
           phaseBExit = 5
           return
         }
-        nextState = run.state
+        nextState = targetState
         routeEpisodeId = run.route_episode_id
         return
       }
 
       // Backfill: state advanced but route_episode_id null.
-      if (run.state === 'planning' || run.state === 'needs-human') {
+      if (run.state === targetState) {
         const backfill = findSignedStateEpisode(
-          projectRoot, args.runId, run.state, key32B, routeFields,
+          projectRoot, args.runId, targetState, key32B, routeFields,
         )
         if (backfill.status === 'match') {
           run.route_episode_id = backfill.episodeId
-          nextState = run.state
+          nextState = targetState
           routeEpisodeId = backfill.episodeId
           return
         }
         if (backfill.status === 'field-mismatch') {
+          const ids = backfill.candidates.map(c => c.episodeId).join(', ')
           process.stderr.write(
-            `error: recoverable-canonical-drift: state=${run.state} but route_episode_id null; ` +
-            `${backfill.candidates.length} signed candidate(s) do not match classified_episode_id\n`,
+            `error: recoverable-canonical-drift: state=${targetState} but route_episode_id null; ` +
+            `${backfill.candidates.length} signed candidate(s) [${ids}] do not match args\n`,
           )
           phaseBExit = 5
           return
         }
         process.stderr.write(
-          `error: recoverable-no-parent: state=${run.state} but route_episode_id null AND no signed route episode on disk\n`,
+          `error: recoverable-no-parent: state=${targetState} but route_episode_id null AND no signed route episode on disk\n`,
         )
         phaseBExit = 5
         return
@@ -1762,36 +1819,24 @@ function recordClassification(args) {
         const ids = orphan.candidates.map(c => c.episodeId).join(', ')
         process.stderr.write(
           `error: recoverable-canonical-drift: ${orphan.candidates.length} signed ${targetState} ` +
-          `episode(s) [${ids}] do not match classified_episode_id=${run.classified_episode_id}\n`,
+          `episode(s) [${ids}] do not match args ` +
+          `(parent_episode=${run.classified_episode_id} + ${JSON.stringify(routeSpec.customFm)})\n`,
         )
         phaseBExit = 5
         return
       }
-      // Fresh emit route.
-      let routeEp
-      if (targetState === 'planning') {
-        routeEp = writeBp1Episode({
-          projectRoot, runId: args.runId, runKey32B: key32B,
-          type: 'state-transition', state: 'planning',
-          summary: `BP-1 planning (source: trivial): ${args.runId}`,
-          parentEpisode: run.classified_episode_id, expectedPostEpisodeId: null,
-          customFm: { source_class: 'trivial' },
-          tags: ['bp1-planning'],
-          body: `# bp1-planning — ${args.runId}\n\nsource_class: \`trivial\`\n`,
-          filenameSuffix: 'planning',
-        })
-      } else {
-        routeEp = writeBp1Episode({
-          projectRoot, runId: args.runId, runKey32B: key32B,
-          type: 'state-transition', state: 'needs-human',
-          summary: `BP-1 needs-human (risky-class ${run.decided_class}): ${args.runId}`,
-          parentEpisode: run.classified_episode_id, expectedPostEpisodeId: null,
-          customFm: { reason: 'risky-class', decided_class: run.decided_class },
-          tags: ['bp1-needs-human'],
-          body: `# bp1-needs-human — ${args.runId}\n\nreason: \`risky-class\`\ndecided_class: \`${run.decided_class}\`\n`,
-          filenameSuffix: 'needs-human',
-        })
-      }
+      // Fresh emit route. customFm/tags/summary/body all derive from routeSpec
+      // so predicate above and write here cannot drift.
+      const routeEp = writeBp1Episode({
+        projectRoot, runId: args.runId, runKey32B: key32B,
+        type: 'state-transition', state: targetState,
+        summary: routeSpec.summary,
+        parentEpisode: run.classified_episode_id, expectedPostEpisodeId: null,
+        customFm: routeSpec.customFm,
+        tags: routeSpec.tags,
+        body: routeSpec.body,
+        filenameSuffix: routeSpec.filenameSuffix,
+      })
       run.state = targetState
       run.route_episode_id = routeEp.episodeId
       nextState = targetState

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -1066,16 +1066,17 @@ function detectRfcs(args) {
       }
       detected.push({ rfc_id: rfcId, run_id: runId, rfc_detected_episode_id: written.episodeId })
     } catch (e) {
-      // Cluster #287 fix: compensating rollback. Each step wrapped so a
-      // mid-rollback throw is observable (not silently swallowed).
+      // Cluster #287 fix: compensating rollback. Reverse-symmetric to the
+      // forward order (generateRunKey → appendRun → writeBp1Episode):
+      // unwind episode → index row → key. If shred-then-index were the
+      // order, a mid-rollback failure could leave the index pointing to a
+      // run with no key (verifier would fail "fingerprint mismatch"
+      // forever). Index-removal-before-shred is the recoverable direction.
+      // codex r1 C2 fix.
       const rollbackErrors = []
       if (episodePath) {
         try { fs.unlinkSync(episodePath) }
         catch (re) { rollbackErrors.push(`unlink-episode: ${re.message}`) }
-      }
-      if (keyGenerated) {
-        try { shredRunKey(projectRoot, runId) }
-        catch (re) { rollbackErrors.push(`shred-key: ${re.message}`) }
       }
       if (appendDone) {
         try {
@@ -1087,6 +1088,13 @@ function detectRfcs(args) {
             }
           })
         } catch (re) { rollbackErrors.push(`remove-run: ${re.message}`) }
+      }
+      if (keyGenerated) {
+        // shredRunKey reports failure via return value, not throw. codex r1
+        // C1 fix: check the result and surface; without this, key shred
+        // failures were silently lost from rollbackErrors AND the sentinel.
+        const sr = shredRunKey(projectRoot, runId)
+        if (sr && sr.error) rollbackErrors.push(`shred-key: ${sr.error}`)
       }
       if (rollbackErrors.length > 0) {
         // Last-resort observability: write sentinel + stderr-log; never swallow.

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -1742,7 +1742,9 @@ function recordClassification(args) {
           && run.state !== targetState) {
         process.stderr.write(
           `error: state-violation (Phase B): run.state=${run.state} but ` +
-          `decided_class=${run.decided_class} implies targetState=${targetState}\n`,
+          `decided_class=${run.decided_class} implies targetState=${targetState}. ` +
+          `Manual recovery: inspect run row + signed episodes; either reset run.state ` +
+          `to 'classified' (if route was emitted in error) or correct decided_class.\n`,
         )
         phaseBExit = 5
         return

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -1020,44 +1020,99 @@ function detectRfcs(args) {
     const rfcId = path.basename(entry.path, '.md')
     const runId = mintRunId(rfcId)
 
-    // Generate run.key + persist.
-    let keyResult
+    // Cluster #287 fix: track per-step progress so we can compensate on
+    // mid-iteration failure. Each step's success is recorded BEFORE moving
+    // to the next; on catch, the rollback walks them in reverse.
+    let keyGenerated = false
+    let appendDone = false
+    let episodePath = null
+    let writtenEpisodeId = null
+
     try {
-      keyResult = generateRunKey(projectRoot, runId)
+      // Step 1: generate run.key.
+      const keyResult = generateRunKey(projectRoot, runId)
+      keyGenerated = true
+      const { key32B } = keyResult
+
+      // Step 2: append run-state row (uses loadIndexLocked internally — CR2-3).
+      const append = appendRun(projectRoot, runId, projectRoot)
+      if (append.error) {
+        throw new Error(`appendRun failed for ${runId}: ${append.error}`)
+      }
+      appendDone = true
+
+      // Step 3: emit bp1-rfc-detected state-transition (atomic via refactored
+      // writer — temp+fsync+rename, see Commit 1).
+      const written = writeBp1Episode({
+        projectRoot, runId, runKey32B: key32B,
+        type: 'state-transition', state: 'rfc-detected',
+        summary: `BP-1 rfc-detected: ${rfcId}`,
+        parentEpisode: null, expectedPostEpisodeId: null,
+        customFm: { rfc_id: rfcId, frontmatter_sha256: entry.frontmatter_sha256 },
+        tags: ['bp1-rfc-detected'],
+        body: `# bp1-rfc-detected — ${runId}\n\nRFC \`${rfcId}\` detected at ${new Date().toISOString()} for project \`${projectRoot}\`.\n`,
+        filenameSuffix: 'rfc-detected',
+      })
+      episodePath = written.episodePath
+      writtenEpisodeId = written.episodeId
+
+      // Step 4: persist rfc_detected_episode_id + state transition.
+      const upd = updateRunState(projectRoot, runId, {
+        state: 'rfc-detected',
+        rfc_detected_episode_id: written.episodeId,
+      })
+      if (upd.error) {
+        throw new Error(`updateRunState failed for ${runId}: ${upd.error}`)
+      }
+      detected.push({ rfc_id: rfcId, run_id: runId, rfc_detected_episode_id: written.episodeId })
     } catch (e) {
-      process.stderr.write(`error: generateRunKey failed for ${runId}: ${e.message}\n`)
+      // Cluster #287 fix: compensating rollback. Each step wrapped so a
+      // mid-rollback throw is observable (not silently swallowed).
+      const rollbackErrors = []
+      if (episodePath) {
+        try { fs.unlinkSync(episodePath) }
+        catch (re) { rollbackErrors.push(`unlink-episode: ${re.message}`) }
+      }
+      if (keyGenerated) {
+        try { shredRunKey(projectRoot, runId) }
+        catch (re) { rollbackErrors.push(`shred-key: ${re.message}`) }
+      }
+      if (appendDone) {
+        try {
+          withRunStateLockExclusive(projectRoot, () => {
+            const idx = loadIndexLocked(projectRoot)
+            if (idx.runs[runId]) {
+              delete idx.runs[runId]
+              writeIndex(projectRoot, idx)
+            }
+          })
+        } catch (re) { rollbackErrors.push(`remove-run: ${re.message}`) }
+      }
+      if (rollbackErrors.length > 0) {
+        // Last-resort observability: write sentinel + stderr-log; never swallow.
+        const sentinel = {
+          original_error: String(e?.message || e),
+          rollback_errors: rollbackErrors,
+          at: new Date().toISOString(),
+          run_id: runId,
+        }
+        const runDir = path.join(projectRoot, '.episodic-memory', 'runs', runId)
+        let sentinelPath = null
+        try {
+          fs.mkdirSync(runDir, { recursive: true })
+          sentinelPath = path.join(runDir, '.rollback-failed.json')
+          fs.writeFileSync(sentinelPath, JSON.stringify(sentinel, null, 2) + '\n')
+          process.stderr.write(`rollback-failed: sentinel at ${sentinelPath}\n`)
+        } catch (sentinelErr) {
+          process.stderr.write(
+            `rollback-failed-sentinel-write-also-failed: ${sentinelErr.message}; ` +
+            `original: ${e?.message}; rollback: ${rollbackErrors.join('; ')}\n`,
+          )
+        }
+      }
+      process.stderr.write(`error: detect-rfcs iteration failed for ${runId}: ${e.message}\n`)
       return 3
     }
-    const { key32B } = keyResult
-
-    // Append run-state row (uses loadIndexLocked internally — CR2-3).
-    const append = appendRun(projectRoot, runId, projectRoot)
-    if (append.error) {
-      process.stderr.write(`error: appendRun failed for ${runId}: ${append.error}\n`)
-      return 3
-    }
-
-    // Emit bp1-rfc-detected state-transition via internal writer.
-    const written = writeBp1Episode({
-      projectRoot, runId, runKey32B: key32B,
-      type: 'state-transition', state: 'rfc-detected',
-      summary: `BP-1 rfc-detected: ${rfcId}`,
-      parentEpisode: null, expectedPostEpisodeId: null,
-      customFm: { rfc_id: rfcId, frontmatter_sha256: entry.frontmatter_sha256 },
-      tags: ['bp1-rfc-detected'],
-      body: `# bp1-rfc-detected — ${runId}\n\nRFC \`${rfcId}\` detected at ${new Date().toISOString()} for project \`${projectRoot}\`.\n`,
-      filenameSuffix: 'rfc-detected',
-    })
-    // Persist rfc_detected_episode_id + state transition.
-    const upd = updateRunState(projectRoot, runId, {
-      state: 'rfc-detected',
-      rfc_detected_episode_id: written.episodeId,
-    })
-    if (upd.error) {
-      process.stderr.write(`error: updateRunState failed for ${runId}: ${upd.error}\n`)
-      return 3
-    }
-    detected.push({ rfc_id: rfcId, run_id: runId, rfc_detected_episode_id: written.episodeId })
   }
 
   process.stdout.write(JSON.stringify({ status: 'ok', detected, inert: false }) + '\n')
@@ -1395,52 +1450,9 @@ function recordClassification(args) {
   }
   const { key32B } = keyResult
 
-  // Load run-state.
-  const idx = loadIndex(projectRoot)
-  const run = idx.runs[args.runId]
-  if (!run) {
-    process.stderr.write(`error: run ${args.runId} not found\n`)
-    return 5
-  }
-  if (run.state !== 'classifier-dispatch-pending') {
-    process.stderr.write(`error: state-violation: run.state=${JSON.stringify(run.state)} expected=classifier-dispatch-pending\n`)
-    return 5
-  }
-  // Equality gate (C2): --pre-episode-id === runState.pre_episode_id.
-  if (args.preEpisodeId !== run.pre_episode_id) {
-    process.stderr.write(`error: state-violation: --pre-episode-id ${args.preEpisodeId} != run.pre_episode_id ${run.pre_episode_id}\n`)
-    return 5
-  }
-
-  // CR2-2: verify parent pre on disk.
-  const verify = verifyEpisodeOnDisk({
-    projectRoot, episodeId: args.preEpisodeId, runKey32B: key32B,
-    expectedType: 'state-transition', expectedState: 'classifier-dispatch-pending',
-    expectedRunId: args.runId,
-  })
-  if (!verify.ok) {
-    try {
-      writeBp1Episode({
-        projectRoot, runId: args.runId, runKey32B: key32B,
-        type: 'failure', state: null,
-        summary: `BP-1 classifier parent-tamper at record-classification: ${args.runId}`,
-        parentEpisode: null, expectedPostEpisodeId: null,
-        customFm: {
-          failure_kind: 'classifier-parent-tamper',
-          field_name: 'pre_episode_id',
-          observed_value: safeTruncate(JSON.stringify(args.preEpisodeId), 66),
-          violation_reason: verify.errors.join('; '),
-        },
-        tags: ['bp1-classifier-parent-tamper'],
-        body: `# bp1-classifier-parent-tamper\n\nErrors:\n\n${verify.errors.map(e => `- \`${e}\``).join('\n')}\n`,
-        filenameSuffix: 'parent-tamper',
-      })
-    } catch (e) { process.stderr.write(`debug: failure-ep emit threw: ${e.message}\n`) }
-    process.stderr.write(`error: parent-tamper: ${verify.errors.join('; ')}\n`)
-    return 5
-  }
-
-  // Single read (HOLD C): read result-file ONCE.
+  // Pre-phase: read result-file + parse + validate (no state mutation).
+  // Failure-episodes for schema-violation are emitted here (atomic via
+  // refactored writer); they do not need lock coordination.
   let resultText
   try {
     resultText = fs.readFileSync(args.resultFile, 'utf8')
@@ -1448,15 +1460,12 @@ function recordClassification(args) {
     process.stderr.write(`error: --result-file unreadable: ${e.message}\n`)
     return 5
   }
-  // Compute sha256 from the in-memory bytes (used for forensic embedding only).
   const _resultSha = crypto.createHash('sha256').update(resultText, 'utf8').digest('hex')
 
-  // Parse + schema-validate.
   let parsed
   try {
     parsed = safeJsonParse(resultText)
   } catch (e) {
-    // Schema-violation failure episode.
     try {
       writeBp1Episode({
         projectRoot, runId: args.runId, runKey32B: key32B,
@@ -1473,7 +1482,7 @@ function recordClassification(args) {
         body: `# bp1-classifier-schema-violation\n\nJSON parse failed: \`${e.message}\`\n`,
         filenameSuffix: 'schema-violation',
       })
-    } catch (e) { process.stderr.write(`debug: failure-ep emit threw: ${e.message}\n`) }
+    } catch (e2) { process.stderr.write(`debug: failure-ep emit threw: ${e2.message}\n`) }
     process.stderr.write(`error: classifier output JSON parse failed: ${e.message}\n`)
     return 5
   }
@@ -1503,68 +1512,307 @@ function recordClassification(args) {
   const decidedClass = parsed.class
   const confidenceStr = String(parsed.confidence)
 
-  // Emit bp1-classified state-transition (parent: pre_episode_id).
-  const classifiedEp = writeBp1Episode({
-    projectRoot, runId: args.runId, runKey32B: key32B,
-    type: 'state-transition', state: 'classified',
-    summary: `BP-1 classified ${decidedClass} (conf=${confidenceStr}): ${args.runId}`,
-    parentEpisode: args.preEpisodeId, expectedPostEpisodeId: null,
-    customFm: {
-      decided_class: decidedClass,
-      classifier_confidence: confidenceStr,   // pre-stringified per writer contract
-    },
-    tags: ['bp1-classified'],
-    body: `# bp1-classified — ${args.runId}\n\nclass: \`${decidedClass}\`\nconfidence: \`${confidenceStr}\`\n`,
-    filenameSuffix: 'classified',
-  })
-  const updClass = updateRunState(projectRoot, args.runId, {
-    state: 'classified', decided_class: decidedClass,
-  })
-  if (updClass.error) {
-    process.stderr.write(`error: updateRunState (classified) failed: ${updClass.error}\n`)
-    return 5
-  }
+  // Cluster #288 fix: split classified-emit and route-emit into two durable
+  // phases. Crash between phases leaves a recoverable state; retry from
+  // 'classified' attaches the existing classified episode + runs Phase B.
+  // codex round-5 ACCEPT 20260516-102831.
 
-  // Route: trivial → planning; else → needs-human.
-  let nextState, routeEpisode
-  if (decidedClass === 'trivial') {
-    routeEpisode = writeBp1Episode({
-      projectRoot, runId: args.runId, runKey32B: key32B,
-      type: 'state-transition', state: 'planning',
-      summary: `BP-1 planning (source: trivial): ${args.runId}`,
-      parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
-      customFm: { source_class: 'trivial' },
-      tags: ['bp1-planning'],
-      body: `# bp1-planning — ${args.runId}\n\nsource_class: \`trivial\`\n`,
-      filenameSuffix: 'planning',
-    })
-    nextState = 'planning'
-  } else {
-    routeEpisode = writeBp1Episode({
-      projectRoot, runId: args.runId, runKey32B: key32B,
-      type: 'state-transition', state: 'needs-human',
-      summary: `BP-1 needs-human (risky-class ${decidedClass}): ${args.runId}`,
-      parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
-      customFm: { reason: 'risky-class', decided_class: decidedClass },
-      tags: ['bp1-needs-human'],
-      body: `# bp1-needs-human — ${args.runId}\n\nreason: \`risky-class\`\ndecided_class: \`${decidedClass}\`\n`,
-      filenameSuffix: 'needs-human',
-    })
-    nextState = 'needs-human'
+  // ---------------------------------------------------------------------
+  // Phase A: emit classified + persist state/decided_class/classified_episode_id
+  // ---------------------------------------------------------------------
+  let classifiedEpisodeId = null
+  let phaseAExit = 0
+  const classifiedFields = {
+    parent_episode: args.preEpisodeId,
+    decided_class: decidedClass,
+    classifier_confidence: confidenceStr,
   }
-  const updRoute = updateRunState(projectRoot, args.runId, { state: nextState })
-  if (updRoute.error) {
-    process.stderr.write(`error: updateRunState (${nextState}) failed: ${updRoute.error}\n`)
-    return 5
+  try {
+    withLockedRun(projectRoot, args.runId, ({ run }) => {
+      if (!run) {
+        process.stderr.write(`error: run ${args.runId} not found\n`)
+        phaseAExit = 5
+        return
+      }
+
+      // Resume / backfill: state at 'classified' or past it. In all
+      // past-Phase-A states, Phase A's job is to verify (or backfill) the
+      // classified_episode_id pointer; the route transition is Phase B's
+      // concern. Includes 'planning' and 'needs-human' for idempotent retry
+      // and pre-bump backfill via signed episode on disk.
+      if (run.state === 'classified' || run.state === 'planning' || run.state === 'needs-human') {
+        if (run.classified_episode_id) {
+          // Verify the stored pointer satisfies CURRENT args.
+          const verify = findSignedStateEpisode(
+            projectRoot, args.runId, 'classified', key32B, classifiedFields,
+          )
+          if (verify.status !== 'match' || verify.episodeId !== run.classified_episode_id) {
+            process.stderr.write(
+              `error: recoverable-canonical-drift: state=${run.state} ` +
+              `classified_episode_id=${run.classified_episode_id} does not match args ` +
+              `(verify.status=${verify.status})\n`,
+            )
+            phaseAExit = 5
+            return
+          }
+          classifiedEpisodeId = run.classified_episode_id
+          return
+        }
+        // Backfill: pre-bump run with no pointer.
+        const backfill = findSignedStateEpisode(
+          projectRoot, args.runId, 'classified', key32B, classifiedFields,
+        )
+        if (backfill.status === 'match') {
+          run.classified_episode_id = backfill.episodeId
+          classifiedEpisodeId = backfill.episodeId
+          return
+        }
+        if (backfill.status === 'field-mismatch') {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=${run.state} but classified_episode_id null; ` +
+            `${backfill.candidates.length} signed candidate(s) do not match current args\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        process.stderr.write(
+          `error: recoverable-no-parent: state=${run.state} but classified_episode_id null AND no signed classified episode on disk\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      if (run.state !== 'classifier-dispatch-pending') {
+        process.stderr.write(
+          `error: state-violation: run.state=${JSON.stringify(run.state)} expected=classifier-dispatch-pending\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      // C2 equality gate: --pre-episode-id === run.pre_episode_id.
+      if (args.preEpisodeId !== run.pre_episode_id) {
+        process.stderr.write(
+          `error: state-violation: --pre-episode-id ${args.preEpisodeId} != run.pre_episode_id ${run.pre_episode_id}\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      // CR2-2: verify parent pre-episode on disk (inside lock).
+      const verifyParent = verifyEpisodeOnDisk({
+        projectRoot, episodeId: args.preEpisodeId, runKey32B: key32B,
+        expectedType: 'state-transition', expectedState: 'classifier-dispatch-pending',
+        expectedRunId: args.runId,
+      })
+      if (!verifyParent.ok) {
+        try {
+          writeBp1Episode({
+            projectRoot, runId: args.runId, runKey32B: key32B,
+            type: 'failure', state: null,
+            summary: `BP-1 classifier parent-tamper at record-classification: ${args.runId}`,
+            parentEpisode: null, expectedPostEpisodeId: null,
+            customFm: {
+              failure_kind: 'classifier-parent-tamper',
+              field_name: 'pre_episode_id',
+              observed_value: safeTruncate(JSON.stringify(args.preEpisodeId), 66),
+              violation_reason: verifyParent.errors.join('; '),
+            },
+            tags: ['bp1-classifier-parent-tamper'],
+            body: `# bp1-classifier-parent-tamper\n\nErrors:\n\n${verifyParent.errors.map(e => `- \`${e}\``).join('\n')}\n`,
+            filenameSuffix: 'parent-tamper',
+          })
+        } catch (e) { process.stderr.write(`debug: failure-ep emit threw: ${e.message}\n`) }
+        process.stderr.write(`error: parent-tamper: ${verifyParent.errors.join('; ')}\n`)
+        phaseAExit = 5
+        return
+      }
+
+      // Orphan-attach: crash-after-classified-emit-before-writeIndex window.
+      const orphan = findSignedStateEpisode(
+        projectRoot, args.runId, 'classified', key32B, classifiedFields,
+      )
+      if (orphan.status === 'match') {
+        run.state = 'classified'
+        run.decided_class = decidedClass
+        run.classified_episode_id = orphan.episodeId
+        classifiedEpisodeId = orphan.episodeId
+        return
+      }
+      if (orphan.status === 'field-mismatch') {
+        const ids = orphan.candidates.map(c => c.episodeId).join(', ')
+        process.stderr.write(
+          `error: recoverable-canonical-drift: ${orphan.candidates.length} signed classified ` +
+          `episode(s) [${ids}] do not match args (parent_episode/decided_class/confidence)\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+      // orphan.status === 'none' → fresh emit.
+      const written = writeBp1Episode({
+        projectRoot, runId: args.runId, runKey32B: key32B,
+        type: 'state-transition', state: 'classified',
+        summary: `BP-1 classified ${decidedClass} (conf=${confidenceStr}): ${args.runId}`,
+        parentEpisode: args.preEpisodeId, expectedPostEpisodeId: null,
+        customFm: {
+          decided_class: decidedClass,
+          classifier_confidence: confidenceStr,
+        },
+        tags: ['bp1-classified'],
+        body: `# bp1-classified — ${args.runId}\n\nclass: \`${decidedClass}\`\nconfidence: \`${confidenceStr}\`\n`,
+        filenameSuffix: 'classified',
+      })
+      run.state = 'classified'
+      run.decided_class = decidedClass
+      run.classified_episode_id = written.episodeId
+      classifiedEpisodeId = written.episodeId
+    })
+  } catch (e) {
+    if (e.code === 'multiple-signed-match') {
+      process.stderr.write(`error: integrity-anomaly multiple-signed-match (Phase A): ${e.message}\n`)
+      return 5
+    }
+    throw e
   }
+  if (phaseAExit !== 0) return phaseAExit
+  if (!classifiedEpisodeId) return 5
+
+  // ---------------------------------------------------------------------
+  // Phase B: emit route (planning|needs-human) + persist state/route_episode_id
+  // ---------------------------------------------------------------------
+  let nextState = null
+  let routeEpisodeId = null
+  let phaseBExit = 0
+  try {
+    withLockedRun(projectRoot, args.runId, ({ run }) => {
+      if (!run) {
+        process.stderr.write(`error: run ${args.runId} missing in Phase B\n`)
+        phaseBExit = 5
+        return
+      }
+
+      const targetState = run.decided_class === 'trivial' ? 'planning' : 'needs-human'
+      const routeFields = { parent_episode: run.classified_episode_id }
+
+      // Idempotent past-Phase-B no-op: state advanced + route_episode_id set.
+      if ((run.state === 'planning' || run.state === 'needs-human') && run.route_episode_id) {
+        const verify = findSignedStateEpisode(
+          projectRoot, args.runId, run.state, key32B, routeFields,
+        )
+        if (verify.status !== 'match' || verify.episodeId !== run.route_episode_id) {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=${run.state} ` +
+            `route_episode_id=${run.route_episode_id} does not match expected parent ` +
+            `(verify.status=${verify.status})\n`,
+          )
+          phaseBExit = 5
+          return
+        }
+        nextState = run.state
+        routeEpisodeId = run.route_episode_id
+        return
+      }
+
+      // Backfill: state advanced but route_episode_id null.
+      if (run.state === 'planning' || run.state === 'needs-human') {
+        const backfill = findSignedStateEpisode(
+          projectRoot, args.runId, run.state, key32B, routeFields,
+        )
+        if (backfill.status === 'match') {
+          run.route_episode_id = backfill.episodeId
+          nextState = run.state
+          routeEpisodeId = backfill.episodeId
+          return
+        }
+        if (backfill.status === 'field-mismatch') {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=${run.state} but route_episode_id null; ` +
+            `${backfill.candidates.length} signed candidate(s) do not match classified_episode_id\n`,
+          )
+          phaseBExit = 5
+          return
+        }
+        process.stderr.write(
+          `error: recoverable-no-parent: state=${run.state} but route_episode_id null AND no signed route episode on disk\n`,
+        )
+        phaseBExit = 5
+        return
+      }
+
+      if (run.state !== 'classified') {
+        process.stderr.write(
+          `error: state-violation (Phase B): run.state=${JSON.stringify(run.state)} expected=classified\n`,
+        )
+        phaseBExit = 5
+        return
+      }
+
+      // Orphan-attach: crash-after-route-emit-before-writeIndex.
+      const orphan = findSignedStateEpisode(
+        projectRoot, args.runId, targetState, key32B, routeFields,
+      )
+      if (orphan.status === 'match') {
+        run.state = targetState
+        run.route_episode_id = orphan.episodeId
+        nextState = targetState
+        routeEpisodeId = orphan.episodeId
+        return
+      }
+      if (orphan.status === 'field-mismatch') {
+        const ids = orphan.candidates.map(c => c.episodeId).join(', ')
+        process.stderr.write(
+          `error: recoverable-canonical-drift: ${orphan.candidates.length} signed ${targetState} ` +
+          `episode(s) [${ids}] do not match classified_episode_id=${run.classified_episode_id}\n`,
+        )
+        phaseBExit = 5
+        return
+      }
+      // Fresh emit route.
+      let routeEp
+      if (targetState === 'planning') {
+        routeEp = writeBp1Episode({
+          projectRoot, runId: args.runId, runKey32B: key32B,
+          type: 'state-transition', state: 'planning',
+          summary: `BP-1 planning (source: trivial): ${args.runId}`,
+          parentEpisode: run.classified_episode_id, expectedPostEpisodeId: null,
+          customFm: { source_class: 'trivial' },
+          tags: ['bp1-planning'],
+          body: `# bp1-planning — ${args.runId}\n\nsource_class: \`trivial\`\n`,
+          filenameSuffix: 'planning',
+        })
+      } else {
+        routeEp = writeBp1Episode({
+          projectRoot, runId: args.runId, runKey32B: key32B,
+          type: 'state-transition', state: 'needs-human',
+          summary: `BP-1 needs-human (risky-class ${run.decided_class}): ${args.runId}`,
+          parentEpisode: run.classified_episode_id, expectedPostEpisodeId: null,
+          customFm: { reason: 'risky-class', decided_class: run.decided_class },
+          tags: ['bp1-needs-human'],
+          body: `# bp1-needs-human — ${args.runId}\n\nreason: \`risky-class\`\ndecided_class: \`${run.decided_class}\`\n`,
+          filenameSuffix: 'needs-human',
+        })
+      }
+      run.state = targetState
+      run.route_episode_id = routeEp.episodeId
+      nextState = targetState
+      routeEpisodeId = routeEp.episodeId
+    })
+  } catch (e) {
+    if (e.code === 'multiple-signed-match') {
+      process.stderr.write(`error: integrity-anomaly multiple-signed-match (Phase B): ${e.message}\n`)
+      return 5
+    }
+    throw e
+  }
+  if (phaseBExit !== 0) return phaseBExit
 
   process.stdout.write(JSON.stringify({
     status: 'ok',
     state: nextState,
     run_id: args.runId,
     decided_class: decidedClass,
-    classified_episode_id: classifiedEp.episodeId,
-    route_episode_id: routeEpisode.episodeId,
+    classified_episode_id: classifiedEpisodeId,
+    route_episode_id: routeEpisodeId,
   }) + '\n')
   return 0
 }

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -56,7 +56,11 @@ import {
 } from './lib/bp1-keys.mjs'
 import {
   appendRun, markTerminal, getRunState, loadIndex, updateRunState,
+  withRunStateLockExclusive, loadIndexLocked, writeIndex,
 } from './lib/bp1-run-state.mjs'
+import {
+  findSignedStateEpisode, withLockedRun, removeRunFromIndex,
+} from './lib/bp1-atomic.mjs'
 import { probeScheduledTasksCapability } from './lib/bp1-probe.mjs'
 import {
   collectEpisodeRecords,
@@ -1101,7 +1105,7 @@ function recordClassifierDispatchPre(args) {
     return 1
   }
 
-  // Load run.key.
+  // Load run.key (key load is project-scoped, not run-state-locked).
   const keyResult = loadRunKey(projectRoot, args.runId)
   if (keyResult.error) {
     process.stderr.write(`error: run.key ${keyResult.error} for ${args.runId}\n`)
@@ -1109,77 +1113,158 @@ function recordClassifierDispatchPre(args) {
   }
   const { key32B } = keyResult
 
-  // Load run-state (unlocked loadIndex; this is an inspection).
-  const idx = loadIndex(projectRoot)
-  const run = idx.runs[args.runId]
-  if (!run) {
-    process.stderr.write(`error: run ${args.runId} not found in run-state\n`)
-    return 5
-  }
-  if (run.state !== 'rfc-detected') {
-    process.stderr.write(`error: state-violation: run.state=${JSON.stringify(run.state)} expected=rfc-detected\n`)
-    return 5
-  }
-  if (!run.rfc_detected_episode_id) {
-    // CR2-fix C1: must have rfc_detected_episode_id pointer to verify.
-    process.stderr.write('error: run.rfc_detected_episode_id is null; cannot verify parent\n')
-    return 5
-  }
+  // All run-state reads + verifies + emits + writes inside one locked
+  // section. Cluster #286 fix: race + crash atomicity via withLockedRun
+  // serialization + atomic-writer rename. Three explicit branches on
+  // entry state; no fresh-emit fall-through from already-advanced state.
+  let exitCode = 0
+  let preEpisodeId = null
+  try {
+    withLockedRun(projectRoot, args.runId, ({ run }) => {
+      if (!run) {
+        process.stderr.write(`error: run ${args.runId} not found in run-state\n`)
+        exitCode = 5
+        return
+      }
 
-  // CR2-2: verify parent rfc-detected episode on disk.
-  const verify = verifyEpisodeOnDisk({
-    projectRoot, episodeId: run.rfc_detected_episode_id, runKey32B: key32B,
-    expectedType: 'state-transition', expectedState: 'rfc-detected',
-    expectedRunId: args.runId,
-  })
-  if (!verify.ok) {
-    // Emit bp1-classifier-parent-tamper failure episode (signed with run.key).
-    try {
-      writeBp1Episode({
-        projectRoot, runId: args.runId, runKey32B: key32B,
-        type: 'failure', state: null,
-        summary: `BP-1 classifier parent-tamper at dispatch-pre: ${args.runId}`,
-        parentEpisode: null, expectedPostEpisodeId: null,
-        customFm: {
-          failure_kind: 'classifier-parent-tamper',
-          field_name: 'rfc_detected_episode_id',
-          observed_value: safeTruncate(JSON.stringify(run.rfc_detected_episode_id), 66),
-          violation_reason: verify.errors.join('; '),
-        },
-        tags: ['bp1-classifier-parent-tamper'],
-        body: `# bp1-classifier-parent-tamper\n\nErrors:\n\n${verify.errors.map(e => `- \`${e}\``).join('\n')}\n`,
-        filenameSuffix: 'parent-tamper',
+      // -------------------------------------------------------------------
+      // Branch 1: state === 'classifier-dispatch-pending' (retry / idempotent).
+      // Do NOT fresh-emit. Verify the stored pre_episode_id satisfies the
+      // current args; if not, recoverable-canonical-drift error.
+      // -------------------------------------------------------------------
+      if (run.state === 'classifier-dispatch-pending') {
+        if (!run.pre_episode_id) {
+          process.stderr.write(
+            'error: recoverable-no-parent: state=classifier-dispatch-pending but pre_episode_id is null\n',
+          )
+          exitCode = 5
+          return
+        }
+        const lookup = findSignedStateEpisode(
+          projectRoot, args.runId, 'classifier-dispatch-pending', key32B,
+          {
+            parent_episode: run.rfc_detected_episode_id,
+            input_sha256: args.inputSha256,
+          },
+        )
+        if (lookup.status !== 'match' || lookup.episodeId !== run.pre_episode_id) {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=classifier-dispatch-pending ` +
+            `pre_episode_id=${run.pre_episode_id} does not match args ` +
+            `(lookup.status=${lookup.status})\n`,
+          )
+          exitCode = 5
+          return
+        }
+        // Idempotent retry: same args, same parent, same stored pointer.
+        preEpisodeId = run.pre_episode_id
+        return
+      }
+
+      // -------------------------------------------------------------------
+      // Branch 2: any state other than 'rfc-detected' → state-violation.
+      // -------------------------------------------------------------------
+      if (run.state !== 'rfc-detected') {
+        process.stderr.write(
+          `error: state-violation: run.state=${JSON.stringify(run.state)} expected=rfc-detected\n`,
+        )
+        exitCode = 5
+        return
+      }
+      if (!run.rfc_detected_episode_id) {
+        process.stderr.write('error: run.rfc_detected_episode_id is null; cannot verify parent\n')
+        exitCode = 5
+        return
+      }
+
+      // -------------------------------------------------------------------
+      // Branch 3: state === 'rfc-detected' (normal path with orphan-attach).
+      // Parent verify happens inside the lock; failure-episode emit is
+      // inside the lock too (atomic writer + small critical section).
+      // -------------------------------------------------------------------
+      const verify = verifyEpisodeOnDisk({
+        projectRoot, episodeId: run.rfc_detected_episode_id, runKey32B: key32B,
+        expectedType: 'state-transition', expectedState: 'rfc-detected',
+        expectedRunId: args.runId,
       })
-    } catch (_e) { /* best-effort forensic */ }
-    process.stderr.write(`error: parent-tamper: ${verify.errors.join('; ')}\n`)
-    return 5
+      if (!verify.ok) {
+        try {
+          writeBp1Episode({
+            projectRoot, runId: args.runId, runKey32B: key32B,
+            type: 'failure', state: null,
+            summary: `BP-1 classifier parent-tamper at dispatch-pre: ${args.runId}`,
+            parentEpisode: null, expectedPostEpisodeId: null,
+            customFm: {
+              failure_kind: 'classifier-parent-tamper',
+              field_name: 'rfc_detected_episode_id',
+              observed_value: safeTruncate(JSON.stringify(run.rfc_detected_episode_id), 66),
+              violation_reason: verify.errors.join('; '),
+            },
+            tags: ['bp1-classifier-parent-tamper'],
+            body: `# bp1-classifier-parent-tamper\n\nErrors:\n\n${verify.errors.map(e => `- \`${e}\``).join('\n')}\n`,
+            filenameSuffix: 'parent-tamper',
+          })
+        } catch (_e) { /* best-effort forensic */ }
+        process.stderr.write(`error: parent-tamper: ${verify.errors.join('; ')}\n`)
+        exitCode = 5
+        return
+      }
+
+      // Orphan-attach scan: a previous invocation may have atomically
+      // emitted the pre-episode but crashed before writeIndex landed; the
+      // signed episode is on disk but run.state is still 'rfc-detected'.
+      const orphan = findSignedStateEpisode(
+        projectRoot, args.runId, 'classifier-dispatch-pending', key32B,
+        {
+          parent_episode: run.rfc_detected_episode_id,
+          input_sha256: args.inputSha256,
+        },
+      )
+      if (orphan.status === 'match') {
+        // Attach orphan: same parent + same input_sha256.
+        run.state = 'classifier-dispatch-pending'
+        run.pre_episode_id = orphan.episodeId
+        preEpisodeId = orphan.episodeId
+        return
+      }
+      if (orphan.status === 'field-mismatch') {
+        const ids = orphan.candidates.map(c => c.episodeId).join(', ')
+        process.stderr.write(
+          `error: recoverable-canonical-drift: ${orphan.candidates.length} signed ` +
+          `pre-episode(s) [${ids}] do not match args.input_sha256 or current ` +
+          `rfc_detected_episode_id\n`,
+        )
+        exitCode = 5
+        return
+      }
+      // orphan.status === 'none' → fresh emit (atomic via refactored writer).
+      const written = writeBp1Episode({
+        projectRoot, runId: args.runId, runKey32B: key32B,
+        type: 'state-transition', state: 'classifier-dispatch-pending',
+        summary: `BP-1 classifier-dispatch-pre: ${args.runId}`,
+        parentEpisode: run.rfc_detected_episode_id,
+        expectedPostEpisodeId: null,
+        customFm: { input_sha256: args.inputSha256 },
+        tags: ['bp1-classifier-dispatch-pre'],
+        body: `# bp1-classifier-dispatch-pre — ${args.runId}\n\ninput_sha256: \`${args.inputSha256}\`\n`,
+        filenameSuffix: 'pre',
+      })
+      run.state = 'classifier-dispatch-pending'
+      run.pre_episode_id = written.episodeId
+      preEpisodeId = written.episodeId
+    })
+  } catch (e) {
+    if (e.code === 'multiple-signed-match') {
+      process.stderr.write(`error: integrity-anomaly multiple-signed-match: ${e.message}\n`)
+      return 5
+    }
+    throw e
   }
 
-  // Emit bp1-classifier-dispatch-pre state-transition.
-  const written = writeBp1Episode({
-    projectRoot, runId: args.runId, runKey32B: key32B,
-    type: 'state-transition', state: 'classifier-dispatch-pending',
-    summary: `BP-1 classifier-dispatch-pre: ${args.runId}`,
-    parentEpisode: run.rfc_detected_episode_id,
-    expectedPostEpisodeId: null,
-    customFm: { input_sha256: args.inputSha256 },
-    tags: ['bp1-classifier-dispatch-pre'],
-    body: `# bp1-classifier-dispatch-pre — ${args.runId}\n\ninput_sha256: \`${args.inputSha256}\`\n`,
-    filenameSuffix: 'pre',
-  })
-
-  // Persist state + pre_episode_id.
-  const upd = updateRunState(projectRoot, args.runId, {
-    state: 'classifier-dispatch-pending',
-    pre_episode_id: written.episodeId,
-  })
-  if (upd.error) {
-    process.stderr.write(`error: updateRunState failed: ${upd.error}\n`)
-    return 5
-  }
+  if (exitCode !== 0) return exitCode
 
   process.stdout.write(JSON.stringify({
-    status: 'ok', pre_episode_id: written.episodeId, run_id: args.runId,
+    status: 'ok', pre_episode_id: preEpisodeId, run_id: args.runId,
   }) + '\n')
   return 0
 }

--- a/scripts/lib/bp1-atomic.mjs
+++ b/scripts/lib/bp1-atomic.mjs
@@ -1,0 +1,253 @@
+/**
+ * bp1-atomic.mjs — Shared primitives for multi-step write atomicity in
+ * BP-1 orchestrator subcommands.
+ *
+ * Closes the architectural cluster #286/#287/#288 (multi-step write
+ * sequence with no atomic rollback). Codex-consensus ACCEPT round 5,
+ * episode 20260516-102831-reply-codex-to-20260516-102614-plan-v5-r-b657.
+ *
+ * ## Primitives
+ *
+ *   findSignedStateEpisode(projectRoot, runId, state, runKey32B, expectedFields?)
+ *     → { status: 'match', episodeId, episodePath, frontmatter }
+ *     | { status: 'none' }
+ *     | { status: 'field-mismatch', candidates: Array<{episodeId, episodePath, frontmatter}> }
+ *     | throws { code: 'multiple-signed-match' }
+ *
+ *     Scans `<projectRoot>/.episodic-memory/episodes/*.md`. Parses
+ *     frontmatter, filters by run_id + state, verifies HMAC + identity
+ *     (id-from-frontmatter must match filename, rename-attack defense).
+ *     If `expectedFields`, additionally filters surviving candidates by
+ *     `frontmatter[k] === v` for each k,v in expectedFields.
+ *
+ *     `none` means no signed orphan exists. `field-mismatch` means signed
+ *     orphan(s) exist but canonical fields differ — caller must treat as
+ *     `recoverable-canonical-drift`, NEVER fresh-emit. `match` is single
+ *     surviving candidate. `multiple-signed-match` throws because writes
+ *     are supposed to be unique per (run_id, state) and two valid
+ *     signed copies are an integrity-class anomaly, not a callable
+ *     recovery case.
+ *
+ *   withLockedRun(projectRoot, runId, fn)
+ *     Sync wrapper around withRunStateLockExclusive. Inside the lock:
+ *       1. idx = loadIndexLocked(projectRoot)
+ *       2. run = idx.runs[runId]   (may be undefined)
+ *       3. result = fn({ idx, run })
+ *       4. writeIndex(projectRoot, idx)
+ *       5. return result
+ *     On fn throw: NO writeIndex call; rethrow.
+ *
+ *     CRITICAL: fn MUST NOT call updateRunState / appendRun / markTerminal
+ *     from inside — those acquire the lock and deadlock. fn mutates the
+ *     idx object in place; primitive writes after fn returns.
+ *
+ *   removeRunFromIndex(idx, runId)
+ *     Pure in-memory `delete idx.runs[runId]`. Caller is responsible for
+ *     writing idx via writeIndex.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { parseBp1Frontmatter } from './bp1-frontmatter.mjs'
+import { canonicalize } from './bp1-canonicalize.mjs'
+import { verifyCanonical } from './bp1-hmac.mjs'
+import {
+  withRunStateLockExclusive,
+  loadIndexLocked,
+  writeIndex,
+} from './bp1-run-state.mjs'
+
+const ID_RE = /^[a-z0-9-]+$/
+const FILENAME_RE = /^([a-z0-9-]+)\.md$/
+
+// ---------------------------------------------------------------------------
+// findSignedStateEpisode
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} projectRoot — absolute path
+ * @param {string} runId — `^[a-z0-9-]+$`
+ * @param {string} state — non-empty; one of VALID_V2_STATES
+ * @param {Buffer} runKey32B — 32-byte HMAC key
+ * @param {Record<string,string>} [expectedFields] — optional predicate map
+ * @returns {{status:'match',episodeId:string,episodePath:string,frontmatter:object}
+ *          | {status:'none'}
+ *          | {status:'field-mismatch',candidates:Array<{episodeId:string,episodePath:string,frontmatter:object}>}}
+ * @throws {Error & {code:'multiple-signed-match'}} when >1 candidate satisfies all predicates
+ */
+export function findSignedStateEpisode(projectRoot, runId, state, runKey32B, expectedFields) {
+  if (typeof projectRoot !== 'string' || !path.isAbsolute(projectRoot)) {
+    throw new TypeError('findSignedStateEpisode: projectRoot must be an absolute path string')
+  }
+  if (typeof runId !== 'string' || !ID_RE.test(runId)) {
+    throw new TypeError(`findSignedStateEpisode: runId shape invalid: ${JSON.stringify(runId)}`)
+  }
+  if (typeof state !== 'string' || state === '') {
+    throw new TypeError('findSignedStateEpisode: state must be a non-empty string')
+  }
+  if (!Buffer.isBuffer(runKey32B) || runKey32B.length !== 32) {
+    throw new TypeError('findSignedStateEpisode: runKey32B must be a 32-byte Buffer')
+  }
+  if (expectedFields != null && (typeof expectedFields !== 'object' || Array.isArray(expectedFields))) {
+    throw new TypeError('findSignedStateEpisode: expectedFields must be an object or omitted')
+  }
+
+  const episodesDir = path.join(projectRoot, '.episodic-memory', 'episodes')
+  let entries
+  try {
+    entries = fs.readdirSync(episodesDir)
+  } catch (e) {
+    if (e.code === 'ENOENT') return { status: 'none' }
+    throw e
+  }
+
+  const allCandidates = []
+  for (const name of entries) {
+    const m = FILENAME_RE.exec(name)
+    if (!m) continue
+    const episodeId = m[1]
+    const episodePath = path.join(episodesDir, name)
+    let buf
+    try {
+      buf = fs.readFileSync(episodePath)
+    } catch (_e) {
+      // File vanished between readdir and read (e.g. concurrent sweep). Skip.
+      continue
+    }
+    let parsed
+    try {
+      parsed = parseBp1Frontmatter(buf)
+    } catch (_e) {
+      // Malformed frontmatter — defensive skip. Validators are the loud-fail
+      // path for corruption; this primitive must not throw on unrelated drift.
+      continue
+    }
+    const fm = parsed.frontmatter
+    // Pre-filter cheap shape checks before HMAC verify.
+    if (fm.run_id !== runId) continue
+    if (fm.state !== state) continue
+    // Identity check: fm.id must match the filename stem (rename-attack defense
+    // mirroring verifyEpisodeOnDisk in bp1-episode-verify.mjs).
+    if (fm.id !== episodeId) continue
+    const storedSig = fm.hmac_signature
+    if (typeof storedSig !== 'string' || storedSig === '') continue
+    // HMAC verification: re-canonicalize from on-disk frontmatter + body, then
+    // verifyCanonical. canonicalize never throws on a well-formed BP-1 fm; the
+    // try wraps any unexpected internal error and treats it as not-a-candidate.
+    let canonicalBytes
+    try {
+      ;({ canonicalBytes } = canonicalize(fm, parsed.body))
+    } catch (_e) {
+      continue
+    }
+    if (!verifyCanonical(canonicalBytes, runKey32B, storedSig)) continue
+    allCandidates.push({ episodeId, episodePath, frontmatter: fm })
+  }
+
+  if (allCandidates.length === 0) {
+    return { status: 'none' }
+  }
+
+  // No predicates: a single signed match wins; multiple signed matches at
+  // the same (run_id, state) is an integrity anomaly.
+  if (expectedFields == null) {
+    if (allCandidates.length === 1) {
+      return { status: 'match', ...allCandidates[0] }
+    }
+    const err = new Error(
+      `findSignedStateEpisode: multiple-signed-match (${allCandidates.length}) for ` +
+      `run_id=${runId} state=${state}`,
+    )
+    err.code = 'multiple-signed-match'
+    err.candidates = allCandidates
+    throw err
+  }
+
+  // Filter by predicates.
+  const filtered = []
+  for (const c of allCandidates) {
+    let ok = true
+    for (const k of Object.keys(expectedFields)) {
+      if (c.frontmatter[k] !== expectedFields[k]) {
+        ok = false
+        break
+      }
+    }
+    if (ok) filtered.push(c)
+  }
+
+  if (filtered.length === 0) {
+    return { status: 'field-mismatch', candidates: allCandidates }
+  }
+  if (filtered.length === 1) {
+    return { status: 'match', ...filtered[0] }
+  }
+  const err = new Error(
+    `findSignedStateEpisode: multiple-signed-match (${filtered.length}) for ` +
+    `run_id=${runId} state=${state} satisfying all predicates`,
+  )
+  err.code = 'multiple-signed-match'
+  err.candidates = filtered
+  throw err
+}
+
+// ---------------------------------------------------------------------------
+// withLockedRun
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync wrapper around withRunStateLockExclusive that loads the locked index,
+ * passes `{idx, run}` to fn, and writes the index after fn returns normally.
+ *
+ * fn must mutate idx in place. fn MUST NOT call updateRunState / appendRun /
+ * markTerminal from inside (those acquire the lock and self-deadlock).
+ *
+ * @template T
+ * @param {string} projectRoot
+ * @param {string} runId
+ * @param {(ctx: {idx: object, run: object|undefined}) => T} fn
+ * @returns {T}
+ */
+export function withLockedRun(projectRoot, runId, fn) {
+  if (typeof projectRoot !== 'string' || !path.isAbsolute(projectRoot)) {
+    throw new TypeError('withLockedRun: projectRoot must be an absolute path string')
+  }
+  if (typeof runId !== 'string' || !ID_RE.test(runId)) {
+    throw new TypeError(`withLockedRun: runId shape invalid: ${JSON.stringify(runId)}`)
+  }
+  if (typeof fn !== 'function') {
+    throw new TypeError('withLockedRun: fn must be a function')
+  }
+  return withRunStateLockExclusive(projectRoot, () => {
+    const idx = loadIndexLocked(projectRoot)
+    const run = idx.runs[runId]
+    const result = fn({ idx, run })
+    writeIndex(projectRoot, idx)
+    return result
+  })
+}
+
+// ---------------------------------------------------------------------------
+// removeRunFromIndex
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure in-memory delete. Caller writes via writeIndex.
+ *
+ * @param {object} idx — v2 index object (must have `.runs`)
+ * @param {string} runId
+ */
+export function removeRunFromIndex(idx, runId) {
+  if (!idx || typeof idx !== 'object' || Array.isArray(idx)) {
+    throw new TypeError('removeRunFromIndex: idx must be an object')
+  }
+  if (typeof runId !== 'string') {
+    throw new TypeError('removeRunFromIndex: runId must be a string')
+  }
+  if (idx.runs && typeof idx.runs === 'object' && Object.prototype.hasOwnProperty.call(idx.runs, runId)) {
+    delete idx.runs[runId]
+  }
+}

--- a/scripts/lib/bp1-episode-writer.mjs
+++ b/scripts/lib/bp1-episode-writer.mjs
@@ -239,7 +239,19 @@ export function writeBp1Episode(opts) {
   lines.push('')
 
   const fileText = lines.join('\n') + bodyText
-  fs.writeFileSync(episodePath, fileText)
+
+  // Atomic write: tmp + fsync + rename. Crash between fsync and rename
+  // leaves a recoverable tmp; crash before rename leaves no observable
+  // final path (cluster #286/#287/#288 — codex round-5 ACCEPT).
+  const tmpPath = `${episodePath}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`
+  const fd = fs.openSync(tmpPath, 'wx', 0o600)
+  try {
+    fs.writeFileSync(fd, fileText)
+    fs.fsyncSync(fd)
+  } finally {
+    fs.closeSync(fd)
+  }
+  fs.renameSync(tmpPath, episodePath)
 
   return { episodeId, episodePath, hmacHex }
 }

--- a/scripts/lib/bp1-episode-writer.mjs
+++ b/scripts/lib/bp1-episode-writer.mjs
@@ -243,6 +243,13 @@ export function writeBp1Episode(opts) {
   // Atomic write: tmp + fsync + rename. Crash between fsync and rename
   // leaves a recoverable tmp; crash before rename leaves no observable
   // final path (cluster #286/#287/#288 — codex round-5 ACCEPT).
+  //
+  // rename-failure cleanup: if the rename itself throws (injected failure
+  // OR real I/O error like ENOSPC), unlink the tmp before rethrowing.
+  // Without this, repeated crash-retry accumulates orphan tmp files in
+  // episodes/. The unlink is best-effort: on unlink failure rethrow the
+  // ORIGINAL error (rename) since that's the actionable one for callers.
+  // codex PR-r1 C3 fix.
   const tmpPath = `${episodePath}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`
   const fd = fs.openSync(tmpPath, 'wx', 0o600)
   try {
@@ -251,7 +258,12 @@ export function writeBp1Episode(opts) {
   } finally {
     fs.closeSync(fd)
   }
-  fs.renameSync(tmpPath, episodePath)
+  try {
+    fs.renameSync(tmpPath, episodePath)
+  } catch (renameErr) {
+    try { fs.unlinkSync(tmpPath) } catch (_e) { /* best-effort tmp cleanup */ }
+    throw renameErr
+  }
 
   return { episodeId, episodePath, hmacHex }
 }

--- a/scripts/lib/bp1-run-state-migrate.mjs
+++ b/scripts/lib/bp1-run-state-migrate.mjs
@@ -4,15 +4,23 @@
  *
  * The v1→v2 migration is additive:
  *   - Bump schema_version: 1 → 2.
- *   - For every existing entry in `runs`, default 3 new optional fields to null:
+ *   - For every existing entry in `runs`, default 5 new optional fields to null:
  *       - decided_class
  *       - pre_episode_id
  *       - rfc_detected_episode_id
+ *       - classified_episode_id    (cluster #286/#287/#288)
+ *       - route_episode_id         (cluster #286/#287/#288)
  *   - v1 fields (`project_root`, `state`, `created_at`, `terminal_at`) preserved
  *     as-is.
  *   - v2 expands the `state` value vocabulary (rfc-detected,
  *     classifier-dispatch-pending, classified, planning, needs-human) but does
  *     NOT rewrite existing state values: a v1 `state: 'active'` stays `active`.
+ *
+ * The v2 branch (input already v2) ALSO normalizes pre-existing rows to
+ * default `classified_episode_id` and `route_episode_id` to null when missing
+ * (soft schema addition without bumping schema_version). This is the
+ * primary recovery path for runs that were persisted before the cluster
+ * #286/#287/#288 schema additions landed.
  *
  * This module exports a **pure function** — no IO, no lock acquisition. Used
  * inside `bp1-run-state.mjs`'s `loadIndex` (unlocked entry point) and
@@ -49,10 +57,17 @@ export function migrateV1ToV2(idx) {
     throw new TypeError('migrateV1ToV2: runs must be an object')
   }
   if (idx.schema_version === V2_SCHEMA) {
-    // Defensive copy so callers cannot tamper our return.
+    // Defensive copy so callers cannot tamper our return. Also normalize
+    // pre-existing rows to default cluster #286/#287/#288 fields to null —
+    // this is a soft schema addition without schema_version bump, and the
+    // normalization here is the single read-side reconciliation point.
     const copy = { schema_version: V2_SCHEMA, runs: {} }
     for (const [runId, run] of Object.entries(idx.runs || {})) {
-      copy.runs[runId] = { ...run }
+      copy.runs[runId] = {
+        ...run,
+        classified_episode_id: run.classified_episode_id ?? null,
+        route_episode_id: run.route_episode_id ?? null,
+      }
     }
     return copy
   }
@@ -71,6 +86,8 @@ export function migrateV1ToV2(idx) {
       decided_class: v1Run.decided_class ?? null,
       pre_episode_id: v1Run.pre_episode_id ?? null,
       rfc_detected_episode_id: v1Run.rfc_detected_episode_id ?? null,
+      classified_episode_id: v1Run.classified_episode_id ?? null,
+      route_episode_id: v1Run.route_episode_id ?? null,
     }
   }
   return out

--- a/scripts/lib/bp1-run-state.mjs
+++ b/scripts/lib/bp1-run-state.mjs
@@ -17,11 +17,21 @@
  *       "decided_class": "trivial|schema|validator|security|multi-actor|
  *                        needs-human-input|null",
  *       "pre_episode_id": "<id>|null",
- *       "rfc_detected_episode_id": "<id>|null"
+ *       "rfc_detected_episode_id": "<id>|null",
+ *       "classified_episode_id": "<id>|null",
+ *       "route_episode_id": "<id>|null"
  *     }
  *   }
  * }
  * ```
+ *
+ * `classified_episode_id` / `route_episode_id` (cluster #286/#287/#288): the
+ * signed state-transition episodes emitted at the `classified` and
+ * `planning|needs-human` transitions. Phase A/B split in `record-classification`
+ * persists these mid-flight so resume after a crash can chain off the correct
+ * parent episode. Both default to null; soft schema addition (no
+ * schema_version bump) — existing v2 rows are normalized to null on read via
+ * `migrateV1ToV2`'s v2 branch.
  *
  * ## API split (slice 2c CR2-3)
  *
@@ -101,12 +111,15 @@ export const VALID_V2_STATES = Object.freeze([
 ])
 
 // Patchable transition fields per v2 schema. updateRunState() refuses
-// unknown keys to keep the on-disk shape locked.
+// unknown keys to keep the on-disk shape locked. `classified_episode_id` /
+// `route_episode_id` added (cluster #286/#287/#288 Phase A/B persistence).
 const VALID_V2_PATCH_FIELDS = Object.freeze([
   'state',
   'decided_class',
   'pre_episode_id',
   'rfc_detected_episode_id',
+  'classified_episode_id',
+  'route_episode_id',
 ])
 
 // Valid classifier output classes (mirrors classifier_output_schema in
@@ -439,6 +452,8 @@ export function appendRun(projectRoot, runId, projectRootCanonical) {
         decided_class: null,
         pre_episode_id: null,
         rfc_detected_episode_id: null,
+        classified_episode_id: null,
+        route_episode_id: null,
       }
       idx.runs[runId] = run
       writeIndex(projectRoot, idx)

--- a/scripts/lib/bp1-run-state.mjs
+++ b/scripts/lib/bp1-run-state.mjs
@@ -375,7 +375,19 @@ export function writeIndex(projectRoot, idx) {
   const target = indexPath(projectRoot)
   fs.mkdirSync(path.dirname(target), { recursive: true })
   const tmpPath = `${target}.tmp.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString('hex')}`
-  fs.writeFileSync(tmpPath, JSON.stringify(idx, null, 2) + '\n')
+  // Durability ordering: episode writes (bp1-episode-writer.mjs) fsync before
+  // rename; index writes do NOT fsync. A crash between durable episode-on-disk
+  // and rename-of-index leaves a signed episode the orchestrator's orphan-
+  // attach path will find on retry (`findSignedStateEpisode` + state-resume).
+  // Reversing the order (index first, episode second) would create the bad
+  // failure mode: index claims episode exists but no signed episode on disk.
+  const fd = fs.openSync(tmpPath, 'wx', 0o600)
+  try {
+    fs.writeFileSync(fd, JSON.stringify(idx, null, 2) + '\n')
+    fs.fsyncSync(fd)
+  } finally {
+    fs.closeSync(fd)
+  }
   fs.renameSync(tmpPath, target)
 }
 

--- a/scripts/lib/bp1-run-state.mjs
+++ b/scripts/lib/bp1-run-state.mjs
@@ -375,12 +375,14 @@ export function writeIndex(projectRoot, idx) {
   const target = indexPath(projectRoot)
   fs.mkdirSync(path.dirname(target), { recursive: true })
   const tmpPath = `${target}.tmp.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString('hex')}`
-  // Durability ordering: episode writes (bp1-episode-writer.mjs) fsync before
-  // rename; index writes do NOT fsync. A crash between durable episode-on-disk
-  // and rename-of-index leaves a signed episode the orchestrator's orphan-
-  // attach path will find on retry (`findSignedStateEpisode` + state-resume).
-  // Reversing the order (index first, episode second) would create the bad
-  // failure mode: index claims episode exists but no signed episode on disk.
+  // Durability ordering: callers MUST sequence episode-emit (atomic
+  // tmp+fsync+rename via bp1-episode-writer.mjs) BEFORE this writeIndex.
+  // Both endpoints fsync now (cluster-#286/#287/#288 round-2 N1 fix). The
+  // invariant is the ORDER, not the per-step durability: if a crash occurs
+  // between episode-rename and index-rename, the signed episode is on disk
+  // and the orchestrator's orphan-attach path finds it via
+  // `findSignedStateEpisode` on retry. Reversing the order (index first)
+  // would create the bad failure mode: index pointer to no-such-episode.
   const fd = fs.openSync(tmpPath, 'wx', 0o600)
   try {
     fs.writeFileSync(fd, JSON.stringify(idx, null, 2) + '\n')

--- a/tests/fixtures/inject-rename-fail.mjs
+++ b/tests/fixtures/inject-rename-fail.mjs
@@ -1,0 +1,17 @@
+// Fixture: monkey-patch fs.renameSync to fail on episode-file renames.
+// Triggered by env var FAIL_EPISODE_RENAME=1. Used by #287 rollback tests
+// to simulate a mid-iteration writer crash and verify the compensating
+// rollback unwinds key + index row + episode tmp file.
+
+import fs from 'node:fs'
+
+const originalRenameSync = fs.renameSync
+
+fs.renameSync = function patchedRenameSync(src, dst) {
+  if (process.env.FAIL_EPISODE_RENAME && typeof dst === 'string'
+      && dst.includes('/.episodic-memory/episodes/')
+      && dst.endsWith('.md')) {
+    throw new Error(`injected episode renameSync failure for ${dst}`)
+  }
+  return originalRenameSync.call(this, src, dst)
+}

--- a/tests/fixtures/inject-rename-fail.mjs
+++ b/tests/fixtures/inject-rename-fail.mjs
@@ -1,11 +1,17 @@
-// Fixture: monkey-patch fs.renameSync to fail on episode-file renames.
-// Triggered by env var FAIL_EPISODE_RENAME=1. Used by #287 rollback tests
-// to simulate a mid-iteration writer crash and verify the compensating
-// rollback unwinds key + index row + episode tmp file.
+// Fixture: monkey-patch fs operations to simulate crashes for #287 tests.
+//
+// FAIL_EPISODE_RENAME=1 — fs.renameSync throws on episode-file renames
+//   (final .md rename). Used to simulate writer-crash mid-iteration so
+//   the compensating rollback path is exercised.
+//
+// FAIL_SHRED_KEY=1 — fs.unlinkSync throws on run.key paths. Used to
+//   force a rollback-step failure (key shred) so the sentinel-write
+//   observability is verified end-to-end (not just smoke-tested).
 
 import fs from 'node:fs'
 
 const originalRenameSync = fs.renameSync
+const originalUnlinkSync = fs.unlinkSync
 
 fs.renameSync = function patchedRenameSync(src, dst) {
   if (process.env.FAIL_EPISODE_RENAME && typeof dst === 'string'
@@ -14,4 +20,13 @@ fs.renameSync = function patchedRenameSync(src, dst) {
     throw new Error(`injected episode renameSync failure for ${dst}`)
   }
   return originalRenameSync.call(this, src, dst)
+}
+
+fs.unlinkSync = function patchedUnlinkSync(target) {
+  if (process.env.FAIL_SHRED_KEY && typeof target === 'string'
+      && target.includes('/.episodic-memory/runs/')
+      && target.endsWith('/run.key')) {
+    throw new Error(`injected run.key unlinkSync failure for ${target}`)
+  }
+  return originalUnlinkSync.call(this, target)
 }

--- a/tests/test-bp1-atomic.mjs
+++ b/tests/test-bp1-atomic.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-atomic.mjs — Primitives shared by cluster #286/#287/#288 fix.
+ *
+ * Coverage (plan v5 final, codex round-5 ACCEPT 20260516-102831):
+ *   - atomic writer: tmp+fsync+rename; crash mid-rename leaves no final
+ *   - findSignedStateEpisode: 0/1/many candidates × (no fields | match | mismatch)
+ *   - findSignedStateEpisode: identity check (filename-vs-fm.id)
+ *   - findSignedStateEpisode: HMAC tamper → no match
+ *   - findSignedStateEpisode: expectedFields → status discrimination
+ *   - withLockedRun: fn mutation persists; fn throw → idx unchanged on disk
+ *   - withLockedRun: re-load inside lock; serialization between concurrent calls
+ *   - removeRunFromIndex: in-memory delete; sibling preserved
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+
+const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
+const { writeBp1Episode } = writerMod
+
+const atomicMod = await import(new URL('../scripts/lib/bp1-atomic.mjs', import.meta.url).href)
+const { findSignedStateEpisode, withLockedRun, removeRunFromIndex } = atomicMod
+
+const runStateMod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.meta.url).href)
+const { appendRun, loadIndex, indexPath } = runStateMod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function mkTmpProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-atomic-test-'))
+  // appendRun expects a .git presence is not required; only orchestrator subcommands check it.
+  return fs.realpathSync(dir)
+}
+
+const KEY = crypto.randomBytes(32)
+const RUN_ID = 'bp1-run-1730000000000-cluster-aabbcc'
+
+function emitPre(projectRoot, runId, key, customFm = {}) {
+  return writeBp1Episode({
+    projectRoot,
+    runId,
+    runKey32B: key,
+    type: 'state-transition',
+    state: 'classifier-dispatch-pending',
+    summary: `pre ${runId}`,
+    parentEpisode: `${runId}-rfc-detected-aabb`,
+    expectedPostEpisodeId: null,
+    customFm: { input_sha256: 'a'.repeat(64), ...customFm },
+    tags: ['bp1-classifier-dispatch-pre'],
+    body: `# pre — ${runId}\n`,
+    filenameSuffix: 'pre',
+  })
+}
+
+// =============================================================================
+// Atomic writer
+// =============================================================================
+
+tap('A1 atomic writer: emits final episode atomically; no tmp leak on success', () => {
+  const projectRoot = mkTmpProject()
+  const result = emitPre(projectRoot, RUN_ID, KEY)
+  assert.ok(fs.existsSync(result.episodePath))
+  const epDir = path.join(projectRoot, '.episodic-memory', 'episodes')
+  const entries = fs.readdirSync(epDir)
+  // No `.tmp.` files left.
+  for (const e of entries) {
+    assert.ok(!e.includes('.tmp.'), `tmp file leaked: ${e}`)
+  }
+})
+
+tap('A2 atomic writer: crash mid-rename → no final path; tmp present', () => {
+  const projectRoot = mkTmpProject()
+  const original = fs.renameSync
+  let tmpSeen = null
+  fs.renameSync = (src, _dst) => { tmpSeen = src; throw new Error('simulated power loss between fsync and rename') }
+  try {
+    let threw = false
+    try { emitPre(projectRoot, RUN_ID, KEY) } catch (_e) { threw = true }
+    assert.ok(threw, 'writer should propagate rename failure')
+    assert.ok(tmpSeen != null, 'rename stub should have been called with tmp path')
+    // No final episode file should exist.
+    const epDir = path.join(projectRoot, '.episodic-memory', 'episodes')
+    const entries = fs.readdirSync(epDir)
+    const finals = entries.filter(e => !e.includes('.tmp.'))
+    assert.equal(finals.length, 0, `unexpected final files: ${finals.join(', ')}`)
+    // The tmp file should be present (cleanable by orphan sweep).
+    const tmps = entries.filter(e => e.includes('.tmp.'))
+    assert.equal(tmps.length, 1, `expected 1 tmp file; got ${tmps.length}`)
+  } finally {
+    fs.renameSync = original
+  }
+})
+
+// =============================================================================
+// findSignedStateEpisode — return-shape discrimination
+// =============================================================================
+
+tap('F1 no episodes dir → status: none', () => {
+  const projectRoot = mkTmpProject()
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
+  assert.deepEqual(r, { status: 'none' })
+})
+
+tap('F2 0 signed candidates → status: none (different run_id)', () => {
+  const projectRoot = mkTmpProject()
+  emitPre(projectRoot, RUN_ID, KEY)
+  const r = findSignedStateEpisode(projectRoot, 'bp1-run-other-aabbcc', 'classifier-dispatch-pending', KEY)
+  assert.deepEqual(r, { status: 'none' })
+})
+
+tap('F3 1 signed candidate, no expectedFields → status: match', () => {
+  const projectRoot = mkTmpProject()
+  const ep = emitPre(projectRoot, RUN_ID, KEY)
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
+  assert.equal(r.status, 'match')
+  assert.equal(r.episodeId, ep.episodeId)
+  assert.equal(r.episodePath, ep.episodePath)
+  assert.equal(r.frontmatter.input_sha256, 'a'.repeat(64))
+  assert.equal(r.frontmatter.run_id, RUN_ID)
+})
+
+tap('F4 1 candidate, expectedFields satisfied → status: match', () => {
+  const projectRoot = mkTmpProject()
+  emitPre(projectRoot, RUN_ID, KEY)
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY, {
+    input_sha256: 'a'.repeat(64),
+    parent_episode: `${RUN_ID}-rfc-detected-aabb`,
+  })
+  assert.equal(r.status, 'match')
+})
+
+tap('F5 1 candidate, expectedFields mismatch on one key → status: field-mismatch with candidate listed', () => {
+  const projectRoot = mkTmpProject()
+  const ep = emitPre(projectRoot, RUN_ID, KEY)
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY, {
+    input_sha256: 'b'.repeat(64),  // mismatch
+  })
+  assert.equal(r.status, 'field-mismatch')
+  assert.equal(r.candidates.length, 1)
+  assert.equal(r.candidates[0].episodeId, ep.episodeId)
+})
+
+tap('F6 2 signed candidates, no expectedFields → throws multiple-signed-match', () => {
+  const projectRoot = mkTmpProject()
+  emitPre(projectRoot, RUN_ID, KEY)
+  emitPre(projectRoot, RUN_ID, KEY)  // duplicate
+  let caught = null
+  try {
+    findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
+  } catch (e) { caught = e }
+  assert.ok(caught)
+  assert.equal(caught.code, 'multiple-signed-match')
+  assert.equal(caught.candidates.length, 2)
+})
+
+tap('F7 2 candidates, 1 satisfies all predicates → status: match', () => {
+  const projectRoot = mkTmpProject()
+  emitPre(projectRoot, RUN_ID, KEY, { input_sha256: 'a'.repeat(64) })
+  const target = emitPre(projectRoot, RUN_ID, KEY, { input_sha256: 'b'.repeat(64) })
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY, {
+    input_sha256: 'b'.repeat(64),
+  })
+  assert.equal(r.status, 'match')
+  assert.equal(r.episodeId, target.episodeId)
+})
+
+tap('F8 HMAC tampered → candidate excluded (treated as no signed)', () => {
+  const projectRoot = mkTmpProject()
+  const ep = emitPre(projectRoot, RUN_ID, KEY)
+  // Tamper the file: replace hmac_signature line.
+  const content = fs.readFileSync(ep.episodePath, 'utf8')
+  const tampered = content.replace(/hmac_signature: [a-f0-9]+/, 'hmac_signature: ' + '0'.repeat(64))
+  fs.writeFileSync(ep.episodePath, tampered)
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
+  assert.deepEqual(r, { status: 'none' })
+})
+
+tap('F9 filename-vs-fm.id mismatch (rename attack) → excluded', () => {
+  const projectRoot = mkTmpProject()
+  const ep = emitPre(projectRoot, RUN_ID, KEY)
+  // Rename the file so filename stem differs from fm.id.
+  const epDir = path.dirname(ep.episodePath)
+  const renamed = path.join(epDir, `${RUN_ID}-renamed-9999.md`)
+  fs.renameSync(ep.episodePath, renamed)
+  const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
+  assert.deepEqual(r, { status: 'none' })
+})
+
+tap('F10 input validation — bad projectRoot, runId, state, key, expectedFields', () => {
+  const projectRoot = mkTmpProject()
+  assert.throws(() => findSignedStateEpisode('relative/path', RUN_ID, 'classifier-dispatch-pending', KEY), /absolute path/)
+  assert.throws(() => findSignedStateEpisode(projectRoot, 'BAD ID', 'classifier-dispatch-pending', KEY), /runId shape/)
+  assert.throws(() => findSignedStateEpisode(projectRoot, RUN_ID, '', KEY), /state must be a non-empty/)
+  assert.throws(() => findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', 'not a buffer'), /32-byte Buffer/)
+  assert.throws(() => findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY, []), /expectedFields/)
+})
+
+// =============================================================================
+// withLockedRun
+// =============================================================================
+
+tap('W1 fn mutation persists via writeIndex on normal return', () => {
+  const projectRoot = mkTmpProject()
+  const append = appendRun(projectRoot, RUN_ID, projectRoot)
+  assert.ok(append.ok)
+  withLockedRun(projectRoot, RUN_ID, ({ idx, run }) => {
+    assert.ok(run)
+    run.state = 'rfc-detected'
+    run.rfc_detected_episode_id = 'fake-ep-id-aabb'
+  })
+  const reread = loadIndex(projectRoot)
+  assert.equal(reread.runs[RUN_ID].state, 'rfc-detected')
+  assert.equal(reread.runs[RUN_ID].rfc_detected_episode_id, 'fake-ep-id-aabb')
+})
+
+tap('W2 fn throw → idx not written; on-disk state unchanged', () => {
+  const projectRoot = mkTmpProject()
+  appendRun(projectRoot, RUN_ID, projectRoot)
+  let caught = null
+  try {
+    withLockedRun(projectRoot, RUN_ID, ({ run }) => {
+      run.state = 'classified'
+      throw new Error('aborted mid-mutation')
+    })
+  } catch (e) { caught = e }
+  assert.ok(caught)
+  assert.equal(caught.message, 'aborted mid-mutation')
+  const reread = loadIndex(projectRoot)
+  assert.equal(reread.runs[RUN_ID].state, 'active', 'state should remain initial')
+})
+
+tap('W3 run undefined when runId not in idx', () => {
+  const projectRoot = mkTmpProject()
+  let seen = null
+  withLockedRun(projectRoot, RUN_ID, ({ idx, run }) => { seen = run; assert.ok(idx) })
+  assert.equal(seen, undefined)
+})
+
+tap('W4 fn return value propagates', () => {
+  const projectRoot = mkTmpProject()
+  appendRun(projectRoot, RUN_ID, projectRoot)
+  const r = withLockedRun(projectRoot, RUN_ID, ({ run }) => ({ found: !!run, state: run?.state }))
+  assert.deepEqual(r, { found: true, state: 'active' })
+})
+
+tap('W5 input validation', () => {
+  const projectRoot = mkTmpProject()
+  assert.throws(() => withLockedRun('relative', RUN_ID, () => {}), /absolute path/)
+  assert.throws(() => withLockedRun(projectRoot, 'BAD ID', () => {}), /runId shape/)
+  assert.throws(() => withLockedRun(projectRoot, RUN_ID, 'not-a-function'), /fn must be a function/)
+})
+
+// =============================================================================
+// removeRunFromIndex
+// =============================================================================
+
+tap('R1 removes the target run; siblings preserved', () => {
+  const idx = {
+    schema_version: 2,
+    runs: {
+      'run-a': { state: 'active' },
+      'run-b': { state: 'classified' },
+      'run-c': { state: 'planning' },
+    },
+  }
+  removeRunFromIndex(idx, 'run-b')
+  assert.equal(idx.runs['run-a'].state, 'active')
+  assert.equal(idx.runs['run-b'], undefined)
+  assert.equal(idx.runs['run-c'].state, 'planning')
+})
+
+tap('R2 no-op if runId absent', () => {
+  const idx = { schema_version: 2, runs: { 'run-a': { state: 'active' } } }
+  removeRunFromIndex(idx, 'run-zzz')
+  assert.equal(idx.runs['run-a'].state, 'active')
+})
+
+tap('R3 input validation', () => {
+  assert.throws(() => removeRunFromIndex(null, 'r'), /idx must be an object/)
+  assert.throws(() => removeRunFromIndex([], 'r'), /idx must be an object/)
+  assert.throws(() => removeRunFromIndex({ runs: {} }, 123), /runId must be a string/)
+})
+
+// =============================================================================
+// Summary
+// =============================================================================
+
+if (fail > 0) {
+  console.log(`\n# FAIL ${pass}/${pass + fail} passed`)
+  process.exit(1)
+}
+console.log(`\n# OK ${pass}/${pass + fail} passed`)

--- a/tests/test-bp1-atomic.mjs
+++ b/tests/test-bp1-atomic.mjs
@@ -79,24 +79,30 @@ tap('A1 atomic writer: emits final episode atomically; no tmp leak on success', 
   }
 })
 
-tap('A2 atomic writer: crash mid-rename → no final path; tmp present', () => {
+tap('A2 atomic writer: rename failure → no final path AND no tmp leak (writer cleans up)', () => {
+  // Contract revised per codex PR-r1 C3: writer is responsible for its own
+  // tmp cleanup on rename failure. The prior contract ("tmp present,
+  // cleanable by orphan sweep") was aspirational — no orphan sweep ever
+  // shipped, so leaked tmps accumulated forever under crash-retry. The
+  // writer now unlinks the tmp before rethrowing the rename error.
   const projectRoot = mkTmpProject()
   const original = fs.renameSync
   let tmpSeen = null
   fs.renameSync = (src, _dst) => { tmpSeen = src; throw new Error('simulated power loss between fsync and rename') }
   try {
     let threw = false
-    try { emitPre(projectRoot, RUN_ID, KEY) } catch (_e) { threw = true }
+    let caughtErr = null
+    try { emitPre(projectRoot, RUN_ID, KEY) } catch (e) { threw = true; caughtErr = e }
     assert.ok(threw, 'writer should propagate rename failure')
+    assert.match(caughtErr.message, /simulated power loss/,
+      'writer rethrows the ORIGINAL rename error (not the tmp-cleanup error)')
     assert.ok(tmpSeen != null, 'rename stub should have been called with tmp path')
-    // No final episode file should exist.
     const epDir = path.join(projectRoot, '.episodic-memory', 'episodes')
     const entries = fs.readdirSync(epDir)
     const finals = entries.filter(e => !e.includes('.tmp.'))
     assert.equal(finals.length, 0, `unexpected final files: ${finals.join(', ')}`)
-    // The tmp file should be present (cleanable by orphan sweep).
     const tmps = entries.filter(e => e.includes('.tmp.'))
-    assert.equal(tmps.length, 1, `expected 1 tmp file; got ${tmps.length}`)
+    assert.equal(tmps.length, 0, `tmp should be cleaned up on rename failure; got: ${tmps.join(', ')}`)
   } finally {
     fs.renameSync = original
   }

--- a/tests/test-bp1-orchestrator-286-race-and-crash.mjs
+++ b/tests/test-bp1-orchestrator-286-race-and-crash.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-orchestrator-286-race-and-crash.mjs —
+ *   record-classifier-dispatch-pre concurrency + crash recovery
+ *   for cluster #286/#287/#288 fix.
+ *
+ * Plan v5 (codex round-5 ACCEPT 20260516-102831-...-b657) matrix:
+ *   286-1 race same-sha → both succeed (attach), no duplicate
+ *   286-2 race different-sha → first wins, second state-violation, no duplicate
+ *   286-3 retry with stale input_sha256 on pending → recoverable-canonical-drift
+ *   286-4 crash mid-rename → tmp present, no final, retry succeeds
+ *   286-5 crash after emit before writeIndex → orphan signed, retry attaches
+ *   286-6 caller cwd != target → all artifacts under target
+ *   286-7 different runIds concurrent → no cross-run attach
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync, spawn } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const ORCHESTRATOR = path.join(REPO, 'scripts', 'bp1-orchestrator.mjs')
+const ARTIFACT_BUILDER = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
+
+const hmacMod = await import(new URL('../scripts/lib/bp1-hmac.mjs', import.meta.url).href)
+const { verifyKeyFingerprint } = hmacMod
+const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.meta.url).href)
+const { loadIndex, withRunStateLockExclusive, loadIndexLocked, writeIndex } = rsmod
+const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
+const { writeBp1Episode } = writerMod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox helpers (mirror classifier-fence test style)
+// ---------------------------------------------------------------------------
+
+function makeProj() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-286-proj-'))
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs', 'rfcs'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function makeHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-286-home-'))
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function writeKey(homeDir) {
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/.verify-key'), key, { mode: 0o600 })
+  return verifyKeyFingerprint(key)
+}
+function buildHash(projectRoot, homeDir) {
+  return JSON.parse(execFileSync('node', [ARTIFACT_BUILDER, '--project', projectRoot, '--json'],
+    { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })).sha256
+}
+function writeConfig(homeDir, projectRoot, fingerprint) {
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/config.json'),
+    JSON.stringify({
+      bp1: {
+        schema_version: 1,
+        activations: {
+          [projectRoot]: {
+            enabled: true,
+            artifact_version_hash: 'sha256:' + buildHash(projectRoot, homeDir),
+            enabled_at: new Date().toISOString(),
+            enabled_via: 'test-fixture',
+            verify_key_id: fingerprint,
+          },
+        },
+      },
+    }, null, 2))
+}
+function writeRfc(projectRoot, name, status = 'accepted') {
+  fs.writeFileSync(path.join(projectRoot, 'docs', 'rfcs', `${name}.md`),
+    `---\nrfc_id: ${name}\nstatus: ${JSON.stringify(status)}\ntitle: ${JSON.stringify('T')}\n---\n\nbody.\n`)
+}
+function runOrch(args, { project, homeDir, callerCwd }) {
+  return spawnSync('node', [ORCHESTRATOR, ...args], {
+    cwd: callerCwd ?? project, encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir },
+  })
+}
+
+function setupRfcDetected({ rfcs = ['RFC-CF'] } = {}) {
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  for (const r of rfcs) writeRfc(project, r)
+  writeConfig(home, project, fp)
+  const r = runOrch(['detect-rfcs', '--project', project], { project, homeDir: home })
+  if (r.status !== 0) throw new Error(`detect-rfcs failed: ${r.stderr}`)
+  const detected = JSON.parse(r.stdout).detected
+  // Map rfcId → { run_id, run.key, rfc_detected_episode_id }
+  const byRfc = {}
+  for (const d of detected) {
+    const runKey = fs.readFileSync(path.join(project, '.episodic-memory/runs', d.run_id, 'run.key'))
+    byRfc[d.rfc_id] = { runId: d.run_id, runKey, rfcDetectedEpisodeId: d.rfc_detected_episode_id }
+  }
+  return { project, home, byRfc, firstRfc: detected[0] }
+}
+
+function preDispatch(ctx, runId, inputSha256, opts = {}) {
+  return runOrch([
+    'record-classifier-dispatch-pre',
+    '--project', ctx.project,
+    '--run-id', runId,
+    '--input-sha256', inputSha256,
+  ], { project: ctx.project, homeDir: ctx.home, callerCwd: opts.callerCwd })
+}
+
+function preDispatchAsync(ctx, runId, inputSha256) {
+  return new Promise((resolve) => {
+    const child = spawn('node', [
+      ORCHESTRATOR,
+      'record-classifier-dispatch-pre',
+      '--project', ctx.project,
+      '--run-id', runId,
+      '--input-sha256', inputSha256,
+    ], {
+      cwd: ctx.project,
+      env: { ...process.env, HOME: ctx.home },
+    })
+    let stdout = '', stderr = ''
+    child.stdout.on('data', (d) => stdout += d)
+    child.stderr.on('data', (d) => stderr += d)
+    child.on('close', (code) => resolve({ status: code, stdout, stderr }))
+  })
+}
+
+const SHA_A = 'a'.repeat(64)
+const SHA_B = 'b'.repeat(64)
+
+// ===========================================================================
+// 286-1: race same-sha → both succeed (one attaches), no duplicate
+// ===========================================================================
+tap('286-1 race same-sha → both succeed (one attaches), no duplicate pre-episode', async () => {
+  const ctx = setupRfcDetected()
+  const { runId } = ctx.byRfc['RFC-CF']
+  const [r1, r2] = await Promise.all([
+    preDispatchAsync(ctx, runId, SHA_A),
+    preDispatchAsync(ctx, runId, SHA_A),
+  ])
+  // Both must succeed.
+  assert.equal(r1.status, 0, `r1 stderr=${r1.stderr}`)
+  assert.equal(r2.status, 0, `r2 stderr=${r2.stderr}`)
+  // Both report the same pre_episode_id (one emitted, one attached).
+  const id1 = JSON.parse(r1.stdout).pre_episode_id
+  const id2 = JSON.parse(r2.stdout).pre_episode_id
+  assert.equal(id1, id2, 'concurrent retries with same sha must report the same pre_episode_id')
+  // Exactly one signed pre-episode on disk for runId.
+  const epDir = path.join(ctx.project, '.episodic-memory', 'episodes')
+  const matching = fs.readdirSync(epDir).filter(n => n.startsWith(runId) && n.endsWith('.md') && n.includes('-pre-'))
+  assert.equal(matching.length, 1, `expected 1 pre-episode; got ${matching.length}: ${matching.join(', ')}`)
+})
+
+// ===========================================================================
+// 286-2: race different-sha → first wins; second exits 5 with drift
+// ===========================================================================
+tap('286-2 race different-sha → first wins; second exits 5; no duplicate emit', async () => {
+  const ctx = setupRfcDetected()
+  const { runId } = ctx.byRfc['RFC-CF']
+  const [r1, r2] = await Promise.all([
+    preDispatchAsync(ctx, runId, SHA_A),
+    preDispatchAsync(ctx, runId, SHA_B),
+  ])
+  // Exactly one success, one failure.
+  const succ = [r1, r2].filter(r => r.status === 0)
+  const fails = [r1, r2].filter(r => r.status === 5)
+  assert.equal(succ.length, 1, `expected 1 success; got ${succ.length}`)
+  assert.equal(fails.length, 1, `expected 1 exit-5; got ${fails.length}`)
+  // The failure carries recoverable-canonical-drift or state-violation language.
+  const failStderr = fails[0].stderr
+  assert.match(failStderr, /recoverable-canonical-drift|state-violation/,
+    `unexpected fail stderr: ${failStderr}`)
+  // Exactly one signed pre-episode on disk for runId.
+  const epDir = path.join(ctx.project, '.episodic-memory', 'episodes')
+  const matching = fs.readdirSync(epDir).filter(n => n.startsWith(runId) && n.includes('-pre-'))
+  assert.equal(matching.length, 1, `expected 1 pre-episode; got ${matching.length}`)
+})
+
+// ===========================================================================
+// 286-3: retry with stale input_sha256 on pending → recoverable-canonical-drift
+// ===========================================================================
+tap('286-3 retry with stale input_sha256 on pending → recoverable-canonical-drift', () => {
+  const ctx = setupRfcDetected()
+  const { runId } = ctx.byRfc['RFC-CF']
+  const r1 = preDispatch(ctx, runId, SHA_A)
+  assert.equal(r1.status, 0)
+  // Same run, advanced to classifier-dispatch-pending. Now retry with a different sha.
+  const r2 = preDispatch(ctx, runId, SHA_B)
+  assert.equal(r2.status, 5, `expected exit 5; got ${r2.status}; stderr=${r2.stderr}`)
+  assert.match(r2.stderr, /recoverable-canonical-drift/)
+})
+
+// ===========================================================================
+// 286-4: crash mid-rename — tmp present, no final; retry succeeds.
+// In-process invocation so we can stub fs.renameSync.
+// ===========================================================================
+tap('286-4 crash mid-rename → tmp present, no final, retry succeeds', () => {
+  const ctx = setupRfcDetected()
+  const { runId } = ctx.byRfc['RFC-CF']
+  // Force renameSync to throw on the first writeBp1Episode call from this
+  // test process. Subsequent (post-restore) calls behave normally. The
+  // orchestrator subprocess uses its OWN fs, so we have to do this part
+  // in-process with the writer directly: emit a tmp via stubbed rename,
+  // then verify the orchestrator subprocess's retry succeeds.
+  const original = fs.renameSync
+  const projectRoot = ctx.project
+  let tmpSeen = null
+  fs.renameSync = (src, _dst) => { tmpSeen = src; throw new Error('simulated power-loss') }
+  try {
+    let threw = false
+    try {
+      writeBp1Episode({
+        projectRoot, runId, runKey32B: ctx.byRfc['RFC-CF'].runKey,
+        type: 'state-transition', state: 'classifier-dispatch-pending',
+        summary: 'pre-mid-rename-crash',
+        parentEpisode: ctx.byRfc['RFC-CF'].rfcDetectedEpisodeId,
+        expectedPostEpisodeId: null,
+        customFm: { input_sha256: SHA_A },
+        tags: ['bp1-classifier-dispatch-pre'],
+        body: '# pre crash test\n',
+        filenameSuffix: 'pre',
+      })
+    } catch (_e) { threw = true }
+    assert.ok(threw)
+    assert.ok(tmpSeen, 'tmp path was generated')
+    // No final PRE-DISPATCH episode (the rfc-detected episode from setup is fine).
+    const epDir = path.join(projectRoot, '.episodic-memory', 'episodes')
+    const preFinals = fs.readdirSync(epDir).filter(n => n.startsWith(runId) && n.includes('-pre-') && !n.includes('.tmp.'))
+    assert.equal(preFinals.length, 0, `unexpected pre-final files: ${preFinals.join(', ')}`)
+  } finally {
+    fs.renameSync = original
+  }
+  // Retry via orchestrator subprocess — should succeed (fresh emit; no orphan match).
+  const r = preDispatch(ctx, runId, SHA_A)
+  assert.equal(r.status, 0, `retry failed: ${r.stderr}`)
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[runId].state, 'classifier-dispatch-pending')
+  assert.ok(idx.runs[runId].pre_episode_id)
+})
+
+// ===========================================================================
+// 286-5: crash after atomic-write before writeIndex — orphan signed,
+// retry attaches the orphan. Simulate by emitting the episode directly,
+// leaving idx unchanged (state still 'rfc-detected'), then run subprocess.
+// ===========================================================================
+tap('286-5 crash after rename before writeIndex → orphan signed, retry attaches', () => {
+  const ctx = setupRfcDetected()
+  const { runId, rfcDetectedEpisodeId, runKey } = ctx.byRfc['RFC-CF']
+  // Emit pre-episode directly (atomic via refactored writer). Do NOT update idx.
+  const orphan = writeBp1Episode({
+    projectRoot: ctx.project, runId, runKey32B: runKey,
+    type: 'state-transition', state: 'classifier-dispatch-pending',
+    summary: 'orphan pre',
+    parentEpisode: rfcDetectedEpisodeId,
+    expectedPostEpisodeId: null,
+    customFm: { input_sha256: SHA_A },
+    tags: ['bp1-classifier-dispatch-pre'],
+    body: '# orphan\n',
+    filenameSuffix: 'pre',
+  })
+  // Idx unchanged: state still 'rfc-detected', pre_episode_id null.
+  const idxBefore = loadIndex(ctx.project)
+  assert.equal(idxBefore.runs[runId].state, 'rfc-detected')
+  assert.equal(idxBefore.runs[runId].pre_episode_id, null)
+  // Retry via orchestrator with matching input_sha256 → orphan attach.
+  const r = preDispatch(ctx, runId, SHA_A)
+  assert.equal(r.status, 0, `attach retry failed: ${r.stderr}`)
+  const idxAfter = loadIndex(ctx.project)
+  assert.equal(idxAfter.runs[runId].state, 'classifier-dispatch-pending')
+  assert.equal(idxAfter.runs[runId].pre_episode_id, orphan.episodeId,
+    'retry should attach the orphan, not emit a new pre-episode')
+  // Confirm: still only 1 signed pre-episode on disk.
+  const epDir = path.join(ctx.project, '.episodic-memory', 'episodes')
+  const matching = fs.readdirSync(epDir).filter(n => n.startsWith(runId) && n.includes('-pre-') && !n.includes('.tmp.'))
+  assert.equal(matching.length, 1, `expected exactly 1 final pre-episode; got ${matching.length}`)
+})
+
+// ===========================================================================
+// 286-6: caller cwd != target → all artifacts under target
+// ===========================================================================
+tap('286-6 caller cwd != target → all artifacts under target', () => {
+  const ctx = setupRfcDetected()
+  const { runId } = ctx.byRfc['RFC-CF']
+  const callerCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-286-caller-'))
+  const r = preDispatch(ctx, runId, SHA_A, { callerCwd })
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  // No .episodic-memory directory should have been created under callerCwd.
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.episodic-memory')),
+    'caller cwd must not host .episodic-memory artifacts')
+  // The pre-episode lives under the target.
+  const epDir = path.join(ctx.project, '.episodic-memory', 'episodes')
+  const matching = fs.readdirSync(epDir).filter(n => n.startsWith(runId) && n.includes('-pre-'))
+  assert.equal(matching.length, 1)
+})
+
+// ===========================================================================
+// 286-7: different runIds concurrent → no cross-run attach
+// ===========================================================================
+tap('286-7 different runIds concurrent → no cross-run attach', async () => {
+  const ctx = setupRfcDetected({ rfcs: ['RFC-CF-A', 'RFC-CF-B'] })
+  const a = ctx.byRfc['RFC-CF-A']
+  const b = ctx.byRfc['RFC-CF-B']
+  const [r1, r2] = await Promise.all([
+    preDispatchAsync(ctx, a.runId, SHA_A),
+    preDispatchAsync(ctx, b.runId, SHA_B),
+  ])
+  assert.equal(r1.status, 0, `r1 stderr=${r1.stderr}`)
+  assert.equal(r2.status, 0, `r2 stderr=${r2.stderr}`)
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[a.runId].state, 'classifier-dispatch-pending')
+  assert.equal(idx.runs[b.runId].state, 'classifier-dispatch-pending')
+  const idA = JSON.parse(r1.stdout).pre_episode_id
+  const idB = JSON.parse(r2.stdout).pre_episode_id
+  assert.notEqual(idA, idB, 'distinct runIds must mint distinct pre-episodes')
+  assert.ok(idA.startsWith(a.runId), `idA should start with runId-A: ${idA}`)
+  assert.ok(idB.startsWith(b.runId), `idB should start with runId-B: ${idB}`)
+})
+
+if (fail > 0) {
+  console.log(`\n# FAIL ${pass}/${pass + fail} passed`)
+  process.exit(1)
+}
+console.log(`\n# OK ${pass}/${pass + fail} passed`)

--- a/tests/test-bp1-orchestrator-287-rollback.mjs
+++ b/tests/test-bp1-orchestrator-287-rollback.mjs
@@ -90,8 +90,10 @@ function setupActiveProject({ rfcs = ['RFC-A'] } = {}) {
 
 // ===========================================================================
 // 287-1 — atomic-rename injection: writer's rename throws → rollback unwinds
+//   key + index row + episode .md AND no .md.tmp.* leak. codex r1 C3 fix:
+//   prior version filtered out .tmp.* files which masked tmp leak class.
 // ===========================================================================
-tap('287-1 emit throws (atomic-rename injected fail) → key + index row + tmp unwound', () => {
+tap('287-1 emit throws (atomic-rename injected fail) → key + index + episode .md + tmp all unwound', () => {
   const { project, home } = setupActiveProject({ rfcs: ['RFC-A'] })
   const r = spawnSync('node', ['--import', INJECT_RENAME, ORCHESTRATOR, 'detect-rfcs', '--project', project], {
     cwd: project,
@@ -114,52 +116,70 @@ tap('287-1 emit throws (atomic-rename injected fail) → key + index row + tmp u
         `run.key should have been shredded for ${e}; got ${subEntries.join(', ')}`)
     }
   }
-  // No FINAL episode files (the failed rename means the .tmp file was created
-  // but rename to final never happened).
+  // No FINAL episode files AND no .md.tmp.* leftovers. The writer's atomic-
+  // rename path failed, so it should have cleaned up its tmp; if not, the
+  // disk accumulates orphan tmps across crash-retry. codex r1 C3.
   const episodesDir = path.join(project, '.episodic-memory', 'episodes')
   if (fs.existsSync(episodesDir)) {
-    const finals = fs.readdirSync(episodesDir).filter(n => n.endsWith('.md') && !n.includes('.tmp.'))
+    const all = fs.readdirSync(episodesDir)
+    const finals = all.filter(n => n.endsWith('.md') && !n.includes('.tmp.'))
+    const tmps = all.filter(n => n.includes('.md.tmp.') || (n.startsWith('.') && n.includes('tmp')))
     assert.equal(finals.length, 0, `no final episode files; got ${finals.join(', ')}`)
+    assert.equal(tmps.length, 0, `no .md.tmp.* leak; got ${tmps.join(', ')}`)
   }
 })
 
 // ===========================================================================
-// 287-2 — sentinel: rollback step itself fails → .rollback-failed.json written
+// 287-2 — rollback step itself fails: episode-rename injection THEN shred-key
+//   injection forces a real rollback failure. Verify (a) .rollback-failed.json
+//   sentinel on disk, (b) stderr contains "rollback-failed: sentinel at ...",
+//   (c) sentinel JSON contains the original error + the shred-key failure
+//   in the rollback_errors array. codex r1 C3 fix: prior smoke test asserted
+//   assert.ok(true), never forced a rollback failure.
 // ===========================================================================
-// We engineer this by injecting a renameSync failure AND by making the
-// run.key directory unwritable so shredRunKey fails. But making it
-// unwritable on macOS requires chmod and is fiddly; a simpler approach is
-// to assert that the orchestrator emits the rollback-failed line when
-// shredRunKey rejects (e.g., file gone). For now, we test the basic
-// observability path: rollback runs to completion in 287-1, so we just
-// verify the sentinel mechanism by simulating a partial rollback state
-// directly. This test is a smoke-test of the sentinel-write path.
-
-tap('287-2 sentinel-write path is reachable (smoke): rollback errors stringify into stderr', () => {
-  // The injected rename in 287-1 should produce a clean rollback (no
-  // sentinel). Verify stderr does NOT contain "rollback-failed:" but DOES
-  // contain the iteration-failure error.
+tap('287-2 forced rollback failure → .rollback-failed.json sentinel + stderr line', () => {
   const { project, home } = setupActiveProject({ rfcs: ['RFC-A'] })
   const r = spawnSync('node', ['--import', INJECT_RENAME, ORCHESTRATOR, 'detect-rfcs', '--project', project], {
     cwd: project,
     encoding: 'utf8',
-    env: { ...process.env, HOME: home, FAIL_EPISODE_RENAME: '1' },
+    env: {
+      ...process.env, HOME: home,
+      FAIL_EPISODE_RENAME: '1',
+      FAIL_SHRED_KEY: '1',
+    },
   })
-  assert.equal(r.status, 3)
+  assert.equal(r.status, 3, `expected exit 3; got ${r.status}; stderr=${r.stderr}`)
   assert.match(r.stderr, /detect-rfcs iteration failed/,
     `expected iteration-failure stderr; got: ${r.stderr}`)
-  // Clean rollback in this scenario — no sentinel expected.
+  assert.match(r.stderr, /rollback-failed: sentinel at /,
+    `expected sentinel-write stderr line; got: ${r.stderr}`)
+
+  // Find the sentinel on disk and verify its contents.
   const runsDir = path.join(project, '.episodic-memory', 'runs')
-  if (fs.existsSync(runsDir)) {
-    const sentinels = fs.readdirSync(runsDir).flatMap(e => {
-      const sub = path.join(runsDir, e)
-      try { return fs.statSync(sub).isDirectory() ? fs.readdirSync(sub).filter(f => f === '.rollback-failed.json') : [] }
-      catch { return [] }
-    })
-    // Sentinel is allowed but not required for the clean-rollback case.
-    // Either way the iteration-failure stderr line is present.
-    assert.ok(true, `sentinels found: ${sentinels.length}`)
+  assert.ok(fs.existsSync(runsDir), 'runs/ should exist')
+  let sentinelPath = null
+  let sentinelContent = null
+  for (const entry of fs.readdirSync(runsDir)) {
+    const sub = path.join(runsDir, entry)
+    if (!fs.statSync(sub).isDirectory()) continue
+    const candidate = path.join(sub, '.rollback-failed.json')
+    if (fs.existsSync(candidate)) {
+      sentinelPath = candidate
+      sentinelContent = JSON.parse(fs.readFileSync(candidate, 'utf8'))
+      break
+    }
   }
+  assert.ok(sentinelPath, `expected .rollback-failed.json on disk; runs/ entries: ${fs.readdirSync(runsDir).join(', ')}`)
+  assert.ok(Array.isArray(sentinelContent.rollback_errors),
+    `sentinel.rollback_errors must be array; got: ${JSON.stringify(sentinelContent)}`)
+  assert.ok(
+    sentinelContent.rollback_errors.some(e => /^shred-key: /.test(e)),
+    `sentinel must record shred-key failure; got: ${JSON.stringify(sentinelContent.rollback_errors)}`,
+  )
+  assert.match(sentinelContent.original_error, /injected episode renameSync failure/,
+    `sentinel.original_error must reference the writer failure; got: ${sentinelContent.original_error}`)
+  assert.ok(sentinelContent.run_id, 'sentinel must include run_id')
+  assert.ok(sentinelContent.at, 'sentinel must include timestamp')
 })
 
 if (fail > 0) {

--- a/tests/test-bp1-orchestrator-287-rollback.mjs
+++ b/tests/test-bp1-orchestrator-287-rollback.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-orchestrator-287-rollback.mjs — detect-rfcs per-RFC iteration
+ * compensating rollback. Cluster #287 fix; plan v5 round-5 ACCEPT.
+ *
+ * Cases (subset; full matrix in plan):
+ *   287-1 emit throws (atomic-rename injected fail) → key + index + tmp
+ *         unwound; no orphaned state for the failed runId; sibling RFCs
+ *         in the same iteration left intact if they ran first.
+ *   287-2 rollback-failed sentinel: when shred fails, .rollback-failed.json
+ *         is written under <projectRoot>/.episodic-memory/runs/<runId>/.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const ORCHESTRATOR = path.join(REPO, 'scripts', 'bp1-orchestrator.mjs')
+const ARTIFACT_BUILDER = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
+const INJECT_RENAME = path.join(REPO, 'tests', 'fixtures', 'inject-rename-fail.mjs')
+
+const hmacMod = await import(new URL('../scripts/lib/bp1-hmac.mjs', import.meta.url).href)
+const { verifyKeyFingerprint } = hmacMod
+const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.meta.url).href)
+const { loadIndex } = rsmod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeProj() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-287-proj-'))
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs', 'rfcs'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function makeHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-287-home-'))
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function writeKey(homeDir) {
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/.verify-key'), key, { mode: 0o600 })
+  return verifyKeyFingerprint(key)
+}
+function buildHash(projectRoot, homeDir) {
+  return JSON.parse(execFileSync('node', [ARTIFACT_BUILDER, '--project', projectRoot, '--json'],
+    { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })).sha256
+}
+function writeConfig(homeDir, projectRoot, fingerprint) {
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/config.json'),
+    JSON.stringify({
+      bp1: {
+        schema_version: 1,
+        activations: {
+          [projectRoot]: {
+            enabled: true,
+            artifact_version_hash: 'sha256:' + buildHash(projectRoot, homeDir),
+            enabled_at: new Date().toISOString(),
+            enabled_via: 'test-fixture',
+            verify_key_id: fingerprint,
+          },
+        },
+      },
+    }, null, 2))
+}
+function writeRfc(projectRoot, name) {
+  fs.writeFileSync(path.join(projectRoot, 'docs', 'rfcs', `${name}.md`),
+    `---\nrfc_id: ${name}\nstatus: ${JSON.stringify('accepted')}\ntitle: ${JSON.stringify('T')}\n---\n\nbody.\n`)
+}
+function setupActiveProject({ rfcs = ['RFC-A'] } = {}) {
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  for (const r of rfcs) writeRfc(project, r)
+  writeConfig(home, project, fp)
+  return { project, home }
+}
+
+// ===========================================================================
+// 287-1 — atomic-rename injection: writer's rename throws → rollback unwinds
+// ===========================================================================
+tap('287-1 emit throws (atomic-rename injected fail) → key + index row + tmp unwound', () => {
+  const { project, home } = setupActiveProject({ rfcs: ['RFC-A'] })
+  const r = spawnSync('node', ['--import', INJECT_RENAME, ORCHESTRATOR, 'detect-rfcs', '--project', project], {
+    cwd: project,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, FAIL_EPISODE_RENAME: '1' },
+  })
+  assert.equal(r.status, 3, `expected exit 3; got ${r.status}; stderr=${r.stderr}`)
+  // No run entries in index (rollback removed the row).
+  const idx = loadIndex(project)
+  assert.deepEqual(idx.runs, {}, `runs index should be empty after rollback; got ${JSON.stringify(idx.runs)}`)
+  // No run.key directories (rollback shredded the key).
+  const runsDir = path.join(project, '.episodic-memory', 'runs')
+  if (fs.existsSync(runsDir)) {
+    const entries = fs.readdirSync(runsDir).filter(n => n !== '_index.json' && !n.startsWith('_index.lock') && !n.startsWith('_index.json.tmp.'))
+    // run.key entries unwound; .rollback-failed.json may or may not be present.
+    for (const e of entries) {
+      const sub = path.join(runsDir, e)
+      const subEntries = fs.readdirSync(sub)
+      assert.ok(!subEntries.includes('run.key'),
+        `run.key should have been shredded for ${e}; got ${subEntries.join(', ')}`)
+    }
+  }
+  // No FINAL episode files (the failed rename means the .tmp file was created
+  // but rename to final never happened).
+  const episodesDir = path.join(project, '.episodic-memory', 'episodes')
+  if (fs.existsSync(episodesDir)) {
+    const finals = fs.readdirSync(episodesDir).filter(n => n.endsWith('.md') && !n.includes('.tmp.'))
+    assert.equal(finals.length, 0, `no final episode files; got ${finals.join(', ')}`)
+  }
+})
+
+// ===========================================================================
+// 287-2 — sentinel: rollback step itself fails → .rollback-failed.json written
+// ===========================================================================
+// We engineer this by injecting a renameSync failure AND by making the
+// run.key directory unwritable so shredRunKey fails. But making it
+// unwritable on macOS requires chmod and is fiddly; a simpler approach is
+// to assert that the orchestrator emits the rollback-failed line when
+// shredRunKey rejects (e.g., file gone). For now, we test the basic
+// observability path: rollback runs to completion in 287-1, so we just
+// verify the sentinel mechanism by simulating a partial rollback state
+// directly. This test is a smoke-test of the sentinel-write path.
+
+tap('287-2 sentinel-write path is reachable (smoke): rollback errors stringify into stderr', () => {
+  // The injected rename in 287-1 should produce a clean rollback (no
+  // sentinel). Verify stderr does NOT contain "rollback-failed:" but DOES
+  // contain the iteration-failure error.
+  const { project, home } = setupActiveProject({ rfcs: ['RFC-A'] })
+  const r = spawnSync('node', ['--import', INJECT_RENAME, ORCHESTRATOR, 'detect-rfcs', '--project', project], {
+    cwd: project,
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, FAIL_EPISODE_RENAME: '1' },
+  })
+  assert.equal(r.status, 3)
+  assert.match(r.stderr, /detect-rfcs iteration failed/,
+    `expected iteration-failure stderr; got: ${r.stderr}`)
+  // Clean rollback in this scenario — no sentinel expected.
+  const runsDir = path.join(project, '.episodic-memory', 'runs')
+  if (fs.existsSync(runsDir)) {
+    const sentinels = fs.readdirSync(runsDir).flatMap(e => {
+      const sub = path.join(runsDir, e)
+      try { return fs.statSync(sub).isDirectory() ? fs.readdirSync(sub).filter(f => f === '.rollback-failed.json') : [] }
+      catch { return [] }
+    })
+    // Sentinel is allowed but not required for the clean-rollback case.
+    // Either way the iteration-failure stderr line is present.
+    assert.ok(true, `sentinels found: ${sentinels.length}`)
+  }
+})
+
+if (fail > 0) {
+  console.log(`\n# FAIL ${pass}/${pass + fail} passed`)
+  process.exit(1)
+}
+console.log(`\n# OK ${pass}/${pass + fail} passed`)

--- a/tests/test-bp1-orchestrator-288-resume.mjs
+++ b/tests/test-bp1-orchestrator-288-resume.mjs
@@ -348,6 +348,195 @@ tap('288-7 trivial happy path: classified_episode_id + route_episode_id persiste
   assert.equal(run.route_episode_id, out.route_episode_id, 'idx must persist route_episode_id')
 })
 
+// ===========================================================================
+// 288-8 — F1 planning: signed orphan planning with mismatched source_class
+// must be rejected as field-mismatch (NOT silently attached).
+// ===========================================================================
+tap('288-8 F1: Phase B planning orphan with mismatched source_class → field-mismatch exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
+
+  // Valid classified for decided_class=trivial.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified trivial', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  // Signed planning episode with RIGHT parent but WRONG source_class.
+  writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'planning',
+    summary: 'tampered planning', parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
+    customFm: { source_class: 'tampered' },   // ≠ 'trivial'
+    tags: ['bp1-planning'], body: '# p\n', filenameSuffix: 'planning',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  // Phase B orphan-scan: parent matches but source_class doesn't → field-mismatch.
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /recoverable-canonical-drift/)
+})
+
+// ===========================================================================
+// 288-9 — F1 needs-human: signed orphan with mismatched decided_class field
+// must be rejected (NOT silently attached). Same fractal-shape sibling.
+// ===========================================================================
+tap('288-9 F1: Phase B needs-human orphan with mismatched decided_class → field-mismatch exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'security', confidence: 0.7, rationale: 'r', classified_fields: ['x'] })
+
+  // Valid classified for decided_class=security.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified security', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'security', classifier_confidence: '0.7' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  // Signed needs-human with right parent but customFm.decided_class flipped.
+  writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'needs-human',
+    summary: 'tampered needs-human', parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
+    customFm: { reason: 'risky-class', decided_class: 'schema' },   // ≠ 'security'
+    tags: ['bp1-needs-human'], body: '# nh\n', filenameSuffix: 'needs-human',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'security'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /recoverable-canonical-drift/)
+})
+
+// ===========================================================================
+// 288-10 — F2 state=planning but decided_class implies needs-human → reject.
+// ===========================================================================
+tap('288-10 F2: run.state=planning but decided_class=schema (targetState mismatch) → state-violation exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'schema', confidence: 0.7, rationale: 'r', classified_fields: ['x'] })
+
+  // Valid classified.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified schema', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'schema', classifier_confidence: '0.7' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  // Idx: state advanced to wrong target (planning), decided_class=schema implies needs-human.
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'planning'   // inconsistent with decided_class
+    idx.runs[ctx.runId].decided_class = 'schema'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /state-violation \(Phase B\)/)
+  assert.match(r.stderr, /targetState=needs-human/)
+})
+
+// ===========================================================================
+// 288-11 — F2 sibling: state=needs-human but decided_class=trivial → reject.
+// ===========================================================================
+tap('288-11 F2: run.state=needs-human but decided_class=trivial (targetState mismatch) → state-violation exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
+
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified trivial', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'needs-human'   // inconsistent
+    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /state-violation \(Phase B\)/)
+  assert.match(r.stderr, /targetState=planning/)
+})
+
+// ===========================================================================
+// 288-12 — happy path PARALLEL: non-trivial → needs-human (sibling of 288-7).
+// Closes the "test trivial only" coverage gap the reviewer flagged.
+// ===========================================================================
+tap('288-12 needs-human happy path: classified + route ids persisted in idx', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'security', confidence: 0.92, rationale: 'r', classified_fields: ['x'] })
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.state, 'needs-human')
+  assert.equal(out.decided_class, 'security')
+  const idx = loadIndex(ctx.project)
+  const run = idx.runs[ctx.runId]
+  assert.equal(run.state, 'needs-human')
+  assert.equal(run.classified_episode_id, out.classified_episode_id)
+  assert.equal(run.route_episode_id, out.route_episode_id)
+})
+
+// ===========================================================================
+// 288-13 — F1 backfill: state=needs-human + route_episode_id null + signed
+// needs-human on disk with WRONG reason field → field-mismatch (not attach).
+// ===========================================================================
+tap('288-13 F1: backfill rejects signed route with mismatched reason field', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'security', confidence: 0.8, rationale: 'r', classified_fields: ['x'] })
+
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'security', classifier_confidence: '0.8' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  // Signed needs-human with right parent, right decided_class, but WRONG reason.
+  writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'needs-human',
+    summary: 'wrong-reason nh', parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
+    customFm: { reason: 'tampered-reason', decided_class: 'security' },   // reason ≠ 'risky-class'
+    tags: ['bp1-needs-human'], body: '# nh\n', filenameSuffix: 'needs-human',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'needs-human'
+    idx.runs[ctx.runId].decided_class = 'security'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    idx.runs[ctx.runId].route_episode_id = null   // pre-bump backfill path
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /recoverable-canonical-drift/)
+})
+
 if (fail > 0) {
   console.log(`\n# FAIL ${pass}/${pass + fail} passed`)
   process.exit(1)

--- a/tests/test-bp1-orchestrator-288-resume.mjs
+++ b/tests/test-bp1-orchestrator-288-resume.mjs
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-orchestrator-288-resume.mjs — record-classification Phase A/B
+ * resume + crash recovery. Cluster #288 fix; plan v5 round-5 ACCEPT.
+ *
+ * Cases:
+ *   288-1 crash between Phase A and Phase B → retry emits route
+ *   288-2 idempotent past-Phase-B → no-op success (same JSON)
+ *   288-3 backfill route_episode_id from signed route on disk
+ *   288-4 drift: stored classified_episode_id mismatches current args → exit 5
+ *   288-5 parent-drift: signed orphan route with wrong parent_episode → exit 5
+ *   288-6 backfill missing parent: state=classified + no episode_id + no signed → exit 5
+ *   288-7 trivial → planning happy path produces classified+route ids in idx
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const ORCHESTRATOR = path.join(REPO, 'scripts', 'bp1-orchestrator.mjs')
+const ARTIFACT_BUILDER = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
+
+const hmacMod = await import(new URL('../scripts/lib/bp1-hmac.mjs', import.meta.url).href)
+const { verifyKeyFingerprint } = hmacMod
+const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.meta.url).href)
+const { loadIndex, withRunStateLockExclusive, loadIndexLocked, writeIndex } = rsmod
+const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
+const { writeBp1Episode } = writerMod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function makeProj() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-288-proj-'))
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs', 'rfcs'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function makeHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-288-home-'))
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function writeKey(homeDir) {
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/.verify-key'), key, { mode: 0o600 })
+  return verifyKeyFingerprint(key)
+}
+function buildHash(projectRoot, homeDir) {
+  return JSON.parse(execFileSync('node', [ARTIFACT_BUILDER, '--project', projectRoot, '--json'],
+    { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })).sha256
+}
+function writeConfig(homeDir, projectRoot, fingerprint) {
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/config.json'),
+    JSON.stringify({
+      bp1: {
+        schema_version: 1,
+        activations: {
+          [projectRoot]: {
+            enabled: true,
+            artifact_version_hash: 'sha256:' + buildHash(projectRoot, homeDir),
+            enabled_at: new Date().toISOString(),
+            enabled_via: 'test-fixture',
+            verify_key_id: fingerprint,
+          },
+        },
+      },
+    }, null, 2))
+}
+function writeRfc(projectRoot, name) {
+  fs.writeFileSync(path.join(projectRoot, 'docs', 'rfcs', `${name}.md`),
+    `---\nrfc_id: ${name}\nstatus: ${JSON.stringify('accepted')}\ntitle: ${JSON.stringify('T')}\n---\n\nbody.\n`)
+}
+function runOrch(args, { project, homeDir }) {
+  return spawnSync('node', [ORCHESTRATOR, ...args], {
+    cwd: project, encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir },
+  })
+}
+
+// Build an active project that has progressed through detect-rfcs + pre-dispatch
+// so the next valid action is record-classification.
+function setupPreDispatched() {
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  writeRfc(project, 'RFC-A')
+  writeConfig(home, project, fp)
+  const dr = runOrch(['detect-rfcs', '--project', project], { project, homeDir: home })
+  if (dr.status !== 0) throw new Error(`detect-rfcs failed: ${dr.stderr}`)
+  const det = JSON.parse(dr.stdout).detected[0]
+  const inputSha = crypto.randomBytes(32).toString('hex')
+  const pd = runOrch([
+    'record-classifier-dispatch-pre',
+    '--project', project,
+    '--run-id', det.run_id,
+    '--input-sha256', inputSha,
+  ], { project, homeDir: home })
+  if (pd.status !== 0) throw new Error(`record-classifier-dispatch-pre failed: ${pd.stderr}`)
+  const pdOut = JSON.parse(pd.stdout)
+  const runKey = fs.readFileSync(path.join(project, '.episodic-memory/runs', det.run_id, 'run.key'))
+  return {
+    project, home,
+    runId: det.run_id,
+    preEpisodeId: pdOut.pre_episode_id,
+    runKey,
+  }
+}
+
+function writeResultFile(project, output = { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] }) {
+  const p = path.join(project, 'classifier-result.json')
+  fs.writeFileSync(p, JSON.stringify(output))
+  return p
+}
+
+function runRecordClassification(ctx, resultFile, opts = {}) {
+  return runOrch([
+    'record-classification',
+    '--project', ctx.project,
+    '--run-id', ctx.runId,
+    '--pre-episode-id', opts.preEpisodeId ?? ctx.preEpisodeId,
+    '--result-file', resultFile,
+  ], { project: ctx.project, homeDir: ctx.home })
+}
+
+// ===========================================================================
+// 288-1 — crash between Phase A and Phase B → retry emits route
+// ===========================================================================
+tap('288-1 crash between Phase A and Phase B → retry emits route from classified', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project)
+
+  // Simulate the post-Phase-A pre-Phase-B state directly: emit a signed
+  // classified episode, then manually set idx { state: 'classified',
+  // classified_episode_id, decided_class }. Do NOT emit a route episode.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: `test-induced classified`,
+    parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    tags: ['bp1-classified'],
+    body: '# classified\n',
+    filenameSuffix: 'classified',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  // Retry with same args → Phase A no-op verify-only, Phase B emits route.
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.state, 'planning', `expected planning; got ${out.state}`)
+  assert.equal(out.classified_episode_id, classifiedEp.episodeId, 'must reuse existing classified ep')
+  assert.ok(out.route_episode_id, 'route episode id present')
+  const idx = loadIndex(ctx.project)
+  const run = idx.runs[ctx.runId]
+  assert.equal(run.state, 'planning')
+  assert.equal(run.classified_episode_id, classifiedEp.episodeId)
+  assert.equal(run.route_episode_id, out.route_episode_id)
+})
+
+// ===========================================================================
+// 288-2 — idempotent past-Phase-B: state advanced + pointers set → no-op
+// ===========================================================================
+tap('288-2 idempotent past-Phase-B → no-op success; same JSON', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.91, rationale: 'r', classified_fields: ['x'] })
+  // First call: emits classified + planning, idx fully advanced.
+  const r1 = runRecordClassification(ctx, resultFile)
+  assert.equal(r1.status, 0, `r1 stderr=${r1.stderr}`)
+  const out1 = JSON.parse(r1.stdout)
+  // Second call with same args → idempotent.
+  const r2 = runRecordClassification(ctx, resultFile)
+  assert.equal(r2.status, 0, `r2 stderr=${r2.stderr}`)
+  const out2 = JSON.parse(r2.stdout)
+  assert.equal(out1.classified_episode_id, out2.classified_episode_id, 'classified id stable')
+  assert.equal(out1.route_episode_id, out2.route_episode_id, 'route id stable')
+  assert.equal(out1.state, out2.state)
+})
+
+// ===========================================================================
+// 288-3 — backfill route_episode_id: state advanced but pointer null + signed
+// route episode on disk → attach pointer; no fresh emit
+// ===========================================================================
+tap('288-3 backfill route_episode_id from signed route episode on disk', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'schema', confidence: 0.7, rationale: 'r', classified_fields: ['x'] })
+
+  // Set up the pre-bump state: emit classified + needs-human directly; idx
+  // shows state=needs-human but route_episode_id=null (simulating a run
+  // persisted before the schema addition landed).
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'test classified', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'schema', classifier_confidence: '0.7' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  const routeEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'needs-human',
+    summary: 'test needs-human', parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
+    customFm: { reason: 'risky-class', decided_class: 'schema' },
+    tags: ['bp1-needs-human'], body: '# nh\n', filenameSuffix: 'needs-human',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'needs-human'
+    idx.runs[ctx.runId].decided_class = 'schema'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    idx.runs[ctx.runId].route_episode_id = null   // pre-bump
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.state, 'needs-human')
+  assert.equal(out.route_episode_id, routeEp.episodeId, 'must attach existing route, not fresh-emit')
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[ctx.runId].route_episode_id, routeEp.episodeId)
+})
+
+// ===========================================================================
+// 288-4 — drift: stored classified_episode_id with different decided_class
+// than args → recoverable-canonical-drift exit 5
+// ===========================================================================
+tap('288-4 drift: stored classified_episode_id with mismatched decided_class → exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
+
+  // Emit a classified episode with a DIFFERENT decided_class than args will produce.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'mismatched', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'schema', classifier_confidence: '0.85' },   // schema ≠ trivial
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'schema'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  // Retry with --result-file claiming trivial. Args.decided_class=trivial does
+  // not match stored classified's decided_class=schema → drift error.
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /recoverable-canonical-drift/)
+})
+
+// ===========================================================================
+// 288-5 — parent-drift: signed orphan route with wrong parent_episode → exit 5
+// ===========================================================================
+tap('288-5 Phase B orphan route with wrong parent_episode → exit 5', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
+
+  // Emit a valid classified.
+  const classifiedEp = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'classified',
+    summary: 'classified', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
+    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
+  })
+  // Emit a planning route with WRONG parent (points to some unrelated id).
+  const fakeParent = `${ctx.runId}-fake-9999`
+  writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'planning',
+    summary: 'wrong-parent planning', parentEpisode: fakeParent, expectedPostEpisodeId: null,
+    customFm: { source_class: 'trivial' },
+    tags: ['bp1-planning'], body: '# p\n', filenameSuffix: 'planning',
+  })
+  // Idx: state=classified + classified_episode_id set, route null.
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
+    writeIndex(ctx.project, idx)
+  })
+
+  // Phase B orphan-scan finds the planning episode but parent_episode
+  // mismatches classified_episode_id → field-mismatch → drift.
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /recoverable-canonical-drift/)
+})
+
+// ===========================================================================
+// 288-6 — backfill missing parent: state=classified + classified_episode_id null + no signed
+// ===========================================================================
+tap('288-6 state=classified + null classified_episode_id + no signed → recoverable-no-parent', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project)
+
+  // Force idx to state=classified with no classified_episode_id and NO signed
+  // classified episode on disk (simulating corrupt pre-bump migration).
+  withRunStateLockExclusive(ctx.project, () => {
+    const idx = loadIndexLocked(ctx.project)
+    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].classified_episode_id = null
+    writeIndex(ctx.project, idx)
+  })
+
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 5)
+  assert.match(r.stderr, /recoverable-no-parent/)
+})
+
+// ===========================================================================
+// 288-7 — happy path: trivial → planning; classified + route pointers in idx
+// ===========================================================================
+tap('288-7 trivial happy path: classified_episode_id + route_episode_id persisted in idx', () => {
+  const ctx = setupPreDispatched()
+  const resultFile = writeResultFile(ctx.project)
+  const r = runRecordClassification(ctx, resultFile)
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.state, 'planning')
+  const idx = loadIndex(ctx.project)
+  const run = idx.runs[ctx.runId]
+  assert.equal(run.state, 'planning')
+  assert.equal(run.classified_episode_id, out.classified_episode_id, 'idx must persist classified_episode_id')
+  assert.equal(run.route_episode_id, out.route_episode_id, 'idx must persist route_episode_id')
+})
+
+if (fail > 0) {
+  console.log(`\n# FAIL ${pass}/${pass + fail} passed`)
+  process.exit(1)
+}
+console.log(`\n# OK ${pass}/${pass + fail} passed`)

--- a/tests/test-bp1-orchestrator-288-resume.mjs
+++ b/tests/test-bp1-orchestrator-288-resume.mjs
@@ -30,6 +30,8 @@ const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.me
 const { loadIndex, withRunStateLockExclusive, loadIndexLocked, writeIndex } = rsmod
 const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
 const { writeBp1Episode } = writerMod
+const fmMod = await import(new URL('../scripts/lib/bp1-frontmatter.mjs', import.meta.url).href)
+const { parseBp1Frontmatter } = fmMod
 
 let pass = 0, fail = 0
 function tap(name, fn) {
@@ -485,7 +487,7 @@ tap('288-11 F2: run.state=needs-human but decided_class=trivial (targetState mis
 // 288-12 — happy path PARALLEL: non-trivial → needs-human (sibling of 288-7).
 // Closes the "test trivial only" coverage gap the reviewer flagged.
 // ===========================================================================
-tap('288-12 needs-human happy path: classified + route ids persisted in idx', () => {
+tap('288-12 needs-human happy path: classified + route ids persisted in idx + customFm round-trips', () => {
   const ctx = setupPreDispatched()
   const resultFile = writeResultFile(ctx.project, { class: 'security', confidence: 0.92, rationale: 'r', classified_fields: ['x'] })
   const r = runRecordClassification(ctx, resultFile)
@@ -498,6 +500,15 @@ tap('288-12 needs-human happy path: classified + route ids persisted in idx', ()
   assert.equal(run.state, 'needs-human')
   assert.equal(run.classified_episode_id, out.classified_episode_id)
   assert.equal(run.route_episode_id, out.route_episode_id)
+  // N3: verify route episode frontmatter actually contains the customFm the
+  // helper produces. Defense-in-depth: catches writer regression silently
+  // dropping customFm fields. Writer's own unit tests check reserved-key
+  // enforcement; this checks predicate↔persist round-trip end-to-end.
+  const routeEpPath = path.join(ctx.project, '.episodic-memory', 'episodes', `${out.route_episode_id}.md`)
+  const fm = parseBp1Frontmatter(fs.readFileSync(routeEpPath)).frontmatter
+  assert.equal(fm.reason, 'risky-class', `route customFm.reason missing/wrong: ${JSON.stringify(fm.reason)}`)
+  assert.equal(fm.decided_class, 'security', `route customFm.decided_class missing/wrong: ${JSON.stringify(fm.decided_class)}`)
+  assert.equal(fm.parent_episode, out.classified_episode_id, 'route parent_episode = classified id')
 })
 
 // ===========================================================================

--- a/tests/test-bp1-run-state-migrate.mjs
+++ b/tests/test-bp1-run-state-migrate.mjs
@@ -61,9 +61,9 @@ tap('M2 single v1 active run gets 3 new null fields', () => {
 })
 
 // =============================================================================
-// M3: v2 input → defensive copy (idempotence)
+// M3: v2 input → defensive copy + cluster #286/#287/#288 field normalization
 // =============================================================================
-tap('M3 v2 input → defensive copy (idempotence + no mutation)', () => {
+tap('M3 v2 input → defensive copy + normalize missing cluster fields to null', () => {
   const v2 = {
     schema_version: V2_SCHEMA,
     runs: {
@@ -80,7 +80,15 @@ tap('M3 v2 input → defensive copy (idempotence + no mutation)', () => {
   }
   const result = migrateV1ToV2(v2)
   assert.equal(result.schema_version, V2_SCHEMA)
-  assert.deepEqual(result, v2)
+  // Pre-existing v2 entry missing cluster #286/#287/#288 fields is normalized
+  // to null defaults (soft schema addition; no schema_version bump).
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].classified_episode_id, null)
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].route_episode_id, null)
+  // All other fields preserved verbatim.
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].state, 'classified')
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].decided_class, 'trivial')
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].pre_episode_id, 'bp1-run-2-bar-ddee-pre-1234')
+  assert.equal(result.runs['bp1-run-2-bar-ddee'].rfc_detected_episode_id, 'bp1-run-2-bar-ddee-rfc-detected-5678')
   // Defensive copy: mutating result doesn't affect v2.
   result.runs['bp1-run-2-bar-ddee'].state = 'aborted'
   assert.equal(v2.runs['bp1-run-2-bar-ddee'].state, 'classified')
@@ -190,6 +198,71 @@ tap('M9 CR2-3 regression — appendRun on v1 index migrates without lock-timeout
   assert.equal(idx.runs['bp1-run-pre-existing-aabb'].rfc_detected_episode_id, null)
   // New run also has the v2 fields populated.
   assert.equal(idx.runs['bp1-run-new-after-migrate-ccdd'].decided_class, null)
+})
+
+// =============================================================================
+// Cluster #286/#287/#288 — soft schema addition (classified_episode_id,
+// route_episode_id). codex round-5 ACCEPT 20260516-102831.
+// =============================================================================
+
+tap('M10 v1 row → v2 with cluster fields nulled', () => {
+  const v1 = {
+    schema_version: V1_SCHEMA,
+    runs: {
+      'bp1-run-cluster-aaaa': {
+        project_root: '/p',
+        state: 'active',
+        created_at: '2026-05-15T10:00:00Z',
+        terminal_at: null,
+      },
+    },
+  }
+  const result = migrateV1ToV2(v1)
+  const r = result.runs['bp1-run-cluster-aaaa']
+  assert.equal(r.classified_episode_id, null)
+  assert.equal(r.route_episode_id, null)
+})
+
+tap('M11 v2 row with cluster fields already set → preserved (not nulled)', () => {
+  const v2 = {
+    schema_version: V2_SCHEMA,
+    runs: {
+      'bp1-run-cluster-bbbb': {
+        project_root: '/p',
+        state: 'planning',
+        created_at: '2026-05-15T10:00:00Z',
+        terminal_at: null,
+        decided_class: 'trivial',
+        pre_episode_id: 'bp1-run-cluster-bbbb-pre-1234',
+        rfc_detected_episode_id: 'bp1-run-cluster-bbbb-rfc-detected-5678',
+        classified_episode_id: 'bp1-run-cluster-bbbb-classified-9999',
+        route_episode_id: 'bp1-run-cluster-bbbb-planning-aaaa',
+      },
+    },
+  }
+  const result = migrateV1ToV2(v2)
+  const r = result.runs['bp1-run-cluster-bbbb']
+  assert.equal(r.classified_episode_id, 'bp1-run-cluster-bbbb-classified-9999')
+  assert.equal(r.route_episode_id, 'bp1-run-cluster-bbbb-planning-aaaa')
+})
+
+tap('M12 migrateV1ToV2 idempotence on cluster fields', () => {
+  const v1 = {
+    schema_version: V1_SCHEMA,
+    runs: { 'bp1-run-idem-cccc': { project_root: '/p', state: 'active', created_at: 't', terminal_at: null } },
+  }
+  const once = migrateV1ToV2(v1)
+  const twice = migrateV1ToV2(once)
+  assert.deepEqual(twice, once)
+})
+
+tap('M13 appendRun initializes new runs with cluster fields nulled', () => {
+  const proj = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-cluster-init-')))
+  const r = appendRun(proj, 'bp1-run-cluster-init-dddd', proj)
+  assert.ok(r.ok)
+  const idx = loadIndex(proj)
+  assert.equal(idx.runs['bp1-run-cluster-init-dddd'].classified_episode_id, null)
+  assert.equal(idx.runs['bp1-run-cluster-init-dddd'].route_episode_id, null)
 })
 
 console.log(`\n# ${pass} passed, ${fail} failed`)

--- a/tests/test-bp1-run-state.mjs
+++ b/tests/test-bp1-run-state.mjs
@@ -176,6 +176,33 @@ tap('US6 markTerminal accepts non-active non-terminal v2 states (e.g. rfc-detect
   assert.equal(loadIndex(proj).runs['bp1-run-us6-aabb'].state, 'aborted')
 })
 
+// Cluster #286/#287/#288 — updateRunState patch-field acceptance for the new
+// classified_episode_id / route_episode_id fields. codex round-5 ACCEPT.
+
+tap('US7 updateRunState accepts classified_episode_id patch', () => {
+  const proj = makeProjectRoot()
+  appendRun(proj, 'bp1-run-us7-aabb', proj)
+  const r = updateRunState(proj, 'bp1-run-us7-aabb', {
+    state: 'classified',
+    decided_class: 'trivial',
+    classified_episode_id: 'bp1-run-us7-aabb-classified-9999',
+  })
+  assert.ok(r.ok)
+  assert.equal(loadIndex(proj).runs['bp1-run-us7-aabb'].classified_episode_id, 'bp1-run-us7-aabb-classified-9999')
+})
+
+tap('US8 updateRunState accepts route_episode_id patch', () => {
+  const proj = makeProjectRoot()
+  appendRun(proj, 'bp1-run-us8-aabb', proj)
+  updateRunState(proj, 'bp1-run-us8-aabb', { state: 'classified', decided_class: 'trivial' })
+  const r = updateRunState(proj, 'bp1-run-us8-aabb', {
+    state: 'planning',
+    route_episode_id: 'bp1-run-us8-aabb-planning-aaaa',
+  })
+  assert.ok(r.ok)
+  assert.equal(loadIndex(proj).runs['bp1-run-us8-aabb'].route_episode_id, 'bp1-run-us8-aabb-planning-aaaa')
+})
+
 tap('RC3 corrupt JSON in _index.json → loadIndex throws (does not silently reset)', () => {
   const proj = makeProjectRoot()
   // Pre-create runs dir + write garbage.


### PR DESCRIPTION
## Summary

Closes cluster `#286 #287 #288` — three sibling bugs in the BP-1 orchestrator (RFC-004 slice 2c), all "multi-step write sequence with no atomic rollback / no crash-resume" shape.

- **#286** — `recordClassifierDispatchPre` race + crash atomicity (concurrent invocations could both emit a `classifier-dispatch-pending` episode; mid-write crashes left orphans with no resume path)
- **#287** — `detectRfcs` per-RFC iteration leaked `run.key` + index row + tmp episode when the writer threw
- **#288** — `recordClassification` emitted classified + route episodes under one state advance, leaving no resume pointer on mid-route crashes

## Approach

- **Atomic episode writer** — tmp + fsync + rename via `bp1-episode-writer.mjs`
- **`bp1-atomic.mjs` primitives** (NEW, ~250 LOC) — `findSignedStateEpisode` (discriminated-union: `match` / `none` / `field-mismatch`), `withLockedRun` (sync wrapper over the run-state lock), `removeRunFromIndex`
- **Run-state schema additions** — `classified_episode_id`, `route_episode_id` (soft addition, no version bump; v2 normalizer defaults nulls on every load path)
- **`recordClassifierDispatchPre`** — three explicit state branches (`classifier-dispatch-pending` retry / `rfc-detected` normal / state-violation) inside `withLockedRun`; orphan-attach uses canonical-fields predicates
- **`detectRfcs`** — per-RFC try/catch with compensating rollback (unlink episode → shred key → remove run row); `.rollback-failed.json` sentinel for unobservable rollback errors
- **`recordClassification`** — Phase A (classified) / Phase B (route) split into two durable `withLockedRun` blocks; `deriveRouteSpec` helper unifies predicate + writer customFm so they cannot drift
- **`writeIndex`** — fsync + ordering documentation (episode-rename always precedes index-rename; orphan-attach handles the crash window)

## Review history

- **Plan tier (codex consensus, 5 rounds → ACCEPT at v5)** — reply `20260516-102831-reply-codex-to-20260516-102614-plan-v5-r-b657`
- **Implementation tier round 1 (negative-scenario-reviewer)**: HOLD with 2 MAJORs (Phase B predicate gap + state-consistency gap, both same root cause — parallel branches not inheriting Phase A's invariant discipline) — reply `20260516-120134-hold-cluster-286-287-288-phase-b-orphan--1cc1`
- **Implementation tier round 2 (negative-scenario-reviewer)**: ACCEPT, 1 MINOR + 2 NITs all closed inline — reply `20260516-122252-accept-cluster-286-287-288-round-2-f1-f2-4c81`

## Deferred follow-ups (filed)

- #296 — `detectRfcs` runId churn across crash-retry (5-field DEFER)
- #297 — schema-violation failure-episode dedup under concurrent invocation (5-field DEFER)
- #298 — `detectRfcs` not idempotent on `(rfc_id, frontmatter_sha256)` (5-field DEFER)

## Commits

1. `08ebc78` Atomic writer + bp1-atomic primitives + tests
2. `c31fb55` Run-state schema additions (classified_episode_id, route_episode_id)
3. `d9eb11e` `#286` record-classifier-dispatch-pre race + crash atomicity
4. `2938a1a` `#287` rollback + `#288` Phase A/B split
5. `206a41f` Round-1 reviewer findings (F1 predicate + F2 state-consistency + F3/F5/F10/F11)
6. `7365c04` Round-2 reviewer nits (N1 comment + N2 operator hint + N3 test depth)

13 files changed, +2386 / -211.

## Test plan

- [x] `test-bp1-atomic.mjs` — 20/20 (atomic writer + primitives)
- [x] `test-bp1-orchestrator-286-race-and-crash.mjs` — 7/7
- [x] `test-bp1-orchestrator-287-rollback.mjs` — 2/2
- [x] `test-bp1-orchestrator-288-resume.mjs` — 13/13 (7 crash-resume + 6 F1/F2 axis tests)
- [x] `test-bp1-orchestrator-classifier-fence.mjs` — 34/34 (existing)
- [x] `test-bp1-orchestrator-detect-rfcs.mjs` — 19/19 (existing)
- [x] `test-bp1-finalize-run.mjs` — 45/45 (existing)
- [x] `test-bp1-episode-writer.mjs` — 10/10 (existing)
- [x] `test-bp1-run-state.mjs` — 22/22
- [x] `test-bp1-run-state-migrate.mjs` — 13/13
- [ ] Smoke E2E from a clean project: `detect-rfcs` → `record-classifier-dispatch-pre` → `record-classification` (trivial path) → idx shows both new pointers
- [ ] Concurrent invocation smoke: two `record-classifier-dispatch-pre` against same `rfc-detected` run → exactly one pending episode persisted

185/185 unit tests green at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
