### PR TITLE
fix(checkpoint-gate): keep POST pair sticky across a delivery + carve out .git/

### DIFF
--- a/hooks/checkpoint-gate.sh
+++ b/hooks/checkpoint-gate.sh
@@ -758,6 +758,21 @@ _arm_checkpoint_required_if_missing() {
   # arm — never consume the approval AND leave the implementation ungated.
   if checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID"; then
     _consume_plan_approved "$MY_SID"
+    # Fix (B) — a NEW planned task just armed a fresh .checkpoint-required:
+    # invalidate any prior delivery's satisfied .post-checkpoint-done so this
+    # task requires its OWN E2E before push. The push sweep no longer clears the
+    # POST pair (see the convergence-sweep comment), so without this a new task
+    # would ride the previous task's post-checkpoint. Placed INSIDE this
+    # arm-success block (alongside the transactional _consume_plan_approved) so a
+    # FAILED arm does NOT wipe POST_DONE (fail-closed). Clear ALL FOUR locations
+    # checkpoint_marker_nonempty_for_session inspects (PRIMARY+LEGACY x
+    # legacy-literal + <sid>-suffixed) — a stale literal POST_DONE would
+    # otherwise let the new task push without a fresh post-checkpoint. Fires once
+    # per task (line 728 early-returns once .checkpoint-required exists).
+    local _pcd_sfx
+    _pcd_sfx="$(namespaced_marker_basename_for_session .post-checkpoint-done "$MY_SID")"
+    rm -f "$PRIMARY_DIR/$_pcd_sfx" "$LEGACY_DIR/$_pcd_sfx" 2>/dev/null || true
+    rm -f "$PRIMARY_DIR/.post-checkpoint-done" "$LEGACY_DIR/.post-checkpoint-done" 2>/dev/null || true
   fi
 }
 
@@ -956,6 +971,22 @@ _tool_call_targets_repo_source() {
   #      its own substrate even if a user edits .gitignore).
   case "$fp_canon" in
     "$repo_canon"/.checkpoints|"$repo_canon"/.checkpoints/*) return 1 ;;
+  esac
+  #
+  #  (1b') .git/ carve-out — git internals (commit-message scratch, PR-body files,
+  #      rebase/merge todo lists, hooks, refs, index) are never tracked repo
+  #      source. git check-ignore does NOT flag .git/ (it is structurally excluded
+  #      from the worktree, not via .gitignore — verified: `git check-ignore
+  #      .git/<f>` exits 1), so without this an Edit/Write under .git/ returns 0
+  #      (repo source) and would arm the pre-checkpoint AND let EDIT 3 clear a
+  #      satisfied post-checkpoint on a NON-source write. Live E2E (this PR) hit
+  #      exactly that: writing the PR body to .git/ cleared POST_DONE between the
+  #      push and gh pr create. Canonical-anchored; a hard infra invariant
+  #      independent of .gitignore (git never tracks its own dir). No bypass:
+  #      .git/ content is not the worktree, so this cannot smuggle tracked source
+  #      past the gate, and the push-gate still independently blocks pushes.
+  case "$fp_canon" in
+    "$repo_canon"/.git|"$repo_canon"/.git/*) return 1 ;;
   esac
   #
   #  (1c) .gitignore carve-out — a gitignored target is by definition NOT tracked
@@ -1598,10 +1629,38 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   # no plan-pending. Other sessions' suffixed markers do not block cleanup.
   if ! plan_pending_blocks_this_session "$MY_SID"; then
     # Rank-2: sweep BOTH legacy literal AND ALL suffixed forms `<X>.<*>` at
-    # both roots. push is the convergence moment — all sessions' progress
-    # rolls up. Cross-session orphans from crashed sessions also get
+    # both roots. push is the convergence moment for the PRE pair
+    # (.checkpoint-required, .pre-checkpoint-done) — a new task re-arms a fresh
+    # pre-checkpoint. Cross-session PRE orphans from crashed sessions also get
     # cleared here.
+    #
+    # The POST pair (.post-checkpoint-required, .post-checkpoint-done) is
+    # DELIBERATELY NOT swept here. A single logical delivery is a SEQUENCE of
+    # push-class actions (git push -> gh pr create -> gh pr review); the prior
+    # blanket sweep wiped THIS session's satisfied .post-checkpoint-done on the
+    # FIRST push, so the 2nd/3rd action self-armed POST_REQ (:1540) and
+    # re-blocked (:1578), demanding a redundant post-checkpoint for the SAME
+    # delivery. POST markers are now own-session-sticky across a delivery:
+    #   - reaped by SessionEnd for clean sessions (em-session-end-prompt.mjs
+    #     CHECKPOINT_QUARTET branch);
+    #   - dominated by SessionStart's force-monotonic baseline
+    #     (em-recall.mjs:875) so crashed-session orphans never deadlock a future
+    #     session's Stop-gate carve-out;
+    #   - invalidated for a NEW task by _arm_checkpoint_required_if_missing
+    #     (re-arm clears POST_DONE) and by the post-write tail (new repo-source
+    #     work after a satisfied post clears POST_DONE).
+    # Keeping .checkpoint-required IN the sweep is load-bearing: it is what makes
+    # a sticky POST_REQ unreachable by the Stop-gate block predicate
+    # (em-recall.mjs:355 keys on .checkpoint-required + empty .post-checkpoint-done).
+    # Crashed-session POST orphans fall under the existing operator-cleanup FU
+    # (em-recall.mjs:726); they are correctness-inert (all consumers own-session).
     for _m in "${CHECKPOINT_CLEANUP_MARKERS[@]}"; do
+      case "$_m" in
+        .post-checkpoint-required|.post-checkpoint-done)
+          # Own-session-sticky across a delivery — see the block comment above.
+          continue
+          ;;
+      esac
       # Legacy literal at both roots.
       rm -f "$PRIMARY_DIR/$_m" "$LEGACY_DIR/$_m" 2>/dev/null || true
       # Suffixed forms `<X>.<*>` at both roots.
@@ -1650,6 +1709,53 @@ case "$TOOL_NAME" in
         # still works for old hooks). Symlink-safe (#364).
         _arm_marker_via_touch_safely "$(write_marker_path "$REPO_ROOT" .post-checkpoint-required)"
       fi
+    fi
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Per-delivery E2E backstop (EDIT 3). New repo-source work AFTER a satisfied
+# post-checkpoint invalidates the prior E2E confirmation for THIS delivery, so
+# the next push requires a fresh post-checkpoint. The push sweep no longer
+# clears the POST pair (sticky across one delivery's push-class actions), and
+# the re-arm clear (fix B) only fires at a NEW plan-approval boundary — so
+# without this, more source edits under the SAME approved plan would push with a
+# stale satisfied POST_DONE and no fresh E2E.
+#
+# Scope (deliberate): Edit/Write/MultiEdit/NotebookEdit to REPO SOURCE only, as
+# decided by _tool_call_targets_repo_source (the same authority the pre-gate
+# uses) — off-repo (memory/settings), .review-store/, .checkpoints/, gitignored,
+# and nonsrc paths return 1 and never clear. Bash is EXCLUDED so git commit /
+# git push plumbing can never falsely clear POST_DONE and reintroduce the
+# redundant-post-checkpoint friction this change exists to remove. Excluding
+# Bash leaves no hole: a repo-source Bash write under an armed .checkpoint-required
+# is already pre-gate-blocked (_bash_label_arms_pre_checkpoint), and off-task
+# untracked Bash with no plan pending is the documented F1 residual (see the F1
+# RESIDUAL note above _bash_label_arms_pre_checkpoint), closed on retry by the
+# PR-B2 agent-classifier nonsrc_write verdict (#351). A .post-checkpoint-done
+# marker write already exited at :1241/:1379, so writing the post-checkpoint
+# itself never reaches here and cannot self-clear. 4-path clear matches
+# checkpoint_marker_nonempty_for_session's full read set.
+#
+# Own-session-scoped: the checkpoint_marker_*_for_session predicates inspect only
+# THIS session's markers, so a crashed session's orphaned POST_REQ/POST_DONE is
+# never touched here. Such orphans are correctness-inert — unreachable by the
+# Stop-gate block (em-recall.mjs:355 requires .checkpoint-required present) and
+# dominated by the SessionStart force-monotonic baseline (em-recall.mjs:875).
+# FILE_PATH and LABEL are guaranteed initialized for these tool types by the
+# allowed-write arming case block above. An empty FILE_PATH — which these tools
+# never emit in practice — makes _tool_call_targets_repo_source return 0 via its
+# conservative empty-path branch, so EDIT 3 proceeds only when the POST markers
+# are also present; that errs toward MORE E2E gating, never less.
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit|NotebookEdit)
+    if _tool_call_targets_repo_source "$REPO_ROOT" "$TOOL_NAME" "$FILE_PATH" "$LABEL" \
+       && checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
+       && checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
+      _pcd_sfx2="$(namespaced_marker_basename_for_session .post-checkpoint-done "$MY_SID")"
+      rm -f "$PRIMARY_DIR/$_pcd_sfx2" "$LEGACY_DIR/$_pcd_sfx2" 2>/dev/null || true
+      rm -f "$PRIMARY_DIR/.post-checkpoint-done" "$LEGACY_DIR/.post-checkpoint-done" 2>/dev/null || true
+      unset _pcd_sfx2
     fi
     ;;
 esac

--- a/hooks/lib/marker-paths.sh
+++ b/hooks/lib/marker-paths.sh
@@ -71,13 +71,22 @@ TASK_SIGNAL_MARKERS=(
   ".plan-approval-pending"
 )
 
-# Push-gate cleanup class — markers cleared on a successful push that has
-# satisfied the post-checkpoint. The push sweep glob-deletes ALL sessions'
-# suffixed forms — convergence semantics for the quartet. .plan-approval-pending
-# is NOT here (plan-gate owns it). .plan-approved is NOT here either (review F1):
-# it is the per-session authorization-to-arm token, so cross-session glob-
-# deletion would skip a concurrent session's pre-checkpoint. It is consumed at
-# arm in the normal flow; own-session orphans are cleaned at SessionEnd.
+# Push-gate cleanup class — the markers the push sweep considers at the
+# convergence (task-complete) moment. IMPORTANT: only the PRE pair
+# (.checkpoint-required, .pre-checkpoint-done) is actually glob-deleted on a
+# successful push. The checkpoint-gate sweep DELIBERATELY skips the POST pair
+# (.post-checkpoint-required, .post-checkpoint-done) via a per-marker `continue`
+# so a single delivery's sequence of push-class actions (git push -> gh pr
+# create -> gh pr review) does not re-demand a fresh post-checkpoint each time.
+# The POST pair is own-session-sticky across a delivery: reaped by SessionEnd
+# and dominated by the SessionStart force-monotonic baseline; crashed-session
+# POST orphans fall under the operator-cleanup FU. See the convergence-sweep
+# comment in hooks/checkpoint-gate.sh. The array still lists all four (it is the
+# full cleanup CLASS; the per-marker skip lives at the sweep site).
+# .plan-approval-pending is NOT here (plan-gate owns it). .plan-approved is NOT
+# here either (review F1): it is the per-session authorization-to-arm token, so
+# cross-session glob-deletion would skip a concurrent session's pre-checkpoint.
+# It is consumed at arm in the normal flow; own-session orphans cleaned at SessionEnd.
 CHECKPOINT_CLEANUP_MARKERS=(
   ".checkpoint-required"
   ".pre-checkpoint-done"

--- a/tests/test-checkpoint-gate.sh
+++ b/tests/test-checkpoint-gate.sh
@@ -335,7 +335,7 @@ assert_allowed "32. Bash writing post-checkpoint-done allowed under push-gate" \
 
 # ============================================================================
 echo ""
-echo "--- Push allowed cleans all 4 markers ---"
+echo "--- Push allowed sweeps PRE pair, keeps POST pair sticky (delivery) ---"
 # ============================================================================
 reset_state
 touch "$PRE_REQ"
@@ -347,18 +347,23 @@ assert_allowed "33. git push allowed when post-done non-empty" \
   "$(mock_json 'Bash' 'git push origin main')"
 assert_marker_absent "34. checkpoint-required cleaned after push" "$PRE_REQ"
 assert_marker_absent "35. pre-checkpoint-done cleaned after push" "$PRE_DONE"
-assert_marker_absent "36. post-checkpoint-required cleaned after push" "$POST_REQ"
-assert_marker_absent "37. post-checkpoint-done cleaned after push" "$POST_DONE"
+# Post pair is now own-session-sticky across a delivery's push-class actions
+# (git push -> gh pr create -> gh pr review). The prior blanket sweep wiped the
+# satisfied post-checkpoint on the first push, forcing a redundant
+# post-checkpoint for the 2nd/3rd action of the SAME delivery.
+assert_marker_exists "36. post-checkpoint-required KEPT after push (sticky)" "$POST_REQ"
+assert_marker_exists "37. post-checkpoint-done KEPT after push (sticky)" "$POST_DONE"
 
-# gh pr create also cleans
+# gh pr create also keeps the POST pair (same delivery) while sweeping PRE.
 reset_state
 touch "$PRE_REQ"
 echo "pre" > "$PRE_DONE"
 touch "$POST_REQ"
 echo "post" > "$POST_DONE"
-assert_allowed "38. gh pr create allowed cleans all markers" \
+assert_allowed "38. gh pr create allowed (PRE swept, POST sticky)" \
   "$(mock_json 'Bash' 'gh pr create --title x --body y')"
-assert_marker_absent "39. all markers cleaned after gh pr create" "$POST_REQ"
+assert_marker_absent "38b. gh pr create swept .checkpoint-required (PRE)" "$PRE_REQ"
+assert_marker_exists "39. post-checkpoint-required KEPT after gh pr create (sticky)" "$POST_REQ"
 
 # ============================================================================
 echo ""
@@ -2044,12 +2049,14 @@ reset_state
 assert_blocked "B1-1. push self-arms + blocks (no prior checkpoint)" \
   "$(mock_json 'Bash' 'git push origin main')" "Post-implementation checkpoint required"
 assert_marker_exists "B1-2. push self-armed .post-checkpoint-required" "$POST_REQ"
-# Write the post-checkpoint, then the push is allowed + sweeps markers.
+# Write the post-checkpoint, then the push is allowed. The POST pair is now
+# own-session-sticky (kept across a delivery's push-class actions), so it is NOT
+# swept here — a follow-on gh pr create / pr review reuses it without re-block.
 echo "e2e done" > "$POST_DONE"
 assert_allowed "B1-3. push allowed after post-checkpoint written" \
   "$(mock_json 'Bash' 'git push origin main')"
-assert_marker_absent "B1-4. allowed push swept .post-checkpoint-required" "$POST_REQ"
-assert_marker_absent "B1-5. allowed push swept .post-checkpoint-done" "$POST_DONE"
+assert_marker_exists "B1-4. allowed push KEPT .post-checkpoint-required (sticky)" "$POST_REQ"
+assert_marker_exists "B1-5. allowed push KEPT .post-checkpoint-done (sticky)" "$POST_DONE"
 
 # ============================================================================
 echo ""
@@ -2263,8 +2270,9 @@ assert_marker_exists "DL-8. consume did NOT clobber prefix-collision sibling .pl
 # token must SURVIVE another session's push sweep. `.plan-approved` is
 # deliberately excluded from CHECKPOINT_CLEANUP_MARKERS so the push glob
 # (`<marker>.*`, all sessions) does NOT delete it — otherwise session B would
-# silently skip its pre-checkpoint after session A pushes. The quartet IS still
-# swept (convergence semantics preserved).
+# silently skip its pre-checkpoint after session A pushes. The PRE pair is still
+# swept on push; the POST pair is now own-session-sticky and intentionally KEPT
+# (see DL-10 + the "Push allowed sweeps PRE pair, keeps POST pair sticky" block).
 reset_state
 DL_SID_B="eeeeeeee-5555-4555-8555-eeeeeeeeeeee"
 : > "$MARKER_DIR/.plan-approved.$DL_SID_B"     # session B's live approval token (pre-arm)
@@ -2273,7 +2281,7 @@ echo "e2e done" > "$POST_DONE"                  # and satisfied → push is allo
 echo "$(mock_json 'Bash' 'git push origin main')" | run_hook >/dev/null 2>&1   # allowed push → cleanup sweep
 assert_marker_exists "DL-9. concurrent session's .plan-approved token SURVIVED another session's push sweep (F1)" \
   "$MARKER_DIR/.plan-approved.$DL_SID_B"
-assert_marker_absent "DL-10. push sweep still cleared the satisfied quartet (.post-checkpoint-done) — convergence intact" \
+assert_marker_exists "DL-10. push KEPT the satisfied .post-checkpoint-done (POST pair sticky across a delivery)" \
   "$POST_DONE"
 
 # DL-11/12/13: codex PR-review P1 regression — a FAILING installed arm helper
@@ -2425,18 +2433,32 @@ assert_marker_exists "DL-EX-A.3b step3a self-armed .post-checkpoint-required.<si
   "$MARKER_DIR/.post-checkpoint-required.$DL_EX_SID"
 
 # Step 3c: agent retries push. POST_REQ exists from step 3a, POST_DONE is
-# non-empty from step 2 → :1524-1525 check passes, push allowed, cleanup
-# sweep at :1546 clears the quartet. Workflow converges in 4 tool calls
-# (pre → post → push → push) WITHOUT requiring any intervening work-write to
-# arm POST_REQ. Pre-fix the equivalent sequence would have been: pre →
-# (post BLOCKED, misleading message) → push BLOCKED (self-arm) → post → push.
+# non-empty from step 2 → push allowed. The PRE pair is swept (convergence for a
+# future NEW task's fresh pre-checkpoint), but the POST pair is now
+# own-session-STICKY — NOT swept — so the rest of this delivery (gh pr create /
+# pr review) reuses it without re-block. Pre-fix the equivalent sequence was:
+# pre → (post BLOCKED, misleading message) → push BLOCKED (self-arm) → post → push.
 assert_allowed "DL-EX-A.3c step3b: retried git push with POST_REQ armed + POST_DONE non-empty — ALLOWED (workflow converges)" \
   "$(jq -n --arg cmd 'git push origin main' --arg cwd "$TEST_DIR" --arg sid "$DL_EX_SID" \
     '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')"
-# Verify cleanup ran (push-gate sweeps the quartet at :1546).
-assert_marker_absent "DL-EX-A.4 push sweep cleared .pre-checkpoint-done.<sid> (convergence)" \
+# Verify the PRE/POST asymmetry: push sweeps the PRE pair (convergence) but KEEPS
+# the POST pair sticky for the rest of the delivery.
+assert_marker_absent "DL-EX-A.4 push sweep cleared .pre-checkpoint-done.<sid> (PRE convergence)" \
   "$MARKER_DIR/.pre-checkpoint-done.$DL_EX_SID"
-assert_marker_absent "DL-EX-A.5 push sweep cleared .post-checkpoint-done.<sid> (convergence)" \
+assert_marker_exists "DL-EX-A.5 push KEPT .post-checkpoint-done.<sid> (POST sticky across delivery)" \
+  "$MARKER_DIR/.post-checkpoint-done.$DL_EX_SID"
+assert_marker_exists "DL-EX-A.6 push KEPT .post-checkpoint-required.<sid> (POST sticky)" \
+  "$MARKER_DIR/.post-checkpoint-required.$DL_EX_SID"
+# Step 4: the SAME delivery continues with a SECOND push-class action (gh pr
+# create) — NO intervening edit. Pre-fix this re-blocked because the first push
+# swept POST_DONE and the 2nd action self-armed POST_REQ + _block_post. Now the
+# sticky post-checkpoint satisfies the gate → ALLOWED, no re-block. This is the
+# exact reported symptom (push -> gh pr create -> gh pr review each re-demanding
+# a post-checkpoint), now fixed.
+assert_allowed "DL-EX-A.7 step4: gh pr create in the SAME delivery — ALLOWED, no re-block (symptom fixed)" \
+  "$(jq -n --arg cmd 'gh pr create --title x --body y' --arg cwd "$TEST_DIR" --arg sid "$DL_EX_SID" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "DL-EX-A.8 gh pr create KEPT the sticky post-checkpoint (delivery continues)" \
   "$MARKER_DIR/.post-checkpoint-done.$DL_EX_SID"
 
 # DL-EX-B: Edit-branch parity — same workflow but the agent uses Write/Edit
@@ -2817,6 +2839,174 @@ else
   echo "  ✓ I364-11c (codex R4 P1, helper): no marker leaked outside the project"; ((passed++))
 fi
 rm -rf "$I364_OUTSIDE_DIR" "$I364_FAKE_HOME5"
+
+# ============================================================================
+echo ""
+echo "--- POST-pair sticky across a delivery + per-delivery E2E backstop ---"
+# ============================================================================
+# Fix: the push sweep no longer clears the POST pair, so push -> gh pr create ->
+# gh pr review in ONE delivery need the post-checkpoint only ONCE (see DL-EX-A.7).
+# A NEW task re-requires it via two mechanisms: fix (B) clears POST_DONE when a
+# fresh .checkpoint-required is armed, and EDIT 3 clears POST_DONE when new
+# repo-source work follows a satisfied post within the same approved plan.
+
+# PPS-1..5 (fix B): a NEW planned task clears the prior delivery's POST_DONE.
+reset_state
+PPS_SID="aaaa1111-2222-4333-8444-aaaa55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_SID"          # sticky from a prior delivery
+echo "old e2e" > "$MARKER_DIR/.post-checkpoint-done.$PPS_SID"
+seed_approval "$MARKER_DIR" "$PPS_SID"                          # NEW plan approved
+assert_blocked "PPS-1. new task: first repo-source Edit arms CR + blocks (new plan)" \
+  "$(jq -n --arg fp "$TEST_DIR/scripts/impl.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_SID" \
+    '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" "Checkpoint required"
+assert_marker_exists "PPS-2. fresh .checkpoint-required.<sid> armed" \
+  "$MARKER_DIR/.checkpoint-required.$PPS_SID"
+assert_marker_absent "PPS-3. fix (B) cleared the stale .post-checkpoint-done.<sid> (new task needs fresh E2E)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_SID"
+assert_marker_absent "PPS-4. arm consumed the approval token" \
+  "$MARKER_DIR/.plan-approved.$PPS_SID"
+assert_blocked "PPS-5. new task push BLOCKED — sticky POST_REQ + (B)-cleared POST_DONE" \
+  "$(jq -n --arg cmd 'git push origin main' --arg cwd "$TEST_DIR" --arg sid "$PPS_SID" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')" "Post-implementation checkpoint required"
+
+# PPS-6..8 (fix B fail-closed): a FAILED arm must NOT clear POST_DONE.
+reset_state
+PPS_FAIL_HOME=$(mktemp -d)
+mkdir -p "$PPS_FAIL_HOME/.episodic-memory/scripts"
+printf '#!/usr/bin/env node\nprocess.exit(1)\n' > "$PPS_FAIL_HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+PPS_FAIL_SID="bbbb1111-2222-4333-8444-bbbb55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_FAIL_SID"
+echo "good e2e" > "$MARKER_DIR/.post-checkpoint-done.$PPS_FAIL_SID"
+seed_approval "$MARKER_DIR" "$PPS_FAIL_SID"
+PPS_FAIL_OUT=$(echo "$(jq -n --arg fp "$TEST_DIR/scripts/impl2.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_FAIL_SID" \
+  '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" | HOME="$PPS_FAIL_HOME" bash "$HOOK" 2>/dev/null)
+if echo "$PPS_FAIL_OUT" | grep -q '"decision".*"block"'; then
+  echo "  ✓ PPS-6. failed arm → Edit FAILS CLOSED (still blocked)"; ((passed++))
+else
+  echo "  ✗ PPS-6. failed arm → expected block, got: $PPS_FAIL_OUT"; ((failed++))
+fi
+assert_marker_absent "PPS-7. failed arm did NOT create .checkpoint-required.<sid>" \
+  "$MARKER_DIR/.checkpoint-required.$PPS_FAIL_SID"
+assert_marker_exists "PPS-8. fix (B) did NOT clear POST_DONE when arm FAILED (fail-closed — no fail-open bypass)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_FAIL_SID"
+rm -rf "$PPS_FAIL_HOME"
+
+# PPS-9..12 (EDIT 3): new repo-source work after a satisfied post re-gates the push.
+reset_state
+PPS_E3_SID="cccc1111-2222-4333-8444-cccc55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_E3_SID"
+echo "e2e done" > "$MARKER_DIR/.post-checkpoint-done.$PPS_E3_SID"
+assert_allowed "PPS-9. new repo-source Edit after satisfied post — ALLOWED (no-plan gate-free)" \
+  "$(jq -n --arg fp "$TEST_DIR/scripts/more.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_E3_SID" \
+    '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_absent "PPS-10. EDIT 3 cleared .post-checkpoint-done.<sid> on new repo-source work" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_E3_SID"
+assert_marker_exists "PPS-11. EDIT 3 left .post-checkpoint-required.<sid> untouched" \
+  "$MARKER_DIR/.post-checkpoint-required.$PPS_E3_SID"
+assert_blocked "PPS-12. push after new work BLOCKED — per-delivery E2E backstop restored" \
+  "$(jq -n --arg cmd 'git push origin main' --arg cwd "$TEST_DIR" --arg sid "$PPS_E3_SID" \
+    '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')" "Post-implementation checkpoint required"
+
+# PPS-13..14 (EDIT 3 scope): an OFF-REPO write must NOT clear POST_DONE.
+reset_state
+PPS_OFF_SID="dddd1111-2222-4333-8444-dddd55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_OFF_SID"
+echo "e2e done" > "$MARKER_DIR/.post-checkpoint-done.$PPS_OFF_SID"
+assert_allowed "PPS-13. off-repo Edit after satisfied post — ALLOWED" \
+  "$(jq -n --arg fp "$TEST_HOME/.claude/settings.json" --arg cwd "$TEST_DIR" --arg sid "$PPS_OFF_SID" \
+    '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "PPS-14. EDIT 3 did NOT clear POST_DONE on an OFF-REPO write (scoped to repo source)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_OFF_SID"
+
+# PPS-15..16 (EDIT 3 vs marker write): writing the post-checkpoint must not self-clear.
+reset_state
+PPS_MW_SID="eeee1111-2222-4333-8444-eeee55556666"
+echo "pre" > "$MARKER_DIR/.pre-checkpoint-done.$PPS_MW_SID"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_MW_SID"
+echo "existing post" > "$MARKER_DIR/.post-checkpoint-done.$PPS_MW_SID"
+assert_allowed "PPS-15. Write to .post-checkpoint-done marker — ALLOWED (marker write)" \
+  "$(jq -n --arg fp "$MARKER_DIR/.post-checkpoint-done.$PPS_MW_SID" --arg cwd "$TEST_DIR" --arg sid "$PPS_MW_SID" \
+    '{tool_name:"Write",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "PPS-16. the post-checkpoint marker write did NOT self-clear via EDIT 3 (exits at :1379)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_MW_SID"
+
+# PPS-17 (cross-session scope of fix B): another session's suffixed POST_DONE survives this session's arm.
+reset_state
+PPS_XA="11110000-2222-4333-8444-aaaa00001111"
+PPS_XB="22220000-2222-4333-8444-bbbb00002222"
+echo "B satisfied" > "$MARKER_DIR/.post-checkpoint-done.$PPS_XB"   # concurrent session B's post-done
+seed_approval "$MARKER_DIR" "$PPS_XA"
+echo "$(jq -n --arg fp "$TEST_DIR/scripts/a.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_XA" \
+  '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')" | run_hook >/dev/null 2>&1
+assert_marker_exists "PPS-17. fix (B) own-session-scoped: session B's .post-checkpoint-done.<sidB> SURVIVED session A's arm" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_XB"
+
+# PPS-18 (EDIT 3 scope — Bash exclusion): a Bash repo-source write must NOT clear
+# POST_DONE. EDIT 3 is Edit/Write/MultiEdit/NotebookEdit only so git commit/push
+# plumbing can never falsely clear it. The marker side-effect is the invariant
+# whether the Bash is allowed through or held for classification. This is a
+# regression guard against accidentally re-adding Bash to the EDIT 3 case (which
+# would reintroduce the redundant-post-checkpoint friction this fix removes).
+reset_state
+PPS_BASH_SID="ffff1111-2222-4333-8444-ffff55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_BASH_SID"
+echo "e2e done" > "$MARKER_DIR/.post-checkpoint-done.$PPS_BASH_SID"
+echo "$(jq -n --arg cmd "echo x > $TEST_DIR/scripts/foo.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_BASH_SID" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},cwd:$cwd,session_id:$sid}')" | run_hook >/dev/null 2>&1
+assert_marker_exists "PPS-18. Bash repo-source write did NOT clear POST_DONE (EDIT 3 excludes Bash)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_BASH_SID"
+
+# PPS-19 (EDIT 3 scope — .review-store/ carve-out): a second-opinion review
+# artifact write under .review-store/ is in-repo but NOT repo source, so
+# _tool_call_targets_repo_source returns 1 and EDIT 3 must NOT clear POST_DONE.
+reset_state
+PPS_RS_SID="abcd1111-2222-4333-8444-abcd55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_RS_SID"
+echo "e2e done" > "$MARKER_DIR/.post-checkpoint-done.$PPS_RS_SID"
+assert_allowed "PPS-19a. Edit under .review-store/ after satisfied post — ALLOWED" \
+  "$(jq -n --arg fp "$TEST_DIR/.review-store/my-review.md" --arg cwd "$TEST_DIR" --arg sid "$PPS_RS_SID" \
+    '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "PPS-19b. EDIT 3 did NOT clear POST_DONE on a .review-store/ write (in-repo, not source)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_RS_SID"
+
+# PPS-20 (EDIT 3 AND-predicate): with POST_DONE present but POST_REQ absent, EDIT
+# 3 must NOT clear — the backstop fires only inside an armed post-checkpoint
+# (POST_REQ exists AND POST_DONE non-empty). Proves the conjunction, not a lone
+# POST_DONE read.
+reset_state
+PPS_NOREQ_SID="99991111-2222-4333-8444-999955556666"
+echo "stale" > "$MARKER_DIR/.post-checkpoint-done.$PPS_NOREQ_SID"   # POST_DONE present, POST_REQ absent
+assert_allowed "PPS-20a. repo-source Edit with POST_DONE but no POST_REQ — ALLOWED" \
+  "$(jq -n --arg fp "$TEST_DIR/scripts/x.mjs" --arg cwd "$TEST_DIR" --arg sid "$PPS_NOREQ_SID" \
+    '{tool_name:"Edit",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "PPS-20b. EDIT 3 did NOT fire without POST_REQ armed (AND-predicate holds)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_NOREQ_SID"
+
+# PPS-21 (EDIT 3 scope — .git/ carve-out): a write under .git/ (commit-msg/PR-body
+# scratch, git internals) is NOT repo source, so EDIT 3 must NOT clear POST_DONE.
+# Regression for the live-E2E miss: writing the PR body to .git/ cleared the
+# satisfied post-checkpoint between the push and gh pr create.
+reset_state
+PPS_GIT_SID="cafe1111-2222-4333-8444-cafe55556666"
+touch "$MARKER_DIR/.post-checkpoint-required.$PPS_GIT_SID"
+echo "e2e done" > "$MARKER_DIR/.post-checkpoint-done.$PPS_GIT_SID"
+assert_allowed "PPS-21a. Write under .git/ after satisfied post — ALLOWED" \
+  "$(jq -n --arg fp "$TEST_DIR/.git/CKPT_PR_BODY.md" --arg cwd "$TEST_DIR" --arg sid "$PPS_GIT_SID" \
+    '{tool_name:"Write",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_exists "PPS-21b. EDIT 3 did NOT clear POST_DONE on a .git/ write (git internals, not source)" \
+  "$MARKER_DIR/.post-checkpoint-done.$PPS_GIT_SID"
+
+# PPS-22 (pre-gate — .git/ carve-out under an approved plan): a .git/ write must
+# not arm the pre-checkpoint even with an approval token present (git internals
+# are never implementation).
+reset_state
+PPS_GIT2_SID="beef1111-2222-4333-8444-beef55556666"
+seed_approval "$MARKER_DIR" "$PPS_GIT2_SID"
+assert_allowed "PPS-22a. Write under .git/ with approval token — ALLOWED (not implementation)" \
+  "$(jq -n --arg fp "$TEST_DIR/.git/COMMIT_EDITMSG" --arg cwd "$TEST_DIR" --arg sid "$PPS_GIT2_SID" \
+    '{tool_name:"Write",tool_input:{file_path:$fp},cwd:$cwd,session_id:$sid}')"
+assert_marker_absent "PPS-22b. .git/ write did NOT arm .checkpoint-required.<sid> (carve-out)" \
+  "$MARKER_DIR/.checkpoint-required.$PPS_GIT2_SID"
 
 echo ""
 echo "Passed: $passed"


### PR DESCRIPTION
## Problem

The push convergence sweep glob-deleted the satisfied `.post-checkpoint-done` on **every** allowed push-class action, so a single delivery — `git push` → `gh pr create` → `gh pr review` — re-demanded a fresh post-checkpoint each time. Reproduced live 3× while creating PR #371.

## Fix

**`hooks/checkpoint-gate.sh`**
- **EDIT 1** — the push sweep now skips the POST pair (`.post-checkpoint-required`, `.post-checkpoint-done`) via a per-marker `continue`; the PRE pair is still swept. Keeping `.checkpoint-required` swept is load-bearing — it keeps a sticky `POST_REQ` unreachable by the Stop-gate block predicate (`em-recall.mjs:355`).
- **EDIT 2 (fix B)** — a NEW planned task's fresh `.checkpoint-required` arm clears this session's `.post-checkpoint-done` (4-path, fail-closed in the arm-success block) so a new task can't ride the prior delivery's E2E.
- **EDIT 3** — new repo-source `Edit`/`Write` after a satisfied post clears `.post-checkpoint-done` so the next push re-requires E2E. Scoped to `Edit`/`Write`/`MultiEdit`/`NotebookEdit` via `_tool_call_targets_repo_source`; **Bash excluded** so `git` plumbing can't falsely clear it.
- **`.git/` carve-out (1b')** in `_tool_call_targets_repo_source` — git internals (commit-message scratch, PR-body files, rebase todo, hooks, refs, index) are never tracked repo source. `git check-ignore` does **not** flag `.git/` (it's structurally excluded from the worktree, not via `.gitignore` — verified `git check-ignore .git/<f>` exits 1), so `.git/` previously fell through to `return 0` (repo source) and let EDIT 3 (and the pre-gate) over-fire. No bypass: `.git/` content is not the worktree, and the push-gate still independently blocks pushes.

**`hooks/lib/marker-paths.sh`** — `CHECKPOINT_CLEANUP_MARKERS` contract comment updated so a future reader does not "restore" the POST sweep.

## Tests

- `tests/test-checkpoint-gate.sh` **373/0** — 7 prior assertions inverted to sticky (36/37/38b/39, B1-4/5, DL-10, DL-EX-A.4–A.8) + 22 PPS cases. PPS-18/19/20 are review-driven negative controls (Bash-exclusion, `.review-store/` carve-out, EDIT 3 AND-predicate); **PPS-21/22 are the `.git/` carve-out** at both EDIT 3 (no POST_DONE clear on a `.git/` write) and the pre-gate (a `.git/` write under an approval token does not arm).
- `tests/test-stop-gate.sh` **31/0** — no regression.

## Reviews

- **Design** — multi-agent workflow, 6 lenses; root cause confirmed; the per-push → once-per-arm backstop hole was found and closed by EDIT 3.
- **Implementation** — multi-agent workflow, **ACCEPT**, `required_changes: []`. Its four MINOR/NIT clarifying-comment findings are folded into the EDIT 3 comment block.

## Live self-demo (this PR)

Deployed the fixed hook (`install.mjs --install-hooks-force`, deployed == source byte-identical), then ran this delivery against it. The sticky fix held — `git push` self-armed `POST_REQ` and blocked for the post-checkpoint **exactly once**, and the push did **not** wipe POST_DONE. The first `gh pr create` then re-blocked: the PR-body file had been written into `.git/`, which the gate did not yet carve out, so EDIT 3 cleared POST_DONE on that non-source write. Same symptom, different cause — fixed by the `.git/` carve-out + PPS-21/22, redeployed, and the delivery re-ran clean (this PR-body write to `.git/` no longer clears the checkpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
