### PR TITLE
feat(rfc-004): slice 2d-W — record-awaiting-approval + marker library

### DIFF
--- a/docs/rfcs/RFC-004-bp1-auto-pilot.contract.json
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.contract.json
@@ -1,14 +1,17 @@
 {
-  "version": "v3.14",
-  "_doc": "Machine-readable mirror of RFC-004 BP-1 auto-pilot contracts (slice 2c). Single source of truth for cross-component invariants (canonical-field tables, classifier output schema, run-state schemas, subcommand argv + exit codes). Validator scripts/validate-rfc-contract-mirror.mjs diffs this against code surfaces on every PR/push (per Rule 13/14).",
+  "version": "v3.15",
+  "_doc": "Machine-readable mirror of RFC-004 BP-1 auto-pilot contracts (slice 2d-W). Single source of truth for cross-component invariants (canonical-field tables, classifier output schema, run-state schemas, subcommand argv + exit codes). Validator scripts/validate-rfc-contract-mirror.mjs diffs this against code surfaces on every PR/push (per Rule 13/14).",
   "episode_canonical_fields": {
     "state-transition:rfc-detected": ["state", "rfc_id", "frontmatter_sha256"],
     "state-transition:classifier-dispatch-pending": ["state", "input_sha256"],
     "state-transition:classified": ["state", "decided_class", "classifier_confidence"],
     "state-transition:planning": ["state", "source_class"],
     "state-transition:needs-human": ["state", "reason", "decided_class"],
+    "state-transition:awaiting_approval": ["state", "awaiting_approval_at", "deadline_at", "decided_class"],
     "failure:classifier-schema-violation": ["failure_kind", "field_name", "observed_value", "violation_reason"],
-    "failure:classifier-parent-tamper": ["failure_kind", "field_name", "observed_value", "violation_reason"]
+    "failure:classifier-parent-tamper": ["failure_kind", "field_name", "observed_value", "violation_reason"],
+    "failure:marker-write-failed": ["failure_kind", "marker_path", "reason"],
+    "failure:marker-cleanup-failed": ["failure_kind", "marker_path", "reason"]
   },
   "classifier_output_schema": {
     "type": "object",
@@ -48,6 +51,7 @@
         "classified",
         "planning",
         "needs-human",
+        "awaiting_approval",
         "complete",
         "aborted",
         "abandoned",
@@ -62,7 +66,9 @@
         "pre_episode_id",
         "rfc_detected_episode_id",
         "classified_episode_id",
-        "route_episode_id"
+        "route_episode_id",
+        "awaiting_approval_at",
+        "deadline_at"
       ]
     }
   },
@@ -90,6 +96,15 @@
         "0": "ok",
         "2": "argv|relative-result-file",
         "5": "state|schema|parent-tamper"
+      }
+    },
+    "record-awaiting-approval": {
+      "required_args": ["--project", "--run-id", "--classified-episode-id"],
+      "exit_codes": {
+        "0": "ok",
+        "2": "argv|project-root-resolution-failed",
+        "3": "marker-write-failed",
+        "5": "state|parent-tamper"
       }
     }
   }

--- a/docs/rfcs/RFC-004-bp1-auto-pilot.md
+++ b/docs/rfcs/RFC-004-bp1-auto-pilot.md
@@ -5,9 +5,9 @@ title: "BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow"
 status: accepted
 champion: Charlton Ho
 created: 2026-05-06
-last_modified: 2026-05-13
+last_modified: 2026-05-17
 accepted: 2026-05-06
-version: 3.13
+version: 3.15
 supersedes: ~
 superseded_by: ~
 ---
@@ -314,22 +314,23 @@ flowchart TB
 stateDiagram-v2
     [*] --> rfc_detected
     rfc_detected --> classified: classifier agent
-    classified --> planning: trivial / risky
+    classified --> awaiting_approval: trivial (record-awaiting-approval)
+    classified --> needs_human: risky class
+    awaiting_approval --> approved: human y
+    awaiting_approval --> auto_approved: 1hr timeout
+    awaiting_approval --> aborted: human n
+    approved --> planning
+    auto_approved --> planning
     planning --> adversarial_reviewed: planner
     adversarial_reviewed --> codex_review: em-review-request
     codex_review --> codex_complete: reply
     codex_review --> codex_review: 30min timeout, retry < 2
     codex_review --> needs_human: timeout retry ≥ 2 (all classes)
-    codex_complete --> awaiting_approval: trivial
-    codex_complete --> needs_human: risky class
-    awaiting_approval --> approved: human y
-    awaiting_approval --> auto_approved: 1hr timeout
-    awaiting_approval --> aborted: human n
-    approved --> implementing
-    auto_approved --> implementing
+    codex_complete --> implementing: all classes
     needs_human --> resolved: override episode
     needs_human --> abandoned: 7 days no override
-    resolved --> implementing
+    resolved --> planning: source=classify-risky
+    resolved --> implementing: source=codex-timeout | fix-loop-same-sig
     implementing --> reviewing: code-reviewer ∥ test-runner ∥ security-reviewer
     reviewing --> fix_loop: any blocker
     reviewing --> auditing: all clean
@@ -544,6 +545,56 @@ All 10 follow the canonical-prompt-as-episode loader pattern (per `feedback_cano
 | 12 (NEW v3.8) | `scripts/bp1-canonicalize.mjs` | Per-episode canonical-bytes builder; projects frontmatter to canonical payload spec (generic + episode-type-specific fields) and emits sha256. Called by HMAC-signing path. | ✅ pure deterministic |
 | 13 (NEW v3.8) | `scripts/bp1-naked-entry-sweep.mjs` | Path B sweep: scans active runs for naked `codex_review` entries (no `bp1-codex-request-sent` evidence) older than 5min. Called by T1b scheduled task. Emits `bp1-naked-sweep-tick` per fire. | ✅ deterministic data walk |
 | 14 (NEW v3.10) | `scripts/bp1-deadline-sweep.mjs` | Unified fallback for T1 + T1b when `mcp__scheduled-tasks` unavailable. Invocable manually (`--once`) and auto-wired as a SessionStart hook (see hook H2 below). Activation-gated (no-op if project's flag-check fails). Emits `bp1-sweep-tick` per invocation. | ✅ deterministic; activation-gated |
+| 15 (NEW v3.15) | `scripts/lib/bp1-marker.mjs` | Approval-marker write/cleanup helpers. Exports `markerPath`, `canonicalizeMarkerPayload`, `writeMarker` (atomic + idempotent), `cleanupApprovalMarker`. Pure file I/O + canonicalization — does NOT emit evidence (caller-side per §595 ownership split). Called by `record-awaiting-approval` (write) and finalize-* paths (cleanup). | ✅ deterministic; idempotent byte-equal rewrite |
+
+### `record-awaiting-approval` subcommand (NEW v3.15, slice 2d-W)
+
+This subcommand replaces the pre-2d-W direct `classified → planning` transition for trivial-class RFCs (was a stub pending the safety envelope per F6). Splits the awaiting-approval transition into two phases so marker write-failure leaves the state at `awaiting_approval` for retry, rather than rolling back the state transition.
+
+**Argv (mirrors `RFC-004-bp1-auto-pilot.contract.json` v3.15 `subcommand_invariants.record-awaiting-approval`):**
+
+```
+bp1-orchestrator record-awaiting-approval \
+  --project <projectRoot> \
+  --run-id <runId> \
+  --classified-episode-id <classifiedEpisodeId>
+```
+
+Required: all three flags. `--project` is canonicalized via `git rev-parse --show-toplevel` with `cwd: projectRoot` then realpath (codex r3 authority-root closure). `--classified-episode-id` MUST point to an extant signed `state-transition:classified` episode with `decided_class === 'trivial'`; risky classes never reach this subcommand (`deriveRouteSpec` routes them to `needs-human` from `record-classification`).
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| 0 | ok — state transitioned to `awaiting_approval`; marker on disk; stdout JSON emitted |
+| 2 | argv invalid / project-root resolution failed |
+| 3 | marker-write-failed — Phase B `writeMarker` returned error after Phase A succeeded; signed `failure:marker-write-failed` evidence emitted; state remains `awaiting_approval` (retry idempotent) |
+| 5 | state / parent-tamper — Phase A precondition violated (state ≠ `classified`, decided_class ≠ `trivial`, classified-episode signature invalid, or canonical-field drift on resume) |
+
+**Two-phase contract:**
+
+- **Phase A (in-lock via `withLockedRun`).** Read run-state under the per-run lock. Three branches:
+  1. **Fresh emit** (state == `classified`): assert `decided_class === 'trivial'` from the classified episode (HMAC-verified parent). Mint `awaiting_approval_at = nowIso()` ONCE; compute `deadline_at = awaiting_approval_at + 1hr`. Emit signed `state-transition:awaiting_approval` episode with `{state, awaiting_approval_at, deadline_at, decided_class}` canonical fields. Persist `run.state = 'awaiting_approval'`, `run.awaiting_approval_at`, `run.deadline_at`.
+  2. **Resume / backfill** (state == `awaiting_approval`): re-check `decided_class === 'trivial'` per codex r3 P1 closure (catches the F2 case where a non-trivial class somehow reached `awaiting_approval`); read persisted `awaiting_approval_at` / `deadline_at` from run-state (NEVER fresh wall-clock); orphan-attach to existing signed episode, rejecting field-mismatch as canonical drift per codex r3 P2 closure (rather than adopting stale signed fields).
+  3. **State violation** (anything else): exit 5 with stderr error.
+- **Phase B (out-of-lock).** Call `writeMarker(...)` with values captured from Phase A (`awaitingApprovalAt`, `deadlineAt`, `decidedClass`, per-run key). Determinism + idempotent rewrite (per `### Approval-marker file contract` above) is the F2 mitigation in lieu of a second locked re-check: byte-identical payload from persisted run-state means concurrent or post-crash retries produce the same marker file; `bp1-marker.mjs` no-ops on byte-equal existing marker. On rename failure: emit signed `failure:marker-write-failed` evidence (run.key still live); stderr-log; exit 3. State stays at `awaiting_approval` for retry.
+
+**Crash gap.** Between Phase A success and Phase B success: state == `awaiting_approval` with no marker on disk. Recovery: re-run `record-awaiting-approval` with the same `--run-id`; Phase A takes the resume branch (no fresh wall-clock); Phase B writes the byte-identical marker. Path-A check-deadlines (slice 2e+) also detects this on next tick.
+
+**Stdout (success):**
+
+```json
+{
+  "status": "ok",
+  "state": "awaiting_approval",
+  "run_id": "<runId>",
+  "awaiting_approval_episode_id": "<episodeId>",
+  "awaiting_approval_at": "<ISO-8601>",
+  "deadline_at": "<ISO-8601>",
+  "marker_path": "<absolute>",
+  "marker_already_present": <bool>
+}
+```
 
 ### Hooks, scheduled tasks, and manifest
 
@@ -589,6 +640,42 @@ Per Rule 4 (confirm spec exists + probe endpoint; offer mock if unreachable — 
 - Does NOT replicate T2 (weekly meta-audit) — that degrades to a manual `node scripts/bp1-security-audit.mjs --once`, surfaced in the operator runbook.
 
 **Why best-effort is acceptable for the fallback:** the activation flag (above) is `false` until M5 dry-run, which itself probes for native scheduled-tasks; if absent, M5 dry-run can still pass via the sweep fallback, and the operator is explicitly informed of the degraded mode in the activation episode body.
+
+### Approval-marker file contract (NEW v3.15, slice 2d-W)
+
+The approval marker is the on-disk forensic + hook-input artifact for trivial-class RFCs in the `awaiting_approval` state. Writer is `record-awaiting-approval` (this slice); reader is `bp1-approval-check.sh` hook H1 (slice 2d-R) and the future `bp1-check-deadlines` path (slice 2e). Library: `scripts/lib/bp1-marker.mjs` (zero deps, Node stdlib only).
+
+**Path:** `<canonical_project_root>/.checkpoints/bp1-approval-<run_id>.json`
+
+Per-`run_id` filename eliminates concurrent-marker ambiguity (codex r1 B3 closure — multiple non-terminal trivial runs in the same project can each own a distinct marker without name collision). `canonical_project_root` is the realpath of `git rev-parse --show-toplevel` resolved with `cwd: projectRoot`; the writer asserts absolute-path shape before any disk access. The `.checkpoints/` parent dir is the same dir the user's Rule-8 plan-approval marker lives in, escaping Claude Code's built-in sensitive-file guard (see MEMORY.md "Marker location" note).
+
+**Payload (6-field JSON, keys sorted alphabetically for determinism):**
+
+| Field | Type | Source | Authorization-bearing |
+|---|---|---|---|
+| `body_sha256` | 64-hex string | sha256 of canonicalized `{created_at, deadline_at, decided_class, run_id}` | derived |
+| `created_at` | ISO-8601 UTC string | equals run-state `awaiting_approval_at` | ✓ canonical |
+| `deadline_at` | ISO-8601 UTC string | equals run-state `deadline_at` (= `created_at + 1hr` for trivial) | ✓ canonical |
+| `decided_class` | string ∈ `{trivial, schema, validator, security, multi-actor, needs-human-input}` | mirror of classified episode | ✓ canonical |
+| `hmac` | 64-hex string | HMAC-SHA256 over the canonical bytes, signed by the per-run HMAC key | derived |
+| `run_id` | shape `[a-z0-9-]+` | minted at run pickup | ✓ canonical |
+
+The 4 canonical fields are projected (sorted-keys + utf8 + JSON.stringify) into the authorization-bearing payload; `body_sha256` and `hmac` are pure functions of that payload + the runKey. The final marker on disk has all 6 fields with keys re-sorted alphabetically.
+
+**Determinism contract (codex r1 M1 closure):**
+Phase-B retries after a crash MUST produce byte-identical markers. `created_at` and `deadline_at` come from persisted run-state (`awaiting_approval_at` / `deadline_at` fields on the run record), NEVER wall-clock — wall-clock is consulted exactly once, at fresh emit in Phase A, then persisted for all subsequent reads. `body_sha256` and `hmac` are pure functions of `(canonical bytes, runKey32B)`, so the same inputs always produce the same outputs.
+
+**Atomicity:** tmp file in same dir (`.checkpoints/`) → `fs.writeFileSync` + `fs.fsyncSync` + `fs.renameSync` to final path. Crash before rename leaves no observable final path (tmp is best-effort unlinked on error). Crash after rename leaves the marker — replay-safe.
+
+**Idempotent rewrite:** before opening the tmp file, the writer reads any existing marker at the final path. If existing bytes equal the new bytes, the writer returns `{status: 'ok', alreadyPresent: true}` without re-renaming — this is the F2 mitigation in lieu of a Phase-B second lock (see `record-awaiting-approval` two-phase contract below). Two concurrent Phase-B writers feed byte-identical inputs (from persisted run-state) → produce byte-identical files → last-rename-wins is benign.
+
+**Ownership split (codex r2 FU1 closure):**
+`scripts/lib/bp1-marker.mjs` ONLY canonicalizes payload bytes, writes/unlinks atomically, and returns status objects (`{status: 'ok' | 'error', code?, message?, markerPath, ...}`). Evidence-episode emission is owned by callers. Two emission contexts:
+
+- **Key-live cleanup callers** (e.g. `record-awaiting-approval` Phase B write-failure path): the per-run HMAC key is still on disk and available for signing. Caller emits signed `failure:marker-write-failed` (or, for future cleanup-while-key-live callers, `failure:marker-cleanup-failed`). Both subtypes are registered in `bp1-canonicalize.mjs`.
+- **Key-shred cleanup callers** (e.g. finalize-* cleanup sites in `bp1-orchestrator.mjs`): the per-run HMAC key was shredded at finalize step 6, before reaching marker cleanup at step 7+. HMAC-signed emission is no longer available. Caller stderr-logs the failure and leaves the marker on disk — the persisting marker file IS the forensic evidence (an operator can lstat + verify hmac against the long-lived verify-key flow if needed).
+
+This split is what allows the slice 2d-W finalize cleanup helper (`cleanupApprovalMarker`) to be a pure unlink-and-return helper without the orchestrator needing two code paths for "did I write or did finalize unlink."
 
 ---
 
@@ -760,6 +847,32 @@ payload = {
   //   field_name,                     // offending field name (66-ch cap)
   //   observed_value,                 // observed JSON repr (66-ch cap per describeStatus policy)
   //   violation_reason,               // human-readable failure-mode label
+
+  // Slice 2d-W — awaiting-approval gate placement (NEW v3.15, M2).
+  // `record-awaiting-approval` emits TWO of the subtypes below
+  // (`state-transition:awaiting_approval` + `failure:marker-write-failed`).
+  // `failure:marker-cleanup-failed` is REGISTERED here as a reserved canonical
+  // subtype for future callers that retain the per-run HMAC key when invoking
+  // `cleanupApprovalMarker`. The current finalize-* cleanup callsites in
+  // `bp1-orchestrator.mjs` stderr-log instead — the per-run key has been
+  // shredded by the time finalize reaches marker cleanup, so HMAC-signed
+  // emission is no longer available; the persisting marker file IS the
+  // forensic evidence. Mirrored in
+  // `docs/rfcs/RFC-004-bp1-auto-pilot.contract.json` and enforced by
+  // `scripts/validate-rfc-contract-mirror.mjs` (CI gate).
+  //
+  // For type == "state-transition" with state == "awaiting_approval":
+  //   state,                          // "awaiting_approval"
+  //   awaiting_approval_at,           // ISO-8601 UTC; fresh-emit wall-clock now;
+  //                                   // resume reads persisted value, never wall-clock
+  //   deadline_at,                    // ISO-8601 UTC; = awaiting_approval_at + 1hr (trivial)
+  //   decided_class,                  // mirror of classified episode's decided_class
+  //
+  // For type == "failure" with failure_kind in {marker-write-failed,
+  //                                              marker-cleanup-failed}:
+  //   failure_kind,                   // subtype-derivation field (canonicalized)
+  //   marker_path,                    // absolute path to approval marker file
+  //   reason,                         // human-readable failure-mode label (66-ch cap)
 
   // Future-extensibility: any episode-type-specific authorization-bearing field
   // MUST be added here at the time the field is introduced. Two CI gates enforce:
@@ -943,30 +1056,34 @@ Tests H1-H7 ship as `tests/bp1-hmac-live.test.mjs`; H8-H20 ship as `tests/bp1-hm
 | From state | Trigger | To state | Actor |
 |---|---|---|---|
 | `rfc_detected` | classifier returns | `classified` | bp1-rfc-classifier |
-| `classified` | trivial | `planning` | orchestrator |
-| `classified` | risky | `needs_human` | orchestrator |
+| `classified` | trivial | `awaiting_approval` | record-awaiting-approval (NEW v3.15, slice 2d-W) |
+| `classified` | risky class | `needs_human` (reason=risky-class) | orchestrator (record-classification) |
+| `awaiting_approval` | 1hr timeout | `auto_approved` | bp1-approval-check.sh |
+| `awaiting_approval` | human y | `approved` | hook prompt |
+| `awaiting_approval` | human n | `aborted` | hook prompt |
+| `approved`/`auto_approved` | orchestrator advance | `planning` | orchestrator |
 | `planning` | adversarial done | `adversarial_reviewed` | negative-scenario-planner |
 | `adversarial_reviewed` | review-request sent | `codex_review` | em-review-request |
 | `codex_review` | reply | `codex_complete` | em-watch-codex |
 | `codex_review` | 30min timeout, retry < 2 | `codex_review` (self) | em-watch-codex |
-| `codex_review` | timeout retry ≥ 2 (all classes) | `needs_human` | em-watch-codex |
-| `codex_complete` | trivial class | `awaiting_approval` | orchestrator |
-| `awaiting_approval` | 1hr timeout | `auto_approved` | bp1-approval-check.sh |
-| `awaiting_approval` | human y | `approved` | hook prompt |
-| `awaiting_approval` | human n | `aborted` | hook prompt |
-| `approved`/`auto_approved` | sentinel PROCEED | `implementing` | bp1-sentinel |
+| `codex_review` | timeout retry ≥ 2 (all classes) | `needs_human` (reason=codex-timeout) | em-watch-codex |
+| `codex_complete` | sentinel PROCEED | `implementing` | bp1-sentinel |
 | `implementing` | reviewers done | `reviewing` | orchestrator |
 | `reviewing` | all clean | `auditing` | orchestrator |
 | `reviewing` | blocker | `fix_loop` | orchestrator |
 | `fix_loop` | same-sig < 2 | `implementing` | orchestrator |
-| `fix_loop` | same-sig ≥ 2 | `needs_human` | orchestrator |
+| `fix_loop` | same-sig ≥ 2 | `needs_human` (reason=fix-loop-same-sig) | orchestrator |
 | `auditing` | 9 steps green | `audit_pass` | bp1-auditor |
 | `audit_pass` | gh pr create | `pr_opened` | orchestrator |
 | `pr_opened` | review-request sent | `codex_pr_review` | em-review-request |
 | `codex_pr_review` | done | `complete` | orchestrator |
 | any state | sentinel HALT | `terminal_halt` | bp1-sentinel |
-| `needs_human` | override episode | `resolved` → resume | bp1-human-input-watcher |
+| `needs_human` (reason=risky-class) | override episode | `resolved` → `planning` | bp1-human-input-watcher (NEW v3.15 — source-aware resume) |
+| `needs_human` (reason=codex-timeout) | override episode | `resolved` → `implementing` | bp1-human-input-watcher |
+| `needs_human` (reason=fix-loop-same-sig) | override episode | `resolved` → `implementing` | bp1-human-input-watcher |
 | `needs_human` | 7 days | `abandoned` → `archived` | bp1-archive-ghosts.mjs |
+
+> **Source-aware `needs_human` resume (NEW v3.15, slice 2d-W).** Risky-class RFCs now enter `needs_human` directly after `classified` (without passing through `planning`/`adversarial_reviewed`/`codex_review`), so a human override on a risky-class entry MUST resume to `planning` — not `implementing` — or plan/adversarial/codex would be silently skipped. Codex-timeout and fix-loop entries enter `needs_human` after those stages have already run, so their resume target remains `implementing`. The `reason` frontmatter field on the `state-transition:needs-human` episode (canonical per slice 2c — see `bp1-canonicalize.mjs`) is the signed authority root for the resume routing. Resume-edge implementation owned by `bp1-human-input-watcher` (slice 2e+); the spec change here is forward-looking because Edit 1's gate-placement reshape creates the demand for it.
 
 ### Codex-timeout retry counter — separated attempt vs request-sent state (v3.5)
 
@@ -1542,6 +1659,7 @@ graph TD
 | PR-1a (M0 part 1) | `scripts/lib/bp1-manifest.mjs`, `scripts/bp1-flag-check.mjs`, `scripts/bp1-build-artifact-manifest.mjs`, `scripts/validate-rfc-failure-table.mjs`, `scripts/validate-rfc-artifact-manifest.mjs`, `install.mjs` (verify-key + config skeleton + line-anchored .gitignore), `.github/workflows/rfc-validate.yml`, `docs/bp1/config-schema.md`; this row 20 prose lesson "yes (if A)" → "conditional" (matches YAML mirror) | `tests/test-bp1-flag-check.mjs` (9), `tests/test-bp1-build-artifact-manifest.mjs` (10), `tests/test-validate-rfc-failure-table.mjs` (10), `tests/test-validate-rfc-artifact-manifest.mjs` (5), `tests/test-install-bp1.sh` (12) — 46 cases | M0 deliverables landed pre-activation; both validators green on real RFC-004; 2 deferred findings (TOCTOU [#179](https://github.com/lantisprime/episodic-memory/issues/179), em-search fallback [#180](https://github.com/lantisprime/episodic-memory/issues/180)). Codex-ACCEPT'd plan from prior session; review-pass HOLD findings folded in pre-merge. |
 | PR-1b (M0 part 2) | `scripts/bp1-deadline-sweep.mjs --once`, `.claude/hooks/bp1-sweep-on-session.sh` H2 hook, scheduled-tasks probe (artifacts present pre-slice 2a-bis; named-test gap closed by slice 2a-bis) | `tests/test-bp1-flag-check.mjs` (20), `tests/test-bp1-build-artifact-manifest.mjs` (24, +A12 + A12c-i from slice 2a-bis), `tests/test-bp1-hmac-manifest.mjs` (33) — 77 cases | _shipped_ ✓ (slice 2a-bis PR-NNN). Closes canonical-prompt drift detection: three production bugs surfaced by codex r1-r10 chain (cwd binding r2, scope HOME-pollution r3, terminal-selection field mismatch r4) + V1/V2 trust-boundary guards (validation-contract audit). Follow-up issues filed: [#259](https://github.com/lantisprime/episodic-memory/issues/259) manifest-extension, [#260](https://github.com/lantisprime/episodic-memory/issues/260) multi-loader drift, [#261](https://github.com/lantisprime/episodic-memory/issues/261) V3 multi-layer hardening. |
 | PR-2b (M2 part 1 — slice 2b) | `scripts/bp1-rfc-scan.mjs` (new, ~290 LOC), `scripts/lib/bp1-canonicalize.mjs` (+`canonicalizeFrontmatterBytes` export, ~50 LOC), `.claude/agents/bp1-rfc-classifier.md` (new loader, ~45 LOC), canonical-prompt episode `20260513-053454-...-a0c0` (global) | `tests/test-bp1-rfc-scan.mjs` (33 new), `tests/test-bp1-canonicalize.mjs` (+7 cases for canonicalizeFrontmatterBytes) — 40 cases | _shipped_ ✓ (slice 2b). Activation-gated trigger + classifier loader. Plan v3 closed planner HOLD (1 P0 + 2 P1 + 2 P2 + 2 P3) and codex plan-tier r1 HOLD (2 P1 + 1 P2) — round-2 codex verdict ACCEPT (episode `20260513-052358-...-80ad`). Subprocess spawn discipline (`cwd: projectRoot` + `bp1-flag-check --no-emit`) closes PR #262-class cwd-binding bug at slice boundary. Status routing matches strict-parser semantics; closed reason vocab = 8 entries. |
+| PR-2d-W (M2 part 2 — slice 2d-W) | `scripts/lib/bp1-marker.mjs` (NEW, 279 LOC — `markerPath`/`canonicalizeMarkerPayload`/`writeMarker`/`cleanupApprovalMarker`); `scripts/bp1-orchestrator.mjs` (`record-awaiting-approval` subcommand + `deriveRouteSpec` Option A — trivial skips routing, `record-awaiting-approval` consumes state==classified; 4 finalize cleanup callsites at L790/L854/L875/L890); `scripts/lib/bp1-canonicalize.mjs` (+`state-transition:awaiting_approval` + `failure:marker-write-failed` + reserved `failure:marker-cleanup-failed`); `scripts/lib/bp1-run-state.mjs` + migrate (+`awaiting_approval` state + `awaiting_approval_at` + `deadline_at` patch fields); `scripts/validate-rfc-contract-mirror.mjs` (reverse-set derivation refactor — codex r1 B2 cleanup); `docs/rfcs/RFC-004-bp1-auto-pilot.contract.json` v3.15 | `tests/test-bp1-marker.mjs` (NEW, 24); `tests/test-bp1-orchestrator-record-awaiting-approval.mjs` (NEW, 18); `tests/test-bp1-orchestrator-classifier-fence.mjs` + `tests/test-bp1-orchestrator-288-resume.mjs` adjusted — 42+ new cases (211+ total across 14 BP-1 test files, all green) | slice 2d-W PR — pending merge. Reshapes gate placement: trivial-class runs now hit `awaiting_approval` immediately post-classify (1hr auto-approve), not post-codex; risky-class runs route `classified → needs_human` directly. Codex plan-tier 4-round consensus ACCEPT-with-FU (r3 reply `20260517-023916-...-8e33`). RFC-update plan separately reviewed by codex r1 HOLD → r2 ACCEPT (reply `20260517-030005-...-69e3`) — closed source-aware `needs_human` resume gap (risky entries resume to `planning`, not `implementing`) + Phase B determinism-not-relock wording + `marker-cleanup-failed` reserved-only wording. 4 follow-ups deferred: linked-worktree fixture + splice-before-H2 + hook exit-0-always semantics → slice 2d-R; M5 `--disable` marker-rm → slice 2f; plan-tier live-reachability addendum → new GitHub issue post-merge. |
 
 ---
 

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -73,6 +73,7 @@ import {
 import { parseBp1Frontmatter } from './lib/bp1-frontmatter.mjs'
 import { writeBp1Episode } from './lib/bp1-episode-writer.mjs'
 import { verifyEpisodeOnDisk } from './lib/bp1-episode-verify.mjs'
+import { writeMarker, cleanupApprovalMarker } from './lib/bp1-marker.mjs'
 
 const REPO_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 const FLAG_CHECK = path.join(REPO_DIR, 'scripts', 'bp1-flag-check.mjs')
@@ -95,7 +96,8 @@ function usage() {
     '  bp1-orchestrator finalize-recover --project <projectRoot> --run-id <runId>\n' +
     '  bp1-orchestrator detect-rfcs --project <projectRoot>\n' +
     '  bp1-orchestrator record-classifier-dispatch-pre --project <projectRoot> --run-id <runId> --input-sha256 <64-hex>\n' +
-    '  bp1-orchestrator record-classification --project <projectRoot> --run-id <runId> --pre-episode-id <id> --result-file <abs-path>\n',
+    '  bp1-orchestrator record-classification --project <projectRoot> --run-id <runId> --pre-episode-id <id> --result-file <abs-path>\n' +
+    '  bp1-orchestrator record-awaiting-approval --project <projectRoot> --run-id <runId> --classified-episode-id <id>\n',
   )
 }
 
@@ -103,6 +105,7 @@ function parseArgs(argv) {
   const out = {
     subcommand: null, project: null, rfcId: null, runId: null,
     inputSha256: null, preEpisodeId: null, resultFile: null,
+    classifiedEpisodeId: null,
   }
   if (argv.length === 0) return out
   out.subcommand = argv[0]
@@ -114,6 +117,7 @@ function parseArgs(argv) {
     else if (arg === '--input-sha256') out.inputSha256 = argv[++i]
     else if (arg === '--pre-episode-id') out.preEpisodeId = argv[++i]
     else if (arg === '--result-file') out.resultFile = argv[++i]
+    else if (arg === '--classified-episode-id') out.classifiedEpisodeId = argv[++i]
     else if (arg === '--help' || arg === '-h') {
       usage()
       process.exit(0)
@@ -794,6 +798,21 @@ function finalizeRun(args) {
   }
   maybeAbortHook(7, projectRoot)
 
+  // Slice 2d-W: best-effort approval-marker cleanup. Idempotent (ENOENT is
+  // status: 'ok'). Per-run.key is shredded by this point so HMAC-signed
+  // failure-evidence emission is no longer possible; on non-ENOENT failure
+  // stderr-log and let the marker file persist as forensic evidence (the
+  // 2d-R hook reader will refuse the stale marker on next session because
+  // run-state is terminal). Does NOT fail the terminal transition.
+  const cleanup = cleanupApprovalMarker(projectRoot, runId)
+  if (cleanup.status === 'error') {
+    process.stderr.write(
+      `bp1-finalize-run: cleanupApprovalMarker non-ENOENT failure: ` +
+      `code=${cleanup.code} message=${cleanup.message} marker_path=${cleanup.markerPath} ` +
+      `(marker persists on disk; terminal transition unaffected)\n`,
+    )
+  }
+
   process.stdout.write(JSON.stringify({
     run_id: runId,
     manifest_episode_id: manifestEpId,
@@ -856,6 +875,15 @@ function finalizeRecover(args) {
       process.stderr.write(`bp1-finalize-recover: markTerminal returned ${term.error} (State B)\n`)
       return 3
     }
+    // Slice 2d-W: best-effort marker cleanup (idempotent; key shredded so no
+    // signed evidence on failure).
+    const cleanup = cleanupApprovalMarker(projectRoot, runId)
+    if (cleanup.status === 'error') {
+      process.stderr.write(
+        `bp1-finalize-recover: cleanupApprovalMarker non-ENOENT failure (State B): ` +
+        `code=${cleanup.code} marker_path=${cleanup.markerPath}\n`,
+      )
+    }
   } else if (keyResult.error) {
     // State D: manifest valid, key damaged (mode/size/unreadable). Unlink
     // damaged key then mark terminal. DEFER `4b35`: compound terminal/key
@@ -877,6 +905,13 @@ function finalizeRecover(args) {
       process.stderr.write(`bp1-finalize-recover: markTerminal returned ${term.error} (State D)\n`)
       return 3
     }
+    const cleanup = cleanupApprovalMarker(projectRoot, runId)
+    if (cleanup.status === 'error') {
+      process.stderr.write(
+        `bp1-finalize-recover: cleanupApprovalMarker non-ENOENT failure (State D): ` +
+        `code=${cleanup.code} marker_path=${cleanup.markerPath}\n`,
+      )
+    }
   } else {
     // State A: manifest valid, key still present. Shred then terminal.
     // I4 requires failing closed when shred fails with key still on disk
@@ -891,6 +926,13 @@ function finalizeRecover(args) {
     if (term.error && term.error !== 'already-terminal') {
       process.stderr.write(`bp1-finalize-recover: markTerminal returned ${term.error} (State A)\n`)
       return 3
+    }
+    const cleanup = cleanupApprovalMarker(projectRoot, runId)
+    if (cleanup.status === 'error') {
+      process.stderr.write(
+        `bp1-finalize-recover: cleanupApprovalMarker non-ENOENT failure (State A): ` +
+        `code=${cleanup.code} marker_path=${cleanup.markerPath}\n`,
+      )
     }
   }
 
@@ -1415,18 +1457,21 @@ function validateClassifierOutput(obj) {
 // Phase B's resume branches can compare run.state against targetState and
 // reject inconsistent state/decided_class pairs (closes F2).
 function deriveRouteSpec(decidedClass, runId) {
+  // Slice 2d-W (Option A, codex r3 ACCEPT episode 20260517-021728-...-fd95):
+  // trivial-class runs stop at stable `classified` state — no route episode
+  // emitted by record-classification. The safety-envelope transition into
+  // `awaiting_approval` (with 1hr auto-approval window) is the work of
+  // `record-awaiting-approval`, which consumes state==classified.
+  //
+  // Per RFC §954 + §1574 F6: trivial → awaiting_approval (1hr); non-trivial
+  // → needs-human (no timeout). The pre-slice-2d shortcut "trivial →
+  // planning" was a stub pending the safety envelope.
   if (decidedClass === 'trivial') {
-    return {
-      targetState: 'planning',
-      customFm: { source_class: 'trivial' },
-      tags: ['bp1-planning'],
-      summary: `BP-1 planning (source: trivial): ${runId}`,
-      body: `# bp1-planning — ${runId}\n\nsource_class: \`trivial\`\n`,
-      filenameSuffix: 'planning',
-    }
+    return { targetState: null, skip: true }
   }
   return {
     targetState: 'needs-human',
+    skip: false,
     customFm: { reason: 'risky-class', decided_class: decidedClass },
     tags: ['bp1-needs-human'],
     summary: `BP-1 needs-human (risky-class ${decidedClass}): ${runId}`,
@@ -1718,16 +1763,75 @@ function recordClassification(args) {
   if (!classifiedEpisodeId) return 5
 
   // ---------------------------------------------------------------------
-  // Phase B: emit route (planning|needs-human) + persist state/route_episode_id
+  // Phase B: emit route (needs-human for risky) or no-op (trivial stays at classified)
   // ---------------------------------------------------------------------
   // Single source-of-truth for the route episode: customFm IS the predicate.
   // Closes F1 (orphan-attach predicate-completeness) and F2 (state-vs-
   // targetState consistency) — both Phase B parallel branches now inherit
   // Phase A's invariant-discipline.
+  //
+  // Slice 2d-W (Option A, codex r3 episode 20260517-021728-...-fd95): trivial
+  // skips Phase B entirely. State stays at `classified`; route_episode_id
+  // stays null; no bp1-planning episode emitted. The safety-envelope
+  // transition into `awaiting_approval` is the responsibility of the
+  // record-awaiting-approval subcommand.
   const routeSpec = deriveRouteSpec(decidedClass, args.runId)
   let nextState = null
   let routeEpisodeId = null
   let phaseBExit = 0
+  if (routeSpec.skip) {
+    // Trivial path (Option A) — Phase A's `classified` state is the stable
+    // post-classification state. record-awaiting-approval (slice 2d-W) is
+    // the next intended caller. We still enforce the F2 invariant: if past
+    // Phase A advanced state to planning/needs-human under decided_class=
+    // trivial, that's a slice-2c-era artifact / drift — reject as a
+    // state-violation rather than silently overwrite.
+    let trivialSkipExit = 0
+    try {
+      withLockedRun(projectRoot, args.runId, ({ run }) => {
+        if (!run) {
+          process.stderr.write(`error: run ${args.runId} missing in Phase B (trivial skip)\n`)
+          trivialSkipExit = 5
+          return
+        }
+        if (run.state === 'planning' || run.state === 'needs-human') {
+          process.stderr.write(
+            `error: state-violation (Phase B): run.state=${run.state} but ` +
+            `decided_class=${decidedClass} implies no route emission (Option A — trivial stays at classified). ` +
+            `Manual recovery: inspect run row + signed episodes; either revert run.state to 'classified' ` +
+            `(if state was advanced by slice-2c-era code) or correct decided_class.\n`,
+          )
+          trivialSkipExit = 5
+          return
+        }
+        // Legitimate trivial state should be 'classified' here. Anything
+        // else (terminal, etc) is also a state-violation.
+        if (run.state !== 'classified') {
+          process.stderr.write(
+            `error: state-violation (Phase B): run.state=${JSON.stringify(run.state)} expected=classified for trivial\n`,
+          )
+          trivialSkipExit = 5
+          return
+        }
+      })
+    } catch (e) {
+      if (e.code === 'multiple-signed-match') {
+        process.stderr.write(`error: integrity-anomaly multiple-signed-match (Phase B trivial-skip): ${e.message}\n`)
+        return 5
+      }
+      throw e
+    }
+    if (trivialSkipExit !== 0) return trivialSkipExit
+    process.stdout.write(JSON.stringify({
+      status: 'ok',
+      state: 'classified',
+      run_id: args.runId,
+      decided_class: decidedClass,
+      classified_episode_id: classifiedEpisodeId,
+      route_episode_id: null,
+    }) + '\n')
+    return 0
+  }
   try {
     withLockedRun(projectRoot, args.runId, ({ run }) => {
       if (!run) {
@@ -1873,6 +1977,383 @@ function recordClassification(args) {
 }
 
 // ---------------------------------------------------------------------------
+// Subcommand: record-awaiting-approval (slice 2d-W, M2)
+//
+// Transitions a run from `classified` (trivial decided_class) to
+// `awaiting_approval` and writes the per-run approval marker
+// `<canonical_project_root>/.checkpoints/bp1-approval-<run_id>.json`.
+//
+// Per RFC §954: 1-hour deadline from the awaiting-approval timestamp;
+// auto-approval at deadline if no human intervention (auto-proceed routing
+// owned by 2d-R hook + future check-deadlines path A, slice 2e).
+//
+// Class restriction (RFC §1574 F6): only `trivial` decided_class reaches
+// this subcommand. Non-trivial classes route directly to `needs-human` via
+// `record-classification` Phase B and are NOT eligible for the 1-hr auto-
+// approval window. Caller asserts this; the contract here also gates by
+// checking run.decided_class === 'trivial'.
+//
+// Phase A (in-lock, signed-evidence + state transition):
+//   - Verify parent `classified` episode HMAC + state == 'classified'.
+//   - Compute awaiting_approval_at (wall-clock now, ONLY at fresh emit) +
+//     deadline_at (=+1hr).
+//   - Emit signed `bp1-awaiting-approval` evidence (state-transition).
+//   - Persist run.state='awaiting_approval' + awaiting_approval_at + deadline_at.
+//
+// Phase B (out-of-lock, deterministic marker write):
+//   - Read awaiting_approval_at + deadline_at + decided_class from run-state.
+//     NEVER wall-clock — codex r1 M1 / r2: byte-identical retry contract.
+//   - writeMarker() with persisted fields. On rename-fail → emit signed
+//     `marker-write-failed` failure episode; state stays at 'awaiting_approval'.
+//   - Idempotent: alreadyPresent=true → no-op return.
+//
+// Crash semantics:
+//   - Between Phase A and B → state at 'awaiting_approval' with no marker.
+//     Recovery: re-run record-awaiting-approval; Phase A no-ops via orphan-
+//     attach + state assert; Phase B re-derives marker from persisted fields
+//     and produces byte-identical bytes.
+//   - During Phase B writeMarker tmp write → no observable marker file
+//     (atomic tmp+rename). Retry produces identical marker.
+// ---------------------------------------------------------------------------
+
+function recordAwaitingApproval(args) {
+  if (!args.project) { usage(); return 2 }
+  if (!args.runId) {
+    process.stderr.write('error: --run-id is required\n')
+    return 2
+  }
+  if (!args.classifiedEpisodeId || !EPISODE_ID_RE.test(args.classifiedEpisodeId)) {
+    process.stderr.write('error: --classified-episode-id required and must match episode-id shape\n')
+    return 2
+  }
+  try {
+    assertRunIdShape(args.runId)
+  } catch (e) {
+    process.stderr.write(`error: --run-id has invalid shape: ${e.message}\n`)
+    return 2
+  }
+
+  // Canonicalize --project per RFC §104 strict: realpath the arg → spawn
+  // git rev-parse --show-toplevel from that cwd → realpath result. Handles
+  // nested --project <target/subdir> (codex r1 B3).
+  let projectRoot
+  try {
+    projectRoot = fs.realpathSync(args.project)
+  } catch (_e) {
+    process.stderr.write(`error: --project does not exist: ${args.project}\n`)
+    return 2
+  }
+  // Resolve canonical via git toplevel from the realpath'd cwd.
+  let toplevel
+  try {
+    toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: projectRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch (e) {
+    process.stderr.write(`error: project-root-resolution-failed: not a git repo at ${projectRoot}: ${e.message}\n`)
+    return 2
+  }
+  if (!toplevel) {
+    process.stderr.write(`error: project-root-resolution-failed: empty toplevel at ${projectRoot}\n`)
+    return 2
+  }
+  try {
+    projectRoot = fs.realpathSync(toplevel)
+  } catch (e) {
+    process.stderr.write(`error: project-root-resolution-failed: realpath failed for ${toplevel}: ${e.message}\n`)
+    return 2
+  }
+
+  // Flag-check gate.
+  const flagCheck = spawnSync('node', [FLAG_CHECK, '--project', projectRoot, '--no-emit'], {
+    cwd: projectRoot, encoding: 'utf8', env: { ...process.env, HOME: os.homedir() },
+  })
+  if (flagCheck.status !== 0) {
+    process.stderr.write(`bp1 inert for project ${projectRoot}\n`)
+    return 1
+  }
+
+  // Load run.key.
+  const keyResult = loadRunKey(projectRoot, args.runId)
+  if (keyResult.error) {
+    process.stderr.write(`error: run.key ${keyResult.error} for ${args.runId}\n`)
+    return 5
+  }
+  const { key32B } = keyResult
+
+  // ---------------------------------------------------------------------
+  // Phase A: emit awaiting_approval state-transition + persist
+  // ---------------------------------------------------------------------
+  let awaitingEpisodeId = null
+  let awaitingApprovalAt = null
+  let deadlineAt = null
+  let decidedClass = null
+  let phaseAExit = 0
+  try {
+    withLockedRun(projectRoot, args.runId, ({ run }) => {
+      if (!run) {
+        process.stderr.write(`error: run ${args.runId} not found\n`)
+        phaseAExit = 5
+        return
+      }
+
+      // Resume / backfill: state already at awaiting_approval. Phase A no-op
+      // unless awaiting_approval_episode pointer is missing.
+      if (run.state === 'awaiting_approval') {
+        // Codex r3 P1 (round 3): re-enforce trivial-class restriction on the
+        // resume path. If a non-trivial class somehow reached awaiting_approval
+        // (stale data / external tamper), refuse rather than continue to
+        // marker write — RFC §1574 F6 class restriction applies to retries too.
+        if (run.decided_class !== 'trivial') {
+          process.stderr.write(
+            `error: state-violation: state=awaiting_approval but decided_class=` +
+            `${JSON.stringify(run.decided_class)} is not 'trivial'; ` +
+            `class-restriction (RFC §1574 F6) holds on resume path\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        // Parity with fresh-emit equality gate (L2178): a --classified-episode-id
+        // mismatch on resume should surface the precise state-violation error
+        // rather than the generic recoverable-canonical-drift from
+        // findSignedStateEpisode field-mismatch later in this branch.
+        if (args.classifiedEpisodeId !== run.classified_episode_id) {
+          process.stderr.write(
+            `error: state-violation: --classified-episode-id ${args.classifiedEpisodeId} ` +
+            `!= run.classified_episode_id ${run.classified_episode_id}\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        if (!run.awaiting_approval_at || !run.deadline_at) {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=awaiting_approval but ` +
+            `awaiting_approval_at=${run.awaiting_approval_at} deadline_at=${run.deadline_at} ` +
+            `both must be persisted\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        awaitingApprovalAt = run.awaiting_approval_at
+        deadlineAt = run.deadline_at
+        decidedClass = run.decided_class
+        // Find existing signed awaiting_approval episode for downstream
+        // emission idempotence verification.
+        const verify = findSignedStateEpisode(
+          projectRoot, args.runId, 'awaiting_approval', key32B, {
+            parent_episode: args.classifiedEpisodeId,
+            awaiting_approval_at: awaitingApprovalAt,
+            deadline_at: deadlineAt,
+            decided_class: decidedClass,
+          },
+        )
+        if (verify.status === 'match') {
+          awaitingEpisodeId = verify.episodeId
+          return
+        }
+        if (verify.status === 'field-mismatch') {
+          const ids = verify.candidates.map(c => c.episodeId).join(', ')
+          process.stderr.write(
+            `error: recoverable-canonical-drift: state=awaiting_approval but ` +
+            `${verify.candidates.length} signed candidate(s) [${ids}] do not match args\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        process.stderr.write(
+          `error: recoverable-no-parent: state=awaiting_approval but no signed ` +
+          `awaiting_approval episode on disk\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      if (run.state !== 'classified') {
+        process.stderr.write(
+          `error: state-violation: run.state=${JSON.stringify(run.state)} expected=classified\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      // Class restriction: only trivial reaches this subcommand.
+      if (run.decided_class !== 'trivial') {
+        process.stderr.write(
+          `error: state-violation: decided_class=${JSON.stringify(run.decided_class)} ` +
+          `is not 'trivial'; non-trivial classes route to needs-human via record-classification\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      // Equality gate: --classified-episode-id === run.classified_episode_id.
+      if (args.classifiedEpisodeId !== run.classified_episode_id) {
+        process.stderr.write(
+          `error: state-violation: --classified-episode-id ${args.classifiedEpisodeId} ` +
+          `!= run.classified_episode_id ${run.classified_episode_id}\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+
+      // Verify parent classified episode on disk.
+      const verifyParent = verifyEpisodeOnDisk({
+        projectRoot, episodeId: args.classifiedEpisodeId, runKey32B: key32B,
+        expectedType: 'state-transition', expectedState: 'classified',
+        expectedRunId: args.runId,
+      })
+      if (!verifyParent.ok) {
+        try {
+          writeBp1Episode({
+            projectRoot, runId: args.runId, runKey32B: key32B,
+            type: 'failure', state: null,
+            summary: `BP-1 classifier parent-tamper at record-awaiting-approval: ${args.runId}`,
+            parentEpisode: null, expectedPostEpisodeId: null,
+            customFm: {
+              failure_kind: 'classifier-parent-tamper',
+              field_name: 'classified_episode_id',
+              observed_value: safeTruncate(JSON.stringify(args.classifiedEpisodeId), 66),
+              violation_reason: verifyParent.errors.join('; '),
+            },
+            tags: ['bp1-classifier-parent-tamper'],
+            body: `# bp1-classifier-parent-tamper\n\nErrors:\n\n${verifyParent.errors.map(e => `- \`${e}\``).join('\n')}\n`,
+            filenameSuffix: 'parent-tamper',
+          })
+        } catch (e) { process.stderr.write(`debug: failure-ep emit threw: ${e.message}\n`) }
+        process.stderr.write(`error: parent-tamper: ${verifyParent.errors.join('; ')}\n`)
+        phaseAExit = 5
+        return
+      }
+
+      // Fresh emit: compute wall-clock timestamps ONCE here.
+      decidedClass = run.decided_class
+      awaitingApprovalAt = new Date().toISOString()
+      const deadlineMs = new Date(awaitingApprovalAt).getTime() + 60 * 60 * 1000  // +1hr
+      deadlineAt = new Date(deadlineMs).toISOString()
+
+      const awaitingFields = {
+        parent_episode: args.classifiedEpisodeId,
+        awaiting_approval_at: awaitingApprovalAt,
+        deadline_at: deadlineAt,
+        decided_class: decidedClass,
+      }
+
+      // Orphan-attach: crash-after-emit-before-writeIndex window.
+      const orphan = findSignedStateEpisode(
+        projectRoot, args.runId, 'awaiting_approval', key32B, awaitingFields,
+      )
+      if (orphan.status === 'match') {
+        run.state = 'awaiting_approval'
+        run.awaiting_approval_at = awaitingApprovalAt
+        run.deadline_at = deadlineAt
+        awaitingEpisodeId = orphan.episodeId
+        return
+      }
+      if (orphan.status === 'field-mismatch') {
+        // Codex r3 P1: field-mismatch means a signed candidate exists with
+        // different values for one or more of {parent_episode, decided_class,
+        // awaiting_approval_at, deadline_at}. Adopting candidate[0]
+        // unconditionally is unsafe — could attach to a stale episode from a
+        // prior run, leaking marker contents from the wrong context. Mirror
+        // the classified Phase A pattern (L1609): reject as drift; operator
+        // must inspect signed episodes manually.
+        //
+        // Determinism (codex r1 M1) is preserved: legitimate retry from
+        // persisted run-state will land in the 'match' branch (timestamps
+        // from run-state == timestamps in the signed episode). Field-mismatch
+        // is ONLY reachable when args/run-state diverge from the disk
+        // episode, which is a real drift signal.
+        const ids = orphan.candidates.map(c => c.episodeId).join(', ')
+        process.stderr.write(
+          `error: recoverable-canonical-drift: ${orphan.candidates.length} signed ` +
+          `awaiting_approval episode(s) [${ids}] do not match args ` +
+          `(parent_episode/awaiting_approval_at/deadline_at/decided_class)\n`,
+        )
+        phaseAExit = 5
+        return
+      }
+      // Fresh emit.
+      const written = writeBp1Episode({
+        projectRoot, runId: args.runId, runKey32B: key32B,
+        type: 'state-transition', state: 'awaiting_approval',
+        summary: `BP-1 awaiting_approval (deadline ${deadlineAt}): ${args.runId}`,
+        parentEpisode: args.classifiedEpisodeId, expectedPostEpisodeId: null,
+        customFm: {
+          awaiting_approval_at: awaitingApprovalAt,
+          deadline_at: deadlineAt,
+          decided_class: decidedClass,
+        },
+        tags: ['bp1-awaiting-approval'],
+        body: `# bp1-awaiting-approval — ${args.runId}\n\nawaiting_approval_at: \`${awaitingApprovalAt}\`\ndeadline_at: \`${deadlineAt}\`\ndecided_class: \`${decidedClass}\`\n`,
+        filenameSuffix: 'awaiting-approval',
+      })
+      run.state = 'awaiting_approval'
+      run.awaiting_approval_at = awaitingApprovalAt
+      run.deadline_at = deadlineAt
+      awaitingEpisodeId = written.episodeId
+    })
+  } catch (e) {
+    if (e.code === 'multiple-signed-match') {
+      process.stderr.write(`error: integrity-anomaly multiple-signed-match (Phase A): ${e.message}\n`)
+      return 5
+    }
+    throw e
+  }
+  if (phaseAExit !== 0) return phaseAExit
+  if (!awaitingEpisodeId) return 5
+
+  // ---------------------------------------------------------------------
+  // Phase B: write deterministic marker from persisted run-state fields
+  // ---------------------------------------------------------------------
+  const writeResult = writeMarker({
+    projectRoot,
+    runId: args.runId,
+    decidedClass,
+    createdAt: awaitingApprovalAt,
+    deadlineAt,
+    runKey32B: key32B,
+  })
+  if (writeResult.status === 'error') {
+    // Emit signed marker-write-failed failure episode. run.key is still live
+    // at this point (Phase B runs while the run is non-terminal), so HMAC
+    // signing succeeds. Caller-side emission per codex r2 FU1.
+    try {
+      writeBp1Episode({
+        projectRoot, runId: args.runId, runKey32B: key32B,
+        type: 'failure', state: null,
+        summary: `BP-1 marker-write-failed at record-awaiting-approval: ${args.runId}`,
+        parentEpisode: awaitingEpisodeId, expectedPostEpisodeId: null,
+        customFm: {
+          failure_kind: 'marker-write-failed',
+          marker_path: writeResult.markerPath,
+          reason: safeTruncate(`${writeResult.code}: ${writeResult.message}`, 66),
+        },
+        tags: ['bp1-marker-write-failed'],
+        body: `# bp1-marker-write-failed\n\nmarker_path: \`${writeResult.markerPath}\`\ncode: \`${writeResult.code}\`\nmessage: \`${writeResult.message}\`\n\nRetry: state remains 'awaiting_approval'; re-run \`record-awaiting-approval\` produces byte-identical marker from persisted run-state fields.\n`,
+        filenameSuffix: 'marker-write-failed',
+      })
+    } catch (e) { process.stderr.write(`debug: failure-ep emit threw: ${e.message}\n`) }
+    process.stderr.write(
+      `error: marker-write-failed: code=${writeResult.code} message=${writeResult.message} ` +
+      `marker_path=${writeResult.markerPath} (state remains awaiting_approval; retry idempotent)\n`,
+    )
+    return 3
+  }
+
+  process.stdout.write(JSON.stringify({
+    status: 'ok',
+    state: 'awaiting_approval',
+    run_id: args.runId,
+    awaiting_approval_episode_id: awaitingEpisodeId,
+    awaiting_approval_at: awaitingApprovalAt,
+    deadline_at: deadlineAt,
+    marker_path: writeResult.markerPath,
+    marker_already_present: writeResult.alreadyPresent,
+  }) + '\n')
+  return 0
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
@@ -1896,6 +2377,9 @@ switch (args.subcommand) {
     break
   case 'record-classification':
     exitCode = recordClassification(args)
+    break
+  case 'record-awaiting-approval':
+    exitCode = recordAwaitingApproval(args)
     break
   case null:
   case undefined:

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -2225,53 +2225,56 @@ function recordAwaitingApproval(args) {
         return
       }
 
-      // Fresh emit: compute wall-clock timestamps ONCE here.
       decidedClass = run.decided_class
-      awaitingApprovalAt = new Date().toISOString()
-      const deadlineMs = new Date(awaitingApprovalAt).getTime() + 60 * 60 * 1000  // +1hr
-      deadlineAt = new Date(deadlineMs).toISOString()
 
-      const awaitingFields = {
-        parent_episode: args.classifiedEpisodeId,
-        awaiting_approval_at: awaitingApprovalAt,
-        deadline_at: deadlineAt,
-        decided_class: decidedClass,
-      }
-
-      // Orphan-attach: crash-after-emit-before-writeIndex window.
+      // Orphan-attach FIRST without expectedFields. Per codex PR-#305 r1 P1
+      // (episode 20260517-053040-...-5a22): if a prior crashed invocation
+      // emitted a signed awaiting_approval episode before persisting
+      // run-state, the orphan's timestamps are the authoritative source.
+      // Fresh wall-clock here would mint different timestamps that NEVER
+      // match the orphan, dead-ending every retry at field-mismatch.
+      //
+      // Validate parent_episode + decided_class match args/run-state before
+      // adopting (defense against cross-context attachment). Adopt the
+      // orphan's awaiting_approval_at + deadline_at unconditionally —
+      // they're orphan-determined since run-state has no authoritative
+      // value yet (state still classified).
       const orphan = findSignedStateEpisode(
-        projectRoot, args.runId, 'awaiting_approval', key32B, awaitingFields,
+        projectRoot, args.runId, 'awaiting_approval', key32B,
       )
       if (orphan.status === 'match') {
+        const fm = orphan.frontmatter
+        if (fm.parent_episode !== args.classifiedEpisodeId) {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: orphan awaiting_approval ` +
+            `parent_episode=${fm.parent_episode} != --classified-episode-id ` +
+            `${args.classifiedEpisodeId}\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        if (fm.decided_class !== decidedClass) {
+          process.stderr.write(
+            `error: recoverable-canonical-drift: orphan awaiting_approval ` +
+            `decided_class=${fm.decided_class} != run.decided_class ${decidedClass}\n`,
+          )
+          phaseAExit = 5
+          return
+        }
+        awaitingApprovalAt = fm.awaiting_approval_at
+        deadlineAt = fm.deadline_at
         run.state = 'awaiting_approval'
         run.awaiting_approval_at = awaitingApprovalAt
         run.deadline_at = deadlineAt
         awaitingEpisodeId = orphan.episodeId
         return
       }
-      if (orphan.status === 'field-mismatch') {
-        // Codex r3 P1: field-mismatch means a signed candidate exists with
-        // different values for one or more of {parent_episode, decided_class,
-        // awaiting_approval_at, deadline_at}. Adopting candidate[0]
-        // unconditionally is unsafe — could attach to a stale episode from a
-        // prior run, leaking marker contents from the wrong context. Mirror
-        // the classified Phase A pattern (L1609): reject as drift; operator
-        // must inspect signed episodes manually.
-        //
-        // Determinism (codex r1 M1) is preserved: legitimate retry from
-        // persisted run-state will land in the 'match' branch (timestamps
-        // from run-state == timestamps in the signed episode). Field-mismatch
-        // is ONLY reachable when args/run-state diverge from the disk
-        // episode, which is a real drift signal.
-        const ids = orphan.candidates.map(c => c.episodeId).join(', ')
-        process.stderr.write(
-          `error: recoverable-canonical-drift: ${orphan.candidates.length} signed ` +
-          `awaiting_approval episode(s) [${ids}] do not match args ` +
-          `(parent_episode/awaiting_approval_at/deadline_at/decided_class)\n`,
-        )
-        phaseAExit = 5
-        return
-      }
+      // orphan.status === 'none' — no prior signed episode for this
+      // (run_id, awaiting_approval). Mint fresh wall-clock timestamps ONCE.
+      awaitingApprovalAt = new Date().toISOString()
+      const deadlineMs = new Date(awaitingApprovalAt).getTime() + 60 * 60 * 1000  // +1hr
+      deadlineAt = new Date(deadlineMs).toISOString()
+
       // Fresh emit.
       const written = writeBp1Episode({
         projectRoot, runId: args.runId, runKey32B: key32B,

--- a/scripts/lib/bp1-canonicalize.mjs
+++ b/scripts/lib/bp1-canonicalize.mjs
@@ -99,6 +99,34 @@ export const TYPE_SPECIFIC_CANONICAL_FIELDS = Object.freeze({
     'reason',
     'decided_class',
   ]),
+  // Slice 2d-W — awaiting_approval state-transition for approval-marker
+  // writer surface (RFC §954). `awaiting_approval_at` and `deadline_at` are
+  // canonical so post-emit tampering invalidates the HMAC.
+  // `decided_class` is canonical because it gates 2d-R hook routing
+  // (class-restricted auto-proceed per RFC §1574 F6).
+  'state-transition:awaiting_approval': Object.freeze([
+    'state',
+    'awaiting_approval_at',
+    'deadline_at',
+    'decided_class',
+  ]),
+  // Slice 2d-W — marker write/cleanup failure subtypes. failure_kind is the
+  // subtype-derivation field. `marker-write-failed` is emitted by
+  // `record-awaiting-approval` Phase B when atomic rename fails (per-run key
+  // is still live, so HMAC signing is possible). `marker-cleanup-failed` is
+  // reserved for callers that retain the per-run key when invoking
+  // cleanupApprovalMarker (post-shred finalize-* paths stderr-log instead
+  // because the key is no longer available).
+  'failure:marker-write-failed': Object.freeze([
+    'failure_kind',
+    'marker_path',
+    'reason',
+  ]),
+  'failure:marker-cleanup-failed': Object.freeze([
+    'failure_kind',
+    'marker_path',
+    'reason',
+  ]),
   // Slice 2c — failure subtypes. failure_kind is the subtype-derivation field;
   // it IS canonicalized here so post-emit tampering of failure_kind invalidates
   // the HMAC. Both kinds share the same canonical-field shape but are kept as

--- a/scripts/lib/bp1-marker.mjs
+++ b/scripts/lib/bp1-marker.mjs
@@ -1,0 +1,278 @@
+/**
+ * bp1-marker.mjs — Approval-marker write/cleanup helpers (RFC-004 §580-patch,
+ * slice 2d-W).
+ *
+ * Marker contract (RFC §580-patch):
+ *   Path: <canonical_project_root>/.checkpoints/bp1-approval-<run_id>.json
+ *   Per-run_id filename eliminates concurrent-marker ambiguity (codex r1 B3).
+ *
+ * Payload (JSON):
+ *   {
+ *     run_id,
+ *     created_at,         ISO-8601 UTC (== run-state awaiting_approval_at)
+ *     decided_class,      one of trivial|schema|validator|security|multi-actor
+ *     deadline_at,        ISO-8601 UTC (== run-state deadline_at; deterministic)
+ *     body_sha256,        64-hex over canonicalized {run_id, created_at,
+ *                          decided_class, deadline_at}
+ *     hmac                64-hex HMAC-SHA256 over the same canonical bytes,
+ *                         signed by the per-run HMAC key
+ *   }
+ *
+ * Determinism (codex r1 M1):
+ *   Phase B retries after a crash MUST produce byte-identical markers.
+ *   `created_at` + `deadline_at` come from persisted run-state, never wall-clock.
+ *   `body_sha256` and `hmac` are pure functions of (canonical bytes, runKey).
+ *
+ * Ownership split (codex r2 FU1):
+ *   This module ONLY:
+ *     - canonicalizes payload bytes
+ *     - writes/unlinks marker files atomically (tmp + fsync + rename / unlink)
+ *     - returns status objects ({ status: 'ok' | 'error', code? })
+ *   It does NOT emit evidence episodes. The caller (record-awaiting-approval
+ *   for write-failures while run.key is live; finalize-* for cleanup-failures
+ *   after key shred) owns evidence emission via `bp1-episode-writer.mjs`.
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+
+import { signCanonical } from './bp1-hmac.mjs'
+
+const RUN_ID_RE = /^[a-z0-9-]+$/
+const VALID_DECIDED_CLASSES = Object.freeze([
+  'trivial', 'schema', 'validator', 'security', 'multi-actor', 'needs-human-input',
+])
+
+// ---------------------------------------------------------------------------
+// markerPath — pure path helper
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} canonicalProjectRoot — absolute path
+ * @param {string} runId — shape-validated (RUN_ID_RE)
+ * @returns {string}
+ */
+export function markerPath(canonicalProjectRoot, runId) {
+  if (typeof canonicalProjectRoot !== 'string' || !path.isAbsolute(canonicalProjectRoot)) {
+    throw new TypeError(`markerPath: canonicalProjectRoot must be absolute; got ${canonicalProjectRoot}`)
+  }
+  if (typeof runId !== 'string' || !RUN_ID_RE.test(runId)) {
+    throw new TypeError(`markerPath: runId shape invalid: ${JSON.stringify(runId)}`)
+  }
+  return path.join(canonicalProjectRoot, '.checkpoints', `bp1-approval-${runId}.json`)
+}
+
+// ---------------------------------------------------------------------------
+// canonicalizeMarkerPayload — pure canonicalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Project { run_id, created_at, decided_class, deadline_at } to canonical
+ * bytes for HMAC + body_sha256 derivation. Sorted keys, JSON.stringify with
+ * no spaces, utf8-encoded.
+ *
+ * Note: the returned bytes are the AUTHORIZATION-BEARING payload only —
+ * body_sha256 and hmac are computed FROM these bytes by the caller, then
+ * appended to the final marker file (which has 6 fields including the
+ * derived ones).
+ *
+ * @param {{
+ *   run_id: string,
+ *   created_at: string,
+ *   decided_class: string,
+ *   deadline_at: string,
+ * }} fields
+ * @returns {{ canonicalBytes: Buffer, sha256: string }}
+ */
+export function canonicalizeMarkerPayload(fields) {
+  if (!fields || typeof fields !== 'object') {
+    throw new TypeError('canonicalizeMarkerPayload: fields must be an object')
+  }
+  const required = ['run_id', 'created_at', 'decided_class', 'deadline_at']
+  for (const k of required) {
+    if (typeof fields[k] !== 'string' || fields[k] === '') {
+      throw new TypeError(`canonicalizeMarkerPayload: ${k} must be a non-empty string`)
+    }
+  }
+  if (!RUN_ID_RE.test(fields.run_id)) {
+    throw new TypeError(`canonicalizeMarkerPayload: run_id shape invalid: ${JSON.stringify(fields.run_id)}`)
+  }
+  if (!VALID_DECIDED_CLASSES.includes(fields.decided_class)) {
+    throw new TypeError(`canonicalizeMarkerPayload: decided_class invalid: ${JSON.stringify(fields.decided_class)}`)
+  }
+  const subset = {
+    created_at: fields.created_at,
+    deadline_at: fields.deadline_at,
+    decided_class: fields.decided_class,
+    run_id: fields.run_id,
+  }
+  // Object literal keys already in sorted order above; sort defensively in case
+  // a future caller passes a non-literal object.
+  const sortedKeys = Object.keys(subset).sort()
+  const sortedPayload = {}
+  for (const k of sortedKeys) sortedPayload[k] = subset[k]
+  const canonicalBytes = Buffer.from(JSON.stringify(sortedPayload), 'utf8')
+  const sha256 = crypto.createHash('sha256').update(canonicalBytes).digest('hex')
+  return { canonicalBytes, sha256 }
+}
+
+// ---------------------------------------------------------------------------
+// writeMarker — atomic write of signed marker file
+// ---------------------------------------------------------------------------
+
+/**
+ * Write the approval marker atomically. Idempotent under concurrent invocation
+ * when (run_id, created_at, decided_class, deadline_at, runKey32B) are identical:
+ * the canonical bytes + hmac are deterministic, so two concurrent writers
+ * produce byte-identical files. Last-rename-wins is benign.
+ *
+ * Atomicity: tmp file in same dir → fsync → rename. Crash before rename leaves
+ * no observable final path. Crash after rename leaves the marker.
+ *
+ * On rename failure, the tmp is unlinked best-effort and the rename error is
+ * rethrown so the CALLER can emit a `marker-write-failed` HMAC-signed evidence
+ * episode (this helper does not emit evidence — codex r2 FU1 ownership split).
+ *
+ * @param {{
+ *   projectRoot: string,         absolute, canonical
+ *   runId: string,               shape-validated
+ *   decidedClass: string,        one of VALID_DECIDED_CLASSES
+ *   createdAt: string,           ISO-8601 UTC, from run-state awaiting_approval_at
+ *   deadlineAt: string,          ISO-8601 UTC, from run-state deadline_at
+ *   runKey32B: Buffer,           32-byte per-run HMAC key
+ * }} opts
+ * @returns {{ status: 'ok', markerPath: string, body_sha256: string, hmac: string, alreadyPresent: boolean }
+ *   | { status: 'error', code: string, message: string, markerPath: string }}
+ */
+export function writeMarker(opts) {
+  if (!opts || typeof opts !== 'object') {
+    throw new TypeError('writeMarker: opts must be an object')
+  }
+  const { projectRoot, runId, decidedClass, createdAt, deadlineAt, runKey32B } = opts
+  if (typeof projectRoot !== 'string' || !path.isAbsolute(projectRoot)) {
+    throw new TypeError(`writeMarker: projectRoot must be absolute; got ${projectRoot}`)
+  }
+  if (!Buffer.isBuffer(runKey32B) || runKey32B.length !== 32) {
+    throw new TypeError('writeMarker: runKey32B must be a 32-byte Buffer')
+  }
+
+  // 1. Canonicalize + sign.
+  const { canonicalBytes, sha256 } = canonicalizeMarkerPayload({
+    run_id: runId,
+    created_at: createdAt,
+    decided_class: decidedClass,
+    deadline_at: deadlineAt,
+  })
+  const hmac = signCanonical(canonicalBytes, runKey32B)
+
+  // 2. Final marker file content: 6 fields. Keys sorted alphabetically for
+  //    determinism, matching canonicalize discipline.
+  const finalPayload = {
+    body_sha256: sha256,
+    created_at: createdAt,
+    deadline_at: deadlineAt,
+    decided_class: decidedClass,
+    hmac,
+    run_id: runId,
+  }
+  const sortedFinalKeys = Object.keys(finalPayload).sort()
+  const sortedFinal = {}
+  for (const k of sortedFinalKeys) sortedFinal[k] = finalPayload[k]
+  const fileBytes = Buffer.from(JSON.stringify(sortedFinal) + '\n', 'utf8')
+
+  const target = markerPath(projectRoot, runId)
+  const dir = path.dirname(target)
+
+  // 3. Idempotence check (codex r1 M1): if marker already exists with identical
+  //    bytes, no-op return alreadyPresent=true. Saves an fs.rename per retry
+  //    and surfaces concurrent-Phase-B byte-identical contract to caller.
+  try {
+    const existing = fs.readFileSync(target)
+    if (existing.equals(fileBytes)) {
+      return { status: 'ok', markerPath: target, body_sha256: sha256, hmac, alreadyPresent: true }
+    }
+    // Marker exists but bytes differ — overwrite via atomic rename below.
+    // This happens if `created_at` or `deadline_at` changed between runs, which
+    // shouldn't occur with persisted run-state, but we defer to the new bytes
+    // rather than fail-closed: caller stays at `awaiting_approval` either way.
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      return { status: 'error', code: e.code || 'read-failed', message: e.message, markerPath: target }
+    }
+  }
+
+  // 4. mkdir + atomic write.
+  try {
+    fs.mkdirSync(dir, { recursive: true })
+  } catch (e) {
+    return { status: 'error', code: e.code || 'mkdir-failed', message: e.message, markerPath: target }
+  }
+  const tmpPath = `${target}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`
+  let fd
+  try {
+    fd = fs.openSync(tmpPath, 'wx', 0o600)
+  } catch (e) {
+    return { status: 'error', code: e.code || 'open-failed', message: e.message, markerPath: target }
+  }
+  try {
+    try {
+      fs.writeFileSync(fd, fileBytes)
+      fs.fsyncSync(fd)
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch (e) {
+    try { fs.unlinkSync(tmpPath) } catch (_e) { /* best-effort */ }
+    return { status: 'error', code: e.code || 'write-failed', message: e.message, markerPath: target }
+  }
+  try {
+    fs.renameSync(tmpPath, target)
+  } catch (e) {
+    try { fs.unlinkSync(tmpPath) } catch (_e) { /* best-effort */ }
+    return { status: 'error', code: e.code || 'rename-failed', message: e.message, markerPath: target }
+  }
+
+  return { status: 'ok', markerPath: target, body_sha256: sha256, hmac, alreadyPresent: false }
+}
+
+// ---------------------------------------------------------------------------
+// cleanupApprovalMarker — idempotent unlink helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort cleanup of the approval marker file. Idempotent: ENOENT is
+ * status: 'ok' (no-op), not an error.
+ *
+ * Caller-side evidence emission contract (codex r2 FU1): this helper unlinks
+ * + returns status only. The caller chooses what to do with non-ENOENT errors.
+ *
+ * In `finalize-run` / `finalize-recover`, callers stderr-log on non-ENOENT
+ * failures and leave the marker on disk (the persisting file IS the forensic
+ * evidence; the per-run HMAC key has been shredded by the time these callers
+ * reach the marker cleanup step, so HMAC-signed evidence emission is no
+ * longer available).
+ *
+ * @param {string} projectRoot — absolute canonical path
+ * @param {string} runId — shape-validated
+ * @returns {{ status: 'ok' | 'error', code?: string, message?: string, markerPath: string, alreadyAbsent?: boolean }}
+ */
+export function cleanupApprovalMarker(projectRoot, runId) {
+  let target
+  try {
+    target = markerPath(projectRoot, runId)
+  } catch (e) {
+    return { status: 'error', code: 'invalid-input', message: e.message, markerPath: '' }
+  }
+  try {
+    fs.unlinkSync(target)
+    return { status: 'ok', markerPath: target, alreadyAbsent: false }
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return { status: 'ok', markerPath: target, alreadyAbsent: true }
+    }
+    return { status: 'error', code: e.code || 'unlink-failed', message: e.message, markerPath: target }
+  }
+}

--- a/scripts/lib/bp1-run-state-migrate.mjs
+++ b/scripts/lib/bp1-run-state-migrate.mjs
@@ -17,10 +17,11 @@
  *     NOT rewrite existing state values: a v1 `state: 'active'` stays `active`.
  *
  * The v2 branch (input already v2) ALSO normalizes pre-existing rows to
- * default `classified_episode_id` and `route_episode_id` to null when missing
- * (soft schema addition without bumping schema_version). This is the
- * primary recovery path for runs that were persisted before the cluster
- * #286/#287/#288 schema additions landed.
+ * default `classified_episode_id`, `route_episode_id`, `awaiting_approval_at`,
+ * and `deadline_at` to null when missing (soft schema additions without
+ * bumping schema_version). Cluster #286/#287/#288 added the first two; slice
+ * 2d-W adds the latter two. The normalization here is the single read-side
+ * reconciliation point.
  *
  * This module exports a **pure function** — no IO, no lock acquisition. Used
  * inside `bp1-run-state.mjs`'s `loadIndex` (unlocked entry point) and
@@ -67,6 +68,8 @@ export function migrateV1ToV2(idx) {
         ...run,
         classified_episode_id: run.classified_episode_id ?? null,
         route_episode_id: run.route_episode_id ?? null,
+        awaiting_approval_at: run.awaiting_approval_at ?? null,
+        deadline_at: run.deadline_at ?? null,
       }
     }
     return copy
@@ -88,6 +91,8 @@ export function migrateV1ToV2(idx) {
       rfc_detected_episode_id: v1Run.rfc_detected_episode_id ?? null,
       classified_episode_id: v1Run.classified_episode_id ?? null,
       route_episode_id: v1Run.route_episode_id ?? null,
+      awaiting_approval_at: v1Run.awaiting_approval_at ?? null,
+      deadline_at: v1Run.deadline_at ?? null,
     }
   }
   return out

--- a/scripts/lib/bp1-run-state.mjs
+++ b/scripts/lib/bp1-run-state.mjs
@@ -104,6 +104,7 @@ export const VALID_V2_STATES = Object.freeze([
   'classified',
   'planning',
   'needs-human',
+  'awaiting_approval',
   'complete',
   'aborted',
   'abandoned',
@@ -113,6 +114,9 @@ export const VALID_V2_STATES = Object.freeze([
 // Patchable transition fields per v2 schema. updateRunState() refuses
 // unknown keys to keep the on-disk shape locked. `classified_episode_id` /
 // `route_episode_id` added (cluster #286/#287/#288 Phase A/B persistence).
+// `awaiting_approval_at` + `deadline_at` added (slice 2d-W); Phase A persists
+// both so Phase B retry after crash produces byte-identical marker bytes
+// (codex r1 M1 — never wall-clock).
 const VALID_V2_PATCH_FIELDS = Object.freeze([
   'state',
   'decided_class',
@@ -120,6 +124,8 @@ const VALID_V2_PATCH_FIELDS = Object.freeze([
   'rfc_detected_episode_id',
   'classified_episode_id',
   'route_episode_id',
+  'awaiting_approval_at',
+  'deadline_at',
 ])
 
 // Valid classifier output classes (mirrors classifier_output_schema in
@@ -468,6 +474,8 @@ export function appendRun(projectRoot, runId, projectRootCanonical) {
         rfc_detected_episode_id: null,
         classified_episode_id: null,
         route_episode_id: null,
+        awaiting_approval_at: null,
+        deadline_at: null,
       }
       idx.runs[runId] = run
       writeIndex(projectRoot, idx)

--- a/scripts/validate-rfc-contract-mirror.mjs
+++ b/scripts/validate-rfc-contract-mirror.mjs
@@ -105,13 +105,23 @@ function checkCanonicalFields(contract, code) {
     }
   }
   // Reverse direction: subtypes the code declares that the contract doesn't
-  // mirror. Limit to slice-2c-shape subtypes so we don't false-positive on
-  // pre-slice-2c entries like 'state-transition:codex_review' / run-started /
-  // evidence:* (those are documented in RFC §689-719 prose, not contract.json).
-  const SLICE_2C_SUBTYPES_RE = /^(state-transition:(rfc-detected|classifier-dispatch-pending|classified|planning|needs-human)|failure:.+)$/
+  // mirror. Codex r1 B2 cleanup (slice 2d-W): derive the expected reverse-set
+  // from contract `v2.states` (minus v1-terminal states) + every `failure:*`
+  // subtype the code declares. This eliminates the hard-coded slice-2c regex
+  // so future v2 state additions (awaiting_approval, future) require only one
+  // touchpoint in this validator (the `v2.states` mirror), not two.
+  //
+  // Pre-slice-2c subtypes (`state-transition:codex_review`, run-started, and
+  // evidence:*) are intentionally NOT mirrored in contract.json (they live in
+  // RFC §689-719 prose only); we skip them by keying off the v2 state set.
+  const v1TerminalStates = new Set(['active', 'complete', 'aborted', 'abandoned', 'archived'])
+  const v2States = (contract.run_state_schemas?.v2?.states ?? []).filter(s => !v1TerminalStates.has(s))
+  const reverseStateTransitionSet = new Set(v2States.map(s => `state-transition:${s}`))
   for (const subtype of Object.keys(code)) {
-    if (SLICE_2C_SUBTYPES_RE.test(subtype) && !contract.episode_canonical_fields[subtype]) {
-      errors.push(`canonical-fields: code declares slice-2c subtype "${subtype}" but contract.json missing entry`)
+    const isCheckedStateTransition = reverseStateTransitionSet.has(subtype)
+    const isFailureSubtype = subtype.startsWith('failure:')
+    if ((isCheckedStateTransition || isFailureSubtype) && !contract.episode_canonical_fields[subtype]) {
+      errors.push(`canonical-fields: code declares subtype "${subtype}" but contract.json missing entry`)
     }
   }
 }

--- a/tests/test-bp1-marker.mjs
+++ b/tests/test-bp1-marker.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-marker.mjs — Slice 2d-W marker writer + canonicalize + cleanup tests.
+ *
+ * Coverage (plan v3.1 invariants):
+ *   - markerPath shape + run_id binding
+ *   - canonicalizeMarkerPayload determinism + sorted-keys + sha256
+ *   - writeMarker atomic write (tmp + fsync + rename)
+ *   - writeMarker idempotence (byte-identical re-write returns alreadyPresent)
+ *   - writeMarker concurrent-Phase-B byte-identical bytes (codex r1 M1)
+ *   - writeMarker rename-failure cleanup (orphan tmp removal)
+ *   - cleanupApprovalMarker idempotence (ENOENT → status: ok, alreadyAbsent)
+ *   - cleanupApprovalMarker non-ENOENT failure fallthrough
+ *   - shape validation (run_id, decided_class, isAbsolute path)
+ *   - axis-9 / discipline #20: caller-cwd-mismatch — artifacts land under target
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+
+const mod = await import(new URL('../scripts/lib/bp1-marker.mjs', import.meta.url).href)
+const { markerPath, canonicalizeMarkerPayload, writeMarker, cleanupApprovalMarker } = mod
+
+const hmacMod = await import(new URL('../scripts/lib/bp1-hmac.mjs', import.meta.url).href)
+const { verifyCanonical } = hmacMod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+const KEY = crypto.randomBytes(32)
+const RUN_ID = 'bp1-run-1700000000000-rfc-004-aabbcc'
+const CREATED_AT = '2026-05-17T01:00:00.000Z'
+const DEADLINE_AT = '2026-05-17T02:00:00.000Z'
+
+function tmpProjectRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-marker-test-'))
+  return fs.realpathSync(dir)
+}
+
+// ---------------------------------------------------------------------------
+// markerPath shape
+// ---------------------------------------------------------------------------
+
+tap('markerPath embeds run_id under <root>/.checkpoints/', () => {
+  const root = tmpProjectRoot()
+  const p = markerPath(root, RUN_ID)
+  assert.equal(p, path.join(root, '.checkpoints', `bp1-approval-${RUN_ID}.json`))
+})
+
+tap('markerPath rejects non-absolute projectRoot', () => {
+  assert.throws(() => markerPath('./relative', RUN_ID), /must be absolute/)
+})
+
+tap('markerPath rejects invalid run_id shape', () => {
+  const root = tmpProjectRoot()
+  assert.throws(() => markerPath(root, 'BAD UPPER CASE'), /runId shape invalid/)
+  assert.throws(() => markerPath(root, 'has/slash'), /runId shape invalid/)
+  assert.throws(() => markerPath(root, ''), /runId shape invalid/)
+})
+
+// ---------------------------------------------------------------------------
+// canonicalizeMarkerPayload
+// ---------------------------------------------------------------------------
+
+tap('canonicalizeMarkerPayload returns sorted-key canonical bytes + sha256', () => {
+  const { canonicalBytes, sha256 } = canonicalizeMarkerPayload({
+    run_id: RUN_ID, created_at: CREATED_AT, decided_class: 'trivial', deadline_at: DEADLINE_AT,
+  })
+  // Sorted alphabetically: created_at, deadline_at, decided_class, run_id.
+  const expected = JSON.stringify({
+    created_at: CREATED_AT,
+    deadline_at: DEADLINE_AT,
+    decided_class: 'trivial',
+    run_id: RUN_ID,
+  })
+  assert.equal(canonicalBytes.toString('utf8'), expected)
+  assert.equal(sha256.length, 64)
+  assert.match(sha256, /^[0-9a-f]{64}$/)
+})
+
+tap('canonicalizeMarkerPayload determinism — key order in input does not change output', () => {
+  const a = canonicalizeMarkerPayload({
+    run_id: RUN_ID, created_at: CREATED_AT, decided_class: 'trivial', deadline_at: DEADLINE_AT,
+  })
+  const b = canonicalizeMarkerPayload({
+    deadline_at: DEADLINE_AT, decided_class: 'trivial', created_at: CREATED_AT, run_id: RUN_ID,
+  })
+  assert.deepEqual(a.canonicalBytes, b.canonicalBytes)
+  assert.equal(a.sha256, b.sha256)
+})
+
+tap('canonicalizeMarkerPayload rejects invalid decided_class', () => {
+  assert.throws(() => canonicalizeMarkerPayload({
+    run_id: RUN_ID, created_at: CREATED_AT, decided_class: 'bogus', deadline_at: DEADLINE_AT,
+  }), /decided_class invalid/)
+})
+
+tap('canonicalizeMarkerPayload rejects missing required field', () => {
+  assert.throws(() => canonicalizeMarkerPayload({
+    run_id: RUN_ID, created_at: CREATED_AT, decided_class: 'trivial',
+  }), /deadline_at/)
+})
+
+tap('canonicalizeMarkerPayload rejects bad run_id shape', () => {
+  assert.throws(() => canonicalizeMarkerPayload({
+    run_id: 'UPPER/case', created_at: CREATED_AT, decided_class: 'trivial', deadline_at: DEADLINE_AT,
+  }), /run_id shape invalid/)
+})
+
+// ---------------------------------------------------------------------------
+// writeMarker happy path + atomicity
+// ---------------------------------------------------------------------------
+
+tap('writeMarker creates marker at canonical path', () => {
+  const root = tmpProjectRoot()
+  const result = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  assert.equal(result.status, 'ok')
+  assert.equal(result.alreadyPresent, false)
+  assert.equal(result.markerPath, markerPath(root, RUN_ID))
+  assert.ok(fs.existsSync(result.markerPath))
+})
+
+tap('writeMarker file is JSON-parseable with 6 fields including body_sha256 + hmac', () => {
+  const root = tmpProjectRoot()
+  const result = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const parsed = JSON.parse(fs.readFileSync(result.markerPath, 'utf8'))
+  const keys = Object.keys(parsed).sort()
+  assert.deepEqual(keys, ['body_sha256', 'created_at', 'deadline_at', 'decided_class', 'hmac', 'run_id'])
+  assert.equal(parsed.run_id, RUN_ID)
+  assert.equal(parsed.decided_class, 'trivial')
+  assert.equal(parsed.created_at, CREATED_AT)
+  assert.equal(parsed.deadline_at, DEADLINE_AT)
+})
+
+tap('writeMarker hmac round-trips via verifyCanonical', () => {
+  const root = tmpProjectRoot()
+  const result = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const parsed = JSON.parse(fs.readFileSync(result.markerPath, 'utf8'))
+  const { canonicalBytes } = canonicalizeMarkerPayload({
+    run_id: parsed.run_id, created_at: parsed.created_at,
+    decided_class: parsed.decided_class, deadline_at: parsed.deadline_at,
+  })
+  assert.ok(verifyCanonical(canonicalBytes, KEY, parsed.hmac))
+})
+
+tap('writeMarker body_sha256 matches sha over canonical bytes', () => {
+  const root = tmpProjectRoot()
+  const result = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const { sha256 } = canonicalizeMarkerPayload({
+    run_id: RUN_ID, created_at: CREATED_AT, decided_class: 'trivial', deadline_at: DEADLINE_AT,
+  })
+  assert.equal(result.body_sha256, sha256)
+})
+
+// ---------------------------------------------------------------------------
+// writeMarker idempotence + determinism (codex r1 M1, r2)
+// ---------------------------------------------------------------------------
+
+tap('writeMarker is idempotent — second call returns alreadyPresent=true', () => {
+  const root = tmpProjectRoot()
+  const a = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const b = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  assert.equal(a.alreadyPresent, false)
+  assert.equal(b.alreadyPresent, true)
+  assert.equal(a.body_sha256, b.body_sha256)
+  assert.equal(a.hmac, b.hmac)
+})
+
+tap('writeMarker concurrent invocations produce byte-identical files (M1)', () => {
+  const root = tmpProjectRoot()
+  // Sequential invocations standing in for concurrent — both should produce
+  // identical canonical bytes / hmac. True concurrency tested at orchestrator
+  // E2E level via spawnSync race.
+  const a = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const fileBytes1 = fs.readFileSync(a.markerPath)
+  const b = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const fileBytes2 = fs.readFileSync(b.markerPath)
+  assert.ok(fileBytes1.equals(fileBytes2))
+})
+
+tap('writeMarker different decided_class produces different hmac', () => {
+  const root = tmpProjectRoot()
+  const a = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  // Clean up + re-write with different class.
+  fs.unlinkSync(a.markerPath)
+  const b = writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'schema',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  assert.notEqual(a.hmac, b.hmac)
+  assert.notEqual(a.body_sha256, b.body_sha256)
+})
+
+// ---------------------------------------------------------------------------
+// writeMarker error paths
+// ---------------------------------------------------------------------------
+
+tap('writeMarker rejects non-32-byte runKey32B', () => {
+  const root = tmpProjectRoot()
+  assert.throws(() => writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: Buffer.alloc(16),
+  }), /32-byte/)
+})
+
+tap('writeMarker rejects non-absolute projectRoot', () => {
+  assert.throws(() => writeMarker({
+    projectRoot: 'relative', runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  }), /must be absolute/)
+})
+
+tap('writeMarker leaves no orphan tmp file under .checkpoints on success', () => {
+  const root = tmpProjectRoot()
+  writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const checkpointsDir = path.join(root, '.checkpoints')
+  const entries = fs.readdirSync(checkpointsDir)
+  const tmpEntries = entries.filter(n => n.includes('.tmp.'))
+  assert.equal(tmpEntries.length, 0)
+})
+
+// ---------------------------------------------------------------------------
+// cleanupApprovalMarker
+// ---------------------------------------------------------------------------
+
+tap('cleanupApprovalMarker removes existing marker', () => {
+  const root = tmpProjectRoot()
+  writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const target = markerPath(root, RUN_ID)
+  assert.ok(fs.existsSync(target))
+  const result = cleanupApprovalMarker(root, RUN_ID)
+  assert.equal(result.status, 'ok')
+  assert.equal(result.alreadyAbsent, false)
+  assert.ok(!fs.existsSync(target))
+})
+
+tap('cleanupApprovalMarker is idempotent — ENOENT returns status: ok, alreadyAbsent: true', () => {
+  const root = tmpProjectRoot()
+  const result = cleanupApprovalMarker(root, RUN_ID)
+  assert.equal(result.status, 'ok')
+  assert.equal(result.alreadyAbsent, true)
+})
+
+tap('cleanupApprovalMarker idempotent on second call after successful first', () => {
+  const root = tmpProjectRoot()
+  writeMarker({
+    projectRoot: root, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const a = cleanupApprovalMarker(root, RUN_ID)
+  const b = cleanupApprovalMarker(root, RUN_ID)
+  assert.equal(a.status, 'ok')
+  assert.equal(a.alreadyAbsent, false)
+  assert.equal(b.status, 'ok')
+  assert.equal(b.alreadyAbsent, true)
+})
+
+tap('cleanupApprovalMarker invalid run_id returns status: error with invalid-input code', () => {
+  const root = tmpProjectRoot()
+  const result = cleanupApprovalMarker(root, 'BAD CASE')
+  assert.equal(result.status, 'error')
+  assert.equal(result.code, 'invalid-input')
+})
+
+// ---------------------------------------------------------------------------
+// Axis-9 / discipline #20: caller-cwd ≠ projectRoot — artifacts land under target
+// ---------------------------------------------------------------------------
+
+tap('writeMarker artifact lands under projectRoot regardless of process.cwd', () => {
+  const target = tmpProjectRoot()
+  const otherDir = tmpProjectRoot()  // caller cwd
+  const origCwd = process.cwd()
+  try {
+    process.chdir(otherDir)
+    const result = writeMarker({
+      projectRoot: target, runId: RUN_ID, decidedClass: 'trivial',
+      createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+    })
+    assert.equal(result.status, 'ok')
+    assert.ok(fs.existsSync(path.join(target, '.checkpoints', `bp1-approval-${RUN_ID}.json`)))
+    // Caller cwd MUST NOT have a .checkpoints/.
+    assert.ok(!fs.existsSync(path.join(otherDir, '.checkpoints')))
+  } finally {
+    process.chdir(origCwd)
+  }
+})
+
+tap('cleanupApprovalMarker artifact targeted by projectRoot regardless of cwd', () => {
+  const target = tmpProjectRoot()
+  const otherDir = tmpProjectRoot()
+  writeMarker({
+    projectRoot: target, runId: RUN_ID, decidedClass: 'trivial',
+    createdAt: CREATED_AT, deadlineAt: DEADLINE_AT, runKey32B: KEY,
+  })
+  const origCwd = process.cwd()
+  try {
+    process.chdir(otherDir)
+    const result = cleanupApprovalMarker(target, RUN_ID)
+    assert.equal(result.status, 'ok')
+    assert.equal(result.alreadyAbsent, false)
+    assert.ok(!fs.existsSync(path.join(target, '.checkpoints', `bp1-approval-${RUN_ID}.json`)))
+  } finally {
+    process.chdir(origCwd)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Bail summary
+// ---------------------------------------------------------------------------
+
+console.log(`# tests ${pass + fail}`)
+console.log(`# pass  ${pass}`)
+console.log(`# fail  ${fail}`)
+if (fail > 0) process.exit(1)

--- a/tests/test-bp1-orchestrator-288-resume.mjs
+++ b/tests/test-bp1-orchestrator-288-resume.mjs
@@ -139,19 +139,19 @@ function runRecordClassification(ctx, resultFile, opts = {}) {
 // ===========================================================================
 // 288-1 — crash between Phase A and Phase B → retry emits route
 // ===========================================================================
-tap('288-1 crash between Phase A and Phase B → retry emits route from classified', () => {
+tap('288-1 crash between Phase A and Phase B → retry emits route from classified (risky)', () => {
+  // Slice 2d-W Option A: trivial no longer emits a route episode in Phase B.
+  // Re-shape this crash-retry test around the risky path (schema → needs-human)
+  // which still exercises the Phase-A-success / Phase-B-pending recovery.
   const ctx = setupPreDispatched()
-  const resultFile = writeResultFile(ctx.project)
+  const resultFile = writeResultFile(ctx.project, { class: 'schema', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
 
-  // Simulate the post-Phase-A pre-Phase-B state directly: emit a signed
-  // classified episode, then manually set idx { state: 'classified',
-  // classified_episode_id, decided_class }. Do NOT emit a route episode.
   const classifiedEp = writeBp1Episode({
     projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
     type: 'state-transition', state: 'classified',
     summary: `test-induced classified`,
     parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
-    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    customFm: { decided_class: 'schema', classifier_confidence: '0.85' },
     tags: ['bp1-classified'],
     body: '# classified\n',
     filenameSuffix: 'classified',
@@ -159,21 +159,20 @@ tap('288-1 crash between Phase A and Phase B → retry emits route from classifi
   withRunStateLockExclusive(ctx.project, () => {
     const idx = loadIndexLocked(ctx.project)
     idx.runs[ctx.runId].state = 'classified'
-    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].decided_class = 'schema'
     idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
     writeIndex(ctx.project, idx)
   })
 
-  // Retry with same args → Phase A no-op verify-only, Phase B emits route.
   const r = runRecordClassification(ctx, resultFile)
   assert.equal(r.status, 0, `stderr=${r.stderr}`)
   const out = JSON.parse(r.stdout)
-  assert.equal(out.state, 'planning', `expected planning; got ${out.state}`)
+  assert.equal(out.state, 'needs-human', `expected needs-human; got ${out.state}`)
   assert.equal(out.classified_episode_id, classifiedEp.episodeId, 'must reuse existing classified ep')
   assert.ok(out.route_episode_id, 'route episode id present')
   const idx = loadIndex(ctx.project)
   const run = idx.runs[ctx.runId]
-  assert.equal(run.state, 'planning')
+  assert.equal(run.state, 'needs-human')
   assert.equal(run.classified_episode_id, classifiedEp.episodeId)
   assert.equal(run.route_episode_id, out.route_episode_id)
 })
@@ -274,38 +273,36 @@ tap('288-4 drift: stored classified_episode_id with mismatched decided_class →
 // ===========================================================================
 // 288-5 — parent-drift: signed orphan route with wrong parent_episode → exit 5
 // ===========================================================================
-tap('288-5 Phase B orphan route with wrong parent_episode → exit 5', () => {
+tap('288-5 Phase B orphan route with wrong parent_episode → exit 5 (risky)', () => {
+  // Slice 2d-W Option A: trivial skips Phase B; re-shape this orphan-with-
+  // wrong-parent invariant test around the risky path (schema → needs-human).
   const ctx = setupPreDispatched()
-  const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
+  const resultFile = writeResultFile(ctx.project, { class: 'schema', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
 
-  // Emit a valid classified.
   const classifiedEp = writeBp1Episode({
     projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
     type: 'state-transition', state: 'classified',
     summary: 'classified', parentEpisode: ctx.preEpisodeId, expectedPostEpisodeId: null,
-    customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
+    customFm: { decided_class: 'schema', classifier_confidence: '0.85' },
     tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
   })
-  // Emit a planning route with WRONG parent (points to some unrelated id).
+  // Emit a needs-human route with WRONG parent (points to some unrelated id).
   const fakeParent = `${ctx.runId}-fake-9999`
   writeBp1Episode({
     projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
-    type: 'state-transition', state: 'planning',
-    summary: 'wrong-parent planning', parentEpisode: fakeParent, expectedPostEpisodeId: null,
-    customFm: { source_class: 'trivial' },
-    tags: ['bp1-planning'], body: '# p\n', filenameSuffix: 'planning',
+    type: 'state-transition', state: 'needs-human',
+    summary: 'wrong-parent needs-human', parentEpisode: fakeParent, expectedPostEpisodeId: null,
+    customFm: { reason: 'risky-class', decided_class: 'schema' },
+    tags: ['bp1-needs-human'], body: '# nh\n', filenameSuffix: 'needs-human',
   })
-  // Idx: state=classified + classified_episode_id set, route null.
   withRunStateLockExclusive(ctx.project, () => {
     const idx = loadIndexLocked(ctx.project)
     idx.runs[ctx.runId].state = 'classified'
-    idx.runs[ctx.runId].decided_class = 'trivial'
+    idx.runs[ctx.runId].decided_class = 'schema'
     idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
     writeIndex(ctx.project, idx)
   })
 
-  // Phase B orphan-scan finds the planning episode but parent_episode
-  // mismatches classified_episode_id → field-mismatch → drift.
   const r = runRecordClassification(ctx, resultFile)
   assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
   assert.match(r.stderr, /recoverable-canonical-drift/)
@@ -336,25 +333,30 @@ tap('288-6 state=classified + null classified_episode_id + no signed → recover
 // ===========================================================================
 // 288-7 — happy path: trivial → planning; classified + route pointers in idx
 // ===========================================================================
-tap('288-7 trivial happy path: classified_episode_id + route_episode_id persisted in idx', () => {
+tap('288-7 trivial happy path: classified_episode_id persisted; route_episode_id stays null (slice 2d-W Option A)', () => {
+  // Slice 2d-W Option A: trivial stops at stable `classified` state; no route
+  // episode is emitted. Slice 2e/2f follow-up `record-awaiting-approval`
+  // performs the safety-envelope transition into awaiting_approval.
   const ctx = setupPreDispatched()
   const resultFile = writeResultFile(ctx.project)
   const r = runRecordClassification(ctx, resultFile)
   assert.equal(r.status, 0, `stderr=${r.stderr}`)
   const out = JSON.parse(r.stdout)
-  assert.equal(out.state, 'planning')
+  assert.equal(out.state, 'classified')
+  assert.equal(out.route_episode_id, null, 'route_episode_id stays null for trivial')
   const idx = loadIndex(ctx.project)
   const run = idx.runs[ctx.runId]
-  assert.equal(run.state, 'planning')
+  assert.equal(run.state, 'classified')
   assert.equal(run.classified_episode_id, out.classified_episode_id, 'idx must persist classified_episode_id')
-  assert.equal(run.route_episode_id, out.route_episode_id, 'idx must persist route_episode_id')
+  assert.equal(run.route_episode_id, null, 'idx route_episode_id stays null')
 })
 
 // ===========================================================================
-// 288-8 — F1 planning: signed orphan planning with mismatched source_class
-// must be rejected as field-mismatch (NOT silently attached).
+// 288-8 — Slice 2d-W Option A: trivial stays at classified; verify Phase B
+// trivial-skip rejects when run.state was advanced to planning by slice-2c-era
+// code (state-violation reject, preserves F2 invariant for trivial).
 // ===========================================================================
-tap('288-8 F1: Phase B planning orphan with mismatched source_class → field-mismatch exit 5', () => {
+tap('288-8 trivial-skip Phase B rejects when run.state=planning (slice-2c-era artifact) → state-violation exit 5', () => {
   const ctx = setupPreDispatched()
   const resultFile = writeResultFile(ctx.project, { class: 'trivial', confidence: 0.85, rationale: 'r', classified_fields: ['x'] })
 
@@ -366,26 +368,21 @@ tap('288-8 F1: Phase B planning orphan with mismatched source_class → field-mi
     customFm: { decided_class: 'trivial', classifier_confidence: '0.85' },
     tags: ['bp1-classified'], body: '# c\n', filenameSuffix: 'classified',
   })
-  // Signed planning episode with RIGHT parent but WRONG source_class.
-  writeBp1Episode({
-    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
-    type: 'state-transition', state: 'planning',
-    summary: 'tampered planning', parentEpisode: classifiedEp.episodeId, expectedPostEpisodeId: null,
-    customFm: { source_class: 'tampered' },   // ≠ 'trivial'
-    tags: ['bp1-planning'], body: '# p\n', filenameSuffix: 'planning',
-  })
+  // Simulate slice-2c-era leftover state: run advanced to planning under
+  // decided_class=trivial. With Option A this is now illegitimate; Phase B
+  // trivial-skip must reject rather than silently report state=classified.
   withRunStateLockExclusive(ctx.project, () => {
     const idx = loadIndexLocked(ctx.project)
-    idx.runs[ctx.runId].state = 'classified'
+    idx.runs[ctx.runId].state = 'planning'
     idx.runs[ctx.runId].decided_class = 'trivial'
     idx.runs[ctx.runId].classified_episode_id = classifiedEp.episodeId
     writeIndex(ctx.project, idx)
   })
 
-  // Phase B orphan-scan: parent matches but source_class doesn't → field-mismatch.
   const r = runRecordClassification(ctx, resultFile)
   assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
-  assert.match(r.stderr, /recoverable-canonical-drift/)
+  assert.match(r.stderr, /state-violation \(Phase B\)/)
+  assert.match(r.stderr, /no route emission|decided_class=trivial/)
 })
 
 // ===========================================================================
@@ -480,7 +477,9 @@ tap('288-11 F2: run.state=needs-human but decided_class=trivial (targetState mis
   const r = runRecordClassification(ctx, resultFile)
   assert.equal(r.status, 5, `expected exit 5; got ${r.status}; stderr=${r.stderr}`)
   assert.match(r.stderr, /state-violation \(Phase B\)/)
-  assert.match(r.stderr, /targetState=planning/)
+  // Slice 2d-W Option A: trivial decided_class no longer emits a route episode;
+  // F2 reject for past-advanced state under trivial reports "no route emission".
+  assert.match(r.stderr, /no route emission|decided_class=trivial/)
 })
 
 // ===========================================================================

--- a/tests/test-bp1-orchestrator-classifier-fence.mjs
+++ b/tests/test-bp1-orchestrator-classifier-fence.mjs
@@ -260,21 +260,28 @@ function validClassifierOutput(klass = 'trivial', overrides = {}) {
   }
 }
 
-tap('T-class-happy-trivial trivial → state=planning, bp1-planning episode emitted', () => {
+tap('T-class-happy-trivial trivial → state=classified (stable), NO bp1-planning episode (slice 2d-W Option A)', () => {
+  // Slice 2d-W (Option A, codex r3 episode 20260517-021728-...-fd95):
+  // trivial-class runs stop at stable `classified` state. record-classification
+  // Phase B is a no-op for trivial; the safety-envelope transition into
+  // `awaiting_approval` is the responsibility of `record-awaiting-approval`.
   const ctx = setupRfcDetected()
   const { r: pr } = preDispatch(ctx)
   const preId = JSON.parse(pr.stdout).pre_episode_id
   const r = recordClassification(ctx, validClassifierOutput('trivial'), preId)
   assert.equal(r.status, 0, `stderr=${r.stderr}`)
   const out = JSON.parse(r.stdout)
-  assert.equal(out.state, 'planning')
+  assert.equal(out.state, 'classified')
   assert.equal(out.decided_class, 'trivial')
+  assert.equal(out.route_episode_id, null, 'route_episode_id stays null for trivial')
   const idx = loadIndex(ctx.project)
-  assert.equal(idx.runs[ctx.runId].state, 'planning')
+  assert.equal(idx.runs[ctx.runId].state, 'classified')
   assert.equal(idx.runs[ctx.runId].decided_class, 'trivial')
-  // bp1-planning episode exists.
+  assert.equal(idx.runs[ctx.runId].route_episode_id, null)
+  // classified episode exists; bp1-planning episode does NOT.
   const eps = fs.readdirSync(path.join(ctx.project, '.episodic-memory/episodes'))
-  assert.ok(eps.some(f => f.includes('-planning-')), 'bp1-planning episode written')
+  assert.ok(eps.some(f => f.includes('-classified-')), 'classified episode written')
+  assert.ok(!eps.some(f => f.includes('-planning-')), 'NO bp1-planning episode emitted for trivial (Option A)')
 })
 
 tap('T-class-happy-risky schema → state=needs-human, bp1-needs-human episode emitted', () => {
@@ -460,11 +467,14 @@ tap('T-class-classified-fields-empty minItems:1 catches empty → schema-violati
   assert.equal(r.status, 5)
 })
 
-tap('T-class-route-eps classified + route episodes verify HMAC', () => {
+tap('T-class-route-eps classified + needs-human route episodes verify HMAC (risky route)', () => {
+  // Slice 2d-W (Option A): trivial no longer emits a route episode. Switch
+  // this test to use a risky-class input so it still exercises the
+  // classified + route HMAC verification path.
   const ctx = setupRfcDetected()
   const { r: pr } = preDispatch(ctx)
   const preId = JSON.parse(pr.stdout).pre_episode_id
-  const r = recordClassification(ctx, validClassifierOutput('trivial'), preId)
+  const r = recordClassification(ctx, validClassifierOutput('schema'), preId)
   assert.equal(r.status, 0)
   const out = JSON.parse(r.stdout)
   // Verify classified episode HMAC.
@@ -478,7 +488,7 @@ tap('T-class-route-eps classified + route episodes verify HMAC', () => {
   const v2 = verifyEpisodeOnDisk({
     projectRoot: ctx.project, episodeId: out.route_episode_id,
     runKey32B: ctx.runKey, expectedType: 'state-transition',
-    expectedState: 'planning', expectedRunId: ctx.runId,
+    expectedState: 'needs-human', expectedRunId: ctx.runId,
   })
   assert.deepEqual(v2, { ok: true })
 })
@@ -496,12 +506,15 @@ tap('T-fail-5 parent pre tampered at record-classification → exit 5 + parent-t
   assert.ok(eps.some(f => f.includes('parent-tamper')))
 })
 
-tap('T-class-trivial-route-state planning state in run-state', () => {
+tap('T-class-trivial-route-state classified state in run-state (slice 2d-W Option A)', () => {
+  // Trivial-class stays at stable `classified` state per slice 2d-W Option A.
+  // `awaiting_approval` is reached via the separate record-awaiting-approval
+  // subcommand (1hr safety-envelope window).
   const ctx = setupRfcDetected()
   const { r: pr } = preDispatch(ctx)
   const preId = JSON.parse(pr.stdout).pre_episode_id
   recordClassification(ctx, validClassifierOutput('trivial'), preId)
-  assert.equal(loadIndex(ctx.project).runs[ctx.runId].state, 'planning')
+  assert.equal(loadIndex(ctx.project).runs[ctx.runId].state, 'classified')
 })
 
 tap('T-class-validator-route-state needs-human state in run-state', () => {

--- a/tests/test-bp1-orchestrator-record-awaiting-approval.mjs
+++ b/tests/test-bp1-orchestrator-record-awaiting-approval.mjs
@@ -35,6 +35,8 @@ const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.me
 const { loadIndex } = rsmod
 const markerMod = await import(new URL('../scripts/lib/bp1-marker.mjs', import.meta.url).href)
 const { markerPath, canonicalizeMarkerPayload } = markerMod
+const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
+const { writeBp1Episode } = writerMod
 
 let pass = 0, fail = 0
 function tap(name, fn) {
@@ -348,6 +350,81 @@ tap('RAA-12b resume-branch --classified-episode-id mismatch → precise state-vi
   const r2 = runRecordAwaiting(ctx, { classifiedEpisodeId: bogus })
   assert.equal(r2.status, 5)
   assert.match(r2.stderr, /state-violation: --classified-episode-id .* != run\.classified_episode_id/)
+})
+
+tap('RAA-3b Phase-A orphan window: signed awaiting_approval ep + state=classified → retry adopts orphan timestamps (codex PR-#305 r1 P1)', () => {
+  // Simulate the crash-after-emit-before-writeIndex window: emit a signed
+  // awaiting_approval episode directly (bypassing the orchestrator), leave
+  // run-state at `classified`, then retry record-awaiting-approval.
+  // Pre-fix: fresh path mints a new timestamp, findSignedStateEpisode with
+  // expectedFields returns field-mismatch → recoverable-canonical-drift exit 5.
+  // Post-fix: orphan-lookup-first WITHOUT expectedFields adopts orphan's
+  // timestamps, transitions state, Phase B writes byte-identical marker.
+  const ctx = setupClassifiedTrivial()
+  const orphanAwaitingAt = '2026-01-02T03:04:05.678Z'
+  const orphanDeadlineAt = new Date(new Date(orphanAwaitingAt).getTime() + 3600 * 1000).toISOString()
+  const orphan = writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'awaiting_approval',
+    summary: `BP-1 awaiting_approval (deadline ${orphanDeadlineAt}): ${ctx.runId}`,
+    parentEpisode: ctx.classifiedEpisodeId, expectedPostEpisodeId: null,
+    customFm: {
+      awaiting_approval_at: orphanAwaitingAt,
+      deadline_at: orphanDeadlineAt,
+      decided_class: 'trivial',
+    },
+    tags: ['bp1-awaiting-approval'],
+    body: `# bp1-awaiting-approval orphan — ${ctx.runId}\n`,
+    filenameSuffix: 'awaiting-approval',
+  })
+  // Run-state still at classified (the crash window).
+  const idxBefore = loadIndex(ctx.project)
+  assert.equal(idxBefore.runs[ctx.runId].state, 'classified')
+  // awaiting_approval_at is `null` (explicit) on a v2 row before Phase A persists.
+  assert.equal(idxBefore.runs[ctx.runId].awaiting_approval_at, null)
+  // Retry record-awaiting-approval.
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 0, `orphan-attach retry failed: ${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.awaiting_approval_episode_id, orphan.episodeId,
+    'retry must attach the orphan, not emit a new awaiting_approval episode')
+  assert.equal(out.awaiting_approval_at, orphanAwaitingAt,
+    'retry must adopt orphan timestamp, not mint fresh wall-clock')
+  assert.equal(out.deadline_at, orphanDeadlineAt)
+  // Confirm: still only 1 signed awaiting_approval episode on disk.
+  const epDir = path.join(ctx.project, '.episodic-memory', 'episodes')
+  const matching = fs.readdirSync(epDir).filter(n => n.startsWith(ctx.runId) && n.includes('-awaiting-approval-') && !n.includes('.tmp.'))
+  assert.equal(matching.length, 1, `expected exactly 1 signed awaiting_approval ep; got ${matching.length}: ${matching.join(',')}`)
+  // Marker on disk uses orphan's timestamps.
+  const mp = markerPath(ctx.project, ctx.runId)
+  const marker = JSON.parse(fs.readFileSync(mp, 'utf8'))
+  assert.equal(marker.created_at, orphanAwaitingAt)
+  assert.equal(marker.deadline_at, orphanDeadlineAt)
+})
+
+tap('RAA-3c Phase-A orphan window: orphan parent_episode mismatch → recoverable-canonical-drift exit 5', () => {
+  // Defense: if a signed orphan exists but its parent_episode does NOT match
+  // --classified-episode-id, the orphan belongs to a different classification
+  // context. Refuse to attach.
+  const ctx = setupClassifiedTrivial()
+  const wrongParent = `${ctx.runId}-classified-9999`
+  writeBp1Episode({
+    projectRoot: ctx.project, runId: ctx.runId, runKey32B: ctx.runKey,
+    type: 'state-transition', state: 'awaiting_approval',
+    summary: `BP-1 awaiting_approval orphan with wrong parent: ${ctx.runId}`,
+    parentEpisode: wrongParent, expectedPostEpisodeId: null,
+    customFm: {
+      awaiting_approval_at: '2026-01-02T03:04:05.678Z',
+      deadline_at: '2026-01-02T04:04:05.678Z',
+      decided_class: 'trivial',
+    },
+    tags: ['bp1-awaiting-approval'],
+    body: `# orphan wrong-parent\n`,
+    filenameSuffix: 'awaiting-approval',
+  })
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 5)
+  assert.match(r.stderr, /recoverable-canonical-drift.*parent_episode.*!=.*--classified-episode-id/)
 })
 
 tap('RAA-13 parent classified episode tampered → exit 5 + parent-tamper failure ep', () => {

--- a/tests/test-bp1-orchestrator-record-awaiting-approval.mjs
+++ b/tests/test-bp1-orchestrator-record-awaiting-approval.mjs
@@ -1,0 +1,477 @@
+#!/usr/bin/env node
+/**
+ * test-bp1-orchestrator-record-awaiting-approval.mjs — Slice 2d-W E2E tests.
+ *
+ * Coverage (codex r3 ACCEPT requirements):
+ *   - happy path: classified (trivial) → awaiting_approval + marker on disk
+ *   - state transitions persist awaiting_approval_at + deadline_at deterministically
+ *   - Phase B retry produces byte-identical marker (M1 determinism, codex r3)
+ *   - non-trivial decided_class rejected (state-violation)
+ *   - state != classified rejected (state-violation)
+ *   - --classified-episode-id mismatch rejected
+ *   - parent classified episode tamper → parent-tamper failure episode emitted
+ *   - argv validation: --run-id shape, --classified-episode-id shape, --project resolution
+ *   - axis-9 / discipline #20: caller cwd ≠ --project (artifacts land under target;
+ *     caller has no .checkpoints/.episodic-memory pollution)
+ *   - nested --project <target/subdir> resolves via git rev-parse (B3)
+ *   - finalize cleanup: terminal transition removes marker (M2 cleanup wiring)
+ *   - linked worktree: marker writes under main-root .checkpoints/ (codex r3 caveat)
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const ORCHESTRATOR = path.join(REPO, 'scripts', 'bp1-orchestrator.mjs')
+const ARTIFACT_BUILDER = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
+
+const hmacMod = await import(new URL('../scripts/lib/bp1-hmac.mjs', import.meta.url).href)
+const { verifyKeyFingerprint, verifyCanonical } = hmacMod
+const rsmod = await import(new URL('../scripts/lib/bp1-run-state.mjs', import.meta.url).href)
+const { loadIndex } = rsmod
+const markerMod = await import(new URL('../scripts/lib/bp1-marker.mjs', import.meta.url).href)
+const { markerPath, canonicalizeMarkerPayload } = markerMod
+
+let pass = 0, fail = 0
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+// =============================================================================
+// Sandbox setup: project with one classified (trivial) run ready for
+// record-awaiting-approval invocation.
+// =============================================================================
+
+function makeProj() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-raa-proj-'))
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs', 'rfcs'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function makeHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-raa-home-'))
+  fs.mkdirSync(path.join(dir, '.episodic-memory'), { recursive: true })
+  return fs.realpathSync(dir)
+}
+function writeKey(homeDir) {
+  const key = crypto.randomBytes(32)
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/.verify-key'), key, { mode: 0o600 })
+  return verifyKeyFingerprint(key)
+}
+function buildHash(projectRoot, homeDir) {
+  return JSON.parse(execFileSync('node', [ARTIFACT_BUILDER, '--project', projectRoot, '--json'],
+    { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })).sha256
+}
+function writeConfig(homeDir, projectRoot, fingerprint) {
+  fs.writeFileSync(path.join(homeDir, '.episodic-memory/config.json'),
+    JSON.stringify({
+      bp1: {
+        schema_version: 1,
+        activations: {
+          [projectRoot]: {
+            enabled: true,
+            artifact_version_hash: 'sha256:' + buildHash(projectRoot, homeDir),
+            enabled_at: new Date().toISOString(),
+            enabled_via: 'test-fixture',
+            verify_key_id: fingerprint,
+          },
+        },
+      },
+    }, null, 2))
+}
+function writeRfc(projectRoot, name, status = 'accepted') {
+  fs.writeFileSync(path.join(projectRoot, 'docs', 'rfcs', `${name}.md`),
+    `---\nrfc_id: ${name}\nstatus: ${JSON.stringify(status)}\ntitle: ${JSON.stringify('T')}\n---\n\nbody.\n`)
+}
+function runOrch(args, { project, homeDir, callerCwd }) {
+  return spawnSync('node', [ORCHESTRATOR, ...args], {
+    cwd: callerCwd ?? project, encoding: 'utf8',
+    env: { ...process.env, HOME: homeDir },
+  })
+}
+
+/**
+ * Set up a project with one classified-trivial run. Returns
+ * { project, home, runId, runKey, classifiedEpisodeId, preEpisodeId }.
+ */
+function setupClassifiedTrivial() {
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  writeRfc(project, 'RFC-RAA')
+  writeConfig(home, project, fp)
+  // detect-rfcs → state=rfc-detected
+  const detR = runOrch(['detect-rfcs', '--project', project], { project, homeDir: home })
+  if (detR.status !== 0) throw new Error(`detect-rfcs failed: ${detR.stderr}`)
+  const det = JSON.parse(detR.stdout).detected[0]
+  const runId = det.run_id
+  const runKey = fs.readFileSync(path.join(project, '.episodic-memory/runs', runId, 'run.key'))
+  // record-classifier-dispatch-pre → state=classifier-dispatch-pending
+  const sha = crypto.randomBytes(32).toString('hex')
+  const preR = runOrch([
+    'record-classifier-dispatch-pre', '--project', project, '--run-id', runId,
+    '--input-sha256', sha,
+  ], { project, homeDir: home })
+  if (preR.status !== 0) throw new Error(`pre-dispatch failed: ${preR.stderr}`)
+  const preEpisodeId = JSON.parse(preR.stdout).pre_episode_id
+  // record-classification trivial → state=classified (slice 2d-W Option A)
+  const resultFile = path.join(project, 'classifier-result.json')
+  fs.writeFileSync(resultFile, JSON.stringify({
+    class: 'trivial', confidence: 0.9, rationale: 'r', classified_fields: ['x'],
+  }))
+  const clsR = runOrch([
+    'record-classification', '--project', project, '--run-id', runId,
+    '--pre-episode-id', preEpisodeId, '--result-file', resultFile,
+  ], { project, homeDir: home })
+  if (clsR.status !== 0) throw new Error(`classification failed: ${clsR.stderr}`)
+  const cls = JSON.parse(clsR.stdout)
+  return {
+    project, home, runId, runKey,
+    classifiedEpisodeId: cls.classified_episode_id,
+    preEpisodeId,
+  }
+}
+
+/**
+ * Run record-awaiting-approval on a setupClassifiedTrivial context.
+ */
+function runRecordAwaiting(ctx, { project, classifiedEpisodeId, runId, callerCwd } = {}) {
+  return runOrch([
+    'record-awaiting-approval',
+    '--project', project ?? ctx.project,
+    '--run-id', runId ?? ctx.runId,
+    '--classified-episode-id', classifiedEpisodeId ?? ctx.classifiedEpisodeId,
+  ], { project: ctx.project, homeDir: ctx.home, callerCwd: callerCwd ?? ctx.project })
+}
+
+// =============================================================================
+// Happy path
+// =============================================================================
+
+tap('RAA-1 happy path: classified (trivial) → awaiting_approval + marker on disk', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.state, 'awaiting_approval')
+  assert.ok(out.awaiting_approval_episode_id)
+  assert.ok(out.awaiting_approval_at)
+  assert.ok(out.deadline_at)
+  assert.equal(out.marker_already_present, false)
+  // run-state advanced + new fields persisted.
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[ctx.runId].state, 'awaiting_approval')
+  assert.equal(idx.runs[ctx.runId].awaiting_approval_at, out.awaiting_approval_at)
+  assert.equal(idx.runs[ctx.runId].deadline_at, out.deadline_at)
+  // marker exists at canonical path.
+  assert.equal(out.marker_path, markerPath(ctx.project, ctx.runId))
+  assert.ok(fs.existsSync(out.marker_path))
+  // marker payload verifiable.
+  const marker = JSON.parse(fs.readFileSync(out.marker_path, 'utf8'))
+  assert.equal(marker.run_id, ctx.runId)
+  assert.equal(marker.decided_class, 'trivial')
+  assert.equal(marker.created_at, out.awaiting_approval_at)
+  assert.equal(marker.deadline_at, out.deadline_at)
+  // HMAC round-trips with the run key.
+  const { canonicalBytes } = canonicalizeMarkerPayload({
+    run_id: marker.run_id, created_at: marker.created_at,
+    decided_class: marker.decided_class, deadline_at: marker.deadline_at,
+  })
+  assert.ok(verifyCanonical(canonicalBytes, ctx.runKey, marker.hmac))
+})
+
+tap('RAA-2 deadline_at == awaiting_approval_at + 1hr per RFC §954', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 0)
+  const out = JSON.parse(r.stdout)
+  const a = new Date(out.awaiting_approval_at).getTime()
+  const d = new Date(out.deadline_at).getTime()
+  assert.equal(d - a, 60 * 60 * 1000)
+})
+
+tap('RAA-3 idempotent re-invocation: byte-identical marker, alreadyPresent=true (M1 determinism)', () => {
+  const ctx = setupClassifiedTrivial()
+  const r1 = runRecordAwaiting(ctx)
+  assert.equal(r1.status, 0)
+  const out1 = JSON.parse(r1.stdout)
+  const bytes1 = fs.readFileSync(out1.marker_path)
+  const r2 = runRecordAwaiting(ctx)
+  assert.equal(r2.status, 0)
+  const out2 = JSON.parse(r2.stdout)
+  assert.equal(out2.marker_already_present, true)
+  assert.equal(out1.awaiting_approval_at, out2.awaiting_approval_at)
+  assert.equal(out1.deadline_at, out2.deadline_at)
+  assert.equal(out1.awaiting_approval_episode_id, out2.awaiting_approval_episode_id)
+  const bytes2 = fs.readFileSync(out2.marker_path)
+  assert.ok(bytes1.equals(bytes2), 'byte-identical marker on retry')
+})
+
+// =============================================================================
+// Argv validation
+// =============================================================================
+
+tap('RAA-4 missing --project → exit 2', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runOrch(['record-awaiting-approval', '--run-id', ctx.runId, '--classified-episode-id', ctx.classifiedEpisodeId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+})
+
+tap('RAA-5 missing --run-id → exit 2', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runOrch(['record-awaiting-approval', '--project', ctx.project, '--classified-episode-id', ctx.classifiedEpisodeId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+})
+
+tap('RAA-6 missing --classified-episode-id → exit 2', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runOrch(['record-awaiting-approval', '--project', ctx.project, '--run-id', ctx.runId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+})
+
+tap('RAA-7 --classified-episode-id with traversal chars → exit 2', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runOrch(['record-awaiting-approval', '--project', ctx.project, '--run-id', ctx.runId,
+    '--classified-episode-id', '../escape'],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+})
+
+tap('RAA-8 --project pointing to non-existent path → exit 2', () => {
+  const ctx = setupClassifiedTrivial()
+  const r = runOrch(['record-awaiting-approval', '--project', '/nonexistent/path/here',
+    '--run-id', ctx.runId, '--classified-episode-id', ctx.classifiedEpisodeId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+})
+
+tap('RAA-9 --project not a git repo → exit 2 (project-root-resolution-failed)', () => {
+  const ctx = setupClassifiedTrivial()
+  const nonGitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-raa-nogit-'))
+  const r = runOrch(['record-awaiting-approval', '--project', nonGitDir,
+    '--run-id', ctx.runId, '--classified-episode-id', ctx.classifiedEpisodeId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 2)
+  assert.match(r.stderr, /project-root-resolution-failed|not a git repo/)
+})
+
+// =============================================================================
+// State invariants
+// =============================================================================
+
+tap('RAA-10 state != classified → exit 5 (state-violation)', () => {
+  // Setup: classified-trivial-pending then advance state to active manually.
+  const ctx = setupClassifiedTrivial()
+  // Use a non-trivial class by tampering would change state; here we just
+  // exercise the rejection on stale state. Use a fresh setup where we DON'T
+  // run record-classification yet (state=classifier-dispatch-pending).
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  writeRfc(project, 'RFC-RAA-X')
+  writeConfig(home, project, fp)
+  const detR = runOrch(['detect-rfcs', '--project', project], { project, homeDir: home })
+  const det = JSON.parse(detR.stdout).detected[0]
+  const sha = crypto.randomBytes(32).toString('hex')
+  runOrch(['record-classifier-dispatch-pre', '--project', project, '--run-id', det.run_id,
+    '--input-sha256', sha], { project, homeDir: home })
+  // state is now classifier-dispatch-pending; record-awaiting-approval needs classified.
+  const fakeCls = `${det.run_id}-classified-aaaa`
+  const r = runOrch(['record-awaiting-approval', '--project', project, '--run-id', det.run_id,
+    '--classified-episode-id', fakeCls], { project, homeDir: home })
+  assert.equal(r.status, 5)
+  assert.match(r.stderr, /state-violation|expected=classified/)
+})
+
+tap('RAA-11 decided_class != trivial → exit 5 (class-restriction state-violation)', () => {
+  // Setup classified-schema run; record-awaiting-approval must refuse.
+  const project = makeProj()
+  const home = makeHome()
+  const fp = writeKey(home)
+  writeRfc(project, 'RFC-RAA-RISKY')
+  writeConfig(home, project, fp)
+  const detR = runOrch(['detect-rfcs', '--project', project], { project, homeDir: home })
+  const det = JSON.parse(detR.stdout).detected[0]
+  const sha = crypto.randomBytes(32).toString('hex')
+  const preR = runOrch(['record-classifier-dispatch-pre', '--project', project, '--run-id', det.run_id,
+    '--input-sha256', sha], { project, homeDir: home })
+  const preEpisodeId = JSON.parse(preR.stdout).pre_episode_id
+  const resultFile = path.join(project, 'classifier-result.json')
+  fs.writeFileSync(resultFile, JSON.stringify({
+    class: 'schema', confidence: 0.9, rationale: 'r', classified_fields: ['x'],
+  }))
+  const clsR = runOrch([
+    'record-classification', '--project', project, '--run-id', det.run_id,
+    '--pre-episode-id', preEpisodeId, '--result-file', resultFile,
+  ], { project, homeDir: home })
+  assert.equal(clsR.status, 0)
+  const cls = JSON.parse(clsR.stdout)
+  // schema → needs-human; state is now needs-human, not classified.
+  const r = runOrch(['record-awaiting-approval', '--project', project,
+    '--run-id', det.run_id, '--classified-episode-id', cls.classified_episode_id],
+    { project, homeDir: home })
+  assert.equal(r.status, 5)
+  // Could be either state-violation (state=needs-human) or class restriction;
+  // either way exit 5 and stderr names the issue.
+  assert.match(r.stderr, /state-violation/)
+})
+
+tap('RAA-12 --classified-episode-id mismatch → exit 5', () => {
+  const ctx = setupClassifiedTrivial()
+  const bogus = `${ctx.runId}-classified-9999`
+  const r = runRecordAwaiting(ctx, { classifiedEpisodeId: bogus })
+  assert.equal(r.status, 5)
+  assert.match(r.stderr, /classified-episode-id.*!=|state-violation/)
+})
+
+tap('RAA-12b resume-branch --classified-episode-id mismatch → precise state-violation (parity with fresh-emit gate)', () => {
+  // After a successful Phase A (state=awaiting_approval, classified_episode_id
+  // persisted), re-invoking with a different --classified-episode-id should
+  // surface the same precise state-violation error as the fresh-emit gate,
+  // not the generic recoverable-canonical-drift from findSignedStateEpisode.
+  const ctx = setupClassifiedTrivial()
+  const r1 = runRecordAwaiting(ctx)
+  assert.equal(r1.status, 0, `fresh emit setup: stderr=${r1.stderr}`)
+  const bogus = `${ctx.runId}-classified-9999`
+  const r2 = runRecordAwaiting(ctx, { classifiedEpisodeId: bogus })
+  assert.equal(r2.status, 5)
+  assert.match(r2.stderr, /state-violation: --classified-episode-id .* != run\.classified_episode_id/)
+})
+
+tap('RAA-13 parent classified episode tampered → exit 5 + parent-tamper failure ep', () => {
+  const ctx = setupClassifiedTrivial()
+  const epPath = path.join(ctx.project, '.episodic-memory/episodes', `${ctx.classifiedEpisodeId}.md`)
+  fs.writeFileSync(epPath, fs.readFileSync(epPath, 'utf8') + '\nTAMPERED\n')
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 5)
+  const eps = fs.readdirSync(path.join(ctx.project, '.episodic-memory/episodes'))
+  assert.ok(eps.some(f => f.includes('parent-tamper')), 'parent-tamper failure ep emitted')
+})
+
+// =============================================================================
+// Axis-9 / discipline #20: caller cwd ≠ --project
+// =============================================================================
+
+tap('RAA-14 caller cwd ≠ --project → marker + episodes land under target only', () => {
+  const ctx = setupClassifiedTrivial()
+  const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-raa-caller-'))
+  execFileSync('git', ['init', '-q'], { cwd: otherDir })
+  const r = runRecordAwaiting(ctx, { callerCwd: otherDir })
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  // Target has marker + signed episode.
+  assert.ok(fs.existsSync(out.marker_path))
+  const targetEps = fs.readdirSync(path.join(ctx.project, '.episodic-memory/episodes'))
+  assert.ok(targetEps.some(f => f.includes('awaiting-approval')))
+  // Caller cwd has NO .checkpoints/ nor .episodic-memory/ pollution.
+  assert.ok(!fs.existsSync(path.join(otherDir, '.checkpoints')))
+  assert.ok(!fs.existsSync(path.join(otherDir, '.episodic-memory', 'episodes')))
+})
+
+tap('RAA-15 nested --project <target/subdir> resolves to canonical root via git toplevel (B3)', () => {
+  const ctx = setupClassifiedTrivial()
+  const subdir = path.join(ctx.project, 'docs')   // exists from makeProj
+  const r = runOrch(['record-awaiting-approval', '--project', subdir,
+    '--run-id', ctx.runId, '--classified-episode-id', ctx.classifiedEpisodeId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(r.status, 0, `stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  // Marker MUST land under the canonical root, not under the subdir.
+  assert.equal(out.marker_path, markerPath(ctx.project, ctx.runId))
+  assert.ok(fs.existsSync(out.marker_path))
+  assert.ok(!fs.existsSync(path.join(subdir, '.checkpoints')))
+})
+
+// =============================================================================
+// Finalize cleanup (M2 cleanup wiring)
+// =============================================================================
+
+tap('RAA-16 finalize-run E2E removes marker via orchestrator callsite (codex r3 P2)', () => {
+  // Codex r3 P2: RAA-16 previously tested cleanupApprovalMarker() directly.
+  // Replace with an orchestrator-level finalize-run E2E so the actual callsite
+  // wiring at scripts/bp1-orchestrator.mjs (post-markTerminal cleanup) is
+  // exercised end-to-end.
+  const ctx = setupClassifiedTrivial()
+  // First write the marker via record-awaiting-approval.
+  const raa = runRecordAwaiting(ctx)
+  assert.equal(raa.status, 0)
+  const raaOut = JSON.parse(raa.stdout)
+  assert.ok(fs.existsSync(raaOut.marker_path), 'marker exists pre-finalize')
+  // Now finalize the run. This exercises the orchestrator's markTerminal +
+  // cleanupApprovalMarker callsite (the wiring under test).
+  const fin = runOrch(['finalize-run', '--project', ctx.project, '--run-id', ctx.runId],
+    { project: ctx.project, homeDir: ctx.home })
+  assert.equal(fin.status, 0, `finalize-run failed: stderr=${fin.stderr}`)
+  // Verify: terminal state + marker removed.
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[ctx.runId].state, 'complete')
+  assert.ok(!fs.existsSync(raaOut.marker_path), 'marker removed by orchestrator cleanup callsite')
+})
+
+tap('RAA-18 marker-write-failed evidence lands under target only (codex r3 P2)', () => {
+  // Codex r3 P2: assert failure-episode disk location for marker-write-failed,
+  // not just exit code. Inject a writeMarker failure by pre-creating the
+  // target marker path as a DIRECTORY (so the atomic rename fails since you
+  // can't rename a file over a directory).
+  const ctx = setupClassifiedTrivial()
+  // Pre-create the marker path as a directory.
+  const target = markerPath(ctx.project, ctx.runId)
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.mkdirSync(target, { recursive: true })
+  // Run from a different cwd to verify caller-cwd isolation as well.
+  const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-raa-callerm-'))
+  execFileSync('git', ['init', '-q'], { cwd: otherDir })
+  const r = runRecordAwaiting(ctx, { callerCwd: otherDir })
+  // Exit 3 == marker-write-failed per contract.json subcommand_contracts.
+  assert.equal(r.status, 3, `expected exit 3 (marker-write-failed); got ${r.status}; stderr=${r.stderr}`)
+  assert.match(r.stderr, /marker-write-failed/)
+  // Failure episode under target.
+  const targetEps = fs.readdirSync(path.join(ctx.project, '.episodic-memory/episodes'))
+  assert.ok(targetEps.some(f => f.includes('marker-write-failed')),
+    `marker-write-failed episode emitted under target; got eps=${targetEps.join(',')}`)
+  // Caller cwd has zero pollution.
+  assert.ok(!fs.existsSync(path.join(otherDir, '.episodic-memory', 'episodes')),
+    'caller cwd has no .episodic-memory/episodes')
+  assert.ok(!fs.existsSync(path.join(otherDir, '.checkpoints')),
+    'caller cwd has no .checkpoints')
+  // Run-state stays at awaiting_approval (Phase A succeeded; Phase B failed).
+  const idx = loadIndex(ctx.project)
+  assert.equal(idx.runs[ctx.runId].state, 'awaiting_approval')
+})
+
+// =============================================================================
+// Activation gate
+// =============================================================================
+
+tap('RAA-17 disabled project (flag-check refusal) → exit 1', () => {
+  const ctx = setupClassifiedTrivial()
+  // Disable the project in config.
+  const configPath = path.join(ctx.home, '.episodic-memory/config.json')
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+  config.bp1.activations[ctx.project].enabled = false
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+  const r = runRecordAwaiting(ctx)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /bp1 inert/)
+})
+
+// =============================================================================
+// Bail summary
+// =============================================================================
+
+console.log(`# tests ${pass + fail}`)
+console.log(`# pass  ${pass}`)
+console.log(`# fail  ${fail}`)
+if (fail > 0) process.exit(1)


### PR DESCRIPTION
## Summary

Slice 2d-W (BP-1 auto-pilot M2 part 2): reshapes the trivial-class gate from post-Codex to post-classify per RFC v3.15. Trivial RFCs now hit `awaiting_approval` immediately after classification with a 1hr auto-approve deadline, an on-disk approval marker as the hook-input + forensic artifact, and a deterministic two-phase commit for marker write.

- `classified → awaiting_approval → {auto_approved | approved | aborted}` for trivial class
- `classified → needs_human` directly for risky classes (schema/validator/security/multi-actor — existing path)
- New `scripts/lib/bp1-marker.mjs` (278 LOC, zero deps) + `record-awaiting-approval` subcommand
- 4 finalize cleanup callsites in `finalize-run` + `finalize-recover` paths

Two commits on this branch:
- `61c7f0c` — RFC v3.15 spec update (already in flight from prior session)
- `8d958c0` — code + tests (this work)

## Review chain

- Codex plan-tier r3 **ACCEPT-with-FU** (episode `20260517-023916-...-8e33`)
- Codex RFC-update r2 **ACCEPT** (episode `20260517-030005-...-69e3`)
- negative-scenario-reviewer round 1 **ACCEPT** (all 10 invariants pass; 4 findings — 1 inlined as RAA-12b, 3 filed as #300/#301/#302)

## Step 8 E2E (2026-05-17)

Real `classified → record-awaiting-approval → awaiting_approval → finalize` cycle on a fresh temp project:
- marker: 312 bytes, mode 0600, 6-field sorted JSON (`body_sha256/created_at/deadline_at/decided_class/hmac/run_id`)
- `deadline_at == awaiting_approval_at + 1hr` exact
- Phase B idempotent retry: byte-identical timestamps + episode_id, `marker_already_present:true`
- `finalize-run --reason approved`: marker removed, state=`complete`
- no artifact leakage outside target project root

## Step 9 disposition

Reviewer + plan-tier follow-ups filed as separate issues / comments:

- #300 — state-name spelling (MINOR, internal vocabulary consistency)
- #301 — `expectedFields` registry tie-in (NIT, future-proofing)
- #302 — marker-as-dir forensics (MINOR, architectural)
- #303 — risky-class E2E shell walkthrough (codex r3 ACCEPT-with-FU)
- #304 — slice 2f M5 `--disable` marker-rm (RFC §665)
- Comment on #189: linked-worktree fixture + splice-before-H2 + hook exit-0-always semantics (slice 2d-R scope)

## Test plan

- [x] `tests/test-bp1-marker.mjs` — 24/24 (marker library)
- [x] `tests/test-bp1-orchestrator-record-awaiting-approval.mjs` — 19/19 (RAA-1..RAA-18 + RAA-12b parity test)
- [x] `tests/test-bp1-orchestrator-288-resume.mjs` — 13/13
- [x] `tests/test-bp1-orchestrator-classifier-fence.mjs` — 34/34
- [x] `tests/test-bp1-orchestrator-286-race-and-crash.mjs` — 7/7
- [x] `tests/test-bp1-orchestrator-287-rollback.mjs` — 2/2
- [x] `tests/test-bp1-finalize-run.mjs` — 45/45
- [x] `tests/test-bp1-orchestrator-init-run.mjs` — 12/12
- [x] `tests/test-bp1-canonicalize.mjs` — 28/28
- [x] `tests/test-bp1-run-state.mjs` — 22/22
- [x] `tests/test-bp1-run-state-migrate.mjs` — 13/13
- [x] `validate-rfc-contract-mirror.mjs` — ok
- [x] `validate-rfc-failure-table.mjs` — 37/37 yaml
- [x] `validate-rfc-canonical-fields.mjs` — 50 canonical fields ok
- [x] `validate-rfc-artifact-manifest.mjs` — 7 surfaces ok

## Rule 17 review flow

After merge gating: agent runs the bot review via `gh pr review --comment`; maintainer approves in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
