### PR TITLE
feat(second-opinion): add opencode (DeepSeek v4-pro) provider + surface spawn errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ node scripts/second-opinion.mjs request \
   --consensus --max-rounds 5 --rebuttal-cb scripts/my-rebuttal.mjs
 ```
 
-Providers: `codex`, `claude-subagent`, `gemini`, `stub` (testing). Storage backends: `files` (`.review-store/`) or `episodic` (uses em-store; default for the cross-tool message bus). Preambles: per-provider defaults at `scripts/second-opinion/preambles/`, overridable via `--preamble <id>` or `<project>/.review-store/preambles/<provider>.md`.
+Providers: `codex`, `claude-subagent`, `gemini`, `opencode` (OpenCode CLI; DeepSeek v4-pro by default, overridable via `OPENCODE_MODEL`), `stub` (testing). Storage backends: `files` (`.review-store/`) or `episodic` (uses em-store; default for the cross-tool message bus). Preambles: per-provider defaults at `scripts/second-opinion/preambles/`, overridable via `--preamble <id>` or `<project>/.review-store/preambles/<provider>.md`.
 
 Bootstrap (writes the install snapshot consumed by validators + the Claude Code PreToolUse gate hook):
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -334,7 +334,7 @@ AI:   I see from a previous session that you chose Tailwind CSS
 
 **How it works:** Both tools read from and write to `~/.episodic-memory/`. The instruction files are different per tool, but the data is shared.
 
-**Cross-tool messaging via the second-opinion harness.** When you ask one tool to review another's plan or diff, `scripts/second-opinion.mjs` writes the request as a local episode, dispatches it to the chosen provider (Codex, Claude subagent, Gemini), and writes the reply back as another episode. Both halves live in `.episodic-memory/` so any tool can read them later. Under the hood, `em-watch-codex.mjs` provides the per-scope cursors that keep replies from being read twice.
+**Cross-tool messaging via the second-opinion harness.** When you ask one tool to review another's plan or diff, `scripts/second-opinion.mjs` writes the request as a local episode, dispatches it to the chosen provider (Codex, Claude subagent, Gemini, OpenCode), and writes the reply back as another episode. Both halves live in `.episodic-memory/` so any tool can read them later. Under the hood, `em-watch-codex.mjs` provides the per-scope cursors that keep replies from being read twice.
 
 ---
 
@@ -372,7 +372,7 @@ node scripts/second-opinion.mjs request \
 
 The `--rebuttal-cb` is a script that takes the reviewer's verdict and decides what to send back next round — accept the findings, push back with new evidence, or stop. Each round is one request episode + one reply episode, so the whole conversation is auditable later via `em-search --tag codex-review --scope local`.
 
-**Providers available:** `codex` (OpenAI Codex CLI), `claude-subagent` (a separate Claude Code session), `gemini` (Google's CLI), and `stub` for testing harness behavior without spending tokens.
+**Providers available:** `codex` (OpenAI Codex CLI), `claude-subagent` (a separate Claude Code session), `gemini` (Google's CLI), `opencode` (the OpenCode CLI, defaulting to the `deepseek/deepseek-v4-pro` model; set `OPENCODE_MODEL` to use a different `provider/model`), and `stub` for testing harness behavior without spending tokens.
 
 **When to use it:** Rule 18 step 2 (any non-trivial implementation needs a second-opinion review on the plan before approval), PR-level reviews before merge, or any time you want a sanity check from a different model family on a load-bearing decision.
 

--- a/hooks/runbooks/second-opinion-add-provider.md
+++ b/hooks/runbooks/second-opinion-add-provider.md
@@ -1,0 +1,128 @@
+# Second-opinion harness — adding a provider (maintainer runbook)
+
+How to add a new review provider (LLM/agent CLI or API) to the second-opinion
+harness. This is the *maintainer* counterpart to `second-opinion-harness.md`
+(which is the *operator* runbook for invoking reviews). Worked reference case:
+the `opencode` provider (DeepSeek v4-pro), added 2026-05-27.
+
+Unlike the operator runbook, this file is NOT injected by the gate hook — it's a
+procedure you read when extending the harness, not a per-invocation reminder.
+
+## The provider contract
+
+Each provider is a module at `scripts/second-opinion/providers/<id>.mjs` exporting:
+
+| Export | Type | Contract |
+|---|---|---|
+| `id` | string | must equal the filename stem and the registry `id` |
+| `binary` | string | the CLI binary name (for `available()` PATH probe) |
+| `available()` | fn → `{ ok: boolean, reason?: string }` | probe binary on PATH + a `--help` signature; never throw |
+| `dispatch({ prompt, projectRoot, timeout })` | fn → `{ ok, exitCode, stdout, stderr, timedOut }` | `spawnSync`, `shell: false`, explicit `cwd: projectRoot`, `stdin: 'ignore'` |
+
+Reference modules: `providers/codex.mjs`, `providers/gemini.mjs` (CLI-shaped).
+`providers/stub.mjs` is the no-CLI fixture.
+
+## The 6 touchpoints (in order)
+
+1. **Provider module** — `providers/<id>.mjs`. Clone `gemini.mjs` (simplest
+   CLI provider). Set `binary`, the `--help` signature regex, and the dispatch
+   argv. Writing the reply episode is the *harness's* job — `dispatch()` only
+   returns raw stdout/stderr.
+
+2. **Provider registry** — add an entry to `providers/index.json`. Validated by
+   `lib/registry-validator.mjs` at install/read/gate time, so every field is
+   mandatory and shape-checked:
+   - `id` — non-empty, unique
+   - `binary` — non-empty string
+   - `cli_match` — non-empty string, **compilable as a RegExp** (see scoping below)
+   - `prompt_max_chars` — non-negative integer
+   - `agent_block_patterns` / `agent_allow_patterns` — arrays of strings (`[]` ok)
+
+3. **Preamble defaults** — `preambles/index.json`: add `default_per_provider.<id>`
+   (a fragment-id list) and any new fragment to the `fragments[]` map. A CLI LLM
+   with no agent loader ships the full review ladder inline as a fragment (see
+   `fragments/gemini-ladder-v1.md`, `fragments/opencode-ladder-v1.md`); a tool
+   with a loader can use a loader-ref fragment (`claude-subagent-loader-ref.md`).
+
+4. **Tests** — extend the 5 suites:
+   - `test-second-opinion-providers.mjs` — add `<id>` to the `PROVIDERS` array
+     (drives the contract/available/dispatch-arg loops).
+   - `test-second-opinion-preamble.mjs` — assert the default preamble composes.
+   - `test-second-opinion-gate.mjs` — add `<id>` to `buildLiveSnapshot`'s
+     providers, then assert the gated invocation blocks AND a non-review
+     invocation is allowed (cli_match scoping).
+   - `test-second-opinion-dispatch.mjs` — `available()` shape smoke test.
+   - `test-install-second-opinion-e2e.mjs` — **REQUIRED**: add `<id>` to
+     `makeAllProvidersUnavailable`'s list (Case 4 must neutralize *every*
+     installed provider or Gate 2 won't fire on a host where `<id>` is present).
+     Optionally assert the snapshot carries `<id>` in Case 1.
+
+5. **Reinstall the snapshot** — `node install.mjs --tool claude-code
+   --install-second-opinion`. Writes `~/.claude/hooks/second-opinion-providers.json`.
+   Watch the output: `Registered provider: <id>` means `available()` passed;
+   `Skip provider <id>: available() returned <reason>` means it failed — fix
+   `available()` before proceeding. The harness fails closed on a stale snapshot,
+   so this step is mandatory, not optional.
+
+6. **Live probe (E2E)** — dispatch a real review through the harness:
+   `node scripts/second-opinion.mjs request --provider <id> --project <abs>
+   --storage files --body "..." --summary "..." --dispatch`. Confirms the CLI is
+   authed and the model responds. If the model isn't authed, surface the auth
+   step to the user (e.g. `opencode auth`) — never stub it silently.
+
+## cli_match scoping — the rule that bites
+
+`cli_match` is what the **gate** (`second-opinion-gate.mjs`) uses to *block
+direct Bash calls* to the provider, forcing them through the harness. Scope it
+to the **review invocation subcommand**, never the bare binary:
+
+- ✅ codex: `^codex\s+exec\b`  ✅ opencode: `^opencode\s+run\b`
+- ❌ `^opencode\b` — would also block the interactive TUI and every other
+  subcommand (`opencode models`, `opencode auth`, …), which has nothing to do
+  with reviews.
+
+This `cli_match` is NOT an allowlist and is unrelated to the checkpoint-gate's
+read-only classifier. Do **not** add provider commands to the checkpoint-gate
+allowlist — the harness spawns the provider via `spawnSync` inside Node, so the
+checkpoint-gate never sees `<id> run`; it only sees the provider-agnostic outer
+`node second-opinion.mjs` call. Adding an agentic command to a read-only
+allowlist would punch a pre-checkpoint bypass.
+
+## CLI-shaped vs API-only providers
+
+- **CLI-shaped** (codex, gemini, opencode): `available()` probes a binary on
+  PATH; `dispatch()` spawns it. This is the common case — clone `gemini.mjs`.
+- **API-only** (HTTPS + key, no CLI): `available()` checks the API-key env var
+  instead of PATH; `dispatch()` does a `fetch` instead of `spawnSync`. There's
+  no Bash call for the gate to catch, so give `cli_match` a never-matching
+  regex (the validator still requires a non-empty compilable string).
+
+## Cross-platform note (open same-class gap)
+
+All current CLI providers use `which <binary>` in `available()`, which is
+POSIX-only — Windows uses `where`. This is a pre-existing same-class gap across
+every provider, not specific to any one. When you touch `available()`, prefer a
+cross-platform probe (`where` on win32, `which` elsewhere) and fix the class.
+
+## Gotchas (learned the hard way)
+
+- **`--help` may print to stderr.** `opencode --help` writes usage to **stderr**,
+  not stdout (`opencode --help 2>/dev/null` is empty). An `available()` that
+  captures stdout only (`stdio: ['ignore', 'pipe', 'ignore']`) will see an empty
+  string and return `cli-help-signature-mismatch`. Capture **both** streams
+  (`['ignore', 'pipe', 'pipe']`) and test the signature against their
+  concatenation. The unit tests won't catch this — they don't assert `ok=true`
+  (CI hosts may lack the binary). The **install step's** `Registered`/`Skip`
+  line is what surfaces it.
+- **Agentic CLIs can edit files.** A `run`-style agent invoked for a review may
+  try to use file-editing tools. Put a "you are reviewing, NOT implementing; do
+  not edit files" instruction in the provider's ladder fragment.
+- **Model pinning lives in the provider module.** The harness calls
+  `dispatch({ prompt, projectRoot })` and does NOT pass a model. Set the model
+  in the module (e.g. `const model = process.env.<TOOL>_MODEL || DEFAULT`).
+
+## Composes with
+
+- `second-opinion-harness.md` — operator runbook (how to *invoke* reviews).
+- `reference_second_opinion_harness.md` — design reference (what the harness IS).
+- `feedback_cross_platform_always.md` — the cross-platform design lens.

--- a/scripts/second-opinion/preambles/fragments/opencode-ladder-v1.md
+++ b/scripts/second-opinion/preambles/fragments/opencode-ladder-v1.md
@@ -1,0 +1,27 @@
+# Review ladder for OpenCode (v1)
+
+You are invoked via `opencode run` as a second-opinion reviewer (model: DeepSeek v4-pro). This prompt IS your full instruction for this run. You are reviewing, NOT implementing: do NOT edit, create, or delete files — respond only with your review.
+
+## Apply this ladder in order before verdict
+
+### 1. Read the request body fully
+The body (provided in the transport block / message) contains the artifact under review + specific scrutiny questions. Read it before forming any opinion.
+
+### 2. Same-class completeness check
+For every claim in the artifact, ask: is there a SAME-CLASS sibling that's missing? E.g., if the artifact validates input X, does it also validate sibling input Y? Missing siblings are class-completeness gaps.
+
+### 3. Negative-scenario coverage
+Run through these axes for any non-trivial change:
+- Empty / null / boundary inputs.
+- Concurrency / race conditions.
+- Path traversal / resource exhaustion.
+- Cross-cutting surfaces (worktree vs main, cwd vs explicit root).
+
+### 4. Three-state verdict
+ACCEPT (no blockers) / ACCEPT-with-FU (minor follow-ups acceptable) / HOLD (blockers; cite each) / REJECT (architecturally wrong).
+
+### 5. Closeout
+
+- List negative scenarios actually examined.
+- If a relevant same-class lesson exists but was NOT covered, say WHY.
+- End your reply with the fenced JSON block per v3 §Consensus-loop v3 contract.

--- a/scripts/second-opinion/preambles/index.json
+++ b/scripts/second-opinion/preambles/index.json
@@ -4,12 +4,14 @@
     "codex": ["review-ladder-v9.4", "env-prefix-discipline-v1"],
     "claude-subagent": ["claude-subagent-loader-ref", "env-prefix-discipline-v1"],
     "gemini": ["gemini-ladder-v1", "env-prefix-discipline-v1"],
+    "opencode": ["opencode-ladder-v1", "env-prefix-discipline-v1"],
     "stub": ["review-ladder-v9.4"]
   },
   "fragments": [
     {"id": "review-ladder-v9.4", "path": "fragments/review-ladder-v9.4.md"},
     {"id": "claude-subagent-loader-ref", "path": "fragments/claude-subagent-loader-ref.md"},
     {"id": "gemini-ladder-v1", "path": "fragments/gemini-ladder-v1.md"},
+    {"id": "opencode-ladder-v1", "path": "fragments/opencode-ladder-v1.md"},
     {"id": "env-prefix-discipline-v1", "path": "fragments/env-prefix-discipline-v1.md"}
   ]
 }

--- a/scripts/second-opinion/providers/claude-subagent.mjs
+++ b/scripts/second-opinion/providers/claude-subagent.mjs
@@ -3,7 +3,7 @@
  *
  * Provider contract (per v3 §Provider availability):
  *   available()  → { ok, reason? }
- *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut }
+ *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut, error }
  *
  * Mechanism: invokes `claude` CLI with the composed prompt as the
  * subagent's task. The `negative-scenario-reviewer` subagent has its own
@@ -75,5 +75,8 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdout: result.stdout ? result.stdout.toString() : '',
     stderr: result.stderr ? result.stderr.toString() : '',
     timedOut: result.signal === 'SIGTERM' && result.error?.code === 'ETIMEDOUT',
+    // Surface spawn failures (ENOENT / bad cwd) instead of discarding them —
+    // status is null on a spawn error, so ok=false but the cause was lost (FU-001).
+    error: result.error ? result.error.message : null,
   }
 }

--- a/scripts/second-opinion/providers/codex.mjs
+++ b/scripts/second-opinion/providers/codex.mjs
@@ -3,7 +3,7 @@
  *
  * Provider contract (per v3 §Provider availability):
  *   available()  → { ok, reason? } — checks CLI binary on PATH + --help signature
- *   dispatch()   → { ok, replyId, replyPath, exitCode, stderr } — runs codex exec
+ *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut, error } — runs codex exec
  *                 with explicit cwd: projectRoot, shell: false
  *
  * Auto-background mitigation: passes stdin: 'ignore' so codex sees stdin EOF
@@ -61,6 +61,7 @@ export function available() {
  *   stdout: string,
  *   stderr: string,
  *   timedOut: boolean,
+ *   error: string | null,   // spawn-failure message (ENOENT / bad cwd), else null
  * }
  *
  * Note: writing the reply episode is the harness's responsibility. This
@@ -83,5 +84,8 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdout: result.stdout ? result.stdout.toString() : '',
     stderr: result.stderr ? result.stderr.toString() : '',
     timedOut: result.signal === 'SIGTERM' && result.error?.code === 'ETIMEDOUT',
+    // Surface spawn failures (ENOENT / bad cwd) instead of discarding them —
+    // status is null on a spawn error, so ok=false but the cause was lost (FU-001).
+    error: result.error ? result.error.message : null,
   }
 }

--- a/scripts/second-opinion/providers/gemini.mjs
+++ b/scripts/second-opinion/providers/gemini.mjs
@@ -3,7 +3,7 @@
  *
  * Provider contract (per v3 §Provider availability):
  *   available()  → { ok, reason? }
- *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut }
+ *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut, error }
  *
  * Mechanism: invokes `gemini` CLI with composed prompt. Gemini has no
  * agent loader, so the gemini-ladder-v1 fragment ships the full review
@@ -62,5 +62,8 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdout: result.stdout ? result.stdout.toString() : '',
     stderr: result.stderr ? result.stderr.toString() : '',
     timedOut: result.signal === 'SIGTERM' && result.error?.code === 'ETIMEDOUT',
+    // Surface spawn failures (ENOENT / bad cwd) instead of discarding them —
+    // status is null on a spawn error, so ok=false but the cause was lost (FU-001).
+    error: result.error ? result.error.message : null,
   }
 }

--- a/scripts/second-opinion/providers/index.json
+++ b/scripts/second-opinion/providers/index.json
@@ -32,6 +32,14 @@
       "prompt_max_chars": 100000,
       "agent_block_patterns": [],
       "agent_allow_patterns": []
+    },
+    {
+      "id": "opencode",
+      "binary": "opencode",
+      "cli_match": "^opencode\\s+run\\b",
+      "prompt_max_chars": 200000,
+      "agent_block_patterns": [],
+      "agent_allow_patterns": []
     }
   ]
 }

--- a/scripts/second-opinion/providers/opencode.mjs
+++ b/scripts/second-opinion/providers/opencode.mjs
@@ -1,0 +1,99 @@
+/**
+ * opencode.mjs — OpenCode CLI provider for the second-opinion harness.
+ *
+ * Provider contract (per v3 §Provider availability — same as codex/gemini):
+ *   available()  → { ok, reason? } — checks CLI binary on PATH + --help signature
+ *   dispatch()   → { ok, exitCode, stdout, stderr, timedOut }
+ *
+ * Mechanism: invokes `opencode run -m <model> <prompt>` non-interactively.
+ * OpenCode is an agentic CLI; `run` is its one-shot (non-TUI) entry point and
+ * prints the model's formatted response to stdout, which the harness captures
+ * and persists as the review reply.
+ *
+ * Model: defaults to deepseek/deepseek-v4-pro (the requested model), overridable
+ * via OPENCODE_MODEL for operators who want a different provider/model pair.
+ * Format is `provider/model` per `opencode run -m`.
+ *
+ * Per v3 §Bypass: invoked from harness Node via spawnSync — Claude Code's
+ * PreToolUse hook does NOT see this child call (the hook sees the OUTER
+ * `node second-opinion.mjs` invocation). The registry's cli_match is scoped to
+ * `^opencode\s+run\b` so the gate blocks only direct `opencode run` Bash calls,
+ * not the interactive TUI or other subcommands.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+const HELP_SIGNATURE = /\bopencode\s+run\b/
+const DEFAULT_MODEL = 'deepseek/deepseek-v4-pro'
+
+export const id = 'opencode'
+export const binary = 'opencode'
+// Resolved once at module-load time. The harness imports each provider module
+// exactly once per process, so OPENCODE_MODEL is read at import — a mid-process
+// env change would not be observed (acceptable: one import per dispatch run).
+export const model = process.env.OPENCODE_MODEL || DEFAULT_MODEL
+
+export function available() {
+  // 1. Binary on PATH.
+  const which = spawnSync('which', [binary], {
+    shell: false, stdio: ['ignore', 'pipe', 'ignore'],
+  })
+  if (which.status !== 0) return { ok: false, reason: 'cli-not-found' }
+
+  // 2. --help parses + matches expected signature (the `run` subcommand).
+  //    OpenCode prints --help to STDERR (not stdout — verified empirically:
+  //    `opencode --help 2>/dev/null` is empty), so capture BOTH streams and
+  //    test the signature against their concatenation.
+  const help = spawnSync(binary, ['--help'], {
+    shell: false, stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000,
+  })
+  if (help.status !== 0) {
+    return { ok: false, reason: 'cli-help-failed', exitCode: help.status }
+  }
+  const helpText = `${help.stdout ? help.stdout.toString() : ''}${help.stderr ? help.stderr.toString() : ''}`
+  if (!HELP_SIGNATURE.test(helpText)) {
+    return {
+      ok: false, reason: 'cli-help-signature-mismatch',
+      expected: String(HELP_SIGNATURE),
+    }
+  }
+  return { ok: true }
+}
+
+/**
+ * dispatch — Run `opencode run -m <model> <prompt>` synchronously.
+ *
+ * Args: {
+ *   prompt: string,        // composed preamble + body (full prompt text)
+ *   projectRoot: string,   // explicit cwd for spawnSync (NEVER inherit)
+ *   timeout?: number,      // milliseconds (default 600000 = 10 min)
+ * }
+ *
+ * Returns: { ok, exitCode, stdout, stderr, timedOut, error }
+ *   error is the spawn-failure message (ENOENT / bad cwd) or null on success.
+ *
+ * Note: writing the reply episode is the harness's responsibility. This
+ * function returns the raw opencode stdout/stderr; harness parses + persists.
+ */
+export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
+  if (!prompt) throw new Error('opencode.dispatch: prompt is required')
+  if (!projectRoot) throw new Error('opencode.dispatch: projectRoot is required')
+
+  const result = spawnSync(binary, ['run', '-m', model, prompt], {
+    cwd: projectRoot,           // CRITICAL: explicit cwd (I-6)
+    shell: false,               // CRITICAL: no shell interpretation (I-6)
+    stdio: ['ignore', 'pipe', 'pipe'],   // stdin: ignore → no hang waiting on input
+    timeout,
+  })
+
+  return {
+    ok: result.status === 0,
+    exitCode: result.status,
+    stdout: result.stdout ? result.stdout.toString() : '',
+    stderr: result.stderr ? result.stderr.toString() : '',
+    timedOut: result.signal === 'SIGTERM' && result.error?.code === 'ETIMEDOUT',
+    // Surface spawn failures (ENOENT / bad cwd) instead of discarding them —
+    // status is null on a spawn error, so ok=false but the cause was lost (FU-001).
+    error: result.error ? result.error.message : null,
+  }
+}

--- a/tests/test-install-second-opinion-e2e.mjs
+++ b/tests/test-install-second-opinion-e2e.mjs
@@ -17,7 +17,7 @@
  *     full-tree hash byte-identical pre vs post (active runtime untouched).
  *
  *   Case 4 — Gate 2 failure with quarantine: pre-existing happy snapshot →
- *     overwrite all 4 provider modules in temp repo copy so every
+ *     overwrite all 5 provider modules in temp repo copy so every
  *     available() returns {ok: false} → install passes Gate 1 (source
  *     registry shape is valid) but Gate 2 fails (installedProviders is
  *     empty → N1) → quarantine pre-existing snapshot to .stale.<ts> so
@@ -128,7 +128,7 @@ function mutateRegistryInvalid(tempRepoCopy) {
 // {ok: false}. installedProviders becomes empty → Gate 2 N1 fires.
 function makeAllProvidersUnavailable(tempRepoCopy) {
   const providersDir = path.join(tempRepoCopy, 'scripts/second-opinion/providers')
-  for (const name of ['stub', 'codex', 'claude-subagent', 'gemini']) {
+  for (const name of ['stub', 'codex', 'claude-subagent', 'gemini', 'opencode']) {
     fs.writeFileSync(
       path.join(providersDir, `${name}.mjs`),
       `export const id = '${name}'\n` +
@@ -224,6 +224,17 @@ test('happy install: exit 0, Done!, full surface populated, snapshot valid', () 
   const snap = JSON.parse(fs.readFileSync(snapshot, 'utf8'))
   assert.ok(Array.isArray(snap.providers) && snap.providers.length >= 1,
     `snapshot.providers must be non-empty, got ${JSON.stringify(snap.providers)}`)
+
+  // If opencode is available() on this host, the installed snapshot must carry
+  // it with the scoped cli_match (gates `opencode run`, not the bare TUI).
+  // available()-filtered: only assert when present so CI hosts without the
+  // opencode CLI still pass.
+  const opencodeEntry = snap.providers.find((p) => p.id === 'opencode')
+  if (opencodeEntry) {
+    assert.strictEqual(opencodeEntry.cli_match, '^opencode\\s+run\\b',
+      `opencode snapshot entry must use scoped cli_match, got ${opencodeEntry.cli_match}`)
+    assert.strictEqual(opencodeEntry.binary, 'opencode')
+  }
 
   // R7-F1: caller cwd untouched (no .episodic-memory / .claude there).
   assert.ok(!fs.existsSync(path.join(callerCwd, '.episodic-memory')),

--- a/tests/test-second-opinion-dispatch.mjs
+++ b/tests/test-second-opinion-dispatch.mjs
@@ -181,6 +181,22 @@ test('codex provider available() returns shape {ok, reason?}', async () => {
   // Don't assert ok=true — codex may or may not be installed in CI.
 })
 
+console.log('\n## OpenCode provider available()')
+test('opencode provider available() returns shape {ok, reason?} + exports model', async () => {
+  const provider = await import(
+    `file://${path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers', 'opencode.mjs')}`
+  )
+  const result = provider.available()
+  assert.ok(typeof result.ok === 'boolean', 'available() must return {ok: boolean}')
+  if (!result.ok) {
+    assert.ok(typeof result.reason === 'string', 'when ok=false, reason must be string')
+  }
+  // model export defaults to deepseek/deepseek-v4-pro (overridable via env).
+  assert.ok(typeof provider.model === 'string' && provider.model.includes('/'),
+    `opencode must export a provider/model string, got: ${provider.model}`)
+  // Don't assert ok=true — opencode may or may not be installed in CI.
+})
+
 // ---------------------------------------------------------------------------
 // --dispatch on unknown provider → error before any spawn
 // ---------------------------------------------------------------------------

--- a/tests/test-second-opinion-gate.mjs
+++ b/tests/test-second-opinion-gate.mjs
@@ -100,6 +100,11 @@ function buildLiveSnapshot(snapshotPath) {
         agent_block_patterns: ['codex:codex-rescue', 'codex:codex-cli-runtime'],
         agent_allow_patterns: ['codex:setup', 'codex:gpt-5-4-prompting', 'codex:codex-result-handling'],
       },
+      {
+        id: 'opencode', binary: 'opencode', cli_match: '^opencode\\s+run\\b',
+        prompt_max_chars: 200000,
+        agent_block_patterns: [], agent_allow_patterns: [],
+      },
     ],
     fragments: hashed.fragments,
     file_hashes: hashed.file_hashes,
@@ -405,6 +410,46 @@ test('codex command + foreground + main repo + small → allow', () => {
   // exec from main repo (the wrapper script we used in this very session).
   assert.strictEqual(r.exitCode, 0)
   assert.strictEqual(r.decision, null)
+})
+
+// opencode provider: cli_match is scoped to `^opencode\s+run\b`, so the
+// review invocation is gated but the bare TUI / other subcommands are not.
+test('opencode run command + run_in_background:true → block', () => {
+  const proj = makeTmpProject()
+  const snap = makeTmpSnapshotPath()
+  buildLiveSnapshot(snap)
+  const r = runHook(
+    { tool_name: 'Bash', tool_input: { command: 'opencode run -m deepseek/deepseek-v4-pro "review this"', run_in_background: true }, cwd: proj },
+    { snapshotPath: snap },
+  )
+  assert.strictEqual(r.decision.decision, 'block')
+  assert.match(r.decision.reason, /run_in_background/)
+})
+
+test('bare opencode (TUI, no run subcommand) → allow (cli_match scoping)', () => {
+  const proj = makeTmpProject()
+  const snap = makeTmpSnapshotPath()
+  buildLiveSnapshot(snap)
+  const r = runHook(
+    { tool_name: 'Bash', tool_input: { command: 'opencode', run_in_background: true }, cwd: proj },
+    { snapshotPath: snap },
+  )
+  // `^opencode\s+run\b` must NOT match bare `opencode` — the interactive TUI
+  // and non-review subcommands stay free even with run_in_background set.
+  assert.strictEqual(r.exitCode, 0)
+  assert.strictEqual(r.decision, null, `expected allow (empty stdout), got: ${r.stdout}`)
+})
+
+test('opencode models subcommand → allow (cli_match scoping)', () => {
+  const proj = makeTmpProject()
+  const snap = makeTmpSnapshotPath()
+  buildLiveSnapshot(snap)
+  const r = runHook(
+    { tool_name: 'Bash', tool_input: { command: 'opencode models deepseek', run_in_background: true }, cwd: proj },
+    { snapshotPath: snap },
+  )
+  assert.strictEqual(r.exitCode, 0)
+  assert.strictEqual(r.decision, null, `expected allow (empty stdout), got: ${r.stdout}`)
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/test-second-opinion-preamble.mjs
+++ b/tests/test-second-opinion-preamble.mjs
@@ -129,6 +129,18 @@ test('default preamble for gemini includes ladder-v1 + env-prefix-discipline', (
   assert.deepStrictEqual(result.fragmentIds, ['gemini-ladder-v1', 'env-prefix-discipline-v1'])
 })
 
+test('default preamble for opencode includes ladder-v1 + env-prefix-discipline', () => {
+  const tmp = makeTmpProject()
+  const result = compose({ provider: 'opencode', projectRoot: tmp, cliFragments: null })
+  assert.strictEqual(result.preambleSource, 'default')
+  assert.deepStrictEqual(result.fragmentIds, ['opencode-ladder-v1', 'env-prefix-discipline-v1'])
+
+  const reg = loadRegistry()
+  const ladder = readFragment(reg.fragments.find((f) => f.id === 'opencode-ladder-v1'))
+  assert.ok(result.preambleBody.includes(ladder),
+    'composed body must include opencode-ladder fragment content')
+})
+
 test('unknown provider with no default → no-default-preamble-for-provider', () => {
   const tmp = makeTmpProject()
   assert.throws(

--- a/tests/test-second-opinion-providers.mjs
+++ b/tests/test-second-opinion-providers.mjs
@@ -3,8 +3,8 @@
  * test-second-opinion-providers.mjs — Per-provider available() shape smoke tests.
  *
  * Coverage:
- *   - All 4 providers (codex, claude-subagent, gemini, stub) export id +
- *     binary + available + dispatch.
+ *   - All 5 providers (codex, claude-subagent, gemini, stub, opencode) export
+ *     id + binary + available + dispatch.
  *   - available() returns {ok: boolean, reason?: string} regardless of
  *     CLI presence (no throw, no undefined fields).
  *   - dispatch() throws on missing required args.
@@ -59,7 +59,7 @@ console.log('# test-second-opinion-providers')
 // All 4 providers exist + export the contract
 // ---------------------------------------------------------------------------
 console.log('\n## Provider module contract')
-const PROVIDERS = ['codex', 'claude-subagent', 'gemini', 'stub']
+const PROVIDERS = ['codex', 'claude-subagent', 'gemini', 'stub', 'opencode']
 for (const id of PROVIDERS) {
   const modPath = path.join(PROVIDERS_DIR, `${id}.mjs`)
   test(`provider module exists: ${id}.mjs`, () => {
@@ -104,6 +104,25 @@ for (const id of PROVIDERS) {
     const mod = await import(`file://${path.join(PROVIDERS_DIR, `${id}.mjs`)}`)
     assert.throws(() => mod.dispatch({ prompt: 'hi' }),
       (e) => /projectRoot is required/.test(e.message))
+  })
+}
+
+// ---------------------------------------------------------------------------
+// FU-001: dispatch() surfaces spawn failures (ENOENT / bad cwd) in `error`
+// instead of discarding result.error. A non-existent cwd makes spawnSync fail
+// with ENOENT regardless of whether the binary is installed, so this is
+// deterministic across CI hosts. Stub is in-process (no spawn) → excluded.
+// ---------------------------------------------------------------------------
+console.log('\n## dispatch() surfaces spawn-failure error (FU-001)')
+const CLI_PROVIDERS = ['codex', 'claude-subagent', 'gemini', 'opencode']
+for (const id of CLI_PROVIDERS) {
+  await asyncTest(`${id}.dispatch() on bad cwd → ok:false + error string`, async () => {
+    const mod = await import(`file://${path.join(PROVIDERS_DIR, `${id}.mjs`)}`)
+    const r = mod.dispatch({ prompt: 'x', projectRoot: '/nonexistent-so-provider-test-xyz-123' })
+    assert.strictEqual(r.ok, false, `${id}: spawn into bad cwd must be ok:false`)
+    assert.strictEqual(typeof r.error, 'string',
+      `${id}: spawn failure must surface error as a string, got ${JSON.stringify(r.error)}`)
+    assert.ok(r.error.length > 0, `${id}: error message must be non-empty`)
   })
 }
 

--- a/tests/test-second-opinion-storage.mjs
+++ b/tests/test-second-opinion-storage.mjs
@@ -280,7 +280,10 @@ test('preamble_source: "default" for codex with no override/flag', () => {
     '--summary', 'codex default preamble',
   ])
   assert.strictEqual(result.preamble_source, 'default')
-  assert.deepStrictEqual(result.fragment_ids, ['review-ladder-v9.4'])
+  // codex default = review ladder + env-prefix discipline (per committed
+  // preambles/index.json). This assertion was stale (review-ladder only) and
+  // failing pre-existing; corrected to match the source-of-truth registry.
+  assert.deepStrictEqual(result.fragment_ids, ['review-ladder-v9.4', 'env-prefix-discipline-v1'])
 })
 
 test('preamble_source: "repo-override" when override file present', () => {
@@ -331,6 +334,54 @@ test('--storage /tmp/foo → invalid-storage-flag', () => {
     '--summary', 'invalid storage',
   ], { expectError: true })
   assert.strictEqual(result.code, 'invalid-storage-flag')
+})
+
+// ---------------------------------------------------------------------------
+// Episodic storage: request + reply round-trip written to episodes AND
+// readable back via em-search. This is the provider-agnostic path every CLI
+// provider uses for reviews (codex, gemini, opencode). Stub stands in for the
+// real provider on the storage path (hermetic — no CLI/network). Live opencode
+// proof: episodes 20260527-235331-...-7fcc (request) + ...-626e (reply).
+// ---------------------------------------------------------------------------
+console.log('\n## Episodic storage request/reply round-trip (em-store write + em-search readback)')
+test('--storage episodic --dispatch writes request+reply episodes, readable via em-search', () => {
+  const tmp = makeTmpProject()
+  const result = runHarness([
+    'request',
+    '--provider', 'stub',
+    '--project', tmp,
+    '--storage', 'episodic',
+    '--body', 'episodic round-trip body',
+    '--summary', 'episodic round-trip test',
+    '--dispatch',
+  ])
+
+  // Writing half: request + reply are local episodes under the project store.
+  assert.strictEqual(result.storage, 'episodic')
+  assert.ok(result.written.id, 'request episode id present')
+  // Compare against realpath(tmp): on macOS mkdtemp returns /var/... but the
+  // episode store path is canonicalized to /private/var/... (the /var symlink).
+  assert.ok(result.written.file.startsWith(fs.realpathSync(tmp)),
+    `request episode under project store, got ${result.written.file}`)
+  assert.ok(fs.existsSync(result.written.file), 'request episode file on disk')
+  assert.ok(result.reply && result.reply.id, 'reply episode id present')
+  assert.ok(fs.existsSync(result.reply.file), 'reply episode file on disk')
+
+  // Reading half: em-search by reply-to-<requestId> tag returns the reply.
+  const emSearch = path.join(REPO_ROOT, 'scripts', 'em-search.mjs')
+  const r = spawnSync('node', [
+    emSearch,
+    '--scope', 'local',
+    '--tag', `reply-to-${result.written.id}`,
+    '--full', '--no-track', '--no-score',
+  ], { cwd: tmp, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env } })
+  assert.strictEqual(r.status, 0, `em-search failed: ${r.stderr.toString()}`)
+  const found = JSON.parse(r.stdout.toString())
+  assert.strictEqual(found.count, 1, `expected 1 reply episode via em-search, got ${found.count}`)
+  assert.strictEqual(found.episodes[0].id, result.reply.id,
+    'em-search returns the written reply episode')
+  assert.ok(found.episodes[0].tags.includes(`reply-to-${result.written.id}`),
+    'reply episode carries reply-to-<requestId> tag (the read key)')
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds an **OpenCode** provider (model `deepseek/deepseek-v4-pro`, overridable via `OPENCODE_MODEL`) to the second-opinion review harness, and fixes a cross-provider follow-up (FU-001) surfaced during the live review.

## Changes
- **New provider** `scripts/second-opinion/providers/opencode.mjs` — `available()` + `dispatch()` (`opencode run -m <model>`, `shell:false`, explicit cwd, `stdin:ignore`).
- **Registry** `providers/index.json` — `cli_match: ^opencode\s+run\b`, scoped to the review subcommand so the gate blocks only `opencode run`, not the interactive TUI or other subcommands.
- **Preamble** default + new `fragments/opencode-ladder-v1.md`.
- **FU-001 fix (all 4 CLI providers)** — `dispatch()` now surfaces spawn failures (ENOENT / bad cwd) via an `error` field instead of discarding `result.error`. `stub` is exempt (in-process).
- **Docs** — README + USER_MANUAL provider lists; new maintainer runbook `hooks/runbooks/second-opinion-add-provider.md`.

## available() gotcha fixed
OpenCode prints `--help` to **stderr**; the initial stdout-only probe returned `cli-help-signature-mismatch` at install. `available()` now reads both streams and matches the signature against their concatenation.

## Tests (all green)
- providers 24/0 (incl. 4 FU-001 cases + opencode contract)
- dispatch 9/0 · gate 23/0 (cli_match scoping: `opencode run` gated, bare `opencode` allowed)
- preamble 44/0 · storage 11/0 (episodic request/reply round-trip + `em-search` readback)
- install-snapshot 14/0 · install-e2e 6/0

## Live E2E
`opencode` → DeepSeek v4-pro returned **ACCEPT** on both `--storage files` and `--storage episodic`. The episodic request/reply were written as local episodes and read back via `em-search --tag reply-to-<id>` — the same path codex replies use.

## Notes
- Second-opinion (codex) review on the plan was waived per request.
- The live opencode review of `opencode.mjs` served as a de-facto code review (ACCEPT + FU-001, now fixed inline across all providers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
