### PR TITLE
fix(classifier): authority-root threading + classifier-marker bootstrap carve-out (rank-10 PR-A)

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -668,7 +668,7 @@ _tool_call_targets_repo_source() {
 # to who-knows-where). Uses _canonicalize_possibly_nonexistent which handles
 # symlinks (32-hop chain), macOS /var → /private/var, and nonexistent
 # ancestors via existence-walk. Env-prefix attack class is already rejected
-# at classifier-tier (command-classifier.sh:1718 returns unsafe_complex);
+# at classifier-tier (command-classifier.sh:1730 returns unsafe_complex);
 # this helper only sees the LABEL=marker_write/REASON=interpreter_classifier_marker
 # case where env-prefix has been filtered upstream.
 _validate_classifier_marker_helper() {
@@ -858,7 +858,7 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     # empirically (pasted marker command blocked with "Checkpoint required").
     #
     # Security layering:
-    #   - Env-prefix already rejected upstream (command-classifier.sh:1718
+    #   - Env-prefix already rejected upstream (command-classifier.sh:1730
     #     returns unsafe_complex for env-prefixed classifier-marker forms).
     #   - Plan-pending invariant still applies (above this branch); plan-
     #     pending blocks classifier-marker just like any other marker_write.

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -652,6 +652,68 @@ _tool_call_targets_repo_source() {
   return 1
 }
 
+# PR-A P1.2: validate that `node <path>/classifier-marker.mjs ...` resolves
+# to a known canonical location. Defense against shimmed binaries
+# (`node /tmp/evil-classifier-marker.mjs --write ...` would otherwise be
+# labeled marker_write/interpreter_classifier_marker by the classifier
+# since the case-arm only matches on basename).
+#
+# Returns 0 if script path resolves to:
+#   - ~/.episodic-memory/scripts/classifier-marker.mjs (installed runtime)
+#   - <repo>/scripts/classifier-marker.mjs (repo-source)
+# Returns 1 otherwise. Caller falls through to normal gate flow (which
+# will typically block under armed checkpoint).
+#
+# Security: requires absolute path (relative paths would resolve via PATH/cwd
+# to who-knows-where). Uses _canonicalize_possibly_nonexistent which handles
+# symlinks (32-hop chain), macOS /var → /private/var, and nonexistent
+# ancestors via existence-walk. Env-prefix attack class is already rejected
+# at classifier-tier (command-classifier.sh:1718 returns unsafe_complex);
+# this helper only sees the LABEL=marker_write/REASON=interpreter_classifier_marker
+# case where env-prefix has been filtered upstream.
+_validate_classifier_marker_helper() {
+  local cmd="$1"
+  local repo_root="$2"
+  # Extract script path: first token after node|python|python3|ruby|perl.
+  # Extraction is positional — node CLI flags before the script (e.g.
+  # `node --inspect-brk script.mjs`) are NOT supported. This is symmetric
+  # with the upstream classifier dispatch at command-classifier.sh:1641
+  # which takes `${TOKS[$((idx+1))]}` as the script directly, so any node-
+  # flag-prefixed form misses both the classifier case-arm AND this
+  # validator (benign consistent miss). Basename `classifier-marker.mjs` is
+  # also exact-match — `.cjs` / `.js` variants would need extending both
+  # sites (per negative-scenario-reviewer B3 audit).
+  local script_path
+  script_path="$(printf '%s' "$cmd" | awk '{
+    for (i=1; i<=NF; i++) {
+      if ($i == "node" || $i == "python" || $i == "python3" || $i == "ruby" || $i == "perl") {
+        if (i+1 <= NF) print $(i+1)
+        exit
+      }
+    }
+  }')"
+  [ -z "$script_path" ] && return 1
+  # Require absolute path. Bare basename / ./relative could resolve to
+  # anywhere; refuse rather than disambiguate.
+  case "$script_path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  local script_canon
+  script_canon="$(_canonicalize_possibly_nonexistent "$script_path")"
+  [ -z "$script_canon" ] && return 1
+  local allowed_global allowed_repo
+  allowed_global="$(_canonicalize_possibly_nonexistent "$HOME/.episodic-memory/scripts/classifier-marker.mjs")"
+  allowed_repo="$(_canonicalize_possibly_nonexistent "$repo_root/scripts/classifier-marker.mjs")"
+  if [ -n "$allowed_global" ] && [ "$script_canon" = "$allowed_global" ]; then
+    return 0
+  fi
+  if [ -n "$allowed_repo" ] && [ "$script_canon" = "$allowed_repo" ]; then
+    return 0
+  fi
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Bash classification — compute label up front for downstream gates.
 # ---------------------------------------------------------------------------
@@ -659,10 +721,25 @@ LABEL=""
 TARGET=""
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
-  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT")"
+  # PR-A P1.1: thread parsed .cwd as authoritative caller cwd. $CWD is
+  # already absolute-normalized at top of file (relative/empty → $(pwd)
+  # fallback per PR #347 R7/P1). Without threading, classify_command's
+  # Tier 0 + Tier 2/3 dispatch use hook process $PWD which diverges from
+  # tool .cwd — codex R1 P1 reproduced marker miss.
+  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT" "$CWD")"
   LABEL="${RESULT%%	*}"
   REST="${RESULT#*	}"
   TARGET="${REST%%	*}"
+  # PR-A P1.2: extract REASON (3rd field) for bootstrap carve-out routing.
+  # classifier-marker.mjs invocations emit `marker_write\t\tinterpreter_classifier_marker`
+  # — empty TARGET but distinguishable REASON.
+  REASON="${REST#*	}"
+  # Belt-and-suspenders trailing-newline strip. `RESULT="$(classify_command ...)"`
+  # already strips trailing newlines via bash command substitution semantics
+  # so this is a no-op on well-formed classifier output (all classifier
+  # printf calls use \n only — no CR source). Per negative-scenario-reviewer
+  # C1 audit: kept as defense against future classifier output drift.
+  REASON="${REASON%$'\n'}"
 
   # Read-only Bash → allow immediately (closes #89).
   if [ "$LABEL" = "read_only" ]; then
@@ -769,6 +846,31 @@ if [ "$TOOL_NAME" = "Bash" ]; then
         exit 0
         ;;
     esac
+
+    # PR-A P1.2: classifier-marker.mjs bootstrap carve-out. The classifier
+    # labels `node <path>/classifier-marker.mjs --write ...` as
+    # marker_write/interpreter_classifier_marker, but the command has empty
+    # TARGET (it's not a path-writing shell verb), so the quartet checks
+    # above can't match. Without this carve-out, the deny-with-hint
+    # mechanism in PR-B would direct the agent to run classifier-marker.mjs,
+    # which would then be blocked by the pre-gate when .checkpoint-required
+    # is armed — making the hint unactionable. Codex R1 P1 reproduced this
+    # empirically (pasted marker command blocked with "Checkpoint required").
+    #
+    # Security layering:
+    #   - Env-prefix already rejected upstream (command-classifier.sh:1718
+    #     returns unsafe_complex for env-prefixed classifier-marker forms).
+    #   - Plan-pending invariant still applies (above this branch); plan-
+    #     pending blocks classifier-marker just like any other marker_write.
+    #   - Helper-identity validation here (_validate_classifier_marker_helper)
+    #     requires absolute script path resolving to canonical installed
+    #     runtime or repo-source location; shimmed `node /tmp/evil...` rejected.
+    if [ "$REASON" = "interpreter_classifier_marker" ]; then
+      if _validate_classifier_marker_helper "$COMMAND" "$REPO_ROOT"; then
+        exit 0
+      fi
+    fi
+
     # Did not satisfy a prerequisite — fall through to pre-gate as a normal
     # write. Pre-gate will block if PRE_REQ armed and PRE_DONE empty.
   fi

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -953,7 +953,15 @@ _detect_helper_invocation() {
 
 _classify_segment() {
   local target_root="$1"  # repo root for marker resolution
-  shift
+  # PR-A P1.1: authoritative caller cwd threaded from classify_command. The
+  # hook's authoritative cwd is parsed JSON .cwd in checkpoint-gate.sh:48 /
+  # plan-gate.sh:37, NOT the hook process $PWD. Tier 0 dispatch (line ~1547)
+  # and Tier 2/3 LLM dispatch (line ~1762) previously used $PWD as
+  # caller_cwd — codex R1 P1 reproduced a marker miss when the .cwd differs
+  # from the hook process cwd (subprocess/process $PWD divergence). Fall
+  # back to $PWD only when caller doesn't thread (tests, CLI use).
+  local caller_cwd_authoritative="${2:-$PWD}"
+  shift 2
 
   # Read all token + redirect records into arrays
   local -a TOKS=()
@@ -1538,13 +1546,17 @@ _classify_segment() {
       # --project-root` cross-repo refusal succeeds. 2>/dev/null swallows
       # helper diagnostics — they don't belong in the hook's stdout JSON.
       #
-      # Codex P1 (file 6/8 R1 REJECT): capture $PWD BEFORE the subshell.
+      # Codex P1 (file 6/8 R1 REJECT): capture caller cwd BEFORE the subshell.
       # Inside the `cd "$target_root" && ...` command substitution, $PWD
       # is the target root, NOT the original caller cwd — passing $PWD
       # there would compute the tuple under the wrong caller_cwd and miss
       # any override staged for the actual caller cwd. Tuple symmetry
       # with classify-correction's write requires the un-subshelled cwd.
-      local __t0_caller_cwd="$PWD"
+      #
+      # PR-A P1.1: use threaded caller_cwd_authoritative (parsed .cwd from
+      # hook stdin) instead of $PWD. Hook process $PWD ≠ tool .cwd in
+      # general; codex R1 P1 reproduced marker miss for that divergence.
+      local __t0_caller_cwd="$caller_cwd_authoritative"
       local __t0_out
       __t0_out="$(cd "$target_root" 2>/dev/null && node "$__t0_helper" \
         --project-root "$target_root" \
@@ -1759,7 +1771,11 @@ _classify_segment() {
           fi
         done
         local __llm_out __llm_label __llm_reason
-        if __llm_out="$(llm_classify_command "$__cmd_text" "$target_root" "$PWD" 2>/dev/null)"; then
+        # PR-A P1.1: pass caller_cwd_authoritative (parsed .cwd from hook
+        # stdin) instead of hook process $PWD. Codex R1 P1: marker written
+        # under nested cwd was a miss when classify_command subprocess
+        # $PWD differs from the .cwd authority.
+        if __llm_out="$(llm_classify_command "$__cmd_text" "$target_root" "$caller_cwd_authoritative" 2>/dev/null)"; then
           __llm_label="${__llm_out%%	*}"
           __llm_reason="${__llm_out#*	}"
           __llm_reason="${__llm_reason%$'\n'}"
@@ -2158,11 +2174,19 @@ _resolve_marker_path() {
 # Args:
 #   $1  command string
 #   $2  repo root (for marker resolution); optional, defaults to cwd
+#   $3  caller cwd authoritative (PR-A P1.1); optional, defaults to $PWD.
+#       Production callers (checkpoint-gate.sh:662, plan-gate.sh:129) thread
+#       the parsed JSON .cwd from hook stdin (the tool-caller's actual cwd).
+#       Tier 0 + Tier 2/3 dispatch previously used hook process $PWD which
+#       diverges from .cwd when the agent invokes a Bash tool from a nested
+#       cwd or a worktree. Codex R1 P1 reproduced marker miss for that
+#       divergence.
 #
 # Output: LABEL\tTARGET\tREASON
 classify_command() {
   local cmd="$1"
   local repo_root="${2:-$(pwd)}"
+  local caller_cwd_authoritative="${3:-$PWD}"
 
   # Run tokenizer
   local stream
@@ -2208,7 +2232,7 @@ classify_command() {
         # End segment, classify
         if [ -n "$seg_lines" ]; then
           local result
-          result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root")"
+          result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative")"
           local lbl="${result%%	*}"
           local rest="${result#*	}"
           local tgt="${rest%%	*}"
@@ -2230,7 +2254,7 @@ classify_command() {
   # Final segment
   if [ -n "$seg_lines" ]; then
     local result
-    result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root")"
+    result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative")"
     local lbl="${result%%	*}"
     local rest="${result#*	}"
     local tgt="${rest%%	*}"

--- a/hooks/plan-gate.sh
+++ b/hooks/plan-gate.sh
@@ -36,7 +36,16 @@ INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)"
-[ -z "$CWD" ] && CWD="$(pwd)"
+# PR-A P1.1: empty OR relative .cwd falls back to hook process cwd. Parity
+# with checkpoint-gate.sh:56-59 PR #347 R7/P1 cwd-binding defense — relative
+# .cwd would otherwise propagate through resolve_repo_root → wrong REPO_ROOT,
+# and downstream classify_command's caller-cwd-authoritative would be
+# non-absolute (breaking marker-cache lookups). Both empty AND non-absolute
+# trigger the fallback.
+case "$CWD" in
+  /*) ;;
+  *)  CWD="$(pwd)" ;;
+esac
 
 # Source classifier + repo-root resolver + marker paths + session-id.
 # Use BASH_SOURCE so symlinked hook invocations resolve correctly.
@@ -126,7 +135,9 @@ fi
 # Classifier-driven Bash gating
 if [ "$TOOL_NAME" = "Bash" ]; then
   COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
-  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT")"
+  # PR-A P1.1: thread parsed .cwd (absolute-normalized above) as authoritative
+  # caller cwd. See checkpoint-gate.sh:662 for rationale + codex R1 P1 evidence.
+  RESULT="$(classify_command "$COMMAND" "$REPO_ROOT" "$CWD")"
   LABEL="${RESULT%%	*}"
   REST="${RESULT#*	}"
   TARGET="${REST%%	*}"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1553,6 +1553,191 @@ fi
 # Cleanup off-repo scratch.
 rm -rf "$OFFREPO_DIR"
 
+# ============================================================================
+echo ""
+echo "--- PR-A P1.2: classifier-marker bootstrap carve-out under armed checkpoint ---"
+# ============================================================================
+# Codex R1 plan-tier P1: classifier-marker.mjs invocations were blocked when
+# .checkpoint-required is armed (empty TARGET → fell through marker_write
+# branch → pre-gate blocked). With the carve-out, valid classifier-marker
+# invocations exit 0; shimmed/relative paths fall through to normal flow.
+
+# Set up canonical helper locations the validator accepts.
+GLOBAL_HELPER_DIR="$TEST_HOME/.episodic-memory/scripts"
+mkdir -p "$GLOBAL_HELPER_DIR"
+touch "$GLOBAL_HELPER_DIR/classifier-marker.mjs"
+GLOBAL_HELPER="$GLOBAL_HELPER_DIR/classifier-marker.mjs"
+
+REPO_HELPER_DIR="$TEST_DIR/scripts"
+mkdir -p "$REPO_HELPER_DIR"
+touch "$REPO_HELPER_DIR/classifier-marker.mjs"
+REPO_HELPER="$REPO_HELPER_DIR/classifier-marker.mjs"
+
+SHIMMED_HELPER_DIR="$(mktemp -d)"
+SHIMMED_HELPER_DIR="$(cd -P "$SHIMMED_HELPER_DIR" && pwd)"
+touch "$SHIMMED_HELPER_DIR/classifier-marker.mjs"
+SHIMMED_HELPER="$SHIMMED_HELPER_DIR/classifier-marker.mjs"
+
+reset_state
+touch "$PRE_REQ"  # arm — pre-gate would block any non-allowed write
+
+# ── Valid global helper path → allowed (key fix) ──
+assert_allowed "NC-1. node ~/.episodic-memory/scripts/classifier-marker.mjs --write allowed under armed .checkpoint-required" \
+  "$(mock_json 'Bash' "node $GLOBAL_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+
+# ── Valid repo-source helper path → allowed ──
+assert_allowed "NC-2. node <repo>/scripts/classifier-marker.mjs --write allowed (repo-source path parity)" \
+  "$(mock_json 'Bash' "node $REPO_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+
+# ── Shimmed binary at /tmp → BLOCKED (helper-identity validation) ──
+assert_blocked "NC-3. Shimmed binary (node /tmp/.../classifier-marker.mjs) BLOCKED under armed checkpoint" \
+  "$(mock_json 'Bash' "node $SHIMMED_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Checkpoint required"
+
+# ── Relative path (./classifier-marker.mjs) → BLOCKED (absolute-path requirement) ──
+assert_blocked "NC-4. Relative ./classifier-marker.mjs path BLOCKED (carve-out requires absolute path)" \
+  "$(mock_json 'Bash' "node ./classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Checkpoint required"
+
+# ── Bare basename → BLOCKED (no PATH lookup allowed) ──
+assert_blocked "NC-5. Bare 'classifier-marker.mjs' (no path) BLOCKED" \
+  "$(mock_json 'Bash' "node classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Checkpoint required"
+
+# ── Env-prefix attempt → BLOCKED (classifier-tier rejection, returns unsafe_complex) ──
+# This already worked pre-PR-A; this test verifies the layering is unchanged.
+assert_blocked "NC-6. Env-prefix BYPASS=1 form BLOCKED (classifier returns unsafe_complex, not marker_write)" \
+  "$(mock_json 'Bash' "BYPASS=1 node $GLOBAL_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+
+# ── Symlink to allowed location → allowed (canonicalization resolves) ──
+SYMLINK_HELPER_DIR="$(mktemp -d)"
+SYMLINK_HELPER_DIR="$(cd -P "$SYMLINK_HELPER_DIR" && pwd)"
+SYMLINK_HELPER="$SYMLINK_HELPER_DIR/classifier-marker.mjs"
+ln -sf "$GLOBAL_HELPER" "$SYMLINK_HELPER"
+assert_allowed "NC-7. Symlink → allowed canonical path allowed (canonicalize follows symlink)" \
+  "$(mock_json 'Bash' "node $SYMLINK_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+
+# ── Symlink to shimmed location → BLOCKED (canonicalize resolves to wrong target) ──
+SYMLINK_TO_EVIL="$SYMLINK_HELPER_DIR/classifier-marker-evil.mjs"
+ln -sf "$SHIMMED_HELPER" "$SYMLINK_TO_EVIL"
+assert_blocked "NC-8. Symlink → shimmed binary BLOCKED (canonicalize unmasks symlink target)" \
+  "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Checkpoint required"
+
+# ── Plan-pending invariant preserved: classifier-marker BLOCKED while plan-pending ──
+# (Even with carve-out, plan-pending check fires earlier and blocks marker_write.)
+reset_state
+touch "$MARKER_DIR/.plan-approval-pending"
+assert_blocked "NC-9. classifier-marker BLOCKED while .plan-approval-pending exists (plan-pending invariant > bootstrap carve-out)" \
+  "$(mock_json 'Bash' "node $GLOBAL_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Plan approval pending"
+
+# ── Read-only mode (no --write flag) also covered by carve-out ──
+reset_state
+touch "$PRE_REQ"
+assert_allowed "NC-10. classifier-marker --read (no --write) also allowed under armed checkpoint" \
+  "$(mock_json 'Bash' "node $GLOBAL_HELPER --read --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc")"
+
+# Cleanup
+rm -rf "$SHIMMED_HELPER_DIR" "$SYMLINK_HELPER_DIR"
+
+# ============================================================================
+echo ""
+echo "--- PR-A P1.1: authority-root threading (caller_cwd != hook \$PWD) ---"
+# ============================================================================
+# Codex R1 plan-tier P1: command-classifier.sh:1762 passed \$PWD as caller_cwd
+# into llm_classify_command instead of the parsed JSON .cwd. Marker written
+# under nested cwd was a miss when classify_command subprocess \$PWD diverged
+# from the .cwd authority. Fix: thread parsed .cwd through classify_command +
+# _classify_segment to both Tier 0 (line 1547) and Tier 2/3 (line 1762).
+
+# Skip if the real classifier-marker.mjs isn't reachable from this repo
+# (e.g., extracted fixture). The integration test needs the real helper.
+REAL_HELPER="$(cd "$(dirname "$HOOK")/.." 2>/dev/null && pwd)/scripts/classifier-marker.mjs"
+if [ -f "$REAL_HELPER" ]; then
+  P11_REPO="$(mktemp -d)"
+  P11_REPO="$(cd -P "$P11_REPO" && pwd)"
+  git -C "$P11_REPO" init -q 2>/dev/null
+  P11_REPO_MARKER_DIR="$P11_REPO/.checkpoints"
+  P11_REPO_PRE_REQ="$P11_REPO_MARKER_DIR/.checkpoint-required"
+  P11_REPO_PRE_DONE="$P11_REPO_MARKER_DIR/.pre-checkpoint-done"
+  mkdir -p "$P11_REPO_MARKER_DIR"
+
+  # Fresh per-test home so classifier-cache.json starts clean.
+  P11_HOME="$(mktemp -d)"
+  P11_HOME="$(cd -P "$P11_HOME" && pwd)"
+
+  # Pre-classify a novel `node /tmp/p11-novel.mjs --inspect` command as
+  # read_only, with caller_cwd = repo root. Need a session id (matches
+  # CLAUDE_CODE_SESSION_ID env semantics).
+  P11_SID="$(uuidgen 2>/dev/null || echo "p11-test-session-$$")"
+  P11_CMD="node /tmp/p11-novel.mjs --inspect"
+
+  # Helper requires process.cwd() == --project-root (§M6) and env
+  # CLAUDE_CODE_SESSION_ID == --session-id (§M4) for honest single-session
+  # write. Drop helper diagnostics to stderr-only so the test stays quiet.
+  P11_WRITE_OUT="$( (cd "$P11_REPO" && CLAUDE_CODE_SESSION_ID="$P11_SID" node "$REAL_HELPER" --write \
+    --project-root "$P11_REPO" \
+    --caller-cwd "$P11_REPO" \
+    --command "$P11_CMD" \
+    --session-id "$P11_SID" \
+    --label read_only \
+    --confidence 0.95 \
+    --reason "P1.1 integration test") 2>&1 )"
+
+  # Marker exists?
+  if ls "$P11_REPO_MARKER_DIR/classify/"*.json >/dev/null 2>&1; then
+    # Arm pre-checkpoint to prove the marker-hit path is allowed under the
+    # exact condition (.checkpoint-required armed) that codex R1 P1 reported.
+    # Without P1.1 threading, marker would miss (hook $PWD != caller_cwd),
+    # classifier would fall through to interpreter_other shared_write, the
+    # pre-gate would block on missing pre-checkpoint marker.
+    touch "$P11_REPO_PRE_REQ"
+
+    # Invoke the hook with cwd=$P11_REPO (.cwd authority) but hook process
+    # pwd != P11_REPO (i.e., simulate launchd / cross-cwd dispatch). Use
+    # a subshell `(cd /tmp && ...)` to force hook $PWD = /tmp.
+    P11_JSON="$(jq -n --arg tn 'Bash' --arg cmd "$P11_CMD" --arg cwd "$P11_REPO" --arg sid "$P11_SID" \
+      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd, session_id: $sid}')"
+    P11_OUTPUT="$( (cd /tmp && echo "$P11_JSON" | HOME="$P11_HOME" CLAUDE_CODE_SESSION_ID="$P11_SID" bash "$HOOK") 2>/dev/null )"
+    P11_EXIT=$?
+
+    # Expected: gate allows (exit 0, empty output) because marker hit
+    # surfaces read_only label → checkpoint-gate.sh exits early on read_only.
+    if [ $P11_EXIT -eq 0 ] && [ -z "$P11_OUTPUT" ]; then
+      echo "  ✓ AR-1. P1.1 round-trip: marker written under repo cwd, hit when hook \$PWD=/tmp but .cwd=repo (read_only allows under armed checkpoint)"
+      ((passed++))
+    else
+      echo "  ✗ AR-1. P1.1 round-trip failed (exit=$P11_EXIT, output=$P11_OUTPUT)"
+      ((failed++))
+    fi
+
+    # Negative control: same command but caller_cwd differs from the written
+    # marker's caller_cwd → marker SHA differs (cache key = project + caller_cwd
+    # + command per classifier-marker.mjs:140) → miss → interpreter_other →
+    # shared_write → pre-gate blocks. This proves the threading is honored:
+    # different .cwd → different classification outcome (impossible without
+    # P1.1 — pre-fix code used hook $PWD as caller_cwd regardless of .cwd).
+    mkdir -p "$P11_REPO/sub"
+    P11_JSON_NEG="$(jq -n --arg tn 'Bash' --arg cmd "$P11_CMD" --arg cwd "$P11_REPO/sub" --arg sid "$P11_SID" \
+      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd, session_id: $sid}')"
+    P11_OUTPUT_NEG="$( (cd /tmp && echo "$P11_JSON_NEG" | HOME="$P11_HOME" CLAUDE_CODE_SESSION_ID="$P11_SID" bash "$HOOK") 2>/dev/null )"
+    if echo "$P11_OUTPUT_NEG" | grep -q '"decision".*"block"'; then
+      echo "  ✓ AR-2. P1.1 threading-sensitivity: different .cwd → miss → blocked (proves .cwd is threaded, not ignored)"
+      ((passed++))
+    else
+      echo "  ✗ AR-2. P1.1 threading-sensitivity expected block (output=$P11_OUTPUT_NEG)"
+      ((failed++))
+    fi
+  else
+    echo "  ⊘ AR-1/AR-2 skipped: classifier-marker.mjs write did not produce marker (sandboxed env or helper rejected)"
+  fi
+
+  rm -rf "$P11_REPO" "$P11_HOME"
+else
+  echo "  ⊘ AR-1/AR-2 skipped: real classifier-marker.mjs not reachable at $REAL_HELPER"
+fi
+
 echo ""
 echo "Passed: $passed"
 echo "Failed: $failed"


### PR DESCRIPTION
## Summary

Closes 2 pre-existing P1 bugs surfaced by codex plan-tier review of rank-10 (issue #333). Foundation for PR-B (deny-with-hint UX + rename `llm-classifier.sh` → `agent-classifier.sh`).

- **P1.1 authority-root threading.** `classify_command` gets a new 3rd parameter `caller_cwd_authoritative` threaded from parsed JSON `.cwd` through `_classify_segment` to Tier 0 + Tier 2/3 LLM dispatch (replaces the previous hook process `$PWD` use). `plan-gate.sh` gets cwd-binding case-statement parity with `checkpoint-gate.sh` PR #347 R7/P1 defense.
- **P1.2 classifier-marker bootstrap carve-out.** New `_validate_classifier_marker_helper` validates absolute script path canonicalizes to `~/.episodic-memory/scripts/classifier-marker.mjs` or `<repo>/scripts/classifier-marker.mjs` (reuses `_canonicalize_possibly_nonexistent`). Carve-out branch inside `LABEL=marker_write`, after plan-pending invariant, exits 0 on validated identity. Shimmed/relative/bare paths fall through.

## Why this matters

Without P1.1, marker writes under one cwd were unreadable from another cwd (hook process `$PWD` ≠ tool `.cwd` divergence). Without P1.2, the deny-with-hint mechanism PR-B will add becomes unactionable because the canonical helper invocation it instructs the agent to run would itself be blocked under armed `.checkpoint-required`.

## Review history

| Layer | Reviewer | Verdict | Findings |
|---|---|---|---|
| Plan R1 | codex | HOLD | 2 P1, 2 P2 — all 4 disposed in R2 plan body |
| Plan R2 | codex | **ACCEPT-with-FU** | scope split β confirmed (PR-A first, PR-B inherits) |
| Code | negative-scenario-reviewer | **ACCEPT-with-FU** | 1 MAJOR (A1, filed as #348), 2 MINOR + 1 NIT inlined as comments |
| PR-level | claude-subagent (codex backgrounded twice; per-user-instruction fallback) | **ACCEPT-with-FU** | 1 NIT inline-fixed (commit `26eb93b`), 1 MINOR filed as #349 |

Episodes:
- Plan R1: `20260524-125023-reply-codex-to-20260524-124657-rank-10-p-4990`
- Plan R2: `20260524-125442-reply-codex-to-20260524-125242-rank-10-p-2b4d`
- PR-level: `20260524-141649-reply-claude-subagent-to-20260524-141133-f9c2`

## Test plan

Full local suite — all 652 tests pass:

- [x] `bash tests/test-checkpoint-gate.sh` → 222/0 (210 baseline + 10 NC carve-out + 2 AR threading)
- [x] `bash tests/test-command-classifier.sh` → 361/0
- [x] `bash tests/test-plan-marker-classifier.sh` → 15/0
- [x] `node tests/test-classifier-marker.mjs` → 17/0
- [x] `node tests/test-llm-classifier.mjs` → 37/0

New tests added in this PR:

- **NC-1..NC-10** in `tests/test-checkpoint-gate.sh` — bootstrap carve-out axes (valid global+repo paths, shimmed binary, relative/bare path, env-prefix, symlink-allowed, symlink-shimmed, plan-pending invariant preserved, --read mode)
- **AR-1** — P1.1 round-trip: marker written under repo cwd, hit when hook `$PWD=/tmp` but `.cwd=repo` (read_only allows under armed checkpoint)
- **AR-2** — P1.1 threading-sensitivity: different `.cwd` → miss → blocked (proves `.cwd` is threaded, not ignored)

## Out-of-scope follow-ups

Filed as separate issues:

- **#348** (P2) — Extend absolute-path `.cwd` defense to 5 other hooks (preflight-gate, preflight-prompt-helper, stop-gate, em-recall-sessionstart, session-handoff-prompt). Surfaced by negative-scenario-reviewer A1 as same-class incomplete fix; out of stated PR-A scope.
- **#349** (P3) — `_validate_classifier_marker_helper` awk extraction breaks on shell-quoted paths with spaces (e.g., macOS `$HOME` with display-name dirs). Surfaced by claude-subagent PR-level review NIT-2; bundle with PR-B's deny-with-hint work where the UX impact gets larger.

## Foundation for PR-B (rank-10 main work)

PR-B will (per codex plan R2 split β):
- Rename `hooks/lib/llm-classifier.sh` → `agent-classifier.sh` + symbol rename (function, helpers, guard)
- Add `needs_classification` label + `agent-classifier-deny-reason.sh` helper for deny-with-hint UX
- Add `--command-file` flag to `classifier-marker.mjs` for long commands (with codex R2's tightening: absolute path, lstat reject symlink, size cap, UTF-8)
- Rename env names `LLM_CLASSIFIER_*` → `AGENT_CLASSIFIER_*` with backward-compat aliases + deprecation log

Closes #333 when both PR-A + PR-B land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
