### PR TITLE
fix(classifier): script-identity cache key for in-repo interpreter commands

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -15,7 +15,7 @@ RFCs document proposed changes to the episodic-memory system. Every non-trivial 
 | RFC-005 | em-move — atomic episode relocation between scopes | draft | Charlton Ho |
 | RFC-006 | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | withdrawn | Charlton Ho |
 | RFC-007 | Graph Projection — first-class traversal over latent episode/rule edges | draft | Charlton Ho |
-| RFC-008 | Decoupling the Enforcement Layer from the Memory Substrate | draft | Charlton Ho |
+| RFC-008 | Decoupling the Enforcement Layer from the Memory Substrate | accepted | Charlton Ho |
 
 ---
 

--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -2,10 +2,10 @@
 rfc_id: RFC-008
 slug: decouple-enforcement-from-substrate
 title: Decoupling the Enforcement Layer from the Memory Substrate
-status: draft
+status: accepted
 champion: Charlton Ho
 created: 2026-05-27
-last_modified: 2026-05-27
+last_modified: 2026-05-28
 supersedes: ~
 superseded_by: ~
 ---
@@ -245,6 +245,36 @@ if action == "block" and effective_tier == STRONG:
 ```
 The contract drives the behavior; the enforcement layer consults the contract. R2 satisfied.
 
+### Validation-contract specification (v9 — closes round-1 review HOLD, findings F1–F10)
+
+Round-1 second-opinion (opencode/DeepSeek-v4-pro, episode `20260528-013519-reply-opencode-to-20260528-013221-second-36d9`) returned **HOLD**: the validators were specified by single-sentence anchors ("fail CI on any non-canonical label") covering ~10% of the contract. This section is the full, **normative** contract — `scripts/validate-bp-contract.mjs` MUST implement every assertion below; CI fails on any violation.
+
+#### Gate cardinality — 3 classification gates + 1 marker-state gate (F2, F10)
+The per-label `gates` object in `taxonomy.json` carries EXACTLY three classification gates: `plan_approval`, `pre_checkpoint`, `post_checkpoint`. The `stop` gate is NOT per-label — it reads marker state, not command labels (see §Gate semantics). `stop.tier` is **pattern-level metadata** at the ROOT of each `bp-XXX.json` (`{ "stop": { "tier": "STRONG" }, "gates": { … } }`), never per-label. `schema.json`'s per-label gate set is therefore `{plan_approval, pre_checkpoint, post_checkpoint}`; `stop.tier` is a root-level property. `enforce-contract.mjs` computes `effective_tier(stop) = min(harness_cap.stop, contract.stop.tier, project_config.stop.tier)` — no label term (F10).
+
+#### Single source of truth for overridability (F9)
+Per-label `overridable: boolean` is canonical. The top-level `non_overridable: [...]` array is DERIVED (`labels.filter(l => !l.overridable).map(l => l.id)`, sorted) — retained only as human-readable convenience + CI cross-check. `validate-bp-contract.mjs` asserts the stored array equals the derived set (bidirectional); drift is a CI failure (Rule 14).
+
+#### `taxonomy_version` hash (F8)
+`taxonomy_version = "sha256:" + SHA256(JSON.stringify(labelsSortedById)).hex`, where `labelsSortedById` is the `labels` array sorted by `id`. The hash covers ONLY the sorted labels array — not `version` / `non_overridable` / `non_overridable_rationale` — so editorial fields change without invalidating classification behavior. Every `bp-XXX.json` AND every plugin `manifest.json` carries `taxonomy_version`; `validate-bp-contract.mjs` and `validate-plugin-registry.mjs` assert it equals the current computed hash, else fail "built against stale taxonomy."
+
+#### OQ-2 CLOSED — classifier sources the taxonomy at runtime (F4)
+`command-classifier.sh` SOURCES its label set from `taxonomy.json` at startup via a zero-dep node helper (`node -e 'process.stdout.write(require("<taxonomy>").labels.map(l=>l.id).join(" "))'`) and fails closed if the resolved set ≠ its expectation. This eliminates label drift by construction (no hand-maintained bash label list). CI asserts the sourcing helper exists, is wired, and that the classifier's emitted-label set and `_priority` case-arm names equal `taxonomy.labels`. The CI-only alternative (parsing labels out of 3000+ lines of bash) is rejected as fragile.
+
+#### Runtime out-of-vocabulary contract — HARD-REJECT, not coerce (F3)
+The thin-waist runtime layer does NOT coerce an unrecognized classifier label to `unknown`. It HARD-REJECTS the transaction (fail-closed) and emits a structured alert (episode + stderr: plugin id, harness, emitted label, command text, timestamp). **Authority-root binding:** the alert episode MUST be written with the harness/git-resolved `project_root` bound as the subprocess `cwd` (or an explicit accepted root flag) — NEVER the inherited caller cwd. `em-store --project X --scope local` writes under the CALLER's `.episodic-memory` when cwd ≠ X (the PR #218 / #326 / #336 orphaned-write class). The alert reports `project_root`, `store_scope`, and `episode_file`; disk-location tests cover cwd-mismatch, nested cwd, linked worktree, and non-git cwd with explicit target. Author-time + CI already guarantee vocabulary closure; if a non-canonical label reaches runtime, something is catastrophically wrong, and silent coercion is a latent behavior-change landmine — a label later added to the taxonomy with `allow` semantics would silently flip prior blocks to allows. Coercion is prohibited.
+
+#### `validate-bp-contract.mjs` — normative assertion checklist (F1, F5, F6, F7)
+1. **Meta-schema (F5):** `taxonomy.json` validates against `patterns/taxonomy.schema.json` (JSON Schema 2020-12) — `version` semver string; `labels` non-empty array; each label requires `id` (non-empty string), `meaning` (string), `overridable` (boolean), `gates` (object); `non_overridable` array-of-strings; `non_overridable_rationale` object keyed by label ids. `schema.json` validates against the same draft.
+2. **Gate-completeness (F1a):** ∀ label, ∀ gate ∈ {plan_approval, pre_checkpoint, post_checkpoint}: `label.gates[gate]` exists.
+3. **No extra gate keys (F1e):** ∀ label: `keys(label.gates) ⊆ {plan_approval, pre_checkpoint, post_checkpoint}`.
+4. **Action-enum closure (F1b):** ∀ label, ∀ gate: `label.gates[gate] ∈ {allow, block}`.
+5. **Overridability equality (F1c, F9):** stored `non_overridable` (sorted) ≡ derived non-overridable set.
+6. **No duplicate ids (F1d):** label ids are unique.
+7. **Vocabulary closure — no dangling references (F6):** the label set referenced by every `bp-XXX.json`, every `manifest.classifier.emits_labels`, the classifier's emitted labels, and the classifier `_priority` case-arms is a SUBSET of `taxonomy.labels`. (`emits_labels ⊆ taxonomy.labels` is shared with `validate-plugin-registry.mjs`; BOTH validators carry it.)
+8. **Stable-ID integrity (F7):** labels may be ADDED but never REMOVED or RENAMED without a major `version` bump. The validator diffs the previous `taxonomy.json` from git; if `|old_ids| == |new_ids|` and `old_ids ≠ new_ids`, fail "possible rename — add the new label + mark the old `deprecated: true`, never rename." `bp-XXX.json.taxonomy_version` mismatch (F8) is a hard fail.
+9. **Golden tests (F5):** `validate-bp-contract.mjs` ships known-good + known-bad fixtures (missing gate, bad action value, overridability mismatch, duplicate id, extra gate key, dangling reference, rename) and asserts the expected pass/fail per fixture. The 10 round-1 negative scenarios map 1:1 to assertions 2–8 + the runtime hard-reject and form the golden-test corpus.
+
 ### Capability-degradable enforcement (maps to R3)
 
 #### Effective tier formula (ternary)
@@ -469,7 +499,7 @@ The `add-enforcement-plugin` skill (`scripts/scaffold-plugin.mjs`) generates `pl
 
 ### Plugin authoring skill + taxonomy conformance (maps to R3, R4, R6, R8, R10)
 
-Because the contract is machine-readable, authoring a conformant plugin is **generated, not hand-rolled**. A scaffolding skill turns "add a harness = a plugin directory" into a guided flow and makes the canonical taxonomy (R4) impossible to violate by emitting it, CI-checking it, and runtime-clamping it.
+Because the contract is machine-readable, authoring a conformant plugin is **generated, not hand-rolled**. A scaffolding skill turns "add a harness = a plugin directory" into a guided flow and makes the canonical taxonomy (R4) impossible to violate by emitting it, CI-checking it, and runtime-rejecting any violation.
 
 **Skill `add-enforcement-plugin`** is backed by a harness-agnostic generator `scripts/scaffold-plugin.mjs` (zero-dep, callable from any harness per R6); the Claude Code *skill* is a thin wrapper over it. Flow:
 1. Prompt for harness name + capability tiers per event + classifier mode (`default` | `override`).
@@ -487,7 +517,7 @@ Net: **R3, R8, and R10 conformance-by-construction** — the author cannot produ
 |---|---|---|
 | **Author-time (skill)** | Injects `LABELS` from `taxonomy.json`; writes `emits_labels` + `taxonomy_version` hash into the manifest; refuses to let an override remap/suppress `unsafe_complex` or `marker_write` | Author inventing a label by hand; overriding infrastructure labels |
 | **CI (`validate-plugin-registry.mjs`)** | Asserts `manifest.classifier.emits_labels ⊆ taxonomy.labels`; asserts `taxonomy_version` == current hash else "built against stale taxonomy"; checks no non-overridable label is suppressed; runs the golden test; validates runbook (R10) | Drift after taxonomy changes; stale manifest; suppressed non-overridable; missing runbook |
-| **Runtime (`enforce-contract.mjs`)** | Normalizes the classifier's return value against `taxonomy.json` — any label ∉ canonical set is coerced to `unknown` (fail-closed) and logged; non-overridable labels always processed by core logic regardless of plugin output | A buggy/malicious override emitting garbage at runtime |
+| **Runtime (`enforce-contract.mjs`)** | Validates the classifier's return value against `taxonomy.json` — any label ∉ canonical set is HARD-REJECTED (fail-closed) with a structured alert (plugin id, harness, label, command, timestamp); coercion to `unknown` is PROHIBITED (F3 — silent coercion is a latent behavior-change landmine). Non-overridable labels always processed by core logic regardless of plugin output | A buggy/malicious override emitting garbage at runtime |
 
 The runtime layer is the spine: the thin waist treats `taxonomy.json` as the **only** vocabulary it accepts, so the canonical 7 labels are the hard boundary of the whole system — even if author-time and CI were skipped.
 
@@ -516,11 +546,11 @@ The runtime layer is the spine: the thin waist treats `taxonomy.json` as the **o
 
 **Phase 1 → R1, R6, R8:** create `plugins/` with subdirectories per harness; `git mv hooks/` → `plugins/claude-code/hooks/` (zero behavior change, byte-identical); create `plugins/_index.json` skeleton; update `install.mjs` to deploy from `plugins/<harness>/hooks/`. ~25-30K (pure git mv + path-reference patching).
 
-**Phase 2 → R2, R3, R4:** convert Markdown patterns to JSON contracts `patterns/bp-001.json`..`bp-012.json`; create `patterns/taxonomy.json` (canonical 7-label set with per-gate allow/block, R3/R4); create `patterns/schema.json` (contract schema, required by the scaffold generator); create `scripts/validate-bp-contract.mjs` (fails CI on any non-canonical label). Contract schema shape: `{ gates: { plan_approval: {tier}, pre_checkpoint: {tier}, post_checkpoint: {tier}, stop: {tier} }, taxonomy_ref: "patterns/taxonomy.json" }`.
+**Phase 2 → R2, R3, R4:** convert Markdown patterns to JSON contracts `patterns/bp-001.json`..`bp-012.json`; create `patterns/taxonomy.json` (canonical 7-label set with per-gate allow/block, R3/R4); create `patterns/schema.json` (contract schema) + `patterns/taxonomy.schema.json` (meta-schema, F5); create `scripts/validate-bp-contract.mjs` (implements the full normative §Validation-contract specification assertion checklist — gate-completeness, action-enum closure, overridability equality, vocabulary closure, stable-ID integrity, `taxonomy_version` binding, golden tests — NOT merely "non-canonical label" detection) + `scripts/validate-taxonomy-schema.mjs` (meta-validation, F5). Contract schema shape: `{ gates: { plan_approval: {tier}, pre_checkpoint: {tier}, post_checkpoint: {tier} }, stop: { tier }, taxonomy_ref: "patterns/taxonomy.json", taxonomy_version: "sha256:…" }` — the three classification gates are per-pattern; `stop` is a root-level marker-state gate (NOT per-label, F2/F10); `taxonomy_version` binds the contract to a taxonomy hash (F8).
 
-**Phase 3 → R1, R2, R3, R5, R9:** `enforce-contract.mjs` — the thin waist. Validates against BP contracts; implementation-boundary detection (R9, lazy-arm on first repo-source write, silent during exploration/planning/architecture); ternary `min()` (R3); classifier dispatch (R4/R5); reads gate action from taxonomy (R3, contract-driven); delegates to `em-recall.mjs --gate` (R1). Two invocation modes: plugin-native import (in-process, STRONG harnesses) + CLI spawn (degrade). Runtime taxonomy clamp: labels not in canonical set → coerced to `unknown` (fail-closed).
+**Phase 3 → R1, R2, R3, R5, R9:** `enforce-contract.mjs` — the thin waist. Validates against BP contracts; implementation-boundary detection (R9, lazy-arm on first repo-source write, silent during exploration/planning/architecture); ternary `min()` (R3); classifier dispatch (R4/R5); reads gate action from taxonomy (R3, contract-driven); delegates to `em-recall.mjs --gate` (R1). Two invocation modes: plugin-native import (in-process, STRONG harnesses) + CLI spawn (degrade). Runtime out-of-vocabulary contract: labels not in the canonical set are HARD-REJECTED (fail-closed) with a structured alert — NOT coerced to `unknown` (F3; see §Validation-contract specification). The alert episode is written with `cwd: project_root` (authority-root binding below).
 
-**Phase 4 → R4, R5:** extract the 7-label taxonomy into `patterns/taxonomy.json`; refactor `command-classifier.sh` to source taxonomy from JSON (or validate at CI that it matches); plugin classifier override interface; override registration in `plugins/_index.json`; non-overridable labels enforced at scaffold + CI + runtime.
+**Phase 4 → R4, R5:** extract the 7-label taxonomy into `patterns/taxonomy.json`; refactor `command-classifier.sh` to source the taxonomy from JSON at runtime (OQ-2 closed — runtime-source; the CI-only alternative is rejected), with CI validating the sourcing helper + label-set equality (F4); plugin classifier override interface; override registration in `plugins/_index.json`; non-overridable labels enforced at scaffold + CI + runtime.
 
 **Phase 5 → R3, R5:** `enforce-config.json` per project (`{ "bp-001": { "plan_approval": "MEDIUM", ... } }`); can only LOWER effective tier (clamp down), never raise; controls classifier activation (`active`/`classifier`); if `active: false` for all plugins → classifier silent (R5).
 
@@ -571,7 +601,7 @@ Full analysis: episode `20260527-073522-deadlock-analysis-7-classes-traced-again
 
 | Class | Deadlock? | Root cause | Fix |
 |-------|-----------|------------|-----|
-| 1 — marker_write misclassified | **TRUE** | Plugin overrides marker_write → gate blocks its own escape hatch | `marker_write: overridable: false` (v4+ taxonomy). Three-layer enforcement: author-time (scaffold), CI (validator), runtime (thin waist clamp to unknown). |
+| 1 — marker_write misclassified | **TRUE** | Plugin overrides marker_write → gate blocks its own escape hatch | `marker_write: overridable: false` (v4+ taxonomy). Three-layer enforcement: author-time (scaffold), CI (validator), runtime (thin waist hard-rejects non-canonical labels; no coercion). |
 | 2 — Invalid SID + plan pending | **TRUE (bug)** | `plan-gate.sh:108-115` F14 early-exit before `marker_write` dispatch at :136. The escape hatch that allows `rm .checkpoints/.plan-approval-pending` is unreachable because F14 exits first. | Reorder: check marker_write targeting plan-marker BEFORE the F14 block. |
 | 3 — Empty marker | No (tax) | Agent writes 0-byte file with `touch()`; gate rejects it. Block message says "must be non-empty." | Already handled — block message at `checkpoint-gate.sh:533` is explicit. Two-step tax, not deadlock. |
 | 4 — Wrong-root (worktree) | UX deadlock | Agent writes to worktree root; gate reads main repo | Message names canonical path. Agent re-reads and re-writes at the correct location. |
@@ -668,7 +698,29 @@ graph TD
 | — | Deadlock class 2: plan-gate.sh F14 ordering bug | Reorder `plan-gate.sh:108-115` before marker_write dispatch at :136 | R4 |
 | — | Runbook pattern generalized from second-opinion | 6-section spec, content-addressed UX-marker, session-scoped, checkpoint-immune | R10 |
 
-### v4 → v8 change log (provenance of this RFC)
+### Post-acceptance validation-layer review — consensus chain (2026-05-28)
+
+After acceptance, the champion flagged the validation/contract layer as thin. A focused second-opinion review was run on that layer and iterated to consensus across two providers.
+
+- **Round 1 — opencode (DeepSeek-v4-pro)**, episode `20260528-013519-reply-opencode-to-20260528-013221-second-36d9`: **HOLD** — 10 findings (5×P1, 3×P2, 2×P3); validators were ~10% specified. All 10 incorporated into §Validation-contract specification (v9).
+- **Round 2 — codex**, episode `20260528-015856-reply-codex-to-20260528-015614-second-op-a1d5`: **HOLD** — 3 P1 (Phase-3/Phase-4 text still contradicted the new hard-reject + OQ-2-closed spec; structured-alert episode had no authority root). Fixed.
+- **Round 3 — codex**, episode `20260528-020158-reply-codex-to-20260528-020026-second-op-9d70`: **HOLD** — 1 P1 (residual "clamp to unknown" reference at the deadlock Class-1 row). Fixed (+ same-class sweep).
+- **Round 4 — codex**, episode `20260528-020458-reply-codex-to-20260528-020303-second-op-b089`: **ACCEPT** — no findings; `em-rfc-validate` passed. Consensus reached.
+
+| # | Sev | Finding | Resolution (v9) |
+|---|-----|---------|-----------------|
+| F1 | P1 | `validate-bp-contract.mjs` ~10% specified | Full normative assertion checklist (gate-completeness, action-enum closure, overridability equality, dup-id, extra-key, meta-schema) |
+| F2 | P1 | `stop` in `schema.json` per-label but only 3 per-label gates | `stop` is root-level pattern metadata; per-label = 3 classification gates |
+| F3 | P1 | runtime coerce→`unknown` is wrong | runtime HARD-REJECTS + structured alert; coercion prohibited |
+| F4 | P1 | OQ-2 open blocks Phase 4 | OQ-2 closed — classifier runtime-sources the taxonomy |
+| F5 | P1 | no meta-validation of validators | `taxonomy.schema.json` + `validate-taxonomy-schema.mjs` + golden tests |
+| F6 | P2 | vocabulary-closure gap (dangling labels) | closure assertion across bp-XXX / manifest / classifier |
+| F7 | P2 | stable-ID rename unprotected | add-never-rename git-diff assertion |
+| F8 | P2 | `taxonomy_version` hash undefined | `sha256` over sorted labels array; carried by contracts + manifests |
+| F9 | P3 | `overridable` double-sourced | per-label `overridable` canonical; `non_overridable` derived + CI-checked |
+| F10 | P3 | `stop` tier computation source unspecified | `stop.tier` root-level; `min(harness, pattern, config)`, no label term |
+
+### v4 → v9 change log (provenance of this RFC)
 
 | # | Change | Version | Reason |
 |---|--------|---------|--------|
@@ -684,6 +736,7 @@ graph TD
 | T10 | Runbook section in build priority + traceability matrix | v6 | Deployment paths, CI validation, scaffold stubs. |
 | T11 | Runbook content specification completed — all 6 sections, common + harness-specific | v7 | Self-trigger checklist, canonical invocation, failure-mode diagnosis, anti-patterns, trigger phrases, composes-with. |
 | T12 | Complete combined v8 spec — all sections unified | v8 | v4 (base) + v5 (R9, boundary, deadlock) + v6 (R10 structure) + v7 (R10 content). Architecture, phases, traceability, build priority, review findings, ground truth all updated. |
+| T13 | Validation-contract specification added — closes round-1 HOLD F1–F10 (normative assertion checklist, `stop` root-level, runtime hard-reject, OQ-2 closed, meta-validation, stable-ID integrity, `taxonomy_version` hash) | v9 | Champion flagged validators as thin; opencode/DeepSeek HOLD with 10 findings, all incorporated. |
 
 ---
 
@@ -692,7 +745,7 @@ graph TD
 | # | Question | Owner | Status |
 |---|---|---|---|
 | OQ-1 | Phase 9 (recall strategies, R7) destination: split between RFC-001 (semantic) and RFC-007 (graph), or a single new substrate RFC? | Charlton Ho | open |
-| OQ-2 | Does `command-classifier.sh` source `taxonomy.json` at runtime, or is the match validated only at CI (Phase 4 offers both)? | — | open |
+| OQ-2 | Does `command-classifier.sh` source `taxonomy.json` at runtime, or is the match validated only at CI? | Charlton Ho | **closed (v9)** — runtime-source via zero-dep node helper; CI validates the sourcing helper + label-set equality. Drift eliminated by construction. See §Validation-contract specification (F4). |
 | OQ-3 | Cursor/Windsurf are WEAK (prompt-injection advisory only) — do they get plugin directories at all, or only a rules-injection artifact? | — | open |
 
 ---

--- a/docs/rfcs/_index.json
+++ b/docs/rfcs/_index.json
@@ -62,7 +62,7 @@
       "id": "RFC-008",
       "slug": "decouple-enforcement-from-substrate",
       "title": "Decoupling the Enforcement Layer from the Memory Substrate",
-      "status": "draft",
+      "status": "accepted",
       "champion": "Charlton Ho",
       "file": "RFC-008-decouple-enforcement-from-substrate.md"
     }

--- a/hooks/lib/agent-classifier.sh
+++ b/hooks/lib/agent-classifier.sh
@@ -169,6 +169,18 @@ agent_classify_command() {
     return 1
   fi
 
+  # FU-1 (codex plan-review R2): env-prefix refusal at the marker-cache AUTHORITY
+  # itself, not only at the shell call sites. A leading `FOO=bar` assignment is a
+  # cross-session attack vector (PR #271/#272 F-4): a command-local env override
+  # can desync session_id and, under the script-identity key, let an env-prefixed
+  # invocation reuse a clean script marker. Refuse here so "env-prefix never
+  # reaches the marker cache" is locally verifiable in ONE place; the call-site
+  # guards (Site A + the interpreter Tier-2/3 branch) remain as defense-in-depth.
+  local _first_tok="${command%%[[:space:]]*}"
+  case "$_first_tok" in
+    [A-Za-z_]*=*) return 1 ;;
+  esac
+
   local session_id
   session_id="$(__agent_classifier_session_id)"
 

--- a/hooks/lib/command-classifier.sh
+++ b/hooks/lib/command-classifier.sh
@@ -987,6 +987,31 @@ _detect_helper_invocation() {
 # caller_cwd_authoritative, env_prefix_count) — identical to how the
 # interpreter branch reads them.
 # ---------------------------------------------------------------------------
+# Resolve the command text used for the marker cache-key lookup. PREFER the raw
+# command threaded from classify_command (_seg_raw_command via dynamic scope) —
+# the EXACT string the agent classified and the deny-hint told it to classify, so
+# normalizeCommand(read) == normalizeCommand(write) exactly, INCLUDING shell
+# redirects (`echo x > src.mjs`). A token-only reconstruction DROPS the redirect
+# (a REDIR record, not a TOK) and would miss the marker. Fall back to the token
+# reconstruction only when the raw command wasn't threaded (direct
+# _classify_segment unit tests); that fallback matches for redirect-free commands.
+# Used by BOTH Site A (_try_agent_marker_verdict) and the interpreter Tier-2/3
+# branch so the two marker-read sites can NEVER drift on quote handling.
+_resolve_marker_cmd_text() {
+  local __t="${_seg_raw_command:-}"
+  if [ -z "$__t" ]; then
+    local __ti
+    for __ti in ${TOKS[@]+"${TOKS[@]}"}; do
+      if [ -z "$__t" ]; then
+        __t="$__ti"
+      else
+        __t="$__t $__ti"
+      fi
+    done
+  fi
+  printf '%s' "$__t"
+}
+
 _try_agent_marker_verdict() {
   # env-prefix forms never escape (cross-session attack class, PR #271).
   if [ "${env_prefix_count:-0}" -ne 0 ]; then
@@ -1008,26 +1033,11 @@ _try_agent_marker_verdict() {
   if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" != "1" ]; then
     return 1
   fi
-  # Command text for the lookup key. PREFER the raw command threaded from
-  # classify_command (_seg_raw_command via dynamic scope) — it is the EXACT
-  # string the agent invoked and the deny-hint tells the agent to classify, so
-  # normalizeCommand(read) == normalizeCommand(write) exactly, INCLUDING shell
-  # redirects (`echo x > src.mjs`). A token-only reconstruction would DROP the
-  # `> src.mjs` redirect (it's a REDIR record, not a TOK) and miss the marker —
-  # the exact #351 redirect class. Fall back to the token reconstruction only
-  # when the raw command wasn't threaded (e.g. direct _classify_segment unit
-  # tests); that fallback matches for redirect-free commands (cp/node …).
-  local __cmd_text="${_seg_raw_command:-}"
-  if [ -z "$__cmd_text" ]; then
-    local __ti
-    for __ti in ${TOKS[@]+"${TOKS[@]}"}; do
-      if [ -z "$__cmd_text" ]; then
-        __cmd_text="$__ti"
-      else
-        __cmd_text="$__cmd_text $__ti"
-      fi
-    done
-  fi
+  # Command text for the lookup key — resolved via the shared helper (raw
+  # threaded command preferred; token reconstruction fallback). Identical
+  # resolution to the interpreter Tier-2/3 branch so the two sites cannot drift.
+  local __cmd_text
+  __cmd_text="$(_resolve_marker_cmd_text)"
   [ -z "$__cmd_text" ] && return 1
   local __agent_out __agent_label
   if __agent_out="$(agent_classify_command "$__cmd_text" "$target_root" "$caller_cwd_authoritative" 2>/dev/null)"; then
@@ -1930,24 +1940,26 @@ _classify_segment() {
           __AGENT_CLASSIFIER_SOURCED=0
         fi
       fi
-      if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" = "1" ]; then
-        # Reconstruct command text from tokens (already shell-unquoted; the
-        # dispatcher collapses whitespace and re-normalizes anyway).
-        local __cmd_text=""
-        local __ti
-        for __ti in ${TOKS[@]+"${TOKS[@]}"}; do
-          if [ -z "$__cmd_text" ]; then
-            __cmd_text="$__ti"
-          else
-            __cmd_text="$__cmd_text $__ti"
-          fi
-        done
+      # R1-finding-1 (codex plan-review BLOCKER): env-prefix forms must NOT
+      # consult the marker cache. Under the script-identity key the env prefix
+      # no longer rides in normalized_command, so `SKIP_PREFLIGHT=1 node x.mjs`
+      # could otherwise reuse the clean `node x.mjs` marker. Guard on the shell's
+      # authoritative env_prefix_count (reliable even when the token/raw
+      # reconstruction drops the prefix) — mirrors Site A (_try_agent_marker_verdict)
+      # and composes with FU-1's guard inside agent_classify_command.
+      if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" = "1" ] && [ "${env_prefix_count:-0}" -eq 0 ]; then
+        # Command text via the shared helper (raw threaded command preferred so
+        # normalizeCommand(read)==normalizeCommand(write) for the residual
+        # non-digest interpreter case; identical resolution to Site A so the two
+        # marker-read sites cannot drift on quoting).
+        local __cmd_text
+        __cmd_text="$(_resolve_marker_cmd_text)"
         local __agent_out __agent_label __agent_reason
         # PR-A P1.1: pass caller_cwd_authoritative (parsed .cwd from hook
         # stdin) instead of hook process $PWD. Codex R1 P1: marker written
         # under nested cwd was a miss when classify_command subprocess
         # $PWD differs from the .cwd authority.
-        if __agent_out="$(agent_classify_command "$__cmd_text" "$target_root" "$caller_cwd_authoritative" 2>/dev/null)"; then
+        if [ -n "$__cmd_text" ] && __agent_out="$(agent_classify_command "$__cmd_text" "$target_root" "$caller_cwd_authoritative" 2>/dev/null)"; then
           __agent_label="${__agent_out%%	*}"
           __agent_reason="${__agent_out#*	}"
           __agent_reason="${__agent_reason%$'\n'}"

--- a/scripts/classifier-marker.mjs
+++ b/scripts/classifier-marker.mjs
@@ -75,6 +75,13 @@ import fs from 'fs'
 import path from 'path'
 import crypto from 'crypto'
 import { resolveRepoRoot } from './lib/local-dir.mjs'
+// Narrow exception to the "does NOT consume classifier-cache" rule: import ONLY
+// the pure isInterpreterScriptIdentity predicate (codex FU-2). It carries no
+// tuple-shape or store-path coupling — it just decides whether a command keys on
+// script identity — so the two stores' tuple shapes (this file keeps session_id +
+// policy versions; classifier-cache does not) stay independent while the
+// key-omission rule is shared, single-sourced, and cannot drift.
+import { isInterpreterScriptIdentity } from './lib/classifier-cache.mjs'
 
 const LABELS = new Set([
   'read_only',
@@ -91,7 +98,11 @@ const LABELS = new Set([
 // Stale markers carrying the old policy version become unreachable and force
 // re-classification (handled at the version-mismatch check ~L380; --vacuum reaps).
 const CLASSIFIER_POLICY_VERSION = 2
-const NORMALIZED_COMMAND_VERSION = 1
+// Bumped 1→2 (script-identity key): in-repo interpreter commands now key on
+// script identity (exe + digest) with normalized_command collapsed to null, so
+// per-request args no longer bust the cache. All markers cached under the old
+// full-command key become unreachable and force a one-shot re-classification.
+const NORMALIZED_COMMAND_VERSION = 2
 const MARKER_SCHEMA_VERSION = 2
 
 const TTL_MS = 24 * 60 * 60 * 1000        // 24h marker freshness
@@ -198,10 +209,18 @@ function buildTuple({ command, projectRoot, callerCwd, sessionId }) {
       }
     } catch {}
   }
+  // Script-identity key (codex plan-review R1-finding-3 + R2 ACCEPT): an in-repo
+  // interpreter command keys on script identity (exe + digest), so its args do
+  // NOT bust the cache and the de-quoting asymmetry between the two shell read
+  // sites becomes moot (the key no longer depends on command text). The full
+  // command is still preserved for debuggability in the marker's informational
+  // `command_normalized` field (see resolveInputTuple — payloadNorm is computed
+  // independently of this keyed tuple).
+  const scriptIdentity = isInterpreterScriptIdentity(command, digest)
   return {
     project_root_canonical: projectRoot,
     caller_cwd_or_rel: callerCwdRelOrAbs,
-    normalized_command: normalizeCommand(command),
+    normalized_command: scriptIdentity ? null : normalizeCommand(command),
     executable_resolved: exeAbs || exeResolved,
     script_digest: digest,
     session_id: sessionId,
@@ -308,7 +327,10 @@ function resolveInputTuple(argv, { projectRoot, callerCwd, sessionId }) {
   const command = resolveCommandArg(argv)
   if (command === undefined) die(2, '--command, --command-file, or --target-path required')
   const tuple = buildTuple({ command, projectRoot, callerCwd, sessionId })
-  return { tuple, sha: cacheKey(tuple), payloadNorm: tuple.normalized_command }
+  // payloadNorm is the INFORMATIONAL command_normalized field, NOT the key.
+  // Computed from the full command (not tuple.normalized_command, which is null
+  // for script-identity keys) so the marker always records what was classified.
+  return { tuple, sha: cacheKey(tuple), payloadNorm: normalizeCommand(command) }
 }
 
 // ----- Path-component hardening (lstat each ancestor, refuse symlinks) -----

--- a/scripts/lib/classifier-cache.mjs
+++ b/scripts/lib/classifier-cache.mjs
@@ -8,9 +8,12 @@
  *   - scripts/classifier-override-persist.mjs (auto-persist write after LLM hit)
  *   - scripts/agent-classifier-dispatch.mjs    (legacy Tier 2/3 dispatcher)
  *
- * scripts/classifier-marker.mjs intentionally does NOT consume this module —
- * its tuple shape extends with session_id + policy versions and its store
- * path is .checkpoints/classify/<sha>.json (not classifier-overrides.jsonl).
+ * scripts/classifier-marker.mjs does NOT consume this module's tuple/store
+ * primitives — its tuple shape extends with session_id + policy versions and
+ * its store path is .checkpoints/classify/<sha>.json (not
+ * classifier-overrides.jsonl). It imports ONLY the pure isInterpreterScriptIdentity
+ * predicate (codex FU-2): a no-coupling boolean so the script-identity key rule
+ * is single-sourced across both stores while their tuple fields stay independent.
  *
  * UNIFIED normalizeCommand: strip trailing `# comment`, collapse whitespace,
  * trim. Pre-PR-#336, classify-correction used the whitespace-only form, so
@@ -177,6 +180,29 @@ export function sha256File(p) {
   }
 }
 
+// isInterpreterScriptIdentity — shared key-omission predicate (codex plan-review
+// R1-finding-3 + R2 FU-2). Returns true iff the command is an INTERPRETER
+// invocation (`node|python|python3|ruby|perl <script> ...`) of an IN-REPO script
+// (non-null `digest`), in which case the cache key should be SCRIPT-IDENTITY:
+// `normalized_command` is collapsed to a constant null so per-request args
+// (`--summary`, `--body-file`, tags …) do NOT bust the cache. The script body
+// is still pinned by `script_digest`, so editing the script re-keys (forces
+// re-classification).
+//
+// Deliberately checks toks[0] (the LITERAL first token), NOT resolveExeAgainstCwd's
+// any-position loop: an env-prefixed (`FOO=bar node …`) or wrapper-prefixed
+// (`time node …`) command keeps its full normalized_command (arg-sensitive) and
+// is NEVER downgraded to script-identity — defense-in-depth with the env-prefix
+// short-circuits at the call sites. Direct in-repo executables (`scripts/x …`,
+// toks[0] not an interpreter) also keep arg-sensitivity.
+export function isInterpreterScriptIdentity(command, digest) {
+  if (!digest) return false
+  const toks = String(command).trim().split(/\s+/)
+  if (toks.length < 2) return false
+  if (!INTERPRETERS.has(path.basename(toks[0] || ''))) return false
+  return !toks[1].startsWith('-')
+}
+
 export function buildTuple({ command, projectRoot, callerCwd }) {
   const cwdCanon = realpathOrSame(callerCwd)
   const callerCwdRelOrAbs = isUnder(cwdCanon, projectRoot)
@@ -195,10 +221,16 @@ export function buildTuple({ command, projectRoot, callerCwd }) {
       }
     } catch {}
   }
+  // Script-identity migration (codex FU-2 — explicit, one-shot): in-repo
+  // interpreter commands key on script identity (exe + digest), NOT args, so
+  // `normalized_command` is collapsed to null. Pre-existing Tier-0 overrides
+  // keyed under the old full-command form become unreachable (re-correction is
+  // one-shot — same contract as the PR #336 normalizeCommand unification).
+  const scriptIdentity = isInterpreterScriptIdentity(command, digest)
   return {
     project_root_canonical: projectRoot,
     caller_cwd_or_rel: callerCwdRelOrAbs,
-    normalized_command: normalizeCommand(command),
+    normalized_command: scriptIdentity ? null : normalizeCommand(command),
     executable_resolved: exeAbs || exeResolved,
     script_digest: digest
   }

--- a/tests/test-script-identity-key.mjs
+++ b/tests/test-script-identity-key.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * tests/test-script-identity-key.mjs
+ *
+ * Locks in the script-identity cache-key behavior across both buildTuple
+ * implementations (classifier-marker.mjs and scripts/lib/classifier-cache.mjs)
+ * + the agent_classify_command env-prefix guard (FU-1).
+ *
+ * Acceptance contract:
+ *   1. In-repo interpreter command (`node scripts/X.mjs <args>`) keys on script
+ *      identity → same key across arg variations.
+ *   2. Direct in-repo executable (`scripts/X <args>`) stays arg-sensitive.
+ *   3. Shell redirects (`echo x > foo`) stay arg-sensitive.
+ *   4. Env-prefixed interpreter command stays arg-sensitive (NOT script-identity).
+ *   5. Flag-prefixed interpreter (`node --inspect ...`) stays arg-sensitive
+ *      (predicate rejects; digest is null anyway).
+ *   6. External (non-in-repo) interpreter script stays arg-sensitive (digest null).
+ *   7. Marker plant + read with varied args round-trips via the same key.
+ *   8. agent_classify_command refuses env-prefix at the cache authority (FU-1).
+ *   9. Predicate parity: classifier-marker and classifier-cache use the SAME
+ *      shared predicate (no parallel divergence).
+ */
+import assert from 'assert'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execSync, spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+import {
+  isInterpreterScriptIdentity,
+  buildTuple as cacheBuildTuple,
+  cacheKey as cacheCacheKey
+} from '../scripts/lib/classifier-cache.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.resolve(__dirname, '..')
+const MARKER = path.join(ROOT, 'scripts', 'classifier-marker.mjs')
+const SHELL_LIB = path.join(ROOT, 'hooks', 'lib', 'command-classifier.sh')
+
+const tests = []
+function test(name, fn) { tests.push({ name, fn }) }
+
+function mkrepo(label) {
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `sik-${label}-`)))
+  const repo = path.join(tmp, 'repo')
+  fs.mkdirSync(repo)
+  execSync('git init -q', { cwd: repo })
+  // Put a real interpreter script in repo so script_digest is non-null.
+  fs.mkdirSync(path.join(repo, 'scripts'))
+  fs.writeFileSync(path.join(repo, 'scripts', 'hello.mjs'), '#!/usr/bin/env node\nconsole.log("hi")\n')
+  return repo
+}
+
+// markerKey — compute the marker's cache_key for a given command by running
+// classifier-marker.mjs --write (returns key in JSON), in dry-run-ish mode
+// (we just want the key; the file is written but discarded with the repo).
+function markerWrite(repo, command, sessionId = 'sik-sid', label = 'read_only') {
+  const r = spawnSync(process.execPath, [
+    MARKER, '--write',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', command,
+    '--session-id', sessionId,
+    '--label', label, '--confidence', '0.9',
+    '--reason', 'sik'
+  ], { cwd: repo, env: { ...process.env, CLAUDE_CODE_SESSION_ID: sessionId }, encoding: 'utf8' })
+  assert.strictEqual(r.status, 0, `marker --write failed: status=${r.status} stderr=${r.stderr}`)
+  return JSON.parse(r.stdout)
+}
+
+function markerRead(repo, command, sessionId = 'sik-sid') {
+  const r = spawnSync(process.execPath, [
+    MARKER, '--read',
+    '--project-root', repo, '--caller-cwd', repo,
+    '--command', command,
+    '--session-id', sessionId
+  ], { cwd: repo, env: { ...process.env, CLAUDE_CODE_SESSION_ID: sessionId }, encoding: 'utf8' })
+  return { status: r.status, stdout: r.stdout, json: r.stdout ? JSON.parse(r.stdout.trim().split('\n').pop()) : null }
+}
+
+// === Predicate-level tests (no I/O) =======================================
+
+test('SI-P01 predicate: in-repo interpreter command + digest → true', () => {
+  assert.strictEqual(isInterpreterScriptIdentity('node scripts/x.mjs --a 1', 'abc'), true)
+  assert.strictEqual(isInterpreterScriptIdentity('python scripts/y.py', 'abc'), true)
+  assert.strictEqual(isInterpreterScriptIdentity('python3 scripts/y.py', 'abc'), true)
+  assert.strictEqual(isInterpreterScriptIdentity('ruby scripts/y.rb', 'abc'), true)
+  assert.strictEqual(isInterpreterScriptIdentity('perl scripts/y.pl', 'abc'), true)
+})
+
+test('SI-P02 predicate: null digest (script missing or external) → false', () => {
+  assert.strictEqual(isInterpreterScriptIdentity('node scripts/x.mjs', null), false)
+  assert.strictEqual(isInterpreterScriptIdentity('node scripts/x.mjs', undefined), false)
+})
+
+test('SI-P03 predicate: direct executable (toks[0] not interpreter) → false', () => {
+  assert.strictEqual(isInterpreterScriptIdentity('scripts/x --a', 'abc'), false)
+  assert.strictEqual(isInterpreterScriptIdentity('./build.sh', 'abc'), false)
+  assert.strictEqual(isInterpreterScriptIdentity('echo hi', 'abc'), false)
+})
+
+test('SI-P04 predicate: env-prefix → false (defense-in-depth with FU-1)', () => {
+  // toks[0]="FOO=bar", basename not in INTERPRETERS → predicate rejects.
+  assert.strictEqual(isInterpreterScriptIdentity('FOO=bar node scripts/x.mjs', 'abc'), false)
+})
+
+test('SI-P05 predicate: flag-prefixed interpreter (`node --inspect`) → false', () => {
+  // toks[1]="--inspect" starts with '-' → predicate rejects.
+  assert.strictEqual(isInterpreterScriptIdentity('node --inspect scripts/x.mjs', 'abc'), false)
+})
+
+test('SI-P06 predicate: wrapper-prefixed (`time node ...`) → false', () => {
+  // toks[0]="time" not in INTERPRETERS → predicate rejects.
+  assert.strictEqual(isInterpreterScriptIdentity('time node scripts/x.mjs', 'abc'), false)
+})
+
+// === classifier-cache.mjs buildTuple key behavior =========================
+
+test('SI-C01 classifier-cache: in-repo interpreter command — args do NOT affect key', () => {
+  const repo = mkrepo('cache-arg-invariant')
+  const t1 = cacheBuildTuple({ command: 'node scripts/hello.mjs --a 1', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'node scripts/hello.mjs --b 2 --c 3', projectRoot: repo, callerCwd: repo })
+  assert.strictEqual(t1.normalized_command, null, 'normalized_command should be null (script-identity)')
+  assert.strictEqual(t2.normalized_command, null)
+  assert.strictEqual(cacheCacheKey(t1), cacheCacheKey(t2), 'arg-variant keys must MATCH for in-repo interpreter')
+})
+
+test('SI-C02 classifier-cache: direct executable — args DO affect key (arg-sensitive)', () => {
+  const repo = mkrepo('cache-direct-arg-sensitive')
+  const t1 = cacheBuildTuple({ command: 'scripts/hello.mjs --a 1', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'scripts/hello.mjs --b 2', projectRoot: repo, callerCwd: repo })
+  assert.notStrictEqual(t1.normalized_command, null)
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2), 'direct executable must stay arg-sensitive')
+})
+
+test('SI-C03 classifier-cache: shell redirect — args DO affect key', () => {
+  const repo = mkrepo('cache-redirect')
+  const t1 = cacheBuildTuple({ command: 'echo x > foo', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'echo y > foo', projectRoot: repo, callerCwd: repo })
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2), 'redirects must stay arg-sensitive')
+})
+
+test('SI-C04 classifier-cache: env-prefix — args DO affect key (NOT script-identity)', () => {
+  const repo = mkrepo('cache-env')
+  const t1 = cacheBuildTuple({ command: 'FOO=bar node scripts/hello.mjs --a', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'FOO=bar node scripts/hello.mjs --b', projectRoot: repo, callerCwd: repo })
+  assert.notStrictEqual(t1.normalized_command, null)
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2))
+})
+
+test('SI-C05 classifier-cache: external interpreter script (digest null) — arg-sensitive', () => {
+  const repo = mkrepo('cache-ext')
+  const t1 = cacheBuildTuple({ command: 'node /usr/local/bin/external.mjs --a', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'node /usr/local/bin/external.mjs --b', projectRoot: repo, callerCwd: repo })
+  assert.strictEqual(t1.script_digest, null, 'external script: digest null')
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2))
+})
+
+test('SI-C06 classifier-cache: different in-repo scripts — different keys', () => {
+  const repo = mkrepo('cache-two-scripts')
+  fs.writeFileSync(path.join(repo, 'scripts', 'world.mjs'), 'console.log("w")\n')
+  const t1 = cacheBuildTuple({ command: 'node scripts/hello.mjs', projectRoot: repo, callerCwd: repo })
+  const t2 = cacheBuildTuple({ command: 'node scripts/world.mjs', projectRoot: repo, callerCwd: repo })
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2), 'different scripts → different keys')
+})
+
+test('SI-C07 classifier-cache: same script, edited body — digest changes → key differs (safety axis 7)', () => {
+  const repo = mkrepo('cache-digest-pin')
+  const script = path.join(repo, 'scripts', 'hello.mjs')
+  const t1 = cacheBuildTuple({ command: 'node scripts/hello.mjs', projectRoot: repo, callerCwd: repo })
+  fs.writeFileSync(script, '// edited\nconsole.log("changed")\n')
+  const t2 = cacheBuildTuple({ command: 'node scripts/hello.mjs', projectRoot: repo, callerCwd: repo })
+  assert.notStrictEqual(t1.script_digest, t2.script_digest)
+  assert.notStrictEqual(cacheCacheKey(t1), cacheCacheKey(t2), 'edited script must invalidate verdict')
+})
+
+// === classifier-marker.mjs end-to-end round-trip ==========================
+
+test('SI-M01 marker round-trip: write with args A, read with args B → HIT (script-identity)', () => {
+  const repo = mkrepo('marker-arg-roundtrip')
+  const sid = 'sik-round-1'
+  const writeOut = markerWrite(repo, 'node scripts/hello.mjs --summary "first call"', sid, 'nonsrc_write')
+  assert.strictEqual(writeOut.label, 'nonsrc_write')
+  // Read with COMPLETELY DIFFERENT args — must HIT under script-identity.
+  const r = markerRead(repo, 'node scripts/hello.mjs --tag a --body x --different', sid)
+  assert.strictEqual(r.status, 0, `marker --read should exit 0; stdout=${r.stdout}`)
+  assert.strictEqual(r.json.status, 'hit', `expected hit on varied args; got: ${JSON.stringify(r.json)}`)
+  assert.strictEqual(r.json.label, 'nonsrc_write')
+  assert.strictEqual(r.json.cache_key, writeOut.cache_key, 'cache_key must MATCH across arg variations')
+})
+
+test('SI-M02 marker non-script-identity: different shell redirects → MISS', () => {
+  const repo = mkrepo('marker-redirect-miss')
+  const sid = 'sik-redirect'
+  markerWrite(repo, 'echo x > foo', sid, 'read_only')
+  const r = markerRead(repo, 'echo y > foo', sid)
+  assert.notStrictEqual(r.json.status, 'hit', 'redirect with different value must MISS')
+})
+
+test('SI-M03 marker: env-prefix variant does NOT hit clean script marker', () => {
+  const repo = mkrepo('marker-env-no-reuse')
+  const sid = 'sik-env'
+  // Plant clean marker.
+  markerWrite(repo, 'node scripts/hello.mjs --a', sid, 'read_only')
+  // Env-prefixed lookup — predicate rejects → key includes normalized_command (with env prefix) → MISS.
+  const r = markerRead(repo, 'FOO=bar node scripts/hello.mjs --a', sid)
+  assert.notStrictEqual(r.json.status, 'hit', 'env-prefix MUST NOT reuse clean script marker')
+})
+
+// === agent_classify_command env-prefix guard (FU-1) =======================
+
+test('SI-A01 agent_classify_command: env-prefix command returns 1 (FU-1)', () => {
+  const repo = mkrepo('agent-env-guard')
+  const sid = 'sik-fu1'
+  // Even with a CLEAN script marker present, the agent_classify_command guard
+  // must refuse to consult the cache for an env-prefixed command.
+  markerWrite(repo, 'node scripts/hello.mjs', sid, 'read_only')
+
+  const out = spawnSync('bash', ['-c', `
+    set -e
+    source "${SHELL_LIB}"
+    # source emits agent-classifier.sh too via internal sourcing; call directly.
+    source "${path.join(ROOT, 'hooks/lib/agent-classifier.sh')}"
+    # FU-1 guard: env-prefix command returns 1 (no decision).
+    if agent_classify_command "FOO=bar node scripts/hello.mjs" "${repo}" "${repo}"; then
+      echo "UNEXPECTED_HIT"
+    else
+      echo "REFUSED_OK"
+    fi
+  `], { env: { ...process.env, CLAUDE_CODE_SESSION_ID: sid }, encoding: 'utf8' })
+
+  assert.ok(out.stdout.includes('REFUSED_OK'), `FU-1 guard must refuse env-prefix; got stdout=${out.stdout} stderr=${out.stderr}`)
+})
+
+// === Run ==================================================================
+
+let pass = 0, fail = 0
+const failures = []
+for (const t of tests) {
+  try {
+    t.fn()
+    console.log(`  ✓ ${t.name}`)
+    pass++
+  } catch (e) {
+    console.log(`  ✗ ${t.name}\n    ${e.message}`)
+    failures.push({ name: t.name, msg: e.message })
+    fail++
+  }
+}
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  ${f.name}: ${f.msg}`)
+  process.exit(1)
+}


### PR DESCRIPTION
# fix(classifier): script-identity cache key for in-repo interpreter commands

## What

Stops the agent-classifier marker cache from re-holding interpreter commands (`node scripts/X.mjs <args>`) on every per-request arg, and removes the read/write key asymmetry between the two shell marker-read sites.

## Why (the two bugs, one root)

1. **Over-granular cache key.** `cacheKey` hashed the tuple including `normalized_command`, so every per-request varying arg (`--summary`, `--body-file`, `--tag`) busted the cache — fresh classification + re-HOLD on each request.
2. **De-quoting asymmetry.** The interpreter Tier-2/3 read site reconstructed `__cmd_text` from shell-unquoted `TOKS` (quotes dropped) while the write path keyed on raw command text (quotes intact), so quoted interpreter commands had write-key ≠ read-key → permanent miss → infinite re-hold.

Empirical trigger from the user: `node scripts/second-opinion.mjs request --provider X --storage episodic --project . --summary "RFC-008 …" --body-file …` re-held on every distinct request even after I classified it.

## How

When the command is an IN-REPO INTERPRETER invocation (`node/python/python3/ruby/perl <in-repo-script> …`) with non-null `script_digest`, key on **script identity** (`executable_resolved` + `script_digest` + `project_root` + `caller_cwd` + `session` + policy versions) and collapse `normalized_command` to `null`. The key no longer depends on command text for that class, so:
- args don't bust the cache (one classify per script per session), and
- the de-quoting asymmetry becomes moot for interpreter commands (key no longer depends on command text).

For everything else (direct executables, redirects, default_write, external-script interpreter commands with no digest, flag-prefixed interpreters) `normalized_command` stays in the keyed tuple — arg-sensitivity preserved where it matters.

```mermaid
flowchart TD
    A[command] --> B{first non-flag token<br/>basename in node/python/python3/ruby/perl?}
    B -- no --> K[keep normalized_command<br/>arg-sensitive key]
    B -- yes --> C{resolved script is<br/>in-repo with script_digest?}
    C -- no --> K
    C -- yes --> S[OMIT normalized_command<br/>SCRIPT-IDENTITY key]
```

## Plan-review (cross-tool, two rounds)

R1 REJECT → 3 findings + R2 FU-1/FU-2 all incorporated:
- **R1-finding-1 (BLOCKER):** env-prefix marker-reuse bypass under script-identity → add `env_prefix_count` guard at the interpreter Tier-2/3 marker lookup (mirrors Site A).
- **R1-finding-2 (MAJOR):** Tier-0 autopersist uses a separate buildTuple in `scripts/lib/classifier-cache.mjs` → apply the SAME predicate to BOTH buildTuple paths via a shared exported helper (preserve each store's distinct field set).
- **R1-finding-3 (MAJOR):** predicate must be "interpreter command (toks[0] basename in INTERPRETERS, toks[1] non-flag) AND non-null in-repo `script_digest`" — NOT just `digest != null` (direct in-repo executables would otherwise lose arg-sensitivity).
- **FU-1:** put env-prefix refusal inside `agent_classify_command` itself (single enforcement point at the marker-cache authority) — call-site guards retained as defense-in-depth.
- **FU-2:** share the predicate/omit *logic* only; do NOT unify marker-only tuple fields (session_id, policy versions) into the Tier-0 tuple.

R2 ACCEPT-with-FU (no blocking findings). Episodes (local, `.episodic-memory/episodes/`):
- R1 reply: `20260528-015528-reply-codex-to-20260528-015255-second-op-730d`
- R2 reply: `20260528-020053-reply-codex-to-20260528-015741-second-op-4564`

## 8-axis symlink/path matrix (enumerated in the plan-review request)

All safe except axis 8 — the **user-accepted residual**: same in-repo interpreter script with different args sharing one verdict (wider trust within the script's identity). Hard-deny lanes (git/gh/rm/tee/redirect-to-repo-source) and per-binary case arms return BEFORE the agent-marker path, so they are unaffected. `script_digest` still pins script body (edit → re-classify).

## Other changes

- `NORMALIZED_COMMAND_VERSION` 1→2 (clean cutover; `--vacuum` reaps old markers).
- Extract `_resolve_marker_cmd_text` shell helper used by BOTH Site A and the interpreter Tier-2/3 branch so the two marker-read sites cannot drift on quote handling for the residual non-digest interpreter case.
- Marker `command_normalized` informational field still records the full command (payloadNorm computed independently of the keyed tuple).
- `classifier-cache.mjs` header comment updated to reflect the narrow predicate exception to the "classifier-marker does NOT consume this module" rule.

## Tests

| Suite | Result |
|---|---|
| `test-script-identity-key` (new, 17 tests) | 17/0 ✓ |
| `test-classifier-marker` | 30/0 ✓ |
| `test-classify-correction` | 16/0 ✓ |
| `test-agent-classifier` | 40/0 ✓ |
| `test-command-classifier.sh` | 424/0 ✓ |
| `test-tier0-overrides` | 35/36 = identical to baseline (`tier0 1 autopersist llm→agent` is pre-existing per MEMORY) |

The new `tests/test-script-identity-key.mjs` covers: predicate parity across both stores (6 tests), arg-invariance for in-repo interpreters in classifier-cache + script-digest pinning safety (7 tests), marker round-trip with varied args HITS (SI-M01 — the headline), env-prefix variants do NOT reuse a clean script marker (SI-M02, SI-M03), FU-1 guard inside `agent_classify_command` refuses cleanly (SI-A01).

## E2E

Verified empirically in-session post-deploy (`install.mjs --install-hooks --install-hooks-force`):
1. Classify `node tests/test-classifier-marker.mjs` once (gate held → I classified → released → test ran 30/0).
2. Without re-classifying, ran `node tests/test-classifier-marker.mjs --some-unused-arg foo` (a previously-unseen arg variation of the same in-repo interpreter script).
3. **No re-hold. Cache hit. Test ran 30/0.** Same script, different args, single classify-and-stick — the bug fix in action.

## Open follow-ups (not in this PR)

- **Adversarial code review via `negative-scenario-reviewer` is queued.** Dispatch is gated by a preflight marker that only fires on user prompt submission and was wiped from `.checkpoints/` during the session. The substrate doesn't allow agent-side preflight-marker writes (`preflight-marker-write.mjs` is hook-only). Resolution: any new user prompt re-arms the marker, then the canonical dispatch becomes possible.
- A possible substrate concern: `.checkpoints/` artifacts (`.plan-approved.<sid>`, `.pre-checkpoint-done.<sid>`, classify markers, preflight markers) were observed being wiped multiple times within this session, forcing repeat classifications. Worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
