### PR TITLE
fix(sessionstart): sanitize spaces in project path canonicalization

### DIFF
--- a/hooks/session-handoff-prompt.sh
+++ b/hooks/session-handoff-prompt.sh
@@ -103,8 +103,11 @@ fi
 #   3. Canonical (even if empty; reads will ENOENT cleanly)
 # ---------------------------------------------------------------------------
 
-# Canonical sanitization (matches user-preferences hook's '/' and '.' → '-').
-_canonical="$(printf '%s' "${REPO_ROOT}" | sed 's|/|-|g; s|\.|-|g')"
+# Canonical sanitization (matches Claude Code's project-dir encoder: '/',
+# '.', and ' ' → '-'). Spaces were previously dropped, sending projects
+# with spaces in their path (e.g. "Home Network Improvement") to an empty
+# memory dir → always-tier batch-Read silently no-ops.
+_canonical="$(printf '%s' "${REPO_ROOT}" | sed 's|/|-|g; s|\.|-|g; s| |-|g')"
 CANONICAL_MEM="${HOME}/.claude/projects/${_canonical}/memory"
 
 # Sanitization variants observed on this machine. If new variants surface,


### PR DESCRIPTION
## Summary
- `session-handoff-prompt.sh` canonicalizer only replaced `/` and `.` → `-`, leaving spaces untouched. Claude Code's project-dir encoder also replaces spaces, so projects with spaces in their path (e.g. `Home Network Improvement`) resolved `MEM_ROOT` to an empty directory.
- Symptom: always-tier batch-Read silently no-ops; agent enters the session without per-project `MEMORY.md` + feedback files. In Home Network Improvement this manifested as the second-opinion harness getting called without the canonical-invocation rules (no `timeout: 600000`, `run_in_background: true`, etc.).
- Fix: add `s| |-|g` to the sed pipeline at line 107 so `MEM_ROOT` matches Claude Code's actual encoded path.

## Test plan
- [ ] Open a session in a project with spaces in its path that IS a git repo. Confirm the SessionStart Q2 directive emits and the 6 always-tier paths point at the populated memory dir.
- [ ] Open a session in a spaces-free git project. Confirm no regression — canonical path unchanged.
- [ ] Verify installed copy at `~/.claude/hooks/session-handoff-prompt.sh` matches repo source after next `--install-hooks` run.

## Notes
- Does NOT address the separate non-git fallback gap (`session-handoff-prompt.sh:91-93`). Projects without a `.git/` still bail and skip the always-tier load. That's a follow-up.
- Does NOT address the runbook-not-read issue in the second-opinion gate (quickref-only inline). Also a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
