### PR TITLE
docs: refresh README + USER_MANUAL for PRs #305..#331

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ Instruction-only support is deliberately modest for OpenCode and Pi Agent:
 
 Future MCP support should be a thin wrapper around existing scripts (`recall`, `search`, `store`, `revise`) with no second store, no daemon, no polling, explicit activation, and reversible uninstall.
 
+## Skills
+
+This project ships two in-tree skills. Each is a self-contained SKILL.md the agent loads on demand.
+
+| Skill | Location | What it does |
+|---|---|---|
+| `episodic-memory` | `instructions/SKILL.md` → installed to `.claude/skills/episodic-memory/`, `.agents/skills/episodic-memory/`, etc. (see [Supported Tools](#supported-tools)) | The main skill the agent reads at session start to learn how to recall, store, revise, and surface episodes. Wraps every `em-*` script. |
+| `classify-correction` | `skills/classify-correction/SKILL.md` (PR [#327](https://github.com/lantisprime/episodic-memory/pull/327)) | Records a per-project override for the LLM checkpoint-gate classifier when a command was mislabeled (e.g. a read-only inspector blocked as `shared_write`). Writes to `<project>/.episodic-memory/classifier-overrides.jsonl`. |
+
+Three additional SKILLs are invoked from `launchd` rather than the agent's session loop — see [Scheduled Routines](#scheduled-routines-launchd-macos): `episodic-memory-daily-mining`, `episodic-memory-weekly-digest`, `instruction-hygiene-maintenance`.
+
 ## Episode Categories
 
 | Category | Use for |
@@ -200,7 +211,8 @@ Behavioral patterns are documentation by default — but the most-violated patte
 - **Session-end prompt** (`em-session-end-prompt.mjs`) — SessionEnd hook that asks about violations
 - **Proactive recall** (`em-recall.mjs`) — surfaces past violations at session start as pre-flight warnings
 - **Checkpoint enforcement gate** (RFC-002 Phase 3b, shipped + activated 2026-05-02 via [#78](https://github.com/lantisprime/episodic-memory/pull/78) and [#84](https://github.com/lantisprime/episodic-memory/pull/84)) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done. Opt-in via `node install.mjs --tool claude-code --install-hooks --project <path>`; registers SessionStart + PreToolUse + SessionEnd hooks in `~/.claude/settings.json`.
-- **BP-1 Auto-Pilot** (RFC-004, M0 + M1 shipped 2026-05-06..09 via [#181](https://github.com/lantisprime/episodic-memory/pull/181), [#186](https://github.com/lantisprime/episodic-memory/pull/186), [#188](https://github.com/lantisprime/episodic-memory/pull/188), [#200](https://github.com/lantisprime/episodic-memory/pull/200), [#206](https://github.com/lantisprime/episodic-memory/pull/206)) — activation gate, deadline sweep, finalize-replay state machine, and HMAC-signed run manifests that mechanically enforce bp-001 (implementation workflow). Replaces documentation-only enforcement for the workflow lifecycle.
+- **LLM intent classifier for the checkpoint gate** (Tier 2/3 shipped 2026-05-22 via [#326](https://github.com/lantisprime/episodic-memory/pull/326); replaced by agent-self-classify marker 2026-05-23 via [#331](https://github.com/lantisprime/episodic-memory/pull/331)) — when the Tier 1 heuristic table doesn't recognize a `Bash` command, the gate consults a per-session marker (`scripts/classifier-marker.mjs`) populated by the active agent's own reasoning, then falls through to the Tier 1 safe-default if no marker exists. Configuration loaded by `scripts/classifier-config-loader.mjs` from `<project>/.episodic-memory/classifier-config.json` (or the global file under `~/.episodic-memory/`); set `enabled: false` to disable LLM dispatch entirely and run on the Tier 1 heuristic alone. False-positives (read-only inspectors blocked as `shared_write`) are corrected via the `classify-correction` skill — see [Skills](#skills) below.
+- **BP-1 Auto-Pilot** (RFC-004, M0 + M1 + M2 shipped 2026-05-06..23 via [#181](https://github.com/lantisprime/episodic-memory/pull/181), [#186](https://github.com/lantisprime/episodic-memory/pull/186), [#188](https://github.com/lantisprime/episodic-memory/pull/188), [#200](https://github.com/lantisprime/episodic-memory/pull/200), [#206](https://github.com/lantisprime/episodic-memory/pull/206), [#305](https://github.com/lantisprime/episodic-memory/pull/305), [#309](https://github.com/lantisprime/episodic-memory/pull/309), [#313](https://github.com/lantisprime/episodic-memory/pull/313), [#322](https://github.com/lantisprime/episodic-memory/pull/322)) — activation gate, deadline sweep, finalize-replay state machine, HMAC-signed run manifests, per-session preflight markers, and the M2 finish-line `bp1-flag-flip` cutover that mechanically enforce bp-001 (implementation workflow). Replaces documentation-only enforcement for the workflow lifecycle.
 
 **External ([user-preferences](https://github.com/lantisprime/user-preferences)):**
 - **Pre-tool hooks** (e.g., `plan-gate.sh`) that block writes during the planning phase
@@ -216,7 +228,7 @@ Episodic-memory and user-preferences are fully independent — install either or
 | [RFC-001](docs/rfcs/RFC-001-memory-improvements.md) | Intelligent Memory: Tag Index, Relevance Scoring, Proactive Recall, Semantic Consolidation | Accepted (Phases 1-3 shipped) |
 | [RFC-002](docs/rfcs/RFC-002-learning-loop.md) | Learning Loop: Violation Tracking, Pattern Refinement, Actionable Recall | Accepted (Phases 1-3 + 3b shipped + runtime-deployed) |
 | [RFC-003](docs/rfcs/RFC-003-pluggable-tool-adapters.md) | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | Accepted (Phase 1 not yet started) |
-| [RFC-004](docs/rfcs/RFC-004-bp1-auto-pilot.md) | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | Accepted (M0 + M1 shipped) |
+| [RFC-004](docs/rfcs/RFC-004-bp1-auto-pilot.md) | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | Accepted (M0 + M1 + M2 shipped) |
 | [RFC-005](docs/rfcs/RFC-005-em-move.md) | em-move — atomic episode relocation between scopes | Draft |
 | [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Accepted (harness shipped PR #222) |
 
@@ -478,7 +490,21 @@ node ~/.episodic-memory/scripts/bp1-deadline-sweep.mjs --once [--project <root>]
 node ~/.episodic-memory/scripts/bp1-orchestrator.mjs init-run --project <root>
 node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-run --run-id <id>
 node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-recover --run-id <id>
+
+# Marker validation — verify a checkpoint marker's HMAC + shape (slice 2d-W, #305)
+node ~/.episodic-memory/scripts/bp1-marker-validate.mjs --marker <path>
+
+# Crash-class classification for SessionStart resumption (slice 2e, #313)
+node ~/.episodic-memory/scripts/bp1-crash-classify.mjs --run-id <id>
+
+# Emit a marker-invalid evidence episode (used by the deadline-firing path, #313)
+node ~/.episodic-memory/scripts/bp1-emit-marker-invalid-evidence.mjs --run-id <id> --reason <code>
+
+# M2 finish-line: flip the BP-1 activation flag (slice 2f, #322)
+node ~/.episodic-memory/scripts/bp1-flag-flip.mjs --enable    # or --disable
 ```
+
+The orchestrator also auto-stubs a missing run on first interaction via `scripts/bp1-auto-stub.mjs` — not normally invoked directly.
 
 ### Compliance Audit & Transcript Mining
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -520,6 +520,21 @@ AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
 
 **To clear a gate:** Approve the AI's plan in chat. The AI writes the checkpoint marker on your behalf — you don't run any commands manually. (Marker location is an internal implementation detail; PR #207 relocated it from `<repo>/.claude/.X` to `<repo>/.checkpoints/.X` to escape Claude Code's built-in sensitive-file prompt — readers honor both during burn-in.)
 
+**False-positive: the gate blocked a read-only command.** The checkpoint gate uses a command classifier (PR #326 / PR #331) to decide whether a `Bash` invocation writes state. The classifier defaults to "shared_write" when uncertain, which can block read-only inspectors (`python3 src/inspect.py`, ad-hoc diagnostics, etc.) that the gate should ignore. When this happens you have three escape hatches:
+
+1. **Record a per-project override** via the `classify-correction` skill. This pins the correct label for that exact command shape in that project — next time the gate sees it, no LLM call, no block:
+   ```bash
+   node ~/.episodic-memory/scripts/classify-correction.mjs \
+     --project-root "$(git rev-parse --show-toplevel)" \
+     --caller-cwd  "$(pwd)" \
+     --command     "python3 src/inspect.py" \
+     --label       read_only \
+     --reason      "inspector — read-only diagnostic, no writes"
+   ```
+   Labels: `read_only`, `shared_write`, `marker_write`, `push_or_pr_create`, `unsafe_complex`. Overrides are per-project (cache key includes the project root + the script's sha256 digest — they don't bleed across repos and re-trigger if the script content changes). See `skills/classify-correction/SKILL.md` for the full reference, including the `--allow-non-git` mode for non-git projects (PR #327).
+2. **Disable LLM dispatch entirely** by setting `enabled: false` in `<project-root>/.episodic-memory/classifier-config.json` (or globally at `~/.episodic-memory/classifier-config.json`). The Tier 1 heuristic table + safe `shared_write` default then apply — useful if you're offline, don't have an API key, or want to minimize cost.
+3. **Remove the hook entry** from `~/.claude/settings.json` to opt out of the gate entirely.
+
 **Behind the scenes — BP-1 Auto-Pilot (RFC-004).** These three gates are part of a run-lifecycle system that signs each implementation run with HMAC, tracks state across crashes, and replays unfinished work via a finalize-recovery state machine. You don't interact with it directly — the gates above are its user-facing edges.
 
 **To opt out entirely:** Don't pass `--install-hooks` during install, or remove the hook entries from `~/.claude/settings.json`.


### PR DESCRIPTION
## Summary

Refreshes `README.md` + `docs/USER_MANUAL.md` to reflect the 12 PRs shipped since the last doc-refresh PR (#294, 2026-05-16). User-facing features that landed without doc coverage:

- **LLM intent classifier for the checkpoint gate** (#326 Tier 2/3, then #331 replaced direct-API with agent-self-classify marker)
- **`classify-correction` skill + script** (#327) — the user's escape hatch when the gate false-positives on a read-only command
- **RFC-004 BP-1 Auto-Pilot M2 finish-line** (#322, with slice 2d-W #305, 2d-R #309, 2e #313)

## What changed

**`README.md`** (+30 / -2):
- New `## Skills` section listing the two in-tree skills (`episodic-memory`, `classify-correction`).
- New "LLM intent classifier" bullet under Behavioral Patterns → Enforcement covering #326 + #331 + the `classifier-config.json` disable knob.
- BP-1 Auto-Pilot bullet extended with #305 / #309 / #313 / #322 and now says "M0 + M1 + M2 shipped".
- RFC-004 row in the RFCs table flipped `M0 + M1 shipped` → `M0 + M1 + M2 shipped`.
- BP-1 Auto-Pilot script block grew 4 new invocations (`bp1-marker-validate`, `bp1-crash-classify`, `bp1-emit-marker-invalid-evidence`, `bp1-flag-flip`) plus a note about `bp1-auto-stub`.

**`docs/USER_MANUAL.md`** (+15 / -0):
- Scenario 12 grew a **"False-positive: the gate blocked a read-only command"** subsection documenting three escape hatches: the `classify-correction` skill (with full invocation), the `classifier-config.json` disable, and full hook removal. This closes a real user-discoverability gap — Scenario 12 previously had no recovery path for a wrongly-blocked command.

## Test plan

- [x] `node scripts/em-rfc-validate.mjs --json` → `{"status":"ok","violations":[]}` (Rule 14 CI gate cross-checking RFC table ↔ `_index.json` ↔ frontmatter).
- [x] `git diff` reviewed end-to-end — additive only, no removal of working content.
- [x] Internal anchors (`#supported-tools`, `#skills`, `#scheduled-routines-launchd-macos`) verified against current README structure.
- [ ] CI checks pass on the PR.

## Out of scope (deliberately deferred)

- `docs/rfcs/README.md` and `docs/rfcs/_index.json` had pre-existing modifications in the working tree at session start — left untouched.
- `docs/rfcs/RFC-007-graph-projection.md` is currently untracked — should land in its own PR with the RFC table row added then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
