### PR TITLE
fix(checkpoint-gate): planning-passive redesign — lazy-arm at first repo write, no session-start arming

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -42,6 +42,27 @@ set -e
 # Cross-gate invariant (Codex ...3503 P1): checkpoint marker writes are
 # blocked while .plan-approval-pending exists (either root). Both gates
 # independently enforce.
+#
+# ---------------------------------------------------------------------------
+# Planning-passive redesign (2026-05-25) + F1 RESIDUAL
+# ---------------------------------------------------------------------------
+# The pre-checkpoint gate no longer arms at SessionStart (em-recall emits an
+# advisory instead). Nothing is armed during planning / discovery / exploration
+# / code review. The pre-checkpoint requirement materializes at the
+# IMPLEMENTATION boundary: the first repo-source Edit/Write/MultiEdit/
+# NotebookEdit lazily arms .checkpoint-required and blocks. Bash is intentionally
+# NOT pre-checkpoint-gated — reviews/inspections/dispatch never block.
+#
+# F1 RESIDUAL (documented + user-accepted): because Bash is ungated by the
+# pre-checkpoint gate, a PURE-Bash implementation (`sed -i`, `cat > file`,
+# `git commit`, `node script-that-writes.mjs`) can mutate repo source WITHOUT
+# ever arming .checkpoint-required, bypassing the Rule 18 pre-checkpoint. This
+# is a deliberate trade: gating all shared_write Bash reintroduced the exact
+# planning-time friction this redesign removes (read-only `node`/inspection
+# commands mis-blocked). Clean closure DEPENDS on the agent-classifier (rank-10
+# PR-B) correctly distinguishing read-only from mutating Bash, so only mutating
+# Bash arms. Tracked as follow-up issue #351 (PR-B agent-classifier dependency).
+# The push-gate + post-checkpoint + stop-gate lifecycle remain fully enforced.
 
 INPUT="$(cat)"
 TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
@@ -521,6 +542,53 @@ _block_plan_pending() {
     '{decision: "block", reason: ("Plan approval pending. Checkpoint marker writes are blocked while " + $path + " exists. Approve the plan first. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
+# Env-prefix wrapper-escape block (codex review FU, 2026-05-25). The classifier
+# flags `<NAME>=value node ... classifier-marker.mjs ...` as
+# unsafe_complex/classifier_marker_env_override (the helper-invocation grammar
+# refuses ANY env-prefix on the carve-out helper). The planning-passive redesign
+# ungates Bash, so without this the form would be allowed — blessing an
+# env-prefix wrapper escape that can poison the classifier-marker cache the gate
+# itself trusts. Reject the FORM (not the var name), independent of the
+# pre-checkpoint gate.
+_block_env_prefix_marker() {
+  jq -nc '{decision: "block", reason: "Env-prefix wrapper escape rejected. An environment-variable assignment before a classifier-marker.mjs invocation (e.g. BYPASS=1 node ... classifier-marker.mjs --write) is refused: env-prefix wrappers can carry gate-bypass payloads and poison the classifier cache. Re-invoke the helper with NO leading VAR=value prefix. Hook: checkpoint-gate.sh."}'
+  exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Lazy-arm .checkpoint-required (planning-passive redesign, 2026-05-25).
+#
+# Replaces session-start arming (em-recall.mjs no longer arms; a recent bp-001
+# violation is now an advisory warning, never a gate-arm). NOTHING is armed
+# during planning / discovering / exploring / code review. The pre-checkpoint
+# requirement materializes only at the IMPLEMENTATION boundary — the first
+# repo-source file write OR the pre-checkpoint-done write, whichever comes
+# first. Arming here (rather than at session start) keeps the downstream
+# post-checkpoint + stop-gate + push-gate lifecycle intact: those key off
+# .checkpoint-required to know a task is active this session.
+#
+# Idempotent: no-op if the marker already exists (own-session or legacy).
+# Best-effort: never aborts the hook under set -e.
+# ---------------------------------------------------------------------------
+_arm_checkpoint_required_if_missing() {
+  if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID"; then
+    return 0
+  fi
+  ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
+  if validate_session_id "$MY_SID"; then
+    local helper="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+    if [ -f "$helper" ]; then
+      CLAUDE_CODE_SESSION_ID="$MY_SID" node "$helper" \
+        --target .checkpoint-required \
+        --action arm-if-missing \
+        --root "$REPO_ROOT" >/dev/null 2>&1 || true
+    else
+      touch "$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .checkpoint-required "$MY_SID")")" 2>/dev/null || true
+    fi
+  else
+    touch "$(write_marker_path "$REPO_ROOT" .checkpoint-required)" 2>/dev/null || true
+  fi
+}
 
 # ---------------------------------------------------------------------------
 # Smart-arming helpers (PR fix/checkpoint-gate-smart-arming, 2026-05-24)
@@ -746,6 +814,16 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     exit 0
   fi
 
+  # Env-prefix wrapper escape on the classifier-marker helper. The classifier
+  # returns unsafe_complex/classifier_marker_env_override for any env-prefixed
+  # helper invocation. Block it DIRECTLY here — independent of the (removed)
+  # Bash pre-checkpoint gate — so the planning-passive Bash allowance can't
+  # bless an env-prefix wrapper escape against the classifier cache. (Codex
+  # review FU, 2026-05-25.)
+  if [ "$REASON" = "classifier_marker_env_override" ]; then
+    _block_env_prefix_marker
+  fi
+
   # Codex round-4 F12 + round-5 F15 + round-6 F18: verb-agnostic relative-
   # marker precheck. Runs for ALL non-read_only Bash when CWD != REPO_ROOT
   # (linked worktree OR nested cwd inside main repo). Catches touch/mv/cp/
@@ -831,16 +909,27 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     # handles both own-suffixed AND legacy literal forms.
     case "$TARGET_BN" in
       .pre-checkpoint-done|.pre-checkpoint-done.*)
-        if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
-           && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
+        # Planning-passive redesign (2026-05-25): allow the pre-checkpoint
+        # block write whenever it isn't already satisfied, and arm
+        # .checkpoint-required at that moment if missing (the implementation
+        # boundary). No longer depends on a session-start arm.
+        if ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
+          _arm_checkpoint_required_if_missing
           exit 0
         fi
         ;;
       .post-checkpoint-done|.post-checkpoint-done.*)
-        if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
-           && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
+        if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
+          # POST_REQ armed → post-checkpoint phase; allow the write (first
+          # write OR idempotent re-write of an already-satisfied marker).
           exit 0
         fi
+        # POST_REQ NOT armed → writing the post-checkpoint before the
+        # lifecycle has armed it. The planning-passive redesign (2026-05-25)
+        # removed Bash from the pre-gate, so a premature marker_write no
+        # longer falls through to a block. Block DIRECTLY here so this branch
+        # is self-contained (tests 17/49/50/56).
+        _block_pre
         ;;
       .plan-approval-pending|.plan-approval-pending.*)
         exit 0
@@ -958,16 +1047,22 @@ case "$TOOL_NAME" in
         # branch — same logic as the Bash branch above).
         case "$TARGET_BN" in
           .pre-checkpoint-done|.pre-checkpoint-done.*)
-            if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
-               && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
+            # Planning-passive redesign (2026-05-25): allow + lazy-arm (see
+            # the Bash-branch counterpart above for rationale).
+            if ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
+              _arm_checkpoint_required_if_missing
               exit 0
             fi
             ;;
           .post-checkpoint-done|.post-checkpoint-done.*)
-            if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
-               && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
+            if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
+              # POST_REQ armed → post-checkpoint phase; allow the write.
               exit 0
             fi
+            # POST_REQ NOT armed → premature post-checkpoint write. marker_write
+            # skips the pre-gate (the `LABEL != marker_write` guard below), so
+            # block DIRECTLY here (planning-passive redesign self-containment).
+            _block_pre
             ;;
           .plan-approval-pending|.plan-approval-pending.*)
             exit 0
@@ -978,22 +1073,48 @@ case "$TOOL_NAME" in
     ;;
 esac
 
-# Rank-2: pre-gate read is session-aware. Own-session marker OR legacy
-# literal triggers the block; other sessions' suffixed markers do not.
+# ---------------------------------------------------------------------------
+# Pre-checkpoint gate — planning-passive + lazy-armed (2026-05-25 redesign).
 #
-# Smart-arming (2026-05-24): the pre-block fires only if the current tool
-# call targets project source. Off-repo Edit/Write (memory writes under
-# ~/.claude/projects/**, skill writes, settings edits) silently allowed.
-# Bash side stays strict (codex R1 6b — all non-marker_write Bash blocks).
-# Stop-gate symmetry preserved transitively: pre-checkpoint stays unwritten,
-# so the post-required arming at lines below also doesn't fire, so em-recall
-# carve-out continues to apply.
-if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
-   && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
-  if _tool_call_targets_repo_source "$REPO_ROOT" "$TOOL_NAME" "$FILE_PATH" "$LABEL"; then
-    _block_pre
-  fi
-fi
+# OLD: em-recall armed .checkpoint-required at SESSION START whenever a bp-001
+# violation existed within 30 days, blocking ALL non-read Bash + repo
+# Edit/Write before any implementation — planning, recall, exploration, and
+# code reviews (codex CLI / second-opinion.mjs) all tripped it. That blocked
+# legitimate pre-implementation work, the core friction users hit.
+#
+# NEW: nothing armed at session start. The pre-checkpoint requirement attaches
+# to the IMPLEMENTATION boundary — the first repo-source file write. Bash is
+# intentionally NOT pre-checkpoint-gated (its safety is the classifier +
+# push-gate + agent-classifier deny-hint), so reviews / inspections /
+# exploration never block and never create a marker.
+#
+# The first repo-source Edit/Write/MultiEdit/NotebookEdit with no
+# .pre-checkpoint-done lazily arms .checkpoint-required (so the post-checkpoint
+# + stop-gate + push-gate lifecycle still tracks the task), then blocks.
+# Off-repo Edit/Write (memory under ~/.claude/projects/**, skills, settings)
+# is silently allowed via _tool_call_targets_repo_source. marker_write writes
+# are handled earlier and skipped here.
+# ---------------------------------------------------------------------------
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    if [ "$LABEL" != "marker_write" ] \
+       && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID" \
+       && _tool_call_targets_repo_source "$REPO_ROOT" "$TOOL_NAME" "$FILE_PATH" "$LABEL"; then
+      # Lazy-arm ONLY when we have a concrete in-repo FILE_PATH. The empty-
+      # FILE_PATH conservative-block path (relative path with no absolute cwd
+      # authority — _tool_call_targets_repo_source returns 0 defensively) must
+      # NOT write a marker: REPO_ROOT there falls back to the hook process cwd
+      # (off-project invocation), so arming would leak .checkpoint-required
+      # into an unrelated repo. Regression: SA-cwd-strict caller-leak. The
+      # block still fires (Rule 18 conservative direction); only the arm is
+      # withheld until a real in-repo write is seen.
+      if [ -n "$FILE_PATH" ]; then
+        _arm_checkpoint_required_if_missing
+      fi
+      _block_pre
+    fi
+    ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Push-gate: only fires for Bash classified as push_or_pr_create.

--- a/hooks/em-recall-sessionstart.sh
+++ b/hooks/em-recall-sessionstart.sh
@@ -154,10 +154,24 @@ fi
 # omit the flag, preserving prior wrapper contract. Validation lives inside
 # em-recall.mjs (warn-on-invalid; no exit-non-zero per codex R2 Q3).
 MY_SID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")"
+
+# Planning-passive redesign (2026-05-25): em-recall no longer ARMS the
+# pre-checkpoint marker at session start. When a recent bp-001 violation
+# exists it now emits an ADVISORY on a dedicated `__BP1_ADVISORY__` stderr
+# sentinel (warning, not a block). Capture stderr (stdout still → /dev/null,
+# the recall body stays suppressed per the original #61 rationale) and surface
+# just the advisory line as SessionStart context — matching the plain-stdout
+# pattern warn_hook_freshness already uses.
+EM_ERR=""
 if [ -n "$MY_SID" ]; then
-  node "$EM_RECALL" --limit 5 --session-start --session-id "$MY_SID" >/dev/null 2>&1 || true
+  EM_ERR="$(node "$EM_RECALL" --limit 5 --session-start --session-id "$MY_SID" 2>&1 >/dev/null || true)"
 else
-  node "$EM_RECALL" --limit 5 --session-start >/dev/null 2>&1 || true
+  EM_ERR="$(node "$EM_RECALL" --limit 5 --session-start 2>&1 >/dev/null || true)"
+fi
+
+BP1_ADVISORY="$(printf '%s\n' "$EM_ERR" | grep '^__BP1_ADVISORY__ ' | head -n1 | sed 's/^__BP1_ADVISORY__ //')"
+if [ -n "$BP1_ADVISORY" ]; then
+  echo "episodic-memory: $BP1_ADVISORY"
 fi
 
 exit 0

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -616,43 +616,14 @@ function resolveProjectName(projectRoot, { ignoreOverride = false, fast = false 
 }
 
 // ---------------------------------------------------------------------------
-// Idempotent marker arming. Best-effort — failures are swallowed so a
-// non-writable .checkpoints/ dir doesn't take down the whole recall.
-//
-// Writes go to PRIMARY (.checkpoints/) only. If the legacy marker exists
-// at .claude/, it's still honored by readers via resolveMarkerRead during
-// burn-in. So "armed" here is satisfied if EITHER root has the marker.
+// NOTE (planning-passive redesign, 2026-05-25): the former
+// armCheckpointMarkerForSession() was removed. em-recall no longer arms the
+// pre-checkpoint gate at SessionStart — a recent bp-001 violation now only
+// emits the __BP1_ADVISORY__ stderr signal (see the call site below). The
+// pre-checkpoint requirement is lazily armed by checkpoint-gate.sh at the first
+// repo-source write (the implementation boundary). shouldArmBp001Checkpoint()
+// is retained as the advisory predicate.
 // ---------------------------------------------------------------------------
-// Rank-2: per-session arming. Writes `.checkpoint-required.<sid>` if
-// neither own-session nor legacy literal exists at either root. Sid is
-// REQUIRED — when missing/invalid, this falls back to legacy-literal-
-// only write at the primary root (preserves pre-rank-2 behavior for
-// graceful degrade per codex R2 Q3).
-//
-// Mirrors checkpoint-marker.mjs actionArmIfMissing semantics: no-op when
-// own-session OR legacy exists; never suppresses on OTHER sessions'
-// suffixed markers (codex C2 R1 P1 fix).
-function armCheckpointMarkerForSession(repoRoot, sid) {
-  try {
-    // Build the no-op-acceptable set: own-session (if sid) + legacy literal.
-    if (sid) {
-      const ownBasename = namespacedMarkerBasenameForSession('.checkpoint-required', sid)
-      if (fs.existsSync(primaryMarkerPath(repoRoot, ownBasename))) return
-      if (fs.existsSync(legacyMarkerPath(repoRoot, ownBasename))) return
-    }
-    if (fs.existsSync(primaryMarkerPath(repoRoot, '.checkpoint-required'))) return
-    if (fs.existsSync(legacyMarkerPath(repoRoot, '.checkpoint-required'))) return
-
-    ensurePrimaryDir(repoRoot)
-    const writeBasename = sid
-      ? namespacedMarkerBasenameForSession('.checkpoint-required', sid)
-      : '.checkpoint-required'
-    fs.writeFileSync(writeMarkerPath(repoRoot, writeBasename), '')
-  } catch {
-    // Best-effort: marker creation failure leaves Phase 3b gate inactive
-    // for this session.
-  }
-}
 
 // ---------------------------------------------------------------------------
 // SYNC: em-search.mjs:loadIndex — update both on change
@@ -784,23 +755,30 @@ if (sessionStartFlag) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 3b activation (RFC-002 Phase 3 / T7): arm the checkpoint marker
-// whenever a recent bp-001-implementation-workflow violation exists,
-// regardless of task_type. The SessionStart hook
-// (hooks/em-recall-sessionstart.sh) does not pass --task-type, so a
-// task-type-conditional arming path was inert in real sessions despite
-// Phase 3b being deployed. bp-001 is workflow discipline that applies to
-// any session that ends up writing files; checkpoint-gate itself only
-// blocks write tools, so the false-positive surface is bounded.
+// Phase 3b activation (RFC-002 Phase 3 / T7): historically armed the checkpoint
+// marker whenever a recent bp-001-implementation-workflow violation existed,
+// regardless of task_type. bp-001 is workflow discipline that applies to any
+// session that ends up writing files.
 // ---------------------------------------------------------------------------
-// Bind arming-time project name to REPO_ROOT (NOT process.cwd() and NOT the
-// --project override). This pairs with armCheckpointMarkerForSession(REPO_ROOT, mySid)
-// below so the project identity used to scope violations matches the marker write
-// authority root. Closes the cross-project bleed where violations in one
-// project armed checkpoint gates in every other project at SessionStart.
+// Bind advisory-time project name to REPO_ROOT (NOT process.cwd() and NOT the
+// --project override) so the project identity used to scope violations matches
+// the repo authority root. Closes the cross-project bleed where violations in
+// one project armed checkpoint gates in every other project at SessionStart.
+// Planning-passive redesign (2026-05-25): a recent bp-001 violation NO LONGER
+// arms the pre-checkpoint gate at session start. That blocked planning,
+// discovery, exploration, and code reviews before any implementation began —
+// the core checkpoint friction. The pre-checkpoint requirement is now lazily
+// armed by checkpoint-gate.sh at the IMPLEMENTATION boundary (first repo-source
+// write). Here we only emit an ADVISORY (warning, never a marker/block) on a
+// dedicated stderr sentinel; em-recall-sessionstart.sh surfaces it via
+// SessionStart additionalContext (closes the #61 swallow for this signal).
 const armingProject = resolveProjectName(REPO_ROOT, { ignoreOverride: true, fast: true })
 if (shouldArmBp001Checkpoint(activeEntries, new Date(), armingProject)) {
-  armCheckpointMarkerForSession(REPO_ROOT, mySid)
+  process.stderr.write(
+    '__BP1_ADVISORY__ A recent bp-001-implementation-workflow violation exists in this project. ' +
+    'The pre-implementation checkpoint is NOT armed during planning — it is required only when you ' +
+    'first edit repo source. Advisory only; not blocking.\n'
+  )
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test-bp001-per-project-arming.mjs
+++ b/tests/test-bp001-per-project-arming.mjs
@@ -1,17 +1,23 @@
 #!/usr/bin/env node
 /**
  * test-bp001-per-project-arming.mjs — Per-project scope for the bp-001
- * checkpoint-gate arming engine (`shouldArmBp001Checkpoint`).
+ * checkpoint-gate advisory engine (`shouldArmBp001Checkpoint`).
  *
  * Before: any bp-001 violation in any project armed .checkpoint-required in
  * EVERY project at SessionStart (cross-project bleed).
- * After: arming only fires when the current REPO_ROOT's resolved project name
- * matches the violation's project field.
+ * Planning-passive redesign (2026-05-25): em-recall NO LONGER arms a marker at
+ * SessionStart. When `shouldArmBp001Checkpoint` is true it emits the
+ * `__BP1_ADVISORY__` stderr signal instead (the pre-checkpoint requirement is
+ * now lazily armed by checkpoint-gate.sh at the first repo-source write). The
+ * per-project SCOPING this file guards is unchanged: the advisory fires only
+ * when the current REPO_ROOT's resolved project matches the violation's
+ * project. Each test asserts BOTH (a) em-recall writes NO marker (removed
+ * arming) and (b) the advisory presence matches the scoping rule.
  *
  * Tests run em-recall.mjs as a subprocess with isolated HOME (fake global
- * episode store) and assert marker placement on disk — pure integration.
+ * episode store) and assert advisory emission + null marker side effect.
  *
- * Plan v3 cases A1-A8.
+ * Plan v3 cases A1-A9 (advisory-adapted).
  */
 
 import { execSync, spawnSync } from 'child_process'
@@ -89,34 +95,41 @@ function markerExists(repoRoot) {
   return fs.lstatSync(p).isFile()
 }
 
+// Planning-passive: the per-project gate is now observed via the advisory
+// sentinel on stderr, not a marker write.
+function advisoryEmitted(stderr) {
+  return /__BP1_ADVISORY__/.test(stderr || '')
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────
 
 const TESTS = []
 const test = (name, fn) => TESTS.push({ name, fn })
 
-test('A1 cross-project: violation in project-A, SessionStart in project-B → NOT armed (THE FIX)', () => {
+test('A1 cross-project: violation in project-A, SessionStart in project-B → NO advisory (THE FIX)', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a1-projA', 'project-a')
   const projB = mkRepo('a1-projB', 'project-b')
   seedViolation(home, { project: 'project-a' })
   const r = runSessionStart(projB, home)
   if (r.status !== 0) return bad('A1', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (markerExists(projB)) return bad('A1', `project-b marker should NOT exist`)
-  if (markerExists(projA)) return bad('A1', `project-a marker should NOT be touched`)
+  if (advisoryEmitted(r.stderr)) return bad('A1', `project-b run must NOT emit bp-001 advisory`)
+  if (markerExists(projB) || markerExists(projA)) return bad('A1', `em-recall must not arm any marker`)
   ok('A1')
 })
 
-test('A2 same-project: violation in project-A, SessionStart in project-A → armed', () => {
+test('A2 same-project: violation in project-A, SessionStart in project-A → advisory (no marker)', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a2-projA', 'project-a')
   seedViolation(home, { project: 'project-a' })
   const r = runSessionStart(projA, home)
   if (r.status !== 0) return bad('A2', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (!markerExists(projA)) return bad('A2', `project-a marker should be armed but is not`)
+  if (!advisoryEmitted(r.stderr)) return bad('A2', `advisory should be emitted but was not`)
+  if (markerExists(projA)) return bad('A2', `em-recall must not arm a marker (lazy-arm moved to gate)`)
   ok('A2')
 })
 
-test('A3 nested cwd: violation in project-A, SessionStart in project-A/sub → armed at A (REPO_ROOT walks up)', () => {
+test('A3 nested cwd: violation in project-A, SessionStart in project-A/sub → advisory (REPO_ROOT walks up)', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a3-projA', 'project-a')
   const sub = path.join(projA, 'sub')
@@ -124,8 +137,8 @@ test('A3 nested cwd: violation in project-A, SessionStart in project-A/sub → a
   seedViolation(home, { project: 'project-a' })
   const r = runSessionStart(sub, home)
   if (r.status !== 0) return bad('A3', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (!markerExists(projA)) return bad('A3', `project-a marker should be armed`)
-  if (markerExists(sub)) return bad('A3', `sub-level marker should NOT exist`)
+  if (!advisoryEmitted(r.stderr)) return bad('A3', `advisory should be emitted`)
+  if (markerExists(projA) || markerExists(sub)) return bad('A3', `em-recall must not arm any marker`)
   ok('A3')
 })
 
@@ -136,22 +149,23 @@ test('A5 --project override does NOT trick the arming: cwd=project-B + --project
   seedViolation(home, { project: 'project-a' })
   const r = runSessionStart(projB, home, ['--project', 'project-a'])
   if (r.status !== 0) return bad('A5', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (markerExists(projB)) return bad('A5', `project-b marker should NOT exist (override must be ignored for arming)`)
-  if (markerExists(projA)) return bad('A5', `project-a marker should NOT be touched`)
+  if (advisoryEmitted(r.stderr)) return bad('A5', `--project override must NOT trigger advisory in project-b`)
+  if (markerExists(projB) || markerExists(projA)) return bad('A5', `em-recall must not arm any marker`)
   ok('A5')
 })
 
-test('A6 out-of-cutoff: 60-day-old violation in project-A → NOT armed', () => {
+test('A6 out-of-cutoff: 60-day-old violation in project-A → NO advisory', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a6-projA', 'project-a')
   seedViolation(home, { project: 'project-a', daysAgo: 60 })
   const r = runSessionStart(projA, home)
   if (r.status !== 0) return bad('A6', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (markerExists(projA)) return bad('A6', `60-day-old violation should not arm`)
+  if (advisoryEmitted(r.stderr)) return bad('A6', `60-day-old violation should not emit advisory`)
+  if (markerExists(projA)) return bad('A6', `em-recall must not arm a marker`)
   ok('A6')
 })
 
-test('A7 multi-project: violations in A,B,C + SessionStart in A → armed (only A counts)', () => {
+test('A7 multi-project: violations in A,B,C + SessionStart in A → advisory (only A counts)', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a7-projA', 'project-a')
   seedViolation(home, { project: 'project-a' })
@@ -159,26 +173,29 @@ test('A7 multi-project: violations in A,B,C + SessionStart in A → armed (only 
   seedViolation(home, { project: 'project-c' })
   const r = runSessionStart(projA, home)
   if (r.status !== 0) return bad('A7', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (!markerExists(projA)) return bad('A7', `A's own violation should arm`)
+  if (!advisoryEmitted(r.stderr)) return bad('A7', `A's own violation should emit advisory`)
+  if (markerExists(projA)) return bad('A7', `em-recall must not arm a marker`)
   ok('A7')
 })
 
-test('A8 superseded: only-violation-for-A is status:superseded → NOT armed (explicit status filter)', () => {
+test('A8 superseded: only-violation-for-A is status:superseded → NO advisory (explicit status filter)', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a8-projA', 'project-a')
   seedViolation(home, { project: 'project-a', status: 'superseded' })
   const r = runSessionStart(projA, home)
   if (r.status !== 0) return bad('A8', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (markerExists(projA)) return bad('A8', `superseded violation must not arm`)
+  if (advisoryEmitted(r.stderr)) return bad('A8', `superseded violation must not emit advisory`)
+  if (markerExists(projA)) return bad('A8', `em-recall must not arm a marker`)
   ok('A8')
 })
 
-test('A9 no violations anywhere: SessionStart in any project → NOT armed', () => {
+test('A9 no violations anywhere: SessionStart in any project → NO advisory', () => {
   const home = mkFakeHome()
   const projA = mkRepo('a9-projA', 'project-a')
   const r = runSessionStart(projA, home)
   if (r.status !== 0) return bad('A9', `em-recall exited ${r.status}: ${r.stderr}`)
-  if (markerExists(projA)) return bad('A9', `clean store must not arm`)
+  if (advisoryEmitted(r.stderr)) return bad('A9', `clean store must not emit advisory`)
+  if (markerExists(projA)) return bad('A9', `em-recall must not arm a marker`)
   ok('A9')
 })
 

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -130,11 +130,23 @@ echo "--- No markers (idle state) ---"
 reset_state
 
 assert_allowed "1.  Read allowed in idle" "$(mock_json 'Read')"
-assert_allowed "2.  Edit allowed in idle" "$(mock_json 'Edit')"
-assert_allowed "3.  Write allowed in idle" "$(mock_json 'Write')"
-assert_allowed "4.  MultiEdit allowed in idle" "$(mock_json 'MultiEdit')"
-assert_allowed "5.  Bash allowed in idle" "$(mock_json 'Bash' 'ls')"
-assert_allowed "6.  git push allowed in idle" "$(mock_json 'Bash' 'git push origin main')"
+# Planning-passive redesign (2026-05-25): no session-start arming. A bare
+# Edit/Write/MultiEdit (no/relative file_path → empty FILE_PATH) cannot be
+# proven off-repo, so the pre-gate conservatively blocks at the implementation
+# boundary. Crucially it does NOT arm .checkpoint-required on the empty-path
+# branch (REPO_ROOT may be a fallback cwd → arming would leak a marker into an
+# unrelated repo; see SA-cwd-strict). Off-repo writes (memory/skills/settings)
+# ARE allowed — see SA-5/6/7.
+assert_blocked "2.  Bare Edit conservatively blocks (empty path, planning-passive)" \
+  "$(mock_json 'Edit')" "Checkpoint required"
+assert_blocked "3.  Bare Write conservatively blocks (empty path)" \
+  "$(mock_json 'Write')" "Checkpoint required"
+assert_blocked "4.  Bare MultiEdit conservatively blocks (empty path)" \
+  "$(mock_json 'MultiEdit')" "Checkpoint required"
+assert_marker_absent "4a. Empty-path conservative block did NOT arm .checkpoint-required (no leak)" "$PRE_REQ"
+assert_allowed "5.  Bash read-only allowed in idle" "$(mock_json 'Bash' 'ls')"
+assert_allowed "6.  git push allowed in idle (push-gate inactive — no POST_REQ)" \
+  "$(mock_json 'Bash' 'git push origin main')"
 assert_marker_absent "7.  post-required NOT armed in idle" "$POST_REQ"
 
 # ============================================================================
@@ -150,17 +162,21 @@ assert_allowed "10. Grep allowed (always)" "$(mock_json 'Grep')"
 assert_blocked "11. Edit blocked by pre-gate" "$(mock_json 'Edit')" "Checkpoint required"
 assert_blocked "12. Write blocked by pre-gate" "$(mock_json 'Write')" "Checkpoint required"
 assert_blocked "13. MultiEdit blocked by pre-gate" "$(mock_json 'MultiEdit')" "Checkpoint required"
-# #89 (Session 1): read-only Bash is now allowed during pre-gate. The shape
-# of test 14 changes from "echo hello" (now read_only / allowed) to a real
-# write that should block.
-assert_blocked "14. Bash write command blocked by pre-gate" \
-  "$(mock_json 'Bash' 'echo hello > /tmp/somefile')" "Checkpoint required"
+# Planning-passive redesign (2026-05-25): Bash is no longer pre-gated. ALL
+# Bash (read_only AND shared_write) passes the pre-gate; only push_or_pr_create
+# (push-gate) and the marker_write allowlist still gate Bash. shared_write Bash
+# that formerly blocked here is now allowed (F1 residual — pure-Bash
+# implementation bypasses the checkpoint; closure tracked via PR-B). The
+# classifier's read_only/shared_write boundary is still exercised in
+# tests/test-command-classifier.sh.
+assert_allowed "14. Bash shared_write now allowed during pre-gate (Bash ungated)" \
+  "$(mock_json 'Bash' 'echo hello > /tmp/somefile')"
 assert_allowed "14b. Bash read-only echo allowed (#89)" \
   "$(mock_json 'Bash' 'echo hello')"
-# Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr checkout mutates local
-# working tree (shared_write), so pre-gate must block it.
-assert_blocked "14c. gh pr checkout blocked by pre-gate (F2 shared_write)" \
-  "$(mock_json 'Bash' 'gh pr checkout 113')" "Checkpoint required"
+# gh pr checkout mutates the local working tree (shared_write); with Bash
+# ungated it is now allowed during the pre-gate (was blocked pre-redesign).
+assert_allowed "14c. gh pr checkout now allowed during pre-gate (Bash ungated)" \
+  "$(mock_json 'Bash' 'gh pr checkout 113')"
 # Negative: read-only PR commands must still pass during pre-gate.
 assert_allowed "14d. gh pr view allowed by pre-gate (read_only)" \
   "$(mock_json 'Bash' 'gh pr view 113')"
@@ -209,21 +225,18 @@ assert_allowed "18h. cat <&5 input-fd-dup allowed" \
 assert_allowed "18i. &>>/dev/null allowed" \
   "$(mock_json 'Bash' 'ls &>>/dev/null')"
 
-# Negative: real file writes via `>&word` MUST still block (codex R4 finding)
-assert_blocked "18j. >&2foo blocks (file redirect, not fd-dup)" \
-  "$(mock_json 'Bash' 'echo hi >&2foo')" "Checkpoint required"
-assert_blocked "18k. >& foo (ws non-digit) blocks" \
-  "$(mock_json 'Bash' 'ls >& foo')" "Checkpoint required"
-assert_blocked "18l. >& \"out.txt\" (quoted file) blocks" \
-  "$(mock_json 'Bash' 'ls >& "/tmp/out.txt"')" "Checkpoint required"
-assert_blocked "18m. 2>file (real file redirect) blocks" \
-  "$(mock_json 'Bash' 'ls 2>/tmp/err.log')" "Checkpoint required"
-assert_blocked "18n. &>>real-file blocks" \
-  "$(mock_json 'Bash' 'ls &>>/tmp/all.log')" "Checkpoint required"
-
-# Most-restrictive across segments: fd-dup-read then push → push wins (blocked)
-assert_blocked "18o. fd-dup then push (compound) blocked by pre-gate" \
-  "$(mock_json 'Bash' 'git status 2>&1 && git push')" "Checkpoint required"
+# Planning-passive: real-file redirects classify as shared_write and — with
+# Bash ungated — are now ALLOWED during the pre-gate (formerly blocked). The
+# fd-dup vs real-file-redirect classifier boundary is owned by FD20-FD24 in
+# tests/test-command-classifier.sh; one representative kept here as a gate
+# regression guard.
+assert_allowed "18j. real file redirect (2>file) now allowed (shared_write, Bash ungated)" \
+  "$(mock_json 'Bash' 'ls 2>/tmp/err.log')"
+# fd-dup followed by push: classifier reduces to push_or_pr_create, but the
+# push-gate is inactive without POST_REQ (only PRE_REQ armed here) → allowed.
+# Chained-push blocking under POST_REQ is covered by tests 68 / 77-80.
+assert_allowed "18o. fd-dup then push allowed (push-gate inactive — no POST_REQ)" \
+  "$(mock_json 'Bash' 'git status 2>&1 && git push')"
 
 # ============================================================================
 echo ""
@@ -351,7 +364,15 @@ echo ""
 echo "--- Edge: missing .claude dir (mkdir -p safety) ---"
 # ============================================================================
 rm -rf "$MARKER_DIR"
-assert_allowed "44. Hook does not crash when .claude/ missing" "$(mock_json 'Edit')"
+# Planning-passive: a concrete in-repo Edit lazily arms .checkpoint-required
+# (ensure_primary_dir mkdir's the missing .checkpoints/) then blocks. The hook
+# must handle the missing marker dir without crashing — assert a clean block
+# plus that the lazy-arm (re)created the dir + marker.
+edit_inrepo_missingdir_json=$(jq -nc --arg fp "$TEST_DIR/src.mjs" --arg cwd "$TEST_DIR" \
+  '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd}')
+assert_blocked "44. Hook handles missing marker dir without crashing (lazy-arm + block)" \
+  "$edit_inrepo_missingdir_json" "Checkpoint required"
+assert_marker_exists "44a. lazy-arm recreated .checkpoint-required under missing .checkpoints/" "$PRE_REQ"
 
 # ============================================================================
 echo ""
@@ -412,14 +433,16 @@ echo "--- #66: heredoc-body bypass blocked (pre-<< check) ---"
 reset_state
 touch "$PRE_REQ"
 
-# Bypass attempt: command writes to readme.md, but heredoc body mentions
-# `> .pre-checkpoint-done`. Pre-fix this would bypass the gate.
-# Post-fix: only the pre-<< portion is checked → no marker redirect → block.
+# Command writes to readme.md (shared_write); the heredoc body merely MENTIONS
+# `> .pre-checkpoint-done`. The classifier correctly does NOT treat the body
+# as a marker write (it stays shared_write, not marker_write). Planning-passive:
+# with Bash ungated, this shared_write is now ALLOWED. The classifier's
+# pre-<<-portion-only parsing is owned by test-command-classifier.sh.
 heredoc_bypass='cat > readme.md <<EOF
 echo > .pre-checkpoint-done
 EOF'
-assert_blocked "54. Heredoc body mentioning marker redirect does NOT bypass" \
-  "$(mock_json 'Bash' "$heredoc_bypass")" "Checkpoint required"
+assert_allowed "54. Heredoc to readme.md allowed (shared_write; body-mention is not a marker write)" \
+  "$(mock_json 'Bash' "$heredoc_bypass")"
 
 # Legitimate heredoc TO the marker: redirect target is in pre-<< portion → allow.
 heredoc_legit='cat > '"$PRE_DONE"' <<EOF
@@ -434,10 +457,11 @@ herestring_legit='tee '"$POST_DONE"' <<<"checkpoint text"'
 assert_blocked "56. Here-string to POST_DONE BLOCKED (POST_REQ not armed)" \
   "$(mock_json 'Bash' "$herestring_legit")" "Checkpoint required"
 
-# Bypass attempt with here-string: < but no redirect to marker in pre-<<<
+# Here-string writes to readme.md (shared_write); body merely mentions the
+# marker. Planning-passive: shared_write Bash is ungated → now allowed.
 herestring_bypass='cat > readme.md <<<"echo > .pre-checkpoint-done"'
-assert_blocked "57. Here-string body mentioning marker does NOT bypass" \
-  "$(mock_json 'Bash' "$herestring_bypass")" "Checkpoint required"
+assert_allowed "57. Here-string to readme.md allowed (shared_write, Bash ungated)" \
+  "$(mock_json 'Bash' "$herestring_bypass")"
 
 # ============================================================================
 echo ""
@@ -464,28 +488,31 @@ assert_blocked "53. Bash with unquoted 'git push' (separate token) IS blocked" \
 
 # ============================================================================
 echo ""
-echo "--- #68 F1: chained marker-write does NOT bypass gate ---"
+echo "--- #68 F1: chained marker-write (planning-passive: shared_write chains now allowed; push-gate + classifier remain) ---"
 # ============================================================================
-# Pre-fix: `echo X > .pre-checkpoint-done; rm -rf /` passed the allowlist
-# because the regex matched the redirect to the marker without anchoring
-# end-of-HEAD. Post-fix: any control operator after the marker filename
-# means no allowlist match → falls through to pre-gate block.
+# Planning-passive (2026-05-25): a marker-write CHAINED with another command
+# reduces (most-restrictive) to shared_write, and with Bash ungated shared_write
+# is ALLOWED. The former "chained command can't bypass the marker allowlist"
+# concern is moot — there is no Bash pre-gate to bypass, and a bare `rm` was
+# already allowed under the F1 residual. Two real boundaries remain and are
+# asserted elsewhere: (1) the push-gate still blocks a chained `git push` when
+# POST_REQ is armed (test 68); (2) the classifier's chain reduction is owned by
+# T70-T76 in test-command-classifier.sh. These chained-write shapes are kept as
+# gate regression guards confirming they now pass.
 reset_state
 touch "$PRE_REQ"
 
-assert_blocked "64. marker-write THEN ; chained command — blocks (no bypass)" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE; rm -rf /tmp/IMPORTANT")" "Checkpoint required"
-assert_blocked "65. marker-write THEN && chained command — blocks" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE && rm -rf /tmp/IMPORTANT")" "Checkpoint required"
-assert_blocked "66. marker-write THEN || chained command — blocks" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE || rm -rf /tmp/IMPORTANT")" "Checkpoint required"
-assert_blocked "67. marker-write THEN | piped command — blocks" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")" "Checkpoint required"
-# Newline-chained variant (#72): grep -E line-by-line evaluation would
-# otherwise let line 1 (the marker write) match alone.
-assert_blocked "67b. marker-write THEN newline + ; chained — blocks (#72)" \
+assert_allowed "64. marker-write THEN ; chained shared_write — allowed (Bash ungated, F1 residual)" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE; rm -rf /tmp/IMPORTANT")"
+assert_allowed "65. marker-write THEN && chained shared_write — allowed" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE && rm -rf /tmp/IMPORTANT")"
+assert_allowed "66. marker-write THEN || chained shared_write — allowed" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE || rm -rf /tmp/IMPORTANT")"
+assert_allowed "67. marker-write THEN | piped shared_write — allowed" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")"
+assert_allowed "67b. marker-write THEN newline + ; chained shared_write — allowed (#72)" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE
-; rm -rf /tmp/IMPORTANT")" "Checkpoint required"
+; rm -rf /tmp/IMPORTANT")"
 
 # Push-gate variant: chained post-marker-write THEN git push must block
 echo "pre done" > "$PRE_DONE"
@@ -541,7 +568,7 @@ assert_blocked "80. 'gh pr create' IS blocked (regression)" \
 
 # ============================================================================
 echo ""
-echo "--- #73: heredoc + post-EOF chained command does NOT bypass ---"
+echo "--- #73: heredoc + post-EOF chain (planning-passive: shared_write chains now allowed) ---"
 # ============================================================================
 # Pre-fix: cat > marker <<EOF\n...\nEOF\nrm -rf / had pre-<< portion that
 # matched allowlist (`cat > marker `), and the post-EOF chained command
@@ -555,15 +582,17 @@ heredoc_chain1="cat > $PRE_DONE <<EOF
 rule18
 EOF
 rm -rf /tmp/IMPORTANT"
-assert_blocked "81. heredoc + post-EOF ; chain — blocks (#73)" \
-  "$(mock_json 'Bash' "$heredoc_chain1")" "Checkpoint required"
+assert_allowed "81. heredoc + post-EOF ; chained shared_write — allowed (Bash ungated, #73)" \
+  "$(mock_json 'Bash' "$heredoc_chain1")"
 
 heredoc_chain2="cat > $PRE_DONE <<EOF
 rule18
 EOF
 && git push origin main"
-assert_blocked "82. heredoc + post-EOF && chain — blocks" \
-  "$(mock_json 'Bash' "$heredoc_chain2")" "Checkpoint required"
+# Chained git push, but push-gate is inactive without POST_REQ (only PRE_REQ
+# armed here) → allowed. Chained-push blocking under POST_REQ is test 68.
+assert_allowed "82. heredoc + post-EOF && git push — allowed (push-gate inactive)" \
+  "$(mock_json 'Bash' "$heredoc_chain2")"
 
 # <<- form (leading tabs allowed on terminator) with post content
 # Session 1: classifier distinguishes chained-command intent. A chained
@@ -578,8 +607,8 @@ assert_allowed "83. <<-EOF + read-only echo chain — allowed (read_only chain)"
 
 # Adversarial dash-EOF with rm chain still blocks (rm is shared_write).
 heredoc_dash_evil=$(printf 'cat > %s <<-EOF\n\tcontent\n\tEOF\nrm -rf /tmp/IMPORTANT' "$PRE_DONE")
-assert_blocked "83b. <<-EOF + rm chain — blocks (shared_write chain)" \
-  "$(mock_json 'Bash' "$heredoc_dash_evil")" "Checkpoint required"
+assert_allowed "83b. <<-EOF + rm chain — allowed (shared_write, Bash ungated)" \
+  "$(mock_json 'Bash' "$heredoc_dash_evil")"
 
 heredoc_quoted="cat > $PRE_DONE <<'EOF'
 literal text
@@ -592,8 +621,8 @@ heredoc_quoted_evil="cat > $PRE_DONE <<'EOF'
 literal text
 EOF
 rm -rf /tmp/IMPORTANT"
-assert_blocked "84b. <<'EOF' + rm chain — blocks (shared_write chain)" \
-  "$(mock_json 'Bash' "$heredoc_quoted_evil")" "Checkpoint required"
+assert_allowed "84b. <<'EOF' + rm chain — allowed (shared_write, Bash ungated)" \
+  "$(mock_json 'Bash' "$heredoc_quoted_evil")"
 
 # Pure heredoc (regression): no post-EOF content → still allowed
 pure_heredoc="cat > $PRE_DONE <<EOF
@@ -613,7 +642,7 @@ assert_allowed "86. Pure heredoc + trailing whitespace — still allowed" \
 
 # ============================================================================
 echo ""
-echo "--- #75: extended terminator forms also caught ---"
+echo "--- #75: extended terminator forms (planning-passive: shared_write chains now allowed) ---"
 # ============================================================================
 # Per Step-6 adversarial probe of #73 fix: <<\EOF (backslash-escaped) and
 # <<123 (digit-start) terminators were valid bash forms my initial sed regex
@@ -625,24 +654,24 @@ heredoc_backslash='cat > '"$PRE_DONE"' <<\EOF
 rule18
 EOF
 rm -rf /tmp/IMPORTANT'
-assert_blocked "87. <<\\EOF backslash-escaped terminator + chain — blocks (#75)" \
-  "$(mock_json 'Bash' "$heredoc_backslash")" "Checkpoint required"
+assert_allowed "87. <<\\EOF backslash-escaped terminator + rm chain — allowed (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_backslash")"
 
 # <<123 (numeric-only terminator) with post chain
 heredoc_numeric='cat > '"$PRE_DONE"' <<123
 rule18
 123
 rm -rf /tmp/IMPORTANT'
-assert_blocked "88. <<123 numeric-only terminator + chain — blocks (#75)" \
-  "$(mock_json 'Bash' "$heredoc_numeric")" "Checkpoint required"
+assert_allowed "88. <<123 numeric-only terminator + rm chain — allowed (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_numeric")"
 
 # <<==EOF== (special chars in terminator) — bash valid
 heredoc_special='cat > '"$PRE_DONE"' <<==EOF==
 rule18
 ==EOF==
 rm -rf /tmp/IMPORTANT'
-assert_blocked "89. <<==EOF== special-char terminator + chain — blocks (#75)" \
-  "$(mock_json 'Bash' "$heredoc_special")" "Checkpoint required"
+assert_allowed "89. <<==EOF== special-char terminator + rm chain — allowed (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_special")"
 
 # Regression: <<\EOF without post-EOF content still allowed
 heredoc_backslash_pure='cat > '"$PRE_DONE"' <<\EOF
@@ -1482,46 +1511,43 @@ assert_blocked "SA-cwd1. Relative FILE_PATH + absolute tool_input.cwd → resolv
 assert_blocked "SA-cwd2. Relative FILE_PATH + absolute top-level .cwd → resolved + block" \
   "$(mock_path_json 'Edit' 'scripts-test.mjs' "$TEST_DIR" "")" "Checkpoint required"
 
-# T_cwd3: relative FILE_PATH + RELATIVE .cwd + RELATIVE tool_input.cwd → ALLOW
+# T_cwd3: relative FILE_PATH + RELATIVE .cwd + RELATIVE tool_input.cwd → BLOCK
 #
-# PR-level codex review (REJECT R1 → fix landed here) caught the bug in this
-# test's prior expectation. The R7/P1 documented behavior is: relative .cwd
-# falls back to hook process pwd. If hook process pwd is NOT the same as the
-# armed test target (i.e. when test runner is invoked from outside $TEST_DIR),
-# the gate checks for `.checkpoint-required` at hook-pwd → finds none → exits
-# 0 → allows. This is the SAME wrong-root-hook = allow behavior that
-# SA-cwd-strict asserts intentionally.
+# Planning-passive redesign (2026-05-25): relative cwds give no absolute
+# authority, so FILE_PATH resolves to "" and the pre-gate conservatively BLOCKS
+# (Rule 18 safe direction). Crucially, the empty-FILE_PATH branch does NOT
+# lazy-arm — so no .checkpoint-required marker is written at the fallback
+# (hook-pwd) root. The no-leak guarantee is asserted explicitly by
+# SA-cwd-strict below; here we assert the conservative block.
 #
-# Prior version asserted "block" which was wrong: it depended on hook-pwd
-# happening to equal $TEST_DIR (only true when test runner is invoked from
-# inside the fixture's temp dir — fragile). The correct assertion is ALLOW.
-# Codex PR-level R1 caught this via running the suite from a fresh cwd.
-assert_allowed "SA-cwd3. Relative FILE_PATH + relative .cwd + relative tool_input.cwd → wrong-root = allow (same shape as SA-cwd-strict)" \
+# (Pre-redesign this asserted ALLOW, because the OLD pre-gate only fired when
+# .checkpoint-required was already armed at the resolved root. With lazy-arm,
+# the empty-path case blocks unconditionally.)
+assert_blocked "SA-cwd3. Relative FILE_PATH + relative cwds → empty path conservatively blocks (no arm)" \
   "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c './relative' --arg tic './relative-dir' \
-    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')"
+    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')" "Checkpoint required"
 
-# T_cwd3-strict: codex R7/P1 ACCEPT criterion — caller cwd != target with
-# relative/empty cwds. Run hook from a separate temp caller cwd. With the
-# R7/P1 CWD fix, an empty top-level .cwd falls back to hook process pwd =
-# caller cwd, which is NOT the target. Predicate then evaluates against the
-# wrong root, and FILE_PATH stays relative-resolved against THAT wrong root.
-# Since target's PRE_REQ is what we armed but hook resolves to caller cwd,
-# the gate doesn't see PRE_REQ at all → allow (gate doesn't fire because
-# wrong-root REPO_ROOT). This is the correct behavior: gate is bound to
-# the input cwd's project; off-project hook invocations don't trigger
-# someone else's gate state. Test asserts the allow.
+# T_cwd3-strict: caller cwd != target with empty cwd. Run hook from a separate
+# temp caller cwd; empty top-level .cwd falls back to hook process pwd =
+# CALLER_TMP. FILE_PATH 'scripts/x.mjs' is relative with no absolute authority
+# → resolves to "" → pre-gate conservatively BLOCKS.
+#
+# CRITICAL invariant (lazy-arm leak regression, 2026-05-25): the empty-FILE_PATH
+# branch must NOT lazy-arm. Before the fix, the block path called
+# _arm_checkpoint_required_if_missing, which wrote .checkpoint-required into
+# CALLER_TMP — leaking a marker into an unrelated repo. Assert a block decision
+# AND zero marker artifacts under CALLER_TMP.
 CALLER_TMP="$(mktemp -d)"
 CALLER_TMP="$(cd -P "$CALLER_TMP" && pwd)"
 SA_CWD_STRICT_JSON="$(jq -n --arg tn 'Edit' --arg fp 'scripts/x.mjs' \
   '{tool_name: $tn, tool_input: {file_path: $fp}, cwd: ""}')"
 SA_CWD_STRICT_OUT="$(cd "$CALLER_TMP" && echo "$SA_CWD_STRICT_JSON" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null)"
-SA_CWD_STRICT_EXIT=$?
-if [ $SA_CWD_STRICT_EXIT -eq 0 ] && [ -z "$SA_CWD_STRICT_OUT" ] \
+if echo "$SA_CWD_STRICT_OUT" | grep -q '"decision".*"block"' \
    && [ ! -e "$CALLER_TMP/.checkpoints" ] && [ ! -e "$CALLER_TMP/.claude" ]; then
-  echo "  ✓ SA-cwd-strict. Caller cwd != target + empty cwd → wrong-root hook = allow + no caller marker leak (R7/P1)"
+  echo "  ✓ SA-cwd-strict. Caller cwd != target + empty cwd → conservative block + NO caller marker leak (lazy-arm leak regression)"
   ((passed++))
 else
-  echo "  ✗ SA-cwd-strict. exit=$SA_CWD_STRICT_EXIT out=$SA_CWD_STRICT_OUT caller_leak=$([ -e "$CALLER_TMP/.checkpoints" ] || [ -e "$CALLER_TMP/.claude" ] && echo yes || echo no)"
+  echo "  ✗ SA-cwd-strict. out=$SA_CWD_STRICT_OUT caller_leak=$([ -e "$CALLER_TMP/.checkpoints" ] || [ -e "$CALLER_TMP/.claude" ] && echo yes || echo no)"
   ((failed++))
 fi
 rm -rf "$CALLER_TMP"
@@ -1560,7 +1586,18 @@ echo "--- PR-A P1.2: classifier-marker bootstrap carve-out under armed checkpoin
 # Codex R1 plan-tier P1: classifier-marker.mjs invocations were blocked when
 # .checkpoint-required is armed (empty TARGET → fell through marker_write
 # branch → pre-gate blocked). With the carve-out, valid classifier-marker
-# invocations exit 0; shimmed/relative paths fall through to normal flow.
+# invocations exit 0.
+#
+# Planning-passive redesign (2026-05-25): the pre-gate no longer gates Bash, so
+# shimmed/relative/bare forms — which fail the carve-out's helper-identity
+# validation and fall through — are now ALLOWED (F1 residual: arbitrary
+# `node <script>` is just shared_write Bash and was always going to run under the
+# freed-Bash design). The validator (_validate_classifier_marker_helper) still
+# rejects them, but its rejection is no longer observable as a block.
+# EXCEPTION: env-prefixed forms (NC-6) are still BLOCKED directly — env-prefix
+# wrapper escape is rejected as a FORM (codex review FU), independent of pre-gating.
+# Other observable boundaries: plan-pending still blocks even shimmed forms
+# (NC-9), and the canonical allow-path still works (NC-1/2/7).
 
 # Set up canonical helper locations the validator accepts.
 GLOBAL_HELPER_DIR="$TEST_HOME/.episodic-memory/scripts"
@@ -1589,25 +1626,26 @@ assert_allowed "NC-1. node ~/.episodic-memory/scripts/classifier-marker.mjs --wr
 assert_allowed "NC-2. node <repo>/scripts/classifier-marker.mjs --write allowed (repo-source path parity)" \
   "$(mock_json 'Bash' "node $REPO_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Shimmed binary at /tmp → BLOCKED (helper-identity validation) ──
-assert_blocked "NC-3. Shimmed binary (node /tmp/.../classifier-marker.mjs) BLOCKED under armed checkpoint" \
-  "$(mock_json 'Bash' "node $SHIMMED_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
-  "Checkpoint required"
+# ── Shimmed binary at /tmp → now ALLOWED (Bash ungated; validator still rejects
+#    but rejection is unobservable as a block) ──
+assert_allowed "NC-3. Shimmed binary (node /tmp/.../classifier-marker.mjs) now allowed (Bash ungated, F1 residual)" \
+  "$(mock_json 'Bash' "node $SHIMMED_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Relative path (./classifier-marker.mjs) → BLOCKED (absolute-path requirement) ──
-assert_blocked "NC-4. Relative ./classifier-marker.mjs path BLOCKED (carve-out requires absolute path)" \
-  "$(mock_json 'Bash' "node ./classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
-  "Checkpoint required"
+# ── Relative path (./classifier-marker.mjs) → now ALLOWED (Bash ungated) ──
+assert_allowed "NC-4. Relative ./classifier-marker.mjs path now allowed (Bash ungated)" \
+  "$(mock_json 'Bash' "node ./classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Bare basename → BLOCKED (no PATH lookup allowed) ──
-assert_blocked "NC-5. Bare 'classifier-marker.mjs' (no path) BLOCKED" \
-  "$(mock_json 'Bash' "node classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
-  "Checkpoint required"
+# ── Bare basename → now ALLOWED (Bash ungated) ──
+assert_allowed "NC-5. Bare 'classifier-marker.mjs' (no path) now allowed (Bash ungated)" \
+  "$(mock_json 'Bash' "node classifier-marker.mjs --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Env-prefix attempt → BLOCKED (classifier-tier rejection, returns unsafe_complex) ──
-# This already worked pre-PR-A; this test verifies the layering is unchanged.
-assert_blocked "NC-6. Env-prefix BYPASS=1 form BLOCKED (classifier returns unsafe_complex, not marker_write)" \
-  "$(mock_json 'Bash' "BYPASS=1 node $GLOBAL_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+# ── Env-prefix attempt → BLOCKED directly (codex review FU). The classifier
+#    flags it unsafe_complex/classifier_marker_env_override; the gate blocks the
+#    FORM regardless of Bash pre-gating, so the planning-passive Bash allowance
+#    can't bless an env-prefix wrapper escape against the classifier cache. ──
+assert_blocked "NC-6. Env-prefix BYPASS=1 form BLOCKED (env-prefix wrapper escape, independent of pre-gate)" \
+  "$(mock_json 'Bash' "BYPASS=1 node $GLOBAL_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Env-prefix wrapper escape"
 
 # ── Symlink to allowed location → allowed (canonicalization resolves) ──
 SYMLINK_HELPER_DIR="$(mktemp -d)"
@@ -1617,12 +1655,12 @@ ln -sf "$GLOBAL_HELPER" "$SYMLINK_HELPER"
 assert_allowed "NC-7. Symlink → allowed canonical path allowed (canonicalize follows symlink)" \
   "$(mock_json 'Bash' "node $SYMLINK_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Symlink to shimmed location → BLOCKED (canonicalize resolves to wrong target) ──
+# ── Symlink to shimmed location → now ALLOWED (Bash ungated; canonicalize still
+#    unmasks the target so the validator rejects, but rejection is unobservable) ──
 SYMLINK_TO_EVIL="$SYMLINK_HELPER_DIR/classifier-marker-evil.mjs"
 ln -sf "$SHIMMED_HELPER" "$SYMLINK_TO_EVIL"
-assert_blocked "NC-8. Symlink → shimmed binary BLOCKED (canonicalize unmasks symlink target)" \
-  "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
-  "Checkpoint required"
+assert_allowed "NC-8. Symlink → shimmed binary now allowed (Bash ungated, F1 residual)" \
+  "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
 # ── Plan-pending invariant preserved: classifier-marker BLOCKED while plan-pending ──
 # (Even with carve-out, plan-pending check fires earlier and blocks marker_write.)
@@ -1712,23 +1750,14 @@ if [ -f "$REAL_HELPER" ]; then
       ((failed++))
     fi
 
-    # Negative control: same command but caller_cwd differs from the written
-    # marker's caller_cwd → marker SHA differs (cache key = project + caller_cwd
-    # + command per classifier-marker.mjs:140) → miss → interpreter_other →
-    # shared_write → pre-gate blocks. This proves the threading is honored:
-    # different .cwd → different classification outcome (impossible without
-    # P1.1 — pre-fix code used hook $PWD as caller_cwd regardless of .cwd).
-    mkdir -p "$P11_REPO/sub"
-    P11_JSON_NEG="$(jq -n --arg tn 'Bash' --arg cmd "$P11_CMD" --arg cwd "$P11_REPO/sub" --arg sid "$P11_SID" \
-      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd, session_id: $sid}')"
-    P11_OUTPUT_NEG="$( (cd /tmp && echo "$P11_JSON_NEG" | HOME="$P11_HOME" CLAUDE_CODE_SESSION_ID="$P11_SID" bash "$HOOK") 2>/dev/null )"
-    if echo "$P11_OUTPUT_NEG" | grep -q '"decision".*"block"'; then
-      echo "  ✓ AR-2. P1.1 threading-sensitivity: different .cwd → miss → blocked (proves .cwd is threaded, not ignored)"
-      ((passed++))
-    else
-      echo "  ✗ AR-2. P1.1 threading-sensitivity expected block (output=$P11_OUTPUT_NEG)"
-      ((failed++))
-    fi
+    # AR-2 RETIRED (planning-passive redesign, 2026-05-25): the former negative
+    # control proved threading by relying on a cache MISS → shared_write →
+    # pre-gate BLOCK. With Bash ungated, shared_write no longer blocks, so the
+    # gate can't discriminate hit-vs-miss for a `node` command (both labels
+    # allow). The caller_cwd cache-key sensitivity that this asserted is owned
+    # by tests/test-classifier-marker.mjs §M5 (cross-repo refusal) and §M6
+    # (caller-cwd may differ from project-root), which test the marker layer
+    # directly rather than through the now-label-agnostic gate.
   else
     echo "  ⊘ AR-1/AR-2 skipped: classifier-marker.mjs write did not produce marker (sandboxed env or helper rejected)"
   fi
@@ -1737,6 +1766,97 @@ if [ -f "$REAL_HELPER" ]; then
 else
   echo "  ⊘ AR-1/AR-2 skipped: real classifier-marker.mjs not reachable at $REAL_HELPER"
 fi
+
+# ============================================================================
+echo ""
+echo "--- Planning-passive redesign: nothing armed at rest; first repo write arms (2026-05-25) ---"
+# ============================================================================
+# Core invariants of the planning-passive redesign:
+#   (1) With NOTHING armed, planning/review/exploration never blocks and never
+#       arms — read-only Bash, node inspections, and shared_write review
+#       commands all pass cleanly with zero marker side effects.
+#   (2) The first repo-source Edit/Write lazily arms .checkpoint-required for
+#       the session AND blocks (the implementation boundary).
+#   (3) Off-repo writes (memory/skills/settings) are allowed and never arm.
+#   (4) Arming is per-session and per-repo: sessions and projects don't bleed.
+PP_REPO="$(mktemp -d)"; PP_REPO="$(cd -P "$PP_REPO" && pwd)"
+git -C "$PP_REPO" init -q 2>/dev/null
+PP_MARKER_DIR="$PP_REPO/.checkpoints"
+mkdir -p "$PP_MARKER_DIR"
+PP_SID_A="11111111-aaaa-4aaa-8aaa-111111111111"
+PP_SID_B="22222222-bbbb-4bbb-8bbb-222222222222"
+
+mock_pp_bash() {  # $1=command $2=sid
+  jq -n --arg cmd "$1" --arg cwd "$PP_REPO" --arg sid "$2" \
+    '{tool_name: "Bash", tool_input: {command: $cmd}, cwd: $cwd, session_id: $sid}'
+}
+mock_pp_edit() {  # $1=abs file_path $2=sid $3=cwd(optional, default PP_REPO)
+  jq -n --arg fp "$1" --arg cwd "${3:-$PP_REPO}" --arg sid "$2" \
+    '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd, session_id: $sid}'
+}
+reset_pp() { rm -rf "$PP_MARKER_DIR"; mkdir -p "$PP_MARKER_DIR"; }
+
+# (1) Planning-passive — nothing armed, nothing blocks, nothing arms
+reset_pp
+assert_allowed "PP-1. read-only Bash (git status) allowed, nothing armed" \
+  "$(mock_pp_bash 'git status' "$PP_SID_A")"
+assert_allowed "PP-2. node em-search (read_only) allowed, nothing armed" \
+  "$(mock_pp_bash 'node scripts/em-search.mjs --tag x' "$PP_SID_A")"
+assert_allowed "PP-3. shared_write review command (second-opinion dispatch) allowed (Bash ungated)" \
+  "$(mock_pp_bash 'node scripts/second-opinion.mjs request --provider codex --dispatch' "$PP_SID_A")"
+assert_marker_absent "PP-4. planning Bash did NOT arm .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+assert_marker_absent "PP-4b. planning Bash did NOT arm legacy .checkpoint-required" \
+  "$PP_MARKER_DIR/.checkpoint-required"
+
+# (2) Lazy-arm — first repo-source Edit arms + blocks
+reset_pp
+assert_blocked "PP-5. first in-repo Edit blocks at implementation boundary" \
+  "$(mock_pp_edit "$PP_REPO/scripts/foo.mjs" "$PP_SID_A")" "Checkpoint required"
+assert_marker_exists "PP-6. first in-repo Edit lazily armed .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+
+# (3) After the session's pre-checkpoint is written → Edit allowed + post armed
+echo "Rule 18 pre-checkpoint" > "$PP_MARKER_DIR/.pre-checkpoint-done.$PP_SID_A"
+assert_allowed "PP-7. in-repo Edit allowed after pre-checkpoint written (session A)" \
+  "$(mock_pp_edit "$PP_REPO/scripts/foo.mjs" "$PP_SID_A")"
+assert_marker_exists "PP-8. allowed Edit armed .post-checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.post-checkpoint-required.$PP_SID_A"
+
+# (4) Off-repo Edit allowed + never arms
+reset_pp
+OFFREPO_PP="$(mktemp -d)"; OFFREPO_PP="$(cd -P "$OFFREPO_PP" && pwd)"
+assert_allowed "PP-9. off-repo Edit allowed (planning-passive smart-arming)" \
+  "$(mock_pp_edit "$OFFREPO_PP/memory/note.md" "$PP_SID_A")"
+assert_marker_absent "PP-10. off-repo Edit did NOT arm .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+rm -rf "$OFFREPO_PP"
+
+# (5) Multisession — two sids arm independently; one's pre-done doesn't unblock the other
+reset_pp
+echo "$(mock_pp_edit "$PP_REPO/scripts/a.mjs" "$PP_SID_A")" | run_hook >/dev/null 2>&1
+echo "$(mock_pp_edit "$PP_REPO/scripts/b.mjs" "$PP_SID_B")" | run_hook >/dev/null 2>&1
+assert_marker_exists "PP-11. session A armed its own .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+assert_marker_exists "PP-12. session B armed its own .checkpoint-required.<sidB>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_B"
+echo "pre A" > "$PP_MARKER_DIR/.pre-checkpoint-done.$PP_SID_A"
+assert_allowed "PP-13. session A unblocked by its OWN pre-done" \
+  "$(mock_pp_edit "$PP_REPO/scripts/a.mjs" "$PP_SID_A")"
+assert_blocked "PP-14. session B still blocked (independent pre-done)" \
+  "$(mock_pp_edit "$PP_REPO/scripts/b.mjs" "$PP_SID_B")" "Checkpoint required"
+
+# (6) Multiproject — edit in repo A never arms repo B
+reset_pp
+PP_REPO_B="$(mktemp -d)"; PP_REPO_B="$(cd -P "$PP_REPO_B" && pwd)"
+git -C "$PP_REPO_B" init -q 2>/dev/null
+mkdir -p "$PP_REPO_B/.checkpoints"
+echo "$(mock_pp_edit "$PP_REPO/scripts/x.mjs" "$PP_SID_A")" | run_hook >/dev/null 2>&1
+assert_marker_exists "PP-15. edit in repo A armed A's .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+assert_marker_absent "PP-16. edit in repo A did NOT arm repo B's .checkpoint-required.<sidA>" \
+  "$PP_REPO_B/.checkpoints/.checkpoint-required.$PP_SID_A"
+rm -rf "$PP_REPO_B" "$PP_REPO"
 
 echo ""
 echo "Passed: $passed"

--- a/tests/test-checkpoints-migration.mjs
+++ b/tests/test-checkpoints-migration.mjs
@@ -21,7 +21,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 
 const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
 const RECALL = path.join(SCRIPTS, 'em-recall.mjs')
@@ -52,6 +52,9 @@ function assertExists(p, msg) {
 }
 function assertMissing(p, msg) {
   if (fs.existsSync(p)) throw new Error(`${msg || 'expected to be missing'}: ${p}`)
+}
+function assertTrue(cond, msg) {
+  if (!cond) throw new Error(msg || 'expected truthy')
 }
 
 function setupRepo() {
@@ -88,10 +91,18 @@ function gateStop(cwd) {
 }
 
 function sessionStart(cwd) {
-  // --session-start writes baseline + arms checkpoint marker if
-  // bp-001 violation activation predicate fires. For these tests we don't
-  // care about violations — we just want the SessionStart side effects.
+  // --session-start writes the .session-baseline. Planning-passive (2026-05-25):
+  // em-recall no longer arms .checkpoint-required; a bp-001 violation now emits
+  // the __BP1_ADVISORY__ stderr signal instead.
   return runRecall(cwd, ['--session-start'])
+}
+
+// stderr-capturing variant — the bp-001 signal is now an advisory on stderr.
+function sessionStartStderr(cwd, extraEnv = {}) {
+  const r = spawnSync('node', [RECALL, '--session-start'], {
+    cwd, encoding: 'utf8', env: { ...process.env, HOME: cwd, ...extraEnv }
+  })
+  return r.stderr || ''
 }
 
 console.log('SessionStart writes baseline at PRIMARY (.checkpoints/):')
@@ -102,8 +113,8 @@ test('baseline lands at .checkpoints/.session-baseline, NOT .claude/', () => {
   assertMissing(path.join(root, '.claude', '.session-baseline'), 'legacy baseline must not be created')
 })
 
-console.log('\narmCheckpointMarker writes to PRIMARY only:')
-test('writes .checkpoints/.checkpoint-required, never touches .claude/', () => {
+console.log('\nbp-001 signal is an advisory; em-recall never arms a marker (planning-passive):')
+test('em-recall emits __BP1_ADVISORY__ and arms NO .checkpoint-required at either root', () => {
   const root = setupRepo()
   // Force activation by seeding a recent bp-001 violation in local store.
   const localEpisodes = path.join(root, '.episodic-memory', 'episodes')
@@ -135,9 +146,14 @@ test
   })
   fs.writeFileSync(path.join(root, '.episodic-memory', 'index.jsonl'), indexLine + '\n')
 
-  sessionStart(root)
-  assertExists(path.join(root, '.checkpoints', '.checkpoint-required'), 'primary marker')
-  assertMissing(path.join(root, '.claude', '.checkpoint-required'), 'legacy marker must not be created')
+  // Planning-passive: em-recall surfaces the advisory (proving the violation was
+  // seen) but arms NO marker. The migration write-path contract (.checkpoints/,
+  // never .claude/) for .checkpoint-required is now exercised by the gate's
+  // lazy-arm — see test-checkpoint-gate.sh PP-6 / PP-15.
+  const stderr = sessionStartStderr(root)
+  assertTrue(/__BP1_ADVISORY__/.test(stderr), `expected advisory on stderr; got: ${stderr}`)
+  assertMissing(path.join(root, '.checkpoints', '.checkpoint-required'), 'em-recall must not arm primary marker')
+  assertMissing(path.join(root, '.claude', '.checkpoint-required'), 'em-recall must not arm legacy marker')
 })
 
 console.log('\nstop-gate carve-out reads BOTH roots:')

--- a/tests/test-em-recall-session-start-early-exit.mjs
+++ b/tests/test-em-recall-session-start-early-exit.mjs
@@ -7,8 +7,11 @@
  * Plan: round-2 ACCEPT episode 20260509-082149-...-6ef8.
  *
  * Layered coverage (T1-T11):
- *   T1  recent active bp-001 violation -> .checkpoint-required armed
- *   T2  no recent violation -> NOT armed
+ *   T1  recent active bp-001 violation -> __BP1_ADVISORY__ emitted, NO marker
+ *       armed (planning-passive redesign 2026-05-25: em-recall no longer arms;
+ *       checkpoint-gate.sh lazily arms at first repo write). Root-resolution
+ *       (T8-T11) is proven via the .session-baseline write, which is retained.
+ *   T2  no recent violation -> no advisory, NOT armed
  *   T3  baseline mtime advances (ordering invariant for stop-gate carve-out)
  *   T4  orphan cleanup removes pre-baseline task-signal markers
  *   T5  NON-session-start path: JSON output structure intact (regression)
@@ -39,7 +42,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execSync } from 'child_process'
+import { execSync, spawnSync } from 'child_process'
 import assert from 'assert'
 
 const HERE = path.dirname(new URL(import.meta.url).pathname)
@@ -157,21 +160,24 @@ function clearLocalStore() {
 }
 
 // ---------------------------------------------------------------------------
-// T1 — recent active bp-001 violation arms .checkpoint-required
+// T1 — recent active bp-001 violation: emits __BP1_ADVISORY__, does NOT arm
+// (planning-passive redesign). Baseline still written unconditionally.
 // ---------------------------------------------------------------------------
-test('T1: --session-start with recent active bp-001 violation arms .checkpoint-required at PRIMARY', () => {
+test('T1: --session-start with recent active bp-001 violation emits advisory + does NOT arm marker', () => {
   clearMarkers()
   clearLocalStore()
   seedBp001Violation()
   // Pre-condition: fixture dirs exist (defensive for negative assertions).
   assert.ok(fs.existsSync(mainRepoReal), 'pre: mainRepo exists')
 
-  execSync(`node ${RECALL} --session-start --scope local --project test --no-track`, {
-    cwd: mainRepo, stdio: ['ignore', 'ignore', 'ignore'],
+  const r = spawnSync('node', [RECALL, '--session-start', '--scope', 'local', '--project', 'test', '--no-track'], {
+    cwd: mainRepo, encoding: 'utf8',
   })
 
-  assert.ok(fs.existsSync(mainCheckpointMarker),
-    `expected ${mainCheckpointMarker} after --session-start with recent violation`)
+  assert.ok(/__BP1_ADVISORY__/.test(r.stderr || ''),
+    `expected __BP1_ADVISORY__ on stderr with recent violation; got: ${r.stderr}`)
+  assert.ok(!fs.existsSync(mainCheckpointMarker),
+    `em-recall must NOT arm ${mainCheckpointMarker} (planning-passive — lazy-arm moved to checkpoint-gate.sh)`)
   assert.ok(fs.existsSync(mainBaseline),
     `expected ${mainBaseline} after --session-start (always written)`)
 })
@@ -379,8 +385,8 @@ test('T9: direct --session-start from linked worktree writes baseline + marker a
 
   assert.ok(fs.existsSync(mainBaseline),
     `baseline must land at canonical main: ${mainBaseline}`)
-  assert.ok(fs.existsSync(mainCheckpointMarker),
-    `marker must land at canonical main: ${mainCheckpointMarker}`)
+  assert.ok(!fs.existsSync(mainCheckpointMarker),
+    `em-recall must NOT arm ${mainCheckpointMarker} (planning-passive — root-resolution proven by baseline)`)
   // Negative + post-fixture-existence guard: worktree dir is still here, so
   // !exists isn't vacuous.
   assert.ok(fs.existsSync(worktreeRootReal),
@@ -406,7 +412,8 @@ test('T10: direct --session-start from nested cwd writes artifacts at repo root,
   })
 
   assert.ok(fs.existsSync(mainBaseline), 'baseline at repo root')
-  assert.ok(fs.existsSync(mainCheckpointMarker), 'marker at repo root')
+  assert.ok(!fs.existsSync(mainCheckpointMarker),
+    'em-recall must NOT arm marker (planning-passive — root-resolution proven by baseline)')
 
   const nestedCheckpointsDir = path.join(nestedDir, '.checkpoints')
   assert.ok(fs.existsSync(nestedDir),
@@ -479,7 +486,8 @@ test('T8: Hook E2E with callerDir != targetRepo writes artifacts under targetRep
 
   // Positive: artifacts at targetRepo.
   assert.ok(fs.existsSync(mainBaseline), 'baseline at targetRepo')
-  assert.ok(fs.existsSync(mainCheckpointMarker), 'marker at targetRepo')
+  assert.ok(!fs.existsSync(mainCheckpointMarker),
+    'em-recall must NOT arm marker at targetRepo (planning-passive)')
 
   // Negative + post-fixture-existence guard.
   assert.ok(fs.existsSync(callerDirReal),
@@ -506,7 +514,8 @@ test('T11: Hook E2E with HOME containing spaces still writes artifacts correctly
   runHookE2E({ tempHome, targetRepo: mainRepoReal, callerCwd: callerDirReal })
 
   assert.ok(fs.existsSync(mainBaseline), 'baseline at targetRepo (HOME-with-spaces)')
-  assert.ok(fs.existsSync(mainCheckpointMarker), 'marker at targetRepo (HOME-with-spaces)')
+  assert.ok(!fs.existsSync(mainCheckpointMarker),
+    'em-recall must NOT arm marker at targetRepo when HOME has spaces (planning-passive)')
   assert.ok(!fs.existsSync(callerPrimaryDir),
     `caller dir must NOT have .checkpoints/ created when HOME has spaces`)
 })

--- a/tests/test-em-repo-root-worktree.mjs
+++ b/tests/test-em-repo-root-worktree.mjs
@@ -7,9 +7,11 @@
  *   1. Resolver unit tests — resolveRepoRoot returns the main repo working
  *      tree from main / linked worktree / nested cwd / non-git / submodule.
  *   2. Integration regression tests — em-recall.mjs invoked from a linked
- *      worktree writes .checkpoint-required at <main>/.claude/, not
- *      <worktree>/.claude/. em-session-end-prompt.mjs invoked from a worktree
- *      cleans markers at <main>/.claude/, not <worktree>/.claude/.
+ *      worktree writes its .session-baseline at <main>/.checkpoints/, not
+ *      <worktree>/.checkpoints/ (planning-passive redesign 2026-05-25: em-recall
+ *      no longer arms .checkpoint-required, so the #106 root-resolution invariant
+ *      is observed via the baseline write). em-session-end-prompt.mjs invoked
+ *      from a worktree cleans markers at <main>, not <worktree>.
  *
  * Defensive ordering (per feedback_test_resource_existence_check.md):
  * each integration assertion checks BOTH "marker exists at main" AND
@@ -172,6 +174,13 @@ const mainMarker = path.join(mainPrimaryDir, '.checkpoint-required')
 const mainMarkerLegacy = path.join(mainLegacyDir, '.checkpoint-required')
 const worktreeMarker = path.join(worktreePrimaryDir, '.checkpoint-required')
 const worktreeMarkerLegacy = path.join(worktreeLegacyDir, '.checkpoint-required')
+// Planning-passive redesign (2026-05-25): em-recall no longer ARMS
+// .checkpoint-required (lazy-arm moved to checkpoint-gate.sh). The #106
+// root-resolution invariant (artifacts land at MAIN, not the worktree) is now
+// observed via the .session-baseline write, which em-recall still performs at
+// the resolved root in --session-start mode.
+const mainBaseline = path.join(mainPrimaryDir, '.session-baseline')
+const worktreeBaseline = path.join(worktreePrimaryDir, '.session-baseline')
 
 function clearMarkers() {
   for (const dir of [mainPrimaryDir, mainLegacyDir, worktreePrimaryDir, worktreeLegacyDir]) {
@@ -187,32 +196,35 @@ function clearMarkers() {
   }
 }
 
-test('em-recall from main writes .checkpoint-required at <main>/.claude/', () => {
+test('em-recall from main writes .session-baseline at <main>/.checkpoints/ (no marker armed)', () => {
   clearMarkers()
-  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+  execSync(`node ${RECALL} --session-start --scope local --project test --no-track`, {
     cwd: mainRepo, stdio: ['ignore', 'ignore', 'ignore'],
   })
-  // Defensive: assert main marker AND verify worktree did not get one too.
-  assert.ok(fs.existsSync(mainMarker), `expected ${mainMarker} after em-recall from main`)
-  assert.ok(!fs.existsSync(worktreeMarker), `unexpected ${worktreeMarker} after em-recall from main`)
+  // Root-resolution observed via baseline; em-recall no longer arms the marker.
+  assert.ok(fs.existsSync(mainBaseline), `expected ${mainBaseline} after em-recall from main`)
+  assert.ok(!fs.existsSync(worktreeBaseline), `unexpected ${worktreeBaseline} after em-recall from main`)
+  assert.ok(!fs.existsSync(mainMarker), `em-recall must NOT arm ${mainMarker} (planning-passive)`)
 })
 
-test('em-recall from linked worktree writes .checkpoint-required at <main>/.claude/, NOT worktree', () => {
+test('em-recall from linked worktree writes .session-baseline at <main>/.checkpoints/, NOT worktree', () => {
   clearMarkers()
-  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+  execSync(`node ${RECALL} --session-start --scope local --project test --no-track`, {
     cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
   })
-  // Positive: marker landed at main repo root.
+  // Positive: baseline landed at main repo root.
   assert.ok(
-    fs.existsSync(mainMarker),
-    `expected ${mainMarker} after em-recall from worktree (regressed #106)`,
+    fs.existsSync(mainBaseline),
+    `expected ${mainBaseline} after em-recall from worktree (regressed #106)`,
   )
-  // Negative: marker did NOT land at worktree (the bug-shape assertion).
-  // Defensive ordering: this assertion is the load-bearing one for #106.
+  // Negative: baseline did NOT land at worktree (the #106 bug-shape assertion).
   assert.ok(
-    !fs.existsSync(worktreeMarker),
-    `marker leaked into worktree: ${worktreeMarker} (this is the #106 bug)`,
+    !fs.existsSync(worktreeBaseline),
+    `baseline leaked into worktree: ${worktreeBaseline} (this is the #106 bug)`,
   )
+  // em-recall must not arm the marker anywhere (planning-passive).
+  assert.ok(!fs.existsSync(mainMarker) && !fs.existsSync(worktreeMarker),
+    `em-recall must NOT arm .checkpoint-required (planning-passive)`)
   // Defensive existence check: verify the worktree dir itself wasn't deleted
   // out from under us before the assertion, which would make the negative
   // check vacuously pass.
@@ -222,13 +234,14 @@ test('em-recall from linked worktree writes .checkpoint-required at <main>/.clau
   )
 })
 
-test('em-recall from nested cwd inside worktree still writes marker at <main>/.claude/', () => {
+test('em-recall from nested cwd inside worktree still writes .session-baseline at <main>/.checkpoints/', () => {
   clearMarkers()
-  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+  execSync(`node ${RECALL} --session-start --scope local --project test --no-track`, {
     cwd: nestedDir, stdio: ['ignore', 'ignore', 'ignore'],
   })
-  assert.ok(fs.existsSync(mainMarker))
-  assert.ok(!fs.existsSync(worktreeMarker), `marker leaked into worktree from nested cwd`)
+  assert.ok(fs.existsSync(mainBaseline))
+  assert.ok(!fs.existsSync(worktreeBaseline), `baseline leaked into worktree from nested cwd`)
+  assert.ok(!fs.existsSync(mainMarker), `em-recall must NOT arm marker (planning-passive)`)
 })
 
 test('em-session-end-prompt from worktree cleans markers at <main>, not worktree', () => {
@@ -295,12 +308,14 @@ test('NEG: stale worktree-local marker (pre-fix legacy state) is preserved, not 
   fs.writeFileSync(worktreeMarkerLegacy, 'legacy-from-pre-106')
   assert.ok(fs.existsSync(worktreeMarkerLegacy), 'pre-condition: legacy worktree marker seeded')
 
-  execSync(`node ${RECALL} --scope local --project test --no-track`, {
+  execSync(`node ${RECALL} --session-start --scope local --project test --no-track`, {
     cwd: worktreeRoot, stdio: ['ignore', 'ignore', 'ignore'],
   })
 
-  // New behavior: marker now lives at main, in the PRIMARY (.checkpoints/) dir.
-  assert.ok(fs.existsSync(mainMarker), 'new arming should land at main/.checkpoints/')
+  // New behavior: em-recall writes the .session-baseline at main/.checkpoints/
+  // (and never arms a marker). Root-resolution still lands at main.
+  assert.ok(fs.existsSync(mainBaseline), 'baseline should land at main/.checkpoints/')
+  assert.ok(!fs.existsSync(mainMarker), 'em-recall must NOT arm a marker (planning-passive)')
   // Legacy worktree marker preserved verbatim — we don't read or modify
   // worktree-local state.
   assert.ok(fs.existsSync(worktreeMarkerLegacy), 'legacy worktree marker should be untouched')

--- a/tests/test-rfc002-phase3.mjs
+++ b/tests/test-rfc002-phase3.mjs
@@ -72,6 +72,13 @@ function recall(args = '', cwd = tmpProject) {
   return JSON.parse(result.trim())
 }
 
+// Planning-passive redesign (2026-05-25): the bp-001 signal is now an advisory
+// on stderr (__BP1_ADVISORY__), not a marker write. Capture stderr to assert it.
+function recallStderr(args = '', cwd = tmpProject) {
+  const r = spawnSync('node', [RECALL, ...args.split(/\s+/).filter(Boolean)], { cwd, env, encoding: 'utf8' })
+  return r.stderr || ''
+}
+
 function recallExit(args = '', cwd = tmpProject) {
   try {
     const stdout = execSync(`node "${RECALL}" ${args}`, { encoding: 'utf8', cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
@@ -300,13 +307,14 @@ test('T5d. Explicit --task-type overrides branch inference', () => {
   assert.deepStrictEqual(ids, ['bp-006-push-after-verify'])
 })
 
-test('T7a. Recall touches .claude/.checkpoint-required when bp-001 violation surfaces', () => {
+test('T7a. Recall emits __BP1_ADVISORY__ + does NOT arm marker when bp-001 surfaces (planning-passive)', () => {
   clearStore()
   clearMarker()
   for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
   rebuild()
-  recall('--task-type implementation --no-track')
-  assert.ok(fs.existsSync(markerPath), '.checkpoint-required should exist after bp-001 surfaces')
+  const stderr = recallStderr('--task-type implementation --no-track')
+  assert.ok(/__BP1_ADVISORY__/.test(stderr), `advisory should be emitted after bp-001 surfaces; got: ${stderr}`)
+  assert.ok(!fs.existsSync(markerPath), 'em-recall must NOT arm .checkpoint-required (lazy-arm moved to checkpoint-gate.sh)')
 })
 
 test('T7b. No marker when only non-bp-001 violations surface', () => {
@@ -319,18 +327,17 @@ test('T7b. No marker when only non-bp-001 violations surface', () => {
   assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist when bp-001 is not surfaced')
 })
 
-test('T7c. Marker arms when bp-001 violations exist even if task type is unclear', () => {
-  // Phase 3b activation fix: the SessionStart hook does not pass --task-type,
-  // and branch inference can return null. Marker arming is now decoupled from
-  // task_type — bp-001 violations alone are sufficient. Without this, the
-  // gate was inert in real sessions despite being deployed.
+test('T7c. Advisory fires (no marker) when bp-001 violations exist even if task type is unclear', () => {
+  // The advisory is decoupled from task_type — bp-001 violations alone are
+  // sufficient. Planning-passive: it surfaces as a warning, never a marker.
   clearStore()
   clearMarker()
   for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
   rebuild()
   setBranch('main') // no keyword match → inferTaskType returns null
-  recall('--no-track')
-  assert.ok(fs.existsSync(markerPath), '.checkpoint-required must exist when bp-001 violations recent, regardless of task_type')
+  const stderr = recallStderr('--no-track')
+  assert.ok(/__BP1_ADVISORY__/.test(stderr), 'advisory must fire when bp-001 recent, regardless of task_type')
+  assert.ok(!fs.existsSync(markerPath), 'em-recall must NOT arm (planning-passive)')
 })
 
 test('T7c2. No marker when there are no recent bp-001 violations (regardless of task type)', () => {
@@ -355,24 +362,25 @@ test('T7c3. No marker when bp-001 violations are older than 30-day cutoff', () =
   assert.ok(!fs.existsSync(markerPath), '.checkpoint-required must not exist for stale (>30d) violations')
 })
 
-test('T7d. Marker creation is idempotent (re-recall does not error)', () => {
+test('T7d. Advisory emission is idempotent (re-recall does not error, never arms)', () => {
   clearStore()
   clearMarker()
   for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
   rebuild()
-  recall('--task-type implementation --no-track')
-  assert.ok(fs.existsSync(markerPath))
-  // Second recall should not throw
-  recall('--task-type implementation --no-track')
-  assert.ok(fs.existsSync(markerPath))
+  assert.ok(/__BP1_ADVISORY__/.test(recallStderr('--task-type implementation --no-track')), 'advisory on first recall')
+  // Second recall should not throw and should still advise
+  assert.ok(/__BP1_ADVISORY__/.test(recallStderr('--task-type implementation --no-track')), 'advisory on second recall (no error)')
+  assert.ok(!fs.existsSync(markerPath), 'em-recall never arms the marker')
 })
 
 test('T7e. em-session-end-prompt.mjs sweeps the marker at session end', () => {
   clearStore()
   clearMarker()
-  for (let d = 1; d <= 3; d++) seedViolation('bp-001-implementation-workflow', d)
-  rebuild()
-  recall('--task-type implementation --no-track')
+  // Planning-passive: the marker is now armed by checkpoint-gate.sh at the first
+  // repo write, not by em-recall. Create it directly to exercise the SessionEnd
+  // sweep (sweep behavior is unchanged by the redesign).
+  fs.mkdirSync(path.join(tmpProject, '.checkpoints'), { recursive: true })
+  fs.writeFileSync(markerPath, '')
   assert.ok(fs.existsSync(markerPath), 'precondition: marker should exist')
   sessionEnd()
   assert.ok(!fs.existsSync(markerPath), 'marker should be removed by session-end script')
@@ -529,32 +537,41 @@ test('T7j. End-to-end: real SessionStart hook arms marker without --task-type (P
   // at the user's installed em-recall, no --task-type passed. Use spawnSync
   // with input rather than echo+pipe so tmpdir paths containing quotes
   // can't corrupt the JSON.
-  spawnSync('bash', [hookPath], {
+  const r = spawnSync('bash', [hookPath], {
     input: stdin, env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
   })
 
-  assert.ok(fs.existsSync(markerOut),
-    '.checkpoint-required must be armed by the real SessionStart hook with no --task-type — Phase 3b activation E2E')
+  // Planning-passive E2E: the real SessionStart hook must SURFACE the bp-001
+  // advisory on stdout (as SessionStart additionalContext) and must NOT arm the
+  // marker — arming moved to checkpoint-gate.sh at the first repo write.
+  assert.ok(/bp-001/i.test(r.stdout || ''),
+    `SessionStart hook must surface the bp-001 advisory on stdout; got: ${r.stdout}`)
+  assert.ok(!fs.existsSync(markerOut),
+    '.checkpoint-required must NOT be armed by the SessionStart hook (planning-passive — lazy-arm moved to the gate)')
+  assert.ok(!fs.existsSync(markerOutLegacy),
+    'legacy .checkpoint-required must NOT be armed by the SessionStart hook')
 
   fs.rmSync(sessionHome, { recursive: true, force: true })
 })
 
-test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next SessionStart re-arms (#128 SessionEnd race tie-breaker)', () => {
-  // Verifies the SessionEnd-race tie-breaker verdict from #128 plan review:
-  // even though SessionEnd unconditionally sweeps all 4 markers, the next
-  // SessionStart re-arms the gate because shouldArmBp001Checkpoint reads
-  // from the EPISODE STORE (persistent), not the marker file. The marker
-  // is just runtime state for the current arming cycle. This test pins the
-  // idempotent-re-arm contract — any future regression that points the
-  // predicate at the marker would silently disarm the gate; this test
-  // catches that.
+test('T7k. Round-trip: advisory → (gate) arm → Stop blocks → SessionEnd sweeps → next SessionStart still advises (#128 episode-store-is-source-of-truth)', () => {
+  // Planning-passive adaptation of the #128 SessionEnd-race tie-breaker. The
+  // durable insight is unchanged: the bp-001 signal derives from the PERSISTENT
+  // episode store, not from marker runtime state — so it survives a SessionEnd
+  // sweep. Pre-redesign this was proven by "SessionStart re-arms the marker";
+  // now SessionStart no longer arms (the gate does, at first repo write), so we
+  // prove it via the ADVISORY: after SessionEnd sweeps all 4 markers, the next
+  // SessionStart STILL emits the bp-001 advisory because shouldArmBp001Checkpoint
+  // reads the episode store. Any regression pointing the predicate at the marker
+  // would silence the advisory; this test catches that.
   //
   // Round-trip:
   //   1. Setup: temp project + seeded bp-001 violation in episode store
-  //   2. SessionStart hook arms .checkpoint-required
+  //   2. SessionStart hook SURFACES advisory (does not arm); simulate the gate
+  //      lazy-arming .checkpoint-required at the first repo write
   //   3. Simulate Stop firing (em-recall --gate stop) → returns block JSON
   //   4. em-session-end-prompt.mjs sweeps all 4 markers
-  //   5. SessionStart hook runs again → .checkpoint-required re-armed
+  //   5. SessionStart hook runs again → still advises (NOT re-armed)
   //   6. Verify the violation episode still exists (source of truth survived)
   const sessionHome = fs.mkdtempSync(path.join(os.tmpdir(), 'em-rfc002-p3-roundtrip-'))
   const sessionProject = path.join(sessionHome, 'project')
@@ -603,12 +620,20 @@ test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next Sessio
   const preDone = path.join(claudeDir, '.pre-checkpoint-done')
   const postDone = path.join(claudeDir, '.post-checkpoint-done')
 
-  // ----- Step 1: First SessionStart arms marker -----
-  spawnSync('bash', [hookPath], {
+  // ----- Step 1: First SessionStart surfaces advisory (does NOT arm) -----
+  const ss1 = spawnSync('bash', [hookPath], {
     input: JSON.stringify({ cwd: sessionProject }),
     env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
   })
-  assert.ok(fs.existsSync(preReq), 'step 1: SessionStart should arm .checkpoint-required')
+  assert.ok(/bp-001/i.test(ss1.stdout || ''),
+    'step 1: SessionStart should surface the bp-001 advisory')
+  assert.ok(!fs.existsSync(preReq),
+    'step 1: SessionStart must NOT arm .checkpoint-required (planning-passive)')
+  // Simulate the gate lazy-arming the marker at the first repo-source write,
+  // so the Stop-gate round-trip below has a real task signal to act on.
+  fs.mkdirSync(claudeDir, { recursive: true })
+  fs.writeFileSync(preReq, '')
+  assert.ok(fs.existsSync(preReq), 'step 1: gate-simulated lazy-arm present')
 
   // ----- Step 2: Stop fires; em-recall --gate stop returns block -----
   // Post-#146 (A2 carve-out): SessionStart now writes .session-baseline.
@@ -655,13 +680,15 @@ test('T7k. Round-trip: arm → Stop blocks → SessionEnd sweeps → next Sessio
   assert.ok(!fs.existsSync(postReq), 'step 3: SessionEnd should sweep .post-checkpoint-required')
   assert.ok(!fs.existsSync(postDone), 'step 3: SessionEnd should sweep .post-checkpoint-done')
 
-  // ----- Step 4: Next SessionStart re-arms marker (idempotent contract) -----
-  spawnSync('bash', [hookPath], {
+  // ----- Step 4: Next SessionStart STILL advises (NOT re-armed) -----
+  const ss2 = spawnSync('bash', [hookPath], {
     input: JSON.stringify({ cwd: sessionProject }),
     env: sessionEnv, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
   })
-  assert.ok(fs.existsSync(preReq),
-    'step 4: SECOND SessionStart should re-arm marker — proves shouldArmBp001Checkpoint reads episode store, not marker')
+  assert.ok(/bp-001/i.test(ss2.stdout || ''),
+    'step 4: SECOND SessionStart still surfaces the advisory — proves shouldArmBp001Checkpoint reads the episode store, not the (swept) marker')
+  assert.ok(!fs.existsSync(preReq),
+    'step 4: SessionStart must NOT re-arm the marker (planning-passive — re-arm happens at the gate on next repo write)')
 
   // ----- Step 5: Violation episode still in the store (source of truth survived) -----
   const indexPath = path.join(sessionProject, '.episodic-memory', 'index.jsonl')


### PR DESCRIPTION
## Summary

Eliminates checkpoint friction during planning. The pre-checkpoint gate no longer arms at SessionStart, and **Bash is removed from the pre-checkpoint gate** — planning / discovery / exploration / code-review never block and never create a marker. The pre-checkpoint requirement now **lazily arms on the first repo-source `Edit`/`Write`/`MultiEdit`/`NotebookEdit`** (the implementation boundary). The push-gate + post-checkpoint + stop-gate lifecycle stay fully enforced.

## What changed
- **`hooks/checkpoint-gate.sh`**
  - Pre-gate is Edit/Write-only with lazy-arm, guarded by a concrete in-repo `FILE_PATH` — the empty-path conservative block no longer leaks `.checkpoint-required` into the hook-cwd repo (caller-leak regression).
  - Marker-write branch is self-contained: a premature `.post-checkpoint-done` write blocks directly via `_block_pre` (was relying on the removed Bash pre-gate).
  - **Env-prefix wrapper-escape block** on classifier-marker invocations (`REASON=classifier_marker_env_override`) — rejects the *form* (`BYPASS=1 …`, `NODE_ENV=…`), not a var-name list.
- **`scripts/em-recall.mjs`** — removed the dead `armCheckpointMarkerForSession`; a recent bp-001 violation now emits the `__BP1_ADVISORY__` stderr signal instead of arming.
- **`hooks/em-recall-sessionstart.sh`** — surfaces the advisory via SessionStart context.
- **Tests** — +16 planning-passive `PP-*` tests (nothing-armed flow, lazy-arm, off-repo allow, multisession, multiproject); ~34 gate tests + 5 em-recall/rfc002/migration suites updated to the advisory + ungated-Bash model.

## F1 residual (accepted)
A pure-Bash implementation (`sed -i`, `cat > file`, `node writer.mjs`) can mutate repo source without arming the pre-checkpoint — a deliberate trade to remove planning-time friction. Clean closure depends on the rank-10 PR-B agent-classifier. Tracked in #351.

## Testing
- `tests/test-checkpoint-gate.sh` → 236/0
- Full CI sweep green: command-classifier 361/0, em-recall suites, rfc002-phase3 29/0, checkpoints-migration 7/0, bp001-per-project-arming 8/0, repo-root-worktree 12/0
- E2E smoke vs the **installed** gate + em-recall → 6/6 (planning-passive allow, lazy-arm block, env-prefix block, push-gate, advisory-not-arm)

## Review
Codex (second-opinion harness): R1 ACCEPT-with-FU (P2 env-prefix wrapper escape) → fixed inline → **R2 ACCEPT, no findings**. Negative repros run: pure-Bash residual, cross-repo marker leak, env-prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
