### PR TITLE
fix(plan-marker): concurrent-session-safe SessionStart sweep

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -39,6 +39,18 @@ jobs:
       - name: Run em-recall session-start orphan-sweep regression
         run: node tests/test-em-recall-session-start-early-exit.mjs
 
+      - name: Run em-recall plan-marker sweep regression (2026-05-18 concurrent-session fix)
+        run: node tests/test-em-recall-plan-marker-sweep.mjs
+
+      - name: Run em-recall --session-id binding regression
+        run: node tests/test-em-recall-session-id-binding.mjs
+
+      - name: Run em-recall-sessionstart hook-wrapper integration (cwd + stdin sid binding)
+        run: bash tests/test-em-recall-sessionstart-hook-binding.sh
+
+      - name: Run no-legacy-plan-marker-writes detector (Rule 13)
+        run: node tests/test-no-legacy-plan-marker-writes.mjs
+
       - name: Run em-strict-lstat regression
         run: node tests/test-em-strict-lstat.mjs
 

--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -148,6 +148,16 @@ fi
 if ! cd "$CWD" 2>/dev/null; then
   exit 0
 fi
-node "$EM_RECALL" --limit 5 --session-start >/dev/null 2>&1 || true
+
+# Parse stdin .session_id for em-recall's --session-id flag (codex R1 P1.2:
+# bind from authoritative SessionStart stdin, not env var). Empty value →
+# omit the flag, preserving prior wrapper contract. Validation lives inside
+# em-recall.mjs (warn-on-invalid; no exit-non-zero per codex R2 Q3).
+MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")"
+if [ -n "$MY_SID" ]; then
+  node "$EM_RECALL" --limit 5 --session-start --session-id "$MY_SID" >/dev/null 2>&1 || true
+else
+  node "$EM_RECALL" --limit 5 --session-start >/dev/null 2>&1 || true
+fi
 
 exit 0

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -37,6 +37,7 @@ import {
   _maxMtimeAcrossRootsStrict,
   _maxMtimeAcrossRootsForPlanMarkerStrict,
 } from './lib/stop-gate-helpers.mjs'
+import { validateSessionId } from './lib/session-id.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -63,6 +64,22 @@ const warnCount = parseInt(flag('--warn-count') || '5000', 10)
 const taskTypeFlag = flag('--task-type')
 const gateFlag = flag('--gate')
 const sessionStartFlag = argv.includes('--session-start')
+
+// --session-id <sid> — bound from SessionStart stdin `.session_id` via the
+// hook wrapper (em-recall-sessionstart.sh). Logging-only in v6 sweep: NOT
+// used to gate any sweep decision. Reserved for forward-compat with future
+// operator-cleanup tooling. Validation: per codex R2 Q3, missing/invalid
+// emits stderr warning, does NOT exit non-zero (hook reliability outweighs
+// strict contract).
+const sessionIdFlag = flag('--session-id')
+let mySid = null
+if (sessionIdFlag !== undefined) {
+  if (sessionIdFlag !== '' && validateSessionId(sessionIdFlag)) {
+    mySid = sessionIdFlag
+  } else if (sessionIdFlag !== '') {
+    process.stderr.write(`em-recall: warn — --session-id "${sessionIdFlag}" failed validateSessionId; treating as missing (no functional impact in v6 sweep)\n`)
+  }
+}
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
@@ -624,6 +641,30 @@ let priorBaselineMtime = null
 if (sessionStartFlag) {
   try {
     ensurePrimaryDir(REPO_ROOT)
+
+    // ---------------------------------------------------------------------
+    // Unconditional legacy-suffix-less plan-marker sweep (post-2026-05-18
+    // deadlock fix; codex R1 P1.4 + R2 P1). Runs OUTSIDE the
+    // priorBaselineMtime guard below so first-ever SessionStart on a fresh
+    // clone (no prior baseline) still reaps any pre-existing legacy orphan.
+    // Suffixed forms `.plan-approval-pending.<sid>` are NEVER swept here —
+    // SessionEnd hook (em-session-end-prompt.mjs, registry E21) owns
+    // own-session cleanup; cross-session crashed-orphan cleanup is the
+    // operator-cleanup FU. legacy-read-only: ok (this site only sweeps the
+    // legacy basename; never writes it).
+    // ---------------------------------------------------------------------
+    for (const dir of [path.join(REPO_ROOT, PRIMARY_MARKER_DIR), path.join(REPO_ROOT, LEGACY_MARKER_DIR)]) {
+      const p = path.join(dir, PLAN_MARKER_LEGACY_BASENAME)
+      try {
+        const st = fs.lstatSync(p)
+        if (!st.isSymbolicLink()) fs.rmSync(p, { force: true })
+      } catch (e) {
+        if (e.code !== 'ENOENT') {
+          process.stderr.write(`em-recall: legacy-plan-marker-sweep skipped ${p}: ${e.code || e.message}\n`)
+        }
+      }
+    }
+
     // Read baseline mtime from BOTH roots; take the most recent.
     for (const baselinePath of [primaryMarkerPath(REPO_ROOT, BASELINE_NAME), legacyMarkerPath(REPO_ROOT, BASELINE_NAME)]) {
       try {
@@ -637,28 +678,15 @@ if (sessionStartFlag) {
 
     if (priorBaselineMtime !== null) {
       for (const name of TASK_SIGNAL_MARKERS) {
-        // #268 fix E20: plan-marker member glob-expands suffixed forms.
-        // Sweep legacy `.plan-approval-pending` + every `.plan-approval-pending.<sid>`
-        // at both roots whose mtime <= prior baseline (stale orphan).
-        if (name === PLAN_MARKER_LEGACY_BASENAME) {
-          const prefix = `${PLAN_MARKER_LEGACY_BASENAME}.`
-          for (const dir of [path.join(REPO_ROOT, PRIMARY_MARKER_DIR), path.join(REPO_ROOT, LEGACY_MARKER_DIR)]) {
-            let entries = []
-            try { entries = fs.readdirSync(dir) } catch { continue }
-            for (const e of entries) {
-              if (e !== PLAN_MARKER_LEGACY_BASENAME && !e.startsWith(prefix)) continue
-              const p = path.join(dir, e)
-              try {
-                const st = fs.lstatSync(p)
-                if (st.isSymbolicLink()) continue
-                if (st.mtimeMs <= priorBaselineMtime) {
-                  fs.rmSync(p, { force: true })
-                }
-              } catch {}
-            }
-          }
-          continue
-        }
+        // Plan-marker class is handled exclusively by the unconditional
+        // legacy-suffix-less sweep above + em-session-end-prompt.mjs for
+        // own-session cleanup. Suffixed forms `.plan-approval-pending.<sid>`
+        // are NEVER swept by SessionStart — any baseline-mtime-based sweep
+        // can false-sweep a still-live session whose marker mtime > baseline
+        // (codex R2 P1: repeated SessionStart/resume rewrites baseline,
+        // then next SessionStart sees marker.mtime <= newer baseline and
+        // would remove it while session is still at plan approval).
+        if (name === PLAN_MARKER_LEGACY_BASENAME) continue
         for (const p of bothMarkerPaths(REPO_ROOT, name)) {
           try {
             const st = fs.lstatSync(p)

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -298,7 +298,14 @@ export const PLAN_MARKER_ENFORCEMENT_SITES = [
 
   // E19-E20: em-recall.mjs iteration consumers.
   { file: 'scripts/em-recall.mjs', line: 170, role: 'TASK_SIGNAL_MARKERS carve-out loop (glob-expands suffixed forms)', kind: 'js-array-iter', semantic_role: 'read-any' },
-  { file: 'scripts/em-recall.mjs', line: 587, role: 'TASK_SIGNAL_MARKERS orphan-clear sweep (glob-expands suffixed forms)', kind: 'js-array-iter', semantic_role: 'sweep-stale' },
+  { file: 'scripts/em-recall.mjs', line: 587, role: 'TASK_SIGNAL_MARKERS orphan-clear sweep (non-plan-marker class only; plan-marker handled by sibling unconditional sweep — post-2026-05-18 deadlock fix)', kind: 'js-array-iter', semantic_role: 'sweep-stale' },
+
+  // E20b: NEW unconditional legacy-suffix-less plan-marker sweep above the
+  // baseline guard. Suffixed forms `.plan-approval-pending.<sid>` are
+  // intentionally NOT swept here (codex R2 P1: baseline-mtime sweep can
+  // false-sweep live sessions on resume). Own-session cleanup remains the
+  // exclusive responsibility of E21 (em-session-end-prompt.mjs).
+  { file: 'scripts/em-recall.mjs', line: 587, role: 'unconditional .plan-approval-pending (suffix-less, legacy-only) sweep above baseline guard — post-2026-05-18 deadlock fix; suffixed forms NEVER swept here', kind: 'js-block', semantic_role: 'sweep-stale' },
 
   // E21: em-session-end-prompt.mjs own-session-only delete (F12 — codex r1 F1 fold).
   { file: 'scripts/em-session-end-prompt.mjs', line: 19, role: 'SessionEnd cleanup (own-session-only — F12)', kind: 'js-array-iter-own-session', semantic_role: 'remove-own-session' },

--- a/tests/test-em-recall-plan-marker-sweep.mjs
+++ b/tests/test-em-recall-plan-marker-sweep.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * test-em-recall-plan-marker-sweep.mjs — Direct em-recall --session-start
+ * invocations exercising the post-2026-05-18 sweep policy:
+ *
+ *   - Legacy suffix-less `.plan-approval-pending` swept UNCONDITIONALLY at
+ *     primary + legacy roots, regardless of baseline state
+ *   - Suffixed `.plan-approval-pending.<sid>` (own AND other) NEVER swept
+ *     by SessionStart (codex R1 P1.1 + R2 P1)
+ *
+ * Scenarios (plan v6 §test matrix):
+ *   P1  legacy at primary root + valid baseline → swept
+ *   P2  legacy at .claude root + valid baseline → swept
+ *   P3  legacy at primary + NO baseline (first-boot) → swept (codex R1 P1.4)
+ *   N1  other-session suffixed → preserved
+ *   N2  7-day-old crashed-session suffixed → preserved
+ *   N5  symlink at legacy path → preserved (lstat-fail-closed)
+ *   N6  repeated SessionStart with same SID-A → own marker preserved
+ *       across multiple SessionStart fires (codex R2 P1 canonical regression)
+ *   N7  concurrent SID-A + SID-B markers → both preserved
+ *   N8  non-git cwd + --project mismatch + baseline → cwd marker swept;
+ *       --project marker untouched (codex R5 P1.2 + R6 ACCEPT-FU)
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const EM_RECALL = path.join(REPO, 'scripts', 'em-recall.mjs')
+
+let passed = 0
+let failed = 0
+const cleanups = []
+process.on('exit', () => { for (const fn of cleanups) try { fn() } catch {} })
+
+function check(cond, msg) {
+  if (cond) { passed++; console.log(`  PASS  ${msg}`) }
+  else { failed++; console.log(`  FAIL  ${msg}`) }
+}
+
+function mkTmpGitRepo() {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-sweep-'))
+  const real = fs.realpathSync(raw)
+  fs.mkdirSync(path.join(real, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(real, '.claude'), { recursive: true })
+  spawnSync('git', ['init', '-q'], { cwd: real })
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  return real
+}
+
+function mkTmpNonGitDir() {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-sweep-nongit-'))
+  const real = fs.realpathSync(raw)
+  fs.mkdirSync(path.join(real, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(real, '.claude'), { recursive: true })
+  // NO git init — non-git cwd
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  return real
+}
+
+function touchWithMtime(p, secondsAgo) {
+  fs.writeFileSync(p, '')
+  const ts = (Date.now() / 1000) - secondsAgo
+  fs.utimesSync(p, ts, ts)
+}
+
+function runSessionStart(cwd, extraArgs = []) {
+  const args = [EM_RECALL, '--limit', '5', '--session-start', ...extraArgs]
+  return spawnSync('node', args, { cwd, encoding: 'utf8' })
+}
+
+// ============================ P1 ============================
+{
+  console.log('P1: legacy at primary + valid baseline → swept')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)  // 1h ago
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)  // 30m ago (newer than baseline — the bug class)
+  const r = runSessionStart(repo)
+  check(r.status === 0, `P1 exit 0 (got ${r.status})`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `P1 legacy swept`)
+}
+
+// ============================ P2 ============================
+{
+  console.log('P2: legacy at .claude root + valid baseline → swept')
+  const repo = mkTmpGitRepo()
+  const cl = path.join(repo, '.claude')
+  touchWithMtime(path.join(repo, '.checkpoints', '.session-baseline'), 3600)
+  touchWithMtime(path.join(cl, '.plan-approval-pending'), 1800)
+  const r = runSessionStart(repo)
+  check(r.status === 0, `P2 exit 0`)
+  check(!fs.existsSync(path.join(cl, '.plan-approval-pending')), `P2 legacy at .claude/ swept`)
+}
+
+// ============================ P3 — first boot, no baseline ============================
+{
+  console.log('P3: legacy at primary + NO baseline (first boot) → swept (codex R1 P1.4)')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  // NO baseline created
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)
+  const r = runSessionStart(repo)
+  check(r.status === 0, `P3 exit 0`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `P3 legacy swept on first boot`)
+}
+
+// ============================ N1 ============================
+{
+  console.log('N1: other-session suffixed → preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.other-session-B'), 1800)
+  const r = runSessionStart(repo, ['--session-id', 'session-A'])
+  check(r.status === 0, `N1 exit 0`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.other-session-B')), `N1 other-session marker preserved`)
+}
+
+// ============================ N2 — old crashed-session orphan ============================
+{
+  console.log('N2: 7-day-old crashed-session suffixed → preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 60)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.crashed-7d'), 7 * 24 * 3600)
+  const r = runSessionStart(repo, ['--session-id', 'session-A'])
+  check(r.status === 0, `N2 exit 0`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.crashed-7d')), `N2 crashed-orphan preserved (operator-cleanup FU)`)
+}
+
+// ============================ N5 — symlink preservation ============================
+{
+  console.log('N5: symlink at legacy path → preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  const target = path.join(repo, 'sentinel.txt')
+  fs.writeFileSync(target, 'must-not-be-deleted')
+  fs.symlinkSync(target, path.join(ck, '.plan-approval-pending'))
+  const r = runSessionStart(repo)
+  check(r.status === 0, `N5 exit 0`)
+  // lstat detects symlink; rmSync is skipped → symlink remains
+  check(fs.lstatSync(path.join(ck, '.plan-approval-pending')).isSymbolicLink(), `N5 symlink preserved (lstat-fail-closed)`)
+  check(fs.existsSync(target), `N5 symlink target intact`)
+}
+
+// ============================ N6 — repeated SessionStart, own marker preserved ============================
+{
+  console.log('N6: repeated SessionStart with same SID-A → own marker preserved (codex R2 P1 regression)')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.session-A'), 1800)
+  // Fire SessionStart 3 times — codex R2 canonical scenario
+  for (let i = 0; i < 3; i++) {
+    const r = runSessionStart(repo, ['--session-id', 'session-A'])
+    check(r.status === 0, `N6 iter ${i + 1} exit 0`)
+    check(fs.existsSync(path.join(ck, '.plan-approval-pending.session-A')), `N6 iter ${i + 1} own marker preserved`)
+  }
+}
+
+// ============================ N7 — concurrent A + B both preserved ============================
+{
+  console.log('N7: concurrent SID-A + SID-B markers → both preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.session-A'), 1800)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.session-B'), 900)
+  const r = runSessionStart(repo, ['--session-id', 'session-A'])
+  check(r.status === 0, `N7 exit 0`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.session-A')), `N7 own SID-A preserved`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.session-B')), `N7 concurrent SID-B preserved`)
+}
+
+// ============================ N8 — non-git cwd + --project mismatch ============================
+{
+  console.log('N8: non-git cwd + --project mismatch + baseline → cwd marker swept; --project untouched (codex R6 FU)')
+  const targetA = mkTmpNonGitDir()  // non-git cwd
+  const targetB = mkTmpGitRepo()    // separate dir passed via --project
+  const ckA = path.join(targetA, '.checkpoints')
+  const ckB = path.join(targetB, '.checkpoints')
+  // Codex R6 FU: pre-create baseline at target-A so the non-plan task-marker
+  // branch also fires alongside the new legacy sweep. Baseline newer than
+  // the legacy marker (older mtime).
+  touchWithMtime(path.join(ckA, '.plan-approval-pending'), 7200)  // 2h ago
+  touchWithMtime(path.join(ckA, '.session-baseline'), 3600)        // 1h ago, newer
+  touchWithMtime(path.join(ckB, '.plan-approval-pending'), 3600)
+  const r = runSessionStart(targetA, ['--project', targetB])
+  check(r.status === 0, `N8 exit 0 (got ${r.status})`)
+  check(!fs.existsSync(path.join(ckA, '.plan-approval-pending')), `N8 target-A legacy swept (cwd authority)`)
+  check(fs.existsSync(path.join(ckB, '.plan-approval-pending')), `N8 target-B legacy UNTOUCHED (--project is non-authoritative for sweeps)`)
+}
+
+// ============================ summary ============================
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/tests/test-em-recall-session-id-binding.mjs
+++ b/tests/test-em-recall-session-id-binding.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * test-em-recall-session-id-binding.mjs — Validates `--session-id` flag
+ * behavior on `em-recall --session-start`.
+ *
+ * Scenarios:
+ *   N3  --session-id missing → em-recall exits 0; legacy swept; suffixed
+ *       all preserved (no functional impact in v6 sweep since suffixed
+ *       forms are never swept here anyway, but flag wiring works)
+ *   N4  --session-id ../../etc/passwd (malformed) → em-recall exits 0
+ *       (warn-on-invalid per codex R2 Q3); legacy still swept; suffixed
+ *       all preserved; stderr contains a warning line
+ *   N4b --session-id empty string → exits 0, treated as missing
+ *   N4c --session-id valid SID → exits 0, no stderr warning
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const EM_RECALL = path.join(REPO, 'scripts', 'em-recall.mjs')
+
+let passed = 0
+let failed = 0
+const cleanups = []
+process.on('exit', () => { for (const fn of cleanups) try { fn() } catch {} })
+
+function check(cond, msg) {
+  if (cond) { passed++; console.log(`  PASS  ${msg}`) }
+  else { failed++; console.log(`  FAIL  ${msg}`) }
+}
+
+function mkTmpGitRepo() {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'em-sidbind-'))
+  const real = fs.realpathSync(raw)
+  fs.mkdirSync(path.join(real, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(real, '.claude'), { recursive: true })
+  spawnSync('git', ['init', '-q'], { cwd: real })
+  cleanups.push(() => fs.rmSync(real, { recursive: true, force: true }))
+  return real
+}
+
+function touchWithMtime(p, secondsAgo) {
+  fs.writeFileSync(p, '')
+  const ts = (Date.now() / 1000) - secondsAgo
+  fs.utimesSync(p, ts, ts)
+}
+
+function runSessionStart(cwd, extraArgs = []) {
+  const args = [EM_RECALL, '--limit', '5', '--session-start', ...extraArgs]
+  return spawnSync('node', args, { cwd, encoding: 'utf8' })
+}
+
+// ============================ N3 ============================
+{
+  console.log('N3: --session-id missing → exit 0; legacy swept; suffixed preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.foreign'), 1800)
+  const r = runSessionStart(repo)  // no --session-id
+  check(r.status === 0, `N3 exit 0`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `N3 legacy still swept (independent of session-id)`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.foreign')), `N3 suffixed preserved`)
+}
+
+// ============================ N4 — malformed sid ============================
+{
+  console.log('N4: --session-id ../../etc/passwd (malformed) → exit 0; warn; legacy swept; suffixed preserved')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)
+  touchWithMtime(path.join(ck, '.plan-approval-pending.foreign'), 1800)
+  const r = runSessionStart(repo, ['--session-id', '../../etc/passwd'])
+  check(r.status === 0, `N4 exit 0 (warn-on-invalid, not exit-non-zero per codex R2 Q3)`)
+  check(r.stderr.includes('failed validateSessionId'), `N4 stderr contains validateSessionId warning`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `N4 legacy still swept (independent of malformed sid)`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.foreign')), `N4 suffixed preserved`)
+}
+
+// ============================ N4b — empty string sid ============================
+{
+  console.log('N4b: --session-id "" (empty) → exit 0, treated as missing, no warning')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)
+  const r = runSessionStart(repo, ['--session-id', ''])
+  check(r.status === 0, `N4b exit 0`)
+  check(!r.stderr.includes('failed validateSessionId'), `N4b empty sid does not emit warning (treated as missing)`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `N4b legacy still swept`)
+}
+
+// ============================ N4c — valid sid ============================
+{
+  console.log('N4c: --session-id <valid uuid-ish> → exit 0, no warning')
+  const repo = mkTmpGitRepo()
+  const ck = path.join(repo, '.checkpoints')
+  touchWithMtime(path.join(ck, '.session-baseline'), 3600)
+  touchWithMtime(path.join(ck, '.plan-approval-pending'), 1800)
+  // Use a valid session-id shape: matches SESSION_ID_RE
+  const r = runSessionStart(repo, ['--session-id', '35522aab-5f44-4b84-b1cc-035cca7b9305'])
+  check(r.status === 0, `N4c exit 0`)
+  check(!r.stderr.includes('failed validateSessionId'), `N4c valid sid does not emit warning`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `N4c legacy still swept`)
+}
+
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/tests/test-em-recall-session-start-early-exit.mjs
+++ b/tests/test-em-recall-session-start-early-exit.mjs
@@ -426,6 +426,13 @@ function buildTempHome(homeRoot) {
     path.join(SCRIPTS, 'lib', 'stop-gate-helpers.mjs'),
     path.join(installedLib, 'stop-gate-helpers.mjs'),
   )
+  // 2026-05-18 concurrent-session fix: em-recall now imports session-id.mjs
+  // for the --session-id flag validation. Mirror per
+  // feedback_fixture_transitive_imports.md.
+  fs.copyFileSync(
+    path.join(SCRIPTS, 'lib', 'session-id.mjs'),
+    path.join(installedLib, 'session-id.mjs'),
+  )
   // No hook-install.json; warn_hook_freshness soft-fails on missing manifest.
   return installedScripts
 }

--- a/tests/test-em-recall-sessionstart-hook-binding.sh
+++ b/tests/test-em-recall-sessionstart-hook-binding.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-em-recall-sessionstart-hook-binding.sh — Integration test exercising
+# hooks/em-recall-sessionstart.sh end-to-end with constructed stdin JSON.
+#
+# Validates codex R3 P1 (hook wrapper coverage), R4 P1.1 (fake HOME),
+# R5 P1.1 (silent soft-noop when em-recall.mjs missing).
+#
+# Scenarios:
+#   H1  caller cwd != target; valid sid; legacy + suffixed pre-existing
+#   H2  nested cwd inside target
+#   H3  linked worktree cwd
+#   H4  stdin .session_id omitted (empty)
+#   H5  stdin .session_id malformed
+#   H6  fake HOME containing installed-runtime em-recall.mjs
+#   H6b fake HOME WITHOUT em-recall.mjs → silent soft-noop (exit 0, no
+#       stdout, no mutation) — codex R5 P1.1 corrected from R4 v4 expectation
+
+set -u
+
+REPO="$(cd -P "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO/hooks/em-recall-sessionstart.sh"
+
+passed=0
+failed=0
+cleanup_dirs=()
+trap 'for d in "${cleanup_dirs[@]}"; do rm -rf "$d" 2>/dev/null || true; done' EXIT
+
+# All scenarios run with HOME pointed at a fake home containing this
+# worktree's em-recall.mjs + lib/. Without this, tests would run against the
+# user's installed em-recall (which may be the pre-fix version) and pass for
+# the wrong reasons or fail confusingly. H6 keeps the fake-HOME assertion
+# explicit, but every scenario benefits from a stable runtime fixture.
+SHARED_FAKE_HOME="$(mktemp -d -t em-hook-sharedhome-XXXXXX)"
+SHARED_FAKE_HOME="$(cd "$SHARED_FAKE_HOME" && pwd -P)"
+mkdir -p "$SHARED_FAKE_HOME/.episodic-memory/scripts/lib"
+cp "$REPO/scripts/em-recall.mjs" "$SHARED_FAKE_HOME/.episodic-memory/scripts/"
+cp "$REPO/scripts/lib/"*.mjs "$SHARED_FAKE_HOME/.episodic-memory/scripts/lib/"
+cleanup_dirs+=("$SHARED_FAKE_HOME")
+export HOME="$SHARED_FAKE_HOME"
+
+check() {
+  local cond="$1" msg="$2"
+  if [ "$cond" = "1" ]; then
+    passed=$((passed + 1))
+    echo "  PASS  $msg"
+  else
+    failed=$((failed + 1))
+    echo "  FAIL  $msg"
+  fi
+}
+
+mk_git_target() {
+  local d
+  d="$(mktemp -d -t em-hook-XXXXXX)"
+  d="$(cd "$d" && pwd -P)"
+  mkdir -p "$d/.checkpoints" "$d/.claude"
+  ( cd "$d" && git init -q )
+  cleanup_dirs+=("$d")
+  printf '%s' "$d"
+}
+
+mk_caller_dir() {
+  local d
+  d="$(mktemp -d -t em-hook-caller-XXXXXX)"
+  d="$(cd "$d" && pwd -P)"
+  cleanup_dirs+=("$d")
+  printf '%s' "$d"
+}
+
+mk_fake_home() {
+  local d
+  d="$(mktemp -d -t em-hook-fakehome-XXXXXX)"
+  d="$(cd "$d" && pwd -P)"
+  mkdir -p "$d/.episodic-memory/scripts/lib"
+  # Copy em-recall.mjs + its lib/ deps for a working installed-runtime fixture.
+  cp "$REPO/scripts/em-recall.mjs" "$d/.episodic-memory/scripts/"
+  cp "$REPO/scripts/lib/"*.mjs "$d/.episodic-memory/scripts/lib/"
+  cleanup_dirs+=("$d")
+  printf '%s' "$d"
+}
+
+mk_empty_fake_home() {
+  local d
+  d="$(mktemp -d -t em-hook-emptyhome-XXXXXX)"
+  d="$(cd "$d" && pwd -P)"
+  # NO em-recall.mjs installed at $d/.episodic-memory/scripts/
+  cleanup_dirs+=("$d")
+  printf '%s' "$d"
+}
+
+stdin_json() {
+  local cwd="$1" sid="${2:-}"
+  if [ -n "$sid" ]; then
+    printf '{"cwd":"%s","session_id":"%s"}' "$cwd" "$sid"
+  else
+    printf '{"cwd":"%s"}' "$cwd"
+  fi
+}
+
+# ============================ H1 ============================
+echo "H1: caller cwd != target; valid sid; legacy + suffixed pre-existing"
+{
+  TARGET="$(mk_git_target)"
+  CALLER="$(mk_caller_dir)"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending.foreign-B"
+  STDIN_JSON="$(stdin_json "$TARGET" "35522aab-5f44-4b84-b1cc-035cca7b9305")"
+  (
+    cd "$CALLER"
+    bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>&1
+  )
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H1 hook exit 0" || check 0 "H1 hook exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H1 legacy swept under target" || check 0 "H1 legacy swept"
+  [ -e "$TARGET/.checkpoints/.plan-approval-pending.foreign-B" ] && check 1 "H1 suffixed preserved" || check 0 "H1 suffixed preserved"
+  # No artifacts under caller
+  [ ! -e "$CALLER/.checkpoints" ] && check 1 "H1 no .checkpoints/ under caller cwd" || check 0 "H1 caller untouched"
+}
+
+# ============================ H2 — nested cwd ============================
+echo "H2: nested cwd inside target (cd to target/subdir)"
+{
+  TARGET="$(mk_git_target)"
+  mkdir -p "$TARGET/subdir"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  # Pass nested dir as stdin .cwd — hook will cd to it; resolveRepoRoot
+  # walks up to target via .git
+  STDIN_JSON="$(stdin_json "$TARGET/subdir" "35522aab-5f44-4b84-b1cc-035cca7b9305")"
+  bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H2 exit 0" || check 0 "H2 exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H2 legacy swept at TARGET (not subdir)" || check 0 "H2 swept at target"
+  [ ! -d "$TARGET/subdir/.checkpoints" ] && check 1 "H2 no .checkpoints/ at subdir" || check 0 "H2 subdir untouched"
+}
+
+# ============================ H3 — linked worktree ============================
+echo "H3: linked worktree cwd"
+{
+  TARGET="$(mk_git_target)"
+  # Make an initial commit so worktree add works
+  ( cd "$TARGET" && git -c user.email=test@example.com -c user.name=test commit --allow-empty -q -m init )
+  WT="$(mktemp -d -t em-hook-wt-XXXXXX)"
+  WT="$(cd "$WT" && pwd -P)"
+  rm -rf "$WT"  # git worktree wants empty path
+  ( cd "$TARGET" && git worktree add -q -b wt-test "$WT" )
+  cleanup_dirs+=("$WT")
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  STDIN_JSON="$(stdin_json "$WT" "35522aab-5f44-4b84-b1cc-035cca7b9305")"
+  bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H3 exit 0" || check 0 "H3 exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H3 swept at MAIN repo (via git-common-dir)" || check 0 "H3 swept at main"
+  # Cleanup
+  ( cd "$TARGET" && git worktree remove --force "$WT" 2>/dev/null ) || true
+  ( cd "$TARGET" && git branch -D wt-test 2>/dev/null ) || true
+}
+
+# ============================ H4 — empty session_id in stdin ============================
+echo "H4: stdin .session_id omitted"
+{
+  TARGET="$(mk_git_target)"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  STDIN_JSON='{"cwd":"'"$TARGET"'"}'  # no .session_id key
+  bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H4 exit 0" || check 0 "H4 exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H4 legacy swept" || check 0 "H4 swept"
+}
+
+# ============================ H5 — malformed session_id ============================
+echo "H5: stdin .session_id malformed"
+{
+  TARGET="$(mk_git_target)"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  STDIN_JSON="$(stdin_json "$TARGET" '../../etc/passwd')"
+  # Capture stderr too for warning assertion
+  STDERR_LOG="$(mktemp)"
+  cleanup_dirs+=("$(dirname "$STDERR_LOG")")
+  bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>"$STDERR_LOG"
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H5 exit 0 (warn-on-invalid)" || check 0 "H5 exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H5 legacy still swept (independent of malformed sid)" || check 0 "H5 swept"
+  # Note: hook swallows stderr via `2>&1 || true`, so warning won't propagate
+  # to our captured stderr. The warning is verified by the
+  # session-id-binding.mjs test (direct invocation, no swallow).
+  rm -f "$STDERR_LOG"
+}
+
+# ============================ H6 — fake HOME with installed runtime ============================
+echo "H6: fake HOME containing installed-runtime em-recall.mjs"
+{
+  TARGET="$(mk_git_target)"
+  CALLER="$(mk_caller_dir)"
+  FAKE_HOME="$(mk_fake_home)"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  STDIN_JSON="$(stdin_json "$TARGET" "35522aab-5f44-4b84-b1cc-035cca7b9305")"
+  (
+    cd "$CALLER"
+    HOME="$FAKE_HOME" bash "$HOOK" <<< "$STDIN_JSON" >/dev/null 2>&1
+  )
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H6 exit 0" || check 0 "H6 exit 0 (got $rc)"
+  [ ! -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H6 swept under TARGET (using fake-HOME runtime)" || check 0 "H6 swept"
+  [ ! -e "$CALLER/.checkpoints" ] && check 1 "H6 caller untouched" || check 0 "H6 caller untouched"
+  [ ! -e "$FAKE_HOME/.checkpoints" ] && check 1 "H6 fake HOME untouched" || check 0 "H6 fake HOME untouched"
+}
+
+# ============================ H6b — fake HOME WITHOUT em-recall.mjs ============================
+echo "H6b: fake HOME WITHOUT em-recall.mjs → silent soft-noop"
+{
+  TARGET="$(mk_git_target)"
+  CALLER="$(mk_caller_dir)"
+  EMPTY_HOME="$(mk_empty_fake_home)"
+  touch -t 202605180100 "$TARGET/.checkpoints/.session-baseline"
+  touch -t 202605180200 "$TARGET/.checkpoints/.plan-approval-pending"
+  STDIN_JSON="$(stdin_json "$TARGET" "35522aab-5f44-4b84-b1cc-035cca7b9305")"
+  STDOUT_LOG="$(mktemp)"
+  (
+    cd "$CALLER"
+    HOME="$EMPTY_HOME" bash "$HOOK" <<< "$STDIN_JSON" >"$STDOUT_LOG" 2>&1
+  )
+  rc=$?
+  [ "$rc" = "0" ] && check 1 "H6b exit 0 (silent soft-noop)" || check 0 "H6b exit 0 (got $rc)"
+  # Marker UNCHANGED — em-recall never ran
+  [ -e "$TARGET/.checkpoints/.plan-approval-pending" ] && check 1 "H6b legacy marker UNCHANGED (no mutation)" || check 0 "H6b marker mutated unexpectedly"
+  # No stdout
+  [ ! -s "$STDOUT_LOG" ] && check 1 "H6b stdout empty (no block-JSON; silent path)" || check 0 "H6b stdout non-empty: $(cat "$STDOUT_LOG")"
+  rm -f "$STDOUT_LOG"
+}
+
+echo
+echo "$passed passed, $failed failed"
+[ "$failed" = "0" ] && exit 0 || exit 1

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -76,8 +76,8 @@ function runGateStop(cwd) {
   return { stdout: r.stdout || '', status: r.status }
 }
 
-function runSessionStart(cwd) {
-  const r = spawnSync('node', [EM_RECALL, '--session-start', '--limit', '1'], {
+function runSessionStart(cwd, extraArgs = []) {
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--limit', '1', ...extraArgs], {
     cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
     env: { ...process.env, HOME: TEST_HOME }
   })
@@ -266,30 +266,64 @@ console.log('\n=== L2 — em-recall --session-start side effects ===')
   else bad('2.3 defensive', `baseline did not advance: before=${baselineM} after=${newBaselineM}`)
 }
 
-// 2.4 in-flight plan-pending (mtime > prior baseline) preserved
+// 2.4 in-flight plan-pending (SUFFIXED, mtime > prior baseline) preserved.
+// Post-2026-05-18 policy (codex R1 P1.1 + R2 P1): suffixed forms are NEVER
+// swept by SessionStart; lifecycle is em-session-end-prompt.mjs (own-session)
+// + operator-cleanup FU (cross-session). Legacy suffix-less `.plan-approval-pending`
+// is covered by 2.4b below.
 {
   const d = mkRepo('2-4'); cleanupDirs.push(d)
   runSessionStart(d) // baseline at T0
   const baseline = path.join(d, '.checkpoints', '.session-baseline')
-  const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending.session-A')
   const baselineM = fs.statSync(baseline).mtimeMs
   fs.writeFileSync(planP, '')
   setMtime(planP, baselineM + 5_000) // newer than prior baseline
-  // second SessionStart: plan-pending should NOT be cleared (in-flight)
-  runSessionStart(d)
-  if (fs.existsSync(planP)) ok('2.4: in-flight plan-pending preserved across SessionStart')
-  else bad('2.4: in-flight plan-pending wrongly cleared', 'plan-pending was newer than prior baseline')
+  // second SessionStart: suffixed plan-pending should NOT be cleared (in-flight)
+  runSessionStart(d, ['--session-id', 'session-A'])
+  if (fs.existsSync(planP)) ok('2.4: in-flight SUFFIXED plan-pending preserved across SessionStart')
+  else bad('2.4: in-flight suffixed plan-pending wrongly cleared', 'suffixed forms must never be swept by SessionStart')
 }
 
-// 2.5 first-ever run with leftover plan-pending leaves it alone
+// 2.4b NEW: in-flight LEGACY-SUFFIX-LESS plan-pending is ALWAYS swept.
+// Codex R1 P1.4 + R2 P1: no current code path writes the suffix-less form;
+// any sighting is orphan. Unconditional sweep above the baseline guard.
+{
+  const d = mkRepo('2-4b'); cleanupDirs.push(d)
+  runSessionStart(d)
+  const baseline = path.join(d, '.checkpoints', '.session-baseline')
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
+  const baselineM = fs.statSync(baseline).mtimeMs
+  fs.writeFileSync(planP, '')
+  setMtime(planP, baselineM + 5_000) // newer than prior baseline (the 2026-05-18 bug class)
+  runSessionStart(d)
+  if (!fs.existsSync(planP)) ok('2.4b: in-flight LEGACY plan-pending swept (codex R1 P1.4 + R2 P1)')
+  else bad('2.4b: legacy plan-pending wrongly preserved', 'legacy form must always be swept')
+}
+
+// 2.5 first-ever run with leftover SUFFIXED plan-pending leaves it alone.
+// Post-fix: suffixed forms never swept by SessionStart.
 {
   const d = mkRepo('2-5'); cleanupDirs.push(d)
+  const planP = path.join(d, '.checkpoints', '.plan-approval-pending.session-A')
+  fs.writeFileSync(planP, '')
+  // No prior baseline exists.
+  runSessionStart(d, ['--session-id', 'session-A'])
+  if (fs.existsSync(planP)) ok('2.5: first-ever SessionStart leaves SUFFIXED plan-pending alone')
+  else bad('2.5: first-ever wrongly cleared suffixed plan-pending', 'suffixed forms must never be swept by SessionStart')
+}
+
+// 2.5b NEW: first-ever run with leftover LEGACY plan-pending is ALWAYS swept.
+// Codex R1 P1.4: the unconditional sweep runs OUTSIDE the priorBaselineMtime
+// guard, so legacy is reaped even when no prior baseline exists.
+{
+  const d = mkRepo('2-5b'); cleanupDirs.push(d)
   const planP = path.join(d, '.checkpoints', '.plan-approval-pending')
   fs.writeFileSync(planP, '')
   // No prior baseline exists.
   runSessionStart(d)
-  if (fs.existsSync(planP)) ok('2.5: first-ever SessionStart leaves plan-pending alone (conservative)')
-  else bad('2.5: first-ever wrongly cleared plan-pending', 'baseline was absent — should be conservative')
+  if (!fs.existsSync(planP)) ok('2.5b: first-ever SessionStart sweeps LEGACY plan-pending even without baseline (codex R1 P1.4)')
+  else bad('2.5b: legacy plan-pending wrongly preserved on first-ever', 'unconditional sweep must fire without baseline')
 }
 
 // ============================================================================
@@ -329,27 +363,45 @@ console.log('\n=== L3 — same-class extension, symlink defense, flag combo ==='
     markers.map((m, i) => `${path.basename(m)}=${cleared[i] ? 'cleared' : 'PRESENT'}`).join(' '))
 }
 
-// 3.2 SessionStart preserves in-flight markers (newer than prior baseline).
-// Symmetric to 2.4 but covers all 3 markers, not just plan-pending.
+// 3.2 SessionStart preserves in-flight NON-plan-marker class members.
+// Post-2026-05-18 fix: plan-marker class has a different lifecycle (codex
+// R1 + R2) — legacy suffix-less always swept, suffixed never swept by
+// SessionStart. Other 2 task-signal markers (checkpoint-required +
+// post-checkpoint-required) retain the in-flight-preserve contract.
 {
   const d = mkRepo('3-2'); cleanupDirs.push(d)
   runSessionStart(d)
   const baseline = path.join(d, '.checkpoints', '.session-baseline')
   const baselineM = fs.statSync(baseline).mtimeMs
-  const markers = [
+  const nonPlanMarkers = [
     '.checkpoint-required',
-    '.post-checkpoint-required',
-    '.plan-approval-pending'
+    '.post-checkpoint-required'
   ].map(m => path.join(d, '.checkpoints', m))
-  for (const m of markers) {
+  for (const m of nonPlanMarkers) {
     fs.writeFileSync(m, '')
     setMtime(m, baselineM + 5_000) // in-flight (mid-session)
   }
-  runSessionStart(d)
-  const preserved = markers.map(m => fs.existsSync(m))
-  if (preserved.every(Boolean)) ok('3.2: SessionStart preserves in-flight markers across all 3 class members')
-  else bad('3.2: in-flight wrongly cleared',
-    markers.map((m, i) => `${path.basename(m)}=${preserved[i] ? 'present' : 'CLEARED'}`).join(' '))
+  // Plus an in-flight LEGACY plan-pending — should be swept regardless
+  const planLegacy = path.join(d, '.checkpoints', '.plan-approval-pending')
+  fs.writeFileSync(planLegacy, '')
+  setMtime(planLegacy, baselineM + 5_000)
+  // Plus an in-flight SUFFIXED plan-pending — should be preserved
+  const planSuffixed = path.join(d, '.checkpoints', '.plan-approval-pending.session-A')
+  fs.writeFileSync(planSuffixed, '')
+  setMtime(planSuffixed, baselineM + 5_000)
+
+  runSessionStart(d, ['--session-id', 'session-A'])
+
+  const nonPlanPreserved = nonPlanMarkers.map(m => fs.existsSync(m))
+  if (nonPlanPreserved.every(Boolean)) ok('3.2: SessionStart preserves in-flight non-plan-marker class members')
+  else bad('3.2: non-plan-marker in-flight wrongly cleared',
+    nonPlanMarkers.map((m, i) => `${path.basename(m)}=${nonPlanPreserved[i] ? 'present' : 'CLEARED'}`).join(' '))
+
+  if (!fs.existsSync(planLegacy)) ok('3.2: in-flight LEGACY plan-pending swept (different lifecycle — codex R1 P1.4)')
+  else bad('3.2: legacy plan-pending wrongly preserved', 'must always be swept')
+
+  if (fs.existsSync(planSuffixed)) ok('3.2: in-flight SUFFIXED plan-pending preserved (different lifecycle — codex R1 P1.1)')
+  else bad('3.2: suffixed plan-pending wrongly swept', 'must never be swept by SessionStart')
 }
 
 // 3.3 Symlink defense (P2-2): a symlinked baseline does not enable the
@@ -478,7 +530,8 @@ function mkE2EHome() {
   // .checkpoints/ migration: marker-paths.mjs ships alongside local-dir.mjs;
   // omit it and em-recall fails to load (same fix as test-stop-gate.sh's
   // mk_fake_home).
-  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'stop-gate-helpers.mjs']) {
+  // 2026-05-18 concurrent-session fix: em-recall now imports session-id.mjs.
+  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'stop-gate-helpers.mjs', 'session-id.mjs']) {
     const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', lib)
     fs.copyFileSync(libSrc, path.join(scripts, 'lib', lib))
   }

--- a/tests/test-no-legacy-plan-marker-writes.mjs
+++ b/tests/test-no-legacy-plan-marker-writes.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * test-no-legacy-plan-marker-writes.mjs — Rule 13 CI grep-fail detector.
+ *
+ * Asserts no code site in scripts/ or hooks/ WRITES the legacy suffix-less
+ * `.plan-approval-pending` basename. Hook readers (plan-gate.sh,
+ * checkpoint-gate.sh, em-recall.mjs sweep, em-audit-compliance.mjs regex,
+ * registry constants, validators, tests) are whitelisted via:
+ *   - explicit `legacy-read-only: ok` tag comment on same line OR within 8
+ *     lines above
+ *   - line being part of a documented enforcement-sites registry entry
+ *   - file basename matching a test fixture / smoke test pattern
+ *
+ * A "write" is any of:
+ *   touch <...>/.plan-approval-pending (no suffix)
+ *   fs.writeFileSync(<...>/.plan-approval-pending, ...) (no suffix)
+ *   echo > <...>/.plan-approval-pending (no suffix)
+ *   tee <...>/.plan-approval-pending (no suffix)
+ *
+ * Detection scope: scripts/, hooks/, install.mjs, docs/AGENT-RULES.md.
+ * Excludes: scratch/, .claude-plugin/, instructions/, tests/, docs/rfcs/notes/.
+ *
+ * Exit 0 = no unwhitelisted writes. Exit 1 = violations.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+
+const SCAN_DIRS = ['scripts', 'hooks']
+const SCAN_FILES = ['install.mjs']
+
+const LEGACY_BASENAME = '.plan-approval-pending'
+const SUFFIX_OK_RE = new RegExp(`\\${LEGACY_BASENAME}\\.[\\w-]`)  // suffixed form
+
+// Write-shape signatures (relaxed — we want zero false negatives).
+const WRITE_SHAPES = [
+  /touch\s+[^\s|;&]*\.plan-approval-pending(?!\.\w)/,
+  /writeFileSync\s*\(\s*[^,]*\.plan-approval-pending(?!\.\w)/,
+  />\s*[^\s|;&]*\.plan-approval-pending(?!\.\w)/,
+  /tee\s+[^\s|;&]*\.plan-approval-pending(?!\.\w)/,
+]
+
+const WHITELIST_TAG = /legacy-read-only:\s*ok/i
+
+// Comment-line prefixes — these lines are documentation, not code, and
+// cannot constitute a write site at runtime. Skip them. Covers .sh (#),
+// .mjs / .js (// and * for jsdoc), and shebang/copyright noise.
+const COMMENT_PREFIX_RE = /^\s*(#|\/\/|\*|--)/
+
+function walkFiles(start, out) {
+  let entries
+  try { entries = fs.readdirSync(start, { withFileTypes: true }) } catch { return }
+  for (const e of entries) {
+    const p = path.join(start, e.name)
+    if (e.isDirectory()) {
+      walkFiles(p, out)
+    } else if (e.isFile()) {
+      out.push(p)
+    }
+  }
+}
+
+const files = []
+for (const d of SCAN_DIRS) walkFiles(path.join(REPO, d), files)
+for (const f of SCAN_FILES) {
+  const p = path.join(REPO, f)
+  if (fs.existsSync(p)) files.push(p)
+}
+
+const violations = []
+
+for (const file of files) {
+  let content
+  try { content = fs.readFileSync(file, 'utf8') } catch { continue }
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    // Skip the suffixed form — that's the correct write
+    if (!line.includes(LEGACY_BASENAME)) continue
+    if (SUFFIX_OK_RE.test(line)) continue
+    if (COMMENT_PREFIX_RE.test(line)) continue
+    // Look for write shapes
+    let matched = false
+    for (const shape of WRITE_SHAPES) {
+      if (shape.test(line)) { matched = true; break }
+    }
+    if (!matched) continue
+    // Check for whitelist tag on same line or within 8 lines above
+    let whitelisted = false
+    for (let j = Math.max(0, i - 8); j <= i; j++) {
+      if (WHITELIST_TAG.test(lines[j])) { whitelisted = true; break }
+    }
+    if (!whitelisted) {
+      violations.push(`  ${path.relative(REPO, file)}:${i + 1}: ${line.trim()}`)
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.log(`FAIL: ${violations.length} unwhitelisted legacy plan-marker write site(s) found:`)
+  for (const v of violations) console.log(v)
+  console.log()
+  console.log('Fix: route writes through scripts/plan-marker.mjs --touch (per-session suffixed form),')
+  console.log('     OR add a `// legacy-read-only: ok` tag comment on the line if this is a READ site.')
+  process.exit(1)
+}
+
+console.log(`PASS: no unwhitelisted legacy plan-marker write sites (scanned ${files.length} files)`)
+process.exit(0)

--- a/tests/test-plan-marker-cross-session.mjs
+++ b/tests/test-plan-marker-cross-session.mjs
@@ -119,34 +119,51 @@ function check(cond, label) {
   check(r.decision === 'block', `X3 legacy → BLOCK (got ${r.decision})`)
 }
 
-// ---------------- X4: orphan-sweep removes stale plan markers ----------------
+// ---------------- X4a: legacy suffix-less swept regardless of baseline -------
+// Post-2026-05-18 fix (codex R1 P1.4 + R2 P1): the legacy suffix-less form
+// is swept UNCONDITIONALLY at SessionStart, even when its mtime is newer
+// than the prior baseline. Suffixed forms `.plan-approval-pending.<sid>`
+// are NEVER swept by SessionStart anymore — that lifecycle belongs to
+// em-session-end-prompt.mjs (own-session) + operator-cleanup FU.
 {
   const root = mkTmpRepo()
   const ck = path.join(root, '.checkpoints')
-  // 3 stale orphans + legacy + a session-baseline whose mtime is NEWER than them.
-  fs.writeFileSync(path.join(ck, '.plan-approval-pending.A'), '')
-  fs.writeFileSync(path.join(ck, '.plan-approval-pending.B'), '')
-  fs.writeFileSync(path.join(ck, '.plan-approval-pending.C'), '')
-  fs.writeFileSync(path.join(ck, '.plan-approval-pending'), '')
-  // Make all markers' mtime old (5 minutes ago).
-  const oldMs = Date.now() / 1000 - 300
-  for (const f of ['.plan-approval-pending.A', '.plan-approval-pending.B', '.plan-approval-pending.C', '.plan-approval-pending']) {
-    fs.utimesSync(path.join(ck, f), oldMs, oldMs)
-  }
-  // Baseline mtime is newer (now).
+  // Legacy marker NEWER than baseline — the bug class from 2026-05-18.
   fs.writeFileSync(path.join(ck, '.session-baseline'), '')
-
-  // Run em-recall --session-start: it will write a NEW baseline and sweep orphans
-  // whose mtime <= prior baseline. The prior baseline mtime IS the "now" baseline
-  // we just wrote, so all 4 stale orphans (5 min ago) should sweep.
+  const baselineMs = Date.now() / 1000 - 3600  // 1h ago
+  fs.utimesSync(path.join(ck, '.session-baseline'), baselineMs, baselineMs)
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending'), '')
+  const markerMs = Date.now() / 1000 - 1800  // 30m ago — NEWER than baseline
+  fs.utimesSync(path.join(ck, '.plan-approval-pending'), markerMs, markerMs)
   const r = spawnSync('node', [EM_RECALL, '--session-start', '--no-track', '--limit', '1'], {
     cwd: root, encoding: 'utf8'
   })
-  check(r.status === 0, `X4 em-recall --session-start exit 0 (got ${r.status})`)
-  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.A')), `X4: orphan A swept`)
-  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.B')), `X4: orphan B swept`)
-  check(!fs.existsSync(path.join(ck, '.plan-approval-pending.C')), `X4: orphan C swept`)
-  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `X4: legacy orphan swept`)
+  check(r.status === 0, `X4a em-recall --session-start exit 0 (got ${r.status})`)
+  check(!fs.existsSync(path.join(ck, '.plan-approval-pending')), `X4a: legacy swept (regardless of baseline mtime — codex R1 P1.4)`)
+}
+
+// ---------------- X4b: suffixed orphans PRESERVED across SessionStart ---------
+// Under post-2026-05-18 policy, SessionStart NEVER sweeps suffixed forms.
+// Was incorrectly swept in pre-fix code (the v3 fix).
+{
+  const root = mkTmpRepo()
+  const ck = path.join(root, '.checkpoints')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.A'), '')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.B'), '')
+  fs.writeFileSync(path.join(ck, '.plan-approval-pending.C'), '')
+  // All suffixed orphans OLD (5 min ago); baseline NEWER (now).
+  const oldMs = Date.now() / 1000 - 300
+  for (const f of ['.plan-approval-pending.A', '.plan-approval-pending.B', '.plan-approval-pending.C']) {
+    fs.utimesSync(path.join(ck, f), oldMs, oldMs)
+  }
+  fs.writeFileSync(path.join(ck, '.session-baseline'), '')
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--no-track', '--limit', '1', '--session-id', '35522aab-5f44-4b84-b1cc-035cca7b9305'], {
+    cwd: root, encoding: 'utf8'
+  })
+  check(r.status === 0, `X4b em-recall --session-start exit 0 (got ${r.status})`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.A')), `X4b: suffixed A PRESERVED (post-fix; codex R1 P1.1 + R2 P1)`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.B')), `X4b: suffixed B PRESERVED`)
+  check(fs.existsSync(path.join(ck, '.plan-approval-pending.C')), `X4b: suffixed C PRESERVED`)
 }
 
 // ---------------- X5: worktree-cwd helper writes at canonical root, not cwd --

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -80,6 +80,9 @@ mk_fake_home() {
   # rank-1 plan v7 (2026-05-12): em-recall also imports stop-gate-helpers.mjs
   # for the active-plan exemption (_maxMtimeAcrossRootsStrict).
   cp "$REPO_ROOT/scripts/lib/stop-gate-helpers.mjs" "$fake_home/.episodic-memory/scripts/lib/stop-gate-helpers.mjs"
+  # 2026-05-18 concurrent-session fix: em-recall imports session-id.mjs for
+  # the --session-id flag (codex R1 P1.2; logging-only in v6 sweep).
+  cp "$REPO_ROOT/scripts/lib/session-id.mjs" "$fake_home/.episodic-memory/scripts/lib/session-id.mjs"
 }
 
 TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"


### PR DESCRIPTION
## Summary

- Fixes the **2026-05-18 cross-session orphan deadlock** where yesterday's `.plan-approval-pending` blocked today's session (stop-gate ↔ checkpoint-gate ↔ plan-gate triple-stack).
- Replaces `mtime <= priorBaselineMtime` predicate (which only catches markers written BEFORE the prior session's start) with a two-tier policy: legacy suffix-less always swept (above baseline guard); suffixed forms NEVER swept by SessionStart.
- Plumbs `--session-id` from SessionStart stdin through `em-recall-sessionstart.sh` → `em-recall.mjs` (codex R1 P1.2: bind from authoritative stdin, not env var).

## Codex consensus

Converged after **6 rounds** — ACCEPT-with-FU at episode `20260518-081021-reply-codex-to-20260518-080814-plan-v6-r-dc3f`.

- R1: 4 P1 + 1 P2 → code-level (sweep predicate wrong, MY_SID env unsafe, probe errors collapse, baseline-gated legacy sweep)
- R2: 1 P1 → own-session-on-resume false-sweep
- R3: 1 P1 + 3 cleanup → hook-wrapper integration test missing
- R4: 2 P1 + 1 P2 → fake-HOME + `--project` axes; drop speculative `semantic_role`
- R5: 2 P1 → H6b silent-soft-noop assertion correction + N8 non-git cwd
- R6: ACCEPT-with-FU → N8 baseline pre-setup (folded into impl)

Full review chain: request episodes `20260518-074308`, `20260518-074932`, `20260518-075252`, `20260518-075619`, `20260518-080502`, `20260518-080814` (local scope).

## Files changed

| File | Δ | Purpose |
|---|---|---|
| `scripts/em-recall.mjs` | ~30 | Lift legacy sweep outside baseline guard; delete buggy plan-marker glob branch; add `--session-id` flag |
| `hooks/em-recall-sessionstart.sh` | ~12 | Parse stdin `.session_id`; pass `--session-id <sid>` |
| `scripts/lib/marker-paths.mjs` | +1 entry, +1 desc | Registry coverage |
| `.github/workflows/plan-marker-validate.yml` | +12 lines | 4 new test steps |
| `tests/test-em-recall-plan-marker-sweep.mjs` | new | 25 assertions (P1-P3, N1-N8) |
| `tests/test-em-recall-session-id-binding.mjs` | new | 13 assertions (N3-N4c) |
| `tests/test-em-recall-sessionstart-hook-binding.sh` | new | 20 assertions (H1-H6b) |
| `tests/test-no-legacy-plan-marker-writes.mjs` | new | Rule 13 grep-fail detector |
| `tests/test-plan-marker-cross-session.mjs` | X4→X4a+X4b | Asserts new policy |
| `tests/test-issue-146.mjs` | 2.4→2.4+2.4b, 2.5→2.5+2.5b, 3.2 split | Asserts new lifecycle |
| `tests/test-em-recall-session-start-early-exit.mjs` | fixture fix | session-id.mjs in fake HOME |
| `tests/test-stop-gate.sh` | fixture fix | session-id.mjs in fake HOME |

## Test plan

- [x] `node scripts/validate-plan-marker-sites.mjs` → OK (2 checks passed)
- [x] `node tests/test-em-recall-plan-marker-sweep.mjs` → 25/25
- [x] `node tests/test-em-recall-session-id-binding.mjs` → 13/13
- [x] `bash tests/test-em-recall-sessionstart-hook-binding.sh` → 20/20
- [x] `node tests/test-no-legacy-plan-marker-writes.mjs` → PASS (104 files scanned)
- [x] `node tests/test-plan-marker-cross-session.mjs` → 30/30 (X4a + X4b added)
- [x] `node tests/test-issue-146.mjs` → 49/49 (2.4b + 2.5b + 3.2 split added)
- [x] `bash tests/test-stop-gate.sh` → 24/24
- [x] `bash tests/test-command-classifier.sh` → 301/301
- [x] `bash tests/test-preflight-gate.sh` → 107/107
- [x] `bash tests/test-preflight-prompt-helper.sh` → 24/24
- [x] `node tests/test-em-recall-session-start-early-exit.mjs` → 11/11
- [x] `node tests/test-em-strict-lstat.mjs` → 5/5
- [x] `node tests/test-checkpoints-migration.mjs` → 7/7
- [x] `node tests/test-plan-marker.mjs` → 32/32

## Concurrent-session safety analysis

| Scenario | Behavior | Verdict |
|---|---|---|
| Session A live + sitting at plan-approval >10min; Session B starts | A's marker preserved (no liveness probe — codex R1 P1.1) | ✅ |
| Session A resumes while still at plan approval (repeated SessionStart) | A's marker preserved on every fire (codex R2 P1 fix) | ✅ |
| Session A crashed mid-plan; Session B starts | A's marker preserved (orphan); B unblocked because per-sid gate | ✅ |
| First-ever SessionStart on fresh clone with legacy orphan | Legacy swept (codex R1 P1.4: outside baseline guard) | ✅ |
| SessionStart wrapper missing `.session_id` in stdin | Legacy still swept; suffixed preserved (codex R2 Q3) | ✅ |
| Symlink at marker path | lstat detects → preserved; stderr warn | ✅ |
| Race: 2 sessions starting in same second | Idempotent `rmSync({force:true})`; ENOENT on second is normal | ✅ |
| Worktree session vs main-repo session | `resolveRepoRoot` via git-common-dir; sweep on main `.checkpoints/` | ✅ |
| Non-git cwd + `--project` mismatch | Sweep follows cwd authority, NOT `--project` (codex R5 P1.2) | ✅ |

## Follow-up issues (post-merge)

1. **Operator-cleanup tool** for crashed-session suffixed orphans: `scripts/plan-marker-operator-sweep.mjs --older-than <duration> --dry-run|--apply`
2. **Sweep telemetry**: count of legacy-suffix-less reaped per SessionStart (informs decision on collapsing legacy OR-fallback)
3. **Collapse legacy OR-fallback** in `plan-gate.sh:115` + `checkpoint-gate.sh:130` after 7d of clean sweep telemetry
4. **CLAUDE.md Rule 8 update**: switch literal `touch`/`rm` to `node ~/.episodic-memory/scripts/plan-marker.mjs --touch|--rm --root <repo>` (helper already enforces per-session basename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
