### PR TITLE
feat(classify-correction): --allow-non-git flag + harden store-dir against symlink/TOCTOU

### DIFF
--- a/scripts/classify-correction.mjs
+++ b/scripts/classify-correction.mjs
@@ -11,13 +11,19 @@
  *     --caller-cwd  <abs-path> \
  *     --command     "<command text>" \
  *     --label       <read_only|shared_write|marker_write|push_or_pr_create|unsafe_complex> \
- *     [--reason     "<note>"]
+ *     [--reason     "<note>"] \
+ *     [--allow-non-git]
  *
  * Recognized by command-classifier.sh as a `helper_write` invocation when the
  * argv shape matches `node <abs-path>/classify-correction.mjs --project-root ...`.
  * The helper rejects an --project-root that does not match
  * resolveRepoRoot(process.cwd()) so a misrouted invocation cannot write into
  * a foreign repo's store.
+ *
+ * --allow-non-git: opt into non-git projects. The .episodic-memory/ directory
+ * must already exist under --project-root (created by the user) and serves as
+ * the explicit opt-in sentinel. The same hardened symlink/realpath validation
+ * applies to both modes.
  */
 
 import fs from 'fs'
@@ -116,33 +122,77 @@ function cacheKey(tuple) {
   return crypto.createHash('sha256').update(canon).digest('hex')
 }
 
-// codex PR #326 R3 BLOCKER: stale-lock identity binding is unsolvable in
-// pure POSIX (no `rename-if-inode-matches` primitive). Per the same-class
-// stop rule (feedback_handoff_complete_bug_class.md), we change the
-// enforcement boundary instead of patching the same class again: drop the
-// lock entirely and rely on `O_APPEND` write atomicity.
+// Shared store-dir validator. Both git and non-git modes route through this.
 //
-// POSIX guarantees that a single `write()` of size <= PIPE_BUF (4096B on
-// Linux/macOS) to a file opened with O_APPEND is atomic — interleaving
-// processes will get whole-line appends without truncation or interleave.
-// Our entries are ~500B JSON. Safe.
+// allowCreate=true  → if storeDir absent, `mkdirSync(storeDir)` (plain, NOT
+//                     recursive — recursive form silently traverses
+//                     symlinked ancestors). Used by git mode for first-time
+//                     creation on a fresh repo.
+// allowCreate=false → missing storeDir is fatal. Used by non-git mode where
+//                     the dir IS the opt-in signal, and at the TOCTOU
+//                     recheck right before append.
 //
-// `fs.appendFileSync(file, line, {flag: 'a'})` opens, writes, closes in one
-// call; Node's underlying syscall uses `O_APPEND` which the kernel honors.
-function appendOverride(storeDir, entry) {
-  fs.mkdirSync(storeDir, { recursive: true })
+// On EEXIST from mkdir (concurrent first-time writers race), re-lstat and
+// fall through to validation — both racers proceed iff the dir is real.
+//
+// On success: storeDir exists, is a real directory (not symlink, not file),
+// and realpath(storeDir) === path.join(projectRootCanon, '.episodic-memory').
+function validateStoreDir(projectRootCanon, { allowCreate }) {
+  const storeDir = path.join(projectRootCanon, '.episodic-memory')
+  const expectedReal = storeDir
+  let st
+  try { st = fs.lstatSync(storeDir) }
+  catch (e) {
+    if (e.code !== 'ENOENT') throw e
+    if (!allowCreate) {
+      die(2, `--project-root (${projectRootCanon}) has no .episodic-memory/ directory; create it first to opt into non-git override scoping, or omit --allow-non-git`)
+    }
+    try { fs.mkdirSync(storeDir) }
+    catch (e2) {
+      if (e2.code === 'EEXIST') {
+        // Concurrent creator won the race — fall through to re-lstat + validate.
+      } else if (e2.code === 'ENOENT') {
+        die(2, `failed to create .episodic-memory/ — an ancestor of ${storeDir} is missing or unresolvable; refusing`)
+      } else if (e2.code === 'ELOOP') {
+        die(2, `failed to create .episodic-memory/ (symlink loop in ancestor); refusing`)
+      } else {
+        throw e2
+      }
+    }
+    st = fs.lstatSync(storeDir)
+  }
+  if (st.isSymbolicLink() || !st.isDirectory()) {
+    die(2, `.episodic-memory must be a real directory (not a symlink or file); refusing to write through link`)
+  }
+  const realStore = fs.realpathSync(storeDir)
+  if (realStore !== expectedReal) {
+    die(2, `.episodic-memory resolves outside expected position (got ${realStore}, expected ${expectedReal}); refusing`)
+  }
+  return storeDir
+}
+
+// Hardened leaf writer. `validateStoreDir` already proved the parent dir is
+// real + at the canonical position; O_NOFOLLOW catches the case where
+// classifier-overrides.jsonl ITSELF is a symlink. PIPE_BUF (4096B) bounds
+// the line size so a single write() is atomic for concurrent appenders.
+function _appendLine(storeDir, entry) {
   const target = path.join(storeDir, 'classifier-overrides.jsonl')
   const line = JSON.stringify(entry) + '\n'
-  // codex R4 BLOCKER F1: O_APPEND atomicity is BYTE-sized (PIPE_BUF =
-  // 4096 bytes), not char-sized. `String.length` counts UTF-16 code units;
-  // a 2200-char ASCII line is 2200 bytes but a 2200-char multibyte UTF-8
-  // line can be > 4096 bytes. Use Buffer.byteLength('utf8') for the real
-  // serialized size the kernel will write.
   const byteLen = Buffer.byteLength(line, 'utf8')
   if (byteLen > 4096) {
     throw new Error(`override entry size ${byteLen} bytes exceeds PIPE_BUF atomicity guarantee (4096B); refusing to append`)
   }
-  fs.appendFileSync(target, line, { flag: 'a' })
+  const flags = fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW
+  let fd
+  try { fd = fs.openSync(target, flags, 0o644) }
+  catch (e) {
+    if (e.code === 'ELOOP' || e.code === 'EMLINK') {
+      die(2, `classifier-overrides.jsonl is a symlink; refusing to write through link`)
+    }
+    throw e
+  }
+  try { fs.writeSync(fd, line) }
+  finally { fs.closeSync(fd) }
   return target
 }
 
@@ -153,6 +203,7 @@ function main() {
   const command = flag(argv, '--command')
   const label = flag(argv, '--label')
   const reason = flag(argv, '--reason') || ''
+  const allowNonGit = argv.includes('--allow-non-git')
 
   if (!projectRootArg) die(2, '--project-root required')
   if (!callerCwd) die(2, '--caller-cwd required')
@@ -165,15 +216,20 @@ function main() {
   if (resolved !== projectRootCanon) {
     die(2, `--project-root (${projectRootCanon}) != resolveRepoRoot(process.cwd()) (${resolved}); refusing cross-repo write`)
   }
-  // F13-fix: reject non-git cwd-fallback. resolveRepoRoot returns the cwd
-  // unchanged when it cannot resolve a git context. The classifier scopes
-  // overrides per git repo; allowing a non-git cwd as its own "project root"
-  // would land overrides in an arbitrary directory's .episodic-memory/.
-  // Require an actual `.git` (file or directory — submodules use file).
-  try {
-    fs.statSync(path.join(projectRootCanon, '.git'))
-  } catch {
-    die(2, `--project-root (${projectRootCanon}) is not a git repository (.git not found); classifier overrides require a git context`)
+
+  // Mode-specific sentinel + store-dir validation (Gate 2).
+  // Git mode: require .git AND allow first-time creation of .episodic-memory.
+  // Non-git mode: skip .git check, require user-created .episodic-memory.
+  let storeDir
+  if (allowNonGit) {
+    storeDir = validateStoreDir(projectRootCanon, { allowCreate: false })
+  } else {
+    try {
+      fs.statSync(path.join(projectRootCanon, '.git'))
+    } catch {
+      die(2, `--project-root (${projectRootCanon}) is not a git repository (.git not found); classifier overrides require a git context, or pass --allow-non-git to opt into .episodic-memory/-scoped overrides`)
+    }
+    storeDir = validateStoreDir(projectRootCanon, { allowCreate: true })
   }
 
   const tuple = buildTuple({ command, projectRoot: projectRootCanon, callerCwd })
@@ -187,8 +243,22 @@ function main() {
     created_at: new Date().toISOString(),
     created_by: 'user-correction'
   }
-  const storeDir = path.join(projectRootCanon, '.episodic-memory')
-  const target = appendOverride(storeDir, entry)
+  if (allowNonGit) entry.allow_non_git = true
+
+  // Test seam: deterministic pause between Gate-2 validation and the append-time
+  // TOCTOU recheck, so tests can plant a symlink/swap state into the window.
+  // Capped at 5s to avoid hanging CI on a misconfigured env var.
+  const pauseMs = Math.min(5000, Math.max(0, parseInt(process.env._CC_TEST_PAUSE_BEFORE_APPEND_MS || '0', 10) || 0))
+  if (pauseMs > 0) {
+    const end = Date.now() + pauseMs
+    while (Date.now() < end) { /* busy-wait keeps the test seam synchronous */ }
+  }
+
+  // Gate 3 — TOCTOU recheck immediately before append (both modes).
+  // Dir must already exist by this point; if it disappeared or was swapped
+  // for a symlink, this catches it.
+  validateStoreDir(projectRootCanon, { allowCreate: false })
+  const target = _appendLine(storeDir, entry)
   process.stdout.write(JSON.stringify({
     status: 'ok',
     file: target,

--- a/skills/classify-correction/SKILL.md
+++ b/skills/classify-correction/SKILL.md
@@ -52,6 +52,39 @@ project's identically-named script. If the script content changes, the digest
 changes, and the override no longer matches — re-run the correction with the
 new content.
 
+## Non-git projects
+
+By default the helper requires `.git` under `--project-root`. For projects
+that are intentionally not checked into git, pass `--allow-non-git`:
+
+```bash
+node ~/.episodic-memory/scripts/classify-correction.mjs \
+  --project-root "$(pwd)" \
+  --caller-cwd  "$(pwd)" \
+  --command     "python3 src/inspect.py" \
+  --label       read_only \
+  --allow-non-git
+```
+
+The `.episodic-memory/` directory under `--project-root` MUST already exist
+(create it yourself: `mkdir .episodic-memory`). It serves as the explicit
+opt-in signal — the helper will not create it implicitly in non-git mode.
+
+The same hardened validation applies to both modes: `.episodic-memory/` must
+be a real directory (rejected if it is a symlink or its realpath escapes the
+project root), and `classifier-overrides.jsonl` is opened with `O_NOFOLLOW`
+so a symlinked leaf is rejected too. Concurrent first-time corrections on a
+fresh git repo are safe — the helper tolerates `EEXIST` from racing creators
+and re-validates the directory before appending.
+
+Linked-worktree behavior is unchanged: `resolveRepoRoot` walks to the main
+repository root via `git rev-parse --git-common-dir`, so worktree callers
+write under the main repo's `.episodic-memory/`, not the worktree's.
+
+**Threat boundary:** the helper does not defend against a same-UID attacker
+who can swap filesystem state within the syscall granularity between the
+final validation and `open()`. Windows is not supported (no `O_NOFOLLOW`).
+
 ## Disabling Tier 3 entirely
 
 If you do not want LLM dispatch at all (offline, no API key, or cost-

--- a/tests/test-classify-correction.mjs
+++ b/tests/test-classify-correction.mjs
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+/**
+ * test-classify-correction.mjs — Tests for classify-correction.mjs
+ * covering the --allow-non-git opt-in + the shared hardened store-dir
+ * validator (symlink reject, realpath equality, O_NOFOLLOW leaf, TOCTOU
+ * recheck, EEXIST-tolerant first-time creation).
+ *
+ * 15 cases — see plan v6 §"Negative-matrix coverage (final v6)".
+ *
+ * Usage: node tests/test-classify-correction.mjs
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import assert from 'assert'
+import crypto from 'crypto'
+import { execFileSync, spawnSync, spawn } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const CORRECTION = path.join(REPO, 'scripts', 'classify-correction.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+const queue = []
+
+function test(name, fn) {
+  queue.push(async () => {
+    try {
+      await fn()
+      passed++
+      console.log(`  ✓ ${name}`)
+    } catch (e) {
+      failed++
+      failures.push({ name, error: e.message })
+      console.log(`  ✗ ${name}: ${e.message}`)
+    }
+  })
+}
+
+function mktmp(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `cc-${prefix}-`)))
+}
+
+function mkrepo(name) {
+  const dir = mktmp(name)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir })
+  return dir
+}
+
+function run(opts) {
+  const { cwd, projectRoot, callerCwd, command = 'python3 foo.py', label = 'read_only', allowNonGit = false, env = {} } = opts
+  const args = [CORRECTION,
+    '--project-root', projectRoot,
+    '--caller-cwd', callerCwd || cwd,
+    '--command', command,
+    '--label', label]
+  if (allowNonGit) args.push('--allow-non-git')
+  return spawnSync(process.execPath, args, {
+    cwd, env: { ...process.env, ...env }, encoding: 'utf8'
+  })
+}
+
+function readLines(file) {
+  if (!fs.existsSync(file)) return []
+  return fs.readFileSync(file, 'utf8').split('\n').filter(Boolean)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+// 1. Positive baseline — git mode, .episodic-memory auto-created
+test('1. git mode positive (auto-create .episodic-memory)', async () => {
+  const repo = mkrepo('t1')
+  const r = run({ cwd: repo, projectRoot: repo })
+  assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}: ${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.strictEqual(out.status, 'ok')
+  assert.strictEqual(out.label, 'read_only')
+  const lines = readLines(path.join(repo, '.episodic-memory', 'classifier-overrides.jsonl'))
+  assert.strictEqual(lines.length, 1)
+  const entry = JSON.parse(lines[0])
+  assert.strictEqual(entry.label, 'read_only')
+  assert.strictEqual(entry.allow_non_git, undefined)
+})
+
+// 2. Non-git mode without sentinel → exit 2
+test('2. non-git mode without .episodic-memory → exit 2', async () => {
+  const dir = mktmp('t2')
+  const r = run({ cwd: dir, projectRoot: dir, allowNonGit: true })
+  assert.strictEqual(r.status, 2)
+  assert.match(r.stderr, /has no \.episodic-memory/)
+})
+
+// 3. Non-git mode positive (sentinel pre-created)
+test('3. non-git mode positive — sentinel exists', async () => {
+  const dir = mktmp('t3')
+  fs.mkdirSync(path.join(dir, '.episodic-memory'))
+  const r = run({ cwd: dir, projectRoot: dir, allowNonGit: true })
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.strictEqual(out.status, 'ok')
+  const lines = readLines(path.join(dir, '.episodic-memory', 'classifier-overrides.jsonl'))
+  assert.strictEqual(lines.length, 1)
+  const entry = JSON.parse(lines[0])
+  assert.strictEqual(entry.allow_non_git, true)
+})
+
+// 4. Cross-repo write rejected
+test('4. cross-repo write → exit 2', async () => {
+  const repoA = mkrepo('t4a')
+  const repoB = mkrepo('t4b')
+  const r = run({ cwd: repoA, projectRoot: repoB, callerCwd: repoA })
+  assert.strictEqual(r.status, 2)
+  assert.match(r.stderr, /refusing cross-repo write/)
+})
+
+// 5. Dir symlink at sentinel (non-git mode) → exit 2
+test('5. non-git: .episodic-memory is symlink → exit 2', async () => {
+  const dir = mktmp('t5')
+  const outside = mktmp('t5out')
+  fs.symlinkSync(outside, path.join(dir, '.episodic-memory'))
+  const r = run({ cwd: dir, projectRoot: dir, allowNonGit: true })
+  assert.strictEqual(r.status, 2)
+  assert.match(r.stderr, /must be a real directory/)
+})
+
+// 6. Nested cwd — git mode (resolveRepoRoot walks subdir → repo root).
+//    Non-git nested cwd is correctly rejected by the cross-repo guard
+//    (resolveRepoRoot returns cwd unchanged without git context); that case
+//    is covered indirectly by test 4. The useful coverage is git mode.
+test('6. git mode: caller cwd nested under project root', async () => {
+  const repo = mkrepo('t6')
+  fs.mkdirSync(path.join(repo, 'sub'))
+  const sub = path.join(repo, 'sub')
+  const r = run({ cwd: sub, projectRoot: repo, callerCwd: sub })
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`)
+  const lines = readLines(path.join(repo, '.episodic-memory', 'classifier-overrides.jsonl'))
+  assert.strictEqual(lines.length, 1)
+})
+
+// 7. Dispatcher-readable shape (override entry has expected fields)
+test('7. override entry shape matches dispatcher schema', async () => {
+  const repo = mkrepo('t7')
+  const r = run({ cwd: repo, projectRoot: repo, command: 'python3 foo.py', label: 'marker_write', env: {} })
+  assert.strictEqual(r.status, 0)
+  const entry = JSON.parse(readLines(path.join(repo, '.episodic-memory', 'classifier-overrides.jsonl'))[0])
+  assert.strictEqual(entry.schema, 1)
+  assert.ok(typeof entry.cache_key === 'string' && entry.cache_key.length === 64)
+  assert.strictEqual(entry.label, 'marker_write')
+  assert.ok(entry.tuple)
+  assert.strictEqual(entry.tuple.project_root_canonical, repo)
+  assert.strictEqual(entry.tuple.normalized_command, 'python3 foo.py')
+})
+
+// 8. Dir removed mid-flight (TOCTOU between Gate 2 and Gate 3)
+test('8. TOCTOU: dir removed between gates → exit 2', async () => {
+  const dir = mktmp('t8')
+  fs.mkdirSync(path.join(dir, '.episodic-memory'))
+  const proc = spawn(process.execPath, [CORRECTION,
+    '--project-root', dir, '--caller-cwd', dir,
+    '--command', 'python3 foo.py', '--label', 'read_only',
+    '--allow-non-git'],
+    { cwd: dir, env: { ...process.env, _CC_TEST_PAUSE_BEFORE_APPEND_MS: '800' } })
+  let stderr = ''
+  proc.stderr.on('data', d => { stderr += d })
+  // Mid-flight: remove the directory
+  await new Promise(res => setTimeout(res, 200))
+  fs.rmSync(path.join(dir, '.episodic-memory'), { recursive: true, force: true })
+  const code = await new Promise(res => proc.on('exit', res))
+  assert.strictEqual(code, 2, `stderr: ${stderr}`)
+  assert.match(stderr, /has no \.episodic-memory|must be a real directory/)
+})
+
+// 9. Dir replaced with symlink mid-flight
+test('9. TOCTOU: dir replaced with symlink → exit 2', async () => {
+  const dir = mktmp('t9')
+  const outside = mktmp('t9out')
+  fs.mkdirSync(path.join(dir, '.episodic-memory'))
+  const proc = spawn(process.execPath, [CORRECTION,
+    '--project-root', dir, '--caller-cwd', dir,
+    '--command', 'python3 foo.py', '--label', 'read_only',
+    '--allow-non-git'],
+    { cwd: dir, env: { ...process.env, _CC_TEST_PAUSE_BEFORE_APPEND_MS: '800' } })
+  let stderr = ''
+  proc.stderr.on('data', d => { stderr += d })
+  await new Promise(res => setTimeout(res, 200))
+  fs.rmSync(path.join(dir, '.episodic-memory'), { recursive: true, force: true })
+  fs.symlinkSync(outside, path.join(dir, '.episodic-memory'))
+  const code = await new Promise(res => proc.on('exit', res))
+  assert.strictEqual(code, 2, `stderr: ${stderr}`)
+  assert.match(stderr, /must be a real directory/)
+  // Outside dir must remain untouched
+  const outsideContents = fs.readdirSync(outside)
+  assert.strictEqual(outsideContents.length, 0, 'outside dir was written to')
+})
+
+// 10. Leaf is symlink (non-git)
+test('10. non-git: classifier-overrides.jsonl is symlink → exit 2', async () => {
+  const dir = mktmp('t10')
+  const outsideFile = path.join(mktmp('t10out'), 'pwned.jsonl')
+  fs.writeFileSync(outsideFile, '')
+  fs.mkdirSync(path.join(dir, '.episodic-memory'))
+  fs.symlinkSync(outsideFile, path.join(dir, '.episodic-memory', 'classifier-overrides.jsonl'))
+  const r = run({ cwd: dir, projectRoot: dir, allowNonGit: true })
+  assert.strictEqual(r.status, 2, `stdout: ${r.stdout} stderr: ${r.stderr}`)
+  assert.match(r.stderr, /is a symlink/)
+  // Outside file untouched
+  assert.strictEqual(fs.readFileSync(outsideFile, 'utf8'), '')
+})
+
+// 11. Leaf is symlink (git mode)
+test('11. git mode: classifier-overrides.jsonl is symlink → exit 2', async () => {
+  const repo = mkrepo('t11')
+  const outsideFile = path.join(mktmp('t11out'), 'pwned.jsonl')
+  fs.writeFileSync(outsideFile, '')
+  fs.mkdirSync(path.join(repo, '.episodic-memory'))
+  fs.symlinkSync(outsideFile, path.join(repo, '.episodic-memory', 'classifier-overrides.jsonl'))
+  const r = run({ cwd: repo, projectRoot: repo })
+  assert.strictEqual(r.status, 2, `stdout: ${r.stdout} stderr: ${r.stderr}`)
+  assert.match(r.stderr, /is a symlink/)
+  assert.strictEqual(fs.readFileSync(outsideFile, 'utf8'), '')
+})
+
+// 12. Dir symlink at sentinel (git mode)
+test('12. git mode: .episodic-memory is symlink → exit 2', async () => {
+  const repo = mkrepo('t12')
+  const outside = mktmp('t12out')
+  fs.symlinkSync(outside, path.join(repo, '.episodic-memory'))
+  const r = run({ cwd: repo, projectRoot: repo })
+  assert.strictEqual(r.status, 2)
+  assert.match(r.stderr, /must be a real directory/)
+  assert.strictEqual(fs.readdirSync(outside).length, 0)
+})
+
+// 13. First-time creation (git, single-process, .episodic-memory absent)
+test('13. git mode: first-time creation succeeds', async () => {
+  const repo = mkrepo('t13')
+  assert.strictEqual(fs.existsSync(path.join(repo, '.episodic-memory')), false)
+  const r = run({ cwd: repo, projectRoot: repo })
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`)
+  const st = fs.lstatSync(path.join(repo, '.episodic-memory'))
+  assert.ok(st.isDirectory() && !st.isSymbolicLink())
+})
+
+// 14. Linked-worktree positive — caller in worktree, writes to main
+test('14. linked worktree: cwd in worktree, target main → writes under main', async () => {
+  const main = mkrepo('t14main')
+  // Need a commit to add a worktree
+  fs.writeFileSync(path.join(main, 'README'), 'x\n')
+  execFileSync('git', ['add', '.'], { cwd: main })
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: main })
+  const wtDir = mktmp('t14wt')
+  // remove the empty dir so git worktree add can create it
+  fs.rmdirSync(wtDir)
+  execFileSync('git', ['worktree', 'add', '-q', wtDir, 'HEAD'], { cwd: main })
+  const wtSub = path.join(fs.realpathSync(wtDir), 'sub')
+  fs.mkdirSync(wtSub)
+  const r = run({ cwd: wtSub, projectRoot: main, callerCwd: wtSub })
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`)
+  // Artifact under MAIN, not worktree
+  assert.ok(fs.existsSync(path.join(main, '.episodic-memory', 'classifier-overrides.jsonl')),
+    'expected classifier-overrides.jsonl under main repo')
+  assert.strictEqual(fs.existsSync(path.join(fs.realpathSync(wtDir), '.episodic-memory')), false,
+    'worktree must NOT have .episodic-memory')
+})
+
+// 15. Concurrent first-time creation in git mode — both succeed, 2 lines
+test('15. git mode: concurrent first-time creators race safely', async () => {
+  const repo = mkrepo('t15')
+  const spawnOne = (suffix) => spawn(process.execPath, [CORRECTION,
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', `python3 foo${suffix}.py`, '--label', 'read_only'],
+    { cwd: repo, env: process.env })
+  const p1 = spawnOne('A')
+  const p2 = spawnOne('B')
+  const [c1, c2] = await Promise.all([
+    new Promise(res => p1.on('exit', res)),
+    new Promise(res => p2.on('exit', res))
+  ])
+  assert.strictEqual(c1, 0, 'p1 should exit 0')
+  assert.strictEqual(c2, 0, 'p2 should exit 0')
+  const lines = readLines(path.join(repo, '.episodic-memory', 'classifier-overrides.jsonl'))
+  assert.strictEqual(lines.length, 2, `expected 2 lines, got ${lines.length}`)
+  // Both lines valid JSON
+  for (const l of lines) JSON.parse(l)
+  // .episodic-memory is a real directory
+  const st = fs.lstatSync(path.join(repo, '.episodic-memory'))
+  assert.ok(st.isDirectory() && !st.isSymbolicLink())
+})
+
+// 16. Linked worktree + --allow-non-git — explicit non-git-mode coverage of
+//     the worktree axis. Main has .git (worktrees require it), but the
+//     script skips the .git check under --allow-non-git, so the path
+//     exercised is: resolveRepoRoot from worktree walks to main → cross-repo
+//     guard matches → allowCreate:false branch verifies pre-created
+//     .episodic-memory → append.
+test('16. linked worktree + --allow-non-git: pre-created sentinel → writes under main', async () => {
+  const main = mkrepo('t16main')
+  fs.writeFileSync(path.join(main, 'README'), 'x\n')
+  execFileSync('git', ['add', '.'], { cwd: main })
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: main })
+  // Pre-create the non-git-mode sentinel under MAIN
+  fs.mkdirSync(path.join(main, '.episodic-memory'))
+  const wtDir = mktmp('t16wt')
+  fs.rmdirSync(wtDir)
+  execFileSync('git', ['worktree', 'add', '-q', wtDir, 'HEAD'], { cwd: main })
+  const wtReal = fs.realpathSync(wtDir)
+  const wtSub = path.join(wtReal, 'sub')
+  fs.mkdirSync(wtSub)
+  const r = run({ cwd: wtSub, projectRoot: main, callerCwd: wtSub, allowNonGit: true })
+  assert.strictEqual(r.status, 0, `stderr: ${r.stderr}`)
+  // Artifact under MAIN
+  const mainFile = path.join(main, '.episodic-memory', 'classifier-overrides.jsonl')
+  assert.ok(fs.existsSync(mainFile), 'expected classifier-overrides.jsonl under main repo')
+  // NO .episodic-memory under worktree
+  assert.strictEqual(fs.existsSync(path.join(wtReal, '.episodic-memory')), false,
+    'worktree must NOT have .episodic-memory')
+  // Entry stamped allow_non_git=true
+  const entry = JSON.parse(readLines(mainFile)[0])
+  assert.strictEqual(entry.allow_non_git, true)
+})
+
+// ── Runner ───────────────────────────────────────────────────────────────
+
+console.log('classify-correction tests (--allow-non-git + hardened validator)')
+for (const t of queue) await t()
+console.log(`\n${passed}/${passed + failed} passed`)
+if (failed > 0) {
+  for (const f of failures) console.log(`  ✗ ${f.name}\n    ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-classify-correction.mjs
+++ b/tests/test-classify-correction.mjs
@@ -5,7 +5,8 @@
  * validator (symlink reject, realpath equality, O_NOFOLLOW leaf, TOCTOU
  * recheck, EEXIST-tolerant first-time creation).
  *
- * 15 cases — see plan v6 §"Negative-matrix coverage (final v6)".
+ * 16 cases — see plan v6 §"Negative-matrix coverage (final v6)" plus
+ * test 16 (linked worktree + --allow-non-git) added in impl review R1.
  *
  * Usage: node tests/test-classify-correction.mjs
  */


### PR DESCRIPTION
## Summary

- Add `--allow-non-git` flag to `scripts/classify-correction.mjs` so the LLM-classifier override flow works on projects that are intentionally not checked into git.
- Replace `mkdirSync({recursive: true}) + appendFileSync` with a shared hardened `validateStoreDir` + `_appendLine` pair that closes a parent-dir-symlink hole codex found in the existing git-mode path. The same hardening now applies to both modes.
- `.episodic-memory/` under `--project-root` must already exist for non-git mode — it serves as the explicit opt-in sentinel (helper will not create it implicitly in that mode).

## Security hardening (applies to both modes — also tightens existing git mode)

- `lstatSync` on the sentinel before any open — rejects if it's a symlink or non-directory.
- Plain `mkdirSync` (NOT recursive) on first-time creation — `recursive: true` silently traverses symlinked ancestors. Plan v6 caught this in R4.
- `realpathSync` equality with `<projectRootCanon>/.episodic-memory` — blocks escape via subtle path tricks.
- `EEXIST` on first-time creation re-validates and proceeds; concurrent first-time creators are safe (test 15).
- `openSync(O_APPEND|O_CREAT|O_WRONLY|O_NOFOLLOW)` on the leaf — rejects symlinked `classifier-overrides.jsonl`.
- TOCTOU recheck via `validateStoreDir(allowCreate: false)` immediately before the append (Gate 3) — deterministic test seam `_CC_TEST_PAUSE_BEFORE_APPEND_MS` (capped at 5s) lets tests plant mid-flight swaps.

## Threat boundary (documented in SKILL.md)

- Same-UID attacker winning sub-syscall TOCTOU between Gate-3 validation and `open()`: **out of scope**.
- Windows: **out of scope** (no `O_NOFOLLOW`).

## Codex review trail

- **Plan review — 6 rounds** (R1 dir-symlink → R2 TOCTOU+mkdir-recursive → R3 leaf-symlink → R4 parent-dir-symlink in git mode → R5 linked-worktree test + EEXIST race → **R6 ACCEPT**)
- **Implementation review — 2 rounds** (R1 HOLD: missing linked-worktree × `--allow-non-git` test → R2 **ACCEPT**, no findings)

## Test plan

- [x] `node tests/test-classify-correction.mjs` — 16/16 pass (new file)
- [x] `node tests/test-llm-classifier.mjs` — 29/29 pass (zero regressions; this suite already covers `classify-correction` via §T6, §T16, §T13, F13-fix, concurrent-append, byte-guard)
- [x] `node --check scripts/classify-correction.mjs` — syntax clean

### Negative-scenario matrix (16 tests)

| # | Scenario | Mode |
|---|---|---|
| 1 | Baseline positive, `.episodic-memory` auto-created | git |
| 2 | No `.episodic-memory` sentinel → exit 2 | non-git |
| 3 | Sentinel pre-created → `allow_non_git=true` stamped | non-git |
| 4 | Cross-repo write → exit 2 | both |
| 5 | `.episodic-memory` is symlink → exit 2 | non-git |
| 6 | Nested cwd under project root | git |
| 7 | Override entry shape (schema, cache_key, tuple) | git |
| 8 | TOCTOU: dir rmRf'd between gates → exit 2 | non-git |
| 9 | TOCTOU: dir replaced with symlink between gates → exit 2 | non-git |
| 10 | Leaf is symlink → exit 2, outside file untouched | non-git |
| 11 | Leaf is symlink → exit 2, outside file untouched | git |
| 12 | `.episodic-memory` is symlink → exit 2 | git |
| 13 | First-time creation, `.episodic-memory` absent | git |
| 14 | Linked worktree: cwd in `<wt>/sub`, writes under `<main>` | git |
| 15 | Two concurrent first-time creators race safely (2 valid lines) | git |
| 16 | Linked worktree + `--allow-non-git` + pre-created sentinel | non-git |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
