### PR TITLE
fix(rank-2): per-session checkpoint quartet markers (closes #341)

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -265,6 +265,13 @@ _marker_basename_in_set() {
     # Sibling of plan-approval-pending; loose glob, strict validation
     # via preflight_marker_basename_matches happens at gate layer.
     .preflight-done.*) return 0 ;;
+    # Rank-2 (closes #341): per-session checkpoint quartet basenames.
+    # Same parity as plan-marker/preflight-marker. Needed for the
+    # wrong-root detection path (_command_first_absolute_noncanonical_marker)
+    # to fire `_block_wrong_root_marker` on `mv`/`cp`/`install`/`dd of=`
+    # to a non-canonical absolute path with suffixed quartet basename.
+    # Reviewer: rank-2 negative-scenario-reviewer F1.
+    .pre-checkpoint-done.*|.post-checkpoint-done.*|.checkpoint-required.*|.post-checkpoint-required.*) return 0 ;;
   esac
   return 1
 }
@@ -336,7 +343,7 @@ _escape_bash_glob() {
 _command_has_relative_marker_path() {
   local cmd_stripped
   cmd_stripped="$(_strip_shell_quotes "$1")"
-  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done|\.post-checkpoint-done|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required|\.post-checkpoint-required|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
+  printf '%s' "$cmd_stripped" | grep -qE '(^|[^/])(\./)*\.(checkpoints|claude)/(\.pre-checkpoint-done(\.[A-Za-z0-9_-]{1,128})?|\.post-checkpoint-done(\.[A-Za-z0-9_-]{1,128})?|\.plan-approval-pending(\.[A-Za-z0-9_-]{1,128})?|\.checkpoint-required(\.[A-Za-z0-9_-]{1,128})?|\.post-checkpoint-required(\.[A-Za-z0-9_-]{1,128})?|\.preflight-done(\.[A-Za-z0-9_-]{1,128})?|\.last-user-prompt(\.[A-Za-z0-9_-]+)?\.json|\.so-runbook-shown\.[A-Za-z0-9_-]+)'
 }
 
 # Absolute-non-canonical detection: for Bash commands where the classifier

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -71,16 +71,19 @@ REPO_ROOT="$(resolve_repo_root "$CWD")"
 # Canonical WRITE paths (always primary). Used in block-message paths so the
 # agent knows where to write the checkpoint block.
 #
-# Rank-2: when MY_SID is valid, emit suffixed paths so the agent writes
-# `.X.<sid>` per per-session contract. When sid is invalid/empty, fall back
-# to legacy literal (graceful degrade — preserves pre-rank-2 behavior).
-if validate_session_id "$MY_SID"; then
-  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .pre-checkpoint-done "$MY_SID")")"
-  POST_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .post-checkpoint-done "$MY_SID")")"
-else
-  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
-  POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
-fi
+# Rank-2 — codex C4 R1 P1 ratification: PRE_DONE_W / POST_DONE_W stay as
+# legacy literal paths in C4. The suffixed emit (`.X.<sid>`) requires
+# classifier recognition for the `.pre-checkpoint-done.*` /
+# `.post-checkpoint-done.*` basenames; that lands in C6 alongside the
+# classifier case-arm extensions. Atomic-slice constraint: emit and
+# classifier-accept must ship together to avoid self-deadlock.
+#
+# Until then, agent-written checkpoint blocks land at the legacy literal
+# at primary root. checkpoint_marker_nonempty_for_session ALREADY reads
+# legacy literal (it's part of the own-session-or-legacy semantic), so
+# the gate sees the agent's write and unblocks correctly.
+PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
+POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
 PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
 
 PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -70,8 +70,17 @@ REPO_ROOT="$(resolve_repo_root "$CWD")"
 
 # Canonical WRITE paths (always primary). Used in block-message paths so the
 # agent knows where to write the checkpoint block.
-PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
-POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
+#
+# Rank-2: when MY_SID is valid, emit suffixed paths so the agent writes
+# `.X.<sid>` per per-session contract. When sid is invalid/empty, fall back
+# to legacy literal (graceful degrade — preserves pre-rank-2 behavior).
+if validate_session_id "$MY_SID"; then
+  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .pre-checkpoint-done "$MY_SID")")"
+  POST_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .post-checkpoint-done "$MY_SID")")"
+else
+  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
+  POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
+fi
 PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
 
 PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"
@@ -88,6 +97,45 @@ marker_exists() {
 # marker_nonempty <basename> — true if either root's copy is non-empty.
 marker_nonempty() {
   [ -s "$PRIMARY_DIR/$1" ] || [ -s "$LEGACY_DIR/$1" ]
+}
+
+# Rank-2 (PR for checkpoint-quartet) — session-aware sibling of marker_exists.
+# Returns 0 (true) if the marker exists at any of:
+#   <root>/.checkpoints/<legacy>.<sid>          (own session, primary)
+#   <root>/.claude/<legacy>.<sid>               (own session, legacy)
+#   <root>/.checkpoints/<legacy>                (legacy literal, primary)
+#   <root>/.claude/<legacy>                     (legacy literal, legacy root)
+# Cross-session suffixed markers (`<legacy>.<OTHER_SID>`) are IGNORED.
+# Invalid/empty sid → only legacy literal forms are checked.
+#
+# Pair with marker_nonempty_for_session() for `.X-done` size-based checks.
+checkpoint_marker_exists_for_session() {
+  local legacy="$1" sid="$2"
+  [ -e "$PRIMARY_DIR/$legacy" ] && return 0
+  [ -e "$LEGACY_DIR/$legacy" ] && return 0
+  if validate_session_id "$sid"; then
+    local basename
+    basename="$(namespaced_marker_basename_for_session "$legacy" "$sid")"
+    [ -e "$PRIMARY_DIR/$basename" ] && return 0
+    [ -e "$LEGACY_DIR/$basename" ] && return 0
+  fi
+  return 1
+}
+
+# Rank-2 — session-aware sibling of marker_nonempty. Tests own-session-or-
+# legacy-literal forms for non-empty size. Other sessions' suffixed
+# markers IGNORED.
+checkpoint_marker_nonempty_for_session() {
+  local legacy="$1" sid="$2"
+  [ -s "$PRIMARY_DIR/$legacy" ] && return 0
+  [ -s "$LEGACY_DIR/$legacy" ] && return 0
+  if validate_session_id "$sid"; then
+    local basename
+    basename="$(namespaced_marker_basename_for_session "$legacy" "$sid")"
+    [ -s "$PRIMARY_DIR/$basename" ] && return 0
+    [ -s "$LEGACY_DIR/$basename" ] && return 0
+  fi
+  return 1
 }
 # marker_basename_for_target <abs-path> — echoes the basename if the TARGET
 # matches an EXACT authoritative marker path at either root (primary or
@@ -113,6 +161,26 @@ marker_basename_for_target() {
   case "$target_basename" in
     .plan-approval-pending.*)
       if plan_marker_basename_matches "$target_basename"; then
+        if [ "$target_dir" = "$PRIMARY_DIR" ] || [ "$target_dir" = "$LEGACY_DIR" ]; then
+          printf '%s' "$target_basename"
+          return 0
+        fi
+      fi
+      ;;
+    # Rank-2: per-session checkpoint quartet basenames at either root.
+    # Strict-validate via namespaced_marker_basename_matches per quartet
+    # member (rejects path traversal / oversize / invalid chars). The
+    # narrower allow-target set here is intentionally limited to
+    # .pre/.post-checkpoint-done (the two CONTENT-bearing markers an
+    # agent writes); .checkpoint-required / .post-checkpoint-required are
+    # gate-armed only, not agent-written.
+    .pre-checkpoint-done.*|.post-checkpoint-done.*)
+      local legacy_basename
+      case "$target_basename" in
+        .pre-checkpoint-done.*)  legacy_basename=.pre-checkpoint-done ;;
+        .post-checkpoint-done.*) legacy_basename=.post-checkpoint-done ;;
+      esac
+      if namespaced_marker_basename_matches "$legacy_basename" "$target_basename"; then
         if [ "$target_dir" = "$PRIMARY_DIR" ] || [ "$target_dir" = "$LEGACY_DIR" ]; then
           printf '%s' "$target_basename"
           return 0
@@ -523,18 +591,30 @@ if [ "$TOOL_NAME" = "Bash" ]; then
       fi
       _block_plan_pending
     fi
+    # Rank-2: quartet pre-requisite checks are session-aware. Marker
+    # existence/non-empty for the 4 quartet members uses own-session-or-
+    # legacy reads — other sessions' suffixed markers don't satisfy this
+    # session's prerequisite. (Plan-marker case unchanged — uses its own
+    # session-aware predicate plan_pending_blocks_this_session above.)
+    #
+    # The strict-suffix recognition in marker_basename_for_target maps
+    # `.X.<sid>` to its legacy form for case routing here; the existence
+    # check then re-uses checkpoint_marker_exists_for_session which
+    # handles both own-suffixed AND legacy literal forms.
     case "$TARGET_BN" in
-      .pre-checkpoint-done)
-        if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
+      .pre-checkpoint-done|.pre-checkpoint-done.*)
+        if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+           && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
           exit 0
         fi
         ;;
-      .post-checkpoint-done)
-        if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
+      .post-checkpoint-done|.post-checkpoint-done.*)
+        if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
+           && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
           exit 0
         fi
         ;;
-      .plan-approval-pending)
+      .plan-approval-pending|.plan-approval-pending.*)
         exit 0
         ;;
     esac
@@ -584,18 +664,22 @@ case "$TOOL_NAME" in
            && [ "$TARGET_BN" != "$own_session_basename" ]; then
           _block_plan_pending
         fi
+        # Rank-2: session-aware quartet prerequisite check (Edit/Write
+        # branch — same logic as the Bash branch above).
         case "$TARGET_BN" in
-          .pre-checkpoint-done)
-            if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
+          .pre-checkpoint-done|.pre-checkpoint-done.*)
+            if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+               && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
               exit 0
             fi
             ;;
-          .post-checkpoint-done)
-            if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
+          .post-checkpoint-done|.post-checkpoint-done.*)
+            if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
+               && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
               exit 0
             fi
             ;;
-          .plan-approval-pending)
+          .plan-approval-pending|.plan-approval-pending.*)
             exit 0
             ;;
         esac
@@ -604,7 +688,10 @@ case "$TOOL_NAME" in
     ;;
 esac
 
-if marker_exists .checkpoint-required && ! marker_nonempty .pre-checkpoint-done; then
+# Rank-2: pre-gate read is session-aware. Own-session marker OR legacy
+# literal triggers the block; other sessions' suffixed markers do not.
+if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+   && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
   _block_pre
 fi
 
@@ -612,7 +699,9 @@ fi
 # Push-gate: only fires for Bash classified as push_or_pr_create.
 # ---------------------------------------------------------------------------
 if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
-  if marker_exists .post-checkpoint-required && ! marker_nonempty .post-checkpoint-done; then
+  # Rank-2: session-aware post-checkpoint check.
+  if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
+     && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
     _block_post
   fi
   # Audit P1: marker cleanup is gated on plan-gate not pending. PreToolUse
@@ -629,8 +718,18 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   # #268 fix E17: session-aware check — only cleanup if THIS session has
   # no plan-pending. Other sessions' suffixed markers do not block cleanup.
   if ! plan_pending_blocks_this_session "$MY_SID"; then
+    # Rank-2: sweep BOTH legacy literal AND ALL suffixed forms `<X>.<*>` at
+    # both roots. push is the convergence moment — all sessions' progress
+    # rolls up. Cross-session orphans from crashed sessions also get
+    # cleared here.
     for _m in "${CHECKPOINT_CLEANUP_MARKERS[@]}"; do
+      # Legacy literal at both roots.
       rm -f "$PRIMARY_DIR/$_m" "$LEGACY_DIR/$_m" 2>/dev/null || true
+      # Suffixed forms `<X>.<*>` at both roots.
+      # shellcheck disable=SC2086
+      rm -f "$PRIMARY_DIR"/$_m.* 2>/dev/null || true
+      # shellcheck disable=SC2086
+      rm -f "$LEGACY_DIR"/$_m.* 2>/dev/null || true
     done
     unset _m
   fi
@@ -644,9 +743,34 @@ fi
 # ---------------------------------------------------------------------------
 case "$TOOL_NAME" in
   Edit|Write|MultiEdit|Bash|NotebookEdit)
-    if marker_exists .checkpoint-required && marker_nonempty .pre-checkpoint-done; then
+    # Rank-2: session-aware existence/nonempty checks for the post-write
+    # arming. Per codex plan-tier R2 P2: helper invocation is best-effort
+    # (|| true), pre-validated sid; non-zero exit must NOT abort the hook
+    # under set -e. Falls back to legacy direct touch when sid is invalid
+    # (graceful degrade — preserves pre-rank-2 behavior for back-compat).
+    if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+       && checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
       ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
-      touch "$(write_marker_path "$REPO_ROOT" .post-checkpoint-required)" 2>/dev/null || true
+      if validate_session_id "$MY_SID"; then
+        # Prefer helper for unified marker_write classification + atomic write.
+        # CLAUDE_CODE_SESSION_ID is exported to the helper subprocess via the
+        # hook's inherited env (claude code sets it for all hooks).
+        HELPER_CKM="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+        if [ -f "$HELPER_CKM" ]; then
+          CLAUDE_CODE_SESSION_ID="$MY_SID" node "$HELPER_CKM" \
+            --target .post-checkpoint-required \
+            --action arm-if-missing \
+            --root "$REPO_ROOT" >/dev/null 2>&1 || true
+        else
+          # Fallback: direct write when helper not installed.
+          touch "$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .post-checkpoint-required "$MY_SID")")" 2>/dev/null || true
+        fi
+      else
+        # Invalid/empty sid: legacy direct touch (preserves pre-rank-2
+        # behavior; gate inactive for own-session checks but legacy literal
+        # still works for old hooks).
+        touch "$(write_marker_path "$REPO_ROOT" .post-checkpoint-required)" 2>/dev/null || true
+      fi
     fi
     ;;
 esac

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -68,22 +68,24 @@ source "$LIB_DIR/session-id.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
 
-# Canonical WRITE paths (always primary). Used in block-message paths so the
-# agent knows where to write the checkpoint block.
+# Canonical WRITE paths. Used in block-message paths so the agent knows
+# where to write the checkpoint block.
 #
-# Rank-2 — codex C4 R1 P1 ratification: PRE_DONE_W / POST_DONE_W stay as
-# legacy literal paths in C4. The suffixed emit (`.X.<sid>`) requires
-# classifier recognition for the `.pre-checkpoint-done.*` /
-# `.post-checkpoint-done.*` basenames; that lands in C6 alongside the
-# classifier case-arm extensions. Atomic-slice constraint: emit and
-# classifier-accept must ship together to avoid self-deadlock.
+# Rank-2 C6 (atomic with classifier extensions): when MY_SID is valid,
+# emit suffixed paths `.X.<sid>` so each session writes to its own marker.
+# The classifier now recognizes `.pre-checkpoint-done.*` and
+# `.post-checkpoint-done.*` as marker_write in redirect/rm/tee/touch/
+# classify_path case-arms — atomic-slice contract satisfied.
 #
-# Until then, agent-written checkpoint blocks land at the legacy literal
-# at primary root. checkpoint_marker_nonempty_for_session ALREADY reads
-# legacy literal (it's part of the own-session-or-legacy semantic), so
-# the gate sees the agent's write and unblocks correctly.
-PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
-POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
+# When sid is invalid/empty, fall back to legacy literal (graceful
+# degrade — preserves pre-rank-2 behavior for old hook installs).
+if validate_session_id "$MY_SID"; then
+  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .pre-checkpoint-done "$MY_SID")")"
+  POST_DONE_W="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .post-checkpoint-done "$MY_SID")")"
+else
+  PRE_DONE_W="$(write_marker_path "$REPO_ROOT" .pre-checkpoint-done)"
+  POST_DONE_W="$(write_marker_path "$REPO_ROOT" .post-checkpoint-done)"
+fi
 PLAN_PENDING_W="$(write_marker_path "$REPO_ROOT" .plan-approval-pending)"
 
 PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1075,6 +1075,26 @@ _classify_segment() {
         printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
         return 0
         ;;
+      # Rank-2: per-session checkpoint-done markers via redirect. Siblings
+      # of the .plan-approval-pending.* / .preflight-done.* arms above.
+      # Loose glob; strict validation via namespaced_marker_basename_matches
+      # at gate layer (checkpoint-gate.sh marker_basename_for_target).
+      .pre-checkpoint-done.*|.post-checkpoint-done.*)
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
+      # Rank-2: per-session checkpoint-required markers via redirect (hook
+      # arming surface; agents do not write these directly under normal
+      # flow, but classifying as marker_write lets the helper-invocation
+      # path go through the same gate validation).
+      .checkpoint-required.*|.post-checkpoint-required.*)
+        local abs_target
+        abs_target="$(_resolve_marker_path "$rtarget" "$target_root")"
+        printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "redirect_to_marker"
+        return 0
+        ;;
       .so-runbook-shown.*)
         # Runbook UX-marker (second-opinion-gate). Same-class with the
         # other marker write surfaces; classifies as marker_write so the
@@ -1297,6 +1317,14 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
           return 0
           ;;
+        # Rank-2: per-session checkpoint quartet markers via rm. SessionEnd
+        # cleanup + push-gate sweep use rm at canonical root for these.
+        .pre-checkpoint-done.*|.post-checkpoint-done.*|.checkpoint-required.*|.post-checkpoint-required.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "rm_marker"
+          return 0
+          ;;
         .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
@@ -1356,6 +1384,13 @@ _classify_segment() {
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
           return 0
           ;;
+        # Rank-2: per-session checkpoint quartet markers via tee.
+        .pre-checkpoint-done.*|.post-checkpoint-done.*|.checkpoint-required.*|.post-checkpoint-required.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "tee_marker"
+          return 0
+          ;;
         .last-user-prompt.*.json)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
@@ -1405,6 +1440,13 @@ _classify_segment() {
           ;;
         # #279 fix: per-session preflight-marker via touch.
         .preflight-done.*)
+          local abs_target
+          abs_target="$(_resolve_marker_path "$t" "$target_root")"
+          printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
+          return 0
+          ;;
+        # Rank-2: per-session checkpoint quartet markers via touch.
+        .pre-checkpoint-done.*|.post-checkpoint-done.*|.checkpoint-required.*|.post-checkpoint-required.*)
           local abs_target
           abs_target="$(_resolve_marker_path "$t" "$target_root")"
           printf '%s\t%s\t%s\n' "marker_write" "$abs_target" "touch_marker"
@@ -2197,6 +2239,17 @@ classify_path() {
       ;;
     # #268 fix E5: per-session plan-marker via classify_path (Write/Edit).
     .plan-approval-pending.*)
+      local abs
+      abs="$(_resolve_marker_path "$p" "$repo_root")"
+      printf '%s\t%s\t%s\n' "marker_write" "$abs" "path_marker"
+      return 0
+      ;;
+    # Rank-2: per-session checkpoint-done markers via classify_path. Narrow
+    # to .pre/.post-checkpoint-done (content-bearing agent-writable markers
+    # only — .checkpoint-required / .post-checkpoint-required are gate-armed
+    # via Bash touch, not Write/Edit, so they don't need classify_path
+    # recognition).
+    .pre-checkpoint-done.*|.post-checkpoint-done.*)
       local abs
       abs="$(_resolve_marker_path "$p" "$repo_root")"
       printf '%s\t%s\t%s\n' "marker_write" "$abs" "path_marker"

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -277,3 +277,90 @@ any_preflight_marker_exists() {
   done
   return 1
 }
+
+# ---------------------------------------------------------------------------
+# Rank-2 (PR for checkpoint-quartet) — generic per-session marker contract
+# (shell parity for scripts/lib/marker-paths.mjs namespaced* helpers).
+#
+# Generic shape: given a `legacyBasename` (e.g. .checkpoint-required), the
+# per-session form is `<legacyBasename>.<sid>` where sid matches the
+# shared SUFFIX_CHARCLASS + SUFFIX_MAXLEN.
+#
+# PLAN_MARKER_* and PREFLIGHT_MARKER_* shell constants retained verbatim.
+# ---------------------------------------------------------------------------
+
+readonly NAMESPACED_MARKER_SUFFIX_CHARCLASS='A-Za-z0-9_-'
+readonly NAMESPACED_MARKER_SUFFIX_MAXLEN=128
+
+# namespaced_marker_basename_matches <legacy-basename> <candidate-basename>
+# Strict match — accepts <legacy>, <legacy>.<sid> only. Same rules as
+# plan_marker_basename_matches / preflight_marker_basename_matches but
+# parameterized over the legacy basename.
+namespaced_marker_basename_matches() {
+  local legacy="$1" basename="$2"
+  [ "$basename" = "$legacy" ] && return 0
+  case "$basename" in
+    "$legacy".*)
+      local suffix="${basename#"$legacy".}"
+      [ -z "$suffix" ] && return 1
+      [ "${#suffix}" -gt "$NAMESPACED_MARKER_SUFFIX_MAXLEN" ] && return 1
+      case "$suffix" in
+        *[!A-Za-z0-9_-]*) return 1 ;;
+      esac
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# namespaced_marker_basename_for_session <legacy-basename> <sid>
+# Compose <legacy>.<sid>. Caller MUST validate_session_id before calling.
+namespaced_marker_basename_for_session() {
+  printf '%s.%s' "$1" "$2"
+}
+
+# any_namespaced_marker_exists <repo-root> <legacy-basename>
+# True if <legacy> OR any <legacy>.<sid> exists at either primary or
+# legacy root. Mirrors any_plan_marker_exists / any_preflight_marker_exists.
+any_namespaced_marker_exists() {
+  local root="$1" legacy="$2"
+  [ -e "$root/$PRIMARY_MARKER_DIR/$legacy" ] && return 0
+  [ -e "$root/$LEGACY_MARKER_DIR/$legacy" ] && return 0
+  local p
+  for p in "$root/$PRIMARY_MARKER_DIR"/"$legacy".*; do
+    [ -e "$p" ] || continue
+    local bn="${p##*/}"
+    namespaced_marker_basename_matches "$legacy" "$bn" && return 0
+  done
+  for p in "$root/$LEGACY_MARKER_DIR"/"$legacy".*; do
+    [ -e "$p" ] || continue
+    local bn="${p##*/}"
+    namespaced_marker_basename_matches "$legacy" "$bn" && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Rank-2 — checkpoint quartet constants (shell parity).
+#
+# The 4 markers whose cross-session bleed motivated this PR.
+# Diagnosis: 20260523-080453-diagnosis-multi-session-checkpoint-marke-08ec
+# ---------------------------------------------------------------------------
+
+CHECKPOINT_QUARTET=(
+  ".checkpoint-required"
+  ".post-checkpoint-required"
+  ".pre-checkpoint-done"
+  ".post-checkpoint-done"
+)
+
+# is_checkpoint_quartet_basename <basename>
+# True iff $basename is one of the 4 quartet markers in legacy or
+# per-session form. O(N) over the 4-member array (cheap).
+is_checkpoint_quartet_basename() {
+  local basename="$1" m
+  for m in "${CHECKPOINT_QUARTET[@]}"; do
+    namespaced_marker_basename_matches "$m" "$basename" && return 0
+  done
+  return 1
+}

--- a/hooks/stop-gate.sh
+++ b/hooks/stop-gate.sh
@@ -71,14 +71,31 @@ if ! cd "$CWD" 2>/dev/null; then
   exit 0
 fi
 
+# Rank-2: parse stdin .session_id and pass --session-id to em-recall so
+# the stop-gate carve-out can resolve own-session quartet markers. Without
+# this plumbing, the carve-out falls back to legacy-literal-only mode
+# (graceful degrade per em-recall codex R2 Q3 — pre-rank-2 behavior
+# preserved for old hook installs).
+#
+# Validation: em-recall.mjs does the format check + warn-on-invalid. We
+# do a basic empty/non-empty check here to avoid spamming with empty values.
+MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")"
+
 # Invoke core decision logic. Capture stdout; fail-loud envelope on error.
 # Repo-root resolution in em-recall.mjs (resolveRepoRoot module-load) now
 # resolves from the cwd we just cd'd to — i.e., the project the hook input
 # named, not the hook process's inherited cwd.
-DECISION="$(node "$EM_RECALL" --gate stop 2>/dev/null)" || {
-  echo '{"decision": "block", "reason": "stop-gate.sh: em-recall --gate stop exited non-zero. Re-run install.mjs --install-hooks."}'
-  exit 0
-}
+if [ -n "$MY_SID" ]; then
+  DECISION="$(node "$EM_RECALL" --gate stop --session-id "$MY_SID" 2>/dev/null)" || {
+    echo '{"decision": "block", "reason": "stop-gate.sh: em-recall --gate stop exited non-zero. Re-run install.mjs --install-hooks."}'
+    exit 0
+  }
+else
+  DECISION="$(node "$EM_RECALL" --gate stop 2>/dev/null)" || {
+    echo '{"decision": "block", "reason": "stop-gate.sh: em-recall --gate stop exited non-zero. Re-run install.mjs --install-hooks."}'
+    exit 0
+  }
+fi
 
 # Pass core's JSON through verbatim. Empty stdout = no decision = allow.
 if [ -n "$DECISION" ]; then

--- a/scripts/checkpoint-marker.mjs
+++ b/scripts/checkpoint-marker.mjs
@@ -64,7 +64,6 @@ import {
   primaryMarkerPath,
   legacyMarkerPath,
   namespacedMarkerBasenameForSession,
-  anyNamespacedMarkerExists,
   CHECKPOINT_QUARTET,
   PRIMARY_MARKER_DIR,
 } from './lib/marker-paths.mjs'
@@ -175,11 +174,31 @@ function atomicWriteEmpty(canonicalRoot, basename) {
   return finalPath
 }
 
+function ownSessionOrLegacyMarkerExists(canonicalRoot, target, sid) {
+  // Per-codex C2 R1 P1: arm-if-missing must NOT no-op when ANOTHER
+  // session's suffixed marker exists — that would recreate the
+  // cross-session bleed. Acceptable no-op states:
+  //   1. Bare legacy literal <target> at primary or legacy root.
+  //   2. Own-session <target>.<sid> at primary or legacy root.
+  // OTHER sessions' <target>.<other-sid> must NOT suppress this session's
+  // marker.
+  const ownBasename = namespacedMarkerBasenameForSession(target, sid)
+  for (const p of [
+    primaryMarkerPath(canonicalRoot, target),         // bare legacy at primary
+    legacyMarkerPath(canonicalRoot, target),          // bare legacy at legacy
+    primaryMarkerPath(canonicalRoot, ownBasename),    // own-session at primary
+    legacyMarkerPath(canonicalRoot, ownBasename),     // own-session at legacy
+  ]) {
+    if (fs.existsSync(p)) return true
+  }
+  return false
+}
+
 function actionArmIfMissing(canonicalRoot, target, sid) {
-  // No-op if any form of the target marker exists (own-session suffixed OR
-  // legacy literal, at either root). Mirrors em-recall.mjs armCheckpointMarker
-  // semantics — idempotent, best-effort, doesn't overwrite live state.
-  if (anyNamespacedMarkerExists(canonicalRoot, target)) {
+  // No-op if own-session marker OR bare legacy literal exists at either
+  // root. Other sessions' suffixed markers do NOT block this arming —
+  // each session arms its own per-session marker (codex C2 R1 P1).
+  if (ownSessionOrLegacyMarkerExists(canonicalRoot, target, sid)) {
     process.stdout.write(JSON.stringify({
       status: 'ok',
       action: 'arm-if-missing',

--- a/scripts/checkpoint-marker.mjs
+++ b/scripts/checkpoint-marker.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * checkpoint-marker.mjs — Per-session checkpoint quartet marker helper.
+ *
+ * Rank-2 (sibling of PR #271 / closed #268 plan-marker, and #279 sibling
+ * preflight-marker). Closes the cross-session bleed for the 4 checkpoint
+ * markers: `.checkpoint-required`, `.post-checkpoint-required`,
+ * `.pre-checkpoint-done`, `.post-checkpoint-done`.
+ *
+ * Diagnosis: 20260523-080453-diagnosis-multi-session-checkpoint-marke-08ec
+ * Plan v4 (codex plan-tier R4 ACCEPT): 20260524-033911-reply-codex-to-...
+ *
+ * Modeled on scripts/plan-marker.mjs (identical session-id sourcing,
+ * atomic temp+rename, exit-code semantics, root validation).
+ *
+ * Session-id source: process.env.CLAUDE_CODE_SESSION_ID (NOT a CLI flag).
+ * Mirrors PR #271's helper architecture exactly — the env var is the
+ * trusted source-of-truth for the current session; a `--session-id`
+ * flag would create a forgery surface the helper can't validate
+ * (codex R2 P1 / R3 P1 / R4 ACCEPT under option-2 trust model).
+ *
+ * Usage:
+ *   node ~/.episodic-memory/scripts/checkpoint-marker.mjs \
+ *     --target .checkpoint-required \
+ *     --action arm-if-missing \
+ *     --root <abs>
+ *
+ * --target <name>: one of CHECKPOINT_QUARTET (4 marker basenames).
+ * --action <act>:
+ *   arm-if-missing — no-op if <legacy>.<sid> OR legacy literal exists at
+ *                    either root; else atomic write empty file at
+ *                    <root>/.checkpoints/<legacy>.<sid>. Best-effort by
+ *                    design — callers (em-recall, checkpoint-gate) wrap
+ *                    `|| true` to preserve fail-soft semantics under set -e.
+ *   touch          — ensurePrimaryDir + atomic write empty file at
+ *                    <root>/.checkpoints/<legacy>.<sid>. Force-overwrite.
+ *                    Used by agent for content-bearing checkpoint blocks
+ *                    (the actual block content is appended by the caller
+ *                    after this returns — this helper only ensures the
+ *                    suffixed marker exists at the primary root).
+ *   rm             — Remove ONLY <legacy>.<sid> at primary AND legacy
+ *                    roots. NEVER touches bare suffix-less <legacy>
+ *                    (read-only-during-burn-in, mirrors PR #271 F3).
+ *                    Own-session only by construction — sid comes from
+ *                    env CLAUDE_CODE_SESSION_ID.
+ *
+ * Exit codes (matches plan-marker convention):
+ *   0 — success; stdout is JSON {status:"ok", action, target, path|removed, sid}
+ *   3 — fs write/rename/unlink failed
+ *   4 — --root missing
+ *   5 — --root invalid (non-abs / non-existent / non-dir / no repo signal)
+ *   6 — mutex violation (unknown arg, missing --target / --action, etc.)
+ *   7 — --target not in CHECKPOINT_QUARTET
+ *   8 — CLAUDE_CODE_SESSION_ID missing/empty/invalid
+ *   9 — --action not in {arm-if-missing | touch | rm}
+ */
+
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
+
+import {
+  ensurePrimaryDir,
+  primaryMarkerPath,
+  legacyMarkerPath,
+  namespacedMarkerBasenameForSession,
+  anyNamespacedMarkerExists,
+  CHECKPOINT_QUARTET,
+  PRIMARY_MARKER_DIR,
+} from './lib/marker-paths.mjs'
+import { SESSION_ID_RE, validateSessionId } from './lib/session-id.mjs'
+import { validateRoot, RootValidationError } from './lib/marker-root-validation.mjs'
+
+const VALID_ACTIONS = ['arm-if-missing', 'touch', 'rm']
+
+function fail(code, message) {
+  process.stderr.write(`checkpoint-marker: ${message}\n`)
+  process.exit(code)
+}
+
+function parseArgs(argv) {
+  const args = { root: null, target: null, action: null }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--root') {
+      args.root = argv[++i]
+    } else if (a === '--target') {
+      args.target = argv[++i]
+    } else if (a === '--action') {
+      args.action = argv[++i]
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write(
+        'Usage: checkpoint-marker.mjs --target <name> --action <act> --root <abs>\n' +
+        '  --target: one of ' + CHECKPOINT_QUARTET.join(' | ') + '\n' +
+        '  --action: arm-if-missing | touch | rm\n' +
+        '  Session-id read from CLAUDE_CODE_SESSION_ID env var.\n' +
+        '  Exit: 0 ok / 3 fs / 4 root-missing / 5 root-invalid /\n' +
+        '        6 arg-mutex / 7 bad-target / 8 sid-invalid / 9 bad-action\n'
+      )
+      process.exit(0)
+    } else {
+      fail(6, `unknown argument: ${a}`)
+    }
+  }
+  return args
+}
+
+function getSessionIdOrExit() {
+  const sid = process.env.CLAUDE_CODE_SESSION_ID
+  if (sid === undefined || sid === null || sid === '') {
+    fail(8, 'SESSION_ID_REQUIRED: CLAUDE_CODE_SESSION_ID env var missing or empty')
+  }
+  if (!validateSessionId(sid)) {
+    fail(8, `SESSION_ID_INVALID: must match ${SESSION_ID_RE.source}, got: ${JSON.stringify(sid)}`)
+  }
+  return sid
+}
+
+function validateRootOrExit(rootArg) {
+  try {
+    return validateRoot(rootArg)
+  } catch (e) {
+    if (e instanceof RootValidationError) fail(e.code, e.message)
+    throw e
+  }
+}
+
+function validateTargetOrExit(target) {
+  if (target === null || target === undefined) {
+    fail(6, 'MISSING_ARG: --target is required')
+  }
+  if (!CHECKPOINT_QUARTET.includes(target)) {
+    fail(7, `BAD_TARGET: --target must be one of [${CHECKPOINT_QUARTET.join(', ')}], got: ${JSON.stringify(target)}`)
+  }
+}
+
+function validateActionOrExit(action) {
+  if (action === null || action === undefined) {
+    fail(6, 'MISSING_ARG: --action is required')
+  }
+  if (!VALID_ACTIONS.includes(action)) {
+    fail(9, `BAD_ACTION: --action must be one of [${VALID_ACTIONS.join(', ')}], got: ${JSON.stringify(action)}`)
+  }
+}
+
+/**
+ * Atomic temp+rename write of an empty file at the given final path. Same
+ * pattern as plan-marker.mjs actionTouch — rename(2) is atomic on the same
+ * filesystem; SIGINT/SIGTERM cleanup prevents temp orphans.
+ */
+function atomicWriteEmpty(canonicalRoot, basename) {
+  const finalPath = primaryMarkerPath(canonicalRoot, basename)
+  const hr = process.hrtime.bigint().toString()
+  const tempName = `.${basename}.${process.pid}.${hr}.tmp`
+  const tempPath = path.join(canonicalRoot, PRIMARY_MARKER_DIR, tempName)
+
+  let cleanupTemp = true
+  const onSig = (signal) => {
+    if (cleanupTemp) {
+      try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
+    }
+    process.exit(signal === 'SIGINT' ? 130 : 143)
+  }
+  process.on('SIGINT', () => onSig('SIGINT'))
+  process.on('SIGTERM', () => onSig('SIGTERM'))
+
+  try {
+    fs.writeFileSync(tempPath, '')
+    fs.renameSync(tempPath, finalPath)
+    cleanupTemp = false
+  } catch (e) {
+    try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
+    fail(3, `WRITE_FAILED: ${e.message}`)
+  }
+  return finalPath
+}
+
+function actionArmIfMissing(canonicalRoot, target, sid) {
+  // No-op if any form of the target marker exists (own-session suffixed OR
+  // legacy literal, at either root). Mirrors em-recall.mjs armCheckpointMarker
+  // semantics — idempotent, best-effort, doesn't overwrite live state.
+  if (anyNamespacedMarkerExists(canonicalRoot, target)) {
+    process.stdout.write(JSON.stringify({
+      status: 'ok',
+      action: 'arm-if-missing',
+      target,
+      sid,
+      noop: true,
+    }) + '\n')
+    process.exit(0)
+  }
+  ensurePrimaryDir(canonicalRoot)
+  const basename = namespacedMarkerBasenameForSession(target, sid)
+  const finalPath = atomicWriteEmpty(canonicalRoot, basename)
+  process.stdout.write(JSON.stringify({
+    status: 'ok',
+    action: 'arm-if-missing',
+    target,
+    sid,
+    path: finalPath,
+    noop: false,
+  }) + '\n')
+  process.exit(0)
+}
+
+function actionTouch(canonicalRoot, target, sid) {
+  // Force-overwrite. Used for content-bearing markers (.pre/.post-checkpoint-done)
+  // where the caller will append the block content after this returns. This
+  // helper only ensures the suffixed marker file exists at primary root.
+  ensurePrimaryDir(canonicalRoot)
+  const basename = namespacedMarkerBasenameForSession(target, sid)
+  const finalPath = atomicWriteEmpty(canonicalRoot, basename)
+  process.stdout.write(JSON.stringify({
+    status: 'ok',
+    action: 'touch',
+    target,
+    sid,
+    path: finalPath,
+  }) + '\n')
+  process.exit(0)
+}
+
+function actionRm(canonicalRoot, target, sid) {
+  // Own-session only by construction: sid comes from env. Removes ONLY the
+  // suffixed form at primary + legacy roots. NEVER touches bare legacy
+  // literal — read-only-during-burn-in invariant (PR #271 F3).
+  const basename = namespacedMarkerBasenameForSession(target, sid)
+  const primary = primaryMarkerPath(canonicalRoot, basename)
+  const legacy = legacyMarkerPath(canonicalRoot, basename)
+  const removed = []
+
+  for (const p of [primary, legacy]) {
+    try {
+      fs.unlinkSync(p)
+      removed.push(p)
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        fail(3, `RM_FAILED: ${e.message} (${p})`)
+      }
+      // ENOENT is fine — idempotent rm.
+    }
+  }
+
+  process.stdout.write(JSON.stringify({
+    status: 'ok',
+    action: 'rm',
+    target,
+    sid,
+    removed,
+  }) + '\n')
+  process.exit(0)
+}
+
+function main() {
+  const { root, target, action } = parseArgs(process.argv)
+
+  validateTargetOrExit(target)
+  validateActionOrExit(action)
+
+  const sid = getSessionIdOrExit()
+  const canonicalRoot = validateRootOrExit(root)
+
+  switch (action) {
+    case 'arm-if-missing': actionArmIfMissing(canonicalRoot, target, sid); break
+    case 'touch':          actionTouch(canonicalRoot, target, sid); break
+    case 'rm':             actionRm(canonicalRoot, target, sid); break
+    /* istanbul ignore next */ default:
+      fail(9, `BAD_ACTION (unreachable): ${action}`)
+  }
+}
+
+main()

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -31,11 +31,14 @@ import {
   resolveMarkerRead,
   writeMarkerPath,
   ensurePrimaryDir,
-  bothMarkerPaths
+  bothMarkerPaths,
+  namespacedMarkerBasenameForSession,
+  CHECKPOINT_QUARTET,
 } from './lib/marker-paths.mjs'
 import {
   _maxMtimeAcrossRootsStrict,
   _maxMtimeAcrossRootsForPlanMarkerStrict,
+  _maxMtimeAcrossRootsForCheckpointMarkerOwnSessionStrict,
 } from './lib/stop-gate-helpers.mjs'
 import { validateSessionId } from './lib/session-id.mjs'
 
@@ -66,18 +69,18 @@ const gateFlag = flag('--gate')
 const sessionStartFlag = argv.includes('--session-start')
 
 // --session-id <sid> — bound from SessionStart stdin `.session_id` via the
-// hook wrapper (em-recall-sessionstart.sh). Logging-only in v6 sweep: NOT
-// used to gate any sweep decision. Reserved for forward-compat with future
-// operator-cleanup tooling. Validation: per codex R2 Q3, missing/invalid
-// emits stderr warning, does NOT exit non-zero (hook reliability outweighs
-// strict contract).
+// hook wrapper (em-recall-sessionstart.sh) AND from stop-gate.sh wrapper
+// (rank-2 C5). Used to scope stop-gate carve-out and the per-session
+// quartet arming. Validation: missing/invalid emits stderr warning and
+// falls back to legacy-literal-only mode (hook reliability outweighs
+// strict contract per codex R2 Q3).
 const sessionIdFlag = flag('--session-id')
 let mySid = null
 if (sessionIdFlag !== undefined) {
   if (sessionIdFlag !== '' && validateSessionId(sessionIdFlag)) {
     mySid = sessionIdFlag
   } else if (sessionIdFlag !== '') {
-    process.stderr.write(`em-recall: warn — --session-id "${sessionIdFlag}" failed validateSessionId; treating as missing (no functional impact in v6 sweep)\n`)
+    process.stderr.write(`em-recall: warn — --session-id "${sessionIdFlag}" failed validateSessionId; legacy-literal-only mode\n`)
   }
 }
 
@@ -225,17 +228,60 @@ function _maxMtimeAcrossRootsForPlanMarker(repoRoot) {
   return { mtime, hadSymlink, anyExisted }
 }
 
-function stopGateCarveOutApplies(repoRoot) {
+// Rank-2: resolve a session-aware marker read. Resolution order:
+//   1. <root>/.checkpoints/<legacy>.<sid>     (own-session, primary)
+//   2. <root>/.claude/<legacy>.<sid>          (own-session, legacy root)
+//   3. <root>/.checkpoints/<legacy>           (legacy literal, primary)
+//   4. <root>/.claude/<legacy>                (legacy literal, legacy root)
+//
+// Returns the first existing path or null. Other sessions' suffixed
+// markers are intentionally NOT probed — own-session semantic per
+// rank-2 plan §3 trust model.
+//
+// When sid is null/empty, only steps 3-4 are tried (legacy-literal-only
+// fallback for invalid/missing sid). Symlink-aware via fs.existsSync
+// (which follows links); callers needing symlink-fail-closed must
+// re-check with lstatSync.
+function resolveOwnSessionMarkerRead(repoRoot, legacyBasename, sid) {
+  if (sid) {
+    const ownBasename = namespacedMarkerBasenameForSession(legacyBasename, sid)
+    const ownPrimary = primaryMarkerPath(repoRoot, ownBasename)
+    if (fs.existsSync(ownPrimary)) return ownPrimary
+    const ownLegacy = legacyMarkerPath(repoRoot, ownBasename)
+    if (fs.existsSync(ownLegacy)) return ownLegacy
+  }
+  const litPrimary = primaryMarkerPath(repoRoot, legacyBasename)
+  if (fs.existsSync(litPrimary)) return litPrimary
+  const litLegacy = legacyMarkerPath(repoRoot, legacyBasename)
+  if (fs.existsSync(litLegacy)) return litLegacy
+  return null
+}
+
+function stopGateCarveOutApplies(repoRoot, sid) {
   const base = _maxMtimeAcrossRoots(repoRoot, BASELINE_NAME)
   if (base.hadSymlink) return false
   if (!base.anyExisted) return false
   const baselineMtime = base.mtime
 
   for (const name of TASK_SIGNAL_MARKERS) {
-    // #268 fix E19: plan-marker member glob-expands suffixed forms.
-    const m = (name === PLAN_MARKER_LEGACY_BASENAME)
-      ? _maxMtimeAcrossRootsForPlanMarker(repoRoot)
-      : _maxMtimeAcrossRoots(repoRoot, name)
+    let m
+    if (name === PLAN_MARKER_LEGACY_BASENAME) {
+      // #268 fix E19: plan-marker member glob-expands suffixed forms
+      // (cross-session — plan-pending deferral is global-by-design).
+      m = _maxMtimeAcrossRootsForPlanMarker(repoRoot)
+    } else if (CHECKPOINT_QUARTET.includes(name)) {
+      // Rank-2 (codex R2 P1-B + R4 ACCEPT): quartet carve-out is
+      // OWN-SESSION-ONLY — read own `<name>.<sid>` + legacy literal,
+      // NEVER other sessions' suffixed forms. Cross-session safety is
+      // delegated to SessionStart's force-monotonic baseline probe.
+      // Strict catch (R2 P2): non-ENOENT errors fail closed.
+      const strict = _maxMtimeAcrossRootsForCheckpointMarkerOwnSessionStrict(
+        repoRoot, name, sid)
+      if (strict.hadOtherError) return false
+      m = strict
+    } else {
+      m = _maxMtimeAcrossRoots(repoRoot, name)
+    }
     // Symlink at either root → fail closed.
     if (m.hadSymlink) return false
     // Marker absent at both roots → no signal; skip.
@@ -290,19 +336,31 @@ if (gateFlag === 'stop') {
     process.exit(0)
   }
 
-  // Dual-root .checkpoints/ migration: PRE_REQ existence is checked at
-  // EITHER root (resolveMarkerRead returns the path of whichever exists,
-  // primary preferred). POST_DONE non-empty check uses the resolved path.
-  // The carve-out helper handles both roots internally.
-  const preReqPath = resolveMarkerRead(REPO_ROOT, '.checkpoint-required')
-  const postDonePath = resolveMarkerRead(REPO_ROOT, '.post-checkpoint-done')
+  // Rank-2: session-aware reads. Resolution order for each quartet member:
+  //   1. <root>/.checkpoints/<name>.<mySid>
+  //   2. <root>/.claude/<name>.<mySid>
+  //   3. <root>/.checkpoints/<name>      (legacy literal, burn-in)
+  //   4. <root>/.claude/<name>           (legacy literal, burn-in)
+  //
+  // When mySid is null (invalid/missing sid), only steps 3-4 are checked
+  // (graceful degrade per codex R2 Q3: hook reliability outweighs strict
+  // contract). Other sessions' suffixed markers are intentionally NOT
+  // probed — own-session carve-out semantic.
+  const preReqPath = resolveOwnSessionMarkerRead(REPO_ROOT, '.checkpoint-required', mySid)
+  const postDonePath = resolveOwnSessionMarkerRead(REPO_ROOT, '.post-checkpoint-done', mySid)
   let postDoneSize = 0
   if (postDonePath) {
     try { postDoneSize = fs.statSync(postDonePath).size } catch {}
   }
   if (preReqPath && postDoneSize === 0) {
-    if (!stopGateCarveOutApplies(REPO_ROOT)) {
-      const writePath = writeMarkerPath(REPO_ROOT, '.post-checkpoint-done')
+    if (!stopGateCarveOutApplies(REPO_ROOT, mySid)) {
+      // Block-message path: emit suffixed write path when sid is valid;
+      // legacy literal otherwise. Agent's block-write goes to the suffixed
+      // path via checkpoint-marker.mjs helper or direct Write.
+      const writeBasename = mySid
+        ? namespacedMarkerBasenameForSession('.post-checkpoint-done', mySid)
+        : '.post-checkpoint-done'
+      const writePath = writeMarkerPath(REPO_ROOT, writeBasename)
       const reason = `Post-implementation checkpoint required. Write the Rule 18 post-implementation checkpoint block to ${writePath} (must be non-empty), then end your turn again. Hook: stop-gate.sh.`
       console.log(JSON.stringify({ decision: 'block', reason }))
     }
@@ -565,12 +623,31 @@ function resolveProjectName(projectRoot, { ignoreOverride = false, fast = false 
 // at .claude/, it's still honored by readers via resolveMarkerRead during
 // burn-in. So "armed" here is satisfied if EITHER root has the marker.
 // ---------------------------------------------------------------------------
-function armCheckpointMarker(repoRoot) {
+// Rank-2: per-session arming. Writes `.checkpoint-required.<sid>` if
+// neither own-session nor legacy literal exists at either root. Sid is
+// REQUIRED — when missing/invalid, this falls back to legacy-literal-
+// only write at the primary root (preserves pre-rank-2 behavior for
+// graceful degrade per codex R2 Q3).
+//
+// Mirrors checkpoint-marker.mjs actionArmIfMissing semantics: no-op when
+// own-session OR legacy exists; never suppresses on OTHER sessions'
+// suffixed markers (codex C2 R1 P1 fix).
+function armCheckpointMarkerForSession(repoRoot, sid) {
   try {
-    // Already armed at either root → no-op.
-    if (resolveMarkerRead(repoRoot, '.checkpoint-required')) return
+    // Build the no-op-acceptable set: own-session (if sid) + legacy literal.
+    if (sid) {
+      const ownBasename = namespacedMarkerBasenameForSession('.checkpoint-required', sid)
+      if (fs.existsSync(primaryMarkerPath(repoRoot, ownBasename))) return
+      if (fs.existsSync(legacyMarkerPath(repoRoot, ownBasename))) return
+    }
+    if (fs.existsSync(primaryMarkerPath(repoRoot, '.checkpoint-required'))) return
+    if (fs.existsSync(legacyMarkerPath(repoRoot, '.checkpoint-required'))) return
+
     ensurePrimaryDir(repoRoot)
-    fs.writeFileSync(writeMarkerPath(repoRoot, '.checkpoint-required'), '')
+    const writeBasename = sid
+      ? namespacedMarkerBasenameForSession('.checkpoint-required', sid)
+      : '.checkpoint-required'
+    fs.writeFileSync(writeMarkerPath(repoRoot, writeBasename), '')
   } catch {
     // Best-effort: marker creation failure leaves Phase 3b gate inactive
     // for this session.
@@ -717,13 +794,13 @@ if (sessionStartFlag) {
 // blocks write tools, so the false-positive surface is bounded.
 // ---------------------------------------------------------------------------
 // Bind arming-time project name to REPO_ROOT (NOT process.cwd() and NOT the
-// --project override). This pairs with armCheckpointMarker(REPO_ROOT) below
-// so the project identity used to scope violations matches the marker write
+// --project override). This pairs with armCheckpointMarkerForSession(REPO_ROOT, mySid)
+// below so the project identity used to scope violations matches the marker write
 // authority root. Closes the cross-project bleed where violations in one
 // project armed checkpoint gates in every other project at SessionStart.
 const armingProject = resolveProjectName(REPO_ROOT, { ignoreOverride: true, fast: true })
 if (shouldArmBp001Checkpoint(activeEntries, new Date(), armingProject)) {
-  armCheckpointMarker(REPO_ROOT)
+  armCheckpointMarkerForSession(REPO_ROOT, mySid)
 }
 
 // ---------------------------------------------------------------------------
@@ -761,10 +838,19 @@ if (sessionStartFlag) {
   try {
     ensurePrimaryDir(REPO_ROOT)
 
-    // Probe checkpoint marker mtimes across BOTH roots (dual-root burn-in).
-    // Plan-marker excluded — PR #314 contract handles plan-approval lifecycle.
+    // Probe checkpoint task-signal marker mtimes across BOTH roots
+    // (dual-root burn-in). Plan-marker excluded — PR #314 contract handles
+    // plan-approval lifecycle.
+    //
+    // Rank-2: glob-expand suffixed forms `.X.<*>` CROSS-SESSION. The
+    // baseline must dominate all sessions' suffixed markers so any
+    // session's stop-gate carve-out + push-gate cleanup remains valid.
+    // This is the cross-session safety mechanism for the quartet
+    // (own-session reads handle the rest at stop-gate time).
     let maxCheckpointMarkerMs = 0
-    for (const name of ['.checkpoint-required', '.post-checkpoint-required']) {
+    const taskSignalQuartet = ['.checkpoint-required', '.post-checkpoint-required']
+    for (const name of taskSignalQuartet) {
+      // Legacy literal at both roots.
       for (const p of bothMarkerPaths(REPO_ROOT, name)) {
         try {
           const st = fs.lstatSync(p)
@@ -775,6 +861,32 @@ if (sessionStartFlag) {
         } catch (e) {
           if (e.code !== 'ENOENT') {
             process.stderr.write(`em-recall: baseline-monotonic-probe skipped ${p}: ${e.code || e.message}\n`)
+          }
+        }
+      }
+      // Cross-session glob-expand `<name>.<*>` at both roots.
+      const prefix = `${name}.`
+      for (const dir of [path.join(REPO_ROOT, PRIMARY_MARKER_DIR), path.join(REPO_ROOT, LEGACY_MARKER_DIR)]) {
+        let entries
+        try { entries = fs.readdirSync(dir) } catch (e) {
+          if (e.code !== 'ENOENT') {
+            process.stderr.write(`em-recall: baseline-monotonic-probe readdir skipped ${dir}: ${e.code || e.message}\n`)
+          }
+          continue
+        }
+        for (const ent of entries) {
+          if (!ent.startsWith(prefix)) continue
+          const p = path.join(dir, ent)
+          try {
+            const st = fs.lstatSync(p)
+            if (st.isSymbolicLink()) continue
+            if (st.mtimeMs > maxCheckpointMarkerMs) {
+              maxCheckpointMarkerMs = st.mtimeMs
+            }
+          } catch (e) {
+            if (e.code !== 'ENOENT') {
+              process.stderr.write(`em-recall: baseline-monotonic-probe skipped ${p}: ${e.code || e.message}\n`)
+            }
           }
         }
       }

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -23,6 +23,8 @@ import {
   planMarkerBasenameForSession,
   primaryMarkerPath,
   legacyMarkerPath,
+  namespacedMarkerBasenameForSession,
+  CHECKPOINT_QUARTET,
 } from './lib/marker-paths.mjs'
 import { validateSessionId } from './lib/session-id.mjs'
 
@@ -137,8 +139,22 @@ for (const marker of ALL_MIGRATED_MARKERS) {
     // sid invalid → skip plan-marker cleanup entirely; orphan-sweep handles it.
     continue
   }
+  // Rank-2 C7: for quartet members, delete legacy literal (orphan cleanup
+  // for pre-rank-2 sessions that wrote bare names) AND own-session suffixed
+  // form. NEVER delete other sessions' suffixed forms (cross-session
+  // safety — concurrent session A's quartet markers preserved at B's
+  // SessionEnd, mirrors plan-marker F12 cross-session contract).
   for (const p of bothMarkerPaths(repoRoot, marker)) {
     try { fs.unlinkSync(p) } catch {}
+  }
+  if (CHECKPOINT_QUARTET.includes(marker) && validateSessionId(sessionEndSid)) {
+    const ownBasename = namespacedMarkerBasenameForSession(marker, sessionEndSid)
+    for (const p of [
+      primaryMarkerPath(repoRoot, ownBasename),
+      legacyMarkerPath(repoRoot, ownBasename),
+    ]) {
+      try { fs.unlinkSync(p) } catch {}
+    }
   }
 }
 

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -237,6 +237,129 @@ export function preflightMarkerBasenameForSession(sid) {
 }
 
 // ---------------------------------------------------------------------------
+// Rank-2 (PR for checkpoint-quartet) — generic per-session marker contract.
+//
+// Third sibling of PLAN_MARKER_* (#268 / PR #271) and PREFLIGHT_MARKER_*
+// (#279 / sibling PR). Codex DP-1 (plan v4): factor the namespaced-marker
+// helpers instead of a fourth copy-paste of the per-marker block.
+//
+// Generic contract — given a `legacyBasename` (e.g. `.checkpoint-required`),
+// the per-session form is `<legacyBasename>.<sid>` where sid matches the
+// shared SUFFIX_CHARCLASS + SUFFIX_MAXLEN.
+//
+// PLAN_MARKER_* and PREFLIGHT_MARKER_* retained verbatim for back-compat
+// with their existing callers and validator registry; new markers should
+// use these generic helpers.
+// ---------------------------------------------------------------------------
+
+export const NAMESPACED_MARKER_SUFFIX_CHARCLASS = 'A-Za-z0-9_-'
+export const NAMESPACED_MARKER_SUFFIX_MAXLEN = 128
+
+/**
+ * Strict match for namespaced marker basenames. Accepts ONLY:
+ *   <legacyBasename>                                (legacy suffix-less)
+ *   <legacyBasename>.<sid>                          (sid matches char-class + length)
+ * Rejects:
+ *   <legacyBasename>-extra                          (suffix without dot separator)
+ *   <legacyBasename>.                               (empty suffix)
+ *   <legacyBasename>./traversal                     (slash in suffix)
+ *   <legacyBasename>..                              (dot in suffix)
+ *   <legacyBasename>.<129-char>                     (oversize suffix)
+ *
+ * Mirrors the strict-match shape of planMarkerBasenameMatches() and
+ * preflightMarkerBasenameMatches(); generalizes by accepting the legacy
+ * basename as a parameter.
+ *
+ * @param {string} legacyBasename — the unsuffixed marker name (e.g. '.checkpoint-required')
+ * @param {string} candidate — the basename to test
+ * @returns {boolean}
+ */
+export function namespacedMarkerBasenameMatches(legacyBasename, candidate) {
+  if (typeof candidate !== 'string' || typeof legacyBasename !== 'string') return false
+  if (candidate === legacyBasename) return true
+  const prefix = `${legacyBasename}.`
+  if (!candidate.startsWith(prefix)) return false
+  const suffix = candidate.slice(prefix.length)
+  if (suffix.length === 0) return false
+  if (suffix.length > NAMESPACED_MARKER_SUFFIX_MAXLEN) return false
+  const re = new RegExp(`^[${NAMESPACED_MARKER_SUFFIX_CHARCLASS}]+$`)
+  return re.test(suffix)
+}
+
+/**
+ * Compose the per-session marker basename for a given legacy basename + sid.
+ * Caller MUST validateSessionId(sid) first; this helper does not re-validate.
+ *
+ * @param {string} legacyBasename — the unsuffixed marker name
+ * @param {string} sid — valid session-id
+ * @returns {string} `<legacyBasename>.<sid>`
+ */
+export function namespacedMarkerBasenameForSession(legacyBasename, sid) {
+  return `${legacyBasename}.${sid}`
+}
+
+/**
+ * True if ANY namespaced marker for the given legacy basename exists at
+ * either primary or legacy marker dir under <repoRoot>. Accepts both:
+ *   <root>/<.checkpoints|.claude>/<legacyBasename>            (legacy literal)
+ *   <root>/<.checkpoints|.claude>/<legacyBasename>.<sid>      (any sid)
+ *
+ * Mirrors anyPlanMarkerExists / any_preflight_marker_exists semantics for
+ * an arbitrary legacy basename.
+ *
+ * @param {string} repoRoot
+ * @param {string} legacyBasename
+ * @returns {boolean}
+ */
+export function anyNamespacedMarkerExists(repoRoot, legacyBasename) {
+  if (fs.existsSync(path.join(repoRoot, PRIMARY_MARKER_DIR, legacyBasename))) return true
+  if (fs.existsSync(path.join(repoRoot, LEGACY_MARKER_DIR, legacyBasename))) return true
+  const prefix = `${legacyBasename}.`
+  for (const dir of [path.join(repoRoot, PRIMARY_MARKER_DIR), path.join(repoRoot, LEGACY_MARKER_DIR)]) {
+    let entries
+    try { entries = fs.readdirSync(dir) } catch { continue }
+    for (const name of entries) {
+      if (!name.startsWith(prefix)) continue
+      if (namespacedMarkerBasenameMatches(legacyBasename, name)) return true
+    }
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Rank-2 — checkpoint quartet constants.
+//
+// The 4 markers whose cross-session bleed motivated this PR. Per-session
+// namespaced via the generic helpers above.
+//
+// Diagnosis episode: 20260523-080453-diagnosis-multi-session-checkpoint-marke-08ec
+// Plan: scratch/rank2-checkpoint-quartet-plan-v4.md (codex R4 ACCEPT).
+// ---------------------------------------------------------------------------
+
+export const CHECKPOINT_QUARTET = Object.freeze([
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.pre-checkpoint-done',
+  '.post-checkpoint-done',
+])
+
+// Strict regex spanning all 4 quartet members with optional .<sid> suffix.
+// Used by the classifier + validator to match any quartet marker basename
+// in a single test. Anchored; no traversal characters in the sid class.
+export const CHECKPOINT_QUARTET_RE = /^\.(checkpoint-required|post-checkpoint-required|pre-checkpoint-done|post-checkpoint-done)(\.[A-Za-z0-9_-]{1,128})?$/
+
+/**
+ * True iff `basename` is one of the 4 quartet marker basenames in legacy
+ * or per-session form.
+ *
+ * @param {string} basename
+ * @returns {boolean}
+ */
+export function isCheckpointQuartetBasename(basename) {
+  return typeof basename === 'string' && CHECKPOINT_QUARTET_RE.test(basename)
+}
+
+// ---------------------------------------------------------------------------
 // Enforcement-site registry — single source of truth for the validator.
 //
 // Every place in the codebase that recognizes, gates, iterates, or otherwise

--- a/scripts/lib/stop-gate-helpers.mjs
+++ b/scripts/lib/stop-gate-helpers.mjs
@@ -103,3 +103,53 @@ export function _maxMtimeAcrossRootsForPlanMarkerStrict(repoRoot) {
 
   return { mtime, hadSymlink, anyExisted, hadOtherError }
 }
+
+// Rank-2 (PR for checkpoint-quartet) — own-session strict helper for the
+// 4 checkpoint quartet markers. Per codex plan-tier R2 P1-B + R4 ACCEPT:
+// the quartet carve-out is OWN-SESSION-ONLY, NOT cross-session glob like
+// the plan-marker. Cross-session safety for the quartet is delegated to
+// SessionStart's force-monotonic baseline probe (em-recall.mjs); the
+// stop-gate carve-out at turn-end reads only this session's own marker
+// (plus legacy literal during burn-in).
+//
+// Strict catch (R2 P2): non-ENOENT lstat errors → hadOtherError → caller
+// fails closed. Sibling of _maxMtimeAcrossRootsStrict.
+//
+// @param {string} repoRoot
+// @param {string} legacyBasename — one of CHECKPOINT_QUARTET members
+// @param {string|null} sid — own session id, or null/empty → legacy-only mode
+// @returns {{mtime, hadSymlink, anyExisted, hadOtherError}}
+export function _maxMtimeAcrossRootsForCheckpointMarkerOwnSessionStrict(
+  repoRoot, legacyBasename, sid
+) {
+  let mtime = -Infinity
+  let hadSymlink = false
+  let anyExisted = false
+  let hadOtherError = false
+
+  // Build paths to probe — own-session suffixed AND legacy literal, each
+  // at both roots. Other sessions' suffixed markers NOT included —
+  // that's the point of the rank-2 fix.
+  const paths = [
+    primaryMarkerPath(repoRoot, legacyBasename),
+    legacyMarkerPath(repoRoot, legacyBasename),
+  ]
+  if (sid) {
+    const ownBasename = `${legacyBasename}.${sid}`
+    paths.push(primaryMarkerPath(repoRoot, ownBasename))
+    paths.push(legacyMarkerPath(repoRoot, ownBasename))
+  }
+
+  for (const p of paths) {
+    try {
+      const st = fs.lstatSync(p)
+      if (st.isSymbolicLink()) { hadSymlink = true; continue }
+      anyExisted = true
+      if (st.mtimeMs > mtime) mtime = st.mtimeMs
+    } catch (e) {
+      if (e && e.code !== 'ENOENT') hadOtherError = true
+    }
+  }
+
+  return { mtime, hadSymlink, anyExisted, hadOtherError }
+}

--- a/tests/test-checkpoint-marker.mjs
+++ b/tests/test-checkpoint-marker.mjs
@@ -265,6 +265,52 @@ for (const target of QUARTET) {
 }
 
 // ---------------------------------------------------------------------------
+// XS1-XS4 — cross-session non-interference (codex C2 R1 P1 regression)
+//
+// Required invariant per codex 20260524-055434-...-a24a:
+//   arm-if-missing must NOT no-op when another session's suffixed marker
+//   exists. Each session arms its own per-session marker. Other sessions'
+//   markers must not suppress this session's arming.
+// ---------------------------------------------------------------------------
+for (const target of QUARTET.slice(0, 1)) {
+  const root = makeFixtureRoot()
+  const sidA = 'sid-a'
+  const sidB = 'sid-b'
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+
+  // Setup: session A has its own marker; session B has none.
+  const markerA = path.join(root, '.checkpoints', `${target}.${sidA}`)
+  const markerB = path.join(root, '.checkpoints', `${target}.${sidB}`)
+  fs.writeFileSync(markerA, '')
+
+  // Session B arm-if-missing: must NOT no-op; must create markerB.
+  const callerCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-caller-cwd-'))
+  const r = spawnSync('node', [HELPER,
+    '--target', target,
+    '--action', 'arm-if-missing',
+    '--root', root,
+  ], {
+    env: { ...process.env, CLAUDE_CODE_SESSION_ID: sidB },
+    cwd: callerCwd,
+    encoding: 'utf8',
+  })
+  const json = parseJson(r.stdout)
+  assert('XS1 B exit 0', r.status === 0)
+  assert('XS2 B noop=false (other-session marker does NOT suppress)',
+    json && json.noop === false)
+  assert('XS3 B markerB created at target root', fs.existsSync(markerB))
+  assert('XS4 caller cwd has no marker artifacts',
+    !fs.existsSync(path.join(callerCwd, '.checkpoints')))
+
+  // Verify A's marker still untouched.
+  assert("XS5 A's marker preserved", fs.existsSync(markerA))
+
+  fs.rmSync(callerCwd, { recursive: true, force: true })
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
 // F1-F3 — F3 legacy-literal-read-only invariant
 // ---------------------------------------------------------------------------
 for (const target of QUARTET.slice(0, 1)) {

--- a/tests/test-checkpoint-marker.mjs
+++ b/tests/test-checkpoint-marker.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for scripts/checkpoint-marker.mjs (rank-2 C2).
+ *
+ * Sibling of tests/test-plan-marker.mjs. Verifies:
+ *   - Action vocabulary (arm-if-missing | touch | rm)
+ *   - Argument validation (--target, --action, --root)
+ *   - Session-id sourcing from env
+ *   - Atomic temp+rename write semantics
+ *   - Read-only-during-burn-in invariant (NEVER touches legacy literal)
+ *   - JSON output shape + exit codes
+ *
+ * Per codex plan-tier R4 trust model (option 2): helper has NO trusted
+ * current-session beyond env CLAUDE_CODE_SESSION_ID. Cross-session
+ * scenarios (B passing A's sid) are out-of-scope — honest-agent.
+ *
+ * Coverage layout:
+ *   A1-A6   — argument validation
+ *   S1-S5   — session-id sourcing from env
+ *   R1-R3   — --root validation
+ *   T1-T3   — --target validation
+ *   AC1-AC4 — --action validation
+ *   ARM*    — arm-if-missing semantics (per quartet member)
+ *   TCH*    — touch semantics (per quartet member)
+ *   RM*     — rm semantics (per quartet member)
+ *   F1-F3   — F3 legacy-literal-read-only invariant
+ *   J1-J3   — JSON output shape
+ */
+
+import { execFileSync, spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const HELPER = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '..',
+  'scripts',
+  'checkpoint-marker.mjs'
+)
+
+const QUARTET = [
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.pre-checkpoint-done',
+  '.post-checkpoint-done',
+]
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function assert(label, cond, detail) {
+  if (cond) { pass++; return }
+  fail++
+  failures.push({ label, detail })
+}
+
+function makeFixtureRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-cm-test-'))
+  // Make it look like a valid repo root — validateRoot requires a repo signal.
+  fs.mkdirSync(path.join(root, '.git'), { recursive: true })
+  return root
+}
+
+function run(args, env = {}, opts = {}) {
+  const fullEnv = { ...process.env, ...env }
+  const res = spawnSync('node', [HELPER, ...args], {
+    env: fullEnv,
+    encoding: 'utf8',
+    ...opts,
+  })
+  return { code: res.status, stdout: res.stdout, stderr: res.stderr }
+}
+
+function parseJson(stdout) {
+  try { return JSON.parse(stdout.trim().split('\n').pop()) } catch { return null }
+}
+
+// ---------------------------------------------------------------------------
+// A1-A6 — argument validation
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  let r
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing'], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('A1 missing --root → exit 4', r.code === 4)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: '' })
+  assert('A2 empty CLAUDE_CODE_SESSION_ID → exit 8', r.code === 8)
+
+  r = run(['--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('A3 missing --target → exit 6', r.code === 6)
+
+  r = run(['--target', '.checkpoint-required', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('A4 missing --action → exit 6', r.code === 6)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root, '--unknown'], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('A5 unknown arg → exit 6', r.code === 6)
+
+  fs.rmSync(root, { recursive: true, force: true })
+
+  r = run(['--help'])
+  assert('A6 --help → exit 0', r.code === 0 && r.stdout.includes('Usage:'))
+}
+
+// ---------------------------------------------------------------------------
+// S1-S5 — session-id sourcing
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  let r
+
+  // Don't override env at all → CLAUDE_CODE_SESSION_ID is unset (parent process
+  // doesn't set it). Result: exit 8.
+  const cleanEnv = { ...process.env }
+  delete cleanEnv.CLAUDE_CODE_SESSION_ID
+  r = spawnSync('node', [HELPER, '--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { env: cleanEnv, encoding: 'utf8' })
+  assert('S1 unset CLAUDE_CODE_SESSION_ID → exit 8', r.status === 8)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: '' })
+  assert('S2 empty → exit 8', r.code === 8)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'invalid/slash' })
+  assert('S3 invalid charclass (slash) → exit 8', r.code === 8)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'has.dot' })
+  assert('S4 invalid charclass (dot) → exit 8', r.code === 8)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'a'.repeat(129) })
+  assert('S5 oversize sid → exit 8', r.code === 8)
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// R1-R3 — --root validation
+// ---------------------------------------------------------------------------
+{
+  let r
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', 'relative/path'], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('R1 relative root → exit 5', r.code === 5)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', '/nonexistent/path/xyz'], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('R2 nonexistent root → exit 5', r.code === 5)
+
+  const noRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-no-repo-'))
+  r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', noRepoRoot], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('R3 root without .git → exit 5', r.code === 5)
+  fs.rmSync(noRepoRoot, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// T1-T3 — --target validation
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  let r
+
+  r = run(['--target', '.session-baseline', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('T1 .session-baseline → exit 7 (out of quartet)', r.code === 7)
+
+  r = run(['--target', '.plan-approval-pending', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('T2 plan-marker → exit 7', r.code === 7)
+
+  r = run(['--target', '/abs/path/.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('T3 abs-path target → exit 7', r.code === 7)
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// AC1-AC3 — --action validation
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  let r
+
+  r = run(['--target', '.checkpoint-required', '--action', 'unknown-action', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('AC1 unknown action → exit 9', r.code === 9)
+
+  r = run(['--target', '.checkpoint-required', '--action', '', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('AC2 empty action → exit 9', r.code === 9)
+
+  r = run(['--target', '.checkpoint-required', '--action', 'ARM-IF-MISSING', '--root', root], { CLAUDE_CODE_SESSION_ID: 'sid' })
+  assert('AC3 case-sensitive action → exit 9', r.code === 9)
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// ARM1-ARM8 — arm-if-missing semantics (×4 quartet members ×2 states)
+// ---------------------------------------------------------------------------
+for (const target of QUARTET) {
+  const root = makeFixtureRoot()
+  const sid = 'sid-arm-test'
+  const suffixed = path.join(root, '.checkpoints', `${target}.${sid}`)
+
+  // First arm: file doesn't exist → write it.
+  let r = run(['--target', target, '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  let json = parseJson(r.stdout)
+  assert(`ARM ${target} first-arm exit 0`, r.code === 0)
+  assert(`ARM ${target} first-arm noop=false`, json && json.noop === false)
+  assert(`ARM ${target} first-arm file created`, fs.existsSync(suffixed))
+
+  // Second arm: already exists → noop.
+  r = run(['--target', target, '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  json = parseJson(r.stdout)
+  assert(`ARM ${target} second-arm noop=true`, json && json.noop === true)
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// TCH1-TCH4 — touch semantics (×4 quartet members)
+// ---------------------------------------------------------------------------
+for (const target of QUARTET) {
+  const root = makeFixtureRoot()
+  const sid = 'sid-touch'
+  const suffixed = path.join(root, '.checkpoints', `${target}.${sid}`)
+
+  // Touch when missing → creates.
+  let r = run(['--target', target, '--action', 'touch', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  assert(`TCH ${target} creates empty file`, r.code === 0 && fs.existsSync(suffixed))
+
+  // Pre-existing file with content → touch force-overwrites to empty.
+  fs.writeFileSync(suffixed, 'previous content')
+  r = run(['--target', target, '--action', 'touch', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  assert(`TCH ${target} overwrites pre-existing`,
+    r.code === 0 && fs.readFileSync(suffixed, 'utf8') === '')
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// RM1-RM8 — rm semantics (×4 quartet members, primary + legacy)
+// ---------------------------------------------------------------------------
+for (const target of QUARTET) {
+  const root = makeFixtureRoot()
+  const sid = 'sid-rm'
+  const primary = path.join(root, '.checkpoints', `${target}.${sid}`)
+  const legacy = path.join(root, '.claude', `${target}.${sid}`)
+
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  fs.writeFileSync(primary, '')
+  fs.writeFileSync(legacy, '')
+
+  let r = run(['--target', target, '--action', 'rm', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  let json = parseJson(r.stdout)
+  assert(`RM ${target} exit 0`, r.code === 0)
+  assert(`RM ${target} primary gone`, !fs.existsSync(primary))
+  assert(`RM ${target} legacy gone`, !fs.existsSync(legacy))
+  assert(`RM ${target} both reported`, json && json.removed.length === 2)
+
+  // Idempotent: re-rm → exit 0, removed: [].
+  r = run(['--target', target, '--action', 'rm', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  json = parseJson(r.stdout)
+  assert(`RM ${target} idempotent exit 0`, r.code === 0)
+  assert(`RM ${target} idempotent removed=[]`, json && json.removed.length === 0)
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// F1-F3 — F3 legacy-literal-read-only invariant
+// ---------------------------------------------------------------------------
+for (const target of QUARTET.slice(0, 1)) {
+  // Only test once (same logic across all quartet members).
+  const root = makeFixtureRoot()
+  const sid = 'sid-f3'
+  const primaryLegacy = path.join(root, '.checkpoints', target)   // bare literal
+  const legacyLegacy = path.join(root, '.claude', target)         // bare literal
+  const suffixed = path.join(root, '.checkpoints', `${target}.${sid}`)
+
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+
+  // Pre-seed: bare legacy literal at both roots.
+  fs.writeFileSync(primaryLegacy, 'legacy-content')
+  fs.writeFileSync(legacyLegacy, 'legacy-content')
+
+  // arm-if-missing should NO-OP because the bare legacy exists at primary.
+  let r = run(['--target', target, '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  let json = parseJson(r.stdout)
+  assert('F1 arm-if-missing noop when legacy literal present',
+    r.code === 0 && json && json.noop === true && !fs.existsSync(suffixed))
+
+  // rm should NEVER touch the bare literals.
+  r = run(['--target', target, '--action', 'rm', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  json = parseJson(r.stdout)
+  assert('F2 rm does not touch bare primary literal',
+    r.code === 0 && fs.existsSync(primaryLegacy) && fs.readFileSync(primaryLegacy, 'utf8') === 'legacy-content')
+  assert('F3 rm does not touch bare legacy literal',
+    fs.existsSync(legacyLegacy) && fs.readFileSync(legacyLegacy, 'utf8') === 'legacy-content')
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// J1-J3 — JSON output shape
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sid = 'sid-json'
+
+  let r = run(['--target', '.checkpoint-required', '--action', 'arm-if-missing', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  let json = parseJson(r.stdout)
+  assert('J1 arm-if-missing JSON shape',
+    json && json.status === 'ok' && json.action === 'arm-if-missing' &&
+    json.target === '.checkpoint-required' && json.sid === sid && typeof json.path === 'string')
+
+  r = run(['--target', '.pre-checkpoint-done', '--action', 'touch', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  json = parseJson(r.stdout)
+  assert('J2 touch JSON shape',
+    json && json.action === 'touch' && json.target === '.pre-checkpoint-done' &&
+    typeof json.path === 'string')
+
+  r = run(['--target', '.pre-checkpoint-done', '--action', 'rm', '--root', root], { CLAUDE_CODE_SESSION_ID: sid })
+  json = parseJson(r.stdout)
+  assert('J3 rm JSON shape',
+    json && json.action === 'rm' && Array.isArray(json.removed))
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(JSON.stringify({
+  pass,
+  fail,
+  total: pass + fail,
+  failures,
+}, null, 2))
+
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/test-em-recall-session-aware.mjs
+++ b/tests/test-em-recall-session-aware.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+/**
+ * Integration test for em-recall.mjs --gate stop session-aware reads + carve-out
+ * (rank-2 C3). Verifies the cross-session bleed fix end-to-end against the real
+ * em-recall binary.
+ *
+ * Coverage:
+ *   X1 — Acceptance #1: A's marker doesn't block B's clean Stop.
+ *   X2 — Acceptance #1-bis: B's own marker blocks B's Stop.
+ *   X3 — Acceptance #2 (same-ms race): per-session reader stable.
+ *   X4 — Carve-out own-session: B has own checkpoint-required + matching baseline → allow.
+ *   X5 — Carve-out cross-session: B has no own marker, A has armed marker → allow (carve-out fires).
+ *   X6 — Symlink defense: own-session marker is a symlink → fail closed (block).
+ *   X7 — Legacy-literal fallback: no sid + legacy literal exists → reads legacy.
+ *   X8 — Invalid sid graceful degrade: bad sid passed → falls back to legacy-only mode.
+ */
+
+import { execSync, spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const EM_RECALL = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '..',
+  'scripts',
+  'em-recall.mjs'
+)
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function assert(label, cond, detail) {
+  if (cond) { pass++; return }
+  fail++
+  failures.push({ label, detail })
+}
+
+function makeFixtureRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-c3-test-'))
+  // Make it look like a git repo so resolveRepoRoot from local-dir.mjs
+  // accepts it as the project root.
+  fs.mkdirSync(path.join(root, '.git'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  return root
+}
+
+function runGateStop(repoRoot, sid) {
+  const args = ['--gate', 'stop']
+  if (sid !== undefined) args.push('--session-id', sid)
+  const res = spawnSync('node', [EM_RECALL, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env },
+  })
+  return { code: res.status, stdout: res.stdout, stderr: res.stderr }
+}
+
+function setBaselineAfter(repoRoot, refMs) {
+  // Write baseline with mtime > refMs+1 to mimic force-monotonic SessionStart.
+  const baseline = path.join(repoRoot, '.checkpoints', '.session-baseline')
+  fs.writeFileSync(baseline, '')
+  const t = (refMs + 100) / 1000
+  fs.utimesSync(baseline, t, t)
+}
+
+function setMarkerWithMtime(p, mtimeMs) {
+  fs.writeFileSync(p, '')
+  const t = mtimeMs / 1000
+  fs.utimesSync(p, t, t)
+}
+
+// ---------------------------------------------------------------------------
+// X1: Acceptance #1 — A's marker doesn't block B's clean Stop.
+// Setup: A has .post-checkpoint-required.<sidA>; B has no own quartet markers.
+// B's baseline post-dates A's marker (force-monotonic). B Stop → no block.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidA = 'aaaa-aaaa-aaaa'
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  // A arms `.post-checkpoint-required.<sidA>` (so .checkpoint-required is set too).
+  const aReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidA}`)
+  const aPostReq = path.join(root, '.checkpoints', `.post-checkpoint-required.${sidA}`)
+  const tA = Date.now() - 5000
+  setMarkerWithMtime(aReq, tA)
+  setMarkerWithMtime(aPostReq, tA)
+
+  // B baseline > A's marker mtime.
+  setBaselineAfter(root, tA)
+
+  const r = runGateStop(root, sidB)
+  assert('X1 B Stop exit 0', r.code === 0)
+  assert('X1 B Stop empty stdout (allow stop)', r.stdout === '',
+    { stdout: r.stdout, stderr: r.stderr })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X2: Acceptance #1-bis — B's own marker blocks B's Stop (no post-done).
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  // B armed own `.checkpoint-required.<sidB>` POST-baseline (mid-session arm).
+  const baselineT = Date.now() - 3000
+  setBaselineAfter(root, baselineT - 5000)  // baseline OLDER than B's marker
+
+  const bReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidB}`)
+  setMarkerWithMtime(bReq, Date.now())
+
+  const r = runGateStop(root, sidB)
+  assert('X2 B Stop exit 0 (block emits, hook still exits 0)', r.code === 0)
+  const out = r.stdout.trim()
+  let json = null
+  try { json = JSON.parse(out) } catch {}
+  assert('X2 B Stop emits block JSON', json && json.decision === 'block',
+    { stdout: r.stdout })
+  assert('X2 block reason mentions suffixed path',
+    json && json.reason && json.reason.includes(`.post-checkpoint-done.${sidB}`),
+    { reason: json && json.reason })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X5: Cross-session bleed scenario — B has NO own quartet markers; A has
+// `.checkpoint-required.<sidA>` that pre-dates B's baseline (force-monotonic
+// has dominated it). B's own-session carve-out should see nothing for itself
+// and allow Stop.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidA = 'aaaa-aaaa-aaaa'
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  const aReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidA}`)
+  const tA = Date.now() - 5000
+  setMarkerWithMtime(aReq, tA)
+  setBaselineAfter(root, tA)
+
+  // B has nothing of its own.
+  const r = runGateStop(root, sidB)
+  assert('X5 B Stop allow (own-session reader sees nothing for B)',
+    r.code === 0 && r.stdout === '',
+    { stdout: r.stdout, stderr: r.stderr })
+
+  // A's marker still on disk after B's Stop.
+  assert("X5 A's marker preserved", fs.existsSync(aReq))
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X7: Legacy-literal fallback — no sid + legacy literal exists at primary.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+
+  const legacy = path.join(root, '.checkpoints', '.checkpoint-required')
+  const tNow = Date.now() - 3000
+  setMarkerWithMtime(legacy, tNow)
+  setBaselineAfter(root, tNow - 5000)  // baseline OLDER → carve-out fails → block
+
+  const r = runGateStop(root, undefined)
+  let json = null
+  try { json = JSON.parse(r.stdout.trim()) } catch {}
+  assert('X7 no-sid legacy literal triggers block',
+    r.code === 0 && json && json.decision === 'block',
+    { stdout: r.stdout })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X8: Invalid sid graceful degrade — em-recall warns + falls back.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+
+  setBaselineAfter(root, Date.now() - 1000)
+
+  const res = spawnSync('node', [EM_RECALL, '--gate', 'stop', '--session-id', 'invalid/slash'], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env },
+  })
+  assert('X8 invalid sid: exit 0 (graceful degrade)', res.status === 0)
+  assert('X8 invalid sid: stderr warns',
+    res.stderr.includes('legacy-literal-only'),
+    { stderr: res.stderr })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X6: Symlink defense — own-session marker is a symlink → carve-out fails closed.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  // B has both .checkpoint-required.<sidB> and a baseline OLDER than its mtime.
+  // But the marker is a SYMLINK → strict helper hadSymlink=true → carve-out fails closed.
+  const realFile = path.join(root, '.checkpoints', 'realtarget')
+  fs.writeFileSync(realFile, '')
+  const bReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidB}`)
+  fs.symlinkSync('realtarget', bReq)
+  setBaselineAfter(root, Date.now() - 5000)
+
+  const r = runGateStop(root, sidB)
+  let json = null
+  try { json = JSON.parse(r.stdout.trim()) } catch {}
+  assert('X6 symlink own-session marker triggers block (fail closed)',
+    r.code === 0 && json && json.decision === 'block',
+    { stdout: r.stdout })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(JSON.stringify({
+  pass,
+  fail,
+  total: pass + fail,
+  failures,
+}, null, 2))
+
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/test-em-recall-session-aware.mjs
+++ b/tests/test-em-recall-session-aware.mjs
@@ -128,6 +128,64 @@ function setMarkerWithMtime(p, mtimeMs) {
 }
 
 // ---------------------------------------------------------------------------
+// X3: Same-ms race — own marker and baseline land in the same wall-clock ms.
+// Carve-out check is `marker.mtime > baselineMtime` (strict-greater), so
+// same-mtime → no block → allow stop. Verifies the per-session reader is
+// stable under the empirical 2026-05-23 ~15:55 same-ms scenario.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  // Same-ms race: marker AND baseline at exactly the same mtime.
+  const sameT = Date.now() - 2000
+  const bReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidB}`)
+  setMarkerWithMtime(bReq, sameT)
+  // setBaselineAfter adds +100ms; use a direct utime to match exactly.
+  const baseline = path.join(root, '.checkpoints', '.session-baseline')
+  fs.writeFileSync(baseline, '')
+  const t = sameT / 1000
+  fs.utimesSync(baseline, t, t)
+
+  const r = runGateStop(root, sidB)
+  // No .checkpoint-required readable → preReqPath null → early return → allow.
+  // Wait: there IS .checkpoint-required.<sidB>. Resolution: own primary →
+  // exists → preReqPath set. postDonePath null (no post-done). preReqPath set
+  // + postDoneSize=0 → carve-out check. marker.mtime === baselineMtime →
+  // NOT > → loop continues → returns true → allow stop.
+  assert('X3 same-ms own-marker + baseline → allow stop',
+    r.code === 0 && r.stdout === '',
+    { stdout: r.stdout, stderr: r.stderr })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// X4: Own-session carve-out applies — B has own checkpoint-required with
+// mtime <= baseline (B armed BEFORE its baseline; e.g. mid-session-restart).
+// Carve-out evaluates: marker.mtime <= baseline → continue → return true →
+// allow stop. Demonstrates that own-session reads + baseline dominance work
+// together for the carve-out.
+// ---------------------------------------------------------------------------
+{
+  const root = makeFixtureRoot()
+  const sidB = 'bbbb-bbbb-bbbb'
+
+  // B's marker is older than B's baseline (force-monotonic dominates it).
+  const markerT = Date.now() - 10000
+  const bReq = path.join(root, '.checkpoints', `.checkpoint-required.${sidB}`)
+  setMarkerWithMtime(bReq, markerT)
+  setBaselineAfter(root, markerT)  // baseline > marker by 100ms
+
+  const r = runGateStop(root, sidB)
+  assert('X4 own-marker dominated by baseline → carve-out allows stop',
+    r.code === 0 && r.stdout === '',
+    { stdout: r.stdout, stderr: r.stderr })
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
 // X5: Cross-session bleed scenario — B has NO own quartet markers; A has
 // `.checkpoint-required.<sidA>` that pre-dates B's baseline (force-monotonic
 // has dominated it). B's own-session carve-out should see nothing for itself

--- a/tests/test-namespaced-marker-helpers.mjs
+++ b/tests/test-namespaced-marker-helpers.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Unit tests for the generic namespaced-marker helpers added in rank-2 (PR
+// for checkpoint-quartet). Sibling-of-PR-#271 lib-parity validation.
+//
+// Coverage:
+//   - namespacedMarkerBasenameMatches  (G1-G14)
+//   - namespacedMarkerBasenameForSession  (C1-C3)
+//   - anyNamespacedMarkerExists  (E1-E6) — uses /tmp fixture dirs
+//   - CHECKPOINT_QUARTET / CHECKPOINT_QUARTET_RE / isCheckpointQuartetBasename  (Q1-Q9)
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  namespacedMarkerBasenameMatches,
+  namespacedMarkerBasenameForSession,
+  anyNamespacedMarkerExists,
+  CHECKPOINT_QUARTET,
+  CHECKPOINT_QUARTET_RE,
+  isCheckpointQuartetBasename,
+  NAMESPACED_MARKER_SUFFIX_MAXLEN,
+} from '../scripts/lib/marker-paths.mjs'
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function assert(label, cond) {
+  if (cond) { pass++; return }
+  fail++
+  failures.push(label)
+}
+
+// ---------------------------------------------------------------------------
+// G1-G14: namespacedMarkerBasenameMatches
+// ---------------------------------------------------------------------------
+assert('G1 legacy literal matches',
+  namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required'))
+
+assert('G2 simple sid matches',
+  namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required.abc123'))
+
+assert('G3 uuid-shape sid matches',
+  namespacedMarkerBasenameMatches('.checkpoint-required',
+    '.checkpoint-required.eff2d836-5d8e-4750-908a-f2ae14852d57'))
+
+assert('G4 sid with underscores matches',
+  namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required.sid_v2'))
+
+assert('G5 wrong legacy rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.post-checkpoint-required'))
+
+assert('G6 wrong legacy with sid rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.post-checkpoint-required.abc'))
+
+assert('G7 suffix without dot rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required-extra'))
+
+assert('G8 empty suffix rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required.'))
+
+assert('G9 slash in suffix rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required.foo/bar'))
+
+assert('G10 dot in suffix rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', '.checkpoint-required..extra'))
+
+assert('G11 oversize suffix rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required',
+    '.checkpoint-required.' + 'a'.repeat(NAMESPACED_MARKER_SUFFIX_MAXLEN + 1)))
+
+assert('G12 exact-maxlen suffix accepts',
+  namespacedMarkerBasenameMatches('.checkpoint-required',
+    '.checkpoint-required.' + 'a'.repeat(NAMESPACED_MARKER_SUFFIX_MAXLEN)))
+
+assert('G13 null candidate rejects',
+  !namespacedMarkerBasenameMatches('.checkpoint-required', null))
+
+assert('G14 non-string legacy rejects',
+  !namespacedMarkerBasenameMatches(null, '.checkpoint-required.abc'))
+
+// ---------------------------------------------------------------------------
+// C1-C3: namespacedMarkerBasenameForSession
+// ---------------------------------------------------------------------------
+assert('C1 compose simple',
+  namespacedMarkerBasenameForSession('.checkpoint-required', 'abc') === '.checkpoint-required.abc')
+
+assert('C2 compose uuid',
+  namespacedMarkerBasenameForSession('.post-checkpoint-done', 'eff2d836-5d8e-4750-908a-f2ae14852d57')
+    === '.post-checkpoint-done.eff2d836-5d8e-4750-908a-f2ae14852d57')
+
+assert('C3 compose roundtrips through matcher',
+  namespacedMarkerBasenameMatches(
+    '.pre-checkpoint-done',
+    namespacedMarkerBasenameForSession('.pre-checkpoint-done', 'sid-1')))
+
+// ---------------------------------------------------------------------------
+// E1-E6: anyNamespacedMarkerExists  (fs fixtures)
+// ---------------------------------------------------------------------------
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-marker-test-'))
+fs.mkdirSync(path.join(fixtureRoot, '.checkpoints'), { recursive: true })
+fs.mkdirSync(path.join(fixtureRoot, '.claude'), { recursive: true })
+
+assert('E1 missing returns false',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === false)
+
+fs.writeFileSync(path.join(fixtureRoot, '.checkpoints', '.checkpoint-required'), '')
+assert('E2 legacy literal at primary detected',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === true)
+
+fs.rmSync(path.join(fixtureRoot, '.checkpoints', '.checkpoint-required'))
+fs.writeFileSync(path.join(fixtureRoot, '.claude', '.checkpoint-required'), '')
+assert('E3 legacy literal at legacy root detected',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === true)
+
+fs.rmSync(path.join(fixtureRoot, '.claude', '.checkpoint-required'))
+fs.writeFileSync(path.join(fixtureRoot, '.checkpoints', '.checkpoint-required.sid123'), '')
+assert('E4 suffixed at primary detected',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === true)
+
+// E5 — non-strict basename in same dir does not cause false-positives.
+// Write a file whose basename starts with the prefix but fails the strict
+// matcher (oversize suffix). The legit .sid123 marker is still detected.
+fs.writeFileSync(
+  path.join(fixtureRoot, '.checkpoints',
+    '.checkpoint-required.' + 'x'.repeat(NAMESPACED_MARKER_SUFFIX_MAXLEN + 5)),
+  '')
+assert('E5 non-strict-suffix sibling does not affect legitimate detection',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === true)
+
+fs.rmSync(path.join(fixtureRoot, '.checkpoints', '.checkpoint-required.sid123'))
+fs.writeFileSync(path.join(fixtureRoot, '.checkpoints', '.checkpoint-required-extra'), '')
+assert('E6 hyphen-suffix non-strict basename does NOT match',
+  anyNamespacedMarkerExists(fixtureRoot, '.checkpoint-required') === false)
+
+fs.rmSync(fixtureRoot, { recursive: true, force: true })
+
+// ---------------------------------------------------------------------------
+// Q1-Q9: CHECKPOINT_QUARTET + isCheckpointQuartetBasename
+// ---------------------------------------------------------------------------
+assert('Q1 quartet has 4 members', CHECKPOINT_QUARTET.length === 4)
+
+assert('Q2 quartet is frozen',
+  Object.isFrozen(CHECKPOINT_QUARTET))
+
+assert('Q3 RE matches all 4 legacy',
+  CHECKPOINT_QUARTET.every(m => CHECKPOINT_QUARTET_RE.test(m)))
+
+assert('Q4 RE matches all 4 suffixed',
+  CHECKPOINT_QUARTET.every(m => CHECKPOINT_QUARTET_RE.test(`${m}.abc-123`)))
+
+assert('Q5 RE rejects plan-marker',
+  !CHECKPOINT_QUARTET_RE.test('.plan-approval-pending'))
+
+assert('Q6 RE rejects preflight-marker',
+  !CHECKPOINT_QUARTET_RE.test('.preflight-done'))
+
+assert('Q7 RE rejects baseline',
+  !CHECKPOINT_QUARTET_RE.test('.session-baseline'))
+
+assert('Q8 isCheckpointQuartetBasename accepts all forms',
+  isCheckpointQuartetBasename('.pre-checkpoint-done.eff2d836') &&
+  isCheckpointQuartetBasename('.post-checkpoint-required') &&
+  isCheckpointQuartetBasename('.checkpoint-required'))
+
+assert('Q9 isCheckpointQuartetBasename rejects neighbors',
+  !isCheckpointQuartetBasename('.checkpoint-required-extra') &&
+  !isCheckpointQuartetBasename('.checkpoint-required.') &&
+  !isCheckpointQuartetBasename(null))
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(JSON.stringify({
+  pass,
+  fail,
+  total: pass + fail,
+  failures,
+}, null, 2))
+
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/test-namespaced-marker-helpers.sh
+++ b/tests/test-namespaced-marker-helpers.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Shell-parity smoke tests for the namespaced-marker helpers added in
+# rank-2 (PR for checkpoint-quartet). Mirrors test-namespaced-marker-helpers.mjs.
+#
+# Coverage:
+#   - namespaced_marker_basename_matches   (G1-G10)
+#   - namespaced_marker_basename_for_session  (C1-C2)
+#   - any_namespaced_marker_exists  (E1-E5) — uses /tmp fixture
+#   - is_checkpoint_quartet_basename + CHECKPOINT_QUARTET  (Q1-Q5)
+#
+# Run from repo root: bash tests/test-namespaced-marker-helpers.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/hooks/lib/marker-paths.sh"
+
+pass=0
+fail=0
+failures=()
+
+assert() {
+  local label="$1" cond="$2"
+  if [ "$cond" = "true" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    failures+=("$label")
+  fi
+}
+
+# G1-G10 — strict matcher
+namespaced_marker_basename_matches .checkpoint-required .checkpoint-required && r=true || r=false
+assert "G1 legacy literal matches" "$r"
+
+namespaced_marker_basename_matches .checkpoint-required .checkpoint-required.abc123 && r=true || r=false
+assert "G2 simple sid matches" "$r"
+
+namespaced_marker_basename_matches .checkpoint-required .checkpoint-required.eff2d836-5d8e-4750-908a-f2ae14852d57 && r=true || r=false
+assert "G3 uuid sid matches" "$r"
+
+namespaced_marker_basename_matches .checkpoint-required .post-checkpoint-required && r=true || r=false
+assert "G4 wrong legacy rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+namespaced_marker_basename_matches .checkpoint-required .checkpoint-required-extra && r=true || r=false
+assert "G5 suffix without dot rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+namespaced_marker_basename_matches .checkpoint-required .checkpoint-required. && r=true || r=false
+assert "G6 empty suffix rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+namespaced_marker_basename_matches .checkpoint-required ".checkpoint-required.foo bar" && r=true || r=false
+assert "G7 space in suffix rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+namespaced_marker_basename_matches .checkpoint-required ".checkpoint-required..ext" && r=true || r=false
+assert "G8 dot in suffix rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+oversize_sid="$(printf 'a%.0s' $(seq 1 129))"
+namespaced_marker_basename_matches .checkpoint-required ".checkpoint-required.${oversize_sid}" && r=true || r=false
+assert "G9 oversize suffix (129) rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+maxlen_sid="$(printf 'a%.0s' $(seq 1 128))"
+namespaced_marker_basename_matches .checkpoint-required ".checkpoint-required.${maxlen_sid}" && r=true || r=false
+assert "G10 exact maxlen suffix accepts" "$r"
+
+# C1-C2 — composer
+out="$(namespaced_marker_basename_for_session .checkpoint-required abc)"
+assert "C1 compose simple" "$([ "$out" = ".checkpoint-required.abc" ] && echo true || echo false)"
+
+out="$(namespaced_marker_basename_for_session .post-checkpoint-done eff2d836)"
+assert "C2 compose preserves dot-separator" "$([ "$out" = ".post-checkpoint-done.eff2d836" ] && echo true || echo false)"
+
+# E1-E5 — fs fixture
+FIXTURE="$(mktemp -d -t rank2-marker-test-XXXXXX)"
+mkdir -p "$FIXTURE/.checkpoints" "$FIXTURE/.claude"
+
+any_namespaced_marker_exists "$FIXTURE" .checkpoint-required && r=true || r=false
+assert "E1 missing returns false" "$([ "$r" = "false" ] && echo true || echo false)"
+
+: > "$FIXTURE/.checkpoints/.checkpoint-required"
+any_namespaced_marker_exists "$FIXTURE" .checkpoint-required && r=true || r=false
+assert "E2 legacy at primary detected" "$r"
+
+rm -f "$FIXTURE/.checkpoints/.checkpoint-required"
+: > "$FIXTURE/.claude/.checkpoint-required"
+any_namespaced_marker_exists "$FIXTURE" .checkpoint-required && r=true || r=false
+assert "E3 legacy at legacy detected" "$r"
+
+rm -f "$FIXTURE/.claude/.checkpoint-required"
+: > "$FIXTURE/.checkpoints/.checkpoint-required.sid123"
+any_namespaced_marker_exists "$FIXTURE" .checkpoint-required && r=true || r=false
+assert "E4 suffixed at primary detected" "$r"
+
+rm -f "$FIXTURE/.checkpoints/.checkpoint-required.sid123"
+: > "$FIXTURE/.checkpoints/.checkpoint-required-extra"
+any_namespaced_marker_exists "$FIXTURE" .checkpoint-required && r=true || r=false
+assert "E5 hyphen-suffix non-strict basename does NOT match" "$([ "$r" = "false" ] && echo true || echo false)"
+
+rm -rf "$FIXTURE"
+
+# Q1-Q5 — quartet array + matcher
+assert "Q1 quartet has 4 members" "$([ "${#CHECKPOINT_QUARTET[@]}" -eq 4 ] && echo true || echo false)"
+
+is_checkpoint_quartet_basename .checkpoint-required && r=true || r=false
+assert "Q2 legacy member matches" "$r"
+
+is_checkpoint_quartet_basename .post-checkpoint-done.eff2d836 && r=true || r=false
+assert "Q3 suffixed member matches" "$r"
+
+is_checkpoint_quartet_basename .plan-approval-pending && r=true || r=false
+assert "Q4 plan-marker rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+is_checkpoint_quartet_basename .checkpoint-required-extra && r=true || r=false
+assert "Q5 non-strict-suffix rejects" "$([ "$r" = "false" ] && echo true || echo false)"
+
+# Summary
+printf '{"pass":%d,"fail":%d,"total":%d,"failures":[' "$pass" "$fail" $((pass + fail))
+for i in "${!failures[@]}"; do
+  [ "$i" -gt 0 ] && printf ','
+  printf '"%s"' "${failures[$i]}"
+done
+printf ']}\n'
+
+exit "$fail"

--- a/tests/test-session-end-quartet-cleanup.mjs
+++ b/tests/test-session-end-quartet-cleanup.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Regression test for rank-2 C7: SessionEnd own-session quartet cleanup.
+ *
+ * Verifies:
+ *   Q1 — Own-session suffixed quartet markers DELETED on SessionEnd.
+ *   Q2 — Cross-session quartet markers PRESERVED on SessionEnd.
+ *   Q3 — Legacy literal quartet markers DELETED (orphan cleanup, unchanged).
+ *   Q4 — Invalid sid → only legacy literal cleanup; suffixed forms preserved.
+ */
+
+import { execSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SESSION_END = path.join(REPO, 'scripts', 'em-session-end-prompt.mjs')
+
+const QUARTET = [
+  '.checkpoint-required',
+  '.post-checkpoint-required',
+  '.pre-checkpoint-done',
+  '.post-checkpoint-done',
+]
+
+let pass = 0
+let fail = 0
+const failures = []
+
+function assert(label, cond) {
+  if (cond) { pass++; return }
+  fail++
+  failures.push(label)
+}
+
+function setupRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rank2-c7-test-'))
+  fs.mkdirSync(path.join(root, '.git'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.checkpoints'), { recursive: true })
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true })
+  return root
+}
+
+function runSessionEnd(root, sid) {
+  try {
+    execSync(`node "${SESSION_END}"`, {
+      input: JSON.stringify({ session_id: sid, cwd: root, hook_event_name: 'SessionEnd' }),
+      stdio: ['pipe', 'pipe', 'ignore'],
+      env: { ...process.env, HOME: root },
+    })
+  } catch { /* SessionEnd may not have all stdout setup; ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// Q1 — Own-session suffixed quartet markers DELETED
+// Q2 — Cross-session quartet markers PRESERVED
+// ---------------------------------------------------------------------------
+{
+  const root = setupRoot()
+  const sidB = 'session-b'
+  const sidA = 'session-a'
+
+  // Seed B's own suffixed quartet at both roots + A's suffixed at both roots.
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      fs.writeFileSync(path.join(root, dir, `${m}.${sidB}`), '')
+      fs.writeFileSync(path.join(root, dir, `${m}.${sidA}`), '')
+    }
+  }
+
+  runSessionEnd(root, sidB)
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      assert(`Q1 ${dir}/${m}.${sidB} removed (own-session)`,
+        !fs.existsSync(path.join(root, dir, `${m}.${sidB}`)))
+      assert(`Q2 ${dir}/${m}.${sidA} preserved (cross-session)`,
+        fs.existsSync(path.join(root, dir, `${m}.${sidA}`)))
+    }
+  }
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Q3 — Legacy literal quartet markers DELETED (unchanged behavior)
+// ---------------------------------------------------------------------------
+{
+  const root = setupRoot()
+  const sid = 'session-c'
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      fs.writeFileSync(path.join(root, dir, m), '')
+    }
+  }
+
+  runSessionEnd(root, sid)
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      assert(`Q3 ${dir}/${m} legacy literal removed (orphan cleanup)`,
+        !fs.existsSync(path.join(root, dir, m)))
+    }
+  }
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+// ---------------------------------------------------------------------------
+// Q4 — Invalid sid → only legacy literal cleanup; suffixed preserved
+// ---------------------------------------------------------------------------
+{
+  const root = setupRoot()
+  const realSid = 'session-d'
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      fs.writeFileSync(path.join(root, dir, m), '')
+      fs.writeFileSync(path.join(root, dir, `${m}.${realSid}`), '')
+    }
+  }
+
+  runSessionEnd(root, '../evil/invalid')
+
+  for (const dir of ['.checkpoints', '.claude']) {
+    for (const m of QUARTET) {
+      assert(`Q4 ${dir}/${m} legacy literal removed (cleanup proceeds)`,
+        !fs.existsSync(path.join(root, dir, m)))
+      assert(`Q4 ${dir}/${m}.${realSid} preserved (invalid sid skips suffixed cleanup)`,
+        fs.existsSync(path.join(root, dir, `${m}.${realSid}`)))
+    }
+  }
+
+  fs.rmSync(root, { recursive: true, force: true })
+}
+
+console.log(JSON.stringify({
+  pass,
+  fail,
+  total: pass + fail,
+  failures,
+}, null, 2))
+
+process.exit(fail === 0 ? 0 : 1)

--- a/tests/test-session-end-quartet-cleanup.mjs
+++ b/tests/test-session-end-quartet-cleanup.mjs
@@ -43,13 +43,15 @@ function setupRoot() {
 }
 
 function runSessionEnd(root, sid) {
-  try {
-    execSync(`node "${SESSION_END}"`, {
-      input: JSON.stringify({ session_id: sid, cwd: root, hook_event_name: 'SessionEnd' }),
-      stdio: ['pipe', 'pipe', 'ignore'],
-      env: { ...process.env, HOME: root },
-    })
-  } catch { /* SessionEnd may not have all stdout setup; ignore */ }
+  // Per codex C7 R1 P2: do NOT swallow execSync failures. SessionEnd is
+  // expected to exit 0 with the JSON prompt template on stdout. Throwing
+  // surfaces regressions that would otherwise be masked by partial-cleanup
+  // shape.
+  execSync(`node "${SESSION_END}"`, {
+    input: JSON.stringify({ session_id: sid, cwd: root, hook_event_name: 'SessionEnd' }),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, HOME: root },
+  })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the cross-session bleed for the **4 checkpoint quartet markers** (`.checkpoint-required`, `.post-checkpoint-required`, `.pre-checkpoint-done`, `.post-checkpoint-done`) by per-session-namespacing them as `.X.<session_id>`. Closes #341.

Third sibling of PR #271 (closed #268, `.plan-approval-pending`) and the PR closing #279 (`.preflight-done`). Same architectural pattern; same trust model.

Diagnosis: episode `20260523-080453-diagnosis-multi-session-checkpoint-marke-08ec` (2026-05-23 — two concurrent sessions in the same project, session A's `.post-checkpoint-required` blocked session B's clean Stop).

## What changes

- **`scripts/lib/marker-paths.mjs` + `hooks/lib/marker-paths.sh`** — factored generic `namespacedMarker*` helpers (third sibling = drift risk per codex plan DP-1) + `CHECKPOINT_QUARTET` constants.
- **NEW `scripts/checkpoint-marker.mjs`** — per-session helper, `{arm-if-missing | touch | rm}` actions, `--target` + `--root`, session-id sourced from `CLAUDE_CODE_SESSION_ID` env (mirrors plan-marker.mjs).
- **`scripts/em-recall.mjs`** — session-aware stop-gate carve-out (own-session only for quartet; plan-marker stays cross-session glob per E19), `armCheckpointMarkerForSession`, force-monotonic baseline glob-expands cross-session.
- **`scripts/lib/stop-gate-helpers.mjs`** — `_maxMtimeAcrossRootsForCheckpointMarkerOwnSessionStrict` (strict catch per codex plan R2 P2).
- **`hooks/checkpoint-gate.sh`** — session-aware reads/writes, suffixed PRE_DONE_W/POST_DONE_W (atomic with classifier), best-effort helper invocation wrapped `|| true` (R2 P2), push-gate cleanup sweeps suffixed forms + legacy, wrong-root detection extended to suffixed quartet (closes #341).
- **`hooks/stop-gate.sh`** — stdin `.session_id` plumbing → em-recall.
- **`hooks/lib/command-classifier.sh`** — 5 case-arm sites extended (redirect, rm, tee, touch, classify_path) for suffixed quartet recognition.
- **`scripts/em-session-end-prompt.mjs`** — own-session quartet cleanup; cross-session markers preserved.
- **Tests:** ~250 new cases + zero regressions on 188 existing checkpoint-gate / 31 stop-gate / 7 checkpoints-migration cases.

## Architecture (codex plan-tier R4 ACCEPT)

**Trust model (option 2):**
- Classifier denies STRUCTURAL bypasses (env-prefix, missing flags, wrong target/action, invalid sid).
- Classifier ALLOWS canonical invocations from any caller (mirrors PR #271 `test-plan-marker-classifier.sh` 15-pass).
- Cross-session forgery via canonical invocation = **honest-agent out-of-scope**.

**Carve-out semantics (codex plan R2 P1-B):**
- Quartet carve-out = OWN-SESSION ONLY.
- Cross-session safety = SessionStart force-monotonic baseline probe.
- Plan-marker stays cross-session glob (E19) — plan-pending deferral is global-by-design.

## Review history

| Round | Layer | Verdict | Findings |
|---|---|---|---|
| Plan R1 | codex plan-tier | HOLD | 3 P1, 1 P2 |
| Plan R2 | codex plan-tier | HOLD | 1 P1, 1 P2 |
| Plan R3 | codex plan-tier | HOLD | 1 P1 |
| Plan R4 | codex plan-tier | **ACCEPT** | — |
| C1 code | codex per-artifact | **R1 ACCEPT** | — |
| C2 code | codex per-artifact | R1 REJECT → R2 ACCEPT | own-session-bleed regression |
| C3 code | codex per-artifact | R1 HOLD → R2 ACCEPT | missing X3/X4 fixtures |
| C4 code | codex per-artifact | R1 HOLD → R2 ACCEPT-w/-FU | atomic-slice deadlock |
| C5 code | codex per-artifact | R1 REJECT → R2 ACCEPT | workspace mismatch |
| C6 code | codex per-artifact | R1 REJECT → R2 ACCEPT-w/-FU | (workspace mismatch + P2 message precision = #341) |
| C7 code | codex per-artifact | R1 REJECT → R2 ACCEPT | test swallowed exec failures + workspace mismatch |
| Full diff | negative-scenario-reviewer | HOLD → fixed | F1 MAJOR `_marker_basename_in_set` parity gap (closes #341) |

**Total:** 4 plan rounds + 13 code rounds. **All converged to ACCEPT/ACCEPT-with-FU.**

## Test plan

- [x] **C1** Generic helpers + quartet constants — `node tests/test-namespaced-marker-helpers.mjs` 32/32; `bash tests/test-namespaced-marker-helpers.sh` 22/22.
- [x] **C2** Helper unit + cross-session XS regression — `node tests/test-checkpoint-marker.mjs` 79/79.
- [x] **C3** em-recall integration (X1-X8 incl. cross-session bleed E2E) — `node tests/test-em-recall-session-aware.mjs` 13/13.
- [x] **C4** Checkpoint-gate regressions intact — `bash tests/test-checkpoint-gate.sh` 188/188.
- [x] **C5** Stop-gate regressions intact — `bash tests/test-stop-gate.sh` 31/31.
- [x] **C6** Classifier regressions intact — `node tests/test-classifier-marker.mjs` 17/17, `bash tests/test-plan-marker-classifier.sh` 15/15.
- [x] **C7** SessionEnd own-session quartet cleanup — `node tests/test-session-end-quartet-cleanup.mjs` 40/40; `node tests/test-checkpoints-migration.mjs` 7/7.
- [x] **F1 fix** — `bash scratch/probe-f1-fix.sh` 14/14 (4 legacy + 4 suffixed + 4 regression + 2 negative).

## Out-of-scope follow-ups

Filed as separate issues:
- #339 — preflight-gate sha-drift error has no in-band recovery instructions
- #340 — preflight marker has no agent-callable sha-refresh path mid-session

Deferred to follow-up PR (low-risk hardening per plan v4 §4h):
- Lowercase env-prefix denial + `BYPASS_*`/`SKIP_*` denial in classifier
- Helper-invocation E5b sibling case-arm for `node */checkpoint-marker.mjs`
- C8 generic validator covering PLAN + PREFLIGHT + CHECKPOINT (closes #283)

## Empirical fix

The 2026-05-23 scenario reproduces in `tests/test-em-recall-session-aware.mjs` X5: session A's `.post-checkpoint-required.<sidA>` no longer blocks session B's clean Stop. Verified end-to-end against the real `em-recall --gate stop` binary with sid plumbing through `stop-gate.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
