### PR TITLE
feat(rfc-008): R0c Follow — relocate second-opinion runbooks to plugins/second-opinion/ (R10)

### DIFF
--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -124,7 +124,7 @@ The pre-checkpoint gate materializes ONLY at the IMPLEMENTATION boundary — the
 
 ### R10 — Enforcement plugin runbooks
 Each enforcement plugin MUST include a runbook in `plugins/<harness>/runbooks/` with specified content per section. The runbook is injected on first invocation per session via content-addressed UX-marker (`.so-runbook-shown.<sha8>`). Runbook marker writes are exempt from checkpoint/plan gating. Session-start lifecycle clears all runbook markers. Content-addressed (sha8 = SHA256(full_runbook_content).hex.slice(0, 8)) — edits invalidate the marker, forcing re-injection.
-**Governed by:** PRINCIPLES.md P4 (Cognitive load > lightweight — the runbook prevents the model from rediscovering the same lessons each session). **Precedent:** second-opinion harness runbook at `hooks/runbooks/second-opinion-harness.md` (118 lines, production since 2026-05-13).
+**Governed by:** PRINCIPLES.md P4 (Cognitive load > lightweight — the runbook prevents the model from rediscovering the same lessons each session). **Precedent:** second-opinion harness runbook at `plugins/second-opinion/runbooks/harness.md` (production since 2026-05-13; relocated from `hooks/runbooks/` in the P1 Follow move).
 
 ### R11 — Pluggable memory-store strategies
 How episodes are persisted is pluggable. The default store is the append-only episode log + lexical index (zero-dep). A **store-strategy** plugin MAY additionally build **derived indexes** from episodes — a knowledge-graph index or another derived structure that makes recall richer. Store strategies are **substrate capabilities** ([CAPABILITIES.md](../../CAPABILITIES.md)): they operate on episodes via `em-store`, register as the `store-strategy` plugin type (R8), and MUST contain no enforcement/gate/marker logic (R1). Derived-index *algorithms* are specified in their own RFC, not here — the knowledge-graph index folds into **RFC-007 (Graph Projection)**.
@@ -1191,7 +1191,7 @@ Summary (full file lists + architecture in the linked per-phase files):
 | **P8** | Cursor (full adapter) + Windsurf (static-rules) plugins — added per F43 | 8 | 0 | ~45K | P3 | R6, R10 |
 | **P9** | Pluggable recall strategies — *deferred to its own RFC* | 5 | 1 | ~50K | — | R7 |
 | Bug | `plan-gate.sh:108–115` ordering fix (deadlock class 2) | 0 | 1 | small | — | R4 |
-| Follow | migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/` | 0 | 1 | small | P1 | R10 |
+| Follow ✓ | migrated `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (DONE) | 0 | 1 | small | P1 | R10 |
 
 Each phase's **architecture diagram, exact file manifest, build steps, hazards, and Done-when boundary** live in its own file under [`docs/rfcs/RFC-008/`](RFC-008/README.md). The stubs below are the navigational index; the table above is the at-a-glance map.
 
@@ -1201,7 +1201,7 @@ Serves R3, R4 (+ closes F11–F51) · depends on: — · **DONE — PR #367 (`d0
 
 #### P1 — Plugin directory + registry + test gauntlet → [RFC-008/P1-plugin-registry.md](RFC-008/P1-plugin-registry.md)
 
-Serves R1, R6, R8 · depends on: P0, R0b′ · **NEXT.** `git mv hooks/` → `plugins/claude-code/hooks/` (byte-identical) + `_index.json` registry + `manifest.json` + `validate-plugin-registry.mjs` + `test-plugin.mjs` 9-step gauntlet + net-new `field_bindings` interpreter. **~84–104K across 4 PRs** (P1a/P1b/P1c + Follow); P1a ships standalone first.
+Serves R1, R6, R8 · depends on: P0, R0b′ · **DONE (P1a #373, P1b #374, P1c #376, Follow this PR — closes P1).** `git mv hooks/` → `plugins/claude-code/hooks/` (byte-identical) + `_index.json` registry + `manifest.json` + `validate-plugin-registry.mjs` + `test-plugin.mjs` 9-step gauntlet + net-new `field_bindings` interpreter + the Follow move `hooks/runbooks/` → `plugins/second-opinion/runbooks/`. **~84–104K across 4 PRs** (P1a/P1b/P1c + Follow); P1a shipped standalone first.
 
 #### P2 — BP contract instances + contract validators → [RFC-008/P2-bp-contracts.md](RFC-008/P2-bp-contracts.md)
 
@@ -1230,7 +1230,7 @@ Serves R7 · **DEFERRED to its own RFC.** The only feature phase; semantic's emb
 #### Non-phase items
 
 - **Bug fix (any time):** `plan-gate.sh:108–115` ordering — F14 early-exit blocks the `marker_write` escape hatch (deadlock class 2, R4).
-- **Follow-up (post-P1):** migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (R10). See [P1-plugin-registry.md](RFC-008/P1-plugin-registry.md#the-runbooks-fork).
+- **Follow-up (post-P1) — DONE (this PR):** migrated `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (R10). See [P1-plugin-registry.md](RFC-008/P1-plugin-registry.md#the-runbooks-fork).
 
 ### Build order and Phase-to-P crosswalk
 
@@ -1247,7 +1247,7 @@ The per-phase manifest above is the single source of truth for what each phase s
 | **P8** | *(none — added v11.1)* | R6, R10 | P3 | Cursor (full adapter, F43) + Windsurf (static-rules); added after the OQ-3 closure. |
 | **P9** | Phase 9 | R7 | — | Recall strategies — **deferred to its own RFC**. |
 | Bug | — | R4 | — | `plan-gate.sh:108–115` ordering fix. |
-| Follow | — | R10 | P1 | Migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/`. |
+| Follow ✓ | — | R10 | P1 | Migrated `hooks/runbooks/` → `plugins/second-opinion/runbooks/` (DONE, this PR). |
 
 ---
 
@@ -1525,7 +1525,7 @@ Consolidated second-opinion review of the v11 + v11.1 + v11.2 spec edits (13 fin
 ## Ground truth hierarchy
 
 1. **PRINCIPLES.md** — governing principles; all design must conform.
-2. **Code on disk** — what works today (`hooks/`, `scripts/`, `plugins/`, `patterns/`, `hooks/runbooks/`).
+2. **Code on disk** — what works today (`scripts/`, `plugins/`, `patterns/`; enforcement hooks at `plugins/claude-code/hooks/`, runbooks at `plugins/*/runbooks/`).
 3. **Accepted RFCs** — RFC-003 (accepted), RFC-004 (accepted).
 4. **This RFC (spec v8)** — requirements R1–R12 anchor all decisions.
 5. **Deadlock analysis** — episode `20260527-073522-deadlock-analysis-7-classes-traced-again-2648`.

--- a/docs/rfcs/RFC-008/P1-plugin-registry.md
+++ b/docs/rfcs/RFC-008/P1-plugin-registry.md
@@ -27,7 +27,7 @@ with its own review → E2E → bug-disposition cycle.
 | **P1a** | The move only: `git mv hooks/ → plugins/claude-code/hooks/` (link-text-identical) + repoint 2 symlinks + `install.mjs` (`REPO_HOOKS` :43, `repoRunbookSrc` :1407) + `scripts/lib/install-manifest.mjs` (:123/:133/:136) + **>100** repo-side test path-refs. **No new contracts.** | ~24–30K | every suite green from the new path; `test-migration-cutover.mjs` green; `install --install-hooks-force` byte-identical (shasum); live gate fires. |
 | **P1b** | `plugins/_index.json` + `claude-code/manifest.json` (= the P0 `good-manifest.json`) + `validate-plugin-registry.mjs` (**M1–M6b + M-cross + M7/M7a/M7b + M8 `RESERVED_DIRS` + M9/M10** + typed/versioned `MAX_SUPPORTED` gate + the **6-axis validator project-root binding matrix**) + net-new `scripts/lib/json-instance-validate.mjs` (fail-closed closed-subset instance validator) + COMMON-rows template + enforcement runbook (**existence/byte-floor/sentinel/§-headers only**) + fixtures (version/symlink/F1 corpus remediation) + `bypass_known.json` claude-code records. **M7c–M7f + §7/§10 runbook content-derivation moved to P1c (F5 split).** | ~28–34K | validator PASS for claude-code; all fixtures behave per `detected_by` (fail at the *attributed* check); `claude-code-as-override.json` proves the override branch is live; `test-p0-schemas.mjs` green. |
 | **P1c** | **M7c–M7f runbook content-derivation** (§7 Table A/B re-derived from capabilities+taxonomy+R3 ternary, §8 modality line, §9 agent-manifest sentinel+schema+cross-field, §10 config/taxonomy cross-binding — byte-coupled to runbook authoring) + `test-plugin.mjs` 9-step gauntlet (5/6 report *deferred-P3*, not pass) + **net-new `field_bindings` interpreter** + `test-plugin-harness-binding.mjs` (**F31/F36/F61**) + a P1-local structured-alert probe with a pinned output contract (`input_project_root` vs `store_root`). | ~34–44K | M7c–M7f byte-equality green; gauntlet steps 1–4,7,8,9 green; 4 binding tests pass. |
-| **Follow** | `hooks/runbooks/ → plugins/second-opinion/runbooks/` (the second-opinion runbooks, kept out of P1a so the move stays single-destination; `second-opinion` is already in `RESERVED_DIRS`). | ~6–8K | runbooks deploy from the new path; M8 does not flag `second-opinion`. |
+| **Follow ✓ (DONE)** | `hooks/runbooks/ → plugins/second-opinion/runbooks/`, renamed to plugin-relative `harness.md`/`add-provider.md` (RFC L1135); deploy dest unchanged so zero hook bytes; `second-opinion` flipped to `presence:on-disk` in `RESERVED_DIRS`. | ~6–8K | runbooks deploy from the new path; M8 does not flag `second-opinion`. |
 
 ## Architecture
 
@@ -301,7 +301,7 @@ runbooks. RFC line 1257 routes them to `plugins/second-opinion/runbooks/`, **not
 `plugins/claude-code/`. So the move splits:
 
 - `hooks/*.sh` + `hooks/lib/` + `hooks/*.mjs` → `plugins/claude-code/hooks/`
-- `hooks/runbooks/` → `plugins/second-opinion/runbooks/` *(the post-P1 follow-up; small)*
+- `hooks/runbooks/` → `plugins/second-opinion/runbooks/` *(DONE in the Follow PR; renamed to `harness.md`/`add-provider.md`; `second-opinion` now `presence:on-disk`)*
 
 ### Ordinary repointing
 

--- a/docs/rfcs/RFC-008/README.md
+++ b/docs/rfcs/RFC-008/README.md
@@ -28,8 +28,8 @@ requirement parent. Each phase file carries its own R-anchors and back-links to 
 - **Bug fix (any time):** `plan-gate.sh:108–115` ordering — F14 early-exit blocks the
   `marker_write` escape hatch (deadlock class 2, R4). See the RFC
   [Deadlock analysis](../RFC-008-decouple-enforcement-from-substrate.md#deadlock-analysis-maps-to-taxonomy-r3-r4-r9).
-- **Follow-up (post-P1):** migrate `hooks/runbooks/` → `plugins/second-opinion/runbooks/`
-  (R10). Tracked in [P1-plugin-registry.md](P1-plugin-registry.md#the-runbooks-fork).
+- **Follow-up (post-P1) — DONE:** migrated `hooks/runbooks/` → `plugins/second-opinion/runbooks/`
+  (R10). See [P1-plugin-registry.md](P1-plugin-registry.md#the-runbooks-fork).
 
 ## Build order
 

--- a/install.mjs
+++ b/install.mjs
@@ -1404,10 +1404,12 @@ if (installSecondOpinion) {
   const repoValidatorSrc    = path.join(REPO_SECOND_OPINION, 'lib', 'registry-validator.mjs')
   const repoLocalDirSrc     = path.join(REPO_DIR, 'scripts', 'lib', 'local-dir.mjs')
   const repoTimeoutFloorSrc = path.join(REPO_HOOKS, 'lib', 'so-timeout-floor.mjs')
-  // RFC-008 P1a: hooks/ moved to plugins/claude-code/hooks/, but hooks/runbooks/
-  // stays at the repo root until the second-opinion Follow PR. Point at REPO_DIR
-  // explicitly (NOT REPO_HOOKS, which now resolves under plugins/claude-code/).
-  const repoRunbookSrc      = path.join(REPO_DIR, 'hooks', 'runbooks', 'second-opinion-harness.md')
+  // RFC-008 Follow (R10): the second-opinion runbooks now live at
+  // plugins/second-opinion/runbooks/ (in-repo name harness.md per RFC L1135).
+  // The deploy dest below stays second-opinion-harness.md, so the gate runtime
+  // path (second-opinion-gate.mjs) is unchanged. REPO_DIR-relative (NOT
+  // REPO_HOOKS, which resolves under plugins/claude-code/).
+  const repoRunbookSrc      = path.join(REPO_DIR, 'plugins', 'second-opinion', 'runbooks', 'harness.md')
 
   const userGateDst         = path.join(userHooksDir, 'second-opinion-gate.mjs')
   const userValidatorDst    = path.join(userHooksLibDir, 'registry-validator.mjs')

--- a/plugins/second-opinion/runbooks/add-provider.md
+++ b/plugins/second-opinion/runbooks/add-provider.md
@@ -1,7 +1,7 @@
 # Second-opinion harness — adding a provider (maintainer runbook)
 
 How to add a new review provider (LLM/agent CLI or API) to the second-opinion
-harness. This is the *maintainer* counterpart to `second-opinion-harness.md`
+harness. This is the *maintainer* counterpart to `harness.md`
 (which is the *operator* runbook for invoking reviews). Worked reference case:
 the `opencode` provider (DeepSeek v4-pro), added 2026-05-27.
 
@@ -123,6 +123,6 @@ cross-platform probe (`where` on win32, `which` elsewhere) and fix the class.
 
 ## Composes with
 
-- `second-opinion-harness.md` — operator runbook (how to *invoke* reviews).
+- `harness.md` — operator runbook (how to *invoke* reviews).
 - `reference_second_opinion_harness.md` — design reference (what the harness IS).
 - `feedback_cross_platform_always.md` — the cross-platform design lens.

--- a/plugins/second-opinion/runbooks/harness.md
+++ b/plugins/second-opinion/runbooks/harness.md
@@ -2,7 +2,7 @@
 
 The harness exists. Use it. But the harness is invoked via the Bash tool, and the Bash tool has its own gotchas. This file is the single-page operator checklist so I stop burning sessions rediscovering the same lessons.
 
-This file is shipped via `install.mjs --install-second-opinion` to `~/.claude/hooks/runbooks/second-opinion-harness.md` and is the source the `second-opinion-gate.mjs` PreToolUse hook injects into context on the first harness invocation per session. Mirror of `feedback_second_opinion_harness_runbook.md` in episodic memory.
+This file lives at `plugins/second-opinion/runbooks/harness.md` and is shipped via `install.mjs --install-second-opinion` to `~/.claude/hooks/runbooks/second-opinion-harness.md` (deploy name unchanged) — the source the `second-opinion-gate.mjs` PreToolUse hook injects into context on the first harness invocation per session. Mirror of `feedback_second_opinion_harness_runbook.md` in episodic memory.
 
 ## ⚠️ Self-trigger checklist — the THREE moments I keep getting wrong
 

--- a/scripts/validate-plugin-registry.mjs
+++ b/scripts/validate-plugin-registry.mjs
@@ -68,7 +68,7 @@ const RESOLUTION_GATES = ["plan_approval", "pre_checkpoint", "post_checkpoint"];
 // dirs do not exist yet and are annotation-only (claude-subagent N2).
 export const RESERVED_DIRS = {
   "episodic-memory": { presence: "on-disk", why: "Claude-Code plugin packaging (.claude-plugin/, scripts/, skills/); exists on main." },
-  "second-opinion": { presence: "reserved-for-Follow", why: "RFC-008 L1257 second-opinion runbooks fork; dir authored in the post-P1 Follow, not yet on disk." },
+  "second-opinion": { presence: "on-disk", why: "RFC-008 L1257/R10 second-opinion runbooks fork; runbook-carrier (NOT an enforcement plugin — manifest.schema is enforcement-only), authored on disk by the Follow move." },
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/test-plugin-registry.mjs
+++ b/tests/test-plugin-registry.mjs
@@ -171,7 +171,7 @@ const CONTEXT_FILES = [
 // ===========================================================================
 {
   assert(RESERVED_DIRS["episodic-memory"] && RESERVED_DIRS["episodic-memory"].presence === "on-disk", "M8: episodic-memory reserved as on-disk");
-  assert(RESERVED_DIRS["second-opinion"] && RESERVED_DIRS["second-opinion"].presence === "reserved-for-Follow", "M8: second-opinion reserved-for-Follow (annotation-only; dir not yet on disk — N2)");
+  assert(RESERVED_DIRS["second-opinion"] && RESERVED_DIRS["second-opinion"].presence === "on-disk", "M8: second-opinion reserved as on-disk (runbook-carrier authored by the Follow move — N2/R10)");
 
   const tmp = mkdtemp();
   try {
@@ -192,11 +192,26 @@ const CONTEXT_FILES = [
 
     // reserved on-disk absent -> reserved_absent (stale exemption risk).
     const tmp2 = mkdtemp();
-    fs.mkdirSync(path.join(tmp2, "plugins/claude-code"), { recursive: true }); // NO episodic-memory dir
+    fs.mkdirSync(path.join(tmp2, "plugins/claude-code"), { recursive: true }); // NO episodic-memory / second-opinion dirs
     c = collect();
     checkBidirectionalDirs(tmp2, [{ directory: "plugins/claude-code" }], c.add, []);
     assert(c.vs.some((v) => v.keyword === "reserved_absent" && v.dir === "episodic-memory"), "M8: an on-disk reserved dir that is absent fails (typo can't silently exempt a real orphan)");
+    // RFC-008 Follow (R10): second-opinion is now on-disk reserved, so its
+    // absence is likewise reserved_absent — the carrier can't be silently exempt.
+    assert(c.vs.some((v) => v.keyword === "reserved_absent" && v.dir === "second-opinion"), "M8: second-opinion on-disk reserved dir absent -> reserved_absent (Follow/R10)");
     rmrf(tmp2);
+
+    // positive: BOTH on-disk reserved dirs present -> no reserved_absent (the
+    // exemption is honest, not stale). Mirrors the live tree post-Follow.
+    const tmp3 = mkdtemp();
+    fs.mkdirSync(path.join(tmp3, "plugins/claude-code"), { recursive: true });
+    fs.mkdirSync(path.join(tmp3, "plugins/episodic-memory"), { recursive: true });
+    fs.mkdirSync(path.join(tmp3, "plugins/second-opinion/runbooks"), { recursive: true });
+    c = collect();
+    checkBidirectionalDirs(tmp3, [{ directory: "plugins/claude-code" }], c.add, []);
+    assert(!c.vs.some((v) => v.keyword === "reserved_absent"), "M8: both on-disk reserved dirs present -> no reserved_absent (Follow/R10)");
+    assert(!c.vs.some((v) => v.dir === "second-opinion"), "M8: present second-opinion carrier raises no orphan/absent violation");
+    rmrf(tmp3);
   } finally { rmrf(tmp); }
 }
 
@@ -405,6 +420,7 @@ function buildLiveProject() {
     fs.copyFileSync(path.join(REPO, rel), dest);
   }
   fs.mkdirSync(path.join(tmp, "plugins/episodic-memory"), { recursive: true }); // on-disk reserved (M8)
+  fs.mkdirSync(path.join(tmp, "plugins/second-opinion/runbooks"), { recursive: true }); // on-disk reserved (M8, Follow/R10)
   return tmp;
 }
 

--- a/tests/test-second-opinion-gate-runbook.mjs
+++ b/tests/test-second-opinion-gate-runbook.mjs
@@ -37,7 +37,7 @@ import { execFileSync, spawnSync } from 'node:child_process'
 
 const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 const HOOK = path.join(REPO_ROOT, 'plugins', 'claude-code', 'hooks', 'second-opinion-gate.mjs')
-const RUNBOOK_SRC = path.join(REPO_ROOT, 'hooks', 'runbooks', 'second-opinion-harness.md')
+const RUNBOOK_SRC = path.join(REPO_ROOT, 'plugins', 'second-opinion', 'runbooks', 'harness.md')
 // Orphan-install fixtures below copy HOOK alone; the gate's harness branch
 // now also dynamic-imports lib/so-timeout-floor.mjs, so fixtures must
 // colocate it or they fail-closed with so-timeout-floor-load-failed before
@@ -139,6 +139,18 @@ function validQuickrefContent() {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+console.log('# Repo runbook source (RFC-008 Follow / R10)')
+
+test('repo runbook source exists at the new plugin path with the sentinel', () => {
+  // Regression for the Follow move: hooks/runbooks/second-opinion-harness.md ->
+  // plugins/second-opinion/runbooks/harness.md. install.mjs deploys from
+  // RUNBOOK_SRC and deriveQuickref() extracts the "Self-trigger checklist"
+  // section, so the file MUST exist at the new path AND carry the sentinel.
+  assert.ok(fs.existsSync(RUNBOOK_SRC), `runbook source missing at ${RUNBOOK_SRC}`)
+  const body = fs.readFileSync(RUNBOOK_SRC, 'utf8')
+  assert.ok(/^## [^\n]*Self-trigger checklist/m.test(body), 'runbook missing "Self-trigger checklist" sentinel (deriveQuickref would fail-closed)')
+})
 
 console.log('# Gate detection — positive cases')
 


### PR DESCRIPTION
## Summary
Relocates the two second-opinion runbooks from `hooks/runbooks/` into a new
`plugins/second-opinion/runbooks/` plugin directory, completing the **P1 hooks-relocation
slice** of RFC-008 (**R10**; serves R1/R6/R8). Per RFC L1135 the in-repo files are renamed to
plugin-relative names while the **deploy name is held stable**, so **zero deployed hook bytes
change**.

## What changed
- **Moves (renames):**
  - `hooks/runbooks/second-opinion-harness.md` → `plugins/second-opinion/runbooks/harness.md`
  - `hooks/runbooks/second-opinion-add-provider.md` → `plugins/second-opinion/runbooks/add-provider.md`
  - `hooks/` is now gone.
- **`install.mjs`:** `repoRunbookSrc` repointed to the new path. Deploy dest
  (`second-opinion-harness.md`), `deriveQuickref`, and the gate runtime path are unchanged.
- **`validate-plugin-registry.mjs`:** `RESERVED_DIRS.second-opinion` flipped
  `reserved-for-Follow` → `on-disk`. It stays a **runbook-carrier** (NOT an `_index.json`
  plugin / NOT a `manifest.json` — `manifest.schema.json` is enforcement-only), now with
  on-disk typo-protection.
- **Tests:** on-disk presence assertions + `reserved_absent` positive/negative coverage
  (`test-plugin-registry.mjs`); a real rename regression test asserting the new-path
  `harness.md` exists + carries the `## ⚠️ Self-trigger checklist` sentinel
  (`test-second-opinion-gate-runbook.mjs`).
- **Docs:** RFC-008 main + P1 spec + RFC-008/README + moved-file cross-refs.

## Review trail (Rule 18)
- **Plan review** (negative-scenario-reviewer): HOLD → folded F1–F4 (atomic-commit ordering,
  RFC L1233, real F3 test, CI-validator verify list).
- **Code review** (negative-scenario-reviewer): ACCEPT-with-FU — 0 blocker / 0 major / 2 minor /
  1 nit. MINOR-2 (stale cross-refs) fixed inline; MINOR-1 (new test un-wired in CI) → #377.

## Verification
- `test-plugin-registry` 200/0 · `test-second-opinion-gate-runbook` 20/0 ·
  `test-so-gate-timeout-floor` 5/0 · gauntlet 7 pass / 2 deferred-P3 / 0 fail.
- Live `validate-plugin-registry --project .` OK — **M8 does not flag `second-opinion`** (done-when).
- `install --install-second-opinion` OK — quickref derived (1729 chars) from the new `harness.md`,
  deployed to the unchanged dest.
- RFC validators (em-rfc-validate / failure-table / artifact-manifest / canonical-fields /
  contract-mirror) all green.

## Follow-up
- The new gate-runbook regression test runs in no CI workflow → tracked in #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
