### PR TITLE
fix(classifier): em-rebuild-index → read_only (metadata sync)

### DIFF
--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1478,11 +1478,11 @@ _classify_segment() {
       script_base="$(basename "$script" 2>/dev/null)"
       case "$script_base" in
         em-search.mjs|em-list.mjs|em-watch-codex.mjs|em-pattern-health.mjs|em-check-stale.mjs|em-rebuild-index.mjs)
-          # em-rebuild-index touches index.jsonl — treat as shared_write
-          if [ "$script_base" = "em-rebuild-index.mjs" ]; then
-            printf '%s\t\t%s\n' "shared_write" "interpreter_em_rebuild"
-            return 0
-          fi
+          # em-rebuild-index writes index.jsonl but the operation is metadata
+          # sync derived deterministically from episode files (idempotent,
+          # atomic-rename, no partial-corruption window). Same gate-class as
+          # em-search (which also writes — access_count). Treating as
+          # read_only so the gate stops false-positive-blocking metadata sync.
           printf '%s\t\t%s\n' "read_only" "interpreter_em_read"
           return 0
           ;;

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -69,6 +69,7 @@ assert_label "T13 empty" "" "read_only"
 assert_label "T14 colon noop" ":" "read_only"
 assert_label "T15 true" "true" "read_only"
 assert_label "T16 node em-search" "node scripts/em-search.mjs --project x" "read_only"
+assert_label "T16b node em-rebuild-index" "node scripts/em-rebuild-index.mjs --scope all" "read_only"
 assert_label "T17 wc -l" "wc -l file.txt" "read_only"
 
 echo ""


### PR DESCRIPTION
## Summary

- Drops the `shared_write` special-case for `em-rebuild-index.mjs` in `hooks/lib/command-classifier.sh:1480-1487`; it now classifies `read_only` like its sibling em-* read scripts.
- Rationale: rebuild is deterministic metadata sync derived from episode files (idempotent, atomic-rename, no partial-corruption window). Same gate-class as `em-search` (which also writes — access_count). The prior `shared_write` label was false-positive-blocking checkpoint-gate when `.checkpoint-required` is armed, forcing manual checkpoint-marker writes for metadata sync that is not Rule-18-scope implementation work.
- Adds regression test T16b in `tests/test-command-classifier.sh`. Full suite: 341/341 pass.

## Test plan

- [x] `bash tests/test-command-classifier.sh` → 341 pass, 0 fail
- [ ] In a session where `.checkpoint-required` is armed and `.pre-checkpoint-done` is missing, `node scripts/em-rebuild-index.mjs --scope all` passes the gate directly (no manual marker write needed).
- [ ] No regressions to em-store / em-revise / em-prune classification (still `shared_write`).

## Context

Same false-positive class as the open observation in episode `20260521-234705` (validate-*.mjs blocked as `shared_write` by checkpoint-gate). User has hit this every session that arms `.checkpoint-required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
