### PR TITLE
fix(checkpoint-gate): path-with-spaces wrong-root detector regression

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -266,47 +266,113 @@ _command_has_relative_marker_path() {
   printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
 }
 
-# E2E-discovered absolute-non-canonical detection: for Bash commands where
-# the classifier returns shared_write (touch/mv/cp/install/dd of=) on an
-# ABSOLUTE marker path NOT under canonical PRIMARY/LEGACY. The
-# marker_write-branch check covers absolute paths classified AS marker_write
-# (redirect/rm/tee); this catches the shared_write-classified-but-targets-
-# marker case. Echoes the first offending path on match (exit 0); empty on
-# no match (exit 1).
+# Absolute-non-canonical detection: for Bash commands where the classifier
+# returns shared_write (touch/mv/cp/install/dd of=) on an ABSOLUTE marker path
+# NOT under canonical PRIMARY/LEGACY. The marker_write-branch check covers
+# absolute paths classified AS marker_write (redirect/rm/tee); this catches
+# the shared_write-classified-but-targets-marker case.
+#
+# Three-pass per-token scan (codex review rounds R1–R8, 2026-05-23):
+#
+#   Pass A   — T token IS itself an absolute marker path. Handles paths
+#              containing spaces because `_tokenize` preserves quoted
+#              whitespace inside a single T value (closes the original bug
+#              class — Home Network Improvement style repos).
+#   Pass A'  — T token has `key=path` prefix (e.g. `of=/path with sp/X`,
+#              `--output=/path with sp/X`). Walks `=`-delimited tails;
+#              re-runs Pass A on each `/`-prefixed candidate. Preserves
+#              spaces in the path portion.
+#   Pass B   — T token CONTAINS an absolute marker-path substring (handles
+#              `bash -c "touch /tmp/.checkpoints/.X"` payloads where the
+#              path arrives inside a multi-word T token, no leading `/`).
+#              Inner paths-with-spaces under this shape remain unhandled —
+#              same as pre-fix behavior; not a new regression.
+#
+# Canonical short-circuit: if Pass A or A' recognizes a canonical full marker
+# candidate, the per-token `continue` skips Pass B for that token. Without
+# this, Pass B's regex would truncate a spacey canonical path at the first
+# space and false-positive against the equality check.
+#
+# Echoes the first offending path on match. Returns 0 always so `x="$(...)"`
+# under `set -e` never triggers script exit on the no-match case.
 _command_first_absolute_noncanonical_marker() {
-  # Empty output = no wrong-root marker found; non-empty = the offending
-  # path. Function always returns 0 so `x="$(...)"` under `set -e` never
-  # triggers script exit on the no-match case (caller uses `[ -n "$x" ]`).
-  local cmd
-  cmd="$(_strip_shell_quotes "$1")"
-  local matches p basename
-  matches=$(printf '%s' "$cmd" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
-  [ -z "$matches" ] && return 0
-  while IFS= read -r p; do
-    [ -z "$p" ] && continue
-    # PR-review P1: occurrence-scoped relative-vs-absolute disambiguation.
-    # Strip all literal `.${p}` occurrences from cmd, then check if $p
-    # still appears. If it does, there's at least one NON-relative
-    # occurrence (a genuine absolute reference). Avoids the global-filter
-    # false-negative where `echo ./tmp/.checkpoints/X >/dev/null; touch
-    # /tmp/.checkpoints/X` would have skipped the check because
-    # `./tmp/.checkpoints/X` exists somewhere in the command.
-    #
-    # PR-review round-2 P1: `${var//pattern/}` interprets glob meta chars
-    # in the pattern. Escape `*`/`?`/`[` in `$p` so the substitution is
-    # truly literal-equivalent (codex episode ...5b9e).
-    local p_escaped
-    p_escaped="$(_escape_bash_glob "$p")"
-    local cmd_filtered="${cmd//\.${p_escaped}/}"
-    if [[ "$cmd_filtered" != *"$p"* ]]; then
-      continue
-    fi
-    basename="${p##*/}"
-    if [ "$p" != "$PRIMARY_DIR/$basename" ] && [ "$p" != "$LEGACY_DIR/$basename" ]; then
-      printf '%s' "$p"
-      return 0
-    fi
-  done <<< "$matches"
+  local cmd="$1"
+  local stream line type val
+  # SIGPIPE-safe capture (feedback_shell_sigpipe_done_pipe.md): capture the
+  # tokenizer output BEFORE iterating so an early `return` inside the loop
+  # doesn't close the pipe while _tokenize is still writing on Linux.
+  stream="$(_tokenize "$cmd")"
+  while IFS= read -r line; do
+    type="${line:0:1}"
+    val="${line:2}"
+    [ "$type" = "T" ] || continue
+
+    local recognized_marker=0
+
+    # ---- Pass A: token IS an absolute marker path.
+    case "$val" in
+      /*)
+        if _marker_basename_in_set "$val"; then
+          if _is_canonical_marker_path "$val"; then
+            recognized_marker=1
+          else
+            printf '%s' "$val"
+            return 0
+          fi
+        fi
+        ;;
+    esac
+
+    # ---- Pass A': `key=path` prefix walk.
+    local rest="$val" candidate
+    while [ "${rest#*=}" != "$rest" ]; do
+      rest="${rest#*=}"
+      case "$rest" in
+        /*)
+          candidate="$rest"
+          if _marker_basename_in_set "$candidate"; then
+            if _is_canonical_marker_path "$candidate"; then
+              recognized_marker=1
+            else
+              printf '%s' "$candidate"
+              return 0
+            fi
+          fi
+          ;;
+      esac
+    done
+
+    # Canonical short-circuit: if Pass A or A' already identified a
+    # canonical full candidate for this token, skip Pass B (which would
+    # truncate a spacey canonical path and false-positive).
+    [ "$recognized_marker" = "1" ] && continue
+
+    # ---- Pass B: token CONTAINS an absolute marker-path substring.
+    local tok_matches p basename p_escaped tok_filtered
+    tok_matches=$(printf '%s' "$val" | grep -oE '/[^[:space:]]*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)' 2>/dev/null || true)
+    [ -z "$tok_matches" ] && continue
+    while IFS= read -r p; do
+      [ -z "$p" ] && continue
+
+      # Per-token occurrence-scoped relative-vs-absolute disambiguation
+      # (preserved from prior code, scoped to the current T value). Strip
+      # literal `.${p}` occurrences from the token; if `$p` no longer
+      # appears, the match was a relative reference (e.g. `./tmp/.X`);
+      # skip. `_escape_bash_glob` handles `*`/`?`/`[` in `$p` so the
+      # substitution stays literal.
+      p_escaped="$(_escape_bash_glob "$p")"
+      tok_filtered="${val//\.${p_escaped}/}"
+      if [[ "$tok_filtered" != *"$p"* ]]; then
+        continue
+      fi
+
+      basename="${p##*/}"
+      if [ "$p" != "$PRIMARY_DIR/$basename" ] && [ "$p" != "$LEGACY_DIR/$basename" ]; then
+        printf '%s' "$p"
+        return 0
+      fi
+    done <<< "$tok_matches"
+  done <<< "$stream"
   return 0
 }
 

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -272,7 +272,7 @@ export const PLAN_MARKER_ENFORCEMENT_SITES = [
   { file: 'hooks/checkpoint-gate.sh', line: 99, role: 'marker_basename_for_target exact-equality', kind: 'shell-equality', semantic_role: 'read-any' },
   { file: 'hooks/checkpoint-gate.sh', line: 120, role: '_marker_basename_in_set closed set', kind: 'shell-case', semantic_role: 'read-any' },
   { file: 'hooks/checkpoint-gate.sh', line: 196, role: '_command_has_relative_marker_path grep-E alternation', kind: 'grep-E-alternation', semantic_role: 'read-any' },
-  { file: 'hooks/checkpoint-gate.sh', line: 213, role: '_command_first_absolute_noncanonical grep-oE alternation', kind: 'grep-E-alternation', semantic_role: 'read-any' },
+  { file: 'hooks/checkpoint-gate.sh', line: 276, role: '_command_first_absolute_noncanonical_marker three-pass detector (token-equality + key=path walk + substring grep with relative-occurrence disambiguation; canonical short-circuit; path-with-spaces safe)', kind: 'shell-tokenizer-three-pass', semantic_role: 'read-any' },
 
   // E10: plan-gate.sh existence check + marker_write allowlist.
   { file: 'hooks/plan-gate.sh', line: 57, role: 'PLAN_PENDING_W resolution + existence check + marker_write allowlist (session-aware after #268 fix)', kind: 'shell-equality', semantic_role: 'read-own-session' },

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1088,6 +1088,282 @@ git -C "$TEST_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null
 git -C "$TEST_DIR" branch -D test-wt-branch 2>/dev/null
 
 # ============================================================================
+# B-S: paths-with-spaces wrong-root detector (codex R1-R8 / PR #<TBD>)
+#
+# Covers the bug class where `_command_first_absolute_noncanonical_marker`
+# truncated absolute marker paths at the first whitespace, breaking marker
+# operations in any repo whose absolute path contains a space (e.g.
+# "Home Network Improvement").
+#
+# Implementation: three-pass per-token scan (whole-token equality, key=path
+# walk, substring-regex with canonical short-circuit + relative disambig).
+# ============================================================================
+
+# ---- B-S helpers ----
+
+# Run hook from an explicit caller process cwd (different from JSON .cwd) so
+# B-S9 / B-S13 / B-S26 actually exercise the caller-cwd ≠ JSON-cwd axis.
+run_hook_from_cwd() {
+  local caller_cwd="$1"
+  (cd "$caller_cwd" && HOME="$TEST_HOME" bash "$HOOK")
+}
+
+# Assert hook blocks AND reason JSON contains BOTH expected-attempted and
+# expected-canonical path literals (substring match via grep -qF / jq -r).
+assert_blocked_with_reason() {
+  local test_name="$1" json="$2" expected_attempted="$3" expected_canonical="$4"
+  local output reason exit_code=0
+  output=$(echo "$json" | run_hook 2>/dev/null) || exit_code=$?
+  if ! echo "$output" | grep -q '"decision".*"block"'; then
+    echo "  ✗ $test_name (expected block; exit=$exit_code output=$output)"
+    ((failed++))
+    return
+  fi
+  reason=$(echo "$output" | jq -r '.reason // ""' 2>/dev/null)
+  if [ -z "$reason" ] || ! printf '%s' "$reason" | grep -qF -- "$expected_attempted"; then
+    echo "  ✗ $test_name (reason missing attempted='$expected_attempted'): $reason"
+    ((failed++))
+    return
+  fi
+  if ! printf '%s' "$reason" | grep -qF -- "$expected_canonical"; then
+    echo "  ✗ $test_name (reason missing canonical='$expected_canonical'): $reason"
+    ((failed++))
+    return
+  fi
+  echo "  ✓ $test_name"
+  ((passed++))
+}
+
+# Paired disk assertion (B-S26): target marker exists (fixture-seeded);
+# caller cwd has no leaked .checkpoints/ dir.
+assert_disk_artifacts() {
+  local test_name="$1" target_marker_path="$2" caller_cwd="$3"
+  if [ ! -e "$target_marker_path" ]; then
+    echo "  ✗ $test_name (target marker missing: $target_marker_path)"
+    ((failed++))
+    return
+  fi
+  if [ -e "$caller_cwd/.checkpoints" ]; then
+    echo "  ✗ $test_name (caller-cwd leak: $(ls -la "$caller_cwd/.checkpoints" 2>&1))"
+    ((failed++))
+    return
+  fi
+  echo "  ✓ $test_name (disk artifacts: target=$target_marker_path, caller no-leak)"
+  ((passed++))
+}
+
+# ---- B-S fixture: spacey main repo + spacey linked worktree ----
+
+SPACE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/em-space test.XXXXXX")"
+SPACE_DIR="$(cd -P "$SPACE_DIR" && pwd)"
+git -C "$SPACE_DIR" init -q 2>/dev/null
+mkdir -p "$SPACE_DIR/.checkpoints"
+touch "$SPACE_DIR/.checkpoints/.checkpoint-required"
+git -C "$SPACE_DIR" -c user.email=t@t.test -c user.name=test commit --allow-empty -m init -q
+
+SPACE_DIR_WT="$(mktemp -d "${TMPDIR:-/tmp}/em-space wt.XXXXXX")"
+SPACE_DIR_WT="$(cd -P "$SPACE_DIR_WT" && pwd)"
+rmdir "$SPACE_DIR_WT"
+
+# R6 P1.1: explicit -b avoids invalid-ref-name from spacey basename
+# (git would otherwise infer the branch as `em-space wt.xxxx` and fail).
+if ! git -C "$SPACE_DIR" worktree add -b test-spacey-wt-branch "$SPACE_DIR_WT" -q; then
+  echo "FAIL: B-S fixture: git worktree add failed (spacey basename branch-inference bug?)"
+  exit 1
+fi
+
+# Fixture precondition: worktree's git-common-dir resolves to main repo.
+B_S_EXPECTED_COMMON_DIR="$SPACE_DIR/.git"
+B_S_ACTUAL_COMMON_DIR="$(git -C "$SPACE_DIR_WT" rev-parse --git-common-dir)"
+case "$B_S_ACTUAL_COMMON_DIR" in
+  /*) ;;
+  *) B_S_ACTUAL_COMMON_DIR="$SPACE_DIR_WT/$B_S_ACTUAL_COMMON_DIR" ;;
+esac
+B_S_ACTUAL_COMMON_DIR="$(cd -P "$B_S_ACTUAL_COMMON_DIR" 2>/dev/null && pwd)" || true
+if [ "$B_S_ACTUAL_COMMON_DIR" != "$B_S_EXPECTED_COMMON_DIR" ]; then
+  echo "FAIL: B-S fixture: common-dir resolved to '$B_S_ACTUAL_COMMON_DIR'; expected '$B_S_EXPECTED_COMMON_DIR'"
+  exit 1
+fi
+
+# Nested subdir under spacey repo (for B-S11).
+SPACE_DIR_NESTED="$SPACE_DIR/sub dir"
+mkdir -p "$SPACE_DIR_NESTED"
+
+# Clean-name canonical repo (for B-S16): canonical bash -c without spaces.
+CLEAN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/em-clean.XXXXXX")"
+CLEAN_DIR="$(cd -P "$CLEAN_DIR" && pwd)"
+git -C "$CLEAN_DIR" init -q 2>/dev/null
+mkdir -p "$CLEAN_DIR/.checkpoints"
+
+# ---- B-S cases ----
+
+# B-S1: quoted canonical absolute path-with-space → no wrong-root block
+assert_no_wrong_root_block "B-S1. Quoted canonical path-with-space" \
+  "$(mock_json_cwd 'Bash' "rm \"$SPACE_DIR/.checkpoints/.plan-approval-pending\"" "$SPACE_DIR")"
+
+# B-S2: quoted non-canonical absolute path-with-space (different repo) → BLOCK
+assert_blocked_with_reason "B-S2. Quoted non-canonical path-with-space" \
+  "$(mock_json_cwd 'Bash' "rm \"/tmp/some other repo/.checkpoints/.pre-checkpoint-done\"" "$SPACE_DIR")" \
+  "/tmp/some other repo/.checkpoints/.pre-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.pre-checkpoint-done"
+
+# B-S3: touch quoted canonical with space → allow
+assert_no_wrong_root_block "B-S3. touch quoted canonical with space" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")"
+
+# B-S4: redirect to quoted canonical with space → allow
+assert_no_wrong_root_block "B-S4. Redirect to quoted canonical with space" \
+  "$(mock_json_cwd 'Bash' "echo done > \"$SPACE_DIR/.checkpoints/.pre-checkpoint-done\"" "$SPACE_DIR")"
+
+# B-S5: cp to quoted non-canonical /tmp marker path-with-space → BLOCK
+assert_blocked_with_reason "B-S5. cp to non-canonical /tmp path-with-space" \
+  "$(mock_json_cwd 'Bash' "cp /etc/hosts \"/tmp/wrong dir/.checkpoints/.plan-approval-pending\"" "$SPACE_DIR")" \
+  "/tmp/wrong dir/.checkpoints/.plan-approval-pending" \
+  "$SPACE_DIR/.checkpoints/.plan-approval-pending"
+
+# B-S6: single-quoted non-canonical absolute path-with-space → BLOCK
+assert_blocked_with_reason "B-S6. Single-quoted non-canonical path-with-space" \
+  "$(mock_json_cwd 'Bash' "rm '/tmp/another dir/.checkpoints/.post-checkpoint-done'" "$SPACE_DIR")" \
+  "/tmp/another dir/.checkpoints/.post-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.post-checkpoint-done"
+
+# B-S7: multiple markers; first is non-canonical → BLOCK
+assert_blocked_with_reason "B-S7. Multiple markers, first non-canonical" \
+  "$(mock_json_cwd 'Bash' "rm '/tmp/wrong/.checkpoints/.pre-checkpoint-done' \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")" \
+  "/tmp/wrong/.checkpoints/.pre-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.pre-checkpoint-done"
+
+# B-S8: regression — unquoted absolute non-canonical (no spaces) → still BLOCK
+assert_blocked_with_reason "B-S8. Regression: unquoted absolute non-canonical (no spaces)" \
+  "$(mock_json_cwd 'Bash' "rm /tmp/nospaces/.checkpoints/.plan-approval-pending" "$SPACE_DIR")" \
+  "/tmp/nospaces/.checkpoints/.plan-approval-pending" \
+  "$SPACE_DIR/.checkpoints/.plan-approval-pending"
+
+# B-S9: caller process cwd ≠ JSON cwd; canonical-with-spaces target → allow + no leak
+B_S9_JSON="$(mock_json_cwd 'Bash' "rm \"$SPACE_DIR/.checkpoints/.plan-approval-pending\"" "$SPACE_DIR")"
+B_S9_OUT=$(echo "$B_S9_JSON" | run_hook_from_cwd "/tmp" 2>/dev/null)
+if echo "$B_S9_OUT" | grep -qE 'non-canonical path|Relative marker reference'; then
+  echo "  ✗ B-S9. Caller cwd=/tmp, JSON cwd=spacey (wrong-root falsely fired): $B_S9_OUT"
+  ((failed++))
+else
+  echo "  ✓ B-S9. Caller cwd=/tmp, JSON cwd=spacey (no wrong-root block)"
+  ((passed++))
+fi
+if [ -e "/tmp/.checkpoints" ]; then
+  echo "  ✗ B-S9 (leak: /tmp/.checkpoints exists)"
+  ((failed++))
+else
+  echo "  ✓ B-S9 (no caller-cwd leak)"
+  ((passed++))
+fi
+
+# B-S10: linked worktree (both spacey, no-space marker in path) → allow
+assert_no_wrong_root_block "B-S10. Linked worktree (spacey), main canonical marker" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR_WT")"
+
+# B-S11: nested cwd under spacey repo → allow
+assert_no_wrong_root_block "B-S11. Nested cwd under spacey repo" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR_NESTED")"
+
+# B-S12: non-git JSON cwd, target=non-canonical with spaces → BLOCK
+assert_blocked_with_reason "B-S12. Non-git JSON cwd, target non-canonical" \
+  "$(mock_json_cwd 'Bash' "rm \"/tmp/no-repo/.checkpoints/.pre-checkpoint-done\"" "/tmp")" \
+  "/tmp/no-repo/.checkpoints/.pre-checkpoint-done" \
+  "/tmp/.checkpoints/.pre-checkpoint-done"
+
+# B-S13: subprocess wrong-cwd inheritance — binds to JSON cwd, not process cwd
+B_S13_JSON="$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")"
+B_S13_OUT=$(echo "$B_S13_JSON" | run_hook_from_cwd "/tmp" 2>/dev/null)
+if echo "$B_S13_OUT" | grep -qE 'non-canonical path|Relative marker reference'; then
+  echo "  ✗ B-S13. Subprocess wrong-cwd inheritance (wrong-root falsely fired): $B_S13_OUT"
+  ((failed++))
+else
+  echo "  ✓ B-S13. Subprocess wrong-cwd inheritance (binds to JSON cwd)"
+  ((passed++))
+fi
+
+# B-S14: bash -c "touch /no-space/.checkpoints/.X" non-canonical → BLOCK (Pass B)
+assert_blocked_with_reason "B-S14. bash -c non-canonical no-space" \
+  "$(mock_json_cwd 'Bash' 'bash -c "touch /tmp/no-space/.checkpoints/.pre-checkpoint-done"' "$SPACE_DIR")" \
+  "/tmp/no-space/.checkpoints/.pre-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.pre-checkpoint-done"
+
+# B-S15: sh -c "rm /no-space/.checkpoints/.X" → BLOCK
+assert_blocked_with_reason "B-S15. sh -c non-canonical no-space" \
+  "$(mock_json_cwd 'Bash' 'sh -c "rm /tmp/other-non-canon/.checkpoints/.post-checkpoint-done"' "$SPACE_DIR")" \
+  "/tmp/other-non-canon/.checkpoints/.post-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.post-checkpoint-done"
+
+# B-S16: bash -c canonical (no-space cwd) → allow (Pass B canonical equality)
+assert_no_wrong_root_block "B-S16. bash -c canonical no-space" \
+  "$(mock_json_cwd 'Bash' "bash -c \"touch $CLEAN_DIR/.checkpoints/.pre-checkpoint-done\"" "$CLEAN_DIR")"
+
+# B-S17: dd of="<canonical spacey>" → allow (Pass A')
+assert_no_wrong_root_block "B-S17. dd of= canonical spacey" \
+  "$(mock_json_cwd 'Bash' "dd if=/dev/null of=\"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")"
+
+# B-S18: dd of="/tmp/wrong path/.X" non-canonical with spaces → BLOCK with full attempted
+assert_blocked_with_reason "B-S18. dd of= non-canonical spacey" \
+  "$(mock_json_cwd 'Bash' "dd if=/dev/null of=\"/tmp/wrong path/.checkpoints/.pre-checkpoint-done\"" "$SPACE_DIR")" \
+  "/tmp/wrong path/.checkpoints/.pre-checkpoint-done" \
+  "$SPACE_DIR/.checkpoints/.pre-checkpoint-done"
+
+# B-S19: --output= non-canonical spacey → BLOCK
+assert_blocked_with_reason "B-S19. --output= non-canonical spacey" \
+  "$(mock_json_cwd 'Bash' "tool --output=\"/sp path/.checkpoints/.plan-approval-pending\"" "$SPACE_DIR")" \
+  "/sp path/.checkpoints/.plan-approval-pending" \
+  "$SPACE_DIR/.checkpoints/.plan-approval-pending"
+
+# B-S20: --output= canonical spacey → allow
+assert_no_wrong_root_block "B-S20. --output= canonical spacey" \
+  "$(mock_json_cwd 'Bash' "tool --output=\"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")"
+
+# B-S21: P2 relative-token disambiguation inside bash -c payload from main cwd
+assert_no_wrong_root_block "B-S21. P2 relative-token disambiguation" \
+  "$(mock_json_cwd 'Bash' "bash -c \"echo ./tmp/.checkpoints/.pre-checkpoint-done >/dev/null\"" "$SPACE_DIR")"
+
+# B-S22: P1 canonical short-circuit (whole-token Pass A) — verifies that
+# Pass B does NOT then false-positive on the same token by truncating spaces.
+assert_no_wrong_root_block "B-S22. P1 canonical short-circuit Pass A" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.plan-approval-pending\"" "$SPACE_DIR")"
+
+# B-S23: P1 canonical short-circuit (Pass A' key=path) — same invariant
+assert_no_wrong_root_block "B-S23. P1 canonical short-circuit Pass A'" \
+  "$(mock_json_cwd 'Bash' "dd if=/dev/null of=\"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR")"
+
+# B-S24: main repo spacey + linked worktree spacey; write MAIN canonical → allow
+assert_no_wrong_root_block "B-S24. Worktree spacey, MAIN canonical target" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR_WT")"
+
+# B-S25: write WORKTREE-LOCAL absolute marker → BLOCK with full attempted+canonical
+assert_blocked_with_reason "B-S25. Worktree spacey, WORKTREE-LOCAL target" \
+  "$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR_WT/.checkpoints/.checkpoint-required\"" "$SPACE_DIR_WT")" \
+  "$SPACE_DIR_WT/.checkpoints/.checkpoint-required" \
+  "$SPACE_DIR/.checkpoints/.checkpoint-required"
+
+# B-S26: paired target + caller disk assertion
+B_S26_CALLER_CWD="$(mktemp -d "${TMPDIR:-/tmp}/em-caller.XXXXXX")"
+B_S26_CALLER_CWD="$(cd -P "$B_S26_CALLER_CWD" && pwd)"
+B_S26_JSON="$(mock_json_cwd 'Bash' "touch \"$SPACE_DIR/.checkpoints/.checkpoint-required\"" "$SPACE_DIR_WT")"
+B_S26_OUT=$(echo "$B_S26_JSON" | run_hook_from_cwd "$B_S26_CALLER_CWD" 2>/dev/null)
+if echo "$B_S26_OUT" | grep -qE 'non-canonical path|Relative marker reference'; then
+  echo "  ✗ B-S26. Disk-paired allow (wrong-root falsely fired): $B_S26_OUT"
+  ((failed++))
+else
+  echo "  ✓ B-S26. Disk-paired allow (no wrong-root block from caller cwd)"
+  ((passed++))
+fi
+assert_disk_artifacts "B-S26. Paired disk artifacts" \
+  "$SPACE_DIR/.checkpoints/.checkpoint-required" \
+  "$B_S26_CALLER_CWD"
+rm -rf "$B_S26_CALLER_CWD"
+
+# ---- B-S cleanup ----
+git -C "$SPACE_DIR" worktree remove --force "$SPACE_DIR_WT" 2>/dev/null
+git -C "$SPACE_DIR" branch -D test-spacey-wt-branch 2>/dev/null
+rm -rf "$SPACE_DIR" "$CLEAN_DIR"
+
+# ============================================================================
 echo ""
 echo "--- Result ---"
 # ============================================================================


### PR DESCRIPTION
## Summary

- Fixes a checkpoint-gate.sh false-positive that blocked legitimate marker `rm`/`touch`/`mv`/Write operations in any repo whose absolute path contains a space (e.g. `Home Network Improvement`). The block message even reported the user's actual target as the canonical path, which was maximally confusing.
- Root cause: `_command_first_absolute_noncanonical_marker` used `grep -oE '/[^[:space:]]*\.checkpoints/<basenames>'`, which truncates paths at the first whitespace.
- Rewrites the detector as a three-pass per-token scan using the classifier's existing `_tokenize` (Pass A = whole-token absolute, Pass A' = `key=path` prefix, Pass B = substring inside multi-word tokens) + canonical short-circuit + relative-token disambiguation.

## Why

User hit this in `Home Network Improvement` while trying to clean up a stale marker. The hook blocked `rm "/Users/.../Home Network Improvement/.checkpoints/.plan-approval-pending"` with: "you wrote `/.checkpoints/.plan-approval-pending` but canonical is `/Users/.../Home Network Improvement/.checkpoints/.plan-approval-pending`" — i.e. the canonical it cited IS the path the user typed. The truncation was happening inside the regex extraction.

Same class affected every project whose absolute path contains a space.

## Changes

```
 hooks/checkpoint-gate.sh      | 146 ++++++++++++++++------
 scripts/lib/marker-paths.mjs  |   2 +-
 tests/test-checkpoint-gate.sh | 276 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 383 insertions(+), 41 deletions(-)
```

- `hooks/checkpoint-gate.sh`: three-pass per-token detector with canonical short-circuit; preserves all pre-existing coverage including `bash -c` payloads and the occurrence-scoped relative-vs-absolute disambiguation.
- `scripts/lib/marker-paths.mjs`: registry row updated (role + kind) to reflect the tokenizer-based detector — keeps `validate-plan-marker-sites.mjs` green.
- `tests/test-checkpoint-gate.sh`: +28 cases under new `B-S` section. New helpers `run_hook_from_cwd`, `assert_blocked_with_reason`, `assert_disk_artifacts`. Spacey-fixture uses explicit `git worktree add -b test-spacey-wt-branch` (avoids invalid-ref-name from spacey basename inference) + git-common-dir precondition assertion.

## Review chain

- **Plan**: codex 8 rounds (R1 registry+matrix; R2 `bash -c` regression catch; R3 `dd of=` prefix; R4 canonical short-circuit + relative disambig BLOCKERs; R5 worktree×spacey coverage; R6 fixture branch-inference + literal-substring asserts; R7 disk-target spelling + caller-cwd helper; R8 ACCEPT).
- **Code review**: codex 1 round ACCEPT, no blocking findings. Episode `20260523-083342-reply-codex-to-20260523-083126-code-revi-706a`.

The high round count on plan review is itself surfacing a meta-FU (tracked separately): consolidate review-preamble axes so similar shell-tokenizer rewrites converge in 1–2 rounds.

## Test plan

- [x] `bash tests/test-checkpoint-gate.sh` → 188/188 pass (160 → 188; 28 new B-S cases)
- [x] `bash tests/test-runbook-marker-checkpoint-gate.sh` → 6/6 pass
- [x] `node tests/test-checkpoints-migration.mjs` → 7/7 pass
- [x] `node scripts/validate-plan-marker-sites.mjs` → OK 2 checks passed
- [x] User-reported scenario reproduced and verified fixed (path-with-spaces repo, canonical marker rm/touch no longer blocked; non-canonical still blocked with FULL evidence in the reason)

## Coverage axes (cwd-sensitive matrix per discipline #20)

| Axis | Cases |
|---|---|
| Quoted absolute path-with-space (canonical / non-canonical) | B-S1, B-S2, B-S3, B-S4, B-S22 |
| `bash -c "..."` non-canonical / canonical | B-S14, B-S15, B-S16 |
| `dd of=`, `--output=` prefix-path | B-S17, B-S18, B-S19, B-S20, B-S23 |
| Single-quoted variant | B-S6 |
| Multi-marker (return first) | B-S7 |
| Regression (no spaces) | B-S8 |
| caller process cwd ≠ JSON cwd | B-S9, B-S13, B-S26 |
| Linked worktree (spacey) | B-S10, B-S24, B-S25 |
| Nested cwd | B-S11 |
| Non-git JSON cwd | B-S12 |
| P2 relative-token disambiguation | B-S21 |
| Paired disk assertion (target + caller no-leak) | B-S26 |

## Followups

- Meta-FU on review-preamble consolidation (filed post-merge as separate issue).
- No deferred findings from code review.
- Pre-existing #329 (`runViolationPreflight` authority-root gap) is sibling-class but NOT addressed here — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
