### PR TITLE
feat(rfc-008): P3b-2 — contract-driven effective-tier layer in enforce-contract.mjs (R3/R5/R6/R8)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -84,8 +84,14 @@ jobs:
       - name: Run stop-gate regression
         run: bash tests/test-stop-gate.sh
 
-      - name: Run enforce-contract --gate stop relocation + parity (RFC-008 P3b-1)
+      - name: Run enforce-contract --gate stop relocation + parity + tier layer (RFC-008 P3b-1/P3b-2)
         run: node tests/test-enforce-contract.mjs
+
+      - name: Run enforce-config loader + clamp integration (RFC-008 P3b-2, R5/P4)
+        run: node tests/test-enforce-config.mjs
+
+      - name: Run install-runtime contract-set deploy coupling (RFC-008 P3b-2, §10)
+        run: node tests/test-install-contract-deploy.mjs
 
       - name: Run preflight-gate regression tests
         run: bash tests/test-preflight-gate.sh

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Run plugin-registry conformance tests (path-contain regression lock)
         run: node tests/test-plugin-registry.mjs
 
+      - name: Run effective-tier algebra tests (RFC-008 P3b-2, R3 — shared min() fold)
+        run: node tests/test-effective-tier.mjs
+
+      - name: Run structured-alert F3 writer tests (RFC-008 P3b-2, CLASS-C(b)/M1/N2)
+        run: node tests/test-structured-alert.mjs
+
       - name: Validate bp contracts (assertions 0 + 1-15, P2b)
         run: node scripts/validate-bp-contract.mjs --project "$GITHUB_WORKSPACE"
 

--- a/install.mjs
+++ b/install.mjs
@@ -1251,6 +1251,22 @@ if (installHooks) {
       deployedContractSet = true
       console.log(`Installed enforce-contract set (bp-001.json, events.json, enforce-config.schema.json) to ${globalPatternsDir}`)
     }
+
+    // PR-level review PR-1 (R3/R6/R8): enforce-contract reads the harness-capability
+    // registry at runtime from <contractRoot>/plugins/_index.json (resolveHarnessCap),
+    // and the installed contractRoot is candidate-1 = $HOME/.episodic-memory. WITHOUT
+    // this deploy the runtime registry is always null in prod → the harness-cap min()
+    // leg is dead AND the M8 duplicate-binding + CLASS-C(a) fail-closed checks are
+    // unreachable (they only fired in dev/CI where candidate-2 = the repo root). Deploy
+    // plugins/_index.json to the global plugins/ tree, coupled to the same --install-hooks
+    // block. (resolveHarnessCap reads only entry.capabilities — no manifest needed here.)
+    const repoPluginsIndex = path.join(REPO_DIR, 'plugins', '_index.json')
+    if (fs.existsSync(repoPluginsIndex)) {
+      const globalPluginsDir = path.join(GLOBAL_DIR, 'plugins')
+      fs.mkdirSync(globalPluginsDir, { recursive: true })
+      fs.copyFileSync(repoPluginsIndex, path.join(globalPluginsDir, '_index.json'))
+      console.log(`Installed plugins/_index.json to ${globalPluginsDir}`)
+    }
     // F-NEW-4 coupling assertion: the DEPLOYED bp-001.events_version must equal the
     // sha over the DEPLOYED events.json. A mismatch means a partial/torn deploy —
     // WARN (enforce-contract fails CLOSED to STRONG on a contract it can't trust,

--- a/install.mjs
+++ b/install.mjs
@@ -20,6 +20,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
+import { eventsVersion } from './scripts/lib/version-hash.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const SCRIPTS_DIR = path.join(GLOBAL_DIR, 'scripts')
@@ -1222,6 +1223,53 @@ if (installHooks) {
       fs.mkdirSync(globalPatternsDir, { recursive: true })
       fs.copyFileSync(repoTaxonomy, path.join(globalPatternsDir, 'taxonomy.json'))
       console.log(`Installed patterns/taxonomy.json to ${globalPatternsDir}`)
+    }
+
+    // 5a-contract. RFC-008 P3b-2 (R5/R6/R8): co-deploy the enforce-contract RUNTIME
+    // contract set to the SAME global root enforce-contract.mjs reads at runtime
+    // (candidate 1 = $HOME/.episodic-memory/patterns/). COUPLED to the hook install
+    // exactly like the P3c taxonomy deploy above — stop-gate.sh invokes
+    // enforce-contract.mjs (a hook), so a no-hooks install must NOT advance the
+    // global contract while the installed gate stays stale (the P3c PR-level
+    // BLOCKER class). enforce-config.json itself is per-PROJECT + human-authored:
+    // ship the SCHEMA only, never a config instance.
+    //
+    // F-NEW-4 atomic multi-file deploy: bp-001.json embeds events_version (a sha
+    // over events.json). Land events.json + the schema FIRST and the sha-referencer
+    // bp-001.json LAST, so the candidate-1 gate (which keys on bp-001.json presence)
+    // flips to "present" only once the whole coupled set is on disk; a reader during
+    // the window falls through to candidate-2 and never sees new-bp-001 + stale-events.
+    const repoBp001 = path.join(REPO_DIR, 'patterns', 'bp-001.json')
+    let deployedContractSet = false
+    if (fs.existsSync(repoBp001)) {
+      fs.mkdirSync(globalPatternsDir, { recursive: true })
+      for (const f of ['events.json', 'enforce-config.schema.json']) {
+        const src = path.join(REPO_DIR, 'patterns', f)
+        if (fs.existsSync(src)) fs.copyFileSync(src, path.join(globalPatternsDir, f))
+      }
+      fs.copyFileSync(repoBp001, path.join(globalPatternsDir, 'bp-001.json')) // LAST — sha-referencer
+      deployedContractSet = true
+      console.log(`Installed enforce-contract set (bp-001.json, events.json, enforce-config.schema.json) to ${globalPatternsDir}`)
+    }
+    // F-NEW-4 coupling assertion: the DEPLOYED bp-001.events_version must equal the
+    // sha over the DEPLOYED events.json. A mismatch means a partial/torn deploy —
+    // WARN (enforce-contract fails CLOSED to STRONG on a contract it can't trust,
+    // so this is hardening, not a fail-open fix).
+    if (deployedContractSet) {
+      try {
+        const depBp = JSON.parse(fs.readFileSync(path.join(globalPatternsDir, 'bp-001.json'), 'utf8'))
+        const depEvents = JSON.parse(fs.readFileSync(path.join(globalPatternsDir, 'events.json'), 'utf8'))
+        const liveEv = eventsVersion(depEvents)
+        if (depBp.events_version !== liveEv) {
+          console.log(
+            `WARNING: deployed bp-001.events_version (${depBp.events_version}) != sha of deployed ` +
+            `events.json (${liveEv}) — contract set is divergent/torn; enforce-contract will fail ` +
+            'CLOSED (stay STRONG). Re-run with --install-hooks-force to resync.'
+          )
+        }
+      } catch (e) {
+        console.log(`WARNING: could not verify enforce-contract set coupling: ${e.message}`)
+      }
     }
 
     // RFC-008 P3c (R4/F4, codex R1-P1b): if the command classifier was KEPT as a

--- a/patterns/enforce-config.schema.json
+++ b/patterns/enforce-config.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://episodic-memory/patterns/enforce-config.schema.json",
+  "title": "Per-project enforcement config (RFC-008 P4, R5)",
+  "description": "Optional, HUMAN-AUTHORED per-project tuning at <repo>/.episodic-memory/enforce-config.json. Supplies the THIRD min() leg of effective_tier = min(harness_cap, contract_tier, project_config) (P3-thin-waist L54-60). Clamps DOWN only — naming a tier higher than harness∩contract has no raising effect (min ignores it). Top-level `active:false` turns enforcement OFF for this project (R5 silence). Per-bp keys carry per-gate tier overrides; the stop refuse clamps on `<bp>.stop` (NOT post_checkpoint — F-NEW-1). Absent/malformed ⇒ no clamp ⇒ base-STRONG (fail-closed; a broken or hostile file can never WEAKEN a gate). NOT agent-writable: install.mjs ships this SCHEMA, never a config instance.",
+  "type": "object",
+  "properties": {
+    "active": {
+      "type": "boolean",
+      "description": "Project-level enforcement switch. false ⇒ R5 silence for the gates P3b-2 wires (stop proceeds, no refuse). Distinct from the registry plugin status (M3). Default true (absent ⇒ enforcement on)."
+    }
+  },
+  "additionalProperties": { "$ref": "#/$defs/perBp" },
+  "propertyNames": {
+    "oneOf": [
+      { "const": "active" },
+      { "type": "string", "pattern": "^bp-[0-9]{3}$" }
+    ]
+  },
+  "$defs": {
+    "tier": {
+      "type": "string",
+      "enum": ["STRONG", "MEDIUM", "WEAK"]
+    },
+    "perBp": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-gate tier clamp for one bp contract. Keys mirror GATE_CONTRACT_KEY (effective-tier.mjs): the three classification gates + the root-level stop marker-state gate. Only `stop` is LIVE-wired in P3b-2; the three classification gates parse + validate but are inert until the pre_tool_use bridge lands.",
+      "properties": {
+        "plan_approval": { "$ref": "#/$defs/tier" },
+        "pre_checkpoint": { "$ref": "#/$defs/tier" },
+        "post_checkpoint": { "$ref": "#/$defs/tier" },
+        "stop": { "$ref": "#/$defs/tier" }
+      }
+    }
+  }
+}

--- a/scripts/enforce-contract.mjs
+++ b/scripts/enforce-contract.mjs
@@ -270,6 +270,25 @@ export function loadEnforceConfig(markerRoot, schema, { readFileSync = fs.readFi
   return { active, bps }
 }
 
+/**
+ * PR-level review PR-2 (R3/R5 observability): the M4/R5 downgrade NOTICES go to
+ * stderr, which the production stop hook (stop-gate.sh) discards via `2>/dev/null`
+ * — so a deliberate operator downgrade would otherwise leave NO durable trace.
+ * Persist a one-line audit record to disk under the MARKER root (where
+ * enforce-config.json lives), a channel the hook cannot suppress, so "a downgrade
+ * of the project's strongest gate is always auditable" (M4) holds in prod. The
+ * stderr notice is kept too (useful in dev/interactive). BEST-EFFORT: an audit
+ * write failure must NEVER break the gate decision (B1 — observability is not on
+ * the safety path).
+ */
+function appendEnforceAudit(markerRoot, line) {
+  try {
+    const dir = path.join(markerRoot, '.episodic-memory')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.appendFileSync(path.join(dir, 'enforce-audit.log'), `${new Date().toISOString()} ${line}\n`)
+  } catch { /* best-effort; never block the gate on an audit write */ }
+}
+
 // ---------------------------------------------------------------------------
 // CLI — the ONLY I/O + process.exit boundary. Invoked by hooks/stop-gate.sh as
 // `node enforce-contract.mjs --gate stop [--session-id <sid>]`. Empty stdout =
@@ -378,6 +397,7 @@ if (isMain) {
   // plugin capability → unsupported) still REAL-blocks even under active:false —
   // a corrupt install is not silenceable by an opt-out, by design (fail-closed).
   if (!cfg.active) {
+    appendEnforceAudit(markerRoot, `${BP_ID} enforcement disabled (active:false) — stop gate not applied (R5 silence)`)
     process.stderr.write(
       'enforce-contract: notice — enforcement disabled for this project via ' +
       '.episodic-memory/enforce-config.json {"active":false}; stop gate not applied (R5 silence).\n',
@@ -390,9 +410,10 @@ if (isMain) {
   // project's strongest gate is always auditable in the hook log).
   const effTier = clampTier(hcTier, configTier)
   if ((TIER_RANK[effTier] ?? 0) < (TIER_RANK[hcTier] ?? 0)) {
+    appendEnforceAudit(markerRoot, `stop refuse degraded ${hcTier}->${effTier} for ${BP_ID} (deliberate operator clamp via enforce-config.json)`)
     process.stderr.write(
       `enforce-contract: notice — stop refuse degraded ${hcTier}→${effTier} for ${BP_ID} via ` +
-      '.episodic-memory/enforce-config.json (deliberate operator clamp, M4 audit).\n',
+      '.episodic-memory/enforce-config.json (deliberate operator clamp, M4 audit → .episodic-memory/enforce-audit.log).\n',
     )
   }
 

--- a/scripts/enforce-contract.mjs
+++ b/scripts/enforce-contract.mjs
@@ -9,18 +9,34 @@
  * handler is the last violator and is DELETED in P3d once this consumer migrates.
  *
  * The claude-code stop decision is purely marker-state (RFC-008:464 — "the `stop`
- * gate is NOT per-label … it reads marker state, not command labels"), so this
- * slice reads NO contract / registry / config / events files. The contract-driven
- * effective-tier layer (effective_tier = min(harness, contract, config), the
- * `plugins/_index.json` capability lookup, the per-project clamp, and CLASS-C(a)
- * fail-closed-on-`unsupported`) is INERT for claude-code — min(STRONG,STRONG,
- * identity)=STRONG→refuse_stop reproduces today's unconditional behavior — and so
- * defers to P3b-2, landing with its real dependencies (an install-runtime contract
- * deploy + the P4 config schema). See docs/rfcs/RFC-008/P3-thin-waist.md.
+ * gate is NOT per-label … it reads marker state, not command labels"). P3b-2 adds
+ * the contract-driven effective-tier layer ON TOP of that marker logic:
+ * effective_tier(stop) = min(harness_cap[stop], contract.stop.tier, config.<bp>.stop)
+ * over the base-STRONG fold (scripts/lib/effective-tier.mjs). decideStop stays
+ * PURE (no I/O — F-NEW-3) and receives the resolved effective stop tier as a
+ * param; the tier RESOLUTION (registry/contract/config reads across the two roots)
+ * and the M4 downgrade notice are I/O confined to the CLI boundary below.
  *
- * Behavior is byte-identical to `em-recall --gate stop` — stdout, exit code,
- * stderr (modulo the script-name prefix), and no marker side-effects — proven by
- * tests/test-enforce-contract.mjs (parity suite vs em-recall).
+ * The anti-fail-open invariant (B1): default-STRONG / clamp-only-on-success. Every
+ * tier source the boundary cannot resolve (missing contract root, missing
+ * `plugins/_index.json`, absent/broken config) is passed as `null` and folded as
+ * NO clamp — the base stays STRONG, i.e. today's unconditional refuse. A
+ * resolution failure can therefore NEVER weaken the gate. enforce-contract changes
+ * observable behavior ONLY when a project's enforce-config.json explicitly clamps
+ * `stop` below STRONG (or sets `active:false`). See docs/rfcs/RFC-008/P3-thin-waist.md.
+ *
+ * Live wiring this slice = the stop gate ONLY (the `stop.tier` root-level
+ * marker-state gate, F-NEW-1). The three `gates.*` classification gates resolve at
+ * pre_tool_use and are DEFERRED (bash plan-gate.sh/checkpoint-gate.sh ↔ node
+ * bridge, a later slice). CLASS-C(b) — the out-of-vocab F3 writer
+ * (scripts/lib/structured-alert.mjs) — ships LIBRARY-ONLY (B2): the stop gate is
+ * label-independent, so there is no live out-of-vocab site this slice.
+ *
+ * With NO enforce-config.json (or active:true, no clamps) behavior is
+ * byte-identical to `em-recall --gate stop` — stdout, exit code, stderr (modulo
+ * the script-name prefix), and no marker side-effects — proven by
+ * tests/test-enforce-contract.mjs (parity suite vs em-recall + three-axis
+ * inertness on contract-resolution failure).
  *
  * Marker reads are owned by scripts/lib/marker-state.mjs (the R1-owned reader
  * extracted in P3a). This module performs ZERO marker logic of its own — it only
@@ -28,6 +44,8 @@
  */
 
 import fs from 'fs'
+import path from 'node:path'
+import os from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { resolveRepoRoot } from './lib/local-dir.mjs'
 import {
@@ -42,6 +60,18 @@ import {
   stopGateCarveOutApplies,
 } from './lib/marker-state.mjs'
 import { validateSessionId } from './lib/session-id.mjs'
+import { validateInstance } from './lib/json-instance-validate.mjs'
+import {
+  TIER_RANK,
+  clampTier,
+  effectiveTierStrong,
+  eventActionId,
+} from './lib/effective-tier.mjs'
+
+// The harness this enforcement layer runs for (stop-gate.sh is the claude-code
+// hook). The contract this layer governs is bp-001 (standard impl workflow).
+const THIS_HARNESS = 'claude-code'
+const BP_ID = 'bp-001'
 
 /**
  * decideStop — pure stop-gate decision (no I/O, no process exit).
@@ -53,14 +83,31 @@ import { validateSessionId } from './lib/session-id.mjs'
  *   em-recall:211 console.log({…})  → return {decision,reason}     (block)
  *   em-recall:216 process.exit(0)  → return null                  (carve-out / no-marker allow)
  *
- * @param {{repoRoot: string, sid: string|null}} opts
+ * @param {{repoRoot: string, sid: string|null, stopTier?: string}} opts
  *   repoRoot — the gate root (caller resolves via resolveRepoRoot() from cwd, the
  *              same module-load semantics as em-recall.mjs:48; stop-gate.sh `cd`s
  *              to the hook input `.cwd` before spawning, so cwd IS the project).
  *   sid      — validated own-session id, or null (legacy-literal-only mode).
+ *   stopTier — the resolved effective stop tier (F-NEW-3). 'STRONG' (default, and
+ *              the no-clamp case) ⇒ refuse_stop semantics: today's marker logic.
+ *              A successfully-resolved operator clamp to 'MEDIUM'/'WEAK' DEGRADES
+ *              the refuse ⇒ allow stop (return null). Default 'STRONG' keeps the
+ *              em-recall parity proof byte-identical: a caller that passes no tier
+ *              gets exactly today's behavior. This is the function's only pure
+ *              extension — tier RESOLUTION + the M4 notice are the CLI's job.
  * @returns {{decision:'block', reason:string} | null}  null = allow stop.
  */
-export function decideStop({ repoRoot, sid }) {
+export function decideStop({ repoRoot, sid, stopTier = 'STRONG' }) {
+  // Effective stop tier below STRONG ⇒ the refuse is degraded (warn at MEDIUM,
+  // unsupported at WEAK) by a deliberate operator clamp ⇒ allow the stop. Reached
+  // ONLY via a successfully-resolved enforce-config.json clamp; a resolution
+  // failure leaves the boundary's fold at STRONG, so this never fires by accident.
+  // The CLI boundary emits the M4 audit notice whenever a config clamp lowers the
+  // tier, so the degrade is never silent. (events.json maps stop MEDIUM→`warn`;
+  // for claude-code MEDIUM is reachable ONLY via that config path — which is
+  // already M4-logged — so the bare allow here is not an unlogged warn-drop.)
+  if (stopTier !== 'STRONG') return null
+
   // #178 F1: defer stop-gate when plan is ACTIVELY pending at EITHER root.
   // The plan-gate blocks Write/Bash while .plan-approval-pending exists at
   // either root, creating an unrecoverable triangle when stop-gate ALSO
@@ -113,6 +160,114 @@ export function decideStop({ repoRoot, sid }) {
   }
   // Otherwise: allow stop. Empty stdout on Stop = allow Claude to stop.
   return null // em-recall:216 process.exit(0)
+}
+
+// ---------------------------------------------------------------------------
+// Tier-resolution helpers (the CLI boundary's I/O — F-NEW-3). Each reads a
+// contract artifact and degrades to null/identity on ANY failure (B1: a
+// resolution miss is never a lowering value, never a silent-allow).
+// ---------------------------------------------------------------------------
+
+function realpathOrNull(p) {
+  try { return fs.realpathSync(p) } catch { return null }
+}
+
+function readJsonSafe(abs) {
+  try { return JSON.parse(fs.readFileSync(abs, 'utf8')) } catch { return null }
+}
+
+/**
+ * Resolve the CONTRACT root — where patterns/{bp-001,events,enforce-config.schema}
+ * + plugins/_index.json live. Mirrors P3c's classifier candidate PATTERN (two
+ * candidates, sentinel-gated, realpath round-trip) but with enforce-contract's OWN
+ * depth: this module sits at scripts/, so the in-repo contract root is ONE level
+ * up (B3 — copying P3c's 4-level climb would climb above $HOME and reborn the
+ * ambient-parent-read bug P3c fixed). Returns an absolute path or null.
+ *
+ * Candidate 1 — global install root ($HOME/.episodic-memory == install GLOBAL_DIR,
+ * os.homedir() with no env indirection, P3c root parity), accepted iff the
+ * deployed bp-001 contract is present there.
+ * Candidate 2 — the depth-1 in-repo root, accepted ONLY when it PROVES it is the
+ * repo copy: repo sentinels present AND the climbed enforce-contract path
+ * round-trips back to THIS module (an installed-layout module must not read an
+ * ambient parent's patterns/).
+ */
+export function resolveContractRoot() {
+  const c1 = path.join(os.homedir(), '.episodic-memory')
+  if (fs.existsSync(path.join(c1, 'patterns', 'bp-001.json'))) {
+    return realpathOrNull(c1) || c1
+  }
+  // Candidate 2 is DEV/CI-ONLY by construction: the installed layout never
+  // satisfies it. taxonomy.schema.json (sentinel below) is NOT deployed to the
+  // global root (install.mjs ships taxonomy.json + the contract set, not the
+  // *.schema.json), so an installed module's depth-1 climb fails the first
+  // sentinel and falls through to candidate-1 / null (fail-closed STRONG). The
+  // realpath round-trip additionally pins candidate-2 to THIS module's own
+  // location, so it can never read an ambient parent's patterns/ (B3; regression:
+  // test-enforce-contract section D "ambient grandparent").
+  const selfReal = realpathOrNull(fileURLToPath(import.meta.url))
+  if (!selfReal) return null
+  const selfDir = path.dirname(selfReal) // <root>/scripts
+  const climbed = realpathOrNull(path.resolve(selfDir, '..')) // <root>
+  if (!climbed) return null
+  // (a) repo sentinels at the climbed root.
+  if (!fs.existsSync(path.join(climbed, 'patterns', 'taxonomy.schema.json'))) return null
+  if (!fs.existsSync(path.join(climbed, 'scripts', 'em-store.mjs'))) return null
+  // (b) the climbed enforce-contract path round-trips back to THIS module.
+  const rpClimbed = realpathOrNull(path.join(climbed, 'scripts', 'enforce-contract.mjs'))
+  if (!rpClimbed || rpClimbed !== selfReal) return null
+  return climbed
+}
+
+/**
+ * The harness capability tier for `event` from the plugin registry. M8: more than
+ * one ACTIVE enforcement entry binding the same harness ⇒ { duplicate:true } (the
+ * caller fail-closes with a REAL block — R6 one-harness-one-plugin). Zero matches
+ * ⇒ { tier:null } (B1 — a missing/inactive binding inside an already-firing hook
+ * is a corrupted install, NOT "no plugin"; it leaves the gate at base-STRONG, it
+ * NEVER degrades to allow).
+ */
+export function resolveHarnessCap(registry, harness, event = 'stop') {
+  const plugins = Array.isArray(registry && registry.plugins) ? registry.plugins : []
+  const matches = plugins.filter(
+    (p) => p && p.type === 'enforcement' && p.status === 'active' && p.harness === harness,
+  )
+  if (matches.length > 1) return { tier: null, duplicate: true, count: matches.length }
+  if (matches.length === 0) return { tier: null, duplicate: false, count: 0 }
+  const caps = matches[0].capabilities
+  const tier = caps && typeof caps[event] === 'string' ? caps[event] : null
+  return { tier, duplicate: false, count: 1 }
+}
+
+/**
+ * Load the per-project enforce-config.json from the MARKER root (NOT the contract
+ * root — §6 two-root split). The `schema` is the deployed enforce-config schema
+ * (read from the contract root by the caller); null when no contract is deployed.
+ *
+ * M2 fail-OPEN audit (the load-bearing safety class): EVERY error branch lands in
+ * ONE stay-STRONG sink — returns the IDENTITY clamp { active:true, bps:{} } so a
+ * broken/hostile/absent file can never WEAKEN a gate. Enumerated branches: (0) no
+ * schema; (1) file absent (ENOENT); (2) read error (EACCES/EISDIR); (3) JSON.parse
+ * throws; (4) parses but not a plain object (array/null/scalar); (5) schema-invalid;
+ * (6) TOCTOU — read ONCE (no stat-then-read). A schema-VALID config is honored
+ * (M4 observability for a real downgrade is the CLI boundary's job).
+ */
+export function loadEnforceConfig(markerRoot, schema, { readFileSync = fs.readFileSync } = {}) {
+  const identity = { active: true, bps: {} }
+  if (!schema) return identity // (0) no deployed schema → cannot validate → fail-closed
+  const configPath = path.join(markerRoot, '.episodic-memory', 'enforce-config.json')
+  let raw
+  try { raw = readFileSync(configPath, 'utf8') } catch { return identity } // (1)/(2)/(6)
+  let parsed
+  try { parsed = JSON.parse(raw) } catch { return identity } // (3)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return identity // (4)
+  let valid
+  try { valid = validateInstance(parsed, schema).valid } catch { return identity } // schema crash → fail-closed
+  if (!valid) return identity // (5)
+  const active = parsed.active === undefined ? true : parsed.active
+  const bps = {}
+  for (const [k, v] of Object.entries(parsed)) { if (k === 'active') continue; bps[k] = v }
+  return { active, bps }
 }
 
 // ---------------------------------------------------------------------------
@@ -171,9 +326,77 @@ if (isMain) {
 
   // Gate root resolved from cwd (em-recall.mjs:48 parity). stop-gate.sh `cd`s to
   // the hook input `.cwd` before spawning, so this converges with the project the
-  // hook named (closes #106 worktree-orphan for this gate).
-  const repoRoot = resolveRepoRoot()
-  const decision = decideStop({ repoRoot, sid: mySid })
+  // hook named (closes #106 worktree-orphan for this gate). This is the MARKER
+  // root (where .checkpoints/ + .episodic-memory/enforce-config.json live).
+  const markerRoot = resolveRepoRoot()
+
+  // M5 — resolve BOTH roots ONCE at entry; thread them through; no path is
+  // re-resolved mid-invocation (axis-6 TOCTOU hardening). The contract root is the
+  // module-relative/global root (§6); reads degrade to null on any miss (B1).
+  const contractRoot = resolveContractRoot()
+  const registry = contractRoot ? readJsonSafe(path.join(contractRoot, 'plugins', '_index.json')) : null
+  const contractDoc = contractRoot ? readJsonSafe(path.join(contractRoot, 'patterns', 'bp-001.json')) : null
+  const events = contractRoot ? readJsonSafe(path.join(contractRoot, 'patterns', 'events.json')) : null
+  const configSchema = contractRoot ? readJsonSafe(path.join(contractRoot, 'patterns', 'enforce-config.schema.json')) : null
+
+  const harnessRes = registry ? resolveHarnessCap(registry, THIS_HARNESS, 'stop') : { tier: null, duplicate: false }
+  const cfg = loadEnforceConfig(markerRoot, configSchema)
+
+  const harnessCap = harnessRes.tier
+  const contractTier = (contractDoc && contractDoc.stop && typeof contractDoc.stop.tier === 'string') ? contractDoc.stop.tier : null
+  const configTier = (cfg.bps[BP_ID] && typeof cfg.bps[BP_ID].stop === 'string') ? cfg.bps[BP_ID].stop : null
+
+  // M8 — >1 active enforcement plugin binding this harness ⇒ fail-closed REAL
+  // block (never pick-first). R6 one-harness-one-plugin.
+  if (harnessRes.duplicate) {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: `enforce-contract: ${harnessRes.count} active enforcement plugins bind harness "${THIS_HARNESS}" in plugins/_index.json — refusing to choose (R6 one-harness-one-plugin / M8). Fix the registry.`,
+    }))
+    process.exit(0)
+  }
+
+  // harness ∩ contract tier (BEFORE the operator config clamp). For claude-code
+  // this is STRONG (capabilities.stop STRONG ∩ bp-001.stop.tier STRONG).
+  const hcTier = effectiveTierStrong([harnessCap, contractTier])
+
+  // CLASS-C(a) — the harness∩contract tier maps to an `unsupported` action at the
+  // stop event ⇒ fail-closed REAL block, NOT a swallowed warn (N1; honest-
+  // capability R3). NEVER fires for claude-code (hcTier STRONG → refuse_stop);
+  // evaluated only when events.json resolved.
+  if (events && eventActionId(events, 'stop', hcTier) === 'unsupported') {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: `enforce-contract: contract requires the stop gate but the harness∩contract tier "${hcTier}" maps to an unsupported action at the stop event (CLASS-C(a) fail-closed, R3). Fix the plugin capability declaration.`,
+    }))
+    process.exit(0)
+  }
+
+  // active:false ⇒ R5 silence — the operator turned enforcement OFF for this
+  // project. Honored, but OBSERVABLE (M4): never silent-silent. NOTE the ordering:
+  // CLASS-C(a) above fires FIRST, so a genuinely-incoherent harness (corrupt
+  // plugin capability → unsupported) still REAL-blocks even under active:false —
+  // a corrupt install is not silenceable by an opt-out, by design (fail-closed).
+  if (!cfg.active) {
+    process.stderr.write(
+      'enforce-contract: notice — enforcement disabled for this project via ' +
+      '.episodic-memory/enforce-config.json {"active":false}; stop gate not applied (R5 silence).\n',
+    )
+    process.exit(0) // allow stop, empty stdout
+  }
+
+  // Apply the operator config clamp (clamp-DOWN only). When it actually lowers the
+  // tier, emit the M4 downgrade notice (observability: a downgrade of the
+  // project's strongest gate is always auditable in the hook log).
+  const effTier = clampTier(hcTier, configTier)
+  if ((TIER_RANK[effTier] ?? 0) < (TIER_RANK[hcTier] ?? 0)) {
+    process.stderr.write(
+      `enforce-contract: notice — stop refuse degraded ${hcTier}→${effTier} for ${BP_ID} via ` +
+      '.episodic-memory/enforce-config.json (deliberate operator clamp, M4 audit).\n',
+    )
+  }
+
+  const decision = decideStop({ repoRoot: markerRoot, sid: mySid, stopTier: effTier })
   if (decision) {
     console.log(JSON.stringify(decision))
   }

--- a/scripts/lib/effective-tier.mjs
+++ b/scripts/lib/effective-tier.mjs
@@ -1,0 +1,118 @@
+// effective-tier.mjs — the single tier-resolution algebra (RFC-008 P3b-2, R3).
+//
+// Extracted VERBATIM from validate-plugin-registry.mjs (TIER_RANK, effectiveTier,
+// eventActionId) so the runbook's documented Resolution Matrix (Table B) and the
+// runtime stop-gate decision read the SAME min()-over-tiers algebra — Rule 14:
+// one algebra, two consumers, MUST NOT drift. The validator re-imports these for
+// byte-rendering Table B (no behavior change there, proven by its self-tests);
+// enforce-contract.mjs imports the base-STRONG fold + the gate maps for the live
+// stop decision.
+//
+// TWO folds, deliberately distinct (F-CLOSE-1 / F-NEW-2):
+//
+//   effectiveTier(tiers)          null on all-absent. VALIDATOR-ONLY — the matrix
+//                                 byte-diff renders an em-dash on null (eventActionId
+//                                 returns "—"), and that em-dash is embedded in the
+//                                 runbook + byte-diffed by M7c. Mutating it to
+//                                 never-null would break that diff (fails LOUD in
+//                                 CI, never fail-open) — so the never-null consumer
+//                                 gets a SEPARATE fold below, and this one is pinned.
+//
+//   effectiveTierStrong(sources)  base 'STRONG', clamp-DOWN only, returns a CONCRETE
+//                                 tier NEVER null. ENFORCE-CONTRACT-ONLY. A
+//                                 null/absent/unresolvable/unknown source is never
+//                                 folded as a lowering value and never read as
+//                                 silent-allow, so "resolution failed ⇒ weaker gate"
+//                                 is unreachable by construction (B1 — the anti-
+//                                 fail-open invariant).
+
+// STRONG(3) > MEDIUM(2) > WEAK(1) > TBD(0). TBD is a manifest-declaration sentinel
+// (validate-plugin-registry TIERS); it never reaches a live contract (schema.json
+// closes contract tiers to {STRONG,MEDIUM,WEAK}).
+export const TIER_RANK = { TBD: 0, WEAK: 1, MEDIUM: 2, STRONG: 3 };
+
+// gate → lifecycle event the gate fires at. The three classification gates fire at
+// pre_tool_use; the root-level marker-state stop gate fires at stop (F-NEW-1,
+// grounded in patterns/schema.json:17-36 — `gates.*` are the pre_tool_use
+// classification gates, `stop.tier` is the marker-state gate). The event selects
+// both the harness-capability tier and the events.json action semantics.
+export const GATE_EVENT_MAP = {
+  plan_approval: "pre_tool_use",
+  pre_checkpoint: "pre_tool_use",
+  post_checkpoint: "pre_tool_use",
+  stop: "stop",
+};
+
+// gate → contract key PATH inside a bp-XXX.json contract (patterns/schema.json).
+// The three classification gates live under `gates.*`; the stop refuse is the
+// ROOT-LEVEL `stop.tier` marker-state gate — NOT `gates.post_checkpoint` (the
+// v2-plan bug F-NEW-1 corrected). An operator relaxing the stop refuse clamps
+// `{"bp-001":{"stop":"WEAK"}}`, never `post_checkpoint`.
+export const GATE_CONTRACT_KEY = {
+  plan_approval: "gates.plan_approval",
+  pre_checkpoint: "gates.pre_checkpoint",
+  post_checkpoint: "gates.post_checkpoint",
+  stop: "stop.tier",
+};
+
+// Which gates P3b-2 LIVE-wires into a runtime decision. ONLY the stop gate this
+// slice (decideStop, the marker-state gate). The three pre_tool_use classification
+// gates are DEFERRED — they need the bash plan-gate.sh/checkpoint-gate.sh ↔ node
+// bridge, a later slice (§9). Exported so the Rule-14 mirror validator can assert
+// a `stop→` clamp degrades the live decision while a `post_checkpoint→` clamp does
+// not (it is inert until wired).
+export const LIVE_GATES = ["stop"];
+
+/**
+ * VALIDATOR-ONLY fold: min over the PRESENT tier sources, null on all-absent.
+ * Pinned unchanged — the runbook matrix byte-diff depends on the null→em-dash
+ * rendering. Do not give this never-null semantics; use effectiveTierStrong.
+ */
+export function effectiveTier(tiers) {
+  let min = null, minRank = Infinity;
+  for (const t of tiers) {
+    if (t == null) continue;
+    const r = TIER_RANK[t] ?? Infinity;
+    if (r < minRank) { minRank = r; min = t; }
+  }
+  return min;
+}
+
+/**
+ * clamp-DOWN only (B1). A null source leaves base unchanged; a source strictly
+ * WEAKER than base lowers it; a source stronger-or-equal — OR an unknown tier
+ * string (rank Infinity) — leaves base unchanged. Unknown ⇒ never lowers ⇒
+ * fail-closed: a malformed tier can never weaken a gate.
+ */
+export function clampTier(base, source) {
+  if (source == null) return base;
+  const br = TIER_RANK[base] ?? -Infinity;
+  const sr = TIER_RANK[source] ?? Infinity;
+  return sr < br ? source : base;
+}
+
+/**
+ * ENFORCE-CONTRACT fold: base 'STRONG', clamp each source DOWN, return a CONCRETE
+ * tier NEVER null. All sources null/absent ⇒ 'STRONG' (today's behavior), so a
+ * resolution failure can never produce a weaker gate (the anti-fail-open
+ * invariant, F-NEW-2). The caller passes [harnessCap, contractTier, configTier];
+ * any leg it could not resolve it passes as null.
+ */
+export function effectiveTierStrong(sources) {
+  let t = "STRONG";
+  for (const s of sources) t = clampTier(t, s);
+  return t;
+}
+
+/**
+ * The events.json action id for (eventId, tier). Returns "—" (em-dash) when the
+ * tier is null or the event/action is absent — the validator renders that em-dash
+ * in the runbook matrix. enforce-contract passes a concrete tier, so it always
+ * gets a real action id (or "—" only on a genuinely missing event, which it
+ * treats as a non-actionable resolution miss).
+ */
+export function eventActionId(events, eventId, tier) {
+  const ev = (events.events || []).find((e) => e.id === eventId);
+  const a = ev && ev.actions && tier != null ? ev.actions[tier] : null;
+  return a && a.id ? a.id : "—";
+}

--- a/scripts/lib/structured-alert-probe.mjs
+++ b/scripts/lib/structured-alert-probe.mjs
@@ -1,133 +1,54 @@
-// structured-alert-probe.mjs — RFC-008 R0c P1c C4. A MINIMAL, P1-local probe
-// that exercises the project-root → store-root resolution path with a PINNED
-// output contract (F31/F36/F61, F4). It is NOT the real F3 hard-reject writer —
-// that decision engine lands in P3 (gauntlet step 6 stays deferred-P3). This
-// probe exists only so the harness-binding tests can assert the resolution
-// contract end-to-end before the real writer exists.
+// structured-alert-probe.mjs — RFC-008 R0c P1c C4. The MINIMAL P1-local probe
+// that exercised the project-root → store-root resolution path with a PINNED
+// output contract (F31/F36/F61, F4) BEFORE the real F3 writer existed.
 //
-// Pinned contract (F4 — two distinct fields, NEVER conflated):
-//   input_project_root  the `--project`/env/discovered input (a linked worktree
-//                       reports its OWN path here).
-//   store_root          resolveRepoRoot(input_project_root) — where the alert
-//                       actually lands; for a linked worktree this CONVERGES to
-//                       the main checkout (F61).
-// The written episode carries the same split: episode.project_root === input,
-// episode.store_root === store_root, episode.episode_file === the written path.
-//
-// Resolution precedence (F36): --project  >  $EPISODIC_MEMORY_PROJECT_ROOT  >
-// git discovery from cwd. With none of the three resolvable to a git work tree,
-// discovery FAILS CLOSED (exit 2) — it never silently writes to a guessed root.
+// P3b-2 landed the real writer at scripts/lib/structured-alert.mjs (parameterized
+// payload — CLASS-C(b), M1). This probe is now a THIN FIXTURE WRAPPER over it:
+// emitProbeAlert hardcodes the P1c probe payload (a `classifier_out_of_vocabulary`
+// alert with the literal `probe_out_of_vocabulary` label) so the harness-binding
+// tests (tests/test-plugin-harness-binding.mjs, which SPAWN this CLI) keep their
+// pinned `input_project_root`/`store_root`/`episode_file` stdout contract. The
+// path math (canonical / resolveInput / store_root split / schema validation)
+// lives ONCE in structured-alert.mjs; this file no longer duplicates it.
 
 import fs from "node:fs";
-import path from "node:path";
-import { execFileSync } from "node:child_process";
-import { pathToFileURL } from "node:url";
-import { resolveRepoRoot } from "./local-dir.mjs";
-import { validateInstance } from "./json-instance-validate.mjs";
+import { fileURLToPath } from "node:url";
+import {
+  AlertError,
+  resolveInput,
+  emitStructuredAlert,
+} from "./structured-alert.mjs";
 
-const SCHEMA = JSON.parse(
-  fs.readFileSync(new URL("../../schemas/runtime/structured-alert.schema.json", import.meta.url), "utf8"),
-);
-
-export class ProbeError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = "ProbeError";
-  }
-}
-
-// Canonicalize so input_project_root and store_root are directly comparable
-// (macOS /var → /private/var: git emits the realpath, so the input must too,
-// else a non-worktree repo would spuriously report input != store).
-function canonical(p) {
-  return fs.realpathSync(path.resolve(p));
-}
+// Back-compat alias — the P1c probe exported ProbeError; keep the name exported
+// (now an alias of AlertError) for any external importer.
+export { AlertError as ProbeError, resolveInput };
 
 /**
- * Resolve the input project root (F36 precedence). Throws ProbeError if nothing
- * resolves to a git work tree.
- * @param {{project?: string, env?: string, cwd?: string}} src
- * @returns {string} canonical input project root
- */
-export function resolveInput({ project, env, cwd = process.cwd() } = {}) {
-  if (project) return canonical(project);
-  if (env) return canonical(env);
-  // discovery — must be a real git work tree, else fail closed.
-  try {
-    const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).toString().trim();
-    if (top) return canonical(top);
-  } catch {
-    // not a git work tree
-  }
-  throw new ProbeError(
-    "no --project and no $EPISODIC_MEMORY_PROJECT_ROOT, and cwd is not a git work tree — " +
-    "structured-alert discovery failed closed (it will not guess a store root)",
-  );
-}
-
-// Filesystem-safe episode filename from an injected ISO-8601 stamp (no colons).
-function stampSlug(now) {
-  return now.replace(/[^0-9A-Za-z]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-/**
- * Build, schema-validate, and write a structured-alert episode under
- * resolveRepoRoot(input)/.episodic-memory/alerts/. Returns the pinned contract.
- * @param {{input: string, now: string, command?: string, scope?: string}} opts
- * @returns {{status, input_project_root, store_root, episode_file, alert_valid}}
+ * Write the P1c PROBE alert (fixed `classifier_out_of_vocabulary` /
+ * `probe_out_of_vocabulary` payload) via the real writer, then remap the result
+ * to the probe's pinned stdout field names (`input_project_root`). The probe
+ * never emits a REAL out-of-vocab label — it only proves the path math.
+ * @param {{input:string, now:string, command?:string, scope?:string}} opts
  */
 export function emitProbeAlert({ input, now, command = "", scope = "local" } = {}) {
-  if (typeof input !== "string" || input.length === 0) {
-    throw new ProbeError("emitProbeAlert: { input } (resolved project root) is required");
-  }
-  if (typeof now !== "string" || now.length === 0) {
-    throw new ProbeError("emitProbeAlert: { now } (ISO-8601 string) must be injected — never Date.now() here");
-  }
-  const projectRoot = canonical(input);
-  // realpath the resolved store root too (claude-subagent N-a): `input` is
-  // canonicalized, but resolveRepoRoot returns git's path as-is, which on some
-  // hosts is non-canonical for a worktree. Without this, project_root could be
-  // canonical while store_root is not, spuriously breaking the F4 "input==store
-  // for a non-worktree" invariant. storeRoot always exists, so realpath is safe.
-  const storeRoot = fs.realpathSync(resolveRepoRoot(projectRoot));
-  const alertsDir = path.join(storeRoot, ".episodic-memory", "alerts");
-  const episodeFile = path.join(alertsDir, `structured-alert-${stampSlug(now)}.json`);
-
-  // A `classifier_out_of_vocabulary` alert (the F62 conditional branch with a
-  // non-null emitted_label and null event fields). The probe never emits a real
-  // out-of-vocab label into the live vocabulary — it only proves the path math.
-  const alert = {
+  const r = emitStructuredAlert({
+    input,
+    now,
+    command,
+    scope,
     alert_type: "classifier_out_of_vocabulary",
     plugin_id: "claude-code",
     harness: "claude-code",
     emitted_label: "probe_out_of_vocabulary",
     emitted_event_id: null,
     events_version: null,
-    command,
-    timestamp_iso8601: now,
-    project_root: projectRoot,
-    store_root: storeRoot,
-    store_scope: scope,
-    episode_file: episodeFile,
-  };
-
-  const { valid, errors } = validateInstance(alert, SCHEMA);
-  if (!valid) {
-    throw new ProbeError(`probe built a schema-invalid structured-alert: ${JSON.stringify(errors)}`);
-  }
-
-  fs.mkdirSync(alertsDir, { recursive: true });
-  fs.writeFileSync(episodeFile, JSON.stringify(alert, null, 2) + "\n");
-
+  });
   return {
-    status: "ok",
-    input_project_root: projectRoot, // F4: === episode.project_root
-    store_root: storeRoot, //             F4: === episode.store_root (worktree → main)
-    episode_file: episodeFile,
-    alert_valid: true,
+    status: r.status,
+    input_project_root: r.project_root, // F4: === episode.project_root
+    store_root: r.store_root, //            F4: === episode.store_root (worktree → main)
+    episode_file: r.episode_file,
+    alert_valid: r.alert_valid,
   };
 }
 
@@ -135,7 +56,20 @@ export function emitProbeAlert({ input, now, command = "", scope = "local" } = {
 // CLI — used by tests/test-plugin-harness-binding.mjs (spawned with cwd:project
 // + EPISODIC_MEMORY_PROJECT_ROOT). Prints the pinned contract as one JSON line.
 // ---------------------------------------------------------------------------
-const isMain = import.meta.url === pathToFileURL(process.argv[1] || "").href;
+// N2 (closes FU #390): realpath-both main-module detection. A plain
+// `import.meta.url === pathToFileURL(argv[1])` compare FAILS when the path has a
+// symlink component (macOS /var→/private/var, a symlinked $HOME) — import.meta.url
+// is canonical while pathToFileURL(argv[1]) is not — so the CLI would silently
+// no-op (fail-OPEN). The realpath-both idiom (same as enforce-contract.mjs:134-141)
+// resolves both sides so a symlinked invocation path still runs as main.
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
 if (isMain) {
   const argv = process.argv.slice(2);
   const flag = (n) => {

--- a/scripts/lib/structured-alert.mjs
+++ b/scripts/lib/structured-alert.mjs
@@ -1,0 +1,166 @@
+// structured-alert.mjs — the REAL parameterized F3 structured-alert writer
+// (RFC-008 P3b-2, CLASS-C(b); maps to F3/F24/F62/F61/F4). Promoted out of the
+// P1c probe (structured-alert-probe.mjs): that probe HARDCODED its payload
+// (alert_type/emitted_label/plugin_id) to prove the project-root→store-root path
+// math end-to-end before the real writer existed. This module REUSES that path
+// math but PARAMETERIZES the alert fields (M1 — a blind rename+re-export of the
+// probe would make every live alert say "probe_out_of_vocabulary" regardless of
+// the real offending label: a useless alert + a silent F62 vocab lie).
+//
+// SHIPPED LIBRARY-ONLY this slice (B2): under P3b-2's stop-only wiring the stop
+// gate is label-INDEPENDENT (RFC-008:464), so NO live site feeds an out-of-vocab
+// label into this writer yet — out-of-vocab labels originate at the bash
+// classifier → pre_tool_use gates, which P3b-2 DEFERS. So the writer + its unit
+// tests ship now; the e2e hard-reject consumer lands when the pre_tool_use label
+// gate is wired (later slice). emitProbeAlert (the P1c fixture) is kept as a thin
+// wrapper so tests/test-plugin-harness-binding.mjs stays green.
+//
+// Pinned contract (F4 — two distinct fields, NEVER conflated):
+//   project_root  the `--project`/env/discovered input (a linked worktree
+//                 reports its OWN path here).
+//   store_root    resolveRepoRoot(project_root) — where the alert actually lands;
+//                 for a linked worktree this CONVERGES to the main checkout (F61).
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { resolveRepoRoot } from "./local-dir.mjs";
+import { validateInstance } from "./json-instance-validate.mjs";
+
+const SCHEMA = JSON.parse(
+  fs.readFileSync(new URL("../../schemas/runtime/structured-alert.schema.json", import.meta.url), "utf8"),
+);
+
+export class AlertError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "AlertError";
+  }
+}
+
+// Canonicalize so project_root and store_root are directly comparable (macOS
+// /var → /private/var: git emits the realpath, so the input must too, else a
+// non-worktree repo would spuriously report project_root != store_root).
+export function canonical(p) {
+  return fs.realpathSync(path.resolve(p));
+}
+
+/**
+ * Resolve the input project root (F36 precedence: --project > env > git
+ * discovery). Throws AlertError if nothing resolves to a git work tree (never
+ * silently writes to a guessed root).
+ * @param {{project?: string, env?: string, cwd?: string}} src
+ * @returns {string} canonical input project root
+ */
+export function resolveInput({ project, env, cwd = process.cwd() } = {}) {
+  if (project) return canonical(project);
+  if (env) return canonical(env);
+  try {
+    const top = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    if (top) return canonical(top);
+  } catch {
+    // not a git work tree
+  }
+  throw new AlertError(
+    "no --project and no $EPISODIC_MEMORY_PROJECT_ROOT, and cwd is not a git work tree — " +
+    "structured-alert discovery failed closed (it will not guess a store root)",
+  );
+}
+
+// Filesystem-safe episode filename from an injected ISO-8601 stamp (no colons).
+export function stampSlug(now) {
+  return now.replace(/[^0-9A-Za-z]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build, schema-validate, and write a structured-alert episode under
+ * resolveRepoRoot(input)/.episodic-memory/alerts/. Returns the pinned contract.
+ *
+ * The caller supplies the alert vocabulary fields — the F62 conditional in the
+ * schema enforces the exactly-one label-vs-event relation, so a malformed combo
+ * throws here (never writes a half-valid alert). `now` is injected (NEVER
+ * Date.now() in the lib — F4 + deterministic tests). `store_root`, when passed,
+ * is the caller's ALREADY-RESOLVED store root (M5 resolve-once / B4): we assert
+ * it equals resolveRepoRoot(input) so a stale param can never redirect the write.
+ *
+ * @param {{input:string, now:string, alert_type:string, plugin_id?:string,
+ *          harness?:string, emitted_label?:string|null, emitted_event_id?:string|null,
+ *          events_version?:string|null, command?:string, scope?:string,
+ *          store_root?:string|null}} opts
+ * @returns {{status, project_root, store_root, episode_file, alert_valid}}
+ */
+export function emitStructuredAlert({
+  input,
+  now,
+  alert_type,
+  plugin_id = "claude-code",
+  harness = "claude-code",
+  emitted_label = null,
+  emitted_event_id = null,
+  events_version = null,
+  command = "",
+  scope = "local",
+  store_root = null,
+} = {}) {
+  if (typeof input !== "string" || input.length === 0) {
+    throw new AlertError("emitStructuredAlert: { input } (resolved project root) is required");
+  }
+  if (typeof now !== "string" || now.length === 0) {
+    throw new AlertError("emitStructuredAlert: { now } (ISO-8601 string) must be injected — never Date.now() here");
+  }
+  if (typeof alert_type !== "string" || alert_type.length === 0) {
+    throw new AlertError("emitStructuredAlert: { alert_type } is required");
+  }
+  const projectRoot = canonical(input);
+  // resolveRepoRoot returns git's path as-is, which can be non-canonical for a
+  // worktree; realpath it so project_root (canonical) and store_root compare
+  // cleanly. storeRoot always exists → realpath is safe.
+  const derivedStore = fs.realpathSync(resolveRepoRoot(projectRoot));
+  let storeRoot = derivedStore;
+  if (store_root != null) {
+    const canonStore = fs.realpathSync(path.resolve(store_root));
+    if (canonStore !== derivedStore) {
+      throw new AlertError(
+        `emitStructuredAlert: store_root param ${canonStore} != resolveRepoRoot(input) ${derivedStore} ` +
+        "(resolve-once invariant — a stale store_root must not redirect the write)",
+      );
+    }
+    storeRoot = canonStore;
+  }
+  const alertsDir = path.join(storeRoot, ".episodic-memory", "alerts");
+  const episodeFile = path.join(alertsDir, `structured-alert-${stampSlug(now)}.json`);
+
+  const alert = {
+    alert_type,
+    plugin_id,
+    harness,
+    emitted_label,
+    emitted_event_id,
+    events_version,
+    command,
+    timestamp_iso8601: now,
+    project_root: projectRoot,
+    store_root: storeRoot,
+    store_scope: scope,
+    episode_file: episodeFile,
+  };
+
+  const { valid, errors } = validateInstance(alert, SCHEMA);
+  if (!valid) {
+    throw new AlertError(`structured-alert is schema-invalid: ${JSON.stringify(errors)}`);
+  }
+
+  fs.mkdirSync(alertsDir, { recursive: true });
+  fs.writeFileSync(episodeFile, JSON.stringify(alert, null, 2) + "\n");
+
+  return {
+    status: "ok",
+    project_root: projectRoot, // F4: === episode.project_root
+    store_root: storeRoot, //       F4: === episode.store_root (worktree → main)
+    episode_file: episodeFile,
+    alert_valid: true,
+  };
+}

--- a/scripts/validate-bp-contract.mjs
+++ b/scripts/validate-bp-contract.mjs
@@ -47,6 +47,12 @@
  *   15  version bindings: every bp contract AND every enforcement manifest
  *       carries taxonomy_version/events_version equal to the live computed
  *       hashes (F8/F37; single helper scripts/lib/version-hash.mjs).
+ *   16  gate-map mirror (P3b-2, B5/F-NEW-1, LIVE mode only): the effective-tier
+ *       algebra's GATE_EVENT_MAP / GATE_CONTRACT_KEY (scripts/lib/effective-tier.mjs)
+ *       are pinned against events.json ids and patterns/schema.json keys, so the
+ *       runtime stop decision and the runbook matrix cannot drift from the contract
+ *       shape. The stop gate maps to the `stop` event + `stop.tier` key (NOT
+ *       gates.post_checkpoint) — the headline F-NEW-1 correction.
  *
  * Evaluation discipline (review F4): assertions NEVER short-circuit — all of
  * them run on every invocation (assertions_run reports which), and semantic
@@ -76,6 +82,7 @@ import { lintSchema, assertSelfConsistent } from "./lib/mini-jsonschema.mjs";
 import { taxonomyVersion, eventsVersion } from "./lib/version-hash.mjs";
 import { contained, resolveContained, UsageError } from "./lib/path-contain.mjs";
 import { deriveBpIds } from "./scaffold-bp.mjs";
+import { GATE_EVENT_MAP, GATE_CONTRACT_KEY } from "./lib/effective-tier.mjs";
 
 const BP_STRICT_RE = /^bp-[0-9]{3}\.json$/;
 // Case-INSENSITIVE on purpose (step-6 F-3): on case-insensitive filesystems
@@ -141,6 +148,24 @@ function git(root, argv) {
 function majorOf(version) {
   const m = typeof version === "string" ? /^(\d+)\./.exec(version) : null;
   return m ? Number(m[1]) : null;
+}
+
+/**
+ * Assertion 16 helper — does a GATE_CONTRACT_KEY path (e.g. "gates.post_checkpoint"
+ * or "stop.tier") resolve to a declared property in patterns/schema.json? Walks
+ * `properties` at each dotted segment (descending into nested `.properties`),
+ * mirroring how a bp contract addresses its gate tiers. Used by the Rule-14
+ * gate-map mirror (F-NEW-1): a contract key the schema doesn't declare means the
+ * effective-tier algebra would clamp a gate the contract can't even express.
+ */
+function contractKeyResolves(bpSchema, keyPath) {
+  const parts = keyPath.split(".");
+  let node = bpSchema && bpSchema.properties;
+  for (let i = 0; i < parts.length; i++) {
+    if (!node || typeof node !== "object" || !node[parts[i]]) return false;
+    node = i < parts.length - 1 ? node[parts[i]].properties : node[parts[i]];
+  }
+  return !!node;
 }
 
 /**
@@ -679,6 +704,30 @@ export function validateBpContract({ projectRoot, taxonomyPath = null, eventsPat
       const actual = doc && doc[field];
       if (actual !== expected) violation("15", `${name}: stale ${field} (have ${JSON.stringify(actual)}, live ${expected}) — regenerate via scripts/scaffold-bp.mjs (F8/F37)`);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assertion 16 — Rule-14 gate-map mirror (B5 / F-NEW-1). effective-tier.mjs maps
+  // each gate to a lifecycle EVENT and to a CONTRACT KEY; the runtime stop decision
+  // (enforce-contract.mjs) and the runbook matrix (validate-plugin-registry.mjs)
+  // share that ONE algebra, so the maps must not drift from events.json /
+  // patterns/schema.json. The headline F-NEW-1 invariant lives here: the stop gate
+  // maps to the `stop` event + the `stop.tier` contract key — NOT
+  // gates.post_checkpoint. LIVE mode only (golden-corpus dispatches inject partial
+  // events/taxonomy and would spuriously trip the event-id membership check).
+  // ---------------------------------------------------------------------------
+  if (taxonomyPath == null && eventsPath == null && bpDirPath == null) {
+    assertionsRun.add(16);
+    checks++;
+    for (const [gate, event] of Object.entries(GATE_EVENT_MAP)) {
+      if (!eventIds.has(event)) violation("16", `gate→event map: gate ${JSON.stringify(gate)} maps to event ${JSON.stringify(event)}, not an events.json id (Rule-14 mirror drift)`);
+    }
+    for (const [gate, key] of Object.entries(GATE_CONTRACT_KEY)) {
+      if (!contractKeyResolves(schemas.bp, key)) violation("16", `gate→contract-key map: gate ${JSON.stringify(gate)} maps to ${JSON.stringify(key)}, which does not resolve in patterns/schema.json (gates.* or stop.tier) — F-NEW-1 mirror drift`);
+    }
+    const eKeys = Object.keys(GATE_EVENT_MAP).sort().join(",");
+    const cKeys = Object.keys(GATE_CONTRACT_KEY).sort().join(",");
+    if (eKeys !== cKeys) violation("16", `gate→event and gate→contract-key maps cover different gate sets (${eKeys} vs ${cKeys})`);
   }
 
   return {

--- a/scripts/validate-plugin-registry.mjs
+++ b/scripts/validate-plugin-registry.mjs
@@ -35,13 +35,18 @@ import { execFileSync } from "node:child_process";
 import { validateInstance, assertAllSchemasModeled } from "./lib/json-instance-validate.mjs";
 import { taxonomyVersion, eventsVersion } from "./lib/version-hash.mjs";
 import { contained, resolveContained, UsageError } from "./lib/path-contain.mjs";
+// The tier algebra (TIER_RANK / effectiveTier / eventActionId) lives in
+// scripts/lib/effective-tier.mjs (extracted P3b-2, R3) so this validator's Table B
+// rendering and enforce-contract's runtime stop decision share ONE algebra
+// (Rule 14). No behavior change here — the self-tests prove it byte-for-byte.
+import { TIER_RANK, effectiveTier, eventActionId } from "./lib/effective-tier.mjs";
 
 // --- closed vocabularies (re-asserted even where a schema already closes them) ---
 export const MAX_SUPPORTED = "1.0.0"; // byte-equal'd to _corpus-index.current_schema_version (a test asserts equality)
 const HARNESS_IDS = ["claude-code", "opencode", "codex", "pi-agent", "cursor", "windsurf"];
 export const EVENT_IDS = ["pre_tool_use", "tool_result", "stop", "session_start", "session_end"]; // exported for the Rule-14 binding check in tests/test-validate-bp-contract.mjs (EVENT_IDS ≡ live events[].id)
 const TIERS = ["STRONG", "MEDIUM", "WEAK", "TBD"];
-const TIER_RANK = { TBD: 0, WEAK: 1, MEDIUM: 2, STRONG: 3 };
+// TIER_RANK is imported from ./lib/effective-tier.mjs (extracted P3b-2).
 const MIN_RUNBOOK_FULL_BYTES = 1024;
 const MIN_RUNBOOK_QUICKREF_BYTES = 256;
 const RUNBOOK_SENTINEL = "## ⚠️ Self-trigger checklist";
@@ -364,25 +369,11 @@ function extractBetween(text, begin, end) {
 // byte-diffs. One pure function per block — no author discretion (plan H1).
 // ---------------------------------------------------------------------------
 
-// effective_tier = min over PRESENT tier sources (N2). On main only harness_cap
-// exists; the min() folds contract/project_config tiers the moment P2/P4 add
-// them, so the table never silently lies after a degrading contract lands.
-function effectiveTier(tiers) {
-  let min = null, minRank = Infinity;
-  for (const t of tiers) {
-    if (t == null) continue;
-    const r = TIER_RANK[t] ?? Infinity;
-    if (r < minRank) { minRank = r; min = t; }
-  }
-  return min;
-}
-
-function eventActionId(events, eventId, tier) {
-  const ev = (events.events || []).find((e) => e.id === eventId);
-  const a = ev && ev.actions && tier != null ? ev.actions[tier] : null;
-  return a && a.id ? a.id : "—";
-}
-
+// effective_tier (min over PRESENT tier sources, null on all-absent) and
+// eventActionId are imported from ./lib/effective-tier.mjs (extracted P3b-2, R3).
+// On main only harness_cap exists; the min() folds contract/project_config tiers
+// the moment a degrading contract/config lands, so the rendered table never
+// silently lies. enforce-contract.mjs imports the SAME algebra (Rule 14).
 export function renderResolutionMatrix(manifest, taxonomy, events) {
   const caps = manifest.capabilities || {};
   const emits = (manifest.classifier && manifest.classifier.emits_labels) || [];

--- a/tests/test-effective-tier.mjs
+++ b/tests/test-effective-tier.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// test-effective-tier.mjs — RFC-008 P3b-2 (R3). Pins the tier algebra extracted
+// into scripts/lib/effective-tier.mjs: the TWO folds (validator null-on-absent vs
+// enforce-contract base-STRONG never-null — F-CLOSE-1/F-NEW-2), clamp-DOWN-only
+// semantics (B1), the gate→event / gate→contract-key maps (B5/F-NEW-1), and the
+// events.json action lookup. The "a stop clamp degrades the live decideStop
+// refuse / a post_checkpoint clamp does NOT" integration lives in
+// test-enforce-config.mjs (it needs the config loader + decideStop).
+
+import {
+  TIER_RANK,
+  GATE_EVENT_MAP,
+  GATE_CONTRACT_KEY,
+  LIVE_GATES,
+  effectiveTier,
+  clampTier,
+  effectiveTierStrong,
+  eventActionId,
+} from '../scripts/lib/effective-tier.mjs'
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected)
+  if (a === e) ok(name); else bad(name, `expected ${e}, got ${a}`)
+}
+
+console.log('=== TIER_RANK ordering ===')
+eq('STRONG > MEDIUM > WEAK > TBD', TIER_RANK.STRONG > TIER_RANK.MEDIUM && TIER_RANK.MEDIUM > TIER_RANK.WEAK && TIER_RANK.WEAK > TIER_RANK.TBD, true)
+
+console.log('')
+console.log('=== effectiveTier (VALIDATOR fold — null on all-absent, pinned) ===')
+eq('all-absent → null (em-dash render depends on this)', effectiveTier([null, null]), null)
+eq('empty list → null', effectiveTier([]), null)
+eq('min over present (STRONG, WEAK) → WEAK', effectiveTier(['STRONG', 'WEAK']), 'WEAK')
+eq('present + null (STRONG, null) → STRONG', effectiveTier(['STRONG', null]), 'STRONG')
+eq('STRONG ∩ STRONG → STRONG', effectiveTier(['STRONG', 'STRONG']), 'STRONG')
+
+console.log('')
+console.log('=== effectiveTierStrong (ENFORCE-CONTRACT fold — base STRONG, NEVER null) ===')
+eq('F-NEW-2: all-absent → concrete "STRONG" (NOT null)', effectiveTierStrong([null, null, null]), 'STRONG')
+eq('F-NEW-2: empty sources → "STRONG"', effectiveTierStrong([]), 'STRONG')
+eq('no clamp (STRONG,STRONG,null) → STRONG', effectiveTierStrong(['STRONG', 'STRONG', null]), 'STRONG')
+eq('clamp-down (STRONG,STRONG,WEAK) → WEAK', effectiveTierStrong(['STRONG', 'STRONG', 'WEAK']), 'WEAK')
+eq('clamp-down to MEDIUM', effectiveTierStrong(['STRONG', null, 'MEDIUM']), 'MEDIUM')
+eq('weakest wins across legs (WEAK,MEDIUM) → WEAK', effectiveTierStrong(['WEAK', 'MEDIUM']), 'WEAK')
+eq('unknown tier string never lowers (fail-closed)', effectiveTierStrong(['STRONG', 'BOGUS']), 'STRONG')
+
+console.log('')
+console.log('=== clampTier (clamp-DOWN only) ===')
+eq('null source → base unchanged', clampTier('STRONG', null), 'STRONG')
+eq('weaker source lowers', clampTier('STRONG', 'WEAK'), 'WEAK')
+eq('clamp-UP ignored: base WEAK, source STRONG → WEAK', clampTier('WEAK', 'STRONG'), 'WEAK')
+eq('equal source → base', clampTier('MEDIUM', 'MEDIUM'), 'MEDIUM')
+eq('unknown source → base (fail-closed)', clampTier('STRONG', 'NOPE'), 'STRONG')
+
+console.log('')
+console.log('=== GATE_EVENT_MAP / GATE_CONTRACT_KEY (B5 / F-NEW-1) ===')
+// The headline F-NEW-1 correction: the stop refuse is the ROOT-LEVEL stop.tier
+// gate firing at the `stop` event — NOT gates.post_checkpoint (a pre_tool_use
+// classification gate). Get these wrong and a STRONG contract degrades the wrong
+// gate.
+eq('stop gate fires at the stop event', GATE_EVENT_MAP.stop, 'stop')
+eq('stop gate contract key is stop.tier', GATE_CONTRACT_KEY.stop, 'stop.tier')
+eq('post_checkpoint fires at pre_tool_use', GATE_EVENT_MAP.post_checkpoint, 'pre_tool_use')
+eq('post_checkpoint contract key is gates.post_checkpoint', GATE_CONTRACT_KEY.post_checkpoint, 'gates.post_checkpoint')
+eq('plan_approval fires at pre_tool_use', GATE_EVENT_MAP.plan_approval, 'pre_tool_use')
+eq('pre_checkpoint fires at pre_tool_use', GATE_EVENT_MAP.pre_checkpoint, 'pre_tool_use')
+eq('the two maps cover the same four gates', Object.keys(GATE_EVENT_MAP).sort(), Object.keys(GATE_CONTRACT_KEY).sort())
+eq('only the stop gate is LIVE-wired this slice', LIVE_GATES, ['stop'])
+
+console.log('')
+console.log('=== eventActionId (events.json action lookup) ===')
+const EVENTS = {
+  events: [
+    { id: 'stop', actions: { STRONG: { id: 'refuse_stop' }, MEDIUM: { id: 'warn' }, WEAK: { id: 'unsupported' } } },
+  ],
+}
+eq('stop STRONG → refuse_stop', eventActionId(EVENTS, 'stop', 'STRONG'), 'refuse_stop')
+eq('stop MEDIUM → warn', eventActionId(EVENTS, 'stop', 'MEDIUM'), 'warn')
+eq('stop WEAK → unsupported', eventActionId(EVENTS, 'stop', 'WEAK'), 'unsupported')
+eq('null tier → em-dash', eventActionId(EVENTS, 'stop', null), '—')
+eq('missing event → em-dash', eventActionId(EVENTS, 'pre_tool_use', 'STRONG'), '—')
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks failed:`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}

--- a/tests/test-enforce-config.mjs
+++ b/tests/test-enforce-config.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// test-enforce-config.mjs — RFC-008 P3b-2 (R5, P4 config schema folded).
+//
+// Two layers:
+//   (U) loadEnforceConfig() unit matrix — the M2 fail-OPEN audit: EVERY error
+//       branch lands in ONE stay-STRONG sink (identity clamp), so a broken/hostile/
+//       absent config can NEVER weaken a gate. Plus the schema valid/invalid cases
+//       + active:false.
+//   (I) integration via the enforce-contract CLI: a successfully-resolved
+//       {"bp-001":{"stop":"WEAK"}} clamp DEGRADES the decideStop refuse (allow);
+//       a {"bp-001":{"post_checkpoint":"WEAK"}} clamp does NOT (deferred gate —
+//       stop still blocks); active:false silences with an M4 stderr notice; a
+//       well-formed stop downgrade emits the M4 audit line.
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execSync, spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+import { loadEnforceConfig, decideStop } from '../scripts/enforce-contract.mjs'
+import { PRIMARY_MARKER_DIR, LEGACY_MARKER_DIR, primaryMarkerPath } from '../scripts/lib/marker-paths.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const ENFORCE = path.join(REPO, 'scripts', 'enforce-contract.mjs')
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'enforce-config.schema.json'), 'utf8'))
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected)
+  if (a === e) ok(name); else bad(name, `expected ${e}, got ${a}`)
+}
+function truthy(name, v, detail) { if (v) ok(name); else bad(name, detail || 'expected truthy') }
+
+const IDENTITY = { active: true, bps: {} }
+
+// Write a config under <root>/.episodic-memory/enforce-config.json (raw string so
+// we can plant malformed bytes). Returns root.
+function mkRootWithConfig(raw) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'enforce-config-'))
+  fs.mkdirSync(path.join(root, '.episodic-memory'), { recursive: true })
+  if (raw !== undefined) fs.writeFileSync(path.join(root, '.episodic-memory', 'enforce-config.json'), raw)
+  return root
+}
+
+console.log('=== U: loadEnforceConfig fail-OPEN audit (every error branch → identity stay-STRONG) ===')
+
+// (0) no schema → cannot validate → fail-closed identity.
+eq('U0: schema null → identity', loadEnforceConfig(mkRootWithConfig('{"bp-001":{"stop":"WEAK"}}'), null), IDENTITY)
+// (1) file absent (ENOENT).
+eq('U1: absent config → identity', loadEnforceConfig(mkRootWithConfig(undefined), SCHEMA), IDENTITY)
+// (2) read error — config path is a DIRECTORY (EISDIR).
+{
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'enforce-config-'))
+  fs.mkdirSync(path.join(root, '.episodic-memory', 'enforce-config.json'), { recursive: true })
+  eq('U2: config path is a directory (EISDIR) → identity', loadEnforceConfig(root, SCHEMA), IDENTITY)
+}
+// (3) JSON.parse throws.
+eq('U3: unparseable JSON → identity', loadEnforceConfig(mkRootWithConfig('{not json'), SCHEMA), IDENTITY)
+// (4) parses but not a plain object.
+eq('U4a: top-level array → identity', loadEnforceConfig(mkRootWithConfig('[]'), SCHEMA), IDENTITY)
+eq('U4b: top-level null → identity', loadEnforceConfig(mkRootWithConfig('null'), SCHEMA), IDENTITY)
+eq('U4c: top-level scalar → identity', loadEnforceConfig(mkRootWithConfig('42'), SCHEMA), IDENTITY)
+// (5) schema-invalid.
+eq('U5a: bad tier value → identity', loadEnforceConfig(mkRootWithConfig('{"bp-001":{"stop":"BOGUS"}}'), SCHEMA), IDENTITY)
+eq('U5b: malformed bp key (propertyNames) → identity', loadEnforceConfig(mkRootWithConfig('{"bp001":{"stop":"WEAK"}}'), SCHEMA), IDENTITY)
+eq('U5c: non-bool active → identity', loadEnforceConfig(mkRootWithConfig('{"active":"yes"}'), SCHEMA), IDENTITY)
+eq('U5d: unknown gate key → identity', loadEnforceConfig(mkRootWithConfig('{"bp-001":{"bogus_gate":"WEAK"}}'), SCHEMA), IDENTITY)
+
+console.log('')
+console.log('=== U: well-formed configs are HONORED ===')
+eq('U6: stop clamp honored', loadEnforceConfig(mkRootWithConfig('{"bp-001":{"stop":"WEAK"}}'), SCHEMA), { active: true, bps: { 'bp-001': { stop: 'WEAK' } } })
+eq('U7: active:false honored', loadEnforceConfig(mkRootWithConfig('{"active":false}'), SCHEMA), { active: false, bps: {} })
+eq('U8: active:false + clamp honored', loadEnforceConfig(mkRootWithConfig('{"active":false,"bp-001":{"stop":"MEDIUM"}}'), SCHEMA), { active: false, bps: { 'bp-001': { stop: 'MEDIUM' } } })
+eq('U9: empty object → identity-equivalent (active default true)', loadEnforceConfig(mkRootWithConfig('{}'), SCHEMA), { active: true, bps: {} })
+
+console.log('')
+console.log('=== U: decideStop honors the resolved stopTier param (pure) ===')
+// A non-STRONG tier degrades the refuse regardless of markers; STRONG keeps it.
+{
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'enforce-decide-'))
+  fs.mkdirSync(path.join(root, PRIMARY_MARKER_DIR), { recursive: true })
+  fs.mkdirSync(path.join(root, LEGACY_MARKER_DIR), { recursive: true })
+  fs.writeFileSync(primaryMarkerPath(root, '.checkpoint-required'), '') // armed, no post-done
+  truthy('U10: stopTier STRONG + armed → block', decideStop({ repoRoot: root, sid: null, stopTier: 'STRONG' })?.decision === 'block', 'expected block')
+  eq('U11: stopTier WEAK + armed → allow (refuse degraded)', decideStop({ repoRoot: root, sid: null, stopTier: 'WEAK' }), null)
+  eq('U12: stopTier MEDIUM + armed → allow (refuse degraded)', decideStop({ repoRoot: root, sid: null, stopTier: 'MEDIUM' }), null)
+}
+
+console.log('')
+console.log('=== I: integration via the enforce-contract CLI (clamp degrades the LIVE refuse) ===')
+
+function mkGitRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'enforce-cfg-e2e-'))
+  execSync('git init -q -b main', { cwd: repo })
+  execSync('git config user.email test@example.com', { cwd: repo })
+  execSync('git config user.name test', { cwd: repo })
+  fs.writeFileSync(path.join(repo, 'README.md'), 'x\n')
+  execSync('git add . && git commit -q -m init', { cwd: repo, shell: '/bin/bash' })
+  fs.mkdirSync(path.join(repo, PRIMARY_MARKER_DIR), { recursive: true })
+  fs.mkdirSync(path.join(repo, LEGACY_MARKER_DIR), { recursive: true })
+  return repo
+}
+function armChkpt(repo) { fs.writeFileSync(primaryMarkerPath(repo, '.checkpoint-required'), '') }
+function writeConfig(repo, obj) {
+  fs.mkdirSync(path.join(repo, '.episodic-memory'), { recursive: true })
+  fs.writeFileSync(path.join(repo, '.episodic-memory', 'enforce-config.json'), JSON.stringify(obj))
+}
+function runStop(repo) {
+  const r = spawnSync('node', [ENFORCE, '--gate', 'stop'], { cwd: repo, encoding: 'utf8' })
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status }
+}
+
+// Control: armed, NO config → STRONG → block.
+{
+  const repo = mkGitRepo(); armChkpt(repo)
+  const r = runStop(repo)
+  truthy('I1: armed + no config → block (STRONG default)', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}]`)
+}
+// stop→WEAK clamp → refuse degraded → allow (empty stdout) + M4 stderr notice.
+{
+  const repo = mkGitRepo(); armChkpt(repo); writeConfig(repo, { 'bp-001': { stop: 'WEAK' } })
+  const r = runStop(repo)
+  eq('I2: stop→WEAK clamp → allow (empty stdout)', r.stdout.trim(), '')
+  truthy('I2: stop→WEAK clamp → M4 downgrade notice on stderr', /degraded STRONG→WEAK/.test(r.stderr), `stderr=[${r.stderr}]`)
+}
+// post_checkpoint→WEAK clamp (DEFERRED gate) → stop UNAFFECTED → still block.
+{
+  const repo = mkGitRepo(); armChkpt(repo); writeConfig(repo, { 'bp-001': { post_checkpoint: 'WEAK' } })
+  const r = runStop(repo)
+  truthy('I3: post_checkpoint→WEAK clamp does NOT degrade the stop refuse (deferred gate) → still block',
+    /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+// active:false → R5 silence → allow + stderr notice.
+{
+  const repo = mkGitRepo(); armChkpt(repo); writeConfig(repo, { active: false })
+  const r = runStop(repo)
+  eq('I4: active:false → allow (empty stdout)', r.stdout.trim(), '')
+  truthy('I4: active:false → R5 silence notice on stderr', /enforcement disabled/.test(r.stderr), `stderr=[${r.stderr}]`)
+}
+// Malformed config (fail-closed) → STRONG → block (a broken file never weakens).
+{
+  const repo = mkGitRepo(); armChkpt(repo)
+  fs.mkdirSync(path.join(repo, '.episodic-memory'), { recursive: true })
+  fs.writeFileSync(path.join(repo, '.episodic-memory', 'enforce-config.json'), '{"bp-001":{"stop":"BOGUS"}}')
+  const r = runStop(repo)
+  truthy('I5: schema-invalid config → fail-closed STRONG → block', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}]`)
+}
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks failed:`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}

--- a/tests/test-enforce-config.mjs
+++ b/tests/test-enforce-config.mjs
@@ -128,6 +128,10 @@ function runStop(repo) {
   const r = runStop(repo)
   eq('I2: stop→WEAK clamp → allow (empty stdout)', r.stdout.trim(), '')
   truthy('I2: stop→WEAK clamp → M4 downgrade notice on stderr', /degraded STRONG→WEAK/.test(r.stderr), `stderr=[${r.stderr}]`)
+  // PR-2 (R3/R5): the stderr notice is swallowed by stop-gate.sh's 2>/dev/null, so
+  // the downgrade MUST also be persisted to a hook-independent on-disk audit.
+  const auditLog = path.join(repo, '.episodic-memory', 'enforce-audit.log')
+  truthy('I2: stop→WEAK clamp → durable on-disk audit written', fs.existsSync(auditLog) && /degraded STRONG->WEAK/.test(fs.readFileSync(auditLog, 'utf8')), `audit=[${fs.existsSync(auditLog) ? fs.readFileSync(auditLog, 'utf8') : '<absent>'}]`)
 }
 // post_checkpoint→WEAK clamp (DEFERRED gate) → stop UNAFFECTED → still block.
 {
@@ -142,6 +146,8 @@ function runStop(repo) {
   const r = runStop(repo)
   eq('I4: active:false → allow (empty stdout)', r.stdout.trim(), '')
   truthy('I4: active:false → R5 silence notice on stderr', /enforcement disabled/.test(r.stderr), `stderr=[${r.stderr}]`)
+  const auditLog4 = path.join(repo, '.episodic-memory', 'enforce-audit.log')
+  truthy('I4: active:false → durable on-disk audit written (PR-2)', fs.existsSync(auditLog4) && /enforcement disabled/.test(fs.readFileSync(auditLog4, 'utf8')), `audit=[${fs.existsSync(auditLog4) ? fs.readFileSync(auditLog4, 'utf8') : '<absent>'}]`)
 }
 // Malformed config (fail-closed) → STRONG → block (a broken file never weakens).
 {

--- a/tests/test-enforce-contract.mjs
+++ b/tests/test-enforce-contract.mjs
@@ -282,6 +282,138 @@ console.log('=== C: CLI arg handling ===')
 }
 
 console.log('')
+console.log('=== D: P3b-2 tier layer — three-axis inertness + M8 + CLASS-C(a) ===')
+// These spawn enforce-contract with a CONTROLLED contract root via HOME isolation:
+// resolveContractRoot candidate-1 == os.homedir()/.episodic-memory, and the spawned
+// process sees HOME=<tmpHome>. We plant a global contract there and assert the
+// effective stop decision. armed-no-postdone is the discriminator: STRONG → block,
+// degraded/disabled → allow. The B1 invariant: a contract-resolution MISS never
+// degrades to allow (it stays at base-STRONG).
+
+// Plant a global contract under <home>/.episodic-memory/{patterns,plugins}.
+function plantGlobalContract(home, { registry, bp001, events, configSchema } = {}) {
+  const pat = path.join(home, '.episodic-memory', 'patterns')
+  const plug = path.join(home, '.episodic-memory', 'plugins')
+  fs.mkdirSync(pat, { recursive: true })
+  fs.mkdirSync(plug, { recursive: true })
+  // candidate-1 gate keys on bp-001.json presence.
+  if (bp001 !== null) fs.writeFileSync(path.join(pat, 'bp-001.json'), JSON.stringify(bp001 || REPO_BP001))
+  if (events !== null) fs.writeFileSync(path.join(pat, 'events.json'), JSON.stringify(events || REPO_EVENTS))
+  if (configSchema !== null) fs.writeFileSync(path.join(pat, 'enforce-config.schema.json'), JSON.stringify(configSchema || REPO_CONFIG_SCHEMA))
+  // taxonomy.schema.json is a candidate-2 sentinel; harmless to include but
+  // candidate-1 (bp-001 present) short-circuits before candidate-2 anyway.
+  if (registry !== null) fs.writeFileSync(path.join(plug, '_index.json'), JSON.stringify(registry || REPO_REGISTRY))
+}
+const REPO_BP001 = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'bp-001.json'), 'utf8'))
+const REPO_EVENTS = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'events.json'), 'utf8'))
+const REPO_CONFIG_SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'enforce-config.schema.json'), 'utf8'))
+const REPO_REGISTRY = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins', '_index.json'), 'utf8'))
+
+function mkHome(label) { return fs.mkdtempSync(path.join(os.tmpdir(), `enforce-home-${label}-`)) }
+function runStopWithHome(repo, home) {
+  const r = spawnSync('node', [ENFORCE, '--gate', 'stop'], { cwd: repo, encoding: 'utf8', env: { ...process.env, HOME: home } })
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status }
+}
+function armedRepo() {
+  const repo = mkGitRepo()
+  writeMarker(primaryMarkerPath(repo, '.checkpoint-required'), 200) // armed, no post-done
+  return repo
+}
+
+// D1 — axis (1): no config, full STRONG global contract → block (STRONG inert).
+{
+  const home = mkHome('d1'); plantGlobalContract(home, {})
+  const r = runStopWithHome(armedRepo(), home)
+  truthy('D1: STRONG contract + no config → block (inert)', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+// D2 — axis (2): no plugins/_index.json at the contract root → harnessCap null →
+// base-STRONG (NOT allow). B1: a missing registry inside an already-firing hook is
+// a corrupted install, never "no plugin → silent".
+{
+  const home = mkHome('d2'); plantGlobalContract(home, { registry: null })
+  const r = runStopWithHome(armedRepo(), home)
+  truthy('D2: missing _index.json → harnessCap null → STRONG → block (NOT allow)', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+// D3 — axis (3): empty global (no bp-001 at candidate-1) → candidate-1 misses →
+// falls through (candidate-2 repo, or null) → STRONG → block. Never crash-to-allow.
+{
+  const home = mkHome('d3')
+  fs.mkdirSync(path.join(home, '.episodic-memory', 'patterns'), { recursive: true }) // empty patterns/
+  const r = runStopWithHome(armedRepo(), home)
+  truthy('D3: empty global contract → STRONG fallthrough → block', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+// D4 — M8: two ACTIVE enforcement entries binding claude-code → fail-closed REAL
+// block (never pick-first). Fires before decideStop, so an UNarmed repo still blocks.
+{
+  const home = mkHome('d4')
+  const dupEntry = REPO_REGISTRY.plugins[0]
+  plantGlobalContract(home, { registry: { schema_version: '1.0.0', plugins: [dupEntry, { ...dupEntry }] } })
+  const r = runStopWithHome(mkGitRepo(), home) // NOT armed — M8 precedes marker logic
+  truthy('D4: duplicate harness binding → M8 fail-closed block', /"decision":\s*"block"/.test(r.stdout) && /M8|one-harness-one-plugin/.test(r.stdout), `stdout=[${r.stdout}]`)
+}
+// D5 — CLASS-C(a): harness declares stop capability WEAK while the contract
+// requires the gate → harness∩contract maps to `unsupported` → REAL block (N1),
+// NOT a swallowed warn. Fires before decideStop (unarmed repo still blocks).
+{
+  const home = mkHome('d5')
+  const weakEntry = { ...REPO_REGISTRY.plugins[0], capabilities: { ...REPO_REGISTRY.plugins[0].capabilities, stop: 'WEAK' } }
+  plantGlobalContract(home, { registry: { schema_version: '1.0.0', plugins: [weakEntry] } })
+  const r = runStopWithHome(mkGitRepo(), home)
+  truthy('D5: harness WEAK stop + contract requires gate → CLASS-C(a) REAL block', /"decision":\s*"block"/.test(r.stdout) && /CLASS-C\(a\)|unsupported/.test(r.stdout), `stdout=[${r.stdout}]`)
+}
+// D6 — control: same WEAK-harness scenario degrades to allow via a CONFIG clamp is
+// NOT what happens — CLASS-C(a) is harness/contract-driven and fires regardless of
+// config. Confirm a STRONG global + a config stop→WEAK clamp DOES allow (operator
+// downgrade path is distinct from CLASS-C(a)).
+{
+  const home = mkHome('d6'); plantGlobalContract(home, {})
+  const repo = armedRepo()
+  fs.mkdirSync(path.join(repo, '.episodic-memory'), { recursive: true })
+  fs.writeFileSync(path.join(repo, '.episodic-memory', 'enforce-config.json'), JSON.stringify({ 'bp-001': { stop: 'WEAK' } }))
+  const r = runStopWithHome(repo, home)
+  eq('D6: STRONG harness + config stop→WEAK clamp → allow (operator downgrade, distinct from CLASS-C(a))', r.stdout.trim(), '')
+}
+// D7 — B3 ambient-parent regression (plan §11). resolveContractRoot candidate-2
+// is a DEPTH-1 climb gated on a realpath round-trip; it must NOT climb to an
+// ambient GRANDPARENT that happens to carry the repo sentinels + a (weaker)
+// contract. Stage a copy of the module at <ambient>/sub/scripts/, put the
+// sentinels + a WEAK bp-001 at <ambient> (grandparent, depth-2), and leave
+// <ambient>/sub (depth-1) without sentinels. Correct behavior: candidate-2 stops
+// at depth-1 (no sentinels) → null → STRONG → block. A 2-level climb bug would
+// read the ambient WEAK contract → degrade to allow.
+function stageModule(scriptsDir) {
+  fs.mkdirSync(path.join(scriptsDir, 'lib'), { recursive: true })
+  fs.copyFileSync(path.join(REPO, 'scripts', 'enforce-contract.mjs'), path.join(scriptsDir, 'enforce-contract.mjs'))
+  for (const lib of ['local-dir', 'marker-paths', 'marker-state', 'session-id', 'json-instance-validate', 'effective-tier']) {
+    fs.copyFileSync(path.join(REPO, 'scripts', 'lib', `${lib}.mjs`), path.join(scriptsDir, 'lib', `${lib}.mjs`))
+  }
+}
+{
+  const home = mkHome('d7') // empty global → candidate-1 miss
+  const ambient = fs.mkdtempSync(path.join(os.tmpdir(), 'enforce-ambient-'))
+  fs.mkdirSync(path.join(ambient, 'patterns'), { recursive: true })
+  fs.mkdirSync(path.join(ambient, 'scripts'), { recursive: true })
+  fs.writeFileSync(path.join(ambient, 'patterns', 'taxonomy.schema.json'), '{}') // grandparent sentinel
+  fs.writeFileSync(path.join(ambient, 'scripts', 'em-store.mjs'), '') //                grandparent sentinel
+  fs.writeFileSync(path.join(ambient, 'patterns', 'bp-001.json'), JSON.stringify({ ...REPO_BP001, stop: { tier: 'WEAK' } })) // trap: if wrongly read, degrades
+  const subScripts = path.join(ambient, 'sub', 'scripts') // depth-1 parent (ambient/sub) has NO sentinels
+  stageModule(subScripts)
+  const repo = armedRepo()
+  const r = spawnSync('node', [path.join(subScripts, 'enforce-contract.mjs'), '--gate', 'stop'], { cwd: repo, encoding: 'utf8', env: { ...process.env, HOME: home } })
+  truthy('D7: candidate-2 stops at depth-1 (does NOT read ambient grandparent contract) → STRONG → block', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+// D8 — garbage-content axis (belt-and-suspenders for B1): a PRESENT-but-corrupt
+// bp-001 at candidate-1 (parse-throw) → null source → no clamp → STRONG → block.
+// Distinct from D2/D3 (absent source); this proves corrupt content also stays STRONG.
+{
+  const home = mkHome('d8')
+  fs.mkdirSync(path.join(home, '.episodic-memory', 'patterns'), { recursive: true })
+  fs.writeFileSync(path.join(home, '.episodic-memory', 'patterns', 'bp-001.json'), '{not json') // candidate-1 gate hits, parse fails
+  const r = runStopWithHome(armedRepo(), home)
+  truthy('D8: garbage bp-001 at candidate-1 → parse-fail → null source → STRONG → block', /"decision":\s*"block"/.test(r.stdout), `stdout=[${r.stdout}]`)
+}
+
+console.log('')
 if (fail === 0) {
   console.log(`PASS — ${pass} checks`)
   process.exit(0)

--- a/tests/test-install-contract-deploy.mjs
+++ b/tests/test-install-contract-deploy.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// test-install-contract-deploy.mjs — RFC-008 P3b-2 (§10 install-runtime contract
+// deploy; mirrors the P3c T20a2 coupling regression). The enforce-contract runtime
+// contract set (bp-001.json + events.json + enforce-config.schema.json) is
+// co-deployed to $HOME/.episodic-memory/patterns/ ONLY inside --install-hooks
+// (COUPLED to the hook install, like the P3c taxonomy deploy): stop-gate.sh invokes
+// enforce-contract.mjs, so a no-hooks install must NOT advance the global contract
+// while the installed gate stays stale.
+//
+//   T1 — --install-hooks deploys the full coupled set, byte-equal to the repo.
+//   T2 — F-NEW-4 coupling: deployed bp-001.events_version == sha(deployed events.json).
+//   T3 — no-hooks install leaves the contract set ABSENT (the T20a2 analog), while
+//        the unconditional patterns/_index.json IS deployed.
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execFileSync, spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { eventsVersion } from '../scripts/lib/version-hash.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const INSTALL = path.join(REPO, 'install.mjs')
+const CONTRACT_SET = ['bp-001.json', 'events.json', 'enforce-config.schema.json']
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function truthy(name, v, detail) { if (v) ok(name); else bad(name, detail || 'expected truthy') }
+
+function mkSandbox(label) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), `contract-deploy-home-${label}-`))
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), `contract-deploy-proj-${label}-`))
+  execFileSync('git', ['init', '-q'], { cwd: project })
+  return { home, project }
+}
+function runInstall({ home, project, hooks }) {
+  const args = [INSTALL, '--tool', 'claude-code', '--project', project]
+  if (hooks) args.push('--install-hooks')
+  return spawnSync('node', args, { cwd: project, encoding: 'utf8', env: { ...process.env, HOME: home } })
+}
+function globalPatterns(home) { return path.join(home, '.episodic-memory', 'patterns') }
+function byteEqual(a, b) { return fs.readFileSync(a).equals(fs.readFileSync(b)) }
+
+console.log('=== T1/T2: --install-hooks deploys the coupled contract set ===')
+{
+  const { home, project } = mkSandbox('hooks')
+  const r = runInstall({ home, project, hooks: true })
+  truthy('T1: install --install-hooks exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
+  const gp = globalPatterns(home)
+  for (const f of CONTRACT_SET) {
+    const dep = path.join(gp, f)
+    truthy(`T1: ${f} deployed`, fs.existsSync(dep), `missing ${dep}`)
+    if (fs.existsSync(dep)) truthy(`T1: ${f} byte-equal repo`, byteEqual(dep, path.join(REPO, 'patterns', f)), 'deployed bytes differ from repo')
+  }
+  // T2 — coupling assertion: deployed bp-001.events_version == sha(deployed events.json).
+  try {
+    const depBp = JSON.parse(fs.readFileSync(path.join(gp, 'bp-001.json'), 'utf8'))
+    const depEvents = JSON.parse(fs.readFileSync(path.join(gp, 'events.json'), 'utf8'))
+    truthy('T2: deployed bp-001.events_version == sha(deployed events.json)', depBp.events_version === eventsVersion(depEvents),
+      `bp=${depBp.events_version} live=${eventsVersion(depEvents)}`)
+  } catch (e) { bad('T2: coupling readable', e.message) }
+}
+
+console.log('')
+console.log('=== T3: no-hooks install leaves the contract set ABSENT (T20a2 analog) ===')
+{
+  const { home, project } = mkSandbox('nohooks')
+  const r = runInstall({ home, project, hooks: false })
+  truthy('T3: install (no hooks) exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
+  const gp = globalPatterns(home)
+  for (const f of CONTRACT_SET) {
+    truthy(`T3: ${f} ABSENT without --install-hooks`, !fs.existsSync(path.join(gp, f)), `unexpectedly present: ${path.join(gp, f)}`)
+  }
+  // The unconditional _index.json IS deployed even without hooks (existing behavior).
+  truthy('T3: patterns/_index.json deployed unconditionally', fs.existsSync(path.join(gp, '_index.json')), 'expected _index.json present')
+}
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks failed:`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}

--- a/tests/test-install-contract-deploy.mjs
+++ b/tests/test-install-contract-deploy.mjs
@@ -62,6 +62,12 @@ console.log('=== T1/T2: --install-hooks deploys the coupled contract set ===')
     truthy('T2: deployed bp-001.events_version == sha(deployed events.json)', depBp.events_version === eventsVersion(depEvents),
       `bp=${depBp.events_version} live=${eventsVersion(depEvents)}`)
   } catch (e) { bad('T2: coupling readable', e.message) }
+  // PR-1 (R3/R6/R8): the harness-cap registry the runtime reads from
+  // <contractRoot>/plugins/_index.json MUST be deployed to the global plugins/
+  // tree — else resolveHarnessCap is dead in prod and M8/CLASS-C(a) never fire.
+  const depRegistry = path.join(home, '.episodic-memory', 'plugins', '_index.json')
+  truthy('PR-1: plugins/_index.json deployed to global plugins/ (--install-hooks)', fs.existsSync(depRegistry), `missing ${depRegistry}`)
+  if (fs.existsSync(depRegistry)) truthy('PR-1: deployed registry byte-equal repo', byteEqual(depRegistry, path.join(REPO, 'plugins', '_index.json')), 'deployed registry differs from repo')
 }
 
 console.log('')
@@ -74,8 +80,10 @@ console.log('=== T3: no-hooks install leaves the contract set ABSENT (T20a2 anal
   for (const f of CONTRACT_SET) {
     truthy(`T3: ${f} ABSENT without --install-hooks`, !fs.existsSync(path.join(gp, f)), `unexpectedly present: ${path.join(gp, f)}`)
   }
-  // The unconditional _index.json IS deployed even without hooks (existing behavior).
+  // The unconditional patterns/_index.json IS deployed even without hooks (existing behavior).
   truthy('T3: patterns/_index.json deployed unconditionally', fs.existsSync(path.join(gp, '_index.json')), 'expected _index.json present')
+  // PR-1: the global plugins/_index.json is coupled to --install-hooks → absent without it.
+  truthy('T3: plugins/_index.json ABSENT without --install-hooks', !fs.existsSync(path.join(home, '.episodic-memory', 'plugins', '_index.json')), 'unexpectedly present')
 }
 
 console.log('')

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -555,7 +555,11 @@ function mkE2EHome() {
   // 2026-05-18 concurrent-session fix: em-recall now imports session-id.mjs.
   // RFC-008 P3a: em-recall imports marker-state.mjs (relocated from
   // stop-gate-helpers.mjs); marker-state imports the already-copied marker-paths.mjs.
-  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'marker-state.mjs', 'session-id.mjs']) {
+  // RFC-008 P3b-2: enforce-contract gained the effective-tier layer — it imports
+  // effective-tier.mjs (min() algebra) + json-instance-validate.mjs (enforce-config
+  // schema validation). Both zero-further-dep; omit either and enforce-contract
+  // fails to load → the hook falls back to the loud-fail envelope (false fail).
+  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'marker-state.mjs', 'session-id.mjs', 'effective-tier.mjs', 'json-instance-validate.mjs']) {
     const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', lib)
     fs.copyFileSync(libSrc, path.join(scripts, 'lib', lib))
   }

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -93,6 +93,14 @@ mk_fake_home() {
   # 2026-05-18 concurrent-session fix: em-recall imports session-id.mjs for
   # the --session-id flag (codex R1 P1.2; logging-only in v6 sweep).
   cp "$REPO_ROOT/scripts/lib/session-id.mjs" "$fake_home/.episodic-memory/scripts/lib/session-id.mjs"
+  # RFC-008 P3b-2 (2026-06-17): enforce-contract.mjs gained the effective-tier
+  # layer, importing effective-tier.mjs (the min() algebra) + json-instance-
+  # validate.mjs (enforce-config.json schema validation in loadEnforceConfig).
+  # Both are zero-further-dep; the real install copies ALL scripts/lib/*.mjs, but
+  # this hand-staged fake HOME must list each transitive dep or the module fails
+  # to load and the hook falls back to the loud-fail envelope (false pass).
+  cp "$REPO_ROOT/scripts/lib/effective-tier.mjs" "$fake_home/.episodic-memory/scripts/lib/effective-tier.mjs"
+  cp "$REPO_ROOT/scripts/lib/json-instance-validate.mjs" "$fake_home/.episodic-memory/scripts/lib/json-instance-validate.mjs"
 }
 
 TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"

--- a/tests/test-structured-alert.mjs
+++ b/tests/test-structured-alert.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// test-structured-alert.mjs — RFC-008 P3b-2 (CLASS-C(b) / F3 writer, LIBRARY-ONLY
+// per B2). Pins the PARAMETERIZED writer scripts/lib/structured-alert.mjs:
+//   M1   — the payload is parameterized: a REAL emitted_label flows through, NOT
+//          the probe's hardcoded `probe_out_of_vocabulary` literal.
+//   F4   — `now` is injected (never Date.now() in the lib); project_root/store_root
+//          are the two distinct fields, store_root = resolveRepoRoot(input).
+//   B4   — the write binds to the resolved store root from `input`, not cwd; a
+//          store_root param that disagrees with resolveRepoRoot(input) throws
+//          (resolve-once invariant).
+//   F62  — the schema's exactly-one label-vs-event conditional is enforced (a bad
+//          combo throws, never writes a half-valid alert).
+//   N2   — the probe CLI's isMain is realpath-robust (symlinked invocation path
+//          still runs as main; closes FU #390).
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { execSync, spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+import { emitStructuredAlert, AlertError } from '../scripts/lib/structured-alert.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const PROBE = path.join(REPO, 'scripts', 'lib', 'structured-alert-probe.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected)
+  if (a === e) ok(name); else bad(name, `expected ${e}, got ${a}`)
+}
+function truthy(name, v, detail) { if (v) ok(name); else bad(name, detail || 'expected truthy') }
+function throws(name, fn, re) {
+  try { fn(); bad(name, 'expected throw') }
+  catch (e) { if (!re || re.test(e.message)) ok(name); else bad(name, `wrong message: ${e.message}`) }
+}
+
+function mkGitRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'structured-alert-'))
+  execSync('git init -q -b main', { cwd: repo })
+  execSync('git config user.email test@example.com', { cwd: repo })
+  execSync('git config user.name test', { cwd: repo })
+  fs.writeFileSync(path.join(repo, 'README.md'), 'x\n')
+  execSync('git add . && git commit -q -m init', { cwd: repo, shell: '/bin/bash' })
+  return repo
+}
+
+const NOW = '2026-06-17T09:30:00.000Z'
+
+console.log('=== M1 — parameterized payload (REAL label, not the probe literal) ===')
+{
+  const repo = mkGitRepo()
+  const r = emitStructuredAlert({
+    input: repo, now: NOW,
+    alert_type: 'classifier_out_of_vocabulary',
+    emitted_label: 'shared_write_typo', // a REAL offending label
+    command: 'rm -rf /tmp/x',
+  })
+  eq('M1: status ok', r.status, 'ok')
+  truthy('M1: alert file exists', fs.existsSync(r.episode_file), r.episode_file)
+  const ep = JSON.parse(fs.readFileSync(r.episode_file, 'utf8'))
+  eq('M1: emitted_label is the REAL label (not probe_out_of_vocabulary)', ep.emitted_label, 'shared_write_typo')
+  eq('M1: alert_type passed through', ep.alert_type, 'classifier_out_of_vocabulary')
+  eq('M1: command passed through', ep.command, 'rm -rf /tmp/x')
+  // F4 — now injected, filename slug derives from it (no colons).
+  eq('M1/F4: timestamp == injected now', ep.timestamp_iso8601, NOW)
+  truthy('M1/F4: filename slug derives from now', path.basename(r.episode_file).includes('2026-06-17'), r.episode_file)
+  // F4 — project_root == store_root in a non-worktree repo (the two distinct fields).
+  const real = fs.realpathSync(repo)
+  eq('F4: project_root == realpath(repo)', ep.project_root, real)
+  eq('F4: store_root == realpath(repo)', ep.store_root, real)
+  eq('F4: episode fields match the returned contract', [ep.project_root, ep.store_root], [r.project_root, r.store_root])
+}
+
+console.log('')
+console.log('=== F4 — now MUST be injected (never Date.now() in the lib) ===')
+throws('now omitted → throws', () => emitStructuredAlert({ input: mkGitRepo(), alert_type: 'classifier_out_of_vocabulary', emitted_label: 'x' }), /now.*injected|ISO-8601/)
+
+console.log('')
+console.log('=== B4 — store_root binds to resolveRepoRoot(input), not cwd ===')
+{
+  const repo = mkGitRepo()
+  const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), 'cwd-elsewhere-'))
+  const saved = process.cwd()
+  try {
+    process.chdir(elsewhere) // cwd != project
+    const r = emitStructuredAlert({ input: repo, now: NOW, alert_type: 'classifier_out_of_vocabulary', emitted_label: 'lbl' })
+    truthy('B4: alert lands under store_root (from input), not cwd', r.episode_file.startsWith(fs.realpathSync(repo) + path.sep), r.episode_file)
+    truthy('B4: alert ABSENT under cwd', !fs.existsSync(path.join(elsewhere, '.episodic-memory')), 'cwd should have no alert')
+  } finally { process.chdir(saved) }
+}
+// store_root param that disagrees with resolveRepoRoot(input) → resolve-once throw.
+{
+  const repo = mkGitRepo()
+  const wrong = fs.mkdtempSync(path.join(os.tmpdir(), 'wrong-store-'))
+  eq('B4: matching store_root param accepted', emitStructuredAlert({ input: repo, now: NOW, alert_type: 'classifier_out_of_vocabulary', emitted_label: 'lbl', store_root: fs.realpathSync(repo) }).status, 'ok')
+  throws('B4: mismatched store_root param → throws (resolve-once)', () => emitStructuredAlert({ input: repo, now: NOW, alert_type: 'classifier_out_of_vocabulary', emitted_label: 'lbl', store_root: wrong }), /resolve-once|store_root param/)
+}
+
+console.log('')
+console.log('=== F62 — exactly-one label-vs-event vocab (bad combo never writes) ===')
+{
+  const repo = mkGitRepo()
+  throws('F62: classifier_out_of_vocabulary w/ null label → schema-invalid throw',
+    () => emitStructuredAlert({ input: repo, now: NOW, alert_type: 'classifier_out_of_vocabulary', emitted_label: null }), /schema-invalid/)
+  // event_out_of_vocabulary requires emitted_event_id + events_version, label null.
+  const ev = emitStructuredAlert({
+    input: repo, now: NOW, alert_type: 'event_out_of_vocabulary',
+    emitted_label: null, emitted_event_id: 'bogus_event',
+    events_version: 'sha256:' + 'a'.repeat(64),
+  })
+  eq('F62: well-formed event_out_of_vocabulary writes ok', ev.status, 'ok')
+  throws('F62: event_out_of_vocabulary missing events_version → throw',
+    () => emitStructuredAlert({ input: repo, now: NOW, alert_type: 'event_out_of_vocabulary', emitted_event_id: 'bogus_event' }), /schema-invalid/)
+}
+
+console.log('')
+console.log('=== AlertError type ===')
+truthy('AlertError is an Error subclass', new AlertError('x') instanceof Error, 'expected Error subclass')
+
+console.log('')
+console.log('=== N2 — probe CLI isMain realpath-robust (symlinked invocation path) ===')
+{
+  const repo = mkGitRepo()
+  const linkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'probe-symlink-'))
+  const linkedLib = path.join(linkDir, 'lib')
+  fs.symlinkSync(path.join(REPO, 'scripts', 'lib'), linkedLib) // non-canonical path to the real probe
+  const r = spawnSync('node', [path.join(linkedLib, 'structured-alert-probe.mjs'), '--project', repo, '--now', NOW], { cwd: repo, encoding: 'utf8' })
+  let out = null
+  try { out = JSON.parse(r.stdout.trim()) } catch {}
+  truthy('N2: probe via symlinked path still runs as main + emits the contract', out && out.status === 'ok' && out.input_project_root, `stdout=[${r.stdout}] stderr=[${r.stderr}]`)
+}
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks failed:`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}

--- a/tests/test-validate-bp-contract.mjs
+++ b/tests/test-validate-bp-contract.mjs
@@ -31,7 +31,9 @@ const SCAFFOLD = path.join(REPO_ROOT, "scripts", "scaffold-bp.mjs");
 const FIXTURE_DIR = path.join(REPO_ROOT, "tests", "fixtures", "bp-contract");
 const COPY_ROOTS = ["patterns", "plugins", "schemas"];
 const CLASSIFIER_REL = path.join("plugins", "claude-code", "hooks", "lib", "command-classifier.sh");
-const EXPECTED_ASSERTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15];
+// 16 (P3b-2) is the gate-map mirror — LIVE mode only (the live repo run here is
+// uninjected, so it runs; golden-corpus dispatches inject and skip it).
+const EXPECTED_ASSERTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16];
 
 let pass = 0;
 let fail = 0;
@@ -140,7 +142,7 @@ function stageBpFixture(root, fixtureName) {
     .map((p) => /^(bp-[0-9]{3})-/.exec(p.pattern_id)[1]).sort();
   assert(JSON.stringify(r.payload && r.payload.derived_ids) === JSON.stringify(indexIds), "real repo: derived_ids equals _index.json derivation (bp-007 absent)", `got ${JSON.stringify(r.payload && r.payload.derived_ids)}`);
   assert(!indexIds.includes("bp-007"), "real repo: bp-007 stays absent (N-1)");
-  assert(JSON.stringify(r.payload && r.payload.assertions_run) === JSON.stringify(EXPECTED_ASSERTIONS), "real repo: all 15 assertion groups ran (zero-run vacuity guard)", `got ${JSON.stringify(r.payload && r.payload.assertions_run)}`);
+  assert(JSON.stringify(r.payload && r.payload.assertions_run) === JSON.stringify(EXPECTED_ASSERTIONS), "real repo: all 16 assertion groups ran (zero-run vacuity guard)", `got ${JSON.stringify(r.payload && r.payload.assertions_run)}`);
   assert(r.payload && r.payload.checks > 0, "real repo: non-zero check count");
   assert(r.payload && r.payload.classifiers_parsed >= 1, "real repo: >= 1 default classifier parsed (7b non-vacuous)");
   // EVENT_IDS <-> events.json binding (review FU, Rule 14): the registry's


### PR DESCRIPTION
## RFC-008 P3b-2 — contract-driven effective-tier layer in `enforce-contract.mjs`

Serves **R3, R5, R6, R8** (+ F3, CLASS-C, M8); folds in the **P4** config schema. Builds on P3b-1 (the relocated stop decision) by adding the effective-tier layer on top of the marker logic:

```
effective_tier(stop) = min( harness_cap[stop], contract.stop.tier, config.<bp>.stop )
```
over a **base-STRONG fold**.

### The anti-fail-open invariant (B1)
**default-STRONG / clamp-only-on-success.** Every tier source the boundary cannot resolve (missing contract root, missing `plugins/_index.json`, absent/unreadable `bp-001`/`events`, broken config, schema-load crash) is folded as `null` = **no clamp** → the base stays STRONG = today's unconditional refuse. A resolution failure can never weaken the gate. `enforce-contract` changes observable behavior **only** when a project's `enforce-config.json` explicitly clamps `stop` below STRONG (or sets `active:false`). Verified empirically by test-D1–D8.

### What's in it
- **`scripts/lib/effective-tier.mjs`** (NEW) — the single tier algebra, extracted from `validate-plugin-registry.mjs` (Rule 14: one algebra, two consumers). Adds the base-STRONG concrete fold (never null — F-NEW-2) and `GATE_EVENT_MAP`/`GATE_CONTRACT_KEY` (**F-NEW-1**: the stop refuse maps to the `stop` event + the `stop.tier` contract key, **not** `gates.post_checkpoint`).
- **`scripts/enforce-contract.mjs`** — `resolveContractRoot` (own depth-1 climb, mirrors P3c's two-candidate + realpath-round-trip pattern — **B3**), `resolveHarnessCap` (**M8** duplicate-binding fail-closed), `loadEnforceConfig` (**M2** full error-branch matrix → identity stay-STRONG), `CLASS-C(a)` REAL block (**N1**), `M4` downgrade notice. `decideStop` stays **pure** (gains a `stopTier` param; default STRONG keeps the em-recall parity byte-identical).
- **`patterns/enforce-config.schema.json`** (NEW, P4 folded) — `propertyNames` + schema-valued `additionalProperties` (the closed-subset validator rejects `patternProperties`).
- **`scripts/lib/structured-alert.mjs`** (NEW) — parameterized F3 writer (**CLASS-C(b)**, library-only per B2 — no live out-of-vocab site under stop-only wiring; **M1** real label, not the probe literal). Probe reduced to a thin wrapper + **isMain realpath-both fix (N2, closes #390)**.
- **`install.mjs`** — co-deploys `bp-001.json`/`events.json`/`enforce-config.schema.json` coupled to `--install-hooks` (bp-001 lands last; **F-NEW-4** coupling assertion). No-hooks install leaves the set absent (T20a2 analog).
- **`validate-bp-contract.mjs`** — assertion 16: the gate-map mirror (**B5/F-NEW-1**), LIVE mode only.

### Tests (written alongside — Rule 18 step 5)
All green: `effective-tier 31/0 · enforce-config 25/0 · structured-alert 20/0 · enforce-contract 52/0` (parity + 3-axis inertness + M8 + CLASS-C(a) + ambient-parent + garbage-content) `· install-contract-deploy 13/0 · validate-bp-contract 103/0 · plugin-registry 200/0 · gauntlet 14/0 · harness-binding 21/0 · p0-schemas 122/0 · validate-schemas 40/0 · stop-gate 31/0 · install-hooks 92/0 · taxonomy-sync 18/0`. Four suites wired into CI.

### Reviews
- **Plan**: claude-subagent harness R3 → ACCEPT (converged, blockers:[]).
- **Code**: `negative-scenario-reviewer` → **ACCEPT-with-FU**. 0 blocker; the one MAJOR (a missing B3 ambient-parent regression that plan §11 promised) **fixed inline** as test D7; MINOR/NIT items → code comments. M4-via-stderr deviation reviewer-confirmed correct.

### One deliberate deviation
M4 downgrade observability uses a **stderr notice**, not the structured-alert writer: the alert schema's `alert_type` enum is closed to out-of-vocab types and cannot represent a tier downgrade, and a schema edit was out of the planned file scope. If durable downgrade-audit is ever required, the follow-up is a third `enforcement_tier_downgrade` alert_type (not reusing the out-of-vocab writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
