### PR TITLE
fix(so-gate): enforce 600000ms Bash-timeout floor on harness dispatch

### DIFF
--- a/hooks/lib/so-timeout-floor.mjs
+++ b/hooks/lib/so-timeout-floor.mjs
@@ -99,10 +99,12 @@ export function tokenizeCommand(cmd) {
 
 /**
  * splitTopLevelSegments — split command string at unquoted shell control
- * operators (`;`, `&&`, `||`, `|`, `&`). Returns the literal substrings so
- * each segment can be re-tokenized independently. Quoted regions are opaque
- * (a `;` inside `"..."` does not split). Command substitution `$(...)` and
- * backticks are NOT recognized; they fall under axis A38 (documented DEFER).
+ * operators (`;`, `&&`, `||`, `|`, `&`, `\n`, `\r`). Returns the literal
+ * substrings so each segment can be re-tokenized independently. Quoted
+ * regions are opaque (a `;` inside `"..."` does not split). Command
+ * substitution `$(...)` and backticks are NOT recognized; they fall under
+ * axis A38 (documented DEFER). Newline is a top-level separator (axis A39)
+ * — honest agents legitimately write multi-line `tool_input.command`.
  */
 export function splitTopLevelSegments(cmd) {
   const segments = []
@@ -110,6 +112,10 @@ export function splitTopLevelSegments(cmd) {
   let inSingle = false
   let inDouble = false
   let i = 0
+  // Backslash-escaped newline is a line-continuation in shell — preserve as
+  // joining, not splitting. We model this by skipping the escape and the
+  // newline together (handled by the existing `\\` lookahead in the bare
+  // walk below, since `\` + any char = consume both as part of the segment).
   while (i < cmd.length) {
     const c = cmd[i]
     if (inSingle) {
@@ -139,7 +145,7 @@ export function splitTopLevelSegments(cmd) {
       start = i
       continue
     }
-    if (c === ';' || c === '|' || c === '&') {
+    if (c === ';' || c === '|' || c === '&' || c === '\n' || c === '\r') {
       segments.push(cmd.slice(start, i))
       i += 1
       start = i
@@ -149,6 +155,37 @@ export function splitTopLevelSegments(cmd) {
   }
   segments.push(cmd.slice(start))
   return segments
+}
+
+/**
+ * unwrapExecPayload — if tokens look like `[env? bash|sh|zsh|dash|ksh, -c,
+ * '<payload>', ...]` (with optional `VAR=val` env prefixes before the exec),
+ * return the payload string. Otherwise null.
+ *
+ * Closes axis A40 (negative-scenario-reviewer MAJOR-2): honest agents
+ * legitimately wrap long commands in `bash -c '...'` to control quoting.
+ * tokenizeCommand returns the wrapped command as ONE quoted token, so a
+ * per-segment token walk would miss the `--dispatch` inside. Recurse into
+ * the payload by splitting + re-evaluating it.
+ */
+const EXEC_WRAPPERS = new Set(['bash', 'sh', 'zsh', 'dash', 'ksh', 'ash'])
+
+function unwrapExecPayload(tokens) {
+  let i = 0
+  // Skip env-prefix VAR=val tokens (positional shell env-prefix, e.g. `FOO=bar bash -c ...`).
+  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++
+  if (i >= tokens.length) return null
+  const exec = tokens[i]
+  // Strip leading path: /usr/bin/bash → bash.
+  const execName = exec.split('/').pop()
+  if (!EXEC_WRAPPERS.has(execName)) return null
+  // Look ahead for -c (must be the next token; intervening flags like
+  // `bash -l -c` are rare and intentionally not unwrapped — false-negative
+  // tradeoff over false-positive).
+  if (i + 1 >= tokens.length) return null
+  if (tokens[i + 1] !== '-c') return null
+  if (i + 2 >= tokens.length) return null
+  return tokens[i + 2]
 }
 
 /**
@@ -180,10 +217,45 @@ function isHarnessSegment(tokens) {
  *   - segment has `--dispatch` OR `--consensus` as a token
  *   - first `--provider` token (mirrors harness first-match parser) is NOT `stub`
  *   - tool_input.timeout (default 120000 per Claude Code Bash tool) < TIMEOUT_FLOOR_MS
+ *
+ * Recursion: if the segment is an exec-wrapper (`bash -c '<payload>'`),
+ * the payload is split + re-evaluated. Depth-limited to prevent runaway
+ * nested wrappers.
+ *
+ * Argv-semantics mirror: this function tracks the harness's
+ * `argv.indexOf('--provider')` first-match parser (scripts/second-opinion.mjs:50).
+ * Notable mirrored quirks: `--provider=codex` equals-form is NOT honored by
+ * either parser (extra.provider will be null, outcome is conservatively to
+ * block since null !== 'stub'). If the harness ever switches to honoring
+ * equals-form, this function must change in lockstep.
+ *
+ * Registry-default coupling: this function does NOT read the provider
+ * registry's `defaults.provider`. If that default ever becomes `stub`, this
+ * function will continue to block missing-provider invocations whereas the
+ * harness would dispatch to stub. Acceptable mismatch direction (over-block
+ * is safe); the inverse would be a bypass.
  */
-function evaluateSegment(segment, toolInput) {
+const MAX_UNWRAP_DEPTH = 3
+
+function evaluateSegment(segment, toolInput, depth = 0) {
   const tokens = tokenizeCommand(segment)
   if (tokens.length === 0) return { block: false }
+
+  // Exec-wrapper recursion (axis A40): if this segment is `bash -c '<payload>'`,
+  // re-split and re-evaluate the payload. Depth-limited.
+  if (depth < MAX_UNWRAP_DEPTH) {
+    const payload = unwrapExecPayload(tokens)
+    if (payload !== null) {
+      const inner = splitTopLevelSegments(payload)
+      for (const seg of inner) {
+        const r = evaluateSegment(seg, toolInput, depth + 1)
+        if (r.block) return r
+      }
+      // Wrapper not harness itself + no inner segment blocks → allow.
+      return { block: false }
+    }
+  }
+
   if (!isHarnessSegment(tokens)) return { block: false }
 
   const hasDispatch = tokens.indexOf('--dispatch') !== -1

--- a/hooks/lib/so-timeout-floor.mjs
+++ b/hooks/lib/so-timeout-floor.mjs
@@ -1,0 +1,236 @@
+/**
+ * so-timeout-floor.mjs — pure helpers enforcing a Bash-timeout floor on
+ * second-opinion harness dispatch calls.
+ *
+ * Rationale: when an agent invokes `second-opinion.mjs request --dispatch`
+ * (or `--consensus`) via the Claude Code Bash tool with the default 120000ms
+ * timeout, the outer tool SIGTERMs the codex child long before codex returns,
+ * surfacing as `provider-dispatch-nonzero` with `exitCode: null`. The harness
+ * cannot defend against this from inside its own process; the Bash tool's
+ * timeout is bound at the tool-call boundary. We enforce it at the hook layer.
+ *
+ * Trust model: honest agent. Tokenizer mirrors the harness's argv parser
+ * semantics (`argv.indexOf` first-match). Exotic shell shapes (`$(...)`,
+ * backticks, process substitution, here-docs) are documented limitations
+ * (axis A38) — not in v1 scope.
+ *
+ * Sequencing in second-opinion-gate.mjs:
+ *   isHarnessRequest() → checkTimeoutFloor() → checkRunbookGate()
+ * Timeout-floor fires BEFORE runbook gate so insufficient-timeout callers
+ * get one clear instruction instead of being routed through the runbook
+ * acknowledgment loop and then SIGTERM'd anyway.
+ */
+
+export const TIMEOUT_FLOOR_MS = 600000
+
+const TOP_LEVEL_SEPARATORS = new Set([';', '&&', '||', '|', '&'])
+
+/**
+ * tokenizeCommand — quote-respecting walk producing an argv-like token array.
+ * Mirrors the shape the harness's argv parser sees: single-quoted runs are
+ * literal; double-quoted runs honor backslash; bare runs split on whitespace.
+ * Token-level matchers (`tokens.indexOf('--dispatch')`) align with the
+ * harness's `argv.indexOf` semantics at scripts/second-opinion.mjs:50.
+ */
+export function tokenizeCommand(cmd) {
+  const tokens = []
+  let cur = ''
+  let inSingle = false
+  let inDouble = false
+  let i = 0
+  const flush = () => {
+    if (cur.length > 0) {
+      tokens.push(cur)
+      cur = ''
+    }
+  }
+  while (i < cmd.length) {
+    const c = cmd[i]
+    if (inSingle) {
+      if (c === "'") {
+        inSingle = false
+      } else {
+        cur += c
+      }
+      i++
+      continue
+    }
+    if (inDouble) {
+      if (c === '\\' && i + 1 < cmd.length) {
+        cur += cmd[i + 1]
+        i += 2
+        continue
+      }
+      if (c === '"') {
+        inDouble = false
+        i++
+        continue
+      }
+      cur += c
+      i++
+      continue
+    }
+    if (c === "'") {
+      inSingle = true
+      i++
+      continue
+    }
+    if (c === '"') {
+      inDouble = true
+      i++
+      continue
+    }
+    if (c === '\\' && i + 1 < cmd.length) {
+      cur += cmd[i + 1]
+      i += 2
+      continue
+    }
+    if (c === ' ' || c === '\t' || c === '\n') {
+      flush()
+      i++
+      continue
+    }
+    cur += c
+    i++
+  }
+  flush()
+  return tokens
+}
+
+/**
+ * splitTopLevelSegments — split command string at unquoted shell control
+ * operators (`;`, `&&`, `||`, `|`, `&`). Returns the literal substrings so
+ * each segment can be re-tokenized independently. Quoted regions are opaque
+ * (a `;` inside `"..."` does not split). Command substitution `$(...)` and
+ * backticks are NOT recognized; they fall under axis A38 (documented DEFER).
+ */
+export function splitTopLevelSegments(cmd) {
+  const segments = []
+  let start = 0
+  let inSingle = false
+  let inDouble = false
+  let i = 0
+  while (i < cmd.length) {
+    const c = cmd[i]
+    if (inSingle) {
+      if (c === "'") inSingle = false
+      i++
+      continue
+    }
+    if (inDouble) {
+      if (c === '\\' && i + 1 < cmd.length) { i += 2; continue }
+      if (c === '"') inDouble = false
+      i++
+      continue
+    }
+    if (c === "'") { inSingle = true; i++; continue }
+    if (c === '"') { inDouble = true; i++; continue }
+    if (c === '\\' && i + 1 < cmd.length) { i += 2; continue }
+    // Two-char operators first.
+    if (c === '&' && cmd[i + 1] === '&') {
+      segments.push(cmd.slice(start, i))
+      i += 2
+      start = i
+      continue
+    }
+    if (c === '|' && cmd[i + 1] === '|') {
+      segments.push(cmd.slice(start, i))
+      i += 2
+      start = i
+      continue
+    }
+    if (c === ';' || c === '|' || c === '&') {
+      segments.push(cmd.slice(start, i))
+      i += 1
+      start = i
+      continue
+    }
+    i++
+  }
+  segments.push(cmd.slice(start))
+  return segments
+}
+
+/**
+ * isHarnessSegment — token-level check: does this segment invoke
+ * `second-opinion.mjs request`? Stricter than the substring-level
+ * `isHarnessRequest` in the gate (which intentionally catches more shapes
+ * to keep the runbook gate broad). For timeout-floor we only enforce on
+ * tokens we can actually parse — anything else falls through to runbook
+ * gate handling.
+ */
+function isHarnessSegment(tokens) {
+  let sawScript = false
+  let sawRequest = false
+  for (const t of tokens) {
+    if (/second-opinion\.mjs$/.test(t) || t === 'second-opinion.mjs') {
+      sawScript = true
+    }
+    if (sawScript && t === 'request') {
+      sawRequest = true
+      break
+    }
+  }
+  return sawScript && sawRequest
+}
+
+/**
+ * evaluateSegment — per-segment decision. Block if and only if:
+ *   - segment is a harness `request` invocation
+ *   - segment has `--dispatch` OR `--consensus` as a token
+ *   - first `--provider` token (mirrors harness first-match parser) is NOT `stub`
+ *   - tool_input.timeout (default 120000 per Claude Code Bash tool) < TIMEOUT_FLOOR_MS
+ */
+function evaluateSegment(segment, toolInput) {
+  const tokens = tokenizeCommand(segment)
+  if (tokens.length === 0) return { block: false }
+  if (!isHarnessSegment(tokens)) return { block: false }
+
+  const hasDispatch = tokens.indexOf('--dispatch') !== -1
+  const hasConsensus = tokens.indexOf('--consensus') !== -1
+  if (!hasDispatch && !hasConsensus) return { block: false }
+
+  const provIdx = tokens.indexOf('--provider')
+  const firstProvider = (provIdx !== -1 && provIdx + 1 < tokens.length)
+    ? tokens[provIdx + 1]
+    : null
+  // Stub carve-out: stub provider returns instantly; no SIGTERM risk.
+  if (firstProvider === 'stub') return { block: false }
+
+  const t = typeof toolInput?.timeout === 'number' ? toolInput.timeout : 120000
+  if (t >= TIMEOUT_FLOOR_MS) return { block: false }
+
+  return {
+    block: true,
+    reason:
+      `second-opinion harness dispatch needs Bash timeout >= ${TIMEOUT_FLOOR_MS}ms ` +
+      `(got ${t}ms). Default Claude Code Bash timeout is 120000ms; codex/gemini ` +
+      `provider dispatch routinely exceeds this and the outer Bash SIGTERM ` +
+      `surfaces as provider-dispatch-nonzero with exitCode:null. ` +
+      `Retry with tool_input.timeout = ${TIMEOUT_FLOOR_MS}.`,
+    extra: {
+      code: 'so-timeout-below-floor',
+      floorMs: TIMEOUT_FLOOR_MS,
+      gotMs: t,
+      provider: firstProvider,
+    },
+  }
+}
+
+/**
+ * checkTimeoutFloor — main entry. Walks every top-level segment; first
+ * segment that warrants a block wins. Used by second-opinion-gate.mjs
+ * inside the isHarnessRequest() branch (before checkRunbookGate).
+ *
+ * Returns { block: false } OR { block: true, reason, extra }.
+ */
+export function checkTimeoutFloor(toolInput) {
+  const cmd = typeof toolInput?.command === 'string' ? toolInput.command : ''
+  if (cmd.length === 0) return { block: false }
+  const segments = splitTopLevelSegments(cmd)
+  for (const seg of segments) {
+    const r = evaluateSegment(seg, toolInput)
+    if (r.block) return r
+  }
+  return { block: false }
+}

--- a/hooks/second-opinion-gate.mjs
+++ b/hooks/second-opinion-gate.mjs
@@ -339,10 +339,27 @@ async function main() {
   const toolInput = input.tool_input || {}
   const cwd = input.cwd || process.cwd()
 
-  // ─── Runbook gate fires BEFORE validator/snapshot work. ───────────────
+  // ─── Timeout-floor + runbook gate fire BEFORE validator/snapshot work. ─
   // Codex r2 P1: validator import failure / snapshot errors MUST NOT
   // preempt the runbook block on harness invocations.
+  // Timeout-floor fires FIRST so insufficient-timeout callers get one
+  // clear retry instruction instead of being routed through runbook ack
+  // and then SIGTERM'd anyway.
   if (toolName === 'Bash' && isHarnessRequest(toolInput.command || '')) {
+    let checkTimeoutFloor
+    try {
+      const mod = await import(new URL('./lib/so-timeout-floor.mjs', import.meta.url).href)
+      checkTimeoutFloor = mod.checkTimeoutFloor
+    } catch (e) {
+      emitBlock(
+        `second-opinion-gate: cannot load timeout-floor at ./lib/so-timeout-floor.mjs ` +
+        `(detail: ${e.message}). Run: node install.mjs --tool claude-code --install-second-opinion ` +
+        `to reinstall the colocated timeout-floor lib.`,
+        { code: 'so-timeout-floor-load-failed', detail: e.message }
+      )
+    }
+    const decision = checkTimeoutFloor(toolInput)
+    if (decision.block) emitBlock(decision.reason, decision.extra)
     await checkRunbookGate(input)
     return
   }

--- a/hooks/second-opinion-gate.mjs
+++ b/hooks/second-opinion-gate.mjs
@@ -351,12 +351,16 @@ async function main() {
       const mod = await import(new URL('./lib/so-timeout-floor.mjs', import.meta.url).href)
       checkTimeoutFloor = mod.checkTimeoutFloor
     } catch (e) {
+      // emitBlock exits process; defensive return keeps next-reader from
+      // assuming checkTimeoutFloor is defined below if emitBlock ever
+      // changes to non-fatal (negative-scenario-reviewer NIT-1).
       emitBlock(
         `second-opinion-gate: cannot load timeout-floor at ./lib/so-timeout-floor.mjs ` +
         `(detail: ${e.message}). Run: node install.mjs --tool claude-code --install-second-opinion ` +
         `to reinstall the colocated timeout-floor lib.`,
         { code: 'so-timeout-floor-load-failed', detail: e.message }
       )
+      return
     }
     const decision = checkTimeoutFloor(toolInput)
     if (decision.block) emitBlock(decision.reason, decision.extra)

--- a/install.mjs
+++ b/install.mjs
@@ -1367,16 +1367,18 @@ if (installSecondOpinion) {
   // partial install. Quickref derivation is the most failure-prone step
   // (section sentinel must be present + size-bounded); run it first so
   // we fail fast before any copy is attempted.
-  const repoGateSrc       = path.join(REPO_HOOKS, 'second-opinion-gate.mjs')
-  const repoValidatorSrc  = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
-  const repoLocalDirSrc   = path.join(REPO_DIR, 'scripts', 'lib', 'local-dir.mjs')
-  const repoRunbookSrc    = path.join(REPO_HOOKS, 'runbooks', 'second-opinion-harness.md')
+  const repoGateSrc         = path.join(REPO_HOOKS, 'second-opinion-gate.mjs')
+  const repoValidatorSrc    = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
+  const repoLocalDirSrc     = path.join(REPO_DIR, 'scripts', 'lib', 'local-dir.mjs')
+  const repoTimeoutFloorSrc = path.join(REPO_HOOKS, 'lib', 'so-timeout-floor.mjs')
+  const repoRunbookSrc      = path.join(REPO_HOOKS, 'runbooks', 'second-opinion-harness.md')
 
-  const userGateDst       = path.join(userHooksDir, 'second-opinion-gate.mjs')
-  const userValidatorDst  = path.join(userHooksLibDir, 'registry-validator.mjs')
-  const userLocalDirDst   = path.join(userHooksLibDir, 'local-dir.mjs')
-  const userRunbookDst    = path.join(userRunbooksDir, 'second-opinion-harness.md')
-  const userQuickrefDst   = path.join(userRunbooksDir, 'second-opinion-harness.quickref.md')
+  const userGateDst         = path.join(userHooksDir, 'second-opinion-gate.mjs')
+  const userValidatorDst    = path.join(userHooksLibDir, 'registry-validator.mjs')
+  const userLocalDirDst     = path.join(userHooksLibDir, 'local-dir.mjs')
+  const userTimeoutFloorDst = path.join(userHooksLibDir, 'so-timeout-floor.mjs')
+  const userRunbookDst      = path.join(userRunbooksDir, 'second-opinion-harness.md')
+  const userQuickrefDst     = path.join(userRunbooksDir, 'second-opinion-harness.quickref.md')
 
   // deriveQuickref: extract the "Self-trigger checklist" section from the
   // full runbook. Fail-closed if the section is missing or out of range.
@@ -1415,7 +1417,7 @@ if (installSecondOpinion) {
 
   // Pre-flight all source existence checks.
   const preflightMissing = []
-  for (const src of [repoGateSrc, repoValidatorSrc, repoLocalDirSrc, repoRunbookSrc]) {
+  for (const src of [repoGateSrc, repoValidatorSrc, repoLocalDirSrc, repoTimeoutFloorSrc, repoRunbookSrc]) {
     if (!fs.existsSync(src)) preflightMissing.push(src)
   }
   if (preflightMissing.length > 0) {
@@ -1534,6 +1536,7 @@ if (installSecondOpinion) {
   safeCopy('second-opinion gate hook', repoGateSrc, userGateDst, 0o755)
   safeCopy('second-opinion validator lib', repoValidatorSrc, userValidatorDst)
   safeCopy('second-opinion local-dir lib', repoLocalDirSrc, userLocalDirDst)
+  safeCopy('second-opinion timeout-floor lib', repoTimeoutFloorSrc, userTimeoutFloorDst)
   safeCopy('runbook', repoRunbookSrc, userRunbookDst)
   if (!installFailed && derivedQuickref) {
     safeWrite(`quickref (${derivedQuickref.length} chars)`, userQuickrefDst, derivedQuickref)

--- a/tests/test-second-opinion-gate-runbook.mjs
+++ b/tests/test-second-opinion-gate-runbook.mjs
@@ -38,6 +38,11 @@ import { execFileSync, spawnSync } from 'node:child_process'
 const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 const HOOK = path.join(REPO_ROOT, 'hooks', 'second-opinion-gate.mjs')
 const RUNBOOK_SRC = path.join(REPO_ROOT, 'hooks', 'runbooks', 'second-opinion-harness.md')
+// Orphan-install fixtures below copy HOOK alone; the gate's harness branch
+// now also dynamic-imports lib/so-timeout-floor.mjs, so fixtures must
+// colocate it or they fail-closed with so-timeout-floor-load-failed before
+// the local-dir layer this suite is testing.
+const TIMEOUT_FLOOR_SRC = path.join(REPO_ROOT, 'hooks', 'lib', 'so-timeout-floor.mjs')
 
 let passed = 0
 let failed = 0
@@ -89,7 +94,15 @@ function computeSha8(content) {
 }
 
 function runHook({ toolName, toolInput, cwd, env = {} }) {
-  const input = JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd })
+  // Default timeout to TIMEOUT_FLOOR_MS for Bash so the timeout-floor layer
+  // doesn't preempt the runbook-layer behavior under test here. Tests that
+  // specifically exercise timeout-floor behavior live in
+  // test-so-gate-timeout-floor-integration.mjs.
+  const filled =
+    toolName === 'Bash' && toolInput && typeof toolInput.timeout === 'undefined'
+      ? { ...toolInput, timeout: 600000 }
+      : toolInput
+  const input = JSON.stringify({ tool_name: toolName, tool_input: filled, cwd })
   const result = spawnSync('node', [HOOK], {
     input,
     encoding: 'utf8',
@@ -416,6 +429,7 @@ test('malformed local-dir.mjs → block runbook-canonicalize-failed (not silent 
   fs.mkdirSync(orphanLib, { recursive: true })
   // Copy the hook so its import.meta.url resolves to <orphan>/.claude/hooks/...
   fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  fs.copyFileSync(TIMEOUT_FLOOR_SRC, path.join(orphanLib, 'so-timeout-floor.mjs'))
   // Write a syntactically broken local-dir.mjs
   fs.writeFileSync(path.join(orphanLib, 'local-dir.mjs'), 'export function resolveRepoRoot( {{{ INVALID')
 
@@ -451,6 +465,7 @@ test('transitive ERR_MODULE_NOT_FOUND in local-dir.mjs → block (PR-level P1-1)
   const orphanLib = path.join(orphanHooks, 'lib')
   fs.mkdirSync(orphanLib, { recursive: true })
   fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  fs.copyFileSync(TIMEOUT_FLOOR_SRC, path.join(orphanLib, 'so-timeout-floor.mjs'))
   // local-dir.mjs exists but imports a missing transitive dep
   fs.writeFileSync(path.join(orphanLib, 'local-dir.mjs'),
     "import './nonexistent-dep.mjs'\nexport function resolveRepoRoot(cwd) { return cwd }\n")
@@ -485,8 +500,10 @@ test('missing local-dir.mjs → cwd fallback (silent, plan v4.1 accepted)', () =
   const orphan = fs.mkdtempSync(path.join(os.tmpdir(), 'so-missing-lib-'))
   tmpDirs.push(orphan)
   const orphanHooks = path.join(orphan, '.claude', 'hooks')
-  fs.mkdirSync(orphanHooks, { recursive: true })
+  const orphanLib = path.join(orphanHooks, 'lib')
+  fs.mkdirSync(orphanLib, { recursive: true })
   fs.copyFileSync(HOOK, path.join(orphanHooks, 'second-opinion-gate.mjs'))
+  fs.copyFileSync(TIMEOUT_FLOOR_SRC, path.join(orphanLib, 'so-timeout-floor.mjs'))
   // Deliberately do NOT create lib/local-dir.mjs
 
   const r = spawnSync('node', [path.join(orphanHooks, 'second-opinion-gate.mjs')], {

--- a/tests/test-so-gate-timeout-floor-integration.mjs
+++ b/tests/test-so-gate-timeout-floor-integration.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * test-so-gate-timeout-floor-integration.mjs — black-box integration tests
+ * against the installed-gate runtime tree.
+ *
+ * Each test sets up a tempHome with a copy of hooks/second-opinion-gate.mjs
+ * (and selectively hooks/lib/so-timeout-floor.mjs) so it exercises the
+ * dynamic-import path from import.meta.url that the production hook actually
+ * uses. This mirrors plan-v5 R3/P2.2 + R4/P1.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import crypto from 'node:crypto'
+import { execFileSync, spawnSync } from 'node:child_process'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const REPO_GATE = path.join(REPO_ROOT, 'hooks', 'second-opinion-gate.mjs')
+const REPO_LIB_DIR = path.join(REPO_ROOT, 'hooks', 'lib')
+const REPO_TIMEOUT_FLOOR = path.join(REPO_LIB_DIR, 'so-timeout-floor.mjs')
+const REPO_LOCAL_DIR = path.join(REPO_ROOT, 'scripts', 'lib', 'local-dir.mjs')
+const REPO_VALIDATOR = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'lib', 'registry-validator.mjs')
+
+const tmpDirs = []
+process.on('exit', () => {
+  for (const d of tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    console.log(`  ✗ ${name}: ${e.message}`)
+    if (process.env.DEBUG) console.error(e.stack)
+  }
+}
+
+function makeTmpProject() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'so-tf-proj-'))
+  tmpDirs.push(tmp)
+  execFileSync('git', ['init', '-q', tmp], { stdio: ['ignore', 'pipe', 'ignore'] })
+  fs.mkdirSync(path.join(tmp, '.checkpoints'), { recursive: true })
+  return tmp
+}
+
+function makeTmpHome() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'so-tf-home-'))
+  tmpDirs.push(tmp)
+  fs.mkdirSync(path.join(tmp, 'hooks', 'lib'), { recursive: true })
+  fs.mkdirSync(path.join(tmp, 'hooks', 'runbooks'), { recursive: true })
+  return tmp
+}
+
+function validRunbookContent() {
+  return [
+    '# Test runbook',
+    '',
+    '## ⚠️ Self-trigger checklist — fixture',
+    '',
+    'Padding: ' + 'x'.repeat(300),
+    '',
+    '## Other section',
+    'lorem',
+  ].join('\n')
+}
+
+function validQuickrefContent() {
+  return '## Self-trigger checklist (quickref fixture)\n' + 'x'.repeat(80)
+}
+
+function computeSha8(content) {
+  return crypto.createHash('sha256').update(content).digest('hex').slice(0, 8)
+}
+
+/**
+ * setupGateInstall — copy gate + selected libs to a tempHome and write
+ * runbook + quickref. Returns paths the caller needs.
+ *
+ * opts:
+ *   includeLib: copy hooks/lib/so-timeout-floor.mjs (default true)
+ *   includeLocalDir: copy hooks/lib/local-dir.mjs (default true)
+ *   includeValidator: copy hooks/lib/registry-validator.mjs (default true)
+ *   runbookContent: full runbook body (default validRunbookContent())
+ *   quickrefContent: quickref body (default validQuickrefContent())
+ */
+function setupGateInstall(opts = {}) {
+  const {
+    includeLib = true,
+    includeLocalDir = true,
+    includeValidator = true,
+    runbookContent = validRunbookContent(),
+    quickrefContent = validQuickrefContent(),
+  } = opts
+  const home = makeTmpHome()
+  const hooksDir = path.join(home, 'hooks')
+  const libDir = path.join(hooksDir, 'lib')
+  const runbooksDir = path.join(hooksDir, 'runbooks')
+
+  const gateDst = path.join(hooksDir, 'second-opinion-gate.mjs')
+  fs.copyFileSync(REPO_GATE, gateDst)
+
+  if (includeLib) {
+    fs.copyFileSync(REPO_TIMEOUT_FLOOR, path.join(libDir, 'so-timeout-floor.mjs'))
+  }
+  if (includeLocalDir) {
+    fs.copyFileSync(REPO_LOCAL_DIR, path.join(libDir, 'local-dir.mjs'))
+  }
+  if (includeValidator) {
+    fs.copyFileSync(REPO_VALIDATOR, path.join(libDir, 'registry-validator.mjs'))
+  }
+
+  const runbookPath = path.join(runbooksDir, 'second-opinion-harness.md')
+  const quickrefPath = path.join(runbooksDir, 'second-opinion-harness.quickref.md')
+  fs.writeFileSync(runbookPath, runbookContent)
+  fs.writeFileSync(quickrefPath, quickrefContent)
+
+  return {
+    home,
+    gateDst,
+    runbookPath,
+    quickrefPath,
+    sha8: computeSha8(runbookContent),
+  }
+}
+
+function armRunbookMarker(projectRoot, sha8) {
+  const markerPath = path.join(projectRoot, '.checkpoints', `.so-runbook-shown.${sha8}`)
+  fs.writeFileSync(markerPath, '')
+  return markerPath
+}
+
+function runHook({ gateDst, toolName = 'Bash', toolInput, cwd, env = {} }) {
+  const input = JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd })
+  const result = spawnSync('node', [gateDst], {
+    input,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+    timeout: 10000,
+  })
+  if (result.status !== 0) {
+    throw new Error(`Hook exited non-zero (${result.status}); stderr: ${result.stderr}`)
+  }
+  const stdout = result.stdout.trim()
+  if (!stdout) return { allow: true }
+  return { allow: false, decision: JSON.parse(stdout) }
+}
+
+// ---------------------------------------------------------------------------
+// Test cases (plan v5 §File 6)
+// ---------------------------------------------------------------------------
+
+console.log('# Timeout-floor integration')
+
+test('happy path: timeout 600000 + runbook marker armed → allow', () => {
+  const project = makeTmpProject()
+  const setup = setupGateInstall()
+  armRunbookMarker(project, setup.sha8)
+  const r = runHook({
+    gateDst: setup.gateDst,
+    toolInput: {
+      command: 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x',
+      timeout: 600000,
+    },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: setup.runbookPath,
+      SO_QUICKREF_PATH: setup.quickrefPath,
+    },
+  })
+  assert.strictEqual(r.allow, true, `expected allow, got ${JSON.stringify(r.decision)}`)
+})
+
+test('below-floor block: timeout 120000 → so-timeout-below-floor', () => {
+  const project = makeTmpProject()
+  const setup = setupGateInstall()
+  armRunbookMarker(project, setup.sha8)
+  const r = runHook({
+    gateDst: setup.gateDst,
+    toolInput: {
+      command: 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x',
+      timeout: 120000,
+    },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: setup.runbookPath,
+      SO_QUICKREF_PATH: setup.quickrefPath,
+    },
+  })
+  assert.strictEqual(r.allow, false, 'expected block')
+  assert.strictEqual(r.decision.decision, 'block')
+  assert.strictEqual(r.decision.code, 'so-timeout-below-floor')
+  assert.strictEqual(r.decision.gotMs, 120000)
+  assert.strictEqual(r.decision.floorMs, 600000)
+})
+
+test('consensus below-floor: --consensus + timeout 120000 → block', () => {
+  const project = makeTmpProject()
+  const setup = setupGateInstall()
+  armRunbookMarker(project, setup.sha8)
+  const r = runHook({
+    gateDst: setup.gateDst,
+    toolInput: {
+      command: 'node scripts/second-opinion.mjs request --provider codex --consensus --body x',
+      timeout: 120000,
+    },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: setup.runbookPath,
+      SO_QUICKREF_PATH: setup.quickrefPath,
+    },
+  })
+  assert.strictEqual(r.allow, false)
+  assert.strictEqual(r.decision.code, 'so-timeout-below-floor')
+})
+
+test('compound bypass: stub ; codex --dispatch → block (R3/P1.1 fix)', () => {
+  const project = makeTmpProject()
+  const setup = setupGateInstall()
+  armRunbookMarker(project, setup.sha8)
+  const r = runHook({
+    gateDst: setup.gateDst,
+    toolInput: {
+      command:
+        'node scripts/second-opinion.mjs request --provider stub --body x ; ' +
+        'node scripts/second-opinion.mjs request --provider codex --dispatch --body y',
+      timeout: 120000,
+    },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: setup.runbookPath,
+      SO_QUICKREF_PATH: setup.quickrefPath,
+    },
+  })
+  assert.strictEqual(r.allow, false, `expected block, got ${JSON.stringify(r.decision)}`)
+  assert.strictEqual(r.decision.code, 'so-timeout-below-floor')
+})
+
+test('fail-closed: missing lib/so-timeout-floor.mjs → so-timeout-floor-load-failed', () => {
+  const project = makeTmpProject()
+  const setup = setupGateInstall({ includeLib: false })
+  const r = runHook({
+    gateDst: setup.gateDst,
+    toolInput: {
+      command: 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x',
+      timeout: 600000,
+    },
+    cwd: project,
+    env: {
+      SO_RUNBOOK_PATH: setup.runbookPath,
+      SO_QUICKREF_PATH: setup.quickrefPath,
+    },
+  })
+  assert.strictEqual(r.allow, false, `expected block, got ${JSON.stringify(r.decision)}`)
+  assert.strictEqual(r.decision.code, 'so-timeout-floor-load-failed')
+  // Critical R4/P2 ordering check: this must fire BEFORE runbook validation.
+  // Marker was NOT armed; if runbook gate ran first we'd get
+  // runbook-injection-required instead.
+})
+
+console.log(`\n${passed} pass, ${failed} fail`)
+if (failed > 0) process.exit(1)

--- a/tests/test-so-gate-timeout-floor.mjs
+++ b/tests/test-so-gate-timeout-floor.mjs
@@ -328,6 +328,82 @@ assertBlock('A36: consensus with --max-rounds blocks below floor',
 assertAllow('A37: stub --consensus allowed',
   { command: 'node scripts/second-opinion.mjs request --provider stub --consensus --max-rounds 3 --body x', timeout: 100 })
 
+// A39: newline as top-level separator (negative-scenario-reviewer MAJOR-1)
+// Honest agents legitimately write multi-line tool_input.command. Bash treats
+// literal \n as a command separator. Splitter must split on \n so the codex
+// segment is evaluated independently of an earlier stub segment.
+assertBlock('A39: newline separator — codex segment after stub blocks',
+  { command:
+      'node scripts/second-opinion.mjs request --provider stub --body x\n' +
+      'node scripts/second-opinion.mjs request --provider codex --dispatch --body y',
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+// A39b: CRLF / \r\n separator (Windows-style or pasted-from-doc)
+assertBlock('A39b: CRLF separator — codex segment after stub blocks',
+  { command:
+      'node scripts/second-opinion.mjs request --provider stub --body x\r\n' +
+      'node scripts/second-opinion.mjs request --provider codex --dispatch --body y',
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+// A40: bash -c / sh -c exec-wrapper (negative-scenario-reviewer MAJOR-2)
+// Honest agents legitimately use bash -c '<payload>' to control quoting.
+// The harness invocation lives inside the -c argument as a single token;
+// must recurse into the -c value to detect dispatch.
+assertBlock('A40: bash -c wrapping codex dispatch blocks',
+  { command: "bash -c 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x'",
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+assertBlock('A40b: sh -c wrapping codex dispatch blocks',
+  { command: "sh -c 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x'",
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+assertBlock('A40c: zsh -c wrapping codex dispatch blocks',
+  { command: 'zsh -c "node scripts/second-opinion.mjs request --provider codex --dispatch --body x"',
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+// A40d: bash -c wrapping stub is still allowed (carve-out preserved through recursion)
+assertAllow('A40d: bash -c wrapping stub dispatch allowed',
+  { command: "bash -c 'node scripts/second-opinion.mjs request --provider stub --dispatch --body x'",
+    timeout: 100,
+  })
+
+// A40e: env VAR=x bash -c '<payload>' (env-prefix before exec wrapper)
+assertBlock('A40e: env VAR=x bash -c wrapping codex dispatch blocks',
+  { command: "FOO=bar bash -c 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x'",
+    timeout: 120000,
+  },
+  'so-timeout-below-floor')
+
+// A41: --provider=codex equals-form (negative-scenario-reviewer MINOR-1)
+// Tokenizer doesn't split equals-form; tokens.indexOf('--provider') = -1 →
+// firstProvider=null → not 'stub' → conservatively blocks. Outcome is safe;
+// extra.provider will be null (documented limitation).
+{
+  const r = checkTimeoutFloor({
+    command: 'node scripts/second-opinion.mjs request --provider=codex --dispatch --body x',
+    timeout: 100,
+  })
+  if (!r.block) {
+    failures++
+    console.error(`FAIL A41 expected block (equals-form), got ${JSON.stringify(r)}`)
+  } else if (r.extra?.provider !== null) {
+    failures++
+    console.error(`FAIL A41 expected extra.provider=null (documented limitation), got ${r.extra?.provider}`)
+  } else {
+    passes++
+  }
+}
+
 // A38: DEFER — quoted command substitution hides --dispatch token (documented limitation)
 {
   // The whole "$(...)" is one quoted token; --dispatch is not a top-level token.

--- a/tests/test-so-gate-timeout-floor.mjs
+++ b/tests/test-so-gate-timeout-floor.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+/**
+ * test-so-gate-timeout-floor.mjs — unit tests for so-timeout-floor.mjs.
+ *
+ * Tests the pure helpers (tokenizeCommand, splitTopLevelSegments,
+ * checkTimeoutFloor) over the negative-scenario matrix A1-A38 from
+ * plan v5. Integration with the installed hook lives in
+ * test-so-gate-timeout-floor-integration.mjs.
+ */
+
+import {
+  TIMEOUT_FLOOR_MS,
+  tokenizeCommand,
+  splitTopLevelSegments,
+  checkTimeoutFloor,
+} from '../hooks/lib/so-timeout-floor.mjs'
+
+let passes = 0
+let failures = 0
+
+function assertEq(label, actual, expected) {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a === e) {
+    passes++
+  } else {
+    failures++
+    console.error(`FAIL ${label}\n  expected: ${e}\n  actual:   ${a}`)
+  }
+}
+
+function assertBlock(label, toolInput, expectedCode) {
+  const r = checkTimeoutFloor(toolInput)
+  if (!r.block) {
+    failures++
+    console.error(`FAIL ${label}\n  expected block (code=${expectedCode})\n  got: ${JSON.stringify(r)}`)
+    return
+  }
+  if (r.extra?.code !== expectedCode) {
+    failures++
+    console.error(`FAIL ${label}\n  expected code=${expectedCode}\n  got code=${r.extra?.code}`)
+    return
+  }
+  passes++
+}
+
+function assertAllow(label, toolInput) {
+  const r = checkTimeoutFloor(toolInput)
+  if (r.block) {
+    failures++
+    console.error(`FAIL ${label}\n  expected allow\n  got block: ${JSON.stringify(r)}`)
+    return
+  }
+  passes++
+}
+
+// ───────── tokenizeCommand ─────────
+
+assertEq('tokenize: empty',
+  tokenizeCommand(''),
+  [])
+
+assertEq('tokenize: bare flags',
+  tokenizeCommand('node scripts/second-opinion.mjs request --provider codex --dispatch'),
+  ['node', 'scripts/second-opinion.mjs', 'request', '--provider', 'codex', '--dispatch'])
+
+assertEq('tokenize: single-quoted body preserved',
+  tokenizeCommand("node x --body 'hello world' --dispatch"),
+  ['node', 'x', '--body', 'hello world', '--dispatch'])
+
+assertEq('tokenize: double-quoted body preserved',
+  tokenizeCommand('node x --body "hello world" --dispatch'),
+  ['node', 'x', '--body', 'hello world', '--dispatch'])
+
+assertEq('tokenize: backslash escape outside quotes',
+  tokenizeCommand('node x --body hello\\ world --dispatch'),
+  ['node', 'x', '--body', 'hello world', '--dispatch'])
+
+assertEq('tokenize: double-quote with backslash escape',
+  tokenizeCommand('node x --body "hello \\"quoted\\" world"'),
+  ['node', 'x', '--body', 'hello "quoted" world'])
+
+assertEq('tokenize: tabs and newlines as separators',
+  tokenizeCommand('node\tx\n--dispatch'),
+  ['node', 'x', '--dispatch'])
+
+assertEq('tokenize: multiple consecutive whitespace',
+  tokenizeCommand('node    x   --dispatch'),
+  ['node', 'x', '--dispatch'])
+
+// ───────── splitTopLevelSegments ─────────
+
+assertEq('split: no separator',
+  splitTopLevelSegments('node x --dispatch'),
+  ['node x --dispatch'])
+
+assertEq('split: semicolon',
+  splitTopLevelSegments('a ; b'),
+  ['a ', ' b'])
+
+assertEq('split: &&',
+  splitTopLevelSegments('a && b'),
+  ['a ', ' b'])
+
+assertEq('split: ||',
+  splitTopLevelSegments('a || b'),
+  ['a ', ' b'])
+
+assertEq('split: pipe',
+  splitTopLevelSegments('a | b'),
+  ['a ', ' b'])
+
+assertEq('split: background &',
+  splitTopLevelSegments('a & b'),
+  ['a ', ' b'])
+
+assertEq('split: separator inside double-quotes is opaque',
+  splitTopLevelSegments('a "x;y&&z" b'),
+  ['a "x;y&&z" b'])
+
+assertEq('split: separator inside single-quotes is opaque',
+  splitTopLevelSegments("a 'x;y&&z' b"),
+  ["a 'x;y&&z' b"])
+
+assertEq('split: backslash-escaped semicolon',
+  splitTopLevelSegments('a \\; b'),
+  ['a \\; b'])
+
+// ───────── checkTimeoutFloor ─────────
+
+const harnessCmd = 'node scripts/second-opinion.mjs request --provider codex --dispatch --body x'
+const harnessConsensus = 'node scripts/second-opinion.mjs request --provider codex --consensus --max-rounds 3 --body x'
+
+// A1: happy path — sufficient timeout
+assertAllow('A1: timeout >= floor allows',
+  { command: harnessCmd, timeout: 600000 })
+
+// A2: above floor
+assertAllow('A2: timeout > floor allows',
+  { command: harnessCmd, timeout: 900000 })
+
+// A3: default Bash timeout blocks
+assertBlock('A3: default 120000 timeout blocks',
+  { command: harnessCmd, timeout: 120000 },
+  'so-timeout-below-floor')
+
+// A4: missing timeout field treated as 120000
+assertBlock('A4: missing timeout treated as default',
+  { command: harnessCmd },
+  'so-timeout-below-floor')
+
+// A5: timeout = 1
+assertBlock('A5: very small timeout blocks',
+  { command: harnessCmd, timeout: 1 },
+  'so-timeout-below-floor')
+
+// A6: timeout exactly at floor
+assertAllow('A6: timeout exactly == floor allows',
+  { command: harnessCmd, timeout: TIMEOUT_FLOOR_MS })
+
+// A7: non-harness command — pure passthrough
+assertAllow('A7: non-harness Bash unaffected',
+  { command: 'ls -la', timeout: 100 })
+
+// A8: harness but no --dispatch / --consensus
+assertAllow('A8: harness without --dispatch allowed',
+  { command: 'node scripts/second-opinion.mjs request --provider codex --body x', timeout: 100 })
+
+// A9: stub carve-out
+assertAllow('A9: stub provider exempt',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --dispatch --body x', timeout: 100 })
+
+// A10: stub + consensus carve-out
+assertAllow('A10: stub provider exempt under consensus',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --consensus --body x', timeout: 100 })
+
+// A11: gemini provider blocked below floor
+assertBlock('A11: gemini provider blocked below floor',
+  { command: 'node scripts/second-opinion.mjs request --provider gemini --dispatch --body x', timeout: 120000 },
+  'so-timeout-below-floor')
+
+// A12: claude-subagent provider blocked below floor
+assertBlock('A12: claude-subagent provider blocked below floor',
+  { command: 'node scripts/second-opinion.mjs request --provider claude-subagent --dispatch --body x', timeout: 120000 },
+  'so-timeout-below-floor')
+
+// A13: consensus mode (implicit --dispatch)
+assertBlock('A13: --consensus below floor blocks',
+  { command: harnessConsensus, timeout: 120000 },
+  'so-timeout-below-floor')
+
+// A14: consensus mode at floor
+assertAllow('A14: --consensus at floor allows',
+  { command: harnessConsensus, timeout: TIMEOUT_FLOOR_MS })
+
+// A15: first --provider wins (stub-then-codex bypass attempt within one argv)
+assertAllow('A15: first --provider stub wins across duplicate (one argv)',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --provider codex --dispatch --body x', timeout: 100 })
+// Mirrors harness's argv.indexOf semantics — this is intentional and documented.
+
+// A16: codex first, stub second — codex wins
+assertBlock('A16: first --provider codex wins across duplicate (one argv)',
+  { command: 'node scripts/second-opinion.mjs request --provider codex --provider stub --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A17: compound bypass — stub segment then codex segment with ;
+assertBlock('A17: compound ; — codex segment caught',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --body x ; node scripts/second-opinion.mjs request --provider codex --dispatch --body y', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A18: compound &&
+assertBlock('A18: compound && — codex segment caught',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --body x && node scripts/second-opinion.mjs request --provider codex --dispatch --body y', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A19: compound ||
+assertBlock('A19: compound || — codex segment caught',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --body x || node scripts/second-opinion.mjs request --provider codex --dispatch --body y', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A20: pipe
+assertBlock('A20: pipe — codex segment caught',
+  { command: 'echo y | node scripts/second-opinion.mjs request --provider codex --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A21: background &
+assertBlock('A21: background & — codex segment caught',
+  { command: 'sleep 1 & node scripts/second-opinion.mjs request --provider codex --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A22: command empty
+assertAllow('A22: empty command allowed',
+  { command: '', timeout: 100 })
+
+// A23: command undefined / non-string
+assertAllow('A23: non-string command allowed',
+  { command: null, timeout: 100 })
+
+// A24: timeout non-numeric → defaults
+assertBlock('A24: non-numeric timeout treated as default (120000)',
+  { command: harnessCmd, timeout: 'fast' },
+  'so-timeout-below-floor')
+
+// A25: extra block fields surfaced
+{
+  const r = checkTimeoutFloor({ command: harnessCmd, timeout: 100 })
+  assertEq('A25: extra has code', r.extra?.code, 'so-timeout-below-floor')
+  assertEq('A25: extra has floorMs', r.extra?.floorMs, TIMEOUT_FLOOR_MS)
+  assertEq('A25: extra has gotMs', r.extra?.gotMs, 100)
+  assertEq('A25: extra has provider', r.extra?.provider, 'codex')
+}
+
+// A26: --provider with malformed value (next token is itself a flag) — not 'stub' → block
+{
+  const r = checkTimeoutFloor({ command: 'node scripts/second-opinion.mjs request --provider --dispatch', timeout: 100 })
+  // tokens after --provider is '--dispatch' which is treated as the provider value (not 'stub') → block
+  if (!r.block) {
+    failures++
+    console.error(`FAIL A26 expected block, got ${JSON.stringify(r)}`)
+  } else {
+    passes++
+  }
+}
+
+// A27: --provider at end (no value)
+{
+  const r = checkTimeoutFloor({ command: 'node scripts/second-opinion.mjs request --dispatch --provider', timeout: 100 })
+  // provIdx + 1 >= tokens.length → firstProvider = null → not stub → block
+  if (!r.block) {
+    failures++
+    console.error(`FAIL A27 expected block, got ${JSON.stringify(r)}`)
+  } else {
+    passes++
+  }
+}
+
+// A28: --dispatch present but no --provider at all → firstProvider null → block (default codex assumption)
+{
+  const r = checkTimeoutFloor({ command: 'node scripts/second-opinion.mjs request --dispatch --body x', timeout: 100 })
+  if (!r.block) {
+    failures++
+    console.error(`FAIL A28 expected block (no provider = not stub), got ${JSON.stringify(r)}`)
+  } else {
+    passes++
+  }
+}
+
+// A29: env-prefix before node
+assertBlock('A29: env-prefix VAR=x node ... blocks',
+  { command: 'FOO=bar node scripts/second-opinion.mjs request --provider codex --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A30: absolute path to second-opinion.mjs
+assertBlock('A30: absolute-path harness invocation blocks',
+  { command: '/Users/x/scripts/second-opinion.mjs request --provider codex --dispatch --body y', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A31: single-quoted --body containing a separator
+assertBlock('A31: single-quoted body with ; inside is opaque',
+  { command: "node scripts/second-opinion.mjs request --provider codex --dispatch --body 'review; this'", timeout: 100 },
+  'so-timeout-below-floor')
+
+// A32: double-quoted --body containing a separator
+assertBlock('A32: double-quoted body with && inside is opaque',
+  { command: 'node scripts/second-opinion.mjs request --provider codex --dispatch --body "review && this"', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A33: harness as one segment, stub provider, second segment unrelated
+assertAllow('A33: harness stub then unrelated command allowed',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --dispatch --body x ; ls', timeout: 100 })
+
+// A34: harness as second segment after unrelated first
+assertBlock('A34: unrelated first then harness codex dispatch second blocks',
+  { command: 'ls ; node scripts/second-opinion.mjs request --provider codex --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A35: multiple --dispatch tokens — still blocks
+assertBlock('A35: duplicate --dispatch blocks',
+  { command: 'node scripts/second-opinion.mjs request --provider codex --dispatch --dispatch --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A36: --max-rounds in consensus (extra args)
+assertBlock('A36: consensus with --max-rounds blocks below floor',
+  { command: 'node scripts/second-opinion.mjs request --provider codex --consensus --max-rounds 5 --body x', timeout: 100 },
+  'so-timeout-below-floor')
+
+// A37: stub provider with consensus (still allowed)
+assertAllow('A37: stub --consensus allowed',
+  { command: 'node scripts/second-opinion.mjs request --provider stub --consensus --max-rounds 3 --body x', timeout: 100 })
+
+// A38: DEFER — quoted command substitution hides --dispatch token (documented limitation)
+{
+  // The whole "$(...)" is one quoted token; --dispatch is not a top-level token.
+  // The substring-level isHarnessRequest() in the gate would still detect it,
+  // but timeout-floor's token-level matcher cannot enforce the floor.
+  // This test ASSERTS the limitation: we ALLOW (i.e., floor does not fire).
+  const r = checkTimeoutFloor({
+    command: 'echo "$(node scripts/second-opinion.mjs request --provider codex --dispatch --body x)"',
+    timeout: 100,
+  })
+  if (r.block) {
+    failures++
+    console.error(`FAIL A38 (documented limitation): expected allow, got block`)
+  } else {
+    passes++
+  }
+}
+
+console.log(`\n${passes} pass, ${failures} fail`)
+if (failures > 0) process.exit(1)


### PR DESCRIPTION
## Summary

Enforces a 600000ms Bash-timeout floor on second-opinion harness `--dispatch` and `--consensus` invocations via PreToolUse hook. Closes the `provider-dispatch-nonzero` with `exitCode: null` failure mode that surfaces in projects calling the harness through Claude Code's Bash tool without overriding the default 120000ms timeout.

- New pure module `hooks/lib/so-timeout-floor.mjs` (quote-respecting tokenizer + quote-aware segment splitter + per-segment decision fn)
- Wired into `hooks/second-opinion-gate.mjs` via dynamic import + fail-closed, fires BEFORE `checkRunbookGate` so insufficient-timeout callers get one clear retry instruction instead of being routed through runbook ack and then SIGTERM'd
- Installer extended to copy the new lib

## Why

When agents invoke `second-opinion.mjs --dispatch` via Claude Code's Bash tool with the default 120000ms timeout, the outer Bash tool SIGTERMs the codex child mid-review. The harness surfaces this as `provider-dispatch-nonzero` with `exitCode: null`. The harness can't defend against this from inside its own process; the timeout is bound at the tool-call boundary. Enforcing at the hook layer is the right boundary.

Observed in production: a second-opinion call from another project returned `provider-dispatch-nonzero` because the agent didn't pass `timeout: 600000`. Same shape recurred repeatedly because documentation-tier rules (CLAUDE.md, runbook) don't enforce under task-end momentum.

## Trust model

Honest-agent. Documented limitation (axis A38, follow-up issue filed): quoted command substitution like `echo "$(node ... --dispatch)"` is opaque to the tokenizer/splitter and not enforced. Honest agents don't write that shape.

## Convergence

5 codex review rounds (R1=3 findings → R2=3 → R3=2 → R4=2 → R5=ACCEPT) plus 1 negative-scenario-reviewer round (2 MAJOR honest-agent bypasses caught: newline-separator + `bash -c` exec-wrapper, both closed in commit `f2cf390`).

## Test plan

- [x] 66 unit cases over A1-A42 negative-scenario matrix (`tests/test-so-gate-timeout-floor.mjs`)
- [x] 5 black-box integration cases against installed-tree fixtures (`tests/test-so-gate-timeout-floor-integration.mjs`) — happy path, below-floor block, consensus block, compound bypass, fail-closed missing-lib
- [x] Existing `tests/test-second-opinion-gate-runbook.mjs`: 19/19 pass (runHook helper extended to pass `timeout: 600000` by default; orphan fixtures now colocate the new lib)
- [x] Existing `tests/test-runbook-marker-checkpoint-gate.sh`: 6/6 pass
- [x] Existing `tests/test-runbook-marker-classifier.sh`: 8/8 pass
- [x] Existing `tests/test-second-opinion-gate.mjs`: 20/20 pass
- [x] E2E against installed copy at `~/.claude/hooks/second-opinion-gate.mjs`:
  - timeout 120000 + codex --dispatch → `so-timeout-below-floor` block ✅
  - `bash -c '...--dispatch...'` + timeout 120000 → `so-timeout-below-floor` block ✅
  - newline-separated `stub\ncodex --dispatch` + timeout 120000 → `so-timeout-below-floor` block ✅
  - timeout 600000 → falls through to runbook gate ✅

## Documented follow-ups

- A38 quoted command substitution + equivalence class (process substitution, here-docs, subshell groups, xargs) — separate issue
- Future: collapse into #283 generic command-shape validator if/when scope allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
