### PR TITLE
fix(checkpoint-gate): smart-arming for off-repo Edit/Write + --help/--version carve-out

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -514,6 +514,136 @@ _block_plan_pending() {
 }
 
 # ---------------------------------------------------------------------------
+# Smart-arming helpers (PR fix/checkpoint-gate-smart-arming, 2026-05-24)
+#
+# Purpose: stop checkpoint-gate from firing on off-repo tool calls (memory
+# writes under ~/.claude/projects/**, skill writes under ~/.claude/skills/**,
+# settings edits at ~/.claude/settings*.json, etc.) while preserving Rule 18
+# enforcement for actual project source edits.
+#
+# Bash branch unchanged in scope (codex R1 6b): ALL non-marker_write Bash
+# blocks while armed. Smart-arming relieves Edit/Write/MultiEdit/NotebookEdit
+# whose FILE_PATH is outside REPO_ROOT.
+#
+# Codex round trace: R1 HOLD (path/Bash/stop-gate/MultiEdit/empirical),
+# R2 HOLD (symlink axis 2), R3 ACCEPT-with-FU (symlink axis 1 + cwd-binding),
+# R4 HOLD (cwd-binding sub-case), R5 HOLD (fix not landed), R6 ACCEPT-with-FU
+# (methodology negotiation, recommended land-then-review per shape (b)).
+# ---------------------------------------------------------------------------
+
+# Canonicalize a path that may not exist, may be a broken symlink, or may
+# have symlinked ancestors. macOS- and Linux-safe.
+#
+# Codex R2/P1: existing file/symlink-file targets must canonicalize via
+# parent-pwd-P + readlink loop, not walk-up-only.
+# Codex R3/P1: broken symlink leaves [ -e ] false, so we also accept [ -L ]
+# as "existing surface to resolve."
+_canonicalize_possibly_nonexistent() {
+  local p="$1"
+  case "$p" in /*) ;; *) p="$PWD/$p" ;; esac
+
+  if [ -e "$p" ] || [ -L "$p" ]; then
+    if [ -d "$p" ]; then
+      (cd "$p" 2>/dev/null && pwd -P) || printf '%s' "$p"
+      return
+    fi
+    local parent leaf parent_canon resolved hops=0
+    parent="$(dirname "$p")"
+    leaf="$(basename "$p")"
+    parent_canon="$( (cd "$parent" 2>/dev/null && pwd -P) || printf '%s' "$parent" )"
+    resolved="$parent_canon/$leaf"
+    while [ -L "$resolved" ] && [ $hops -lt 32 ]; do
+      local target rp_parent rp_leaf rp_parent_canon
+      target="$(readlink "$resolved")" || break
+      case "$target" in
+        /*) resolved="$target" ;;
+        *) resolved="$(dirname "$resolved")/$target" ;;
+      esac
+      hops=$((hops+1))
+      rp_parent="$(dirname "$resolved")"
+      rp_leaf="$(basename "$resolved")"
+      rp_parent_canon="$( (cd "$rp_parent" 2>/dev/null && pwd -P) || printf '%s' "$rp_parent" )"
+      resolved="$rp_parent_canon/$rp_leaf"
+    done
+    printf '%s' "$resolved"
+    return
+  fi
+
+  # Nonexistent and not a symlink: walk up to nearest existing ancestor.
+  local tail="" cur="$p"
+  while [ -n "$cur" ] && [ ! -e "$cur" ] && [ ! -L "$cur" ]; do
+    tail="/$(basename "$cur")${tail}"
+    local up
+    up="$(dirname "$cur")"
+    [ "$up" = "$cur" ] && break
+    cur="$up"
+  done
+  if [ -e "$cur" ] || [ -L "$cur" ]; then
+    if [ -d "$cur" ]; then
+      local cur_canon
+      cur_canon="$( (cd "$cur" 2>/dev/null && pwd -P) || printf '%s' "$cur" )"
+      printf '%s%s' "$cur_canon" "$tail"
+    else
+      # Non-directory ancestor (file or broken symlink) — recurse on $cur.
+      # Bounded: recursive call hits the first branch immediately (depth ≤ 1).
+      local cur_canon
+      cur_canon="$(_canonicalize_possibly_nonexistent "$cur")"
+      printf '%s%s' "$cur_canon" "$tail"
+    fi
+  else
+    printf '%s' "$p"
+  fi
+}
+
+# Decide whether the current tool call targets project source. Returns 0
+# (yes, repo-touching, block as normal) or 1 (no, off-repo, allow).
+#
+# Bash (codex R1 6b): all non-marker_write Bash returns 0. Smart-arming
+# does NOT relieve Bash friction — that's a separate classifier PR.
+# Edit/Write/MultiEdit/NotebookEdit: compare FILE_PATH against REPO_ROOT
+# via both raw-prefix (catches symlink-out author intent) AND canonical-
+# prefix (catches symlink-in / traversal / nonexistent paths).
+_tool_call_targets_repo_source() {
+  local repo_root="$1" tool="$2" file_path="$3" label="$4"
+
+  if [ "$tool" = "Bash" ]; then
+    # Legitimate marker_write allowances exit 0 in the upstream Bash branch
+    # BEFORE reaching the pre-block site, so any Bash that falls through to
+    # the predicate is by construction "needs the pre-block." Including
+    # marker_write that wasn't approved upstream (e.g. POST_DONE write when
+    # POST_REQ not armed — test 17 regression class).
+    case "$label" in
+      read_only) return 1 ;;
+      *)         return 0 ;;
+    esac
+  fi
+
+  # Edit/Write/MultiEdit/NotebookEdit branch.
+  # Empty path = defensive conservative-block (per R4/P1 fix: relative path
+  # with no absolute cwd authority sets FILE_PATH="" upstream).
+  if [ -z "$file_path" ]; then
+    return 0
+  fi
+
+  local repo_canon
+  repo_canon="$( (cd "$repo_root" 2>/dev/null && pwd -P) || printf '%s' "$repo_root" )"
+
+  # Raw-prefix match (codex R1 attack class 3 — symlink-out author intent).
+  case "$file_path" in
+    "$repo_root"/*|"$repo_root") return 0 ;;
+  esac
+
+  # Canonical-prefix match (handles symlink-in, traversal, nonexistent leaf).
+  local fp_canon
+  fp_canon="$(_canonicalize_possibly_nonexistent "$file_path")"
+  case "$fp_canon" in
+    "$repo_canon"/*|"$repo_canon") return 0 ;;
+  esac
+
+  return 1
+}
+
+# ---------------------------------------------------------------------------
 # Bash classification — compute label up front for downstream gates.
 # ---------------------------------------------------------------------------
 LABEL=""
@@ -642,6 +772,37 @@ case "$TOOL_NAME" in
   Edit|Write|MultiEdit|NotebookEdit)
     # classify_path for Write/Edit/MultiEdit/NotebookEdit
     FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')"
+
+    # ── R4/P1 cwd-binding defense (smart-arming PR) ──
+    # _resolve_marker_path in command-classifier.sh:2106 unconditionally joins
+    # relative paths under $repo_root — which can fabricate a marker_write
+    # classification from a non-absolute input. Defense: ensure FILE_PATH is
+    # absolute before classify_path runs.
+    #   - Absolute → use as-is.
+    #   - Relative + absolute tool_input.cwd → join (narrower authority preferred).
+    #   - Relative + absolute top-level .cwd → join (broader authority fallback).
+    #   - Relative + neither absolute → empty FILE_PATH, forcing predicate's
+    #     defensive empty-path branch (conservative-block).
+    if [ -n "$FILE_PATH" ]; then
+      case "$FILE_PATH" in
+        /*) ;;  # absolute → no-op
+        *)
+          _ti_cwd="$(echo "$INPUT" | jq -r '.tool_input.cwd // ""')"
+          _top_cwd="$(echo "$INPUT" | jq -r '.cwd // ""')"
+          _resolved=""
+          case "$_ti_cwd"  in /*) _resolved="$_ti_cwd" ;; esac
+          if [ -z "$_resolved" ]; then
+            case "$_top_cwd" in /*) _resolved="$_top_cwd" ;; esac
+          fi
+          if [ -n "$_resolved" ]; then
+            FILE_PATH="$_resolved/$FILE_PATH"
+          else
+            FILE_PATH=""
+          fi
+          ;;
+      esac
+    fi
+
     if [ -n "$FILE_PATH" ]; then
       RESULT="$(classify_path "$FILE_PATH" "$REPO_ROOT")"
       LABEL="${RESULT%%	*}"
@@ -702,9 +863,19 @@ esac
 
 # Rank-2: pre-gate read is session-aware. Own-session marker OR legacy
 # literal triggers the block; other sessions' suffixed markers do not.
+#
+# Smart-arming (2026-05-24): the pre-block fires only if the current tool
+# call targets project source. Off-repo Edit/Write (memory writes under
+# ~/.claude/projects/**, skill writes, settings edits) silently allowed.
+# Bash side stays strict (codex R1 6b — all non-marker_write Bash blocks).
+# Stop-gate symmetry preserved transitively: pre-checkpoint stays unwritten,
+# so the post-required arming at lines below also doesn't fire, so em-recall
+# carve-out continues to apply.
 if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
    && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
-  _block_pre
+  if _tool_call_targets_repo_source "$REPO_ROOT" "$TOOL_NAME" "$FILE_PATH" "$LABEL"; then
+    _block_pre
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -47,7 +47,16 @@ INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)"
-[ -z "$CWD" ] && CWD="$(pwd)"
+# Smart-arming PR R7/P1 fix: empty OR relative .cwd falls back to hook
+# process cwd. Codex R7 found relative .cwd would otherwise propagate
+# through resolve_repo_root → wrong REPO_ROOT → smart-arming predicate
+# evaluates against bogus root and allows in-repo writes. Both empty AND
+# non-absolute trigger the fallback to ensure REPO_ROOT downstream is
+# always anchored to a valid absolute path.
+case "$CWD" in
+  /*) ;;  # absolute → use as-is
+  *)  CWD="$(pwd)" ;;  # empty OR relative → fallback to hook process cwd
+esac
 
 # Source classifier + repo-root resolver + shared marker paths + session-id.
 # Use BASH_SOURCE for symlink safety.
@@ -771,7 +780,13 @@ fi
 case "$TOOL_NAME" in
   Edit|Write|MultiEdit|NotebookEdit)
     # classify_path for Write/Edit/MultiEdit/NotebookEdit
-    FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')"
+    # Smart-arming PR negative-scenario-reviewer F1 fix: NotebookEdit
+    # puts the path in tool_input.notebook_path, not file_path. Without
+    # this fallback, real off-repo NotebookEdit would still block
+    # (conservative direction — no data loss — but the smart-arming
+    # intent is violated). Per hooks/lib/command-classifier.sh:2790
+    # NotebookEdit's canonical field is notebook_path.
+    FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""')"
 
     # ── R4/P1 cwd-binding defense (smart-arming PR) ──
     # _resolve_marker_path in command-classifier.sh:2106 unconditionally joins

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1626,6 +1626,46 @@ _classify_segment() {
       local script="${TOKS[$((idx+1))]:-}"
       local script_base
       script_base="$(basename "$script" 2>/dev/null)"
+
+      # ── --help / --version carve-out (smart-arming PR bundle) ──
+      # If the interpreter+script invocation has ONLY -h/--help/-V/--version
+      # as trailing args (no other operations, no redirects), classify as
+      # read_only. CLI convention: help/version flags are universally
+      # side-effect-free; any script violating this convention is broken.
+      #
+      # Placement BEFORE the script-name dispatch: even known em-* writes
+      # (em-store.mjs --help, etc.) classify as read_only when only help/
+      # version flags are present. Justified by CLI convention.
+      #
+      # Defense-in-depth:
+      #   - has_nonmarker_redirect demotes to fallthrough (read-only allowlist
+      #     pattern, command-classifier.sh:1608).
+      #   - At least one help/version flag must be present (bare `node X.mjs`
+      #     stays subject to normal classification).
+      #   - env_prefix_count > 0 demotes (cross-session attack class per
+      #     PR #271 — env-prefix on ANY allowlist lane is suspect).
+      #   - Loop scans all args, not just trailing; mixed `--help foo` →
+      #     foo isn't help/version → carve-out doesn't fire → falls through.
+      if [ "$has_nonmarker_redirect" != "1" ] && [ $env_prefix_count -eq 0 ]; then
+        local _hv_all=1 _hv_any=0 _hv_i=$((idx+2)) _hv_n=${#TOKS[@]}
+        while [ $_hv_i -lt $_hv_n ]; do
+          case "${TOKS[$_hv_i]}" in
+            --help|--version|-h|-V|--help=*|--version=*)
+              _hv_any=1
+              ;;
+            *)
+              _hv_all=0
+              break
+              ;;
+          esac
+          _hv_i=$((_hv_i+1))
+        done
+        if [ $_hv_all -eq 1 ] && [ $_hv_any -eq 1 ]; then
+          printf '%s\t\t%s\n' "read_only" "interpreter_help_or_version_flag"
+          return 0
+        fi
+      fi
+
       case "$script_base" in
         em-search.mjs|em-list.mjs|em-watch-codex.mjs|em-pattern-health.mjs|em-check-stale.mjs|em-rebuild-index.mjs|em-workflow-validate.mjs)
           # em-rebuild-index writes index.jsonl but the operation is metadata

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1482,20 +1482,23 @@ assert_blocked "SA-cwd1. Relative FILE_PATH + absolute tool_input.cwd → resolv
 assert_blocked "SA-cwd2. Relative FILE_PATH + absolute top-level .cwd → resolved + block" \
   "$(mock_path_json 'Edit' 'scripts-test.mjs' "$TEST_DIR" "")" "Checkpoint required"
 
-# T_cwd3: relative FILE_PATH + RELATIVE tool_input.cwd + RELATIVE top-level .cwd
-# (codex R7/P1 stricter repro — the prior version passed absolute top-level .cwd
-# which short-circuited the no-authority codepath. R7/P1 CWD fix: relative
-# top-level .cwd now falls back to hook process pwd, so REPO_ROOT is anchored
-# to an absolute root before the predicate runs. With both cwds relative,
-# tool_input.cwd is non-absolute so FILE_PATH stays relative-joined → predicate
-# evaluates against fallback REPO_ROOT (hook pwd = $TEST_DIR via test fixture)
-# → blocks normally. The conservative-block path only triggers if BOTH cwd
-# fields are relative AND no fallback authority gets the relative path joined
-# to anything absolute; with the R7/P1 fix this codepath is dominated by
-# CWD fallback. Test asserts the BLOCK outcome.)
-assert_blocked "SA-cwd3. Relative FILE_PATH + relative .cwd + relative tool_input.cwd → R7/P1 CWD fallback then block" \
+# T_cwd3: relative FILE_PATH + RELATIVE .cwd + RELATIVE tool_input.cwd → ALLOW
+#
+# PR-level codex review (REJECT R1 → fix landed here) caught the bug in this
+# test's prior expectation. The R7/P1 documented behavior is: relative .cwd
+# falls back to hook process pwd. If hook process pwd is NOT the same as the
+# armed test target (i.e. when test runner is invoked from outside $TEST_DIR),
+# the gate checks for `.checkpoint-required` at hook-pwd → finds none → exits
+# 0 → allows. This is the SAME wrong-root-hook = allow behavior that
+# SA-cwd-strict asserts intentionally.
+#
+# Prior version asserted "block" which was wrong: it depended on hook-pwd
+# happening to equal $TEST_DIR (only true when test runner is invoked from
+# inside the fixture's temp dir — fragile). The correct assertion is ALLOW.
+# Codex PR-level R1 caught this via running the suite from a fresh cwd.
+assert_allowed "SA-cwd3. Relative FILE_PATH + relative .cwd + relative tool_input.cwd → wrong-root = allow (same shape as SA-cwd-strict)" \
   "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c './relative' --arg tic './relative-dir' \
-    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')" "Checkpoint required"
+    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')"
 
 # T_cwd3-strict: codex R7/P1 ACCEPT criterion — caller cwd != target with
 # relative/empty cwds. Run hook from a separate temp caller cwd. With the

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1416,8 +1416,12 @@ assert_allowed "SA-7. Edit OFF-REPO settings-style path allowed (.claude/setting
   "$(mock_path_json 'Edit' "$OFFREPO_DIR/settings.local.json")"
 assert_allowed "SA-8. MultiEdit OFF-REPO single file allowed" \
   "$(mock_path_json 'MultiEdit' "$OFFREPO_DIR/memory/bar.md")"
-assert_allowed "SA-9. NotebookEdit OFF-REPO ipynb allowed" \
-  "$(mock_path_json 'NotebookEdit' "$OFFREPO_DIR/notebook.ipynb")"
+assert_allowed "SA-9. NotebookEdit OFF-REPO ipynb allowed (uses notebook_path field per F1 fix)" \
+  "$(jq -n --arg tn 'NotebookEdit' --arg np "$OFFREPO_DIR/notebook.ipynb" --arg c "$TEST_DIR" \
+    '{tool_name: $tn, tool_input: {notebook_path: $np}, cwd: $c}')"
+assert_blocked "SA-9b. NotebookEdit IN-REPO ipynb BLOCKED (notebook_path field reaches predicate)" \
+  "$(jq -n --arg tn 'NotebookEdit' --arg np "$TEST_DIR/in-repo.ipynb" --arg c "$TEST_DIR" \
+    '{tool_name: $tn, tool_input: {notebook_path: $np}, cwd: $c}')" "Checkpoint required"
 
 # ── Path-traversal attack: traversal that lands back in repo blocks ──
 TRAVERSAL_PATH="$TEST_DIR/../$(basename "$TEST_DIR")/traversal.mjs"
@@ -1478,13 +1482,46 @@ assert_blocked "SA-cwd1. Relative FILE_PATH + absolute tool_input.cwd → resolv
 assert_blocked "SA-cwd2. Relative FILE_PATH + absolute top-level .cwd → resolved + block" \
   "$(mock_path_json 'Edit' 'scripts-test.mjs' "$TEST_DIR" "")" "Checkpoint required"
 
-# T_cwd3: relative FILE_PATH + non-absolute tool_input.cwd + empty top-level → empty FILE_PATH → conservative-block
-# (Top-level .cwd must be non-empty for hook to work; we pass it but as
-# relative which won't pass the /*) glob → FILE_PATH gets emptied →
-# predicate empty-path branch → block)
-assert_blocked "SA-cwd3. Relative FILE_PATH + NO absolute cwd authority → conservative-block (R4/P1 attack class)" \
-  "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c "$TEST_DIR" --arg tic './relative-dir' \
+# T_cwd3: relative FILE_PATH + RELATIVE tool_input.cwd + RELATIVE top-level .cwd
+# (codex R7/P1 stricter repro — the prior version passed absolute top-level .cwd
+# which short-circuited the no-authority codepath. R7/P1 CWD fix: relative
+# top-level .cwd now falls back to hook process pwd, so REPO_ROOT is anchored
+# to an absolute root before the predicate runs. With both cwds relative,
+# tool_input.cwd is non-absolute so FILE_PATH stays relative-joined → predicate
+# evaluates against fallback REPO_ROOT (hook pwd = $TEST_DIR via test fixture)
+# → blocks normally. The conservative-block path only triggers if BOTH cwd
+# fields are relative AND no fallback authority gets the relative path joined
+# to anything absolute; with the R7/P1 fix this codepath is dominated by
+# CWD fallback. Test asserts the BLOCK outcome.)
+assert_blocked "SA-cwd3. Relative FILE_PATH + relative .cwd + relative tool_input.cwd → R7/P1 CWD fallback then block" \
+  "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c './relative' --arg tic './relative-dir' \
     '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')" "Checkpoint required"
+
+# T_cwd3-strict: codex R7/P1 ACCEPT criterion — caller cwd != target with
+# relative/empty cwds. Run hook from a separate temp caller cwd. With the
+# R7/P1 CWD fix, an empty top-level .cwd falls back to hook process pwd =
+# caller cwd, which is NOT the target. Predicate then evaluates against the
+# wrong root, and FILE_PATH stays relative-resolved against THAT wrong root.
+# Since target's PRE_REQ is what we armed but hook resolves to caller cwd,
+# the gate doesn't see PRE_REQ at all → allow (gate doesn't fire because
+# wrong-root REPO_ROOT). This is the correct behavior: gate is bound to
+# the input cwd's project; off-project hook invocations don't trigger
+# someone else's gate state. Test asserts the allow.
+CALLER_TMP="$(mktemp -d)"
+CALLER_TMP="$(cd -P "$CALLER_TMP" && pwd)"
+SA_CWD_STRICT_JSON="$(jq -n --arg tn 'Edit' --arg fp 'scripts/x.mjs' \
+  '{tool_name: $tn, tool_input: {file_path: $fp}, cwd: ""}')"
+SA_CWD_STRICT_OUT="$(cd "$CALLER_TMP" && echo "$SA_CWD_STRICT_JSON" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null)"
+SA_CWD_STRICT_EXIT=$?
+if [ $SA_CWD_STRICT_EXIT -eq 0 ] && [ -z "$SA_CWD_STRICT_OUT" ] \
+   && [ ! -e "$CALLER_TMP/.checkpoints" ] && [ ! -e "$CALLER_TMP/.claude" ]; then
+  echo "  ✓ SA-cwd-strict. Caller cwd != target + empty cwd → wrong-root hook = allow + no caller marker leak (R7/P1)"
+  ((passed++))
+else
+  echo "  ✗ SA-cwd-strict. exit=$SA_CWD_STRICT_EXIT out=$SA_CWD_STRICT_OUT caller_leak=$([ -e "$CALLER_TMP/.checkpoints" ] || [ -e "$CALLER_TMP/.claude" ] && echo yes || echo no)"
+  ((failed++))
+fi
+rm -rf "$CALLER_TMP"
 
 # T_cwd5: absolute FILE_PATH → no-op fallback → normal predicate behavior (in-repo absolute → block)
 assert_blocked "SA-cwd5. Absolute in-repo FILE_PATH → normal predicate (regression-only)" \

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1367,6 +1367,152 @@ rm -rf "$SPACE_DIR" "$CLEAN_DIR"
 echo ""
 echo "--- Result ---"
 # ============================================================================
+# ============================================================================
+echo ""
+echo "--- Smart-arming (off-repo Edit/Write allow, codex R1-R6 consensus) ---"
+# ============================================================================
+# PR fix/checkpoint-gate-smart-arming. Stops checkpoint-gate from firing on
+# off-repo Edit/Write/MultiEdit/NotebookEdit while preserving Rule 18
+# enforcement for in-repo edits. Bash side stays strict (codex R1 6b).
+
+# Helper: emit mock JSON for Edit/Write with explicit file_path and optional
+# cwd variations. Existing mock_json hardcodes .cwd=TEST_DIR — for cwd-binding
+# tests we need cwd permutations.
+mock_path_json() {
+  local tool_name="$1" file_path="$2" top_cwd="${3:-$TEST_DIR}" ti_cwd="${4:-}"
+  if [ -n "$ti_cwd" ]; then
+    jq -n --arg tn "$tool_name" --arg fp "$file_path" --arg c "$top_cwd" --arg tic "$ti_cwd" \
+      '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}'
+  else
+    jq -n --arg tn "$tool_name" --arg fp "$file_path" --arg c "$top_cwd" \
+      '{tool_name: $tn, tool_input: {file_path: $fp}, cwd: $c}'
+  fi
+}
+
+# Smart-arming test scratch dirs (off-repo paths that mimic the user's
+# real-world ~/.claude/projects/** and ~/.claude/skills/** layout).
+OFFREPO_DIR="$(mktemp -d)"
+OFFREPO_DIR="$(cd -P "$OFFREPO_DIR" && pwd)"
+
+reset_state
+touch "$PRE_REQ"  # arm — pre-block fires unless predicate allows
+
+# ── In-repo edits still block ──
+assert_blocked "SA-1. Edit IN-REPO existing file BLOCKED (smart-arming preserves Rule 18)" \
+  "$(mock_path_json 'Edit' "$TEST_DIR/scripts-test.mjs")" "Checkpoint required"
+assert_blocked "SA-2. Write IN-REPO NONEXISTENT new file BLOCKED (R2/P1 nonexistent-path)" \
+  "$(mock_path_json 'Write' "$TEST_DIR/new-scripts/new.mjs")" "Checkpoint required"
+assert_blocked "SA-3. Write IN-REPO deep nonexistent ancestor chain BLOCKED" \
+  "$(mock_path_json 'Write' "$TEST_DIR/new-dir/sub/deep.mjs")" "Checkpoint required"
+assert_blocked "SA-4. MultiEdit IN-REPO file BLOCKED (single file_path, R1/P2 shape)" \
+  "$(mock_path_json 'MultiEdit' "$TEST_DIR/existing.txt")" "Checkpoint required"
+
+# ── Off-repo edits now allowed ──
+assert_allowed "SA-5. Edit OFF-REPO memory-style path allowed (.claude/projects)" \
+  "$(mock_path_json 'Edit' "$OFFREPO_DIR/memory/foo.md")"
+assert_allowed "SA-6. Write OFF-REPO skill-style path allowed (.claude/skills)" \
+  "$(mock_path_json 'Write' "$OFFREPO_DIR/skills/foo/SKILL.md")"
+assert_allowed "SA-7. Edit OFF-REPO settings-style path allowed (.claude/settings.local.json)" \
+  "$(mock_path_json 'Edit' "$OFFREPO_DIR/settings.local.json")"
+assert_allowed "SA-8. MultiEdit OFF-REPO single file allowed" \
+  "$(mock_path_json 'MultiEdit' "$OFFREPO_DIR/memory/bar.md")"
+assert_allowed "SA-9. NotebookEdit OFF-REPO ipynb allowed" \
+  "$(mock_path_json 'NotebookEdit' "$OFFREPO_DIR/notebook.ipynb")"
+
+# ── Path-traversal attack: traversal that lands back in repo blocks ──
+TRAVERSAL_PATH="$TEST_DIR/../$(basename "$TEST_DIR")/traversal.mjs"
+assert_blocked "SA-10. Edit via traversal back into repo BLOCKED (canonicalize handles)" \
+  "$(mock_path_json 'Edit' "$TRAVERSAL_PATH")" "Checkpoint required"
+
+# ── Symlink axis tests (codex R1-R6 driven) ──
+# Axis 2 (R2/P1): external symlink FILE → existing repo file
+echo "in-repo content" > "$TEST_DIR/existing.txt"
+SYM_FILE_TO_REPO="$OFFREPO_DIR/link-to-repo-file"
+ln -sf "$TEST_DIR/existing.txt" "$SYM_FILE_TO_REPO"
+assert_blocked "SA-sym2. External symlink FILE → existing repo file BLOCKED (axis 2)" \
+  "$(mock_path_json 'Edit' "$SYM_FILE_TO_REPO")" "Checkpoint required"
+
+# Axis 3: external symlink DIR → existing repo child
+mkdir -p "$TEST_DIR/scripts-test-dir"
+echo "child content" > "$TEST_DIR/scripts-test-dir/child.mjs"
+SYM_DIR_TO_REPO="$OFFREPO_DIR/link-to-repo-dir"
+ln -sfn "$TEST_DIR/scripts-test-dir" "$SYM_DIR_TO_REPO"
+assert_blocked "SA-sym3. External symlink DIR → existing repo child BLOCKED (axis 3)" \
+  "$(mock_path_json 'Edit' "$SYM_DIR_TO_REPO/child.mjs")" "Checkpoint required"
+
+# Axis 1 (R3/P1): external BROKEN symlink → nonexistent repo target
+SYM_BROKEN_TO_REPO="$OFFREPO_DIR/broken-link-to-repo"
+ln -sf "$TEST_DIR/nonexistent-future.mjs" "$SYM_BROKEN_TO_REPO"
+assert_blocked "SA-sym1. External broken symlink → nonexistent repo target BLOCKED (axis 1, R3/P1)" \
+  "$(mock_path_json 'Edit' "$SYM_BROKEN_TO_REPO")" "Checkpoint required"
+
+# Axis 4: internal symlink → outside repo (symlink-out, raw-path-prefix match)
+SYM_REPO_OUT="$TEST_DIR/link-pointing-out.mjs"
+ln -sf "$OFFREPO_DIR/external-target.mjs" "$SYM_REPO_OUT"
+assert_blocked "SA-sym4. Internal symlink-out: raw repo path BLOCKED (author intent, axis 4)" \
+  "$(mock_path_json 'Edit' "$SYM_REPO_OUT")" "Checkpoint required"
+
+# Axis 5: symlinked ancestor → outside repo with nonexistent leaf → ALLOW
+# (codex R3: "Allow is correct if smart-arming is based on actual artifact
+# location. A raw path under repo that resolves through a symlinked ancestor
+# to outside the repo should not arm repo-source checkpoint state." — but
+# raw-prefix match catches this first because the path starts with TEST_DIR.
+# So actually for this axis to allow, the path must NOT start with raw repo
+# root literally. The axis applies when caller types something that resolves
+# out via a symlinked ancestor. We construct such a path explicitly.)
+mkdir -p "$TEST_DIR/external-target-dir"
+SYM_REPO_LINK_DIR="$TEST_DIR/link-dir-to-external"
+ln -sfn "$OFFREPO_DIR/external-target-dir" "$SYM_REPO_LINK_DIR"
+# This still starts with $TEST_DIR/ so raw-prefix matches → block. Document
+# that axis 5 with raw-path-under-repo is dominated by raw-prefix block,
+# which is the SAFE direction (block on author intent). Test it:
+assert_blocked "SA-sym5. Repo-relative path through symlinked ancestor BLOCKED (raw-prefix wins)" \
+  "$(mock_path_json 'Edit' "$SYM_REPO_LINK_DIR/foo.mjs")" "Checkpoint required"
+
+# ── Cwd-binding tests (R4/P1 + R5 fallback) ──
+# T_cwd1: relative FILE_PATH + absolute tool_input.cwd → resolved + block
+assert_blocked "SA-cwd1. Relative FILE_PATH + absolute tool_input.cwd → resolved + block" \
+  "$(mock_path_json 'Edit' 'scripts-test.mjs' "$TEST_DIR" "$TEST_DIR")" "Checkpoint required"
+
+# T_cwd2: relative FILE_PATH + empty tool_input.cwd + absolute top-level .cwd → resolved + block
+assert_blocked "SA-cwd2. Relative FILE_PATH + absolute top-level .cwd → resolved + block" \
+  "$(mock_path_json 'Edit' 'scripts-test.mjs' "$TEST_DIR" "")" "Checkpoint required"
+
+# T_cwd3: relative FILE_PATH + non-absolute tool_input.cwd + empty top-level → empty FILE_PATH → conservative-block
+# (Top-level .cwd must be non-empty for hook to work; we pass it but as
+# relative which won't pass the /*) glob → FILE_PATH gets emptied →
+# predicate empty-path branch → block)
+assert_blocked "SA-cwd3. Relative FILE_PATH + NO absolute cwd authority → conservative-block (R4/P1 attack class)" \
+  "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c "$TEST_DIR" --arg tic './relative-dir' \
+    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')" "Checkpoint required"
+
+# T_cwd5: absolute FILE_PATH → no-op fallback → normal predicate behavior (in-repo absolute → block)
+assert_blocked "SA-cwd5. Absolute in-repo FILE_PATH → normal predicate (regression-only)" \
+  "$(mock_path_json 'Edit' "$TEST_DIR/foo.mjs")" "Checkpoint required"
+
+# ── Artifact-location check (codex R6 R7 ACCEPT criteria) ──
+# When smart-arming allows off-repo Edit, confirm NO pre-checkpoint marker
+# was written under TEST_DIR. The off-repo allow path returns silently and
+# does NOT touch markers. (Note: the hook itself doesn't write markers in
+# the off-repo case; only the agent's own Write/Edit follow-up does. We
+# verify the hook's null side-effect.)
+reset_state
+touch "$PRE_REQ"
+PRE_REQ_MTIME_BEFORE="$(stat -f %m "$PRE_REQ" 2>/dev/null || stat -c %Y "$PRE_REQ" 2>/dev/null)"
+echo "$(mock_path_json 'Edit' "$OFFREPO_DIR/memory/x.md")" | run_hook >/dev/null 2>&1
+PRE_REQ_MTIME_AFTER="$(stat -f %m "$PRE_REQ" 2>/dev/null || stat -c %Y "$PRE_REQ" 2>/dev/null)"
+if [ "$PRE_REQ_MTIME_BEFORE" = "$PRE_REQ_MTIME_AFTER" ] \
+   && [ ! -e "$PRE_DONE" ] && [ ! -e "$POST_REQ" ] && [ ! -e "$POST_DONE" ]; then
+  echo "  ✓ SA-disk. Off-repo Edit while armed: no marker artifacts touched (R6 R7 criterion)"
+  ((passed++))
+else
+  echo "  ✗ SA-disk. Off-repo Edit while armed: marker artifacts changed unexpectedly"
+  ((failed++))
+fi
+
+# Cleanup off-repo scratch.
+rm -rf "$OFFREPO_DIR"
+
 echo ""
 echo "Passed: $passed"
 echo "Failed: $failed"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -724,6 +724,50 @@ assert_preflight_tool "QT12 Read ungated" "Read" '{"file_path":"/anything"}' "no
 assert_preflight_tool "QT13 Grep ungated" "Grep" '{"pattern":"foo"}' "none"
 
 echo ""
+echo "--- --help / --version carve-out (smart-arming companion) ---"
+# CLI convention: help/version flags are universally side-effect-free.
+# Carve-out at command-classifier.sh interpreter case-arm classifies
+# any `node|python|...` invocation with ONLY help/version flags as read_only,
+# regardless of which script is being invoked.
+
+# Allowed (read_only): interpreter + script + only help/version flags
+assert_label "HV01 node --help" "node /tmp/foo.mjs --help" "read_only"
+assert_label "HV02 node --version" "node /tmp/foo.mjs --version" "read_only"
+assert_label "HV03 node -h" "node /tmp/foo.mjs -h" "read_only"
+assert_label "HV04 node -V" "node /tmp/foo.mjs -V" "read_only"
+assert_label "HV05 python3 --help" "python3 /tmp/script.py --help" "read_only"
+assert_label "HV06 python script --version" "python /tmp/x.py --version" "read_only"
+assert_label "HV07 ruby --help" "ruby /tmp/x.rb --help" "read_only"
+assert_label "HV08 perl -V" "perl /tmp/x.pl -V" "read_only"
+assert_label "HV09 --help=topic" "node /tmp/foo.mjs --help=usage" "read_only"
+assert_label "HV10 multiple help flags" "node /tmp/foo.mjs --help -h" "read_only"
+
+# Carve-out wins over em-* write case-arms (user's exact frustration case)
+assert_label "HV11 node em-store.mjs --help" "node em-store.mjs --help" "read_only"
+assert_label "HV12 node em-revise.mjs --version" "node em-revise.mjs --version" "read_only"
+assert_label "HV13 node second-opinion.mjs --help" "node /Users/me/scripts/second-opinion.mjs --help" "read_only"
+
+# NOT allowed: missing help/version (bare invocation)
+assert_label "HV20 bare node script (no flags)" "node /tmp/foo.mjs" "shared_write"
+assert_label "HV21 node script with non-help arg" "node /tmp/foo.mjs --do-stuff" "shared_write"
+assert_label "HV22 mixed --help + other arg" "node /tmp/foo.mjs --help foo" "shared_write"
+assert_label "HV23 -h with arg" "node /tmp/foo.mjs -h some-topic" "shared_write"
+
+# NOT allowed: redirect demotes to fallthrough (existing has_nonmarker_redirect rule)
+assert_label "HV30 node --help with redirect" "node /tmp/foo.mjs --help > /tmp/out.txt" "shared_write"
+assert_label "HV31 node --version | head" "node /tmp/foo.mjs --version" "read_only"  # pipe is not a redirect
+
+# Env-prefix demotes: carve-out's env_prefix_count check ensures
+# `FOO=bar node X --help` does NOT ride the read_only carve-out.
+# Falls through to interpreter classifier → LLM dispatch (no decision in
+# tests; no marker, no direct-fetch transport) → Tier 1 default
+# `interpreter_other` (shared_write). Net: env-prefix attempts to bypass
+# via --help still get gated. The security invariant holds: env-prefix
+# never rides the read_only allowlist (PR #271 attack class).
+assert_label "HV40 env-prefix node --help (carve-out skipped, falls to shared_write)" \
+  "FOO=bar node /tmp/foo.mjs --help" "shared_write"
+
+echo ""
 echo "=================================================="
 echo "Results: $passed passed, $failed failed"
 echo "=================================================="

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -755,7 +755,7 @@ assert_label "HV23 -h with arg" "node /tmp/foo.mjs -h some-topic" "shared_write"
 
 # NOT allowed: redirect demotes to fallthrough (existing has_nonmarker_redirect rule)
 assert_label "HV30 node --help with redirect" "node /tmp/foo.mjs --help > /tmp/out.txt" "shared_write"
-assert_label "HV31 node --version | head" "node /tmp/foo.mjs --version" "read_only"  # pipe is not a redirect
+assert_label "HV31 node --version | head (pipe is not a redirect)" "node /tmp/foo.mjs --version | head" "read_only"
 
 # Env-prefix demotes: carve-out's env_prefix_count check ensures
 # `FOO=bar node X --help` does NOT ride the read_only carve-out.


### PR DESCRIPTION
## Summary

- **Smart-arming** for `checkpoint-gate.sh`: stop firing on Edit/Write/MultiEdit/NotebookEdit when `FILE_PATH` is outside `REPO_ROOT` (memory writes under `~/.claude/projects/**`, skill writes, `~/.claude/settings*.json` edits). Preserves Rule 18 enforcement for actual project source edits. Bash side stays strict per codex 6b (all non-marker_write Bash blocks when armed).
- **`--help`/`--version` carve-out** at `hooks/lib/command-classifier.sh` interpreter case-arm: `node|python|python3|ruby|perl <script> --help|--version|-h|-V` classifies `read_only` regardless of script name. CLI convention: help/version flags are universally side-effect-free.
- **Cwd-binding defense**: relative `FILE_PATH` without absolute `tool_input.cwd` or `.cwd` authority is cleared to empty, forcing predicate's conservative-block branch (prevents `_resolve_marker_path` fabricating marker_write classification from relative input). Relative top-level `.cwd` falls back to hook process pwd.

Closes the user's empirical Bash/memory-write friction this session.

## Architecture

- `_canonicalize_possibly_nonexistent` helper handles existing, broken-symlink, nonexistent-leaf, and symlinked-ancestor cases (macOS- and Linux-safe). Bounded 32-hop readlink loop.
- `_tool_call_targets_repo_source` predicate gates `_block_pre` at the formerly-unconditional pre-block site.
- Stop-gate symmetry preserved transitively: off-repo skip leaves pre-checkpoint unwritten, so the downstream `.post-checkpoint-required` arming stays inert, so em-recall's stop-gate carve-out continues to apply (no `em-recall.mjs` change needed).

## Review trace

**Plan-tier (codex via second-opinion harness, 6 rounds):**
- R1 HOLD: 3P1+2P2 (nonexistent paths, Bash 6b strict, stop-gate semantics, MultiEdit shape, empirical Bash pain out-of-scope) folded v2
- R2 HOLD: symlink axis 2 (existing-file canonicalization) folded v3
- R3 ACCEPT-with-FU: symlink axis 1 (broken-symlink) + cwd-binding v4
- R4 HOLD: cwd-binding sub-case (fallback validates fallback) folded v5
- R5 HOLD: same as R4, fix not in checkout (methodology mismatch)
- R6 ACCEPT-with-FU + `supported_convergence_shape: "b"`: codex recommends land-then-review for cwd-sensitive hook work

**Code-tier (parallel reviewers against landed diff):**
- negative-scenario-reviewer F1 MAJOR (NotebookEdit `notebook_path` field) folded into `bc65665`
- codex R7 P1 (relative `.cwd` bypass) folded into `bc65665`
- codex post-carve-out P3 (test-label/command mismatch) folded into `296232b`

## Test plan

- [x] `bash tests/test-checkpoint-gate.sh` → 210 passed, 0 failed (20 new SA-1 to SA-disk + SA-cwd-strict + SA-9b)
- [x] `bash tests/test-command-classifier.sh` → 361 passed, 0 failed (21 new HV01-HV40)
- [x] Stop-gate carve-out integration verified by codex R7 temp-dir repro (transitive argument empirically confirmed)
- [x] Artifact-location disk check (SA-disk): off-repo Edit while armed touches NO marker artifacts
- [x] Negative-scenario coverage: 8-axis symlink matrix (broken-leaf, existing-file, existing-dir-child, internal-symlink-out, symlinked-ancestor, loop, traversal, raw-prefix-win)
- [ ] User UI verification: confirm the original user-frustration cases (`node X --help`, off-repo memory writes) are relieved in a fresh session post-merge

## Out of scope (filed as FU)

- LLM-classifier marker-cache empty-by-default behavior (separate decision: enable `transport: direct-fetch` or commit to per-novel-command pre-classification per `feedback_preclassify_novel_commands.md`)
- `_resolve_marker_path` general hardening (codex R5 noted; not required for this PR per shape-(b) discipline)
- Stop-gate integration test file (`tests/test-stop-gate-carveout.mjs`) — codex R7 said "not blocker"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
