### PR TITLE
feat(rfc-008): P3c — classifier runtime-sources taxonomy.json (R4/F4/F6)

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Run validate-bp-contract self-tests (golden corpus + stable-ID E2E)
         run: node tests/test-validate-bp-contract.mjs
+
+      - name: Run command-classifier regression suite (label-emit / _priority lock)
+        run: bash tests/test-command-classifier.sh
+
+      - name: Run classifier taxonomy runtime-sourcing tests (RFC-008 P3c, R4/F4)
+        run: bash tests/test-classifier-taxonomy-sync.sh

--- a/install.mjs
+++ b/install.mjs
@@ -295,6 +295,13 @@ if (fs.existsSync(repoPatternsIndex)) {
   console.log(`Installed patterns/_index.json to ${globalPatternsDir}`)
 }
 
+// NOTE: patterns/taxonomy.json is a RUNTIME dependency of command-classifier.sh,
+// NOT a global-validation artifact like _index.json — so it is co-deployed WITH
+// the classifier inside the `if (installHooks)` block (§5a-tax below), never
+// unconditionally here. Deploying it in the main body would advance runtime
+// candidate-1 on a no-hooks install while leaving an already-installed classifier
+// stale + unwarned (PR-level codex BLOCKER; R4/F4 root parity + sync coupling).
+
 // ---------------------------------------------------------------------------
 // 2. Create local .episodic-memory in target project
 // ---------------------------------------------------------------------------
@@ -1200,6 +1207,52 @@ if (installHooks) {
         'not fully installed (divergent local edit on command-classifier.sh?); ' +
         're-run with --install-hooks-force'
       )
+    }
+
+    // 5a-tax. RFC-008 P3c (R4/F4): co-deploy patterns/taxonomy.json to the SAME
+    // global root the classifier reads at runtime (candidate 1 =
+    // $HOME/.episodic-memory/patterns/taxonomy.json; GLOBAL_DIR = os.homedir()/
+    // .episodic-memory, no EPISODIC_MEMORY_HOME indirection — codex R2-P2 root
+    // parity). This is INSIDE the installHooks block so taxonomy and classifier
+    // advance together: a no-hooks install touches neither (PR-level codex
+    // BLOCKER — taxonomy must not advance candidate-1 while the installed
+    // classifier stays stale + unwarned).
+    const repoTaxonomy = path.join(REPO_DIR, 'patterns', 'taxonomy.json')
+    if (fs.existsSync(repoTaxonomy)) {
+      fs.mkdirSync(globalPatternsDir, { recursive: true })
+      fs.copyFileSync(repoTaxonomy, path.join(globalPatternsDir, 'taxonomy.json'))
+      console.log(`Installed patterns/taxonomy.json to ${globalPatternsDir}`)
+    }
+
+    // RFC-008 P3c (R4/F4, codex R1-P1b): if the command classifier was KEPT as a
+    // divergent local edit while taxonomy.json was (re)deployed just above, the
+    // installed classifier and the global taxonomy may disagree. Two cases,
+    // distinguished by whether the kept file carries the runtime-sourcing helper:
+    //   pre-P3c  (no _ensure_taxonomy_synced): runs stale hardcoded labels and is
+    //            NOT taxonomy-synced — the gate is silently unprotected by
+    //            runtime-sourcing (no fail-closed at all).
+    //   post-P3c (has the helper): will FAIL CLOSED loudly on any drift until
+    //            re-forced.
+    if (libResults['command-classifier.sh'] === 'skipped-divergent') {
+      let keptClassifier = ''
+      try {
+        keptClassifier = fs.readFileSync(
+          path.join(userHooksLibDir, 'command-classifier.sh'), 'utf8')
+      } catch { /* unreadable → treat as pre-P3c (no helper) below */ }
+      if (keptClassifier.includes('_ensure_taxonomy_synced')) {
+        console.log(
+          'WARNING: command-classifier.sh kept (divergent local edit) while ' +
+          'taxonomy.json was redeployed — the kept classifier will FAIL CLOSED ' +
+          'on any taxonomy drift. Re-run with --install-hooks-force to sync.'
+        )
+      } else {
+        console.log(
+          'WARNING: command-classifier.sh kept (divergent local edit) is pre-P3c ' +
+          '— it does NOT runtime-source taxonomy.json and is NOT taxonomy-synced ' +
+          '(runs stale hardcoded labels). Re-run with --install-hooks-force to ' +
+          'install runtime label-sourcing.'
+        )
+      }
     }
 
     // 5a. Hook specs imported from scripts/lib/install-manifest.mjs (single

--- a/plugins/claude-code/hooks/lib/command-classifier.sh
+++ b/plugins/claude-code/hooks/lib/command-classifier.sh
@@ -2400,6 +2400,129 @@ _resolve_marker_path() {
 #       cwd or a worktree. Codex R1 P1 reproduced marker miss for that
 #       divergence.
 #
+# ---------------------------------------------------------------------------
+# Runtime taxonomy sourcing (RFC-008 P3c, maps to R4 / F4 / F6)
+# ---------------------------------------------------------------------------
+# The label vocabulary is single-sourced from patterns/taxonomy.json at runtime
+# and fail-closed if it drifts from this classifier's own label authority. Per
+# F4 (OQ-2 closed) this eliminates a hand-maintained bash label list "by
+# construction"; the bash label authority is the _priority() case-arms (already
+# CI-validated == taxonomy.labels by validate-bp-contract.mjs assertion 7b), so
+# the runtime check compares taxonomy.labels against _priority arms — NO second
+# parallel list (adversarial GAP-1).
+#
+# Resolution (codex R2-P1 / R2-P2):
+#   candidate 1: $HOME/.episodic-memory/patterns/taxonomy.json — the SAME root
+#                install.mjs writes (GLOBAL_DIR, install.mjs:24) and the idiom
+#                the hooks already use (checkpoint-gate.sh:741). No
+#                EPISODIC_MEMORY_HOME indirection (os.homedir() wouldn't honor
+#                it); tests isolate via HOME.
+#   candidate 2: in-repo copy via the $BASH_SOURCE climb, used ONLY when the
+#                climbed root PROVES it is the repo copy (repo sentinels present
+#                AND the classifier path round-trips). The installed layout
+#                (~/.claude/hooks/lib) fails the predicate, so it can never read
+#                an ambient parent patterns/taxonomy.json (authority-root
+#                containment).
+#   No EM_TAXONOMY_PATH env override (codex R1-P1: command-local env taxonomy
+#   authority is a bypass vector, PR-271).
+#
+# Fail-closed surfaces via a blocking label (unsafe_complex) with a distinct
+# reason so logs disambiguate misconfig from a dangerous command. marker_write
+# is NEVER fail-closed (deadlock-class-1 escape hatch, taxonomy.json
+# non_overridable_rationale): classify_command exempts marker_write and
+# classify_path's marker cases return before the guard.
+
+_TAXONOMY_SYNC_DONE=""     # plain, NON-exported per-process guard (adversarial
+_TAXONOMY_SYNC_STATUS=""   # axis-7: a child re-sources + re-validates rather
+_TAXONOMY_SYNC_REASON=""   # than inheriting a stale "passed" flag)
+
+# Physical (symlink-resolved) path of a file by resolving its DIRECTORY via
+# `cd -P` (cross-platform; no GNU `readlink -f`). Resolves the /var→/private/var
+# class that fail-opened P3b-1's isMain check.
+_taxonomy_file_realpath() {
+  local f="$1" d b
+  d="$(dirname "$f")" || return 1
+  b="$(basename "$f")"
+  d="$(cd -P "$d" 2>/dev/null && pwd)" || return 1
+  printf '%s/%s' "$d" "$b"
+}
+
+# The single bash label authority: the _priority() case-arm names, sorted and
+# space-joined. declare -f is bash-native and formatting-stable for our regex
+# (matches `<label>)` whether inline or on its own line; never matches `*)` or
+# `case "$1" in`).
+_priority_arm_labels() {
+  declare -f _priority \
+    | sed -n 's/^[[:space:]]*\([a-z][a-z_]*\)).*/\1/p' \
+    | sort | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}
+
+# Echo the resolved taxonomy.json path, or empty + return 1 if none qualifies.
+_taxonomy_resolve_path() {
+  # Candidate 1 — global install root (== install.mjs GLOBAL_DIR).
+  local c1="$HOME/.episodic-memory/patterns/taxonomy.json"
+  if [ -f "$c1" ]; then
+    _taxonomy_file_realpath "$c1" 2>/dev/null || printf '%s' "$c1"
+    return 0
+  fi
+  # Candidate 2 — in-repo copy, CONDITIONAL on a repo-layout proof predicate.
+  local self_dir climbed
+  self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || return 1
+  climbed="$(cd -P "$self_dir/../../../.." 2>/dev/null && pwd)" || return 1
+  # (a) repo sentinels present at the climbed root.
+  [ -f "$climbed/patterns/taxonomy.schema.json" ] || return 1
+  [ -f "$climbed/scripts/em-store.mjs" ] || return 1
+  # (b) the climbed classifier path round-trips back to THIS sourced file.
+  local rp_self rp_climbed
+  rp_self="$(_taxonomy_file_realpath "${BASH_SOURCE[0]}" 2>/dev/null)" || return 1
+  rp_climbed="$(_taxonomy_file_realpath "$climbed/plugins/claude-code/hooks/lib/command-classifier.sh" 2>/dev/null)" || return 1
+  [ "$rp_self" = "$rp_climbed" ] || return 1
+  local c2="$climbed/patterns/taxonomy.json"
+  [ -f "$c2" ] || return 1
+  _taxonomy_file_realpath "$c2" 2>/dev/null || printf '%s' "$c2"
+  return 0
+}
+
+# Validate (once per process) that taxonomy.labels == _priority arms. Returns 0
+# when synced; non-zero on drift/unresolved with the reason cached in
+# _TAXONOMY_SYNC_REASON.
+_ensure_taxonomy_synced() {
+  if [ -n "$_TAXONOMY_SYNC_DONE" ]; then
+    [ "$_TAXONOMY_SYNC_STATUS" = "ok" ]
+    return
+  fi
+  _TAXONOMY_SYNC_DONE=1
+
+  local tax_path
+  tax_path="$(_taxonomy_resolve_path)"
+  if [ -z "$tax_path" ] || [ ! -f "$tax_path" ]; then
+    _TAXONOMY_SYNC_STATUS="unresolved"
+    _TAXONOMY_SYNC_REASON="taxonomy_unresolved"
+    return 1
+  fi
+
+  # Zero-dep node read; exit!=0 on missing node / parse error / non-array labels
+  # (bash MUST branch on the exit code, not merely empty stdout — adversarial
+  # GAP-3). readFileSync+JSON.parse, NOT require() (require-cache footgun, Q2).
+  local actual
+  if ! actual="$(node -e 'const fs=require("fs");const t=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));if(!Array.isArray(t.labels))process.exit(3);process.stdout.write(t.labels.map(l=>l.id).sort().join(" "))' "$tax_path" 2>/dev/null)"; then
+    _TAXONOMY_SYNC_STATUS="unresolved"
+    _TAXONOMY_SYNC_REASON="taxonomy_unresolved"
+    return 1
+  fi
+
+  local expected
+  expected="$(_priority_arm_labels)"
+  if [ "$actual" = "$expected" ]; then
+    _TAXONOMY_SYNC_STATUS="ok"
+    _TAXONOMY_SYNC_REASON=""
+    return 0
+  fi
+  _TAXONOMY_SYNC_STATUS="drift"
+  _TAXONOMY_SYNC_REASON="taxonomy_drift"
+  return 1
+}
+
 # Output: LABEL\tTARGET\tREASON
 classify_command() {
   local cmd="$1"
@@ -2485,6 +2608,19 @@ classify_command() {
     final_reason="empty_command"
   fi
 
+  # RFC-008 P3c (R4/F4): fail-closed on taxonomy drift/unresolved. The guard
+  # NEVER overrides the two NON-OVERRIDABLE labels — marker_write (deadlock
+  # escape hatch) and unsafe_complex (already maximally blocking) — symmetric
+  # with taxonomy.json non_overridable. Everything else degrades to
+  # unsafe_complex so a possibly-mislabeled write cannot slip through as a read.
+  if [ "$final_label" != "marker_write" ] && [ "$final_label" != "unsafe_complex" ]; then
+    if ! _ensure_taxonomy_synced; then
+      final_label="unsafe_complex"
+      final_target=""
+      final_reason="$_TAXONOMY_SYNC_REASON"
+    fi
+  fi
+
   printf '%s\t%s\t%s\n' "$final_label" "$final_target" "$final_reason"
 }
 
@@ -2544,6 +2680,15 @@ classify_path() {
       return 0
       ;;
   esac
+  # RFC-008 P3c (R4/F4): fail-closed on taxonomy drift/unresolved for the
+  # non-marker write path. The marker cases above already returned (deadlock
+  # escape preserved). codex R1-P1: classify_path is the SECOND public label
+  # emitter (Write/Edit/MultiEdit/NotebookEdit via checkpoint-gate.sh:1359) and
+  # MUST front the same shared guard as classify_command.
+  if ! _ensure_taxonomy_synced; then
+    printf '%s\t\t%s\n' "unsafe_complex" "$_TAXONOMY_SYNC_REASON"
+    return 0
+  fi
   printf '%s\t\t%s\n' "shared_write" "path_default"
   return 0
 }

--- a/scripts/validate-bp-contract.mjs
+++ b/scripts/validate-bp-contract.mjs
@@ -231,6 +231,12 @@ export function extractPriorityArms(text, relPath, violation) {
       // keyword form `function _priority`.
       if (/^\s*\(\s*\)/.test(after) || /\bfunction\s+$/.test(before)) { defIdx.push(i); continue; }
       if (/\$\(\s*$/.test(before)) continue; // $( call site (this OCCURRENCE only — the rest of the line is still scanned)
+      // `declare -f _priority` (P3c runtime-sourcing) READS the function body;
+      // it cannot redefine it, so this OCCURRENCE is inert like a $(-call site.
+      // A trailing same-line redefinition (`declare -f _priority; _priority() {`)
+      // is still caught — its `() {` is a SEPARATE occurrence flagged as a def
+      // opener (→ defIdx > 1 fails). Allowlist only the `declare -<…f…> ` prefix.
+      if (/\bdeclare\s+-[A-Za-z]*f[A-Za-z]*\s+$/.test(before)) continue;
       unproven.push(i + 1);
     }
   }
@@ -270,6 +276,106 @@ export function extractPriorityArms(text, relPath, violation) {
   }
   if (!sawEsac) { violation(`${relPath}: _priority() case block has no esac — unparseable (fail-closed)`); return null; }
   return arms;
+}
+
+/**
+ * Assertion 7c (RFC-008 P3c — maps to R4 / F4 / F6). Verifies the default
+ * classifier RUNTIME-SOURCES its label set from taxonomy.json. Robust parser,
+ * not a plain grep (codex R1-P2: grep passes on comments / dead code):
+ *   (a) `_ensure_taxonomy_synced` is defined exactly once (non-comment).
+ *   (b) it is called (live, non-definition) from BOTH `classify_command` and
+ *       `classify_path` bodies — the two public label emitters (codex R1-P1).
+ *   (c) every emit-site label LITERAL (`printf '<fmt>' "<label>" …`) is a
+ *       taxonomy label — F6 vocabulary closure over emit sites, INDEPENDENT of
+ *       the `_priority` arms (7b); catches a typo'd `shared_writ` 7b can't see.
+ * Returns true when all pass; emits violations + returns false otherwise.
+ * Body ranges are delimited by the next COLUMN-0 function opener so `${…}`
+ * expansions and the nested `_consider()` helper don't perturb the scan.
+ */
+export function checkTaxonomySourcing(text, relPath, labelIds, violation) {
+  // Comment-aware logical-line assembly (mirror of extractPriorityArms).
+  const phys = text.split(/\r?\n/);
+  const lines = [];
+  for (let i = 0; i < phys.length; i++) {
+    let cur = phys[i];
+    if (!/^\s*#/.test(cur)) {
+      while (cur.endsWith("\\") && i + 1 < phys.length) { cur = cur.slice(0, -1) + phys[++i]; }
+    }
+    lines.push(cur);
+  }
+  const isComment = (l) => l.trim().startsWith("#");
+  const GUARD = "_ensure_taxonomy_synced";
+  const GUARD_DEF_RE = /^\s*(?:function\s+)?_ensure_taxonomy_synced\s*\(\s*\)\s*\{/;
+  const GUARD_TOKEN_RE = /\b_ensure_taxonomy_synced\b/;
+  const TOPFN_RE = /^[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\)\s*\{/;
+  let ok = true;
+
+  // (a) exactly one non-comment definition.
+  const defLines = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!isComment(lines[i]) && GUARD_DEF_RE.test(lines[i])) defLines.push(i);
+  }
+  if (defLines.length === 0) {
+    violation("7", `${relPath}: no ${GUARD}() definition — R4/F4 require the default classifier to runtime-source taxonomy.json (fail-closed)`);
+    ok = false;
+  } else if (defLines.length > 1) {
+    violation("7", `${relPath}: ${defLines.length} ${GUARD}() definitions (expected exactly one) — bash last-wins ambiguity (fail-closed)`);
+    ok = false;
+  }
+
+  // (b) live call from BOTH public entry-point bodies.
+  const bodyRange = (fnRe) => {
+    let start = -1;
+    for (let i = 0; i < lines.length; i++) { if (fnRe.test(lines[i])) { start = i; break; } }
+    if (start === -1) return null;
+    let end = lines.length - 1;
+    for (let i = start + 1; i < lines.length; i++) { if (TOPFN_RE.test(lines[i])) { end = i - 1; break; } }
+    return [start, end];
+  };
+  const callsGuardIn = (range) => {
+    for (let i = range[0]; i <= range[1]; i++) {
+      if (isComment(lines[i])) continue;
+      if (GUARD_DEF_RE.test(lines[i])) continue;        // the definition, not a call
+      if (GUARD_TOKEN_RE.test(lines[i])) return true;   // a live call/use
+    }
+    return false;
+  };
+  for (const [fn, fnRe] of [
+    ["classify_command", /^classify_command\s*\(\s*\)\s*\{/],
+    ["classify_path", /^classify_path\s*\(\s*\)\s*\{/],
+  ]) {
+    const range = bodyRange(fnRe);
+    if (!range) { violation("7", `${relPath}: ${fn}() body not found — cannot verify ${GUARD} is wired into it (fail-closed)`); ok = false; continue; }
+    if (!callsGuardIn(range)) { violation("7", `${relPath}: ${fn}() does not call ${GUARD} — both public emitters must front the runtime-sourcing guard (codex R1-P1; fail-closed)`); ok = false; }
+  }
+
+  // (c) emit-site label literals ⊆ taxonomy (F6 over emit sites). Scoped to the
+  // taxonomy-label emitters: the `*preflight*` functions emit Layer-D
+  // claim-classes (`codex-review-handoff`, `none`, …) via the SAME printf shape,
+  // so they are excluded by tracking the current column-0 function. The final
+  // reducer emit uses `"$final_label"` (a variable) which the literal-only regex
+  // skips by construction.
+  const FN_OPEN_RE = /^([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*\{/;
+  // Label-emit shape only: format begins with `%s\t` (label<TAB>…), matching the
+  // classifier's `'%s\t%s\t%s\n'` / `'%s\t\t%s\n'` emits. A bare `printf '%s'
+  // "word"` (no tab) is NOT a label emit and is excluded by construction.
+  const EMIT_RE = /\bprintf\s+'%s\\t[^']*'\s+"([a-z_][a-z_]*)"/g;
+  let curFn = "";
+  for (let i = 0; i < lines.length; i++) {
+    if (isComment(lines[i])) continue;
+    const fm = FN_OPEN_RE.exec(lines[i]);
+    if (fm) curFn = fm[1];
+    if (/preflight/.test(curFn)) continue; // claim-class vocabulary, not taxonomy labels
+    EMIT_RE.lastIndex = 0;
+    let m;
+    while ((m = EMIT_RE.exec(lines[i])) !== null) {
+      if (!labelIds.has(m[1])) {
+        violation("7", `${relPath}: emit-site label literal ${JSON.stringify(m[1])} (line ${i + 1}) is not a taxonomy label (F6 emit-site vocabulary closure)`);
+        ok = false;
+      }
+    }
+  }
+  return ok;
 }
 
 export function validateBpContract({ projectRoot, taxonomyPath = null, eventsPath = null, bpDirPath = null } = {}) {
@@ -441,13 +547,16 @@ export function validateBpContract({ projectRoot, taxonomyPath = null, eventsPat
     try { clsReal = fs.realpathSync(clsLex); }
     catch { violation("7", `${rel}: default classifier script missing — R4 requires the default classifier; arm closure cannot be verified (fail-closed)`); continue; }
     if (!contained(clsReal, root)) { violation("7", `${rel}: classifier resolves outside the project root — refusing to read`); continue; }
-    const arms = extractPriorityArms(fs.readFileSync(clsReal, "utf8"), rel, (d) => violation("7", d));
+    const clsSrc = fs.readFileSync(clsReal, "utf8");
+    const arms = extractPriorityArms(clsSrc, rel, (d) => violation("7", d));
     if (arms === null) continue;
     classifiersParsed++;
     const armSet = new Set(arms);
     if (new Set(arms).size !== arms.length) violation("7", `${rel}: duplicate _priority case arm(s)`);
     for (const a of armSet) if (!labelIds.has(a)) violation("7", `${rel}: _priority arm ${JSON.stringify(a)} is not a taxonomy label (extra arm)`);
     for (const id of labelIds) if (!armSet.has(id)) violation("7", `${rel}: taxonomy label ${JSON.stringify(id)} has NO _priority arm — it would rank priority 0, below read_only, a silent downgrade in most-restrictive-wins reduction (L473)`);
+    // Assertion 7c — default classifier runtime-sources taxonomy.json (P3c, F4/F6).
+    checkTaxonomySourcing(clsSrc, rel, labelIds, violation);
   }
   checks++;
   if (manifests.some((m) => m.manifest.classifier && m.manifest.classifier.mode === "default") && classifiersParsed === 0) {

--- a/tests/test-classifier-taxonomy-sync.sh
+++ b/tests/test-classifier-taxonomy-sync.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# test-classifier-taxonomy-sync.sh — RFC-008 P3c runtime taxonomy-sourcing tests
+# for hooks/lib/command-classifier.sh (maps to R4 / F4 / F6).
+#
+# Usage: bash tests/test-classifier-taxonomy-sync.sh
+#
+# Each case runs the classifier in a FRESH bash process (the _ensure_taxonomy_
+# synced guard caches per-process via a NON-exported var) with a controlled
+# HOME and a chosen classifier copy, so we can drive every resolution branch:
+#   - installed-layout copy: candidate-2 repo-proof predicate FAILS (no repo
+#     sentinels above ~/.claude/hooks/lib), so candidate 1 ($HOME/.episodic-
+#     memory/patterns/taxonomy.json) is the only source — full control.
+#   - real in-repo classifier: candidate 2 (proven climb) resolves.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/plugins/claude-code/hooks/lib/command-classifier.sh"
+GOOD_TAX="$REPO_ROOT/patterns/taxonomy.json"
+TAB=$'\t'
+
+if [ ! -f "$LIB" ]; then echo "FAIL: $LIB not found"; exit 1; fi
+if [ ! -f "$GOOD_TAX" ]; then echo "FAIL: $GOOD_TAX not found"; exit 1; fi
+
+passed=0
+failed=0
+
+# --- fixtures -------------------------------------------------------------
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/p3c-taxsync.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Installed-layout classifier copy: $TMP/home/.claude/hooks/lib/...
+INST_HOME="$TMP/home"
+INST_LIB_DIR="$INST_HOME/.claude/hooks/lib"
+mkdir -p "$INST_LIB_DIR"
+cp "$LIB" "$INST_LIB_DIR/command-classifier.sh"
+INST_LIB="$INST_LIB_DIR/command-classifier.sh"
+
+# Helper: write a candidate-1 taxonomy under a given HOME dir.
+plant_global_tax() {  # home_dir  src_json
+  local home="$1" src="$2"
+  mkdir -p "$home/.episodic-memory/patterns"
+  cp "$src" "$home/.episodic-memory/patterns/taxonomy.json"
+}
+
+# Drift taxonomy: good labels + one EXTRA id (set != _priority arms).
+DRIFT_TAX="$TMP/drift.json"
+node -e 'const fs=require("fs");const t=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));t.labels.push({id:"extra_label",meaning:"x",overridable:true,gates:{plan_approval:"block",pre_checkpoint:"block",post_checkpoint:"block"}});fs.writeFileSync(process.argv[2],JSON.stringify(t))' "$GOOD_TAX" "$DRIFT_TAX"
+
+# Malformed taxonomy: labels is not an array.
+MALFORMED_TAX="$TMP/malformed.json"
+printf '%s' '{"labels":"nope"}' > "$MALFORMED_TAX"
+
+# Empty taxonomy: labels is an empty array.
+EMPTY_TAX="$TMP/empty.json"
+printf '%s' '{"labels":[]}' > "$EMPTY_TAX"
+
+# --- run helpers (fresh process per call) ---------------------------------
+cc() {  # home  lib  cmd   -> "label<TAB>target<TAB>reason"
+  HOME="$1" bash -c 'source "$1"; classify_command "$2" "/tmp/p3c-rr"' _ "$2" "$3" 2>/dev/null
+}
+cp_() {  # home  lib  path  -> classify_path
+  HOME="$1" bash -c 'source "$1"; classify_path "$2" "/tmp/p3c-rr"' _ "$2" "$3" 2>/dev/null
+}
+label_of() { printf '%s' "${1%%"$TAB"*}"; }
+reason_of() { local r="${1#*"$TAB"}"; printf '%s' "${r#*"$TAB"}"; }
+
+assert_eq() {  # desc  actual  expected
+  if [ "$2" = "$3" ]; then
+    echo "  ✓ $1"; passed=$((passed+1))
+  else
+    echo "  ✗ $1"; echo "    expected: $3"; echo "    got:      $2"; failed=$((failed+1))
+  fi
+}
+
+echo ""
+echo "--- candidate 1 (installed layout): in-sync ---"
+plant_global_tax "$INST_HOME" "$GOOD_TAX"
+out="$(cc "$INST_HOME" "$INST_LIB" "ls -la")"
+assert_eq "S01 in-sync: ls stays read_only" "$(label_of "$out")" "read_only"
+out="$(cc "$INST_HOME" "$INST_LIB" "git push")"
+assert_eq "S02 in-sync: git push stays push_or_pr_create" "$(label_of "$out")" "push_or_pr_create"
+
+echo ""
+echo "--- drift → fail-closed (taxonomy_drift) ---"
+plant_global_tax "$INST_HOME" "$DRIFT_TAX"
+out="$(cc "$INST_HOME" "$INST_LIB" "ls -la")"
+assert_eq "S10 drift: ls → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+assert_eq "S11 drift: reason=taxonomy_drift" "$(reason_of "$out")" "taxonomy_drift"
+
+echo ""
+echo "--- marker_write is NEVER fail-closed (deadlock escape) ---"
+# drift still planted
+out="$(cc "$INST_HOME" "$INST_LIB" "rm $INST_HOME/.checkpoints/.plan-approval-pending")"
+assert_eq "S12 drift: marker rm stays marker_write" "$(label_of "$out")" "marker_write"
+out="$(cp_ "$INST_HOME" "$INST_LIB" ".pre-checkpoint-done")"
+assert_eq "S13 drift: classify_path marker stays marker_write" "$(label_of "$out")" "marker_write"
+
+echo ""
+echo "--- classify_path non-marker fail-closes under drift (codex R1-P1) ---"
+out="$(cp_ "$INST_HOME" "$INST_LIB" "scripts/em-store.mjs")"
+assert_eq "S14 drift: classify_path src → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+assert_eq "S15 drift: classify_path reason=taxonomy_drift" "$(reason_of "$out")" "taxonomy_drift"
+
+echo ""
+echo "--- empty labels array → fail-closed ---"
+plant_global_tax "$INST_HOME" "$EMPTY_TAX"
+out="$(cc "$INST_HOME" "$INST_LIB" "ls -la")"
+assert_eq "S20 empty labels: ls → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+
+echo ""
+echo "--- malformed (labels non-array) → taxonomy_unresolved via node exit!=0 ---"
+plant_global_tax "$INST_HOME" "$MALFORMED_TAX"
+out="$(cc "$INST_HOME" "$INST_LIB" "ls -la")"
+assert_eq "S30 malformed: ls → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+assert_eq "S31 malformed: reason=taxonomy_unresolved" "$(reason_of "$out")" "taxonomy_unresolved"
+
+echo ""
+echo "--- unresolved (no taxonomy anywhere, installed layout) ---"
+EMPTY_HOME="$TMP/emptyhome"
+mkdir -p "$EMPTY_HOME/.claude/hooks/lib"
+cp "$LIB" "$EMPTY_HOME/.claude/hooks/lib/command-classifier.sh"
+out="$(cc "$EMPTY_HOME" "$EMPTY_HOME/.claude/hooks/lib/command-classifier.sh" "ls -la")"
+assert_eq "S40 unresolved: ls → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+assert_eq "S41 unresolved: reason=taxonomy_unresolved" "$(reason_of "$out")" "taxonomy_unresolved"
+
+echo ""
+echo "--- installed-layout ambient fallback REJECTED (codex R2-P1) ---"
+# climbed root = $AMB_HOME/.. (4 up from .claude/hooks/lib). Plant an ambient
+# patterns/taxonomy.json at the climbed root WITHOUT repo sentinels → predicate
+# must fail → taxonomy_unresolved, NOT a successful ambient read.
+AMB_BASE="$TMP/amb"
+AMB_HOME="$AMB_BASE/a/b/home"   # climb from home/.claude/hooks/lib goes up 4 → $AMB_BASE/a/b/home? no:
+# .claude/hooks/lib -> hooks -> .claude -> home -> b  (4 levels up from lib dir's parent chain)
+mkdir -p "$AMB_HOME/.claude/hooks/lib"
+cp "$LIB" "$AMB_HOME/.claude/hooks/lib/command-classifier.sh"
+# climbed = realpath("$AMB_HOME/.claude/hooks/lib/../../../..") = "$AMB_BASE/a/b"
+AMB_CLIMB="$AMB_BASE/a/b"
+mkdir -p "$AMB_CLIMB/patterns"
+cp "$GOOD_TAX" "$AMB_CLIMB/patterns/taxonomy.json"   # ambient taxonomy, no sentinels
+out="$(cc "$AMB_HOME" "$AMB_HOME/.claude/hooks/lib/command-classifier.sh" "ls -la")"
+assert_eq "S50 ambient: predicate rejects → unsafe_complex" "$(label_of "$out")" "unsafe_complex"
+assert_eq "S51 ambient: reason=taxonomy_unresolved (not ambient read)" "$(reason_of "$out")" "taxonomy_unresolved"
+
+echo ""
+echo "--- in-repo candidate-2 proof (real classifier, empty HOME) ---"
+NO_GLOBAL_HOME="$TMP/noglobal"
+mkdir -p "$NO_GLOBAL_HOME"
+out="$(cc "$NO_GLOBAL_HOME" "$LIB" "ls -la")"
+assert_eq "S60 candidate-2 in-repo resolves: ls read_only" "$(label_of "$out")" "read_only"
+
+echo ""
+echo "--- symlinked HOME path still resolves (/var→/private/var class) ---"
+SYM_REAL="$TMP/symreal"
+mkdir -p "$SYM_REAL/.claude/hooks/lib"
+cp "$LIB" "$SYM_REAL/.claude/hooks/lib/command-classifier.sh"
+plant_global_tax "$SYM_REAL" "$GOOD_TAX"
+SYM_LINK="$TMP/symlink-home"
+ln -s "$SYM_REAL" "$SYM_LINK"
+out="$(cc "$SYM_LINK" "$SYM_LINK/.claude/hooks/lib/command-classifier.sh" "git push")"
+assert_eq "S70 symlinked home: in-sync resolves, push stays push" "$(label_of "$out")" "push_or_pr_create"
+
+echo ""
+echo "--- non-exported guard: child re-validates ---"
+# Source under in-sync, run once (sets guard), then a child bash must NOT see
+# _TAXONOMY_SYNC_DONE inherited (it is non-exported).
+plant_global_tax "$INST_HOME" "$GOOD_TAX"
+inherited="$(HOME="$INST_HOME" bash -c 'source "$1"; classify_command "ls" "/tmp/rr" >/dev/null; bash -c "printf %s \"\${_TAXONOMY_SYNC_DONE:-UNSET}\""' _ "$INST_LIB" 2>/dev/null)"
+assert_eq "S80 guard var not exported to child" "$inherited" "UNSET"
+
+echo ""
+echo "=================================================="
+echo "Results: $passed passed, $failed failed"
+echo "=================================================="
+[ "$failed" -eq 0 ]

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -731,6 +731,49 @@ if echo "$output" | grep -q "Skipped orphan sweep"; then r=true; else r=false; f
 assert_eq "T19f sweep-withheld message printed on divergent command-classifier" "true" "$r"
 
 # ---------------------------------------------------------------------------
+# T20: RFC-008 P3c — taxonomy.json runtime-sourcing co-deploy + divergent WARN
+# ---------------------------------------------------------------------------
+# T20a: an --install-hooks install co-deploys patterns/taxonomy.json to the SAME
+# global root the classifier reads at runtime ($HOME/.episodic-memory/patterns),
+# byte-equal to the repo (codex R2-P2 install/runtime root parity). Coupled to
+# the classifier deploy so taxonomy never advances on its own.
+reset_state
+run_installer --install-hooks >/dev/null 2>&1
+GLOBAL_TAX="$TEST_HOME/.episodic-memory/patterns/taxonomy.json"
+[ -f "$GLOBAL_TAX" ] && r=true || r=false
+assert_eq "T20a taxonomy.json co-deployed to global patterns dir (--install-hooks)" "true" "$r"
+if cmp -s "$REPO_ROOT/patterns/taxonomy.json" "$GLOBAL_TAX"; then r=true; else r=false; fi
+assert_eq "T20b deployed taxonomy.json is byte-equal to repo" "true" "$r"
+
+# T20a2 (PR-level codex BLOCKER regression): a NO-hooks install must NOT deploy
+# the global taxonomy — otherwise it would advance runtime candidate-1 while an
+# already-installed classifier stays stale + unwarned (silent taxonomy_drift).
+reset_state
+run_installer >/dev/null 2>&1
+[ -f "$TEST_HOME/.episodic-memory/patterns/taxonomy.json" ] && r=true || r=false
+assert_eq "T20a2 no-hooks install does NOT deploy global taxonomy (coupling)" "false" "$r"
+
+# T20c: pre-P3c divergent classifier (no _ensure_taxonomy_synced helper) kept +
+# taxonomy redeployed → WARN that the gate is NOT taxonomy-synced (codex R1-P1b).
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks/lib"
+printf '#!/bin/bash\n# user-customized divergent classifier (pre-P3c, no helper)\n' \
+  > "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
+output=$(run_installer_capture --install-hooks)
+if echo "$output" | grep -q "pre-P3c"; then r=true; else r=false; fi
+assert_eq "T20c pre-P3c divergent classifier emits 'not taxonomy-synced' WARN" "true" "$r"
+
+# T20d: post-P3c divergent classifier (HAS the helper) kept + taxonomy redeployed
+# → WARN that it will FAIL CLOSED on drift (the other split branch).
+reset_state
+mkdir -p "$TEST_HOME/.claude/hooks/lib"
+printf '#!/bin/bash\n_ensure_taxonomy_synced() { :; }\n# divergent local edit, post-P3c\n' \
+  > "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
+output=$(run_installer_capture --install-hooks)
+if echo "$output" | grep -q "FAIL CLOSED"; then r=true; else r=false; fi
+assert_eq "T20d post-P3c divergent classifier emits 'FAIL CLOSED' WARN" "true" "$r"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/test-validate-bp-contract.mjs
+++ b/tests/test-validate-bp-contract.mjs
@@ -331,6 +331,37 @@ classifierCase("F-1R5: definition after a trailing-backslash COMMENT line", () =
 }
 
 // ---------------------------------------------------------------------------
+// Assertion 7c (RFC-008 P3c — R4/F4/F6): default classifier runtime-sources
+// taxonomy.json. Robust parser (codex R1-P2), two-emitter coverage (R1-P1),
+// emit-site vocabulary closure (GAP-2), and the `declare -f _priority` allowlist
+// regression that the runtime-sourcing derivation depends on.
+// ---------------------------------------------------------------------------
+// String forms exactly mirror the in-file guard blocks (\t/\n are literal
+// backslash-escapes in the bash printf format).
+const CP_GUARD = '  if ! _ensure_taxonomy_synced; then\n    printf \'%s\\t\\t%s\\n\' "unsafe_complex" "$_TAXONOMY_SYNC_REASON"\n    return 0\n  fi\n';
+const CC_GUARD_INNER = '    if ! _ensure_taxonomy_synced; then\n      final_label="unsafe_complex"\n      final_target=""\n      final_reason="$_TAXONOMY_SYNC_REASON"\n    fi\n';
+classifierCase("7c: missing _ensure_taxonomy_synced definition (helper deleted)", () => {
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER.replace("_ensure_taxonomy_synced() {", "_ensure_taxonomy_renamed_away() {"));
+}, "no _ensure_taxonomy_synced() definition");
+classifierCase("7c: classify_path does not call the guard (codex R1-P1)", () => {
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER.replace(CP_GUARD, ""));
+}, "classify_path() does not call _ensure_taxonomy_synced");
+classifierCase("7c: classify_command does not call the guard (codex R1-P1)", () => {
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER.replace(CC_GUARD_INNER, ""));
+}, "classify_command() does not call _ensure_taxonomy_synced");
+classifierCase("7c: typo'd emit-site label literal (GAP-2)", () => {
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER.replace('"shared_write" "rm_non_marker"', '"shared_writ" "rm_non_marker"'));
+}, 'emit-site label literal "shared_writ"');
+// FP control: `declare -f _priority` (the runtime-sourcing derivation) reads the
+// function body — it is inert and must stay green (extractPriorityArms allowlist).
+{
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER + '\nprobe_declare() {\n  local x="$(declare -f _priority)"\n  printf \'%s\' "$x"\n}\n');
+  const r = run(["--project", SANDBOX, "--json"]);
+  assert(r.exit === 0, "7c FP control: `declare -f _priority` read stays green (P3c)", `exit=${r.exit} violations=${JSON.stringify((r.payload && r.payload.violations || []).filter((v) => v.check === "7").map((v) => v.detail.slice(0, 80)))}`);
+  fs.writeFileSync(CLS_ABS, ORIG_CLASSIFIER);
+}
+
+// ---------------------------------------------------------------------------
 // 6. Stable-ID E2E (assertions 8/14) — all branches incl. A2 + N-5.
 // ---------------------------------------------------------------------------
 // (a) rename without major bump -> assertion 8 violation


### PR DESCRIPTION
## RFC-008 P3c — classifier runtime-sources `taxonomy.json` (R4 / F4 / F6)

Part of [RFC-008](docs/rfcs/RFC-008/P3-thin-waist.md). The classifier-runtime-sourcing slice of P3 (independent of the P3b-2 tier layer and P3d em-recall purification, per workplan v125).

### What changes
`command-classifier.sh` now sources its label vocabulary from `patterns/taxonomy.json` at runtime via a zero-dep node helper and **fails closed** if the resolved set drifts from the `_priority()` case-arms — the single bash label authority CI already pins `== taxonomy` (assertion 7b). This eliminates the hand-maintained label list **by construction** (F4 / OQ-2-closed).

- **`_ensure_taxonomy_synced` guard** fronts **both** public emitters (`classify_command` + `classify_path`); it **never** overrides the two non-overridable labels — `marker_write` (deadlock-class-1 escape hatch) and `unsafe_complex` (already maximally blocking).
- **Resolution:** candidate 1 = `$HOME/.episodic-memory/patterns/taxonomy.json` (== install `GLOBAL_DIR`); candidate 2 = a **conditional** in-repo climb gated on repo sentinels **and** a classifier realpath round-trip — the installed layout can never read an ambient parent `taxonomy.json` (authority-root containment; `cd -P` realpath handles the `/var→/private/var` class).
- **`install.mjs`** co-deploys `taxonomy.json` to the same global root, **coupled to the classifier deploy** (inside `--install-hooks`) so a no-hooks install never advances the taxonomy while the classifier stays stale. Emits a divergent-classifier WARN (pre-P3c-no-helper vs post-P3c split).
- **`validate-bp-contract.mjs` assertion 7c** (robust parser, not grep): the guard is defined + called from both entry points, and emit-site label literals ⊆ taxonomy. `extractPriorityArms` allowlists `declare -f _priority` (an inert read).

### Tests
| Suite | Result |
|---|---|
| `test-command-classifier.sh` (regression) | 430/0 |
| `test-classifier-taxonomy-sync.sh` (new) | 18/0 |
| `test-validate-bp-contract.mjs` (7c + allowlist) | 103/0 |
| `test-install-hooks.sh` (T20 co-deploy/WARN + BLOCKER regression) | 92/0 |
| live E2E (real install → deployed classify → drift fail-closed) | 8/0 |

`test-command-classifier.sh` + `test-classifier-taxonomy-sync.sh` wired into CI (`plugin-validate.yml`).

### Review trail
- **Plan:** `negative-scenario-planner` HOLD (3 P1) + codex R1 HOLD(5) → R2 HOLD(2) → **R3 ACCEPT**.
- **Code:** `negative-scenario-reviewer` **ACCEPT** — 4 adversarial axes (authority-root fail-OPEN, fail-OPEN under error, marker_write exemption, validator allowlist bypass) all fail-closed with shell repros.
- **PR-level:** codex R1 **REJECT** — 1 BLOCKER (no-hooks install advanced the global taxonomy unwarned → silent `taxonomy_drift`). Fixed (taxonomy deploy coupled to classifier + `T20a2` regression). claude-subagent R2 **ACCEPT** (consensus converged).

### Defers (per workplan v125)
Plugin override interface + F3 runtime alert → P3b-2; TSV→NDJSON → P4; em-recall purification → P3d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
