### PR TITLE
fix(em-recall): scope bp-001 arming to current project (closes cross-project bleed)

### DIFF
--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -498,19 +498,54 @@ function runViolationPreflight(activeEntries, taskType, patterns) {
 // inference returns null. Pure function — testable in isolation and stable
 // for #80's later validator-backed gate to swap.
 // ---------------------------------------------------------------------------
-function shouldArmBp001Checkpoint(activeEntries, now) {
+function shouldArmBp001Checkpoint(activeEntries, now, currentProject) {
+  // Fail-closed: without a resolved project name we cannot scope the match.
+  // The 30-day window arming engine bleeds across projects without this guard.
+  if (!currentProject) return false
   const cutoff = new Date(now)
   cutoff.setDate(cutoff.getDate() - 30)
   const cutoffStr = cutoff.toISOString().slice(0, 10)
   const tag = 'violated:bp-001-implementation-workflow'
   return activeEntries.some(e =>
     e &&
+    e.status !== 'superseded' &&
     e.category === 'violation' &&
+    e.project === currentProject &&
     Array.isArray(e.tags) &&
     e.tags.includes(tag) &&
     typeof e.date === 'string' &&
     e.date >= cutoffStr
   )
+}
+
+// Resolve the project name for ARMING purposes (binds to REPO_ROOT, not cwd).
+// Precedence: --project override (unless ignored) → <projectRoot>/package.json
+// `name` → `git remote get-url origin` basename (subprocess cwd = projectRoot)
+// → path.basename(projectRoot).
+//
+// ignoreOverride:true for the bp-001 arming call site — the marker writes to
+// REPO_ROOT/.checkpoints/ so the project identity used to filter violations
+// must also bind to REPO_ROOT. Letting --project override the arming-time name
+// re-creates the cross-project bleed via a different surface (codex R2 P1).
+function resolveProjectName(projectRoot, { ignoreOverride = false } = {}) {
+  if (!ignoreOverride && projectOverride) return projectOverride
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'))
+    if (pkg.name && pkg.name.trim()) return pkg.name.trim()
+  } catch {}
+
+  try {
+    const remoteUrl = execSync('git remote get-url origin', {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim()
+    const match = remoteUrl.match(/\/([^/]+?)(?:\.git)?$/) || remoteUrl.match(/:([^/]+?)(?:\.git)?$/)
+    if (match) return match[1]
+  } catch {}
+
+  return path.basename(projectRoot)
 }
 
 // ---------------------------------------------------------------------------
@@ -555,31 +590,16 @@ function loadIndex(dataDir, source) {
 function inferContext() {
   const ctx = { project: null, branch_tokens: [], keywords: [], effective_tokens: [] }
 
-  // Always read package.json for keywords (even when project is overridden)
+  // Always read REPO_ROOT/package.json for keywords (independent of project resolution).
   try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'))
+    const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'))
     if (Array.isArray(pkg.keywords)) ctx.keywords = pkg.keywords.map(k => k.toLowerCase().trim()).filter(Boolean)
-    if (!projectOverride && pkg.name && pkg.name.trim()) ctx.project = pkg.name.trim()
   } catch {}
 
-  // 1. Project name: override → package.json (above) → git remote → basename(cwd)
-  if (projectOverride) {
-    ctx.project = projectOverride
-  } else if (!ctx.project) {
-    // Try git remote
-    try {
-      const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()
-      // SSH: git@github.com:org/repo.git → repo
-      // HTTPS: https://github.com/org/repo.git → repo
-      const match = remoteUrl.match(/\/([^/]+?)(?:\.git)?$/) || remoteUrl.match(/:([^/]+?)(?:\.git)?$/)
-      if (match) ctx.project = match[1]
-    } catch {}
-
-    // Fallback to basename(cwd)
-    if (!ctx.project) {
-      ctx.project = path.basename(process.cwd())
-    }
-  }
+  // Project name resolution — root-bound, honors --project override here (recall
+  // output filtering is the intended override contract). Arming path uses
+  // ignoreOverride:true at the dedicated call site.
+  ctx.project = resolveProjectName(REPO_ROOT)
 
   // 2. Branch tokens
   try {
@@ -687,7 +707,13 @@ if (sessionStartFlag) {
 // any session that ends up writing files; checkpoint-gate itself only
 // blocks write tools, so the false-positive surface is bounded.
 // ---------------------------------------------------------------------------
-if (shouldArmBp001Checkpoint(activeEntries, new Date())) {
+// Bind arming-time project name to REPO_ROOT (NOT process.cwd() and NOT the
+// --project override). This pairs with armCheckpointMarker(REPO_ROOT) below
+// so the project identity used to scope violations matches the marker write
+// authority root. Closes the cross-project bleed where violations in one
+// project armed checkpoint gates in every other project at SessionStart.
+const armingProject = resolveProjectName(REPO_ROOT, { ignoreOverride: true })
+if (shouldArmBp001Checkpoint(activeEntries, new Date(), armingProject)) {
   armCheckpointMarker(REPO_ROOT)
 }
 

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -527,7 +527,14 @@ function shouldArmBp001Checkpoint(activeEntries, now, currentProject) {
 // REPO_ROOT/.checkpoints/ so the project identity used to filter violations
 // must also bind to REPO_ROOT. Letting --project override the arming-time name
 // re-creates the cross-project bleed via a different surface (codex R2 P1).
-function resolveProjectName(projectRoot, { ignoreOverride = false } = {}) {
+//
+// fast:true skips the `git remote get-url` subprocess. The arming call site
+// passes fast:true because (a) SessionStart fires every session and the test
+// contract (test-em-recall-session-start-early-exit.mjs T7) forbids this git
+// invocation during --session-start, and (b) violations record project names
+// matching package.json `name` (the em-store convention), so the git-remote
+// fallback rarely contributes a different match than basename(projectRoot).
+function resolveProjectName(projectRoot, { ignoreOverride = false, fast = false } = {}) {
   if (!ignoreOverride && projectOverride) return projectOverride
 
   try {
@@ -535,15 +542,17 @@ function resolveProjectName(projectRoot, { ignoreOverride = false } = {}) {
     if (pkg.name && pkg.name.trim()) return pkg.name.trim()
   } catch {}
 
-  try {
-    const remoteUrl = execSync('git remote get-url origin', {
-      cwd: projectRoot,
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe']
-    }).trim()
-    const match = remoteUrl.match(/\/([^/]+?)(?:\.git)?$/) || remoteUrl.match(/:([^/]+?)(?:\.git)?$/)
-    if (match) return match[1]
-  } catch {}
+  if (!fast) {
+    try {
+      const remoteUrl = execSync('git remote get-url origin', {
+        cwd: projectRoot,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe']
+      }).trim()
+      const match = remoteUrl.match(/\/([^/]+?)(?:\.git)?$/) || remoteUrl.match(/:([^/]+?)(?:\.git)?$/)
+      if (match) return match[1]
+    } catch {}
+  }
 
   return path.basename(projectRoot)
 }
@@ -712,7 +721,7 @@ if (sessionStartFlag) {
 // so the project identity used to scope violations matches the marker write
 // authority root. Closes the cross-project bleed where violations in one
 // project armed checkpoint gates in every other project at SessionStart.
-const armingProject = resolveProjectName(REPO_ROOT, { ignoreOverride: true })
+const armingProject = resolveProjectName(REPO_ROOT, { ignoreOverride: true, fast: true })
 if (shouldArmBp001Checkpoint(activeEntries, new Date(), armingProject)) {
   armCheckpointMarker(REPO_ROOT)
 }

--- a/tests/test-bp001-per-project-arming.mjs
+++ b/tests/test-bp001-per-project-arming.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * test-bp001-per-project-arming.mjs — Per-project scope for the bp-001
+ * checkpoint-gate arming engine (`shouldArmBp001Checkpoint`).
+ *
+ * Before: any bp-001 violation in any project armed .checkpoint-required in
+ * EVERY project at SessionStart (cross-project bleed).
+ * After: arming only fires when the current REPO_ROOT's resolved project name
+ * matches the violation's project field.
+ *
+ * Tests run em-recall.mjs as a subprocess with isolated HOME (fake global
+ * episode store) and assert marker placement on disk — pure integration.
+ *
+ * Plan v3 cases A1-A8.
+ */
+
+import { execSync, spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const REPO_ROOT = path.resolve(new URL('..', import.meta.url).pathname)
+const EM_RECALL = path.join(REPO_ROOT, 'scripts', 'em-recall.mjs')
+
+let pass = 0, fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+
+// ── Fixture builders ─────────────────────────────────────────────────────
+
+function mkRepo(label, packageName) {
+  const raw = fs.mkdtempSync(path.join(os.tmpdir(), `bp001-${label}-`))
+  const d = fs.realpathSync(raw)
+  execSync(`git init -q -b main "${d}"`)
+  execSync(`git -C "${d}" config user.email t@t`)
+  execSync(`git -C "${d}" config user.name t`)
+  if (packageName) {
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: packageName }, null, 2))
+  }
+  fs.writeFileSync(path.join(d, 'README.md'), 'x\n')
+  execSync(`git -C "${d}" add . `)
+  execSync(`git -C "${d}" commit -q -m init`)
+  fs.mkdirSync(path.join(d, '.checkpoints'), { recursive: true })
+  return d
+}
+
+function mkFakeHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bp001-home-'))
+  fs.mkdirSync(path.join(home, '.episodic-memory', 'episodes'), { recursive: true })
+  // Empty global index — tests append entries as needed.
+  fs.writeFileSync(path.join(home, '.episodic-memory', 'index.jsonl'), '')
+  return home
+}
+
+function seedViolation(home, { project, date, status = 'active', daysAgo = null, tag = 'violated:bp-001-implementation-workflow' }) {
+  const epDate = daysAgo !== null
+    ? new Date(Date.now() - daysAgo * 86400000).toISOString().slice(0, 10)
+    : (date || new Date().toISOString().slice(0, 10))
+  const id = `${epDate.replace(/-/g, '')}-test-violation-${Math.random().toString(36).slice(2, 8)}`
+  const entry = {
+    id,
+    date: epDate,
+    time: '12:00',
+    project,
+    category: 'violation',
+    status,
+    tags: [tag, 'behavioral-pattern'],
+    summary: `test bp-001 violation in ${project}`
+  }
+  fs.appendFileSync(path.join(home, '.episodic-memory', 'index.jsonl'),
+    JSON.stringify(entry) + '\n')
+  fs.writeFileSync(path.join(home, '.episodic-memory', 'episodes', `${id}.md`),
+    `---\nid: ${id}\ndate: ${epDate}\ntime: "12:00"\nproject: ${project}\ncategory: violation\nstatus: ${status}\ntags: [${tag}, behavioral-pattern]\nsummary: test bp-001 violation in ${project}\n---\n\n# test\n`)
+  return id
+}
+
+function runSessionStart(cwd, home, extraArgs = []) {
+  const r = spawnSync('node', [EM_RECALL, '--session-start', '--limit', '1', ...extraArgs], {
+    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: home }
+  })
+  return { stdout: r.stdout || '', stderr: r.stderr || '', status: r.status }
+}
+
+function markerExists(repoRoot) {
+  const p = path.join(repoRoot, '.checkpoints', '.checkpoint-required')
+  if (!fs.existsSync(p)) return false
+  return fs.lstatSync(p).isFile()
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+const TESTS = []
+const test = (name, fn) => TESTS.push({ name, fn })
+
+test('A1 cross-project: violation in project-A, SessionStart in project-B → NOT armed (THE FIX)', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a1-projA', 'project-a')
+  const projB = mkRepo('a1-projB', 'project-b')
+  seedViolation(home, { project: 'project-a' })
+  const r = runSessionStart(projB, home)
+  if (r.status !== 0) return bad('A1', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (markerExists(projB)) return bad('A1', `project-b marker should NOT exist`)
+  if (markerExists(projA)) return bad('A1', `project-a marker should NOT be touched`)
+  ok('A1')
+})
+
+test('A2 same-project: violation in project-A, SessionStart in project-A → armed', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a2-projA', 'project-a')
+  seedViolation(home, { project: 'project-a' })
+  const r = runSessionStart(projA, home)
+  if (r.status !== 0) return bad('A2', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (!markerExists(projA)) return bad('A2', `project-a marker should be armed but is not`)
+  ok('A2')
+})
+
+test('A3 nested cwd: violation in project-A, SessionStart in project-A/sub → armed at A (REPO_ROOT walks up)', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a3-projA', 'project-a')
+  const sub = path.join(projA, 'sub')
+  fs.mkdirSync(sub)
+  seedViolation(home, { project: 'project-a' })
+  const r = runSessionStart(sub, home)
+  if (r.status !== 0) return bad('A3', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (!markerExists(projA)) return bad('A3', `project-a marker should be armed`)
+  if (markerExists(sub)) return bad('A3', `sub-level marker should NOT exist`)
+  ok('A3')
+})
+
+test('A5 --project override does NOT trick the arming: cwd=project-B + --project project-a → NOT armed', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a5-projA', 'project-a')
+  const projB = mkRepo('a5-projB', 'project-b')
+  seedViolation(home, { project: 'project-a' })
+  const r = runSessionStart(projB, home, ['--project', 'project-a'])
+  if (r.status !== 0) return bad('A5', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (markerExists(projB)) return bad('A5', `project-b marker should NOT exist (override must be ignored for arming)`)
+  if (markerExists(projA)) return bad('A5', `project-a marker should NOT be touched`)
+  ok('A5')
+})
+
+test('A6 out-of-cutoff: 60-day-old violation in project-A → NOT armed', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a6-projA', 'project-a')
+  seedViolation(home, { project: 'project-a', daysAgo: 60 })
+  const r = runSessionStart(projA, home)
+  if (r.status !== 0) return bad('A6', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (markerExists(projA)) return bad('A6', `60-day-old violation should not arm`)
+  ok('A6')
+})
+
+test('A7 multi-project: violations in A,B,C + SessionStart in A → armed (only A counts)', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a7-projA', 'project-a')
+  seedViolation(home, { project: 'project-a' })
+  seedViolation(home, { project: 'project-b' })
+  seedViolation(home, { project: 'project-c' })
+  const r = runSessionStart(projA, home)
+  if (r.status !== 0) return bad('A7', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (!markerExists(projA)) return bad('A7', `A's own violation should arm`)
+  ok('A7')
+})
+
+test('A8 superseded: only-violation-for-A is status:superseded → NOT armed (explicit status filter)', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a8-projA', 'project-a')
+  seedViolation(home, { project: 'project-a', status: 'superseded' })
+  const r = runSessionStart(projA, home)
+  if (r.status !== 0) return bad('A8', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (markerExists(projA)) return bad('A8', `superseded violation must not arm`)
+  ok('A8')
+})
+
+test('A9 no violations anywhere: SessionStart in any project → NOT armed', () => {
+  const home = mkFakeHome()
+  const projA = mkRepo('a9-projA', 'project-a')
+  const r = runSessionStart(projA, home)
+  if (r.status !== 0) return bad('A9', `em-recall exited ${r.status}: ${r.stderr}`)
+  if (markerExists(projA)) return bad('A9', `clean store must not arm`)
+  ok('A9')
+})
+
+// ── Runner ───────────────────────────────────────────────────────────────
+
+console.log('bp-001 per-project arming integration tests')
+for (const t of TESTS) {
+  try { t.fn() } catch (e) { bad(t.name, `threw: ${e.message}`) }
+}
+console.log(`\n${pass}/${pass + fail} passed`)
+if (fail > 0) {
+  for (const f of failures) console.log(`  ✗ ${f}`)
+  process.exit(1)
+}

--- a/tests/test-checkpoints-migration.mjs
+++ b/tests/test-checkpoints-migration.mjs
@@ -61,7 +61,12 @@ function setupRepo() {
   git(root, 'config user.email test@example.com')
   git(root, 'config user.name test')
   fs.writeFileSync(path.join(root, 'README.md'), '# t\n')
-  git(root, 'add README.md')
+  // Pin project name to 'test' so resolveProjectName(root, {ignoreOverride:true})
+  // matches the seeded violations (which use project: 'test'). Without this,
+  // post-Option-E arming binds to basename(root) which is the random mkdtemp
+  // suffix → no project match → no arm → tests that rely on arming fail.
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: 'test' }, null, 2))
+  git(root, 'add README.md package.json')
   git(root, 'commit -q -m init')
   return root
 }

--- a/tests/test-em-recall-session-start-early-exit.mjs
+++ b/tests/test-em-recall-session-start-early-exit.mjs
@@ -91,7 +91,13 @@ git(mainRepo, 'init -q -b main')
 git(mainRepo, 'config user.email test@example.com')
 git(mainRepo, 'config user.name test')
 fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
-git(mainRepo, 'add README.md')
+// package.json with name='test' so arming-path resolveProjectName(mainRepo)
+// resolves to 'test' (matches seeded violation's --project test). Post-Option-E
+// arming requires e.project === resolveProjectName(REPO_ROOT, {fast:true}); without
+// this fixture the arming would fall to basename(mainRepo)='main' and tests
+// expecting marker arming would fail.
+fs.writeFileSync(path.join(mainRepo, 'package.json'), JSON.stringify({ name: 'test' }, null, 2))
+git(mainRepo, 'add README.md package.json')
 git(mainRepo, 'commit -q -m init')
 git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
 fs.mkdirSync(nestedDir, { recursive: true })

--- a/tests/test-em-repo-root-worktree.mjs
+++ b/tests/test-em-repo-root-worktree.mjs
@@ -71,7 +71,11 @@ git(mainRepo, 'init -q -b main')
 git(mainRepo, 'config user.email test@example.com')
 git(mainRepo, 'config user.name test')
 fs.writeFileSync(path.join(mainRepo, 'README.md'), '# test\n')
-git(mainRepo, 'add README.md')
+// package.json with name='test' so resolveProjectName(mainRepo) returns 'test'
+// — the seeded violation also uses --project test, so the per-project arming
+// predicate (post Option E) matches and armCheckpointMarker fires.
+fs.writeFileSync(path.join(mainRepo, 'package.json'), JSON.stringify({ name: 'test' }, null, 2))
+git(mainRepo, 'add README.md package.json')
 git(mainRepo, 'commit -q -m init')
 git(mainRepo, `worktree add -q -b wt-branch ${worktreeRoot}`)
 fs.mkdirSync(nestedDir, { recursive: true })


### PR DESCRIPTION
## Summary

- `shouldArmBp001Checkpoint` (em-recall.mjs:501) had no project filter — a bp-001 violation in ANY project armed `.checkpoint-required` in EVERY project at SessionStart. Real symptom: Home Network Improvement (no own violations) hit the checkpoint gate on every Bash/Edit/Write because of episodic-memory's violation history.
- Fix: scope the predicate to the resolved current project, with root-bound name resolution (`REPO_ROOT`, not `process.cwd()`) and override-ignored at the arming site (`--project` stays valid for recall-output filtering only).

## Security / correctness hardening (codex R1+R2)

- `resolveProjectName(projectRoot, {ignoreOverride})` is root-bound — reads `<projectRoot>/package.json`, passes `{cwd: projectRoot}` to `git remote get-url origin`, falls back to `basename(projectRoot)`. No `process.cwd()` references in the resolution path.
- Arming site uses `ignoreOverride:true` — `--project project-a` from cwd=project-b can no longer arm project-b's gate via a different surface (codex R2 P1).
- Predicate fail-closed when `currentProject` is null/empty.
- Predicate explicitly checks `e.status !== 'superseded'` — no longer relying on upstream `activeEntries` filtering for that contract (codex R1 P2).

## Codex review trail

- Plan R1: HOLD — P1 (bind helper to REPO_ROOT), P2 (explicit status filter), P2 (integration tests required). Episode `20260523-064954-reply-codex-to-20260523-064748-bp-001-pe-70ad`.
- Plan R2: HOLD — P1 (`--project` override authority split for arming), P2 (FU spec strengthening). Episode `20260523-065359-reply-codex-to-20260523-065156-bp-001-pe-99f8`.
- All findings ACCEPT'd and incorporated in plan v3. R3 dispatch was blocked by the session preflight gate after a context compaction; **a fresh PR-level codex review will run on this PR's consolidated diff post-creation**.

## Test plan

- [x] `node tests/test-bp001-per-project-arming.mjs` — **8/8 pass** (new file)
  - A1 cross-project (THE BUG FIX) → not armed
  - A2 same-project → armed
  - A3 nested cwd → armed at REPO_ROOT
  - A5 `--project` override from wrong cwd → not armed (codex R2 P1 fix)
  - A6 out-of-cutoff (60 days) → not armed
  - A7 multi-project store → armed only when local matches
  - A8 superseded violation → not armed (explicit status filter)
  - A9 clean store → not armed
- [x] `node tests/test-issue-146.mjs` — **51/51 pass** (zero regression)
- [x] `node tests/test-rfc002-phase3.mjs` — **29/29 pass** (zero regression)
- [x] `node tests/test-em-repo-root-worktree.mjs` — **12/12 pass** (test fixture updated: added `package.json` to mainRepo so seeded `--project test` violation matches `resolveProjectName(mainRepo)` post-fix)

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Violation in episodic-memory + SessionStart in episodic-memory | Arms | Arms ✓ |
| Violation in episodic-memory + SessionStart in Home Network Improvement | **Arms (BUG)** | Not armed ✓ |
| Violations in A, B, C + SessionStart in A | Arms | Arms (only A's match) ✓ |
| Out-of-cutoff violation | Not armed | Not armed ✓ |
| Superseded violation matching project | Not armed (via upstream filter) | Not armed (explicit + upstream) ✓ |
| `--project A` from cwd=B with A's violation | **Arms B (BUG)** | Not armed ✓ |
| currentProject=null (fail-closed) | Arms (current behavior) | Not armed ✓ |

## Follow-up (Rule 18 step 9, post-merge)

GitHub issue to be filed: same-class authority-root gap in `runViolationPreflight` (`em-recall.mjs:472`) — emits cross-project warnings without a project filter. Lower-friction surface than gate arming; deferred for a separate cycle. FU body will include authority-root statement (file:line), cwd-mismatch repro requirement, and cross-reference to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
