### PR TITLE
feat(classifier): replace direct-API Tier 3 with agent-self-classify marker

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Run command-classifier full regression
         run: bash tests/test-command-classifier.sh
 
+      - name: Run classifier-marker hardening + multi-session/multi-project tests (PR #331)
+        run: node tests/test-classifier-marker.mjs
+
+      - name: Run llm-classifier (shell wrapper + dispatcher + marker hot path) tests (PR #331)
+        run: node tests/test-llm-classifier.mjs
+
       - name: Run stop-gate regression
         run: bash tests/test-stop-gate.sh
 

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1496,7 +1496,39 @@ _classify_segment() {
           # helper validates --project-root == resolveRepoRoot(process.cwd()).
           # Same gate-treatment as em-search (label=read_only, reason carries
           # the helper-write nature).
+          #
+          # Same-class env-prefix defense as plan-marker.mjs (PR #272 F-4):
+          # `FOO=bar node classify-correction.mjs --project-root ...` MUST NOT
+          # ride the allowlist lane. Reject any leading POSIX env assignment.
+          if [ $env_prefix_count -gt 0 ]; then
+            printf '%s\t\t%s\n' "unsafe_complex" "classify_correction_env_override"
+            return 0
+          fi
           printf '%s\t\t%s\n' "read_only" "interpreter_classify_correction"
+          return 0
+          ;;
+        classifier-marker.mjs)
+          # Agent-self-classify helper (replaces direct-API Tier 3). Writes
+          # only to <project>/.checkpoints/classify/<sha>.json after the
+          # helper validates --project-root == resolveRepoRoot(process.cwd())
+          # and refuses cross-repo writes / symlinked ancestors / wrong cwd.
+          #
+          # Same-class env-prefix defense as plan-marker.mjs and
+          # classify-correction.mjs: leading env assignment is a
+          # cross-session attack vector (PR #271 / PR #272 F-4). The
+          # command-local env override can desync the classifier's view of
+          # session_id from the helper's view, planting a marker for the
+          # wrong session. Reject any env-prefix invocation form.
+          if [ $env_prefix_count -gt 0 ]; then
+            printf '%s\t\t%s\n' "unsafe_complex" "classifier_marker_env_override"
+            return 0
+          fi
+          # Marker-write label: gate-treatment matches preflight-marker-write
+          # / plan-marker (writes only to .checkpoints/ + helper validates
+          # its own authority). Read invocations are also marker_write —
+          # the read mode never writes anything but the gate doesn't need
+          # to distinguish; helper enforces.
+          printf '%s\t\t%s\n' "marker_write" "interpreter_classifier_marker"
           return 0
           ;;
       esac

--- a/hooks/lib/llm-classifier.sh
+++ b/hooks/lib/llm-classifier.sh
@@ -1,26 +1,61 @@
 #!/usr/bin/env bash
-# episodic-memory-hook-version: 2026-05-23.1
-# llm-classifier.sh — Tier 2/3 classifier wrapper for command-classifier.sh.
+# episodic-memory-hook-version: 2026-05-23.2
+# llm-classifier.sh — Tier 2/3 marker-cache wrapper for command-classifier.sh.
+#
+# REPLACES PR #326's direct-Anthropic-API fetch. The active Claude Code
+# session classifies its own Bash commands using its own reasoning (already
+# paid for via the user's subscription tokens) and records the verdict via
+# `scripts/classifier-marker.mjs --write`. This wrapper just READS the marker.
+#
+# Cost: ZERO new LLM calls in the hot path. Zero new API keys. Zero new
+# billing meters. The marker file IS the cache.
 #
 # Sourced from hooks/lib/command-classifier.sh. Provides one function:
 #
 #   llm_classify_command <command> <repo_root> <caller_cwd>
 #       echoes "<label>\t<source>" on success (exit 0)
-#       echoes "" and returns 1 on no-decision (caller falls back to Tier 1)
+#       echoes "" and returns 1 on no-decision (caller falls back to Tier 1
+#       conservative default OR the hook returns deny-with-hint via the
+#       caller's own emit path)
 #
-# The dispatcher (scripts/llm-classifier-dispatch.mjs) handles:
-#   - cache tuple build + sha256 key
-#   - project-local override > global cache > Tier 3 dispatch
-#   - project_root_used echo verification
-#   - cache write under lock
+# On marker miss, this wrapper does NOT directly emit a deny structure.
+# The caller (command-classifier.sh) gets no-decision and falls through to
+# its conservative default. The hook entry point (checkpoint-gate.sh / the
+# PreToolUse glue) is responsible for translating the "interpreter_other"
+# conservative default into a helpful deny reason when LLM_CLASSIFIER_HINT
+# mode is enabled. See `hooks/lib/llm-classifier-deny-reason.sh`.
 #
-# Cwd binding: dispatcher is invoked inside a (cd "$REPO_ROOT" && ...) subshell
-# so its process.cwd() matches --project-root. The dispatcher re-verifies and
-# rejects mismatches. Defense in depth: shell forces cwd; dispatcher checks.
+# Legacy direct-API dispatch path is retained behind the
+# LLM_CLASSIFIER_LEGACY_TRANSPORT=direct-fetch config field (file-based,
+# NOT env-prefix per PR #271 attack-class lesson). Default: marker-only.
 
-# Resolution: hooks/lib/llm-classifier.sh sits next to command-classifier.sh.
-# Installed scripts live at ~/.episodic-memory/scripts/. Detect both layouts.
-__llm_classifier_resolve_dispatcher() {
+# Resolution: hooks/lib/ sits next to scripts/. Installed scripts live at
+# ~/.episodic-memory/scripts/. Detect both layouts.
+#
+# Codex CR R2 BLOCKER fix: NO env-var override seam. An ambient
+# `CLASSIFIER_MARKER_PATH` pointing at a stub helper could fabricate a
+# `{"status":"hit","label":"read_only",...}` JSON response and bypass the
+# marker artifact entirely. Helper resolution is hard-bound to
+# installed-runtime OR repo-source paths — both authoritative.
+__llm_classifier_resolve_marker_helper() {
+  local global="$HOME/.episodic-memory/scripts/classifier-marker.mjs"
+  if [ -f "$global" ]; then
+    printf '%s' "$global"
+    return 0
+  fi
+  # Repo-source fallback (dev / pre-install).
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local repo="$self_dir/../../scripts/classifier-marker.mjs"
+  if [ -f "$repo" ]; then
+    printf '%s' "$repo"
+    return 0
+  fi
+  return 1
+}
+
+# Legacy dispatch (for --legacy-direct-fetch tests / rollback only).
+__llm_classifier_resolve_legacy_dispatcher() {
   if [ -n "${LLM_CLASSIFIER_DISPATCH_PATH:-}" ] && [ -f "$LLM_CLASSIFIER_DISPATCH_PATH" ]; then
     printf '%s' "$LLM_CLASSIFIER_DISPATCH_PATH"
     return 0
@@ -30,7 +65,6 @@ __llm_classifier_resolve_dispatcher() {
     printf '%s' "$global"
     return 0
   fi
-  # Repo-source fallback (dev / pre-install).
   local self_dir
   self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local repo="$self_dir/../../scripts/llm-classifier-dispatch.mjs"
@@ -39,6 +73,23 @@ __llm_classifier_resolve_dispatcher() {
     return 0
   fi
   return 1
+}
+
+# Read session_id from $CLAUDE_CODE_SESSION_ID (canonical env var name in
+# this repo, set by Claude Code when spawning hook subprocesses; mirrors
+# what scripts/plan-marker.mjs already depends on).
+#
+# Fall back to "unknown" so cache hits still work in test/CI contexts where
+# the session_id env var isn't injected. session_id="unknown" markers can
+# only match other invocations under the same fallback, so test isolation
+# is preserved without breaking unit tests. In production runs under Claude
+# Code, CLAUDE_CODE_SESSION_ID is always set; the fallback never triggers.
+__llm_classifier_session_id() {
+  if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    printf '%s' "$CLAUDE_CODE_SESSION_ID"
+    return 0
+  fi
+  printf '%s' "unknown"
 }
 
 llm_classify_command() {
@@ -50,70 +101,140 @@ llm_classify_command() {
     return 1
   fi
 
-  local dispatcher
-  if ! dispatcher="$(__llm_classifier_resolve_dispatcher)"; then
-    # No dispatcher available — caller falls back to Tier 1.
-    return 1
+  local session_id
+  session_id="$(__llm_classifier_session_id)"
+
+  # --- Marker-cache read (primary path) ---
+  local marker_helper marker_hit=0
+  if marker_helper="$(__llm_classifier_resolve_marker_helper)"; then
+    local out
+    # Subshell cd forces helper's process.cwd() to repo_root regardless of
+    # caller cwd. Helper re-verifies. 2>/dev/null suppresses helper
+    # diagnostics from polluting hook stdout — they're captured in the
+    # helper's JSON reason field when needed.
+    out="$(cd "$repo_root" 2>/dev/null && node "$marker_helper" --read \
+      --project-root "$repo_root" \
+      --caller-cwd "$caller_cwd" \
+      --command "$command" \
+      --session-id "$session_id" 2>/dev/null)"
+    local rc=$?
+    if [ $rc -eq 0 ] && [ -n "$out" ]; then
+      # Parse JSON without jq using a small inline node one-liner. Same
+      # label-allowlist defense as before — unknown labels reach awk only
+      # if they passed the allowlist filter.
+      local parsed
+      parsed="$(printf '%s' "$out" | node -e '
+        const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+        let buf = ""
+        process.stdin.on("data", c => buf += c)
+        process.stdin.on("end", () => {
+          try {
+            const last = buf.trim().split("\n").pop()
+            const j = JSON.parse(last)
+            if (j.status !== "hit") { process.stdout.write(""); return }
+            let label = j.label || ""
+            if (label && !ALLOWED.has(label)) label = ""
+            const root = String(j.project_root_used || "").replace(/[\t\n\r]/g, "_")
+            process.stdout.write(`${label}\t${root}`)
+          } catch { process.stdout.write("") }
+        })
+      ' 2>/dev/null)"
+
+      if [ -n "$parsed" ]; then
+        local label root
+        label="$(printf '%s' "$parsed" | awk -F'\t' '{print $1}')"
+        root="$(printf '%s' "$parsed" | awk -F'\t' '{print $2}')"
+        # Re-verify project_root_used echo before applying (defense in depth).
+        if [ -n "$label" ] && [ "$root" = "$repo_root" ]; then
+          printf '%s\t%s\n' "$label" "interpreter_marker_cache_hit"
+          return 0
+        fi
+      fi
+    fi
+    # Marker miss → fall through to legacy check (per codex code-review
+    # MAJOR #3: returning rc=1 here made the rollback path unreachable;
+    # legacy direct-fetch must get a chance to fire even when the marker
+    # helper exists and the marker lookup misses).
   fi
 
-  local out
-  # Subshell cd forces dispatcher's cwd to repo_root regardless of caller cwd.
-  # 2>/dev/null suppresses warnings (e.g. ANTHROPIC_API_KEY missing) from
-  # interfering with hook stdout — they're recorded inside the dispatcher's
-  # reason field instead.
-  out="$(cd "$repo_root" 2>/dev/null && node "$dispatcher" \
-    --project-root "$repo_root" \
-    --caller-cwd "$caller_cwd" \
-    --command "$command" 2>/dev/null)"
-  local rc=$?
-
-  if [ -z "$out" ]; then
-    return 1
+  # --- Legacy direct-fetch fallback (rollback / offline CI only) ---
+  # Activated by config field, NOT env-prefix (PR #271 attack class).
+  # Config lives at <project>/.episodic-memory/classifier-config.json or
+  # ~/.episodic-memory/classifier-config.json with field:
+  #   { "transport": "direct-fetch" }
+  if __llm_classifier_legacy_enabled "$repo_root"; then
+    local dispatcher
+    if dispatcher="$(__llm_classifier_resolve_legacy_dispatcher)"; then
+      __llm_classifier_legacy_log "$repo_root"
+      local out
+      out="$(cd "$repo_root" 2>/dev/null && node "$dispatcher" \
+        --project-root "$repo_root" \
+        --caller-cwd "$caller_cwd" \
+        --command "$command" 2>/dev/null)"
+      if [ -n "$out" ]; then
+        local parsed
+        parsed="$(printf '%s' "$out" | node -e '
+          const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+          let buf = ""
+          process.stdin.on("data", c => buf += c)
+          process.stdin.on("end", () => {
+            try {
+              const last = buf.trim().split("\n").pop()
+              const j = JSON.parse(last)
+              let label = j.label || ""
+              if (label && !ALLOWED.has(label)) label = ""
+              const source = String(j.source || "").replace(/[\t\n\r]/g, "_")
+              const root = String(j.project_root_used || "").replace(/[\t\n\r]/g, "_")
+              process.stdout.write(`${label}\t${source}\t${root}`)
+            } catch { process.stdout.write("") }
+          })
+        ' 2>/dev/null)"
+        if [ -n "$parsed" ]; then
+          local label source root
+          label="$(printf '%s' "$parsed" | awk -F'\t' '{print $1}')"
+          source="$(printf '%s' "$parsed" | awk -F'\t' '{print $2}')"
+          root="$(printf '%s' "$parsed" | awk -F'\t' '{print $3}')"
+          if [ -n "$label" ] && [ "$root" = "$repo_root" ]; then
+            printf '%s\tinterpreter_llm_legacy_%s\n' "$label" "$source"
+            return 0
+          fi
+        fi
+      fi
+    fi
   fi
 
-  # Parse JSON without jq — extract label, source, and project_root_used via
-  # a small inline node one-liner (fast; same runtime already loaded).
-  # F9-fix: validate label against allowlist inside the parser so a label
-  # carrying tabs / newlines / unknown values can never reach awk's field
-  # split. Unknown label → empty (caller treats as no-decision).
-  local parsed
-  parsed="$(printf '%s' "$out" | node -e '
-    const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
-    let buf = ""
-    process.stdin.on("data", c => buf += c)
-    process.stdin.on("end", () => {
-      try {
-        const last = buf.trim().split("\n").pop()
-        const j = JSON.parse(last)
-        let label = j.label || ""
-        if (label && !ALLOWED.has(label)) label = ""
-        const source = String(j.source || "").replace(/[\t\n\r]/g, "_")
-        const root = String(j.project_root_used || "").replace(/[\t\n\r]/g, "_")
-        process.stdout.write(`${label}\t${source}\t${root}`)
-      } catch { process.stdout.write("") }
-    })
-  ' 2>/dev/null)"
+  return 1
+}
 
-  if [ -z "$parsed" ]; then
-    return 1
+# Check classifier-config.json transport field. Default: marker-only.
+__llm_classifier_legacy_enabled() {
+  local repo_root="$1"
+  local cfg_project="$repo_root/.episodic-memory/classifier-config.json"
+  local cfg_global="$HOME/.episodic-memory/classifier-config.json"
+  local cfg=""
+  if [ -f "$cfg_project" ]; then cfg="$cfg_project"
+  elif [ -f "$cfg_global" ]; then cfg="$cfg_global"
   fi
+  if [ -z "$cfg" ]; then return 1; fi
+  # node -e places user positional args at argv[1+] (no synthetic [eval] entry).
+  node -e '
+    try {
+      const fs = require("fs")
+      const j = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+      process.exit(j && j.transport === "direct-fetch" ? 0 : 1)
+    } catch { process.exit(1) }
+  ' "$cfg" 2>/dev/null
+}
 
-  local label source root
-  label="$(printf '%s' "$parsed" | awk -F'\t' '{print $1}')"
-  source="$(printf '%s' "$parsed" | awk -F'\t' '{print $2}')"
-  root="$(printf '%s' "$parsed" | awk -F'\t' '{print $3}')"
-
-  # FU-4 shell-side defense: re-verify project_root_used echo before applying.
-  if [ "$root" != "$repo_root" ]; then
-    return 1
-  fi
-
-  # No-label outcome (Tier 3 fallback heuristic, env-prefix, etc.) → caller
-  # falls back to its own Tier 1.
-  if [ -z "$label" ]; then
-    return 1
-  fi
-
-  printf '%s\t%s\n' "$label" "interpreter_llm_${source}"
-  return 0
+# One-line telemetry log of legacy use. Burn-in surface — if no legacy log
+# entries accumulate over a release, the legacy path can be removed.
+__llm_classifier_legacy_log() {
+  local repo_root="$1"
+  local log_dir="$HOME/.episodic-memory"
+  local log_file="$log_dir/legacy-fetch.log.jsonl"
+  if [ ! -d "$log_dir" ]; then mkdir -p "$log_dir" 2>/dev/null || return 0; fi
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"ts":"%s","project_root":"%s","reason":"legacy_direct_fetch_used"}\n' \
+    "$ts" "$repo_root" >> "$log_file" 2>/dev/null || return 0
 }

--- a/scripts/classifier-marker.mjs
+++ b/scripts/classifier-marker.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+/**
+ * classifier-marker.mjs — Read/write per-session classification markers.
+ *
+ * Replaces the direct-API Tier 3 dispatch from PR #326. The active Claude
+ * Code session classifies its own Bash commands using its own reasoning
+ * (already paid for via the user's subscription tokens) and records the
+ * verdict here. A PreToolUse shell hook reads the marker and gates.
+ *
+ * Mode: --read
+ *   Args: --project-root <abs> --caller-cwd <abs> --command <text>
+ *         --session-id <string>
+ *   Emits the cached JSON verdict on stdout, exit 0; exits 1 if no marker
+ *   exists or marker is stale/invalid.
+ *
+ * Mode: --write
+ *   Args: above + --label <L> --confidence <N> --reason <S>
+ *   Atomically writes to <project>/.checkpoints/classify/<sha>.json.
+ *   Exits 0 on success; exits 2 on input/binding error.
+ *
+ * Mode: --vacuum
+ *   Args: --project-root <abs> [--max-age-days N (default 30)]
+ *   Removes marker files older than max-age. Idempotent.
+ *
+ * Threat model (deliberate scope):
+ *   IN-SCOPE   — honest agent drift (skipped classification, sloppy labels);
+ *                honest concurrent sessions (no accidental marker bleed);
+ *                stale markers across schema/policy upgrades;
+ *                path-component symlink swaps.
+ *   OUT-OF-SCOPE — adversarial agent compromise; adversarial cross-session
+ *                  marker forgery (an attacker who can pass --session-id <X>
+ *                  with any X can write a marker for that session — no userspace
+ *                  defense without OS-level isolation); compromised local user
+ *                  with FS write access (already game over).
+ *
+ * Marker schema v2:
+ *   {
+ *     label, confidence, reason, command_normalized,
+ *     _project_root_canonical, _cache_key, _session_id, _request_nonce,
+ *     _marker_version: 2,
+ *     _classifier_policy_version, _normalized_command_version,
+ *     recorded_at, _expires_at,
+ *     classified_by: "agent_self"
+ *   }
+ *
+ * Marker path:
+ *   <project>/.checkpoints/classify/<sha>.json
+ * where <sha> = sha256(canonical({
+ *   project_root_canonical, caller_cwd_or_rel, normalized_command,
+ *   executable_resolved, script_digest,
+ *   session_id, classifier_policy_version, normalized_command_version
+ * }))
+ *
+ * Bumping CLASSIFIER_POLICY_VERSION or NORMALIZED_COMMAND_VERSION below
+ * changes the sha for every cached tuple, making all existing markers
+ * unreachable. Use --vacuum to reap them.
+ *
+ * Allowlisted in command-classifier.sh as `interpreter_classifier_marker`
+ * with strict argv-shape match + env-prefix-form rejection (per PR #271
+ * cross-session attack class).
+ */
+
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import { resolveRepoRoot } from './lib/local-dir.mjs'
+
+const LABELS = new Set([
+  'read_only',
+  'shared_write',
+  'marker_write',
+  'push_or_pr_create',
+  'unsafe_complex'
+])
+
+// Path-versioning fields. Bumping either makes ALL existing markers
+// unreachable via their old paths and forces re-classification.
+const CLASSIFIER_POLICY_VERSION = 1
+const NORMALIZED_COMMAND_VERSION = 1
+const MARKER_SCHEMA_VERSION = 2
+
+const TTL_MS = 24 * 60 * 60 * 1000        // 24h marker freshness
+const VACUUM_MAX_AGE_DAYS_DEFAULT = 30    // vacuum default
+const REASON_MAX = 500                    // reason field cap
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/
+
+function flag(argv, name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+function die(code, msg) {
+  process.stderr.write(`classifier-marker: ${msg}\n`)
+  process.exit(code)
+}
+
+function realpathOrSame(p) {
+  try { return fs.realpathSync(p) } catch { return p }
+}
+
+function isUnder(child, parent) {
+  return child === parent || child.startsWith(parent + path.sep)
+}
+
+function normalizeCommand(raw) {
+  // Strip trailing # comments, collapse whitespace, trim.
+  return String(raw).replace(/#.*$/, '').replace(/\s+/g, ' ').trim()
+}
+
+const INTERPRETERS = new Set(['node', 'python', 'python3', 'ruby', 'perl'])
+function resolveExeAgainstCwd(command, callerCwd) {
+  const toks = command.trim().split(/\s+/)
+  for (let i = 0; i < toks.length; i++) {
+    if (INTERPRETERS.has(path.basename(toks[i]))) {
+      const script = toks[i + 1]
+      if (script && !script.startsWith('-')) {
+        return path.resolve(callerCwd, script)
+      }
+      return null
+    }
+  }
+  if (toks[0]) {
+    if (toks[0].startsWith('/') || toks[0].startsWith('./') || toks[0].startsWith('../')) {
+      return path.resolve(callerCwd, toks[0])
+    }
+    return toks[0]
+  }
+  return null
+}
+
+function sha256File(p) {
+  try {
+    return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex')
+  } catch {
+    return null
+  }
+}
+
+function buildTuple({ command, projectRoot, callerCwd, sessionId }) {
+  const cwdCanon = realpathOrSame(callerCwd)
+  const callerCwdRelOrAbs = isUnder(cwdCanon, projectRoot)
+    ? (path.relative(projectRoot, cwdCanon) || '.')
+    : cwdCanon
+  const exeResolved = resolveExeAgainstCwd(command, cwdCanon)
+  let exeAbs = null
+  let digest = null
+  if (exeResolved && exeResolved.startsWith('/')) {
+    try {
+      if (fs.statSync(exeResolved).isFile()) {
+        exeAbs = realpathOrSame(exeResolved)
+        if (isUnder(exeAbs, projectRoot)) {
+          digest = sha256File(exeAbs)
+        }
+      }
+    } catch {}
+  }
+  return {
+    project_root_canonical: projectRoot,
+    caller_cwd_or_rel: callerCwdRelOrAbs,
+    normalized_command: normalizeCommand(command),
+    executable_resolved: exeAbs || exeResolved,
+    script_digest: digest,
+    session_id: sessionId,
+    classifier_policy_version: CLASSIFIER_POLICY_VERSION,
+    normalized_command_version: NORMALIZED_COMMAND_VERSION
+  }
+}
+
+function cacheKey(tuple) {
+  // Sort keys lexicographically; primitive values only.
+  const sorted = {}
+  for (const k of Object.keys(tuple).sort()) sorted[k] = tuple[k]
+  return crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('hex')
+}
+
+// ----- Path-component hardening (lstat each ancestor, refuse symlinks) -----
+
+// validateMarkerStoreDir — hardens .checkpoints/ + .checkpoints/classify/
+// against symlink swaps. Used by ALL THREE modes (--read, --write, --vacuum)
+// per codex code-review BLOCKER #1. allowCreate=true creates dirs on first
+// use (write/vacuum); allowCreate=false treats absence as a miss.
+//
+// Returns: { classifyDir } on success, { missing: true } if allowCreate=false
+// and the path doesn't exist yet. die(2) on any symlink/realpath drift.
+function validateMarkerStoreDir(projectRootCanon, { allowCreate, missingIsMiss }) {
+  const checkpointsDir = path.join(projectRootCanon, '.checkpoints')
+  const classifyDir = path.join(checkpointsDir, 'classify')
+
+  // Step 1: ensure .checkpoints/ AND .checkpoints/classify/ are real dirs.
+  // lstat each ancestor (NOT just the leaf) — a symlinked .checkpoints would
+  // otherwise let writes / reads / vacuums escape to an arbitrary external
+  // path. Codex BLOCKER #1: prior --read and --vacuum only checked the leaf.
+  for (const dir of [checkpointsDir, classifyDir]) {
+    let st
+    try { st = fs.lstatSync(dir) }
+    catch (e) {
+      if (e.code !== 'ENOENT') throw e
+      if (!allowCreate) {
+        if (missingIsMiss) return { missing: true, classifyDir }
+        die(2, `marker store path missing: ${dir}; refusing`)
+      }
+      try { fs.mkdirSync(dir) }
+      catch (e2) {
+        if (e2.code === 'EEXIST') { /* race winner — fall through to re-lstat */ }
+        else if (e2.code === 'ENOENT') die(2, `failed to create ${dir} — an ancestor is missing or unresolvable`)
+        else if (e2.code === 'ELOOP') die(2, `failed to create ${dir} (symlink loop in ancestor)`)
+        else throw e2
+      }
+      st = fs.lstatSync(dir)
+    }
+    if (st.isSymbolicLink() || !st.isDirectory()) {
+      die(2, `${dir} must be a real directory (not a symlink or file); refusing to operate through link`)
+    }
+  }
+  // Step 2: realpath equality — refuse if any ancestor resolved outside the
+  // canonical position via a symlinked parent earlier in the chain. This
+  // catches the symlinked-checkpoints-ancestor escape codex flagged.
+  const realClassify = fs.realpathSync(classifyDir)
+  if (realClassify !== classifyDir) {
+    die(2, `${classifyDir} resolves outside expected position (got ${realClassify}); refusing`)
+  }
+  return { classifyDir }
+}
+
+// ----- Marker write (O_NOFOLLOW, atomic temp+rename) -----
+
+function writeMarker(classifyDir, sha, payload) {
+  const target = path.join(classifyDir, `${sha}.json`)
+  const body = JSON.stringify(payload, null, 2) + '\n'
+
+  // Codex code-review BLOCKER #2: lstat the target leaf BEFORE existsSync /
+  // readFileSync. The prior code checked existsSync first, which followed a
+  // symlinked target leaf — if the symlink pointed to a fresh same-tuple JSON
+  // payload, the function returned noop_same_tuple without ever rejecting
+  // the symlink. lstat-first closes that bypass class.
+  let targetLst = null
+  try { targetLst = fs.lstatSync(target) }
+  catch (e) {
+    if (e.code !== 'ENOENT') throw e
+    // No file → fresh write, no same-tuple check needed.
+  }
+  if (targetLst && targetLst.isSymbolicLink()) {
+    die(2, `target marker is a symlink; refusing to overwrite through link`)
+  }
+
+  // Write-once-or-same: if marker already exists with matching tuple + fresh,
+  // treat as no-op success. Same-tuple second writer doesn't overwrite.
+  if (targetLst && targetLst.isFile()) {
+    try {
+      const existingTxt = fs.readFileSync(target, 'utf8')
+      const existing = JSON.parse(existingTxt)
+      const tupleMatch =
+        existing._cache_key === payload._cache_key &&
+        existing._project_root_canonical === payload._project_root_canonical &&
+        existing._session_id === payload._session_id &&
+        existing._classifier_policy_version === payload._classifier_policy_version &&
+        existing._normalized_command_version === payload._normalized_command_version
+      if (tupleMatch) {
+        // Refresh expires_at only if existing is still fresh; otherwise overwrite.
+        const expiresAt = Date.parse(existing._expires_at || '')
+        if (Number.isFinite(expiresAt) && expiresAt > Date.now()) {
+          return { status: 'noop_same_tuple', file: target }
+        }
+      }
+      // Tuple mismatch or stale → overwrite intentionally.
+    } catch {
+      // Corrupt marker; overwrite.
+    }
+  }
+
+  // Atomic temp+rename within the same real directory.
+  const tmp = path.join(classifyDir, `.${sha}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`)
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW
+  let fd
+  try { fd = fs.openSync(tmp, flags, 0o644) }
+  catch (e) {
+    if (e.code === 'ELOOP' || e.code === 'EMLINK') {
+      die(2, `marker temp path is a symlink; refusing to write through link`)
+    }
+    throw e
+  }
+  try { fs.writeSync(fd, body) }
+  finally { fs.closeSync(fd) }
+
+  // Re-validate parent realpath before rename — symlink swap defense.
+  const realParent = fs.realpathSync(classifyDir)
+  if (realParent !== classifyDir) {
+    try { fs.unlinkSync(tmp) } catch {}
+    die(2, `marker dir realpath drifted during write; refusing rename`)
+  }
+
+  // Refuse rename-through-symlinked target leaf.
+  try {
+    const targetLst = fs.lstatSync(target)
+    if (targetLst.isSymbolicLink()) {
+      try { fs.unlinkSync(tmp) } catch {}
+      die(2, `target marker is a symlink; refusing to overwrite through link`)
+    }
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      try { fs.unlinkSync(tmp) } catch {}
+      throw e
+    }
+  }
+
+  // Note: per codex BLOCKER #2 fix, the leaf-symlink check now happens at
+  // the START of writeMarker (before existsSync), not here. This trailing
+  // lstat is redundant but kept for defense in depth — a TOCTOU swap between
+  // the start-of-function lstat and this rename would still get caught.
+  fs.renameSync(tmp, target)
+  return { status: 'written', file: target }
+}
+
+// ----- Marker read (validates tuple, TTL, schema, labels) -----
+
+function readMarker(classifyDir, sha, expectedTuple, sessionId) {
+  const target = path.join(classifyDir, `${sha}.json`)
+  let st
+  try { st = fs.lstatSync(target) }
+  catch (e) {
+    if (e.code === 'ENOENT') return { status: 'miss', reason: 'no_marker' }
+    throw e
+  }
+  if (st.isSymbolicLink()) {
+    return { status: 'reject', reason: 'marker_is_symlink' }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(target, 'utf8'))
+  } catch (e) {
+    return { status: 'reject', reason: `marker_parse_error: ${e.message}` }
+  }
+
+  // Schema version.
+  if (parsed._marker_version !== MARKER_SCHEMA_VERSION) {
+    return { status: 'reject', reason: `marker_schema_mismatch: got=${parsed._marker_version} expected=${MARKER_SCHEMA_VERSION}` }
+  }
+
+  // Tuple bindings (defense in depth — path versioning makes most of these
+  // unreachable, but the read-side still rejects tampered bodies).
+  if (parsed._project_root_canonical !== expectedTuple.project_root_canonical) {
+    return { status: 'reject', reason: 'tamper_project_root_mismatch' }
+  }
+  if (parsed._cache_key !== sha) {
+    return { status: 'reject', reason: 'tamper_cache_key_mismatch' }
+  }
+  if (parsed._session_id !== sessionId) {
+    return { status: 'reject', reason: 'session_id_mismatch' }
+  }
+  if (parsed._classifier_policy_version !== CLASSIFIER_POLICY_VERSION) {
+    return { status: 'reject', reason: 'policy_version_mismatch' }
+  }
+  if (parsed._normalized_command_version !== NORMALIZED_COMMAND_VERSION) {
+    return { status: 'reject', reason: 'command_version_mismatch' }
+  }
+
+  // Label allowlist.
+  if (!LABELS.has(parsed.label)) {
+    return { status: 'reject', reason: `invalid_label: ${parsed.label}` }
+  }
+
+  // TTL.
+  const expiresAt = Date.parse(parsed._expires_at || '')
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+    return { status: 'stale', reason: 'expired' }
+  }
+
+  return { status: 'hit', payload: parsed }
+}
+
+// ----- Vacuum (reap markers older than max-age) -----
+
+function vacuumMarkers(projectRootCanon, maxAgeDays) {
+  // Codex BLOCKER #1 fix: vacuum MUST apply the same ancestor validation as
+  // --write — otherwise a symlinked .checkpoints/ would let the vacuum delete
+  // files OUTSIDE the project (codex reproduced this: `--vacuum` reported the
+  // target project_root_used while removing files under <external>/.checkpoints/).
+  const v = validateMarkerStoreDir(projectRootCanon, { allowCreate: false, missingIsMiss: true })
+  if (v.missing) return { removed: 0, scanned: 0 }
+  const classifyDir = v.classifyDir
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000
+  let removed = 0, scanned = 0
+  for (const entry of fs.readdirSync(classifyDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue
+    scanned++
+    const p = path.join(classifyDir, entry.name)
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) continue   // never touch symlinks during vacuum
+      if (st.mtimeMs < cutoff) {
+        fs.unlinkSync(p)
+        removed++
+      }
+    } catch {}
+  }
+  return { removed, scanned }
+}
+
+// ----- CLI entry -----
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + '\n')
+}
+
+function mainRead(argv) {
+  const projectRootArg = flag(argv, '--project-root')
+  const callerCwd = flag(argv, '--caller-cwd')
+  const command = flag(argv, '--command')
+  const sessionId = flag(argv, '--session-id')
+
+  if (!projectRootArg) die(2, '--project-root required')
+  if (!callerCwd) die(2, '--caller-cwd required')
+  if (command === undefined) die(2, '--command required')
+  if (!sessionId) die(2, '--session-id required')
+  if (!SESSION_ID_RE.test(sessionId)) die(2, `--session-id "${sessionId}" does not match ${SESSION_ID_RE}`)
+
+  const projectRoot = realpathOrSame(path.resolve(projectRootArg))
+
+  // Codex BLOCKER #1 fix: --read MUST apply the same ancestor validation as
+  // --write. Symlinked .checkpoints/ would otherwise let a read escape to an
+  // external store. missingIsMiss=true treats absent dirs as cache miss (not
+  // an error) since reads can legitimately fire before any write.
+  const v = validateMarkerStoreDir(projectRoot, { allowCreate: false, missingIsMiss: true })
+  if (v.missing) {
+    emit({ status: 'miss', reason: 'no_marker_dir', project_root_used: projectRoot })
+    process.exit(1)
+  }
+  const classifyDir = v.classifyDir
+
+  const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
+  const sha = cacheKey(tuple)
+  const result = readMarker(classifyDir, sha, tuple, sessionId)
+
+  if (result.status === 'hit') {
+    emit({
+      status: 'hit',
+      label: result.payload.label,
+      confidence: result.payload.confidence,
+      reason: result.payload.reason,
+      project_root_used: projectRoot,
+      cache_key: sha,
+      session_id: sessionId
+    })
+    process.exit(0)
+  }
+  emit({
+    status: result.status,
+    reason: result.reason,
+    project_root_used: projectRoot,
+    cache_key: sha,
+    session_id: sessionId
+  })
+  process.exit(1)
+}
+
+function mainWrite(argv) {
+  const projectRootArg = flag(argv, '--project-root')
+  const callerCwd = flag(argv, '--caller-cwd')
+  const command = flag(argv, '--command')
+  const sessionId = flag(argv, '--session-id')
+  const label = flag(argv, '--label')
+  const confidenceStr = flag(argv, '--confidence')
+  const reasonRaw = flag(argv, '--reason') || ''
+
+  if (!projectRootArg) die(2, '--project-root required')
+  if (!callerCwd) die(2, '--caller-cwd required')
+  if (command === undefined) die(2, '--command required')
+  if (!sessionId) die(2, '--session-id required')
+  if (!label) die(2, '--label required')
+  if (!LABELS.has(label)) die(2, `invalid --label "${label}" (allowed: ${[...LABELS].join(', ')})`)
+  if (!SESSION_ID_RE.test(sessionId)) die(2, `--session-id "${sessionId}" does not match ${SESSION_ID_RE}`)
+  const confidence = Number(confidenceStr)
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    die(2, `--confidence must be a number in [0,1]; got "${confidenceStr}"`)
+  }
+
+  // Defense-in-depth (per codex R3 honest-agent threat model): if the
+  // canonical session-id env var is set, the --session-id flag MUST match.
+  // Catches honest-agent typos and accidental cross-session writes when
+  // Claude Code's runtime exposes the authoritative session_id. Does NOT
+  // defend against adversarial argv forge (out-of-scope per threat model).
+  const envSid = process.env.CLAUDE_CODE_SESSION_ID
+  if (envSid && envSid !== sessionId) {
+    die(2, `--session-id "${sessionId}" != CLAUDE_CODE_SESSION_ID env "${envSid}"; refusing cross-session write`)
+  }
+
+  // Cross-repo write defense — helper refuses to write into a foreign repo.
+  const projectRoot = realpathOrSame(path.resolve(projectRootArg))
+  const resolvedFromCwd = realpathOrSame(resolveRepoRoot(process.cwd()))
+  if (resolvedFromCwd !== projectRoot) {
+    die(2, `--project-root (${projectRoot}) != resolveRepoRoot(process.cwd()) (${resolvedFromCwd}); refusing cross-repo write`)
+  }
+
+  const { classifyDir } = validateMarkerStoreDir(projectRoot, { allowCreate: true, missingIsMiss: false })
+  const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
+  const sha = cacheKey(tuple)
+  const nowIso = new Date().toISOString()
+  const payload = {
+    label,
+    confidence,
+    reason: String(reasonRaw).slice(0, REASON_MAX),
+    command_normalized: tuple.normalized_command,
+    _project_root_canonical: projectRoot,
+    _cache_key: sha,
+    _session_id: sessionId,
+    _request_nonce: crypto.randomUUID(),
+    _marker_version: MARKER_SCHEMA_VERSION,
+    _classifier_policy_version: CLASSIFIER_POLICY_VERSION,
+    _normalized_command_version: NORMALIZED_COMMAND_VERSION,
+    recorded_at: nowIso,
+    _expires_at: new Date(Date.now() + TTL_MS).toISOString(),
+    classified_by: 'agent_self'
+  }
+  const written = writeMarker(classifyDir, sha, payload)
+  emit({
+    status: written.status,
+    file: written.file,
+    label,
+    cache_key: sha,
+    session_id: sessionId,
+    project_root_used: projectRoot
+  })
+  process.exit(0)
+}
+
+function mainVacuum(argv) {
+  const projectRootArg = flag(argv, '--project-root')
+  const maxAgeStr = flag(argv, '--max-age-days')
+  if (!projectRootArg) die(2, '--project-root required')
+  const projectRoot = realpathOrSame(path.resolve(projectRootArg))
+  const maxAge = maxAgeStr ? Number(maxAgeStr) : VACUUM_MAX_AGE_DAYS_DEFAULT
+  if (!Number.isFinite(maxAge) || maxAge < 1) die(2, `--max-age-days must be >= 1; got ${maxAgeStr}`)
+  const r = vacuumMarkers(projectRoot, maxAge)
+  emit({ status: 'ok', ...r, project_root_used: projectRoot, max_age_days: maxAge })
+  process.exit(0)
+}
+
+function main() {
+  const argv = process.argv.slice(2)
+  if (argv.includes('--read')) return mainRead(argv)
+  if (argv.includes('--write')) return mainWrite(argv)
+  if (argv.includes('--vacuum')) return mainVacuum(argv)
+  die(2, 'one of --read, --write, --vacuum required')
+}
+
+try { main() } catch (err) {
+  die(1, err?.message || String(err))
+}

--- a/tests/test-classifier-marker.mjs
+++ b/tests/test-classifier-marker.mjs
@@ -1,0 +1,581 @@
+#!/usr/bin/env node
+/**
+ * test-classifier-marker.mjs — Tests for scripts/classifier-marker.mjs
+ *
+ * Covers the agent-self-classify + marker-gate design (replaces PR #326's
+ * direct-API Tier 3 dispatch). Tests assert:
+ *
+ *   §M1   write + read round-trip in honest single-session case
+ *   §M2   multi-session: same command from session A and session B write
+ *         to DIFFERENT marker paths; session A's read can never see B's
+ *   §M3   multi-project: same command from project P1 and P2 write under
+ *         different .checkpoints/classify/ dirs; cross-repo write refused
+ *   §M4   cross-session env defense: CLAUDE_CODE_SESSION_ID env mismatch
+ *         with --session-id flag → refused
+ *   §M5   cross-repo write: resolveRepoRoot(cwd) != --project-root → refused
+ *   §M6   helper requires explicit cwd: subprocess invoked with cwd != root
+ *         → refused
+ *   §M7   write-once-or-same: concurrent writers for same tuple are no-ops
+ *   §M8   marker leaf symlink → write refused, read refused
+ *   §M9   marker store ancestor symlink → write refused
+ *   §M10  expired marker (past _expires_at) → read returns stale
+ *   §M11  schema/policy/command version mismatch → read rejects as tamper
+ *   §M12  adversarial label in marker body → read rejects
+ *   §M13  vacuum reaps stale markers (>30d mtime), preserves fresh ones
+ *   §M14  vacuum never touches symlinks even when stale
+ *
+ * Zero-dep: uses node:test + assert + fs + child_process.
+ *
+ * Usage: node tests/test-classifier-marker.mjs
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import assert from 'assert'
+import { execFileSync, spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const HELPER = path.join(REPO, 'scripts', 'classifier-marker.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+const queue = []
+
+function test(name, fn) {
+  queue.push(async () => {
+    try {
+      await fn()
+      passed++
+      console.log(`  ✓ ${name}`)
+    } catch (e) {
+      failed++
+      failures.push({ name, error: e.message, stack: e.stack })
+      console.log(`  ✗ ${name}: ${e.message}`)
+    }
+  })
+}
+
+function mktmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `clsmarker-${prefix}-`))
+}
+
+function mkrepo(name) {
+  const dir = mktmp(name)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir })
+  return fs.realpathSync(dir)
+}
+
+function runHelper(args, opts = {}) {
+  return spawnSync(process.execPath, [HELPER, ...args], {
+    cwd: opts.cwd || process.cwd(),
+    env: { ...process.env, ...(opts.env || {}) },
+    encoding: 'utf8',
+    timeout: 15000
+  })
+}
+
+function parseStdout(r) {
+  try { return JSON.parse((r.stdout || '').trim().split('\n').pop() || 'null') }
+  catch { return null }
+}
+
+// ----- §M1: write + read round-trip -----
+test('§M1 honest single-session write + read round-trip', () => {
+  const repo = mkrepo('m1')
+  const sid = 's_m1_' + crypto.randomBytes(4).toString('hex')
+  const cmd = 'node ./scripts/foo.mjs --arg=value'
+
+  const w = runHelper(['--write',
+    '--project-root', repo,
+    '--caller-cwd', repo,
+    '--command', cmd,
+    '--session-id', sid,
+    '--label', 'shared_write',
+    '--confidence', '0.85',
+    '--reason', 'writes to project files'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `write failed: ${w.stderr}`)
+  const wj = parseStdout(w)
+  assert.ok(wj.status === 'written' || wj.status === 'noop_same_tuple', `bad write status: ${wj.status}`)
+  assert.strictEqual(wj.label, 'shared_write')
+
+  const r = runHelper(['--read',
+    '--project-root', repo,
+    '--caller-cwd', repo,
+    '--command', cmd,
+    '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 0, `read failed: ${r.stderr}`)
+  const rj = parseStdout(r)
+  assert.strictEqual(rj.status, 'hit')
+  assert.strictEqual(rj.label, 'shared_write')
+})
+
+// ----- §M2: multi-session isolation -----
+test('§M2 multi-session: same command in 2 sessions → different markers, no cross-read', () => {
+  const repo = mkrepo('m2')
+  const sidA = 's_A_' + crypto.randomBytes(4).toString('hex')
+  const sidB = 's_B_' + crypto.randomBytes(4).toString('hex')
+  const cmd = 'node ./scripts/foo.mjs'
+
+  // Session A writes read_only
+  const wA = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sidA,
+    '--label', 'read_only', '--confidence', '0.9', '--reason', 'session A view'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(wA.status, 0, `A write: ${wA.stderr}`)
+  const fileA = parseStdout(wA).file
+
+  // Session B writes shared_write
+  const wB = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sidB,
+    '--label', 'shared_write', '--confidence', '0.9', '--reason', 'session B view'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(wB.status, 0, `B write: ${wB.stderr}`)
+  const fileB = parseStdout(wB).file
+
+  // Different marker paths
+  assert.notStrictEqual(fileA, fileB, 'sessions A and B must write to different marker paths')
+
+  // Both files exist independently
+  assert.ok(fs.existsSync(fileA), 'session A marker missing on disk')
+  assert.ok(fs.existsSync(fileB), 'session B marker missing on disk')
+
+  // Session A reads its own → hit with read_only
+  const rA = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sidA
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const rAj = parseStdout(rA)
+  assert.strictEqual(rAj.status, 'hit')
+  assert.strictEqual(rAj.label, 'read_only', 'session A must read its own label')
+
+  // Session B reads its own → hit with shared_write
+  const rB = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sidB
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const rBj = parseStdout(rB)
+  assert.strictEqual(rBj.status, 'hit')
+  assert.strictEqual(rBj.label, 'shared_write', 'session B must read its own label')
+})
+
+// ----- §M3: multi-project isolation -----
+test('§M3 multi-project: same command in 2 projects → different stores, cross-repo write refused', () => {
+  const repo1 = mkrepo('m3p1')
+  const repo2 = mkrepo('m3p2')
+  const sid = 's_m3_' + crypto.randomBytes(4).toString('hex')
+  const cmd = 'node ./scripts/foo.mjs'
+
+  // Write to repo1 from repo1's cwd
+  const w1 = runHelper(['--write',
+    '--project-root', repo1, '--caller-cwd', repo1,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '0.9', '--reason', 'p1'
+  ], { cwd: repo1, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w1.status, 0, `p1 write: ${w1.stderr}`)
+
+  // Write to repo2 from repo2's cwd
+  const w2 = runHelper(['--write',
+    '--project-root', repo2, '--caller-cwd', repo2,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'shared_write', '--confidence', '0.9', '--reason', 'p2'
+  ], { cwd: repo2, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w2.status, 0, `p2 write: ${w2.stderr}`)
+
+  // Markers land under their own project's .checkpoints/classify/
+  const dir1 = path.join(repo1, '.checkpoints', 'classify')
+  const dir2 = path.join(repo2, '.checkpoints', 'classify')
+  assert.ok(fs.readdirSync(dir1).length > 0, 'p1 marker dir empty')
+  assert.ok(fs.readdirSync(dir2).length > 0, 'p2 marker dir empty')
+  // No markers cross-pollinate
+  const inP1ForP2 = fs.readdirSync(dir1).filter(f =>
+    fs.readFileSync(path.join(dir1, f), 'utf8').includes(repo2))
+  assert.strictEqual(inP1ForP2.length, 0, 'p2 marker leaked into p1 store')
+
+  // Cross-repo write attempt: from repo1 cwd, target repo2 → REFUSED
+  const xw = runHelper(['--write',
+    '--project-root', repo2, '--caller-cwd', repo2,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'unsafe_complex', '--confidence', '1', '--reason', 'cross-repo'
+  ], { cwd: repo1, env: { CLAUDE_CODE_SESSION_ID: '' } })  // cwd is repo1 but target is repo2
+  assert.strictEqual(xw.status, 2, 'cross-repo write must fail with exit 2')
+  assert.match(xw.stderr, /refusing cross-repo write/)
+})
+
+// ----- §M4: CLAUDE_CODE_SESSION_ID env defense -----
+test('§M4 env vs argv session-id mismatch → refused', () => {
+  const repo = mkrepo('m4')
+  const r = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'ls', '--session-id', 'forged-sid',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: 'authentic-sid' } })
+  assert.strictEqual(r.status, 2, 'env-mismatch must refuse')
+  assert.match(r.stderr, /refusing cross-session write/)
+})
+
+// ----- §M5: cross-repo write refused at resolveRepoRoot boundary -----
+test('§M5 resolveRepoRoot != --project-root → refused', () => {
+  const repo = mkrepo('m5a')
+  const otherRepo = mkrepo('m5b')
+  // cwd is otherRepo but --project-root is repo
+  const r = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'ls', '--session-id', 'sid-x',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: otherRepo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 2, 'mismatched root must refuse')
+  assert.match(r.stderr, /refusing cross-repo write/)
+})
+
+// ----- §M6: helper cwd binding -----
+test('§M6 caller cwd may differ from --project-root, but helper subprocess cwd MUST equal --project-root', () => {
+  const repo = mkrepo('m6')
+  const callerCwd = mktmp('m6caller')
+  // Helper invocation with cwd: repo (correct) — caller cwd field differs
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', callerCwd,
+    '--command', 'ls', '--session-id', 'sid-m6',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'caller elsewhere'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `correct subprocess cwd should succeed: ${w.stderr}`)
+  // Marker lands under repo, NOT under callerCwd
+  const markerDir = path.join(repo, '.checkpoints', 'classify')
+  assert.ok(fs.readdirSync(markerDir).length > 0, 'marker missing under target')
+  assert.ok(!fs.existsSync(path.join(callerCwd, '.checkpoints')), 'marker leaked under caller cwd')
+
+  // Helper invocation with cwd: callerCwd (wrong) → refused
+  const w2 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', callerCwd,
+    '--command', 'ls', '--session-id', 'sid-m6b',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'wrong cwd'
+  ], { cwd: callerCwd, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w2.status, 2, 'wrong subprocess cwd must refuse')
+})
+
+// ----- §M7: write-once-or-same -----
+test('§M7 concurrent same-tuple writers are no-op success', () => {
+  const repo = mkrepo('m7')
+  const sid = 'sid-m7'
+  const cmd = 'node ./scripts/x.mjs'
+
+  const w1 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '0.9', '--reason', 'first'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w1.status, 0)
+  const j1 = parseStdout(w1)
+  assert.strictEqual(j1.status, 'written')
+
+  // Second writer with same tuple
+  const w2 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '0.9', '--reason', 'second'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w2.status, 0, `second writer must succeed: ${w2.stderr}`)
+  const j2 = parseStdout(w2)
+  assert.strictEqual(j2.status, 'noop_same_tuple', `expected noop_same_tuple, got ${j2.status}`)
+  assert.strictEqual(j1.file, j2.file)
+})
+
+// ----- §M8: marker leaf symlink → write/read refused -----
+test('§M8 marker leaf symlink → write refuses (O_NOFOLLOW)', () => {
+  const repo = mkrepo('m8')
+  // First do a real write to create the dir
+  runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'ls', '--session-id', 'sid-m8',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'seed'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+
+  // Plant a symlink at a marker path that a DIFFERENT command's sha would produce
+  const dir = path.join(repo, '.checkpoints', 'classify')
+  const targetPath = path.join('/tmp', 'symlink-target-' + crypto.randomBytes(4).toString('hex'))
+  fs.writeFileSync(targetPath, '{}')
+  // We can't easily predict the sha, but we can simulate the attack by making
+  // the FIRST write produce a symlinked marker. Cheaper test: pre-place a
+  // symlink at any *.json under classify/ and verify a subsequent write to
+  // THAT specific sha gets rejected. Use a known cmd to compute predictable
+  // tuple — but the sha changes per session. Instead, verify the O_NOFOLLOW
+  // open path: pre-create temp file as symlink, run helper, observe behavior.
+  //
+  // Concretely: place a symlink at a future temp-write path basename pattern.
+  // The helper writes to `.<sha>.<pid>.<ts>.<rand>.tmp` — these paths are
+  // unpredictable, so direct symlink injection at the temp is impractical.
+  // Instead test the leaf-overwrite path: pre-create a symlink AT the final
+  // marker path and trigger overwrite.
+
+  // Run a write to get the sha used
+  const w0 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'unique-m8-cmd', '--session-id', 'sid-m8',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'first'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w0.status, 0)
+  const sha = parseStdout(w0).cache_key
+  const markerPath = path.join(dir, `${sha}.json`)
+  // Remove the legit marker, replace with symlink
+  fs.unlinkSync(markerPath)
+  fs.symlinkSync(targetPath, markerPath)
+
+  // Trigger an overwrite (stale → overwrite path). The lstat check rejects.
+  // Same tuple = noop_same_tuple, BUT because we removed the real file and
+  // replaced with symlink, the existsSync check sees the symlink as existing,
+  // the JSON.parse of symlinked target succeeds (`{}` is valid JSON), but
+  // tuple-match fails → tries to overwrite → leaf lstat catches symlink.
+  const w1 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'unique-m8-cmd', '--session-id', 'sid-m8',
+    '--label', 'shared_write', '--confidence', '1', '--reason', 'attempt overwrite'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  // Either O_NOFOLLOW on temp or lstat on target catches it.
+  assert.strictEqual(w1.status, 2, 'symlink leaf overwrite must be refused')
+  assert.match(w1.stderr, /symlink/, `expected symlink rejection: ${w1.stderr}`)
+
+  // Read also refuses
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'unique-m8-cmd', '--session-id', 'sid-m8'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 1, 'read through symlink must miss/reject')
+  const rj = parseStdout(r)
+  assert.strictEqual(rj.status, 'reject')
+  assert.strictEqual(rj.reason, 'marker_is_symlink')
+
+  fs.unlinkSync(targetPath)
+})
+
+// ----- §M9: marker store ancestor symlink → write refused -----
+test('§M9 .checkpoints/ symlinked → write refuses', () => {
+  const repo = mkrepo('m9')
+  // Replace .checkpoints with a symlink to /tmp
+  const elsewhere = mktmp('m9-target')
+  fs.symlinkSync(elsewhere, path.join(repo, '.checkpoints'))
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'ls', '--session-id', 'sid-m9',
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 2, 'symlinked .checkpoints must refuse')
+  assert.match(w.stderr, /must be a real directory/)
+})
+
+// ----- §M10: expired marker → stale -----
+test('§M10 expired marker → read reports stale', () => {
+  const repo = mkrepo('m10')
+  const sid = 'sid-m10'
+  const cmd = 'ls'
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0)
+  const sha = parseStdout(w).cache_key
+  const markerFile = path.join(repo, '.checkpoints', 'classify', `${sha}.json`)
+  // Rewrite _expires_at to past
+  const body = JSON.parse(fs.readFileSync(markerFile, 'utf8'))
+  body._expires_at = new Date(Date.now() - 60_000).toISOString()
+  fs.writeFileSync(markerFile, JSON.stringify(body, null, 2))
+
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 1)
+  assert.strictEqual(parseStdout(r).status, 'stale')
+})
+
+// ----- §M11: schema-version tamper rejection -----
+test('§M11 _marker_version mismatch → read rejects as tamper', () => {
+  const repo = mkrepo('m11')
+  const sid = 'sid-m11'
+  const cmd = 'ls'
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const sha = parseStdout(w).cache_key
+  const markerFile = path.join(repo, '.checkpoints', 'classify', `${sha}.json`)
+  const body = JSON.parse(fs.readFileSync(markerFile, 'utf8'))
+  body._marker_version = 999  // tamper
+  fs.writeFileSync(markerFile, JSON.stringify(body, null, 2))
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 1)
+  assert.match(parseStdout(r).reason, /marker_schema_mismatch/)
+})
+
+// ----- §M12: adversarial label in marker body -----
+test('§M12 unknown label in marker body → read rejects', () => {
+  const repo = mkrepo('m12')
+  const sid = 'sid-m12'
+  const cmd = 'ls'
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const sha = parseStdout(w).cache_key
+  const markerFile = path.join(repo, '.checkpoints', 'classify', `${sha}.json`)
+  const body = JSON.parse(fs.readFileSync(markerFile, 'utf8'))
+  body.label = 'evil_inject'  // not in LABELS
+  fs.writeFileSync(markerFile, JSON.stringify(body, null, 2))
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 1)
+  assert.match(parseStdout(r).reason, /invalid_label/)
+})
+
+// ----- §M13: vacuum reaps stale markers -----
+test('§M13 vacuum reaps stale (>maxAge) markers, preserves fresh', () => {
+  const repo = mkrepo('m13')
+  const sid = 'sid-m13'
+  // Write two markers
+  const wA = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'old-cmd', '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'old'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const wB = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'fresh-cmd', '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'fresh'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const fileA = parseStdout(wA).file
+  const fileB = parseStdout(wB).file
+
+  // Backdate file A's mtime to 60d ago
+  const ago = (Date.now() - 60 * 24 * 60 * 60 * 1000) / 1000
+  fs.utimesSync(fileA, ago, ago)
+
+  const v = runHelper(['--vacuum', '--project-root', repo, '--max-age-days', '30'],
+    { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(v.status, 0, `vacuum: ${v.stderr}`)
+  const vj = parseStdout(v)
+  assert.strictEqual(vj.removed, 1, `expected 1 removed, got ${vj.removed}`)
+  assert.ok(!fs.existsSync(fileA), 'stale marker not removed')
+  assert.ok(fs.existsSync(fileB), 'fresh marker incorrectly removed')
+})
+
+// ----- §M15: codex code-review BLOCKER #1 regression — --read with symlinked .checkpoints/ -----
+test('§M15 (codex CR BLOCKER #1) symlinked .checkpoints/ → --read refuses', () => {
+  const repo = mkrepo('m15')
+  const elsewhere = mktmp('m15-elsewhere')
+  // Plant a fake "hit" payload at the external store
+  fs.mkdirSync(path.join(elsewhere, 'classify'), { recursive: true })
+  // Symlink .checkpoints → elsewhere
+  fs.symlinkSync(elsewhere, path.join(repo, '.checkpoints'))
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', 'ls', '--session-id', 'sid-m15'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  // Must refuse, not follow the symlink to read external content.
+  assert.strictEqual(r.status, 2, `--read through symlinked ancestor must refuse; got status=${r.status}`)
+  assert.match(r.stderr, /must be a real directory/, `expected ancestor rejection: ${r.stderr}`)
+})
+
+// ----- §M16: codex code-review BLOCKER #1 regression — --vacuum with symlinked .checkpoints/ -----
+test('§M16 (codex CR BLOCKER #1) symlinked .checkpoints/ → --vacuum refuses (no external deletion)', () => {
+  const repo = mkrepo('m16')
+  const external = mktmp('m16-external')
+  // Plant an external "stale" marker that vacuum would delete IF it followed the symlink
+  const externalClassify = path.join(external, 'classify')
+  fs.mkdirSync(externalClassify, { recursive: true })
+  const externalMarker = path.join(externalClassify, 'fake.json')
+  fs.writeFileSync(externalMarker, '{}')
+  const ago = (Date.now() - 100 * 86400 * 1000) / 1000
+  fs.utimesSync(externalMarker, ago, ago)
+  // Symlink .checkpoints → external
+  fs.symlinkSync(external, path.join(repo, '.checkpoints'))
+
+  const v = runHelper(['--vacuum', '--project-root', repo, '--max-age-days', '30'],
+    { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(v.status, 2, `--vacuum through symlinked ancestor must refuse; got status=${v.status}`)
+  // External file MUST still exist — vacuum must not have followed the symlink.
+  assert.ok(fs.existsSync(externalMarker), 'vacuum deleted external file via symlinked ancestor (BLOCKER reproduced)')
+})
+
+// ----- §M17: codex code-review BLOCKER #2 regression — leaf-symlink-same-tuple bypass -----
+test('§M17 (codex CR BLOCKER #2) leaf symlink with same-tuple body → write still refuses', () => {
+  const repo = mkrepo('m17')
+  const sid = 'sid-m17'
+  const cmd = 'unique-m17-cmd'
+  // First, do a legitimate write
+  const w0 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'seed'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w0.status, 0)
+  const sha = parseStdout(w0).cache_key
+  const markerPath = path.join(repo, '.checkpoints', 'classify', `${sha}.json`)
+  const legitBody = fs.readFileSync(markerPath, 'utf8')
+
+  // Move the real marker outside the repo
+  const elsewhere = mktmp('m17-elsewhere')
+  const externalMarker = path.join(elsewhere, 'real-marker.json')
+  fs.writeFileSync(externalMarker, legitBody)   // SAME tuple, valid body
+  fs.unlinkSync(markerPath)
+  fs.symlinkSync(externalMarker, markerPath)
+
+  // Trigger a write that would hit the same-tuple noop path
+  const w1 = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', cmd, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '1', '--reason', 'attempt bypass'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  // Must refuse — lstat-FIRST detects the symlink before the same-tuple
+  // check ever runs.
+  assert.strictEqual(w1.status, 2, `leaf symlink with same-tuple body MUST refuse; got status=${w1.status}`)
+  assert.match(w1.stderr, /symlink/, `expected symlink rejection: ${w1.stderr}`)
+})
+
+// ----- §M14: vacuum skips symlinks -----
+test('§M14 vacuum never touches symlinks (even stale by mtime)', () => {
+  const repo = mkrepo('m14')
+  const dir = path.join(repo, '.checkpoints', 'classify')
+  fs.mkdirSync(dir, { recursive: true })
+  const target = mktmp('m14-target')
+  const targetFile = path.join(target, 'inner.json')
+  fs.writeFileSync(targetFile, '{}')
+  const symlinkPath = path.join(dir, 'symlinked.json')
+  fs.symlinkSync(targetFile, symlinkPath)
+  // Backdate the SYMLINK's mtime
+  const ago = (Date.now() - 100 * 24 * 60 * 60 * 1000) / 1000
+  try { fs.lutimesSync(symlinkPath, ago, ago) } catch {}
+
+  const v = runHelper(['--vacuum', '--project-root', repo, '--max-age-days', '30'],
+    { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(v.status, 0)
+  // Symlink should survive (vacuum skips symlinks)
+  assert.ok(fs.lstatSync(symlinkPath).isSymbolicLink(), 'vacuum removed symlink — must not')
+})
+
+// ----- Runner -----
+async function run() {
+  console.log('classifier-marker.mjs tests')
+  for (const t of queue) await t()
+  console.log(`\n${passed} passed, ${failed} failed`)
+  if (failed > 0) {
+    console.log('\nFailures:')
+    for (const f of failures) console.log(`  ${f.name}: ${f.error}`)
+    process.exit(1)
+  }
+}
+run().catch(e => { console.error(e); process.exit(1) })

--- a/tests/test-llm-classifier.mjs
+++ b/tests/test-llm-classifier.mjs
@@ -727,6 +727,227 @@ echo "rc=$?"
 })
 
 // ---------------------------------------------------------------------------
+// §M-shell — shell wrapper reads classifier-marker.mjs verdict
+// (post-PR #326 design: zero-LLM hot path)
+// ---------------------------------------------------------------------------
+test('§M-shell wrapper hits marker cache when classifier-marker.mjs verdict exists', () => {
+  const project = mkrepo('shell-marker')
+  const MARKER = path.join(REPO, 'scripts', 'classifier-marker.mjs')
+  const sid = 'session-shell-marker'
+  // Use the SAME command string at seed time and lookup time. The cache
+  // tuple includes normalized_command verbatim — `./x.py` and `/abs/x.py`
+  // hash to different sha values even though they resolve to the same file.
+  const cmdText = `python3 ${project}/scripts/maybe-write.py`
+  const w = spawnSync(process.execPath, [
+    MARKER, '--write',
+    '--project-root', project,
+    '--caller-cwd', project,
+    '--command', cmdText,
+    '--session-id', sid,
+    '--label', 'shared_write',
+    '--confidence', '0.9',
+    '--reason', 'agent self-classify'
+  ], { cwd: project, env: { CLAUDE_CODE_SESSION_ID: '' }, encoding: 'utf8' })
+  assert.strictEqual(w.status, 0, `seed failed: ${w.stderr}`)
+
+  // Source shell wrapper, expect it to find the marker and emit the label.
+  const script = `#!/usr/bin/env bash
+set -u
+source ${WRAPPER}
+export CLAUDE_CODE_SESSION_ID=${sid}
+out="$(llm_classify_command "${cmdText}" "${project}" "${project}" 2>&1)"
+rc=$?
+echo "rc=$rc"
+echo "out=$out"
+`
+  const tmp = path.join(project, 'run-marker.sh')
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  assert.match(r.stdout, /rc=0/, `expected rc=0 on marker hit; got: ${r.stdout}`)
+  assert.match(r.stdout, /shared_write/, `expected shared_write label; got: ${r.stdout}`)
+  assert.match(r.stdout, /interpreter_marker_cache_hit/, `expected new source tag; got: ${r.stdout}`)
+})
+
+test('§M-shell wrapper misses cleanly when no marker exists → rc=1', () => {
+  const project = mkrepo('shell-marker-miss')
+  const script = `#!/usr/bin/env bash
+set -u
+source ${WRAPPER}
+export CLAUDE_CODE_SESSION_ID=session-no-marker
+out="$(llm_classify_command "python3 ${project}/scripts/never-classified.py" "${project}" "${project}" 2>&1)"
+rc=$?
+echo "rc=$rc"
+`
+  const tmp = path.join(project, 'run-miss.sh')
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  assert.match(r.stdout, /rc=1/, `expected rc=1 on miss; got: ${r.stdout}`)
+})
+
+test('§M-shell wrapper rejects marker from another session_id', () => {
+  const project = mkrepo('shell-marker-cross')
+  const MARKER = path.join(REPO, 'scripts', 'classifier-marker.mjs')
+  // Seed under session A
+  spawnSync(process.execPath, [
+    MARKER, '--write',
+    '--project-root', project,
+    '--caller-cwd', project,
+    '--command', 'python3 ./scripts/x.py',
+    '--session-id', 'session-A',
+    '--label', 'read_only',
+    '--confidence', '1',
+    '--reason', 'seed'
+  ], { cwd: project, env: { CLAUDE_CODE_SESSION_ID: '' }, encoding: 'utf8' })
+  // Run wrapper as session B → no hit (different sha → marker not at expected path)
+  const script = `#!/usr/bin/env bash
+set -u
+source ${WRAPPER}
+export CLAUDE_CODE_SESSION_ID=session-B
+out="$(llm_classify_command "python3 ${project}/scripts/x.py" "${project}" "${project}" 2>&1)"
+rc=$?
+echo "rc=$rc"
+`
+  const tmp = path.join(project, 'run-cross.sh')
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  assert.match(r.stdout, /rc=1/, `cross-session must miss; got: ${r.stdout}`)
+})
+
+// ---------------------------------------------------------------------------
+// §EP-marker — env-prefix rejection at command-classifier.sh for
+// classifier-marker.mjs helper invocations (same-class with PR #272 F-4)
+// ---------------------------------------------------------------------------
+test('§EP-marker env-prefix wrapper around classifier-marker.mjs → unsafe_complex', () => {
+  const cls = COMMAND_CLASSIFIER
+  const script = `#!/usr/bin/env bash
+set -u
+source ${cls}
+out="$(classify_command "FOO=bar node /repo/scripts/classifier-marker.mjs --write --project-root /repo --caller-cwd /repo --command ls --session-id sid --label read_only --confidence 1 --reason x" "/repo")"
+echo "$out"
+`
+  const tmp = path.join(os.tmpdir(), `ep-marker-${Date.now()}.sh`)
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  fs.unlinkSync(tmp)
+  // First column is the label; reason includes classifier_marker_env_override.
+  assert.match(r.stdout, /unsafe_complex/, `expected unsafe_complex; got: ${r.stdout}`)
+  assert.match(r.stdout, /classifier_marker_env_override/, `expected reason tag; got: ${r.stdout}`)
+})
+
+test('§EP-marker canonical classifier-marker.mjs invocation → marker_write', () => {
+  const cls = COMMAND_CLASSIFIER
+  const script = `#!/usr/bin/env bash
+set -u
+source ${cls}
+out="$(classify_command "node /repo/scripts/classifier-marker.mjs --write --project-root /repo --caller-cwd /repo --command ls --session-id sid --label read_only --confidence 1 --reason x" "/repo")"
+echo "$out"
+`
+  const tmp = path.join(os.tmpdir(), `ep-marker-ok-${Date.now()}.sh`)
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  fs.unlinkSync(tmp)
+  assert.match(r.stdout, /marker_write/, `expected marker_write; got: ${r.stdout}`)
+  assert.match(r.stdout, /interpreter_classifier_marker/, `expected source tag; got: ${r.stdout}`)
+})
+
+test('§LM4 (codex CR R2 BLOCKER) ambient CLASSIFIER_MARKER_PATH env override is ignored — no fabrication vector', () => {
+  // Regression: prior code resolved the marker helper via CLASSIFIER_MARKER_PATH
+  // env var BEFORE the installed/repo path, letting a stub print
+  // {"status":"hit","label":"read_only",...} and bypass the marker artifact.
+  // Fix: env-override seam removed entirely; helper resolution is hard-bound
+  // to installed-runtime or repo-source paths only.
+  const project = mkrepo('classifier-marker-path-env')
+  // Plant a stub that WOULD fabricate a hit if used
+  const stub = path.join(project, 'fabricator.mjs')
+  fs.writeFileSync(stub, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  status: 'hit',
+  label: 'read_only',
+  confidence: 1,
+  reason: 'FABRICATED',
+  project_root_used: ${JSON.stringify(project)},
+  cache_key: 'fake',
+  session_id: 'fake'
+}) + '\\n')
+process.exit(0)
+`)
+  fs.chmodSync(stub, 0o755)
+
+  // Note: we don't expect this env var to do anything — but we set it to
+  // verify the wrapper IGNORES it.
+  const script = `#!/usr/bin/env bash
+set -u
+source ${WRAPPER}
+export CLAUDE_CODE_SESSION_ID=session-classifier-marker-env
+export CLASSIFIER_MARKER_PATH=${stub}
+out="$(llm_classify_command "python3 ${project}/scripts/x.py" "${project}" "${project}" 2>&1)"
+rc=$?
+echo "rc=$rc"
+echo "out=$out"
+`
+  const tmp = path.join(project, 'run-env-override.sh')
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  // No marker exists; the env-override stub MUST be ignored; wrapper returns
+  // rc=1 (no decision), and "FABRICATED" must NEVER appear.
+  assert.match(r.stdout, /rc=1/, `env override must be ignored; got: ${r.stdout}`)
+  assert.doesNotMatch(r.stdout, /FABRICATED/, `stub helper must not be invoked; got: ${r.stdout}`)
+  assert.doesNotMatch(r.stdout, /interpreter_marker_cache_hit/, `no cache hit possible without real marker; got: ${r.stdout}`)
+})
+
+test('§LM3 (codex CR MAJOR #3) shell wrapper falls through to legacy when marker misses + transport=direct-fetch', async () => {
+  // Regression test: prior code returned rc=1 at marker miss before checking
+  // legacy config, making the rollback path unreachable.
+  await withMockApi({ label: 'read_only', confidence: 0.95, reason: 'legacy mock' }, async (base) => {
+    const project = mkrepo('legacy-rollback')
+    // Set config to opt into direct-fetch transport
+    const cfgDir = path.join(project, '.episodic-memory')
+    fs.mkdirSync(cfgDir, { recursive: true })
+    fs.writeFileSync(path.join(cfgDir, 'classifier-config.json'),
+      JSON.stringify({ transport: 'direct-fetch' }, null, 2))
+    const script = `#!/usr/bin/env bash
+set -u
+source ${WRAPPER}
+export CLAUDE_CODE_SESSION_ID=session-legacy
+export LLM_CLASSIFIER_DISPATCH_PATH=${DISPATCH}
+export ANTHROPIC_API_KEY=mock-key
+export LLM_CLASSIFIER_API_BASE=${base}
+# No marker exists → marker-read misses → legacy must activate
+out="$(llm_classify_command "node ${project}/scripts/foo.mjs" "${project}" "${project}" 2>&1)"
+rc=$?
+echo "rc=$rc"
+echo "out=$out"
+`
+    const tmp = path.join(project, 'run-legacy.sh')
+    fs.writeFileSync(tmp, script)
+    // spawnAsync is REQUIRED for mock-using tests: spawnSync blocks the parent's
+    // event loop, preventing the in-process mock server from serving requests.
+    const r = await spawnAsync('bash', [tmp])
+    assert.match(r.stdout, /rc=0/, `expected rc=0 from legacy fallback; got stdout=${r.stdout} stderr=${r.stderr}`)
+    assert.match(r.stdout, /interpreter_llm_legacy/, `expected legacy source tag; got: ${r.stdout}`)
+  })
+})
+
+test('§EP-correction env-prefix wrapper around classify-correction.mjs → unsafe_complex', () => {
+  // Same-class hardening (added in this PR): the existing classify-correction
+  // allowlist now rejects env-prefix invocations to match plan-marker.mjs /
+  // classifier-marker.mjs discipline.
+  const cls = COMMAND_CLASSIFIER
+  const script = `#!/usr/bin/env bash
+set -u
+source ${cls}
+out="$(classify_command "FOO=bar node /repo/scripts/classify-correction.mjs --project-root /repo --caller-cwd /repo --command ls --label read_only" "/repo")"
+echo "$out"
+`
+  const tmp = path.join(os.tmpdir(), `ep-correction-${Date.now()}.sh`)
+  fs.writeFileSync(tmp, script)
+  const r = spawnSync('bash', [tmp], { encoding: 'utf8' })
+  fs.unlinkSync(tmp)
+  assert.match(r.stdout, /unsafe_complex/, `expected unsafe_complex; got: ${r.stdout}`)
+  assert.match(r.stdout, /classify_correction_env_override/, `expected reason tag; got: ${r.stdout}`)
+})
+
+// ---------------------------------------------------------------------------
 // §T12 — prompt injection defense (uses mock API)
 // ---------------------------------------------------------------------------
 test('§T12 prompt injection in command does not flip mock label', async () => {


### PR DESCRIPTION
## Summary

Replaces PR #326's direct-API Tier 3 LLM classifier (which billed every Bash cache-miss against a separate `ANTHROPIC_API_KEY` meter on top of the user's Claude Code subscription) with an **agent-self-classify + marker-gate** design. The active Claude Code session classifies its own commands using its own reasoning (already paid for via the user's subscription tokens) and writes the verdict to `.checkpoints/classify/<sha>.json`. A PreToolUse shell hook reads the marker and gates.

**Cost: zero new LLM calls in the hot path. Zero new API keys. Zero new billing meters.**

## Design (codex-reviewed: design R1 HOLD → R2 HOLD → R3 ACCEPT-with-FU)

- **Per-session marker** (`session_id` in sha preimage) — no cross-session bleed.
- **Per-project marker** (`project_root_canonical` in preimage + body) — no multi-project pollination; helper refuses cross-repo writes.
- **Path-versioned** (`classifier_policy_version` + `normalized_command_version` in preimage) — schema/policy upgrade invalidates all old markers.
- **Marker hardening**: lstat each ancestor; `O_NOFOLLOW` on writes; same-real-directory temp+rename; explicit `--project-root` required; refuses without `resolveRepoRoot(cwd) == --project-root`; refuses without `CLAUDE_CODE_SESSION_ID` env match.
- **Write-once-or-same** race semantics; 24h TTL; `--vacuum` reaps >30d markers.
- **Threat model**: defends honest-agent drift + honest concurrent sessions + stale markers across upgrades + symlink swaps. Does NOT defend adversarial cross-session forge (`--session-id` is argv-controlled).

## Code (codex-reviewed: code R1 HOLD → R2 HOLD → R3 ACCEPT-with-FU)

- **R1 BLOCKER fix:** `--read` and `--vacuum` now apply same lstat-ancestor validation as `--write` (closes symlinked-`.checkpoints` escape).
- **R1 BLOCKER fix:** `writeMarker` lstats target leaf BEFORE `existsSync`/read (closes leaf-symlink-same-tuple bypass).
- **R1 MAJOR fix:** marker-miss falls through to legacy direct-fetch when config field `transport: "direct-fetch"` set (rollback was unreachable).
- **R2 BLOCKER fix:** `CLASSIFIER_MARKER_PATH` env override removed entirely — helper resolution hard-bound to installed-runtime OR repo-source path.

## What changed

| Path | Change |
|---|---|
| `scripts/classifier-marker.mjs` | NEW. Read/write/vacuum helper with full hardening + tuple binding + write-once-or-same. |
| `hooks/lib/llm-classifier.sh` | Rewired hot path to marker-read; legacy direct-fetch retained behind explicit `transport: "direct-fetch"` config field (NOT env-prefix). |
| `hooks/lib/command-classifier.sh` | New Tier 1 allowlist `interpreter_classifier_marker` with env-prefix-form rejection. Same-class env-prefix hardening added to existing `interpreter_classify_correction` allowlist. |
| `tests/test-classifier-marker.mjs` | NEW. 17 tests: multi-session/multi-project isolation, env defense, cross-repo refusal, O_NOFOLLOW, symlinked ancestors, write-once-or-same, TTL, schema/policy version, vacuum, M15/M16/M17 regressions. |
| `tests/test-llm-classifier.mjs` | Adapted: existing 29 PR #326 tests preserved (legacy direct-fetch path); 8 new tests (shell-wrapper marker hit/miss/cross-session; env-prefix rejection for classifier-marker + classify-correction; LM3 legacy-fallback regression; LM4 env-override-fabrication regression). |

## Linked worktree behavior

The marker artifact root is the **canonical project root** as resolved by `scripts/lib/local-dir.mjs::resolveRepoRoot` (which uses `git rev-parse --git-common-dir` and converges on the main repo's working tree for linked worktrees of main). Codex PR-level review verified: writing to the linked worktree root is refused; writing to the hook-resolved main root succeeds. Concurrent linked worktrees share the main repo's `.checkpoints/classify/` namespace but per-session shas keep their markers separate.

## Safety properties

1. **Per-session isolation.** Marker path includes `session_id`. Session B never sees Session A's marker.
2. **Per-project isolation.** Marker path is `<project>/.checkpoints/classify/<sha>.json`. Helper refuses `--project-root != resolveRepoRoot(cwd)`.
3. **Path-component hardening.** lstat each ancestor; refuse any symlinked parent; `O_NOFOLLOW` on `open()`; realpath equality check before rename.
4. **Cross-repo write defense.** `resolveRepoRoot(cwd) != --project-root` → exit 2.
5. **Env-defense.** When `CLAUDE_CODE_SESSION_ID` env is set, helper refuses `--session-id` argv that disagrees.
6. **No env-override on marker resolution.** `CLASSIFIER_MARKER_PATH` removed — helper resolution hard-bound.
7. **Schema/policy versioning.** `_classifier_policy_version` and `_normalized_command_version` in sha preimage → bump invalidates all old markers.
8. **Adversarial label rejection.** Read-side LABELS allowlist rejects unknown values.
9. **Write-once-or-same.** Concurrent same-tuple writers are no-op success.
10. **Vacuum hardening.** `--vacuum` applies same ancestor validation; never follows symlinks.

## Test plan

- [x] `node tests/test-classifier-marker.mjs` — 17/17 pass.
- [x] `node tests/test-llm-classifier.mjs` — 37/37 pass.
- [x] Multi-session isolation: §M2 asserts session A and session B → different marker paths.
- [x] Multi-project isolation: §M3 asserts P1 and P2 → markers under each project's own `.checkpoints/`; cross-repo write refused.
- [x] §M15 (codex R1 BLOCKER#1 regression): symlinked `.checkpoints/` → `--read` refuses.
- [x] §M16 (codex R1 BLOCKER#1 regression): symlinked `.checkpoints/` → `--vacuum` refuses; external file survives.
- [x] §M17 (codex R1 BLOCKER#2 regression): leaf symlink with same-tuple body → write refuses.
- [x] §LM3 (codex R1 MAJOR#3 regression): marker miss + `transport: "direct-fetch"` → legacy fallback fires.
- [x] §LM4 (codex R2 BLOCKER regression): `CLASSIFIER_MARKER_PATH` stub helper ignored; no fabricated hit.
- [x] §EP-marker / §EP-correction: env-prefix wrapper around both helpers → `unsafe_complex`.

## Migration / rollback

- **Default:** marker-gate only. No `ANTHROPIC_API_KEY` required in hot path.
- **Rollback:** set `~/.episodic-memory/classifier-config.json` (or `<project>/.episodic-memory/classifier-config.json`) to `{"transport": "direct-fetch"}`. Legacy dispatcher reactivates; existing 29 PR #326 tests cover its behavior unchanged.
- **No env-prefix opt-in form** anywhere.
- **Telemetry:** legacy use logs to `~/.episodic-memory/legacy-fetch.log.jsonl` for burn-in surfacing.

## Deferred follow-up

- **codex CR R3 FU (non-blocking):** `LLM_CLASSIFIER_DISPATCH_PATH` env-override is the same shape as the removed `CLASSIFIER_MARKER_PATH` but gated behind explicit `transport: "direct-fetch"` config. Remove when retiring legacy direct-fetch entirely. Will file as follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
