### PR TITLE
RFC-008: capability charter, typed + versioned plugin registry, per-phase split

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,121 @@
+# Capabilities
+
+The capability charter for the episodic-memory project. This is the **guiding post**: it names
+the capability families of the **memory substrate** — the ways the system *uses* episodes — the
+single substrate they all operate on, and the rule for adding new ones as the project grows.
+RFCs and the plugin manager (RFC-008) derive their substrate plugin **types** from this
+document.
+
+**Scope boundary (read first).** Capabilities are about **using the memory substrate** —
+storing, recalling, and learning from episodes. They do **not** enforce workflows. Enforcing
+agent workflow discipline is the job of **behavior patterns** (`bp-XXX`) and the enforcement
+layer, which is *decoupled* from the substrate (the thesis of RFC-008) and is **not** a
+capability listed here. See
+[Enforcement is not a substrate capability](#enforcement-is-not-a-substrate-capability).
+
+Companion to [PRINCIPLES.md](PRINCIPLES.md): the principles say *how* we build; this says
+*what the substrate does with episodes*.
+
+---
+
+## The substrate: episodes
+
+Everything reduces to **episodes** — store and recall episodes, then act on them
+([Principle 1](PRINCIPLES.md#1-memory-is-the-substrate)). A **capability** is a way of *using*
+episodes. The substrate stays small and pure; capabilities are pluggable operations layered
+over it, and they **MUST stay enforcement-free** (Principle 1; RFC-008 R1 — no gate / marker /
+workflow logic in the substrate).
+
+---
+
+## The capability families
+
+All three are ways of **using episodes**. None of them enforce workflows.
+
+| Capability | What it does | Operates on | Substrate script | Plugin type | Default |
+|---|---|---|---|---|---|
+| **Memory-store strategy** | Persists episodes and builds derived indexes from them (e.g. knowledge graph) | episodes (write) + derived indexes | `em-store` | `store-strategy` | append-only log + lexical index |
+| **Recall strategy** | Retrieves + ranks episodes for use | episodes (read) | `em-recall` | `recall-strategy` | lexical tag-based (zero-dep) |
+| **Learning strategy** | Derives new knowledge from episodes + derived indexes, writes it back as global episodes | indexes (read) → episodes (write) | `em-store` (write-back) | `learning` | none (opt-in) |
+
+### 1. Memory-store strategy
+How episodes are persisted, and what **derived** structures are built alongside them. Default:
+append-only episode log + lexical index. A store strategy may, in future, maintain a derived
+**knowledge-graph index** or another derived index that makes recall richer. Derived indexes
+are a substrate concern — built from episodes, consumed by recall and learning.
+
+### 2. Recall strategy
+How episodes are found and ranked for use. Default: lexical, tag-based, zero-dependency.
+Alternatives — semantic (embeddings), graph traversal, hybrid (RRF) — are opt-in
+`recall-strategy` plugins. Algorithms live in their own RFCs (RFC-001 Intelligent Memory,
+RFC-007 Graph Projection); this charter owns only the capability contract.
+
+### 3. Learning strategy
+How the system turns accumulated episodes (and the derived indexes a store strategy builds)
+into **new** knowledge, written back as new global episodes for future recall. Reads indexes,
+persists derived knowledge via `em-store`. Opt-in, substrate-side, enforcement-free.
+
+---
+
+## The unifying invariant
+
+Every capability is **a way to use memory episodes** — storing them, recalling them, or
+learning from them. This is the test for "does X belong here":
+
+- X is an operation over episodes that **does not** enforce workflow → it is a substrate
+  capability (this document).
+- X **enforces** workflow discipline → it belongs to **behavior patterns**, not here (below).
+- X **cannot** be expressed as episodes at all → it is the trigger for a new RFC
+  ([Principle 1](PRINCIPLES.md#1-memory-is-the-substrate)).
+
+---
+
+## Enforcement is not a substrate capability
+
+Enforcing agent workflow discipline — plan-approval gates, checkpoints, push gates — is the job
+of **behavior patterns** (`patterns/bp-XXX.json`) executed by the **enforcement layer**, **not**
+a way of using the memory substrate. RFC-008 exists precisely to keep these apart:
+
+- The substrate (`em-store` / `em-recall` / `em-search`) is pure store-and-recall and contains
+  **zero** gate / marker / workflow logic (RFC-008 R1).
+- Behavior-pattern enforcement is a **separate layer** that reads contracts and decides
+  block / allow — it depends on the substrate, never the reverse (RFC-008 R2 / R6).
+
+The plugin manager *does* host an `enforcement` plugin type, but it lives in the enforcement
+layer alongside the three substrate-capability types — it is **not** a capability of the memory
+itself. Keep the boundary sharp: **a capability uses memory; behavior patterns enforce
+workflow.**
+
+---
+
+## Adding a new capability (the forward rule)
+
+The project **will** grow new ways to use episodes. A new **substrate capability** is sanctioned
+only when it satisfies all of the following:
+
+1. **Episode-expressible, not workflow-enforcing** — it is an operation over episodes
+   (store / recall / derive). If it enforces workflow, it is a behavior-pattern concern, not a
+   capability. If it cannot be expressed as episodes at all, it is a new-RFC conversation
+   (Principle 1).
+2. **A registered plugin type** — it becomes a `type` in the plugin registry (RFC-008 R8 typed
+   registry), added as an additive **MINOR** schema-version bump (R8 versioned-contract clause),
+   never an ad-hoc edit to a merged contract.
+3. **Complete contract** — it ships its own (a) registry sub-schema (the slot),
+   (b) descriptor / manifest schema, (c) runtime IO schema, and (d) a conformance test gauntlet.
+   "Supported" means **schema-validated and test-covered**, not merely present.
+4. **Enforcement-free** — it stays inside the substrate layer and contains no gate / marker /
+   workflow logic (RFC-008 R1). This is the non-negotiable boundary.
+5. **Honest + consensual** — declares its capability tier (Principle 5) and explicit activation /
+   side-effects (Principles 3, 10); algorithm-heavy capabilities cross-reference their own RFC
+   (this charter owns the *contract*; the RFC owns the *algorithm*).
+
+---
+
+## Relation to other docs
+
+- [PRINCIPLES.md](PRINCIPLES.md) — build constraints (*how*); Principle 1 is this charter's root.
+- [RFC-008](docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md) — **decouples enforcement
+  from the substrate** (R1) and provides the typed plugin manager that hosts both the three
+  substrate-capability types and the separate `enforcement` type (R8).
+- RFC-001 (Intelligent Memory), RFC-007 (Graph Projection) — algorithms for specific recall /
+  store / learning strategies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Cross-tool episodic memory system for AI coding assistants (Claude Code, Cursor,
 - Per-project: `.episodic-memory/` (local episodes + index)
 - `docs/rfcs/` — RFC specs; implement from those with status `ACCEPTED`. Index: `docs/rfcs/README.md` + `_index.json`.
 - `PRINCIPLES.md` — governing principles (memory-as-substrate, JSON-defs/`.mjs`-adapters, explicit activation, etc.). Read before planning/designing/implementing; new features that violate a principle either revise it or get rejected.
+- `CAPABILITIES.md` — capability charter (the guiding post): the substrate capability families the project supports — memory-store strategy, recall strategy, learning strategy — and the rule for adding new ones as plugin types. Capabilities *use* the memory substrate; they do NOT enforce workflows (that is behavior patterns' job, a decoupled layer). Read alongside `PRINCIPLES.md` before adding any capability or plugin type.
 
 ## Development conventions
 - Scripts are `.mjs` (ESM) with zero external dependencies

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -14,6 +14,8 @@ Episodic memory — store and recall episodes — is the only data layer. If a f
 
 **How to apply:** When you reach for a queue, daemon, IPC channel, or "let's just spin up a small server," stop. Express it as episodes first. If the episode model genuinely cannot carry the use case, that is the moment for a new RFC, not a workaround.
 
+**Capability families.** The sanctioned ways to *use* the substrate — memory-store strategy, recall strategy, learning strategy — and the rule for adding new ones are enumerated in [CAPABILITIES.md](CAPABILITIES.md). Capabilities *use* memory; they do **not** enforce workflows — that is the job of behavior patterns (`bp-XXX`), a separate decoupled layer (RFC-008). A capability that cannot be expressed as an operation over episodes does not belong to the substrate.
+
 ---
 
 ## 2. Behavior definitions are data; execution belongs behind stable adapter contracts

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ A **shared memory layer for AI coding agents**. Different agentic AI platforms �
 
 Works with: **Claude Code**, **Cursor**, **Codex (OpenAI)**, **OpenCode**, **Pi Agent**, **Windsurf / Continue**
 
-The design principles guiding the system are documented in [PRINCIPLES.md](PRINCIPLES.md).
+The design principles guiding the system are documented in [PRINCIPLES.md](PRINCIPLES.md); the capability families the substrate supports are charted in [CAPABILITIES.md](CAPABILITIES.md).
+
+> ### 🏗️ Major re-architecture in progress (RFC-008)
+>
+> The enforcement layer (behavior-pattern gates/hooks) is being **decoupled from the memory substrate**, and the system is moving to a **typed plugin model** — `enforcement`, `recall-strategy`, `store-strategy`, and `learning` plugins, each a registered, schema-validated, **versioned** contract. The capability families and the rule for extending them are the guiding post in **[CAPABILITIES.md](CAPABILITIES.md)**; the full design is **[RFC-008](docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md)** (accepted; building in phases — P0 schema contracts merged, P1 plugin registry next).
+>
+> **This does not break current usage.** The file-based store, the CLI, and the cross-tool behavior described below are unaffected today — the substrate (`em-store` / `em-recall` / `em-search`) stays a stable, zero-dependency store-and-recall API throughout the migration. Enforcement plugins beyond Claude Code arrive incrementally as later phases land.
 
 ## Capabilities
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -25,8 +25,17 @@ RFCs document proposed changes to the episodic-memory system. Every non-trivial 
 docs/rfcs/
   README.md       <- this file
   TEMPLATE.md     <- copy this when creating a new RFC
+  RFC-NNN-<slug>.md
+  RFC-008/        <- per-phase architecture + implementation plans for a large RFC
+                     (one file per build phase; linked from the RFC's TOC)
   archived/       <- closed RFCs (implemented, withdrawn, superseded)
 ```
+
+> **Companion phase directories.** When an `accepted` RFC's build-phase detail grows large
+> enough to crowd the RFC body (architecture diagrams, per-phase file manifests, hazards),
+> extract it into a sibling `RFC-NNN/` directory — one file per phase — and link each from
+> the RFC's table of contents. The RFC body keeps the summary table, crosswalk, traceability
+> matrix, and the live implementation ledger. First instance: `RFC-008/`.
 
 ---
 

--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -5,7 +5,7 @@ title: Decoupling the Enforcement Layer from the Memory Substrate
 status: accepted
 champion: Charlton Ho
 created: 2026-05-27
-last_modified: 2026-05-29
+last_modified: 2026-05-30
 supersedes: ~
 superseded_by: ~
 ---
@@ -16,12 +16,12 @@ superseded_by: ~
 > **spec v8** (episode `20260527-081221-consolidated-rearchitecture-spec-v8-comp-000c`,
 > supersedes chain v7 → v6 → v5 → v4 → v3). The parent-goal containment is recorded in
 > `20260527-051225-decoupling-enforcement-from-memory-subst-c4af`. Every design element
-> below maps to a requirement (R1–R10); no element exists without a requirement parent.
+> below maps to a requirement (R1–R12); no element exists without a requirement parent.
 
 ## Table of contents
 
 - [AI context](#ai-context)
-- [Requirements (R1–R10)](#requirements-r1r10)
+- [Requirements (R1–R12)](#requirements-r1r12)
 - [Problem](#problem)
 - [Proposal](#proposal)
   - [Architecture](#architecture-maps-to-r1-r2-r3-r6-r8-r9-r10)
@@ -42,6 +42,15 @@ superseded_by: ~
   - [Plugin authoring skill + taxonomy conformance](#plugin-authoring-skill--taxonomy-conformance-maps-to-r3-r4-r6-r8-r10)
   - [Scope](#scope)
 - [Build phases (P0–P9): manifest and boundaries](#build-phases-p0p9-manifest-and-boundaries)
+  - Per-phase architecture + implementation plans (in [`RFC-008/`](RFC-008/README.md)):
+    - [P0 — Locked schema + data contracts](RFC-008/P0-schema-contracts.md) · DONE (#367)
+    - [P1 — Plugin directory + registry + test gauntlet](RFC-008/P1-plugin-registry.md) · NEXT
+    - [P2 — BP contract instances + contract validators](RFC-008/P2-bp-contracts.md)
+    - [P3 — Thin waist + classifier runtime-sourcing + em-recall purification](RFC-008/P3-thin-waist.md)
+    - [P4 — Per-project `enforce-config.json`](RFC-008/P4-enforce-config.md)
+    - [P5–P7 — Per-tool plugins (OpenCode / Codex / Pi Agent)](RFC-008/P5-P7-tool-plugins.md)
+    - [P8 — Cursor + Windsurf plugins](RFC-008/P8-cursor-windsurf.md)
+    - [P9 — Pluggable recall strategies](RFC-008/P9-recall-strategies.md) · deferred
   - [Build order and Phase-to-P crosswalk](#build-order-and-phase-to-p-crosswalk)
 - [Requirement traceability matrix](#requirement-traceability-matrix)
 - [Deadlock analysis](#deadlock-analysis-maps-to-taxonomy-r3-r4-r9)
@@ -64,7 +73,7 @@ superseded_by: ~
 
 ---
 
-## Requirements (R1–R10)
+## Requirements (R1–R12)
 
 These are the anchors. Every architecture decision in this RFC maps to one or more of these requirements. **No design element exists without a requirement parent.**
 
@@ -78,7 +87,7 @@ Enforcement (BP gates, classifiers, markers, contracts) is decoupled from the me
 **Governed by:** PRINCIPLES.md P9 (Core never imports adapters; adapters import core).
 
 ### R2 — Pluggable enforcement; episodic-memory dictates the contract
-BP enforcements are plugins. Episodic-memory defines WHAT must be enforced (contracts in `patterns/bp-XXX.json`). Plugins implement HOW the agent harness executes the enforcement. The contract flows FROM episodic-memory TO plugins, not the other direction.
+BP enforcements are plugins. Episodic-memory defines WHAT must be enforced (contracts in `patterns/bp-XXX.json`). Plugins implement HOW the agent harness executes the enforcement. The contract flows FROM episodic-memory TO plugins, not the other direction. In the typed plugin registry (R8) this is the **`enforcement`** plugin type — the **only** type in the enforcement layer; the substrate-capability types (`recall-strategy`, `store-strategy`, `learning`) *use* episodes and never enforce workflow (see [CAPABILITIES.md](../../CAPABILITIES.md)).
 **Governed by:** PRINCIPLES.md P2 (Behavior definitions are data), P11 (Portable core contract).
 
 ### R3 — Capability mapping contract
@@ -103,7 +112,11 @@ Each enforcement plugin is tied to exactly one agent harness: Pi Agent, OpenCode
 
 ### R8 — Plugin registry
 All enforcement plugins and recall strategies MUST be registered in `plugins/_index.json`. The registry is the single source of truth for: which plugins exist, which harness they bind to, their capability declarations, and their classifier override status. Installers, the enforcement thin waist, and the classifier activation gate all consult the registry. Unregistered plugins are invisible to the system.
-**Governed by:** PRINCIPLES.md P2 (Behavior definitions are data), Rule 14 (Machine-readable blocks for drift-prone state).
+
+**v11.9 typed-registry clause (R8 plugin types; capability layering):** Every registry entry declares a **`type`** ∈ {`enforcement`, `recall-strategy`, `store-strategy`, `learning`}; a missing or unrecognized type is **hard-rejected**. Each type carries its **own** registry sub-schema, descriptor/manifest schema, runtime-IO schema, and conformance test gauntlet — "registered" means schema-validated and test-covered *for that type*, never merely listed. The types span **two layers**: **`enforcement`** is the sole enforcement-layer type and binds to behavior-pattern contracts (R2); the other three are **substrate capabilities** (R7, R11, R12) that *use* episodes and MUST contain no gate/marker/workflow logic (R1). The capability families and the rule for adding new types are the guiding post in [CAPABILITIES.md](../../CAPABILITIES.md); a new type is an additive MINOR bump under the versioned-contract clause below.
+
+**v11.9 versioned-contract clause (R8 contract-evolution; backward/forward compatibility):** The registry (`plugins/_index.json`) and its meta-schema MUST carry a REQUIRED **`schema_version`** (semver), mapped to BOTH the schema (which declares the contract version it defines) and the registry validator (`validate-plugin-registry.mjs`, which enforces it). An unversioned registry is **hard-rejected** (no version ⇒ no validation, never a silent default). The validator supports a version **range**, not an exact pin: **backward** (registry version ≤ the validator's max within the same major ⇒ validate with that version's rules; a newer validator still reads older registries), **forward** (registry major > the validator's max ⇒ **fail closed** with "registry written against newer contract vX; upgrade the validator" — never silently mis-validate an unknown contract), and **additive minor** (a new plugin kind / new optional field within the same major ⇒ accepted by construction). A **MINOR** bump is additive-only and backward-compatible; a **MAJOR** bump is breaking (removed/renamed field, tightened `required`, changed enum semantics). This is what makes "register a future plugin kind" a safe, validated MINOR bump rather than an ad-hoc edit to a merged contract. A single `CURRENT_SCHEMA_VERSION` constant is asserted byte-equal across the schema, the validator's max-supported version, and the golden fixtures, with a CI check that fails on divergence.
+**Governed by:** PRINCIPLES.md P2 (Behavior definitions are data), P11 (Portable core contract), Rule 14 (Machine-readable blocks for drift-prone state).
 
 ### R9 — No checkpoints during exploration, planning, or architecture design
 The pre-checkpoint gate materializes ONLY at the IMPLEMENTATION boundary — the first repo-source file write. Nothing is armed during exploration, planning, discovery, architecture design, or code review. Bash is intentionally ungated from the pre-checkpoint gate so reviews, inspections, exploration, and architecture work never block and never create markers. The post-checkpoint, push-gate, and stop-gate lifecycle remains fully enforced once implementation begins.
@@ -112,6 +125,14 @@ The pre-checkpoint gate materializes ONLY at the IMPLEMENTATION boundary — the
 ### R10 — Enforcement plugin runbooks
 Each enforcement plugin MUST include a runbook in `plugins/<harness>/runbooks/` with specified content per section. The runbook is injected on first invocation per session via content-addressed UX-marker (`.so-runbook-shown.<sha8>`). Runbook marker writes are exempt from checkpoint/plan gating. Session-start lifecycle clears all runbook markers. Content-addressed (sha8 = SHA256(full_runbook_content).hex.slice(0, 8)) — edits invalidate the marker, forcing re-injection.
 **Governed by:** PRINCIPLES.md P4 (Cognitive load > lightweight — the runbook prevents the model from rediscovering the same lessons each session). **Precedent:** second-opinion harness runbook at `hooks/runbooks/second-opinion-harness.md` (118 lines, production since 2026-05-13).
+
+### R11 — Pluggable memory-store strategies
+How episodes are persisted is pluggable. The default store is the append-only episode log + lexical index (zero-dep). A **store-strategy** plugin MAY additionally build **derived indexes** from episodes — a knowledge-graph index or another derived structure that makes recall richer. Store strategies are **substrate capabilities** ([CAPABILITIES.md](../../CAPABILITIES.md)): they operate on episodes via `em-store`, register as the `store-strategy` plugin type (R8), and MUST contain no enforcement/gate/marker logic (R1). Derived-index *algorithms* are specified in their own RFC, not here — the knowledge-graph index folds into **RFC-007 (Graph Projection)**.
+**Governed by:** PRINCIPLES.md P1 (Memory is the substrate), P2 (Behavior definitions are data), P6 (Tokens are the budget). **Peer of:** R7 (recall strategies) — the store-side analog.
+
+### R12 — Pluggable learning
+The system can derive **new** knowledge from accumulated episodes (and the derived indexes a store strategy builds) and persist it back as new **global** episodes for future recall. A **learning** plugin reads indexes, derives knowledge, and writes it via `em-store`. Learning is a **substrate capability** ([CAPABILITIES.md](../../CAPABILITIES.md)): opt-in, registered as the `learning` plugin type (R8), substrate-side, and enforcement-free (R1) — it never gates or blocks; it only produces episodes. Learning *algorithms* (embeddings, summarization, graph inference) are specified in their own RFC — they fold into **RFC-001 (Intelligent Memory)**.
+**Governed by:** PRINCIPLES.md P1 (Memory is the substrate), P6 (Tokens are the budget), P7 (State changes are episodes). **Peer of:** R7, R11 — the three substrate-capability requirements.
 
 ---
 
@@ -1151,9 +1172,11 @@ The runtime layer is the spine: the thin waist treats `taxonomy.json` as the **o
 
 ## Build phases (P0–P9): manifest and boundaries
 
-**Canonical build order is P0 → P9.** P0 (the locked schema + data layer) was added in v11; the older "Phase 1–9" prose numbering is retired and mapped via the **[Build order and Phase-to-P crosswalk](#build-order-and-phase-to-p-crosswalk)** at the end of this section. Each phase below carries an exact file manifest and an explicit **Depends on / Done when** boundary, so the start and stop of every phase is unambiguous.
+**Canonical build order is P0 → P9.** P0 (the locked schema + data layer) was added in v11; the older "Phase 1–9" prose numbering is retired and mapped via the **[Build order and Phase-to-P crosswalk](#build-order-and-phase-to-p-crosswalk)** at the end of this section.
 
-Summary (detail + file lists in the per-phase blocks that follow):
+> **Per-phase detail lives in [`docs/rfcs/RFC-008/`](RFC-008/README.md)** — one file per phase, each carrying the phase's **architecture diagram, exact file manifest, build steps, hazards, and Done-when boundary**. The table + crosswalk below are the at-a-glance map; the stubs that follow link to each phase file. This keeps the RFC body navigable as the per-phase implementation detail accretes.
+
+Summary (full file lists + architecture in the linked per-phase files):
 
 | P | Phase | New | Mod | Est | Depends on | Serves |
 |---|-------|----:|----:|-----|-----------|--------|
@@ -1170,91 +1193,44 @@ Summary (detail + file lists in the per-phase blocks that follow):
 | Bug | `plan-gate.sh:108–115` ordering fix (deadlock class 2) | 0 | 1 | small | — | R4 |
 | Follow | migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/` | 0 | 1 | small | P1 | R10 |
 
-#### P0 — Locked schema + data contracts · serves R3, R4 (+ closes F11–F51) · depends on: —
+Each phase's **architecture diagram, exact file manifest, build steps, hazards, and Done-when boundary** live in its own file under [`docs/rfcs/RFC-008/`](RFC-008/README.md). The stubs below are the navigational index; the table above is the at-a-glance map.
 
-**Ships — 20 files (17 JSON-Schema docs + 3 JSON data files). NO *shipped* `.mjs` runtime/CI validators (those are P1/P2/P3 per T17).** *(T17 clarification, v11.8: the `.mjs` exclusion scopes to shipped runtime/CI validators under `scripts/`. Test-only `.mjs` under `tests/` is permitted and required — Rule-18 step 5 ships tests alongside, and the project's tests are all `.mjs`; see the P0 done-when verification gate below.)*
+#### P0 — Locked schema + data contracts → [RFC-008/P0-schema-contracts.md](RFC-008/P0-schema-contracts.md)
 
-- `patterns/taxonomy.json` *(data)* · `patterns/taxonomy.schema.json`
-- `patterns/events.json` *(data, v11)* · `patterns/events.schema.json` *(v11)*
-- `patterns/schema.json` *(bp-XXX contract meta-schema)*
-- `plugins/manifest.schema.json` · `plugins/_index.schema.json` · `plugins/installed-state.schema.json` · `plugins/bypass_known.schema.json`
-- `plugins/bypass_known.json` *(data; pre-populated with Codex `pre_tool_use: { ceiling: "MEDIUM" }`)*
-- `schemas/runtime/`: `classifier-output.schema.json` · `adapter-call.schema.json` · `adapter-response.schema.json` · `structured-alert.schema.json`
-- `schemas/events/` *(v11)*: `event-pre-tool-use` · `event-tool-result` · `event-stop` · `event-session-start` · `event-session-end` *(`.schema.json`)*
-- `schemas/runbook-agent-manifest.schema.json` *(v11.2, F49)*
+Serves R3, R4 (+ closes F11–F51) · depends on: — · **DONE — PR #367 (`d078fdc`).** 20 files (17 schemas + 3 data); no shipped `.mjs` validators (T17); test-only validity-gate linter closes the R0b-R3 fail-open class.
 
-**Done when:** all 20 files exist; each schema is itself a valid JSON-Schema 2020-12 doc; the golden-corpus fixtures (`tests/fixtures/plugins/`, `tests/fixtures/harness-events/`) are staged. Cross-file validation (vocabulary closure, hash equality, realpath/symlink containment, regex try-compile, adapter-write observation) runs once the P1/P2/P3 validators land — P0 only STAGES the fixtures that exercise those.
+#### P1 — Plugin directory + registry + test gauntlet → [RFC-008/P1-plugin-registry.md](RFC-008/P1-plugin-registry.md)
 
-**P0 validity-verification gate (v11.8 — closes the "valid 2020-12 doc" done-condition under zero-dep).** "Each schema is a valid JSON-Schema 2020-12 doc" is proven by a **test-only** keyword-grammar linter `tests/lib/mini-jsonschema.mjs` (driven by `tests/test-p0-schemas.mjs`), NOT by interpreting the official meta-schema (whose `$dynamicRef`/`$dynamicAnchor` machinery is the most error-prone corner of the spec — replicating it is the wrong patch class). The linter: (a) allowlists the 2020-12 keyword set and **fails on any unknown keyword** (a typo like `requiredd` is a hard fail, never a silent pass); (b) grammar-checks each keyword (`items`→schema, so `items:[]` FAILS; `required`→array-of-unique-strings; `type`→valid name(s); `properties`/`patternProperties`/`$defs`/`dependentSchemas`→object-of-schemas; etc.) recursing into every subschema-bearing position; (c) derives its recurse-set from a single declared `SUBSCHEMA_KEYWORDS` table covering ALL 2020-12 subschema-bearing keywords — single-schema: `items, additionalProperties, unevaluatedItems, unevaluatedProperties, contains, propertyNames, if, then, else, not, contentSchema`; schema-array: `prefixItems, allOf, anyOf, oneOf`; object→schema-map: `properties, patternProperties, $defs, dependentSchemas` — and **self-asserts that `keys(SUBSCHEMA_KEYWORDS) ∪ value-grammar-keywords == allowlist`**, so a future allowlisted keyword that bears a subschema cannot be added without classifying it (the recurse-set cannot silently go incomplete — closing the fail-open class where e.g. `{"propertyNames":{"items":[]}}` would otherwise pass). The negative corpus MUST include `items:[]`, `required:"x"`, `type:"banana"`, `properties:[]`, `{requiredd:[]}`, and the deep cases `{propertyNames:{items:[]}}` / `{unevaluatedProperties:{type:"banana"}}` / `{dependentSchemas:{a:{items:[]}}}`. Full official-meta-schema validation is owned by P2's `scripts/validate-schemas.mjs` (M2), which re-validates these P0 schemas when it lands; to prevent two-hand-rolled-validator drift the P0 linter and the P2 validator **share one negative corpus** as a common conformance fixture (P2 FU, tracked as a GitHub issue at P0 ship time).
+Serves R1, R6, R8 · depends on: P0 · **NEXT.** `git mv hooks/` → `plugins/claude-code/hooks/` (byte-identical) + `_index.json` registry + `manifest.json` + `validate-plugin-registry.mjs` + `test-plugin.mjs` 9-step gauntlet. ~25–30K.
 
-> **Count note:** authoritative total = **17 schemas + 3 data files = 20**. (The v11.2 changelog's "18 schema-class docs" shorthand counted `bypass_known.json` among the schema-class group; the enumeration above is authoritative.)
+#### P2 — BP contract instances + contract validators → [RFC-008/P2-bp-contracts.md](RFC-008/P2-bp-contracts.md)
 
-#### P1 — Plugin directory + registry + test gauntlet · serves R1, R6, R8 · depends on: P0
+Serves R2, R3, R4 · depends on: P0 · queued (parallelizable with P1). `bp-001.json … bp-012.json` + `validate-bp-contract.mjs` + `validate-taxonomy-schema.mjs`; lands the shared-negative-corpus drift guard (issue #368).
 
-**Ships:**
-- `plugins/` with per-harness subdirectories
-- `git mv hooks/` → `plugins/claude-code/hooks/` *(byte-identical; zero behavior change)*
-- `plugins/_index.json` *(registry skeleton; validated against P0 `_index.schema.json`)*
-- `plugins/claude-code/manifest.json` *(gains the `invocation_modality` field, M4b)*
-- `install.mjs` updated to deploy from `plugins/<harness>/hooks/`
-- `scripts/validate-plugin-registry.mjs` *(the M1–M10 + M7a–M7f assertion checklist)* + `scripts/test-plugin.mjs` *(the 9-step gauntlet)* + golden plugin/event fixtures
+#### P3 — Thin waist + classifier runtime-sourcing + em-recall purification → [RFC-008/P3-thin-waist.md](RFC-008/P3-thin-waist.md)
 
-**Done when:** the git mv is byte-identical (existing hook behavior unchanged); `_index.json` + the claude-code `manifest.json` validate against the P0 schemas; author-time + schema gauntlet steps pass for claude-code. *(Gauntlet steps that round-trip through `enforce-contract.mjs` — steps 5/6 — are exercised once P3 lands.)* ~25–30K (pure git mv + path-reference patching).
+Serves R1, R2, R3, R4, R5, R9 (+ F38) · depends on: P0, P2 · queued. `enforce-contract.mjs` + `lib/marker-state.mjs` + classifier runtime-sourcing + **em-recall STRICT DELETION** (F38/F60). The load-bearing phase; where gauntlet steps 5/6 finally run.
 
-#### P2 — BP contract instances + contract validators · serves R2, R3, R4 · depends on: P0
+#### P4 — Per-project `enforce-config.json` → [RFC-008/P4-enforce-config.md](RFC-008/P4-enforce-config.md)
 
-**Ships:**
-- `patterns/bp-001.json` … `patterns/bp-012.json` *(the contract DATA; each carries `taxonomy_version` + `events_version` bindings)*
-- `scripts/validate-bp-contract.mjs` *(the full normative §Validation-contract assertion checklist — gate-completeness, action-enum closure, overridability equality, vocabulary closure, stable-ID integrity, version binding, events assertions 10–15)* + `scripts/validate-taxonomy-schema.mjs` *(meta-validation, F5)*
+Serves R3, R5 · depends on: P3 · queued *(legacy "Phase 5")*. `effective_tier = min(harness, contract, project_config)` clamps DOWN only; `active: false` makes the classifier silent (R5).
 
-Contract shape: `{ gates: { plan_approval, pre_checkpoint, post_checkpoint }, stop: { tier }, taxonomy_ref, taxonomy_version, events_version }` — three per-pattern classification gates; `stop` is a root-level marker-state gate (not per-label, F2/F10).
+#### P5–P7 — Per-tool plugins (OpenCode / Codex / Pi Agent) → [RFC-008/P5-P7-tool-plugins.md](RFC-008/P5-P7-tool-plugins.md)
 
-**Done when:** every `bp-XXX.json` validates against `patterns/schema.json` and passes `validate-bp-contract.mjs` against the locked P0 schemas + golden corpus.
+Serves R6, R10 · depends on: P3 · queued *(legacy "Phase 6/7/8")*. Same template instantiated three times: `manifest.json` + adapter + 10-section runbook + fixtures, each at its declared capability tiers. Codex `pre_tool_use: MEDIUM` (multi-edit bypass documented).
 
-#### P3 — Thin waist + classifier runtime-sourcing + em-recall purification · serves R1, R2, R3, R4, R5, R9 (+ F38) · depends on: P0, P2
+#### P8 — Cursor + Windsurf plugins → [RFC-008/P8-cursor-windsurf.md](RFC-008/P8-cursor-windsurf.md)
 
-**Ships:**
-- `scripts/enforce-contract.mjs` *(the thin waist: validates contracts, ternary `min()` effective tier (R3), R9 implementation-boundary detection (lazy-arm on first repo-source write, silent during exploration/planning), classifier dispatch (R4/R5), reads gate action from taxonomy + per-tier semantics from `events.json`, reads marker state via `marker-state.mjs`; two invocation modes — in-process import for STRONG harnesses + CLI spawn for degrade; out-of-vocab labels HARD-REJECTED with a structured alert via `em-store`, F3)*
-- `scripts/lib/marker-state.mjs` *(marker reads, owned by the enforcement layer)*
-- **Classifier runtime-sourcing (legacy "Phase 4", folded here):** refactor `command-classifier.sh` to source the 7-label set from `taxonomy.json` at runtime (OQ-2 closed); plugin classifier-override interface; override registration in `_index.json`; non-overridable labels enforced at scaffold + CI + runtime
-- **em-recall purification — STRICT DELETION (F38, F60):** remove from `em-recall.mjs` the `--gate` flag + handler, the `stop-gate-helpers.mjs` import, all marker reads, and the `.checkpoints/` migration code *(net diff is negative LOC; substrate restored to pure recall)*
-- `install.mjs` deploys `lib/marker-state.mjs` + verifies em-recall is v11-purified (F45); `tests/test-install-em-recall-purified.mjs`
+Serves R6, R10 · depends on: P3 · queued *(added per F43/OQ-3, v11.1)*. Cursor = full adapter (STRONG, not WEAK); Windsurf = static-rules (WEAK, no runtime adapter) → gauntlet steps 8/9 `static-rules` carve-out (F56).
 
-**Done when:** `enforce-contract.mjs` passes contract validation + the full 9-step gauntlet against the P1 plugins; `em-recall.mjs` (and `em-store.mjs` / `em-search.mjs`) contain zero gate-vocabulary tokens (F60 CI grep guard green); the install-purification sentinel test passes.
+#### P9 — Pluggable recall strategies → [RFC-008/P9-recall-strategies.md](RFC-008/P9-recall-strategies.md)
 
-#### P4 — Per-project config · serves R3, R5 · depends on: P3 · (legacy "Phase 5")
-
-**Ships:** `enforce-config.json` per project (`{ "bp-001": { "plan_approval": "MEDIUM", ... }, "active": true/false }`).
-
-**Done when:** the ternary `min()` clamps effective tier DOWN only (never raises); `active: false` for all plugins makes the classifier silent (R5 — no hook spawn, no token cost).
-
-#### P5–P7 — Per-tool plugins · serves R6, R10 · depends on: P3 · (legacy "Phase 6/7/8")
-
-Each plugin ships `manifest.json` + `capabilities/enforcement.{mjs,ts,py}` adapter + `runbooks/enforcement.md` (the 10 required sections, R10) + harness-event fixtures.
-
-- **P5 — `plugins/opencode/`** (TypeScript): `pre_tool_use: STRONG, tool_result: STRONG, session_start: MEDIUM, stop: MEDIUM`
-- **P6 — `plugins/codex/`** (Python hooks): `pre_tool_use: MEDIUM` (multi-edit bypass documented), `stop: STRONG, session_start: STRONG`
-- **P7 — `plugins/pi-agent/`** (`tool_call` + `session_shutdown`/`turn_end`): `pre_tool_use: STRONG, stop: MEDIUM, session_start: STRONG`
-
-**Done when:** each passes the `test-plugin.mjs` 9-step gauntlet at its declared tiers.
-
-#### P8 — Cursor + Windsurf plugins · serves R6, R10 · depends on: P3 · (added per F43/OQ-3, v11.1)
-
-- **`plugins/cursor/`** — full adapter (Cursor is STRONG-capable, NOT WEAK; see §Capability-degradable enforcement): `pre_tool_use: STRONG, tool_result: MEDIUM, stop: MEDIUM, session_start: STRONG, session_end: STRONG`
-- **`plugins/windsurf/`** — static-rules (WEAK): installer + `.windsurf/rules/episodic-memory-enforcement.md` + `runbooks/enforcement.md` + manifest declaring `session_start: WEAK` only; NO runtime adapter
-
-**Done when:** Cursor passes the full gauntlet; Windsurf passes the static-rules gauntlet carve-out (steps 8/9 validate the deploy artifact, not adapter dispatch — F56).
-
-#### P9 — Pluggable recall strategies · serves R7 · DEFERRED to its own RFC
-
-**Ships (when carved out):** `em-recall/strategies/` (lexical default zero-dep; semantic opt-in `requiresEmbeddings: true`; graph zero-dep; hybrid RRF) + `em-recall/strategies/_index.json`.
-
-**Why deferred:** the only FEATURE phase; semantic's embedding dependency is in tension with the zero-dep principle, so it is carved into a separate RFC rather than landing here.
+Serves R7 · **DEFERRED to its own RFC.** The only feature phase; semantic's embedding dependency conflicts with the zero-dep principle. Semantic folds into RFC-001; graph into RFC-007.
 
 #### Non-phase items
 
 - **Bug fix (any time):** `plan-gate.sh:108–115` ordering — F14 early-exit blocks the `marker_write` escape hatch (deadlock class 2, R4).
-- **Follow-up (post-P1):** migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (R10).
+- **Follow-up (post-P1):** migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (R10). See [P1-plugin-registry.md](RFC-008/P1-plugin-registry.md#the-runbooks-fork).
 
 ### Build order and Phase-to-P crosswalk
 
@@ -1286,9 +1262,11 @@ The per-phase manifest above is the single source of truth for what each phase s
 | R5 — Classifier activation gating | Classifier pseudocode, enforce-config.json `active` field | P3, P5 | P6 |
 | R6 — Plugin-to-harness binding | plugins/<harness>/ structure, one-per-harness | P6, P7, P8 | P9, P11 |
 | R7 — Pluggable recall strategies | Recall strategies registry, em-recall/strategies/ | P9 | P6, P1 |
-| R8 — Plugin registry | plugins/_index.json, validation CI check | P1, all | P2, Rule 14 |
+| R8 — Plugin registry (typed + versioned contract) | plugins/_index.json, validation CI check; `type` discriminator + per-type schema/validator/gauntlet; `schema_version` + validator range / fail-closed-forward; `CURRENT_SCHEMA_VERSION` drift-guard | P0 (fields), P1 (validator), all | P2, P11, Rule 14 |
 | R9 — No checkpoints during exploration | Implementation boundary detection, planning-passive redesign, classifier pseudocode guard | P3 | P4, P6 |
 | R10 — Enforcement plugin runbooks | Runbook content spec, content-addressed UX-markers, checkpoint exemption, per-plugin paths, CI validation | P5-P7, scaffold | P4 |
+| R11 — Pluggable memory-store strategies | `store-strategy` plugin type, derived indexes (knowledge-graph), `em-store` write path | deferred (own RFC; cf. RFC-007) | P1, P2, P6 |
+| R12 — Pluggable learning | `learning` plugin type, derive-and-write-back to global episodes via `em-store` | deferred (own RFC; cf. RFC-001) | P1, P6, P7 |
 
 ---
 
@@ -1530,6 +1508,7 @@ Consolidated second-opinion review of the v11 + v11.1 + v11.2 spec edits (13 fin
 | T28 | v11.6 round-4 (cap) review fold (F66–F67): codex round-4 confirmed F64+F65 closed, HOLD at the 4-round cap with 2 trivial drifts — F66 (`log_paths` authority root: entries absolute or relative-to-`project_root`, M7e-normalized; adapter writes ≡ step-9 scan root by construction), F67 (stale `<projectRoot>` alert-location line → `store_root/.episodic-memory/`). Both ACCEPT + folded. Codex instructed "do not spawn round 5; consult the champion" — escalated; no round 5 auto-dispatched. | v11.6 | codex round-4 (reply `…233020…42dc`). Round-cap discipline engaged (`20260528-082255-codex-round-cap-engagement-signal`): monotonic convergence (8→3→2→2), all post-round-1 findings were second-order-prefigured or prior-fix drift, never architectural — champion decides accept-as-folded vs one confirmation round. |
 | T30 | v11.8 R0b pre-implementation plan review folds (codex R1→R2 + claude-subagent R3 closeout): (a) **F37 event-payload lock completed** — the four previously hand-waved canonical payload shapes (`tool_result`, `stop`, `session_start`, `session_end`) now carry explicit `required`/optional field tables + cross-event invariants in §"Five canonical event-payload schemas", so plugin authors cannot invent incompatible payloads (the exact F37 gap P0 exists to close); (b) **P0 validity-verification gate specified** — "valid 2020-12 doc" is proven by a test-only keyword-grammar linter (`tests/lib/mini-jsonschema.mjs`) with allowlist + fail-on-unknown-keyword + a declared `SUBSCHEMA_KEYWORDS` table that **self-asserts completeness against the allowlist** (closes the fail-open class where invalid subschemas nested under un-recursed keywords like `propertyNames`/`unevaluatedProperties`/`dependentSchemas` would pass); full official-meta-schema validation deferred to P2's `validate-schemas.mjs`, sharing one negative corpus to prevent drift; (c) **T17 `.mjs` carve-out clarified** — the exclusion scopes to shipped runtime/CI validators under `scripts/`; test-only `.mjs` under `tests/` is permitted/required; (d) **fixture detection-layer attribution** — `tests/fixtures/plugins/_corpus-index.json` annotates each golden fixture with `_detected_by ∈ {p0-schema, p1-registry-validator, p2-cross-file-validator, p3-runtime}` + records the canonical hash-serialization contract. | v11.8 | Rule-18 step-2 plan review before P0 implementation. Codex R1 HOLD (3 findings, all ACCEPT: validity test, event-schema lock, fixture attribution) → R2 HOLD (1: `$dynamicRef`-guarded fail-open) → claude-subagent R3 closeout (codex ETIMEDOUT ×3 from SessionStart-bloated stdin; documented fallback) caught the same class one nesting level deeper (incomplete recurse-set) — closed via the self-asserting `SUBSCHEMA_KEYWORDS` table. Trajectory 3→1→1; no architectural REJECT; no R1–R10 challenged. Reply episodes `…060801…9a99` / `…063458…b5ef` / `…064415…537a`. No requirement/deliverable count changed (still 20 P0 files). |
 | T29 | v11.7 phase-boundary restructure (no spec-content change): consolidated the three overlapping phase representations (the "9 phases" estimate table, the prose "Phase 1–9" blocks, and the "Build priority" P-table) into ONE per-phase manifest under §"Build phases (P0–P9): manifest and boundaries". Each phase is now a delimited block with an exact file manifest + explicit Depends-on / Done-when boundary; added a Phase-to-P crosswalk retiring the legacy-"Phase N" vs P-N numbering mismatch (legacy Phase 4 classifier folds into P3; Phase 5 = P4; Phase 6/7/8 = P5/6/7); surfaced P0 (schemas, no validators per T17) and P8 (Cursor+Windsurf per F43) as explicit slots that the old table lacked; pinned the P0 file count to an enumerated 20 (17 schemas + 3 data), superseding the "18 schema-class docs" shorthand. TOC anchors updated. | v11.7 | User: "in the rfc its hard for me to distinguish which belongs to which phases like p0, i cant immediately see the boundary where p0 starts and where it stops." Pure presentation/clarity refactor; no requirement or deliverable semantics changed. |
+| T31 | v11.9 capability-model + typed-registry folds (user requirements #1–#2 + capability-charter boundary): (a) **`CAPABILITIES.md` established** — new top-level guiding-post charter naming the three substrate capability families (memory-store strategy, recall strategy, learning strategy) + the forward rule for adding new ones as plugin types; anchored from `PRINCIPLES.md` P1 and `CLAUDE.md` project-structure; (b) **R8 typed-registry clause** — every registry entry declares `type ∈ {enforcement, recall-strategy, store-strategy, learning}` (missing/unknown → hard-reject); each type carries its own registry sub-schema + descriptor + runtime-IO schema + conformance gauntlet; types span two layers (enforcement vs substrate); (c) **R8 versioned-contract clause** — REQUIRED `schema_version` (semver) mapped to schema + validator; validator supports a range with backward / forward (fail-closed-forward) / additive-minor semantics; `CURRENT_SCHEMA_VERSION` byte-equal drift-guard across schema/validator/fixtures; (d) **R2 clarified** — the `enforcement` type is the sole enforcement-layer type, bound to `bp-XXX`; the three substrate-capability types use episodes and never enforce; (e) **R11 (pluggable memory-store strategies)** + **R12 (pluggable learning)** added — substrate-side, enforcement-free (R1); derived-index / learning algorithms cross-ref RFC-007 / RFC-001. Requirements R1–R10 → R1–R12; traceability matrix + heading/TOC updated. | v11.9 | User directives 2026-05-30: (#1) "schema version must be present … mapped to schema and registry validator … ensures backward and forward compatibility"; (#2) "registry and plugin management must have plugin type … behavior pattern's enforcement plugin, recall strategy plugins, memory store strategy plugins, and learning plugins … each capability must be supported … complete with schema validator and tests"; plus the boundary correction "capabilities must focus on using the memory substrates, not enforcing any workflows — that's the job of behavior patterns." Schema/validator/test *implementation* is future (P0 `type` + `schema_version` fields; P1 validator dispatch) — the requirements now gate it. The versioning requirement was initially mis-placed as a standalone R11 and folded into R8 per champion ("part of the major 10 requirements"); R11/R12 are reserved for the two genuinely-new substrate capabilities. |
 
 ---
 
@@ -1548,7 +1527,7 @@ Consolidated second-opinion review of the v11 + v11.1 + v11.2 spec edits (13 fin
 1. **PRINCIPLES.md** — governing principles; all design must conform.
 2. **Code on disk** — what works today (`hooks/`, `scripts/`, `plugins/`, `patterns/`, `hooks/runbooks/`).
 3. **Accepted RFCs** — RFC-003 (accepted), RFC-004 (accepted).
-4. **This RFC (spec v8)** — requirements R1–R10 anchor all decisions.
+4. **This RFC (spec v8)** — requirements R1–R12 anchor all decisions.
 5. **Deadlock analysis** — episode `20260527-073522-deadlock-analysis-7-classes-traced-again-2648`.
 6. **Runbook analysis** — episode `20260527-080017-runbook-infrastructure-analysis-second-o-43d9`.
 7. **Design review episodes** — second-opinion chain 2026-05-27 (v3 → v4 → v5 → v6 → v7 → v8).

--- a/docs/rfcs/RFC-008/P0-schema-contracts.md
+++ b/docs/rfcs/RFC-008/P0-schema-contracts.md
@@ -1,0 +1,103 @@
+# P0 — Locked schema + data contracts
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** **DONE** — PR #367 (`d078fdc`, 2026-05-29). Verified green on merged main:
+`node tests/test-p0-schemas.mjs` → 89/0; `em-rfc-validate` consistent. Docs + schema only —
+nothing deployed.
+**Serves:** R3, R4 (+ closes findings F11–F51).
+**Depends on:** — (cheapest, no deps).
+
+## What P0 is
+
+P0 is the **locked contract layer**: every JSON-Schema document and data file the later
+phases validate against, shipped *before* any code so the validators (P1/P2/P3) have a
+fixed target. No shipped `.mjs` runtime/CI validators (T17) — those land in P1+. Test-only
+`.mjs` under `tests/` is permitted and required (Rule-18 ships tests alongside).
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph DATA["Data (the source of truth)"]
+        TAX["patterns/taxonomy.json<br/>(7 labels + non_overridable)"]
+        EVS["patterns/events.json<br/>(5 events + action semantics)"]
+        BYP["plugins/bypass_known.json<br/>(Codex pre_tool_use: MEDIUM ceiling)"]
+    end
+
+    subgraph SCH["Schemas (shape contracts, additionalProperties:false)"]
+        TAXS["patterns/taxonomy.schema.json"]
+        EVSS["patterns/events.schema.json"]
+        META["patterns/schema.json<br/>(bp-XXX contract meta-schema)"]
+        PLUG["plugins/manifest, _index,<br/>installed-state, bypass_known .schema.json"]
+        RUNB["schemas/runbook-agent-manifest.schema.json"]
+        RT["schemas/runtime/<br/>classifier-output, adapter-call,<br/>adapter-response, structured-alert"]
+        EVT["schemas/events/<br/>event-{pre-tool-use,tool-result,<br/>stop,session-start,session-end}"]
+    end
+
+    subgraph GATE["Test-only validity gate (tests/)"]
+        LINT["tests/lib/mini-jsonschema.mjs<br/>(2020-12 keyword-grammar linter;<br/>self-asserting SUBSCHEMA_KEYWORDS;<br/>ALLOWLIST=57)"]
+        VH["tests/lib/version-hash.mjs"]
+        T["tests/test-p0-schemas.mjs = 89/0"]
+        FIX["tests/fixtures/plugins/* (>=16 golden)<br/>tests/fixtures/harness-events/claude-code/*"]
+    end
+
+    LINT --> T
+    VH --> T
+    SCH --> T
+    FIX --> T
+    TAX -. taxonomy_version sha256:7ea41ed8... .-> VH
+    EVS -. events_version sha256:13f01e5a... .-> VH
+```
+
+## Ships — 20 files (17 schemas + 3 data)
+
+- `patterns/taxonomy.json` *(data)* · `patterns/taxonomy.schema.json`
+- `patterns/events.json` *(data)* · `patterns/events.schema.json`
+- `patterns/schema.json` *(bp-XXX contract meta-schema)*
+- `plugins/manifest.schema.json` · `plugins/_index.schema.json` ·
+  `plugins/installed-state.schema.json` · `plugins/bypass_known.schema.json`
+- `plugins/bypass_known.json` *(data; pre-populated with Codex `pre_tool_use: { ceiling: "MEDIUM" }`)*
+- `schemas/runtime/`: `classifier-output` · `adapter-call` · `adapter-response` ·
+  `structured-alert` *(`.schema.json`)*
+- `schemas/events/`: `event-pre-tool-use` · `event-tool-result` · `event-stop` ·
+  `event-session-start` · `event-session-end` *(`.schema.json`)*
+- `schemas/runbook-agent-manifest.schema.json` *(F49)*
+
+Test-only (T17-permitted): `tests/lib/mini-jsonschema.mjs`, `tests/lib/version-hash.mjs`,
+`tests/test-p0-schemas.mjs`, `tests/fixtures/plugins/*`, `tests/fixtures/harness-events/claude-code/*`.
+
+## Implementation notes (as shipped)
+
+- **The validity gate is a keyword-grammar linter, not a meta-schema interpreter.**
+  Replicating 2020-12 `$dynamicRef`/`$dynamicAnchor` machinery is the wrong patch class. The
+  linter (a) allowlists the 2020-12 keyword set and **fails on any unknown keyword**, (b)
+  grammar-checks each keyword recursing into every subschema-bearing position, (c) derives
+  its recurse-set from a single `SUBSCHEMA_KEYWORDS` table and **self-asserts**
+  `keys(SUBSCHEMA_KEYWORDS) ∪ value-grammar-keywords == allowlist` — so a future
+  subschema-bearing keyword cannot be added without classifying it. This closes the R0b-R3
+  fail-open class (e.g. `{"propertyNames":{"items":[]}}` would otherwise pass).
+- **Canonical hashes baked:** `taxonomy_version = sha256:7ea41ed8…`,
+  `events_version = sha256:13f01e5a…` (computed over the sorted `labels` array only — editorial
+  fields change without invalidating classification behavior).
+- Full official-meta-schema validation is owned by **P2**'s `scripts/validate-schemas.mjs`,
+  which re-validates these P0 schemas when it lands.
+
+## Done when ✓
+
+All 20 files exist; each schema is a valid JSON-Schema 2020-12 doc (proven by the test-only
+linter); the golden-corpus fixtures are staged. Cross-file validation (vocabulary closure,
+hash equality, realpath/symlink containment, regex try-compile, adapter-write observation)
+runs once the P1/P2/P3 validators land — P0 only **stages** the fixtures that exercise them.
+
+## Follow-up
+
+**Issue [#368](https://github.com/lantisprime/episodic-memory/issues/368)** — P2 must share
+ONE negative corpus between the P0 linter (`tests/lib/mini-jsonschema.mjs`) and P2's
+`scripts/validate-schemas.mjs` (RFC line 1188; drift guard, Rule 14). Blocked by P2.
+
+## Maps to
+
+R3 (capability mapping contract), R4 (default classifier + plugin override). Principle
+anchors: P2, P11.

--- a/docs/rfcs/RFC-008/P1-plugin-registry.md
+++ b/docs/rfcs/RFC-008/P1-plugin-registry.md
@@ -1,0 +1,290 @@
+# P1 — Plugin directory + registry + test gauntlet
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** **NEXT.** Rule-18 plan → second-opinion → approval → implement.
+**Serves:** R1 (memory is substrate), R6 (plugin-to-harness binding), R8 (plugin registry).
+**Depends on:** P0 (met — PR #367).
+**Estimate:** ~25–30K (mostly `git mv` + path-reference patching).
+
+## What P1 is
+
+P1 is the **structural move** that turns `hooks/` (a Claude-Code-specific pile) into the
+first entry of a **harness-agnostic plugin registry** — plus the two validators that make
+"a plugin" a checkable contract rather than a convention. **Zero runtime behavior change:**
+the hooks do exactly what they do now, just from a new path, registered and validated.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph P0["P0 - locked contracts (merged, #367)"]
+        IDXS["plugins/_index.schema.json"]
+        MANS["plugins/manifest.schema.json"]
+        RAMS["schemas/runbook-agent-manifest.schema.json"]
+        TAX["patterns/taxonomy.json<br/>(+ taxonomy_version hash)"]
+        EVS["schemas/events/event-*.schema.json"]
+        FIX["tests/fixtures/plugins/*<br/>tests/fixtures/harness-events/claude-code/*"]
+    end
+
+    subgraph P1NEW["P1 - new artifacts"]
+        IDX["plugins/_index.json<br/>(registry: harness to plugin, caps, override status)"]
+        MAN["plugins/claude-code/manifest.json<br/>(+ invocation_modality: agent)"]
+        VPR["scripts/validate-plugin-registry.mjs<br/>(M1-M10 + M7a-M7f)"]
+        TP["scripts/test-plugin.mjs<br/>(9-step gauntlet)"]
+        HB["tests/test-plugin-harness-binding.mjs<br/>(F31/F36 - 3 acceptance tests)"]
+    end
+
+    subgraph MOVE["P1 - git mv (byte-identical)"]
+        OLD["hooks/*.sh, hooks/lib/, *.mjs"] -->|git mv| NEW["plugins/claude-code/hooks/"]
+    end
+
+    INSTALL["install.mjs<br/>(repointed: deploy FROM plugins/claude-code/hooks/)"]
+
+    IDXS -. validates .-> IDX
+    MANS -. validates .-> MAN
+    RAMS -. validates .-> MAN
+    TAX -. taxonomy_version + emits_labels subset of labels .-> VPR
+    IDX --> VPR
+    MAN --> VPR
+    NEW --> INSTALL
+    IDX --> TP
+    EVS -. replay target .-> TP
+    FIX -. fed through adapter .-> TP
+    MAN --> TP
+```
+
+**How to read this — contract before code, top to bottom.** The diagram has three grouped
+regions plus one free-standing node, and the *line style carries meaning*: a **dotted** edge
+(`-. label .->`) is a **contract / validation** relationship ("this checks that"); a
+**solid** edge is a **data-flow / production** relationship ("this feeds or becomes that").
+
+- **Top region — `P0` (locked, merged in #367).** Everything here already exists on `main`
+  before P1 starts; P1 *reads* it but never changes it. `IDXS` / `MANS` / `RAMS` are the
+  three JSON-Schema 2020-12 documents defining the *shape* of a registry, a manifest, and a
+  manifest's embedded §9 agent-manifest. `TAX` is `taxonomy.json` plus its `taxonomy_version`
+  hash — the canonical 7-label vocabulary. `EVS` is the set of per-event payload schemas, and
+  `FIX` is the committed fixture corpus (golden plugins + recorded claude-code harness
+  events). These six are the fixed contract P1 is measured against.
+- **Middle region — `P1NEW` (what this phase authors).** Two are *data*: `IDX`
+  (`plugins/_index.json`, the harness→plugin registry) and `MAN`
+  (`plugins/claude-code/manifest.json`, newly carrying `invocation_modality: agent`). Three
+  are *code*: `VPR` (`validate-plugin-registry.mjs`, the static M1–M10 + M7a–M7f checker),
+  `TP` (`test-plugin.mjs`, the 9-step gauntlet), and `HB` (the three F31/F36 project-root
+  binding acceptance tests).
+- **Bottom region — `MOVE` (the structural `git mv`).** `OLD` (`hooks/*.sh`, `hooks/lib/`,
+  `*.mjs`) moves byte-identically to `NEW` (`plugins/claude-code/hooks/`). That single solid
+  `git mv` arrow *is* the behavioral promise of the phase: the bytes don't change, only the
+  path.
+
+**The edges are where the phase's safety argument lives:**
+
+- The three dotted **`validates`** edges (`IDXS→IDX`, `MANS→MAN`, `RAMS→MAN`) mean **no P1
+  artifact is trusted until it passes the P0 schema it was built against** —
+  `additionalProperties:false` everywhere, so an unknown key *fails* rather than being
+  silently ignored. `MAN` carries two incoming validate arrows because it is checked twice:
+  by `MANS` for manifest shape and by `RAMS` for its embedded agent-manifest.
+- The dotted **`TAX → VPR`** edge (`taxonomy_version + emits_labels ⊆ labels`) is the
+  **staleness + vocabulary-closure gate**: `VPR` recomputes `sha256(sortedLabels)` and demands
+  the manifest's stored `taxonomy_version` byte-match it (catches "built against stale
+  taxonomy"), and demands every label the plugin claims to emit actually exists in the
+  taxonomy (no dangling vocabulary).
+- The solid **`IDX → VPR`** and **`MAN → VPR`** edges feed the registry + manifest *into* the
+  validator as its inputs. `VPR` also enforces the **bidirectional** rule — every
+  `plugins/<harness>/` dir has a registry entry and vice-versa — which is internal to `VPR`,
+  so it has no separate incoming edge.
+- The solid **`NEW → INSTALL`** edge is the **one real wiring change** outside the move:
+  `install.mjs` repoints its deploy source to `plugins/claude-code/hooks/`. `INSTALL` floats
+  free of the subgraphs because it is neither new code nor being moved — just an existing
+  script getting a single path edit.
+- The edges into **`TP`** are the gauntlet's inputs: `IDX` (solid — *which* plugin to test)
+  plus three reference feeds — `EVS` (dotted "replay target": the schema each replayed event
+  must validate against), `FIX` (dotted "fed through adapter": the recorded events to replay),
+  and `MAN` (solid: the declared capabilities the replay outcomes are checked against).
+
+**What the diagram deliberately does *not* show:** any edge from `P1NEW` into an enforcement
+runtime. There is none yet — the decision engine (`enforce-contract.mjs`) doesn't exist until
+P3, which is precisely why two of the gauntlet's nine steps are stubbed (see the sequence
+below).
+
+## Sequence — a conformance run
+
+The `graph` above is the static wiring. This is what actually *happens* when the two new
+validators run against the claude-code plugin: first static conformance
+(`validate-plugin-registry.mjs`), then the `test-plugin.mjs` gauntlet — with the P3 stub
+boundary (steps 5/6) made explicit.
+
+```mermaid
+sequenceDiagram
+    actor CI as Dev / CI
+    participant VPR as validate-plugin-registry.mjs
+    participant SCH as P0 schemas + taxonomy.json
+    participant TP as test-plugin.mjs
+    participant ADP as claude-code adapter
+    participant EVS as schemas/events/*
+
+    Note over CI,EVS: Static conformance - runs fully in P1
+    CI->>VPR: validate-plugin-registry.mjs
+    VPR->>SCH: load _index.json + manifest.json
+    SCH-->>VPR: schema validation (M1/M2, additionalProperties:false)
+    VPR->>SCH: taxonomy_version byte-equals sha256(sortedLabels) (M6)
+    VPR->>VPR: emits_labels subset of taxonomy.labels (M7)
+    VPR->>VPR: path-authority containment via realpath (M7b)
+    VPR->>VPR: runbook S1-S10 + matrix + modality + agent-manifest (M7a-M7f)
+    VPR->>VPR: bidirectional registry-to-dir
+    VPR-->>CI: PASS or structured failure
+
+    Note over CI,EVS: 9-step gauntlet - project root required (F31/F36)
+    CI->>TP: test-plugin.mjs --project <root>
+    TP->>TP: resolve root + set EPISODIC_MEMORY_PROJECT_ROOT
+    loop steps 1-4
+        TP->>SCH: schema + runbook sentinel + COMMON byte-equality
+    end
+    Note over TP: steps 5-6 STUBBED until P3<br/>enforce-contract round-trip + F3 hard-reject
+    TP->>TP: step 7 author-time conformance
+    TP->>ADP: step 8 replay harness-event fixtures (F39)
+    ADP-->>TP: canonical payload
+    TP->>EVS: validate payload + field bindings + tier-vs-outcome
+    TP->>TP: step 9 runbook-derived invocation parity (F47)
+    TP-->>CI: gauntlet PASS (1-4,7,8,9), 5-6 deferred to P3
+```
+
+**How to read this — two independent passes, one driver.** `Dev / CI` (the left-hand actor)
+is the only initiator; everything else is a script or contract it calls. **Arrow vocabulary:**
+a solid `->>` is a call / dispatch, a dashed `-->>` is a return, a **self-arrow** (a box
+calling itself) is an internal check needing no collaborator, and the two **`Note over
+CI,EVS`** bands split the run into its two passes. Those passes are *separately runnable* — CI
+can run static conformance without the gauntlet and vice-versa; they're drawn in order because
+that's the normal CI sequence, not because one feeds the other.
+
+**Pass 1 — static conformance (`validate-plugin-registry.mjs`), runs fully in P1.** CI invokes
+`VPR`. `VPR` calls `SCH` to load `_index.json` + the manifest and gets back the M1/M2
+`additionalProperties:false` schema pass (dashed return). It makes a second `SCH` call for the
+`taxonomy_version` byte-equality check (M6). The next four messages are **self-arrows** —
+`emits_labels ⊆ taxonomy.labels` (M7), `realpath` path-authority containment (M7b), the
+bundled runbook checks §1–§10 + resolution-matrix + modality + agent-manifest (M7a–M7f), and
+the bidirectional registry↔dir check — because each is a computation `VPR` runs on data it
+already holds, with no external collaborator. The dashed `VPR-->>CI` return carries a clean
+PASS *or a structured failure* (which assertion, and why — never a bare exit code).
+
+**Pass 2 — the 9-step gauntlet (`test-plugin.mjs`), `--project <root>` required.** The first
+self-arrow is the F31/F36 binding: `TP` resolves the project root and sets
+`EPISODIC_MEMORY_PROJECT_ROOT` so every subprocess it later spawns lands its artifacts under
+the right repo. The **`loop steps 1-4`** frame runs those four checks (schema, runbook
+sentinel, COMMON-row byte-equality) as a unit against `SCH`. The **`Note over TP: steps 5-6
+STUBBED until P3`** is the load-bearing caveat of the entire phase, drawn explicitly: steps 5
+and 6 are the round-trip through `enforce-contract.mjs` plus the F3 hard-reject simulator, and
+that engine does not exist yet — so in P1 they are intentionally *inert, not failing*. Step 7
+(author-time conformance) is another self-arrow. **Step 8 is the only true collaboration in the
+gauntlet:** `TP` calls the **`ADP` (claude-code adapter)** to replay each recorded fixture
+event; the adapter returns a *canonical payload* (dashed return), which `TP` then validates
+against `EVS` — asserting the payload matches the event schema, the field bindings produced the
+expected values, and the tier-vs-outcome matches the manifest's declared capabilities (F39).
+Step 9 (runbook-derived invocation parity, F47) is a final self-arrow. The closing `TP-->>CI`
+return states the honest result: steps 1–4, 7, 8, 9 PASS; 5–6 deferred to P3 — **green, but
+green with a documented gap, not green-meaning-complete.**
+
+**Why `ADP` is its own participant and the validators aren't:** the adapter is the one
+component whose job is to *translate* (raw harness event → canonical payload), so it genuinely
+receives a call and returns a transformed value. The M-checks and most gauntlet steps are
+assertions over already-loaded data — which is why they read as self-arrows rather than
+collaborations. The diagram is showing you where the real inter-component contracts are versus
+where a single script is just doing its own bookkeeping.
+
+## Ships
+
+- `plugins/` with per-harness subdirectories
+- `git mv hooks/` → `plugins/claude-code/hooks/` *(byte-identical; zero behavior change)*
+- `plugins/_index.json` *(registry skeleton; validated against P0 `_index.schema.json`)*
+- `plugins/claude-code/manifest.json` *(gains the `invocation_modality` field, M4b)*
+- `install.mjs` updated to deploy from `plugins/<harness>/hooks/`
+- `scripts/validate-plugin-registry.mjs` *(M1–M10 + M7a–M7f assertion checklist)*
+- `scripts/test-plugin.mjs` *(the 9-step gauntlet)* + golden plugin/event fixtures
+- `tests/test-plugin-harness-binding.mjs` *(F31/F36 — 3 acceptance tests)*
+
+## The two new scripts (the real work)
+
+### `validate-plugin-registry.mjs` — static conformance
+
+Walks every `_index.json` entry + `manifest.json` and asserts:
+
+| Assertion | Check |
+|---|---|
+| **M1 / M2** | every `_index.json` and `manifest.json` validates against its P0 `*.schema.json` (`additionalProperties:false` everywhere) |
+| **M6** | `manifest.taxonomy_version` byte-equals the live `sha256(sortedLabels)` hash → else "built against stale taxonomy" |
+| **M7** | vocabulary closure — `emits_labels ⊆ taxonomy.labels`, no dangling references |
+| **M7a** | runbook §1–§10 headers all present (each checked individually); COMMON rows byte-match `scripts/scaffold-plugin/templates/common-rows.md` |
+| **M7b** | path-authority containment — every manifest-referenced path `realpath`-contained under `plugins/<harness>/` (the symlink-escape class) |
+| **M7c** | §7 resolution-matrix re-derived from `manifest.capabilities` + `taxonomy.json` + R3 ternary, byte-diffed against the embedded tables |
+| **M7d** | §8 modality line byte-equals `manifest.invocation_modality` |
+| **M7e** | §9 agent-manifest sentinel + JSON parse + validate against `runbook-agent-manifest.schema.json` + cross-field consistency (credentials-iff-api, redaction regex compile, env-var name regex, posix-path forward-slash, `log_paths` presence-for-api) |
+| **M7f** | §10 config/taxonomy cross-binding — every value byte-equals its derived source-of-truth |
+| **bidirectional** | every `plugins/<harness>/` dir has a registry entry; every entry has a dir |
+
+### `test-plugin.mjs` — the 9-step gauntlet
+
+The universal "does this plugin conform" oracle. **In P1, steps 5/6 are stubbed** — they
+round-trip through `enforce-contract.mjs`, which does not exist until P3. What runs in P1:
+
+| Step | Runs in P1? | Checks |
+|------|:-----------:|--------|
+| 1–4 | ✅ | schema validation, runbook present + sentinel + COMMON-row byte-equality |
+| 5–6 | ⏸ P3 | thin-waist round-trip + F3 hard-reject simulator |
+| 7 | ✅ | author-time conformance |
+| 8 | ✅ | **synthetic event replay (F39)** — feed each `tests/fixtures/harness-events/claude-code/*` through the adapter; assert canonical payload validates against `schemas/events/*`, field bindings produced expected values, tier-vs-outcome matches `manifest.capabilities` |
+| 9 | ✅ | **runbook-derived invocation parity (F47)** — read `command_shapes` + `dispatch_examples` from runbook §9, dispatch each, assert output shape + return code |
+
+**Project-root binding (F31/F36).** `--project <root>` is **required** (or `git rev-parse
+--show-toplevel` discovery, failing clearly on non-git cwd). Every spawned subprocess gets
+`cwd: projectRoot` + `EPISODIC_MEMORY_PROJECT_ROOT=<projectRoot>`. **`--project` wins** over
+an inherited `EPISODIC_MEMORY_PROJECT_ROOT`. Structured-alert episodes land under
+`store_root/.episodic-memory/` where `store_root = resolveRepoRoot(projectRoot)`. The 3
+acceptance tests in `tests/test-plugin-harness-binding.mjs`: inherited-env override; non-git
+cwd discovery failure; on-disk artifact location.
+
+## Hazards — where "byte-identical git mv" quietly isn't
+
+These are verified against the current on-disk `hooks/` tree.
+
+### Symlink depth breaks
+
+`hooks/lib/` contains two **relative** symlinks:
+
+```
+hooks/lib/local-dir.mjs          -> ../../scripts/lib/local-dir.mjs
+hooks/lib/registry-validator.mjs -> ../../scripts/second-opinion/lib/registry-validator.mjs
+```
+
+From `hooks/lib/`, `../../` is the repo root. From `plugins/claude-code/hooks/lib/`, `../../`
+is `plugins/` — so both targets resolve to nonexistent paths after the move. `git mv`
+preserves the link text verbatim, so the links must be **re-pointed** to
+`../../../../scripts/...`. This is the single most likely thing to silently break the hooks,
+and it also interacts with the symlink-rejection logic shipped in #363/#364 — re-pointed
+links must still pass the marker substrate's `[ ! -L ]` / lstat predicates where relevant.
+
+### The `runbooks/` fork
+
+`hooks/runbooks/` holds the two **second-opinion** runbooks, not Claude-Code enforcement
+runbooks. RFC line 1257 routes them to `plugins/second-opinion/runbooks/`, **not**
+`plugins/claude-code/`. So the move splits:
+
+- `hooks/*.sh` + `hooks/lib/` + `hooks/*.mjs` → `plugins/claude-code/hooks/`
+- `hooks/runbooks/` → `plugins/second-opinion/runbooks/` *(the post-P1 follow-up; small)*
+
+### Ordinary repointing
+
+`install.mjs` deploy source; `.claude-plugin/plugin.json` hook paths; any repo-root-relative
+path references inside the scripts. Internal `$(dirname "$0")/lib/...` references survive the
+wholesale move; absolute or root-relative ones do not.
+
+## Done when ✓
+
+The `git mv` is byte-identical (existing hook behavior unchanged); `_index.json` + the
+claude-code `manifest.json` validate against the P0 schemas; author-time + schema gauntlet
+steps (1–4, 7, 8, 9) pass for claude-code. *(Steps 5/6 — the `enforce-contract.mjs`
+round-trip — are exercised once P3 lands.)*
+
+## Maps to
+
+R1, R6, R8. Principle anchors: P9, P11, Rule 14.

--- a/docs/rfcs/RFC-008/P2-bp-contracts.md
+++ b/docs/rfcs/RFC-008/P2-bp-contracts.md
@@ -1,0 +1,82 @@
+# P2 — BP contract instances + contract validators
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** queued (parallelizable with P1 — both depend only on P0).
+**Serves:** R2 (pluggable enforcement, episodic-memory dictates contract), R3, R4.
+**Depends on:** P0 (met).
+**Estimate:** ~35K.
+
+## What P2 is
+
+P2 ships the **contract DATA** (`bp-001.json` … `bp-012.json`) plus the validators that
+enforce the §Validation-contract assertion checklist against it. This is where the
+behavior-practice patterns become machine-readable contracts the thin waist (P3) reads.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph P0["P0 (merged)"]
+        META["patterns/schema.json<br/>(bp-XXX meta-schema)"]
+        TAX["patterns/taxonomy.json<br/>(taxonomy_version)"]
+        EVS["patterns/events.json<br/>(events_version)"]
+        CORP["shared negative corpus<br/>(issue #368)"]
+    end
+
+    subgraph P2NEW["P2 - new artifacts"]
+        BP["patterns/bp-001.json ... bp-012.json<br/>{ gates, stop, taxonomy_ref,<br/>taxonomy_version, events_version }"]
+        VBP["scripts/validate-bp-contract.mjs<br/>(assertions: gate-completeness, action-enum<br/>closure, overridability equality, vocab<br/>closure, stable-ID, version binding, 10-15)"]
+        VTS["scripts/validate-taxonomy-schema.mjs<br/>(meta-validation, F5)"]
+        VS["scripts/validate-schemas.mjs<br/>(official 2020-12 meta-schema, M2;<br/>re-validates P0 schemas)"]
+    end
+
+    META -. validates .-> BP
+    TAX -. taxonomy_version + emits_labels subset of labels .-> VBP
+    EVS -. events_version .-> VBP
+    BP --> VBP
+    META --> VTS
+    CORP -. shared fixture .-> VS
+    CORP -. shared fixture .-> VTS
+```
+
+## Ships
+
+- `patterns/bp-001.json` … `patterns/bp-012.json` — the contract DATA; each carries
+  `taxonomy_version` + `events_version` bindings.
+- `scripts/validate-bp-contract.mjs` — the full normative §Validation-contract assertion
+  checklist: gate-completeness, action-enum closure, overridability equality, vocabulary
+  closure, stable-ID integrity, version binding, events assertions 10–15.
+- `scripts/validate-taxonomy-schema.mjs` — meta-validation (F5).
+
+## Contract shape
+
+```json
+{
+  "gates": { "plan_approval": "...", "pre_checkpoint": "...", "post_checkpoint": "..." },
+  "stop": { "tier": "..." },
+  "taxonomy_ref": "patterns/taxonomy.json",
+  "taxonomy_version": "sha256:…",
+  "events_version": "sha256:…"
+}
+```
+
+Three per-pattern classification gates; `stop` is a **root-level marker-state gate** (not
+per-label, F2/F10).
+
+## Implementation note — shared negative corpus (issue #368)
+
+P2 lands the drift guard from P0's follow-up: the P0 linter
+(`tests/lib/mini-jsonschema.mjs`) and P2's `scripts/validate-schemas.mjs` (the official
+2020-12 meta-schema validator, M2) **share one negative corpus** as a common conformance
+fixture, so the two hand-rolled validators cannot drift (Rule 14). RFC line 1188.
+
+## Done when ✓
+
+Every `bp-XXX.json` validates against `patterns/schema.json` and passes
+`validate-bp-contract.mjs` against the locked P0 schemas + golden corpus.
+
+## Maps to
+
+R2, R3, R4. Principle anchors: P2, P11.

--- a/docs/rfcs/RFC-008/P3-thin-waist.md
+++ b/docs/rfcs/RFC-008/P3-thin-waist.md
@@ -1,0 +1,81 @@
+# P3 — Thin waist + classifier runtime-sourcing + em-recall purification
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** queued.
+**Serves:** R1, R2, R3, R4, R5, R9 (+ F38).
+**Depends on:** P0 (met), P2.
+**Estimate:** ~55K (the load-bearing phase).
+
+## What P3 is
+
+P3 is the **real decoupling**: it introduces `enforce-contract.mjs` (the thin waist that
+owns the block/allow/warn/inject decision), gives the enforcement layer its own marker-state
+reader, and — the negative-LOC payoff — **strips all gate logic out of `em-recall.mjs`**,
+restoring the substrate to pure recall. After P3, `em-recall.mjs` is never on the
+enforcement path.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph CONTRACT["Contract (P0 + P2)"]
+        BP["patterns/bp-XXX.json"]
+        TAX["patterns/taxonomy.json"]
+        EVS["patterns/events.json"]
+        IDX["plugins/_index.json"]
+    end
+
+    subgraph WAIST["P3 - enforcement thin waist (NEW)"]
+        EC["scripts/enforce-contract.mjs<br/>- validates contracts<br/>- effective_tier = min(harness, contract, config) (R3)<br/>- R9 impl-boundary (lazy-arm on first repo write)<br/>- classifier dispatch (R4/R5)<br/>- out-of-vocab -> HARD-REJECT + structured alert (F3)"]
+        MS["scripts/lib/marker-state.mjs<br/>(marker reads - owned by enforcement)"]
+        CC["command-classifier.sh<br/>(refactored: source 7 labels from<br/>taxonomy.json at runtime, OQ-2)"]
+    end
+
+    subgraph SUBSTRATE["Substrate - PURIFIED (F38/F60)"]
+        ER["em-recall.mjs<br/>DROP --gate flag + handler<br/>DROP stop-gate-helpers.mjs import<br/>DROP all marker reads<br/>DROP .checkpoints/ migration<br/>= pure recall"]
+        ES["em-store.mjs / em-search.mjs<br/>(zero gate-vocabulary tokens)"]
+    end
+
+    BP --> EC
+    TAX --> EC
+    TAX -. runtime label source .-> CC
+    EVS --> EC
+    IDX -->|plugin lookup R8| EC
+    EC --> MS
+    EC --> CC
+    EC -. structured alert via em-store .-> ES
+    EC -. NEVER calls .-> ER
+```
+
+## Ships
+
+- `scripts/enforce-contract.mjs` — the thin waist. Validates contracts; computes the ternary
+  `min()` effective tier (R3); R9 implementation-boundary detection (lazy-arm on first
+  repo-source write, silent during exploration/planning); classifier dispatch (R4/R5); reads
+  gate action from taxonomy + per-tier semantics from `events.json`; reads marker state via
+  `marker-state.mjs`. **Two invocation modes** — in-process import for STRONG harnesses + CLI
+  spawn for degrade. Out-of-vocab labels HARD-REJECTED with a structured alert via `em-store`
+  (F3).
+- `scripts/lib/marker-state.mjs` — marker reads, owned by the enforcement layer.
+- **Classifier runtime-sourcing** (legacy "Phase 4", folded here): refactor
+  `command-classifier.sh` to source the 7-label set from `taxonomy.json` at runtime (OQ-2
+  closed); plugin classifier-override interface; override registration in `_index.json`;
+  non-overridable labels enforced at scaffold + CI + runtime.
+- **em-recall purification — STRICT DELETION (F38, F60):** remove from `em-recall.mjs` the
+  `--gate` flag + handler, the `stop-gate-helpers.mjs` import, all marker reads, and the
+  `.checkpoints/` migration code. *Net diff is negative LOC.*
+- `install.mjs` deploys `lib/marker-state.mjs` + verifies em-recall is v11-purified (F45);
+  `tests/test-install-em-recall-purified.mjs`.
+
+## Done when ✓
+
+`enforce-contract.mjs` passes contract validation + the **full 9-step gauntlet** against the
+P1 plugins (this is where gauntlet steps 5/6 finally run); `em-recall.mjs` (and
+`em-store.mjs` / `em-search.mjs`) contain **zero gate-vocabulary tokens** (F60 CI grep guard
+green); the install-purification sentinel test passes.
+
+## Maps to
+
+R1, R2, R3, R4, R5, R9. Principle anchors: P4, P6.

--- a/docs/rfcs/RFC-008/P4-enforce-config.md
+++ b/docs/rfcs/RFC-008/P4-enforce-config.md
@@ -1,0 +1,44 @@
+# P4 — Per-project `enforce-config.json`
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** queued. *(Legacy "Phase 5".)*
+**Serves:** R3, R5.
+**Depends on:** P3.
+**Estimate:** ~25K.
+
+## What P4 is
+
+P4 adds the **per-project tuning surface**: a single `enforce-config.json` that clamps
+effective enforcement tier DOWN per project and can switch the classifier off entirely
+(R5 — no hook spawn, no token cost when inactive).
+
+## Architecture
+
+```mermaid
+graph LR
+    HARN["harness_capability<br/>(plugin manifest)"]
+    CONTRACT["contract_tier<br/>(bp-XXX.json)"]
+    CFG["enforce-config.json<br/>{ 'bp-001': { 'plan_approval': 'MEDIUM', ... },<br/>'active': true|false }"]
+
+    HARN --> MIN
+    CONTRACT --> MIN
+    CFG --> MIN["effective_tier =<br/>min(harness, contract, project_config)<br/>(clamps DOWN only - never raises)"]
+    CFG -. active:false .-> SILENT["classifier silent<br/>(no hook spawn, R5)"]
+    MIN --> ACTION["resolved gate action"]
+```
+
+## Ships
+
+`enforce-config.json` per project — `{ "bp-001": { "plan_approval": "MEDIUM", ... },
+"active": true/false }`.
+
+## Done when ✓
+
+The ternary `min()` clamps effective tier **DOWN only** (never raises); `active: false` for
+all plugins makes the classifier silent (R5 — no hook spawn, no token cost).
+
+## Maps to
+
+R3, R5. Principle anchor: the project-config leg of the R3 effective-tier formula.

--- a/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
+++ b/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
@@ -1,0 +1,61 @@
+# P5–P7 — Per-tool plugins (OpenCode · Codex · Pi Agent)
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** queued. *(Legacy "Phase 6 / 7 / 8".)*
+**Serves:** R6 (plugin-to-harness binding), R10 (enforcement runbooks).
+**Depends on:** P3.
+**Estimate:** P5 ~45K · P6 ~40K · P7 ~35K.
+
+> These three phases are grouped here because they are the **same template instantiated
+> three times** — each is a plugin directory built from the P1 scaffold + gauntlet at its
+> own declared capability tiers. If a phase grows enough bespoke detail to warrant its own
+> file, split it out then.
+
+## What P5–P7 are
+
+Each phase ships one harness plugin: `manifest.json` +
+`capabilities/enforcement.{mjs,ts,py}` adapter + `runbooks/enforcement.md` (the 10 required
+sections, R10) + harness-event fixtures. The universal `test-plugin.mjs` gauntlet (P1) is
+the quality bar — no bespoke per-plugin test scripts.
+
+## Architecture (shared shape)
+
+```mermaid
+graph TB
+    subgraph PLUGIN["plugins/[harness]/ (one per phase)"]
+        MAN["manifest.json<br/>(invocation_modality, capabilities tiers,<br/>taxonomy_version, emits_labels)"]
+        ADP["capabilities/enforcement.{ts,py,mjs}<br/>(adapter: raw harness event to canonical payload)"]
+        RB["runbooks/enforcement.md<br/>(S1-S10, COMMON + harness-specific + auto-gen)"]
+        FX["harness-event fixtures"]
+    end
+
+    EC["enforce-contract.mjs (P3 thin waist)"]
+    IDX["plugins/_index.json (registry)"]
+    TP["test-plugin.mjs (9-step gauntlet)"]
+
+    ADP -->|canonical payload| EC
+    MAN -->|register| IDX
+    TP -. validates all 9 steps .-> PLUGIN
+```
+
+## Ships (per phase)
+
+| Phase | Dir | Language | Declared capabilities |
+|-------|-----|----------|-----------------------|
+| **P5** | `plugins/opencode/` | TypeScript | `pre_tool_use: STRONG, tool_result: STRONG, session_start: MEDIUM, stop: MEDIUM` |
+| **P6** | `plugins/codex/` | Python hooks | `pre_tool_use: MEDIUM` *(multi-edit bypass documented)*, `stop: STRONG, session_start: STRONG` |
+| **P7** | `plugins/pi-agent/` | `tool_call` + `session_shutdown`/`turn_end` | `pre_tool_use: STRONG, stop: MEDIUM, session_start: STRONG` |
+
+**Honesty note (P5 principle):** Codex `pre_tool_use` is declared **MEDIUM**, not STRONG —
+its PreToolUse has a known multi-edit bypass. Push-gate + stop-gate are the hard enforcement
+for Codex.
+
+## Done when ✓
+
+Each plugin passes the `test-plugin.mjs` 9-step gauntlet at its declared tiers.
+
+## Maps to
+
+R6, R10. Principle anchors: P9, P11 (binding); P4 (runbooks).

--- a/docs/rfcs/RFC-008/P8-cursor-windsurf.md
+++ b/docs/rfcs/RFC-008/P8-cursor-windsurf.md
@@ -1,0 +1,78 @@
+# P8 — Cursor (full adapter) + Windsurf (static-rules) plugins
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** queued. *(Added per F43 / OQ-3 closure, v11.1.)*
+**Serves:** R6, R10.
+**Depends on:** P3.
+**Estimate:** ~45K.
+
+## What P8 is
+
+P8 adds the two harnesses that don't fit the P5–P7 mold: **Cursor** is STRONG-capable (a
+full adapter, *not* WEAK — the v8–v11 matrix had this wrong; corrected from official-doc
+research), and **Windsurf** is WEAK static-rules only — no runtime adapter, just an
+install-time rules artifact. Windsurf is the reason gauntlet steps 8/9 carry a
+`static-rules` carve-out.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph CURSOR["plugins/cursor/ - full adapter (STRONG)"]
+        CMAN["manifest.json<br/>pre_tool_use:STRONG, tool_result:MEDIUM,<br/>stop:MEDIUM, session_start:STRONG, session_end:STRONG"]
+        CADP["capabilities/enforcement adapter"]
+        CRB["runbooks/enforcement.md (S1-S10)"]
+    end
+
+    subgraph WIND["plugins/windsurf/ - static-rules (WEAK)"]
+        WMAN["manifest.json<br/>invocation_modality: static-rules<br/>session_start: WEAK only"]
+        WRULES[".windsurf/rules/episodic-memory-enforcement.md<br/>(install-time deploy - NO runtime adapter)"]
+        WRB["runbooks/enforcement.md (S1-S10)"]
+    end
+
+    EC["enforce-contract.mjs"]
+    TP["test-plugin.mjs gauntlet"]
+
+    CADP -->|canonical payload| EC
+    TP -->|steps 8/9: adapter dispatch| CURSOR
+    TP -->|steps 8/9: static-rules carve-out<br/>validate deploy artifact, not dispatch| WIND
+```
+
+## Ships
+
+- **`plugins/cursor/`** — full adapter (Cursor is STRONG-capable; see
+  §Capability-degradable enforcement): `pre_tool_use: STRONG, tool_result: MEDIUM,
+  stop: MEDIUM, session_start: STRONG, session_end: STRONG`.
+- **`plugins/windsurf/`** — static-rules (WEAK): installer +
+  `.windsurf/rules/episodic-memory-enforcement.md` + `runbooks/enforcement.md` + manifest
+  declaring `session_start: WEAK` only; **NO runtime adapter**.
+
+## Static-rules carve-out (F56)
+
+For `invocation_modality == "static-rules"` there is no adapter to dispatch through, so the
+gauntlet branches on modality rather than failing the plugin:
+
+- **Step 8** asserts the declared `event_translations[<event>].source_format` is a recognized
+  static-deploy descriptor (e.g. `"windsurf-rules-deploy"`) with empty `field_bindings`, and
+  that the §10a `install_time_config` artifact is generated/placed as declared.
+- **Step 9** asserts install-time rule-file generation lands at the declared path —
+  `dispatch_examples` are deploy assertions, not adapter round-trips.
+
+## Capability research provenance (F59)
+
+Cursor + Windsurf capability matrices are backed by committed research at
+`memory/knowledge_base/cursor-hooks.md` and `memory/knowledge_base/windsurf-rules.md`
+(`fetched: 2026-05-28` + source URLs). `em-rfc-validate.mjs` asserts every cited
+knowledge_base file exists on disk. Re-validate the live matrices against vendor docs before
+implementation lands.
+
+## Done when ✓
+
+Cursor passes the full gauntlet; Windsurf passes the static-rules gauntlet carve-out
+(steps 8/9 validate the deploy artifact, not adapter dispatch — F56).
+
+## Maps to
+
+R6, R10.

--- a/docs/rfcs/RFC-008/P9-recall-strategies.md
+++ b/docs/rfcs/RFC-008/P9-recall-strategies.md
@@ -1,0 +1,51 @@
+# P9 — Pluggable recall strategies
+
+> Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
+> [RFC-008/README.md](README.md).
+
+**Status:** **DEFERRED — carved to its own RFC.** Not implemented under RFC-008.
+**Serves:** R7.
+**Depends on:** — (no deps within this RFC).
+**Estimate:** ~50K (when carved out).
+
+## What P9 is — and why it's deferred
+
+P9 is the only **feature** phase (everything else is the substrate↔enforcement
+re-architecture). It would make `em-recall`'s ranking strategy pluggable: lexical (default,
+zero-dep), semantic (opt-in, `requiresEmbeddings: true`), graph (zero-dep), and a hybrid RRF
+combiner.
+
+It is **deferred to its own RFC** because:
+
+- Recall strategies are **substrate-side, not enforcement** — out of this RFC's scope.
+- The semantic strategy's **embedding dependency conflicts with the zero-dep principle**, a
+  trade-off that must be decided deliberately rather than smuggled into a re-architecture PR.
+
+## Architecture (sketch — for the future RFC)
+
+```mermaid
+graph LR
+    Q["em-recall query"] --> REG["em-recall/strategies/_index.json<br/>(strategy registry)"]
+    REG --> LEX["lexical (default, zero-dep)"]
+    REG --> SEM["semantic (requiresEmbeddings: true)"]
+    REG --> GRAPH["graph (zero-dep)"]
+    LEX --> RRF["hybrid RRF combiner"]
+    SEM --> RRF
+    GRAPH --> RRF
+    RRF --> RESULT["ranked episodes"]
+```
+
+## Would ship (when carved out)
+
+`em-recall/strategies/` (lexical default zero-dep; semantic opt-in `requiresEmbeddings:
+true`; graph zero-dep; hybrid RRF) + `em-recall/strategies/_index.json`.
+
+## Destination
+
+Semantic embeddings fold into **RFC-001 — Intelligent Memory** (`accepted`); graph traversal
+folds into **RFC-007 — Graph Projection** (`draft`). See the RFC
+[Related RFCs](../RFC-008-decouple-enforcement-from-substrate.md#related-rfcs) section.
+
+## Maps to
+
+R7. Principle anchors: P6, P1.

--- a/docs/rfcs/RFC-008/README.md
+++ b/docs/rfcs/RFC-008/README.md
@@ -1,0 +1,44 @@
+# RFC-008 — per-phase architecture + implementation plans
+
+This directory holds the **per-phase detail** for [RFC-008 — Decoupling the Enforcement
+Layer from the Memory Substrate](../RFC-008-decouple-enforcement-from-substrate.md). The
+RFC body keeps the at-a-glance summary table, the Phase-to-P crosswalk, the requirement
+traceability matrix, and the live implementation ledger. Each phase's **architecture
+diagram, file manifest, build steps, hazards, and done-when boundary** live here, one file
+per phase, so the RFC body stays navigable.
+
+Every design element still maps to a requirement (R1–R12); no element exists without a
+requirement parent. Each phase file carries its own R-anchors and back-links to the RFC.
+
+## Phases
+
+| Phase | File | Serves | Depends on | Status |
+|-------|------|--------|-----------|--------|
+| **P0** | [P0-schema-contracts.md](P0-schema-contracts.md) | R3, R4 | — | **DONE** — PR #367 (`d078fdc`) |
+| **P1** | [P1-plugin-registry.md](P1-plugin-registry.md) | R1, R6, R8 | P0 | **NEXT** |
+| **P2** | [P2-bp-contracts.md](P2-bp-contracts.md) | R2, R3, R4 | P0 | queued |
+| **P3** | [P3-thin-waist.md](P3-thin-waist.md) | R1, R2, R3, R4, R5, R9 | P0, P2 | queued |
+| **P4** | [P4-enforce-config.md](P4-enforce-config.md) | R3, R5 | P3 | queued |
+| **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | queued |
+| **P8** | [P8-cursor-windsurf.md](P8-cursor-windsurf.md) | R6, R10 | P3 | queued |
+| **P9** | [P9-recall-strategies.md](P9-recall-strategies.md) | R7 | — | **DEFERRED** — own RFC |
+
+## Non-phase items
+
+- **Bug fix (any time):** `plan-gate.sh:108–115` ordering — F14 early-exit blocks the
+  `marker_write` escape hatch (deadlock class 2, R4). See the RFC
+  [Deadlock analysis](../RFC-008-decouple-enforcement-from-substrate.md#deadlock-analysis-maps-to-taxonomy-r3-r4-r9).
+- **Follow-up (post-P1):** migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/`
+  (R10). Tracked in [P1-plugin-registry.md](P1-plugin-registry.md#the-runbooks-fork).
+
+## Build order
+
+```
+P0 ─┬─> P2 ─> P3 ─┬─> P4
+P1 ─┘             ├─> P5 / P6 / P7
+                  └─> P8
+P9 — carved to its own RFC (no deps in this RFC)
+```
+
+Canonical ordering is **P0 → P9**. The older "Phase 1–9" prose labels are retired; the
+crosswalk in the RFC body maps legacy labels to P-numbers.


### PR DESCRIPTION
## Summary

Two coherent strands of RFC-008 documentation. **No runtime code.**

### Capability model
- **`CAPABILITIES.md`** — new guiding-post charter naming the three **substrate** capability families: memory-store strategy, recall strategy, learning strategy — plus the forward rule for adding new ones as plugin types. Enforcement is explicitly **not** a substrate capability (it is behavior patterns' job, a decoupled layer).
- **RFC-008 R8** — *typed-registry clause* (a `type` discriminator over `{enforcement, recall-strategy, store-strategy, learning}`, each with its own registry sub-schema + validator + conformance gauntlet; two-layer split) and *versioned-contract clause* (required `schema_version` mapped to schema and validator, range with fail-closed-forward, `CURRENT_SCHEMA_VERSION` drift-guard).
- **RFC-008 R2** clarified — `enforcement` is the sole enforcement-layer type, bound to `bp-XXX`.
- **R11** (pluggable memory-store strategies) + **R12** (pluggable learning) added; `R1-R10` to `R1-R12`; traceability matrix + `T31` changelog entry.
- `PRINCIPLES.md` P1, `CLAUDE.md` project structure, and `README.md` re-architecture notice all point to the charter.

### Per-phase split
- `docs/rfcs/RFC-008/` — README + per-phase files (P0-P9), each with a Mermaid architecture diagram; **P1** gains a conformance **sequence diagram** + detailed "how to read" narratives. RFC body TOC links to the phase files.

## Scope / safety
- **Docs/spec only.** The substrate (`em-store` / `em-recall` / `em-search`), CLI, and hooks are unchanged.
- Schema/validator/test **implementation** of the new `type` + `schema_version` fields is the future **P0** (schema revision) + **P1** (validator dispatch) work these requirements now gate.

## Validation
- `node scripts/em-rfc-validate.mjs` -> RFC registry consistent (8/8/8).
- P1 Mermaid sequence diagram validated `valid: true`; phase diagrams pure-ASCII `graph` syntax.
- `R1-R12` heading / TOC / boilerplate / matrix consistency swept; no stray R11/R12 references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
