### PR TITLE
feat(rfc-008): P4a — per-project enforce-config wired into the 3 pre_tool_use gates

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Run enforce-contract --gate stop relocation + parity + tier layer (RFC-008 P3b-1/P3b-2)
         run: node tests/test-enforce-contract.mjs
 
+      - name: Run --resolve-gate per-project pre_tool_use consult (RFC-008 P4a, R3/R5 — gateDisposition + closed-token CLI)
+        run: node tests/test-resolve-gate.mjs
+
+      - name: Run --resolve-gate bash bridge contract (RFC-008 P4a, F5 — exact-token match, ||-envelope fail-closed, plan-gate honors silence/clamp)
+        run: bash tests/test-resolve-gate-bridge.sh
+
       - name: Run enforce-contract --session-start side-effects relocation (RFC-008 P3d)
         run: node tests/test-enforce-contract-session-start.mjs
 

--- a/patterns/enforce-config.schema.json
+++ b/patterns/enforce-config.schema.json
@@ -25,7 +25,7 @@
     "perBp": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Per-gate tier clamp for one bp contract. Keys mirror GATE_CONTRACT_KEY (effective-tier.mjs): the three classification gates + the root-level stop marker-state gate. Only `stop` is LIVE-wired in P3b-2; the three classification gates parse + validate but are inert until the pre_tool_use bridge lands.",
+      "description": "Per-gate tier clamp for one bp contract. Keys mirror GATE_CONTRACT_KEY (effective-tier.mjs): the three classification gates + the root-level stop marker-state gate. All four are LIVE-wired: `stop` since P3b-2 (decideStop), and the three pre_tool_use classification gates since P4a via the bash plan-gate.sh/checkpoint-gate.sh ↔ `enforce-contract --resolve-gate` bridge.",
       "properties": {
         "plan_approval": { "$ref": "#/$defs/tier" },
         "pre_checkpoint": { "$ref": "#/$defs/tier" },

--- a/plugins/claude-code/hooks/checkpoint-gate.sh
+++ b/plugins/claude-code/hooks/checkpoint-gate.sh
@@ -109,6 +109,13 @@ source "$LIB_DIR/session-id.sh"
 
 REPO_ROOT="$(resolve_repo_root "$CWD")"
 
+# RFC-008 P4a: the enforcement resolver the per-project enforce-config.json consult
+# spawns. Global install path (parity with stop-gate.sh:68 + the helpers below); a
+# missing binary makes `node` exit non-zero → "" → the gate keeps blocking
+# (fail-closed, B1). Never re-resolves the root — the consult passes REPO_ROOT as
+# --marker-root (F4).
+ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+
 # Canonical WRITE paths. Used in block-message paths so the agent knows
 # where to write the checkpoint block.
 #
@@ -1424,6 +1431,42 @@ case "$TOOL_NAME" in
 esac
 
 # ---------------------------------------------------------------------------
+# RFC-008 P4a (R3/R5) — pre_checkpoint per-project enforce-config consult.
+#
+# Placement (F11): AFTER the integrity prechecks (env-prefix, relative-marker,
+# wrong-root) and the marker_write branches above — so those integrity blocks and
+# the marker_write-branch lifecycle blocks (plan-pending, premature-post) remain
+# NON-silenceable (parity with M8; a corrupt/hostile marker write can never be
+# silenced by active:false). BEFORE both pre-checkpoint gate bodies (Edit/Write
+# and Bash) so a single consult covers both (F2).
+#
+# Gate selection (F9): this site handles pre_checkpoint ONLY. The push path
+# (LABEL=push_or_pr_create) is post_checkpoint and is consulted separately inside
+# the push-gate (so its silence still runs the marker-cleanup sweep — F10). Guard
+# this consult out for push so we don't resolve the wrong gate's clamp here.
+#
+# Spawn discipline: only when a pre-checkpoint block is actually imminent — pre-done
+# unmet AND (a checkpoint is armed OR a plan is approved this session). The common
+# no-task path stays pure-bash, zero node spawn. Exact-equality safe-token match
+# (never substring); any other output (empty / non-zero via `|| PRE_DISP=""` /
+# garbage) falls through to the existing pre-checkpoint blocks (fail-closed, B1).
+#
+# R5 scope note (review MINOR-2): this consult sits ABOVE the Bash agent-classifier
+# hold (_block_needs_classification). When a plan is approved AND active:false, a
+# novel-unevaluated Bash command is silenced too — intended: active:false turns OFF
+# all bp-001 pre_checkpoint enforcement for this project, the classification hold
+# included (it only exists to route would-be pre-checkpoint writes).
+if [ "$TOOL_NAME" != "Bash" ] || [ "$LABEL" != "push_or_pr_create" ]; then
+  if ! checkpoint_marker_nonempty_for_session .pre-checkpoint-done "$MY_SID" \
+     && { checkpoint_marker_exists_for_session .checkpoint-required "$MY_SID" || _plan_approved_exists_for_session "$MY_SID"; }; then
+    PRE_DISP="$(node "$ENFORCE_CONTRACT" --resolve-gate pre_checkpoint --marker-root "$REPO_ROOT" 2>/dev/null)" || PRE_DISP=""
+    if [ "$PRE_DISP" = "silence" ] || [ "$PRE_DISP" = "clamp-off" ]; then
+      exit 0
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Pre-checkpoint gate — planning-passive + lazy-armed (2026-05-25 redesign).
 #
 # OLD: em-recall armed .checkpoint-required at SESSION START whenever a bp-001
@@ -1556,6 +1599,21 @@ esac
 # Push-gate: only fires for Bash classified as push_or_pr_create.
 # ---------------------------------------------------------------------------
 if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
+  # RFC-008 P4a (R3/R5) — post_checkpoint per-project enforce-config consult (F9
+  # gate selection: the push path IS the post_checkpoint gate). F10: on silence/
+  # clamp-off we must NOT bare `exit 0` — that would skip the load-bearing marker-
+  # cleanup sweep below and strand .checkpoint-required, deadlocking the stop gate
+  # when post_checkpoint is clamped but stop is left STRONG (schema permits
+  # independent per-gate keys). Instead set POST_SILENCED, which suppresses the
+  # self-arm + both _block_post emitters but lets control fall through to the SAME
+  # cleanup an allowed push runs — clearing .checkpoint-required so stop can't
+  # deadlock. Exact-equality token; `|| POST_DISP=""` keeps non-zero/empty/garbage
+  # fail-closed (push still gated).
+  POST_DISP="$(node "$ENFORCE_CONTRACT" --resolve-gate post_checkpoint --marker-root "$REPO_ROOT" 2>/dev/null)" || POST_DISP=""
+  POST_SILENCED=0
+  if [ "$POST_DISP" = "silence" ] || [ "$POST_DISP" = "clamp-off" ]; then
+    POST_SILENCED=1
+  fi
   # B1 (#351, §11b/§15-C3 — D7 backstop): push self-arms .post-checkpoint-required
   # regardless of pre-checkpoint state, so push is an INDEPENDENT hard gate even
   # when the pre-checkpoint was escaped via an agent verdict (D7 made the pre-
@@ -1568,7 +1626,7 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   # satisfied done-marker; closes the read-after-arm TOCTOU, §15-C3/F2). The
   # cross-session sweep below is NOT weakened (load-bearing for orphan cleanup).
   _push_self_arm_created=0
-  if ! checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
+  if [ "$POST_SILENCED" != "1" ] && ! checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
     ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
     if validate_session_id "$MY_SID"; then
       HELPER_CKM_PUSH="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
@@ -1603,14 +1661,16 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
       fi
     fi
   fi
-  if [ "$_push_self_arm_created" = "1" ]; then
+  if [ "$POST_SILENCED" != "1" ] && [ "$_push_self_arm_created" = "1" ]; then
     # Created THIS invocation → cannot already have a satisfied
     # .post-checkpoint-done. Block unconditionally without re-reading (TOCTOU-free).
     _block_post
   fi
   # Rank-2: session-aware post-checkpoint check (already-armed path — a prior
   # invocation or post-write arming armed post-req; block until it's satisfied).
-  if checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
+  # P4a (F10): suppressed under POST_SILENCED so the cleanup below still runs.
+  if [ "$POST_SILENCED" != "1" ] \
+     && checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID" \
      && ! checkpoint_marker_nonempty_for_session .post-checkpoint-done "$MY_SID"; then
     _block_post
   fi

--- a/plugins/claude-code/hooks/plan-gate.sh
+++ b/plugins/claude-code/hooks/plan-gate.sh
@@ -100,6 +100,26 @@ case "$TOOL_NAME" in
     ;;
 esac
 
+# RFC-008 P4a (R3/R5): per-project enforce-config consult — ONE site, placed after
+# the read-only allow and BEFORE every plan block path (the F14 fail-closed block
+# AND the main block), so active:false silences even the probe-drift defense (there
+# is no enforcement to protect when the operator turned plan_approval off).
+#
+# Spawn the resolver ONLY when a plan marker actually exists — the no-plan common
+# path stays pure-bash with zero node spawn. A safe token is matched by EXACT
+# STRING EQUALITY (never substring): a diagnostic line that merely CONTAINS
+# "silence"/"clamp-off" must NOT unblock. ANY other resolver output — empty,
+# non-zero exit (caught by `|| GATE_DISP=""`), garbage, multi-line — leaves
+# GATE_DISP unmatched and falls through to the existing block paths (fail-closed,
+# B1). A missing enforce-contract.mjs makes `node` exit non-zero → "" → block.
+ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+if _any_plan_marker_exists_local; then
+  GATE_DISP="$(node "$ENFORCE_CONTRACT" --resolve-gate plan_approval --marker-root "$REPO_ROOT" 2>/dev/null)" || GATE_DISP=""
+  if [ "$GATE_DISP" = "silence" ] || [ "$GATE_DISP" = "clamp-off" ]; then
+    exit 0
+  fi
+fi
+
 # F14 fail-closed: invalid/missing/empty session_id is a probe-drift threat
 # distinct from honest-agent forgery. If ANY plan marker exists, BLOCK with
 # a clear reason — the agent must either provide a valid session_id in

--- a/plugins/claude-code/runbooks/enforcement.md
+++ b/plugins/claude-code/runbooks/enforcement.md
@@ -157,7 +157,7 @@ block below against the derived source-of-truth.
 <!-- CONFIG:BEGIN -->
 **10a — Configuration.**
 
-- `enforce_config_keys`: none yet — the per-project `enforce-config.json` schema lands in P4; M7f 10a is present-and-parses until then.
+- `enforce_config_keys`: `active` (R5 project switch) + `bp-001.{plan_approval,post_checkpoint,pre_checkpoint,stop}` per-bp tier clamps (RFC-008 P4; schema `patterns/enforce-config.schema.json`; clamp-DOWN only; resolved by `enforce-contract --gate stop` / `--resolve-gate <gate>`).
 - `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.
 
 **10b — Taxonomies.**

--- a/scripts/enforce-contract.mjs
+++ b/scripts/enforce-contract.mjs
@@ -74,6 +74,8 @@ import {
   clampTier,
   effectiveTierStrong,
   eventActionId,
+  GATE_EVENT_MAP,
+  GATE_CONTRACT_KEY,
 } from './lib/effective-tier.mjs'
 
 // The harness this enforcement layer runs for (stop-gate.sh is the claude-code
@@ -182,6 +184,23 @@ function realpathOrNull(p) {
 
 function readJsonSafe(abs) {
   try { return JSON.parse(fs.readFileSync(abs, 'utf8')) } catch { return null }
+}
+
+/**
+ * Navigate a dotted contract path (GATE_CONTRACT_KEY value, e.g. "gates.plan_approval"
+ * or "stop.tier") and return the leaf iff it is a string; null otherwise. Used to read
+ * the per-gate contract tier out of bp-001.json: `gates.<gate>` is a bare tier string,
+ * `stop.tier` is the nested stop marker-state tier. A non-object intermediate or a
+ * non-string leaf returns null ⇒ the effective-tier fold treats it as no-clamp
+ * (base-STRONG), so a malformed contract can never weaken a gate (B1).
+ */
+function dottedGet(obj, dotted) {
+  let cur = obj
+  for (const k of String(dotted).split('.')) {
+    if (cur == null || typeof cur !== 'object') return null
+    cur = cur[k]
+  }
+  return typeof cur === 'string' ? cur : null
 }
 
 /**
@@ -295,6 +314,52 @@ function appendEnforceAudit(markerRoot, line) {
     fs.mkdirSync(dir, { recursive: true })
     fs.appendFileSync(path.join(dir, 'enforce-audit.log'), `${new Date().toISOString()} ${line}\n`)
   } catch { /* best-effort; never block the gate on an audit write */ }
+}
+
+/**
+ * gateDisposition — pure per-gate (pre_tool_use) resolution (no I/O, no exit).
+ * The pre_tool_use sibling of decideStop: the CLI boundary resolves the registry/
+ * contract/config reads and passes them in; this returns a CLOSED disposition token
+ * the bash gate consumes. The bash gate BLOCKS by default and skips its block ONLY
+ * on an explicit safe token (F5 fail-closed inversion vs the stop gate's
+ * empty=allow), so any disposition that is not 'silence'/'clamp-off' keeps the gate
+ * enforcing.
+ *
+ * Ordering is load-bearing (F7 — parity with the stop path enforce-contract.mjs:
+ * M8 duplicate REAL-blocks BEFORE the active:false silence). A corrupt registry is
+ * NOT silenceable by an operator opt-out, by design.
+ *
+ *   'block'     — M8: >1 active enforcement plugin binds this harness. Corrupt
+ *                 install; non-silenceable. (Stdout-wise identical to 'enforce' —
+ *                 both keep the gate blocking — but distinguished for the audit/
+ *                 diagnostic and to encode the precedence explicitly.)
+ *   'silence'   — operator set active:false (R5). Gate does not fire.
+ *   'clamp-off' — effective tier resolves to a pre_tool_use action other than
+ *                 `block` (MEDIUM=warn / WEAK=inject) via a deliberate operator
+ *                 clamp. Gate is degraded to allow (the MEDIUM side-band warn is
+ *                 satisfied by the CLI's appendEnforceAudit; WEAK's next-turn inject
+ *                 is not reachable from a PreToolUse hook and is approximated by the
+ *                 audit line — documented).
+ *   'enforce'   — base STRONG (action `block`), OR any unresolved/unknown action
+ *                 (events.json missing, '—', 'unsupported'): fail-closed to blocking.
+ *
+ * @param {{duplicate:boolean, harnessCap:?string, contractTier:?string,
+ *          active:boolean, configTier:?string, events:?object, event:string}} o
+ * @returns {{token:'block'|'silence'|'clamp-off'|'enforce', hcTier:?string, effTier:?string}}
+ */
+export function gateDisposition({ duplicate, harnessCap, contractTier, active, configTier, events, event }) {
+  if (duplicate) return { token: 'block', hcTier: null, effTier: null }
+  if (active === false) return { token: 'silence', hcTier: null, effTier: null }
+  const hcTier = effectiveTierStrong([harnessCap, contractTier])
+  const effTier = clampTier(hcTier, configTier)
+  // eventActionId is NOT null-safe (the stop path guards `events &&` at its call
+  // site — enforce-contract.mjs:526). A null events.json (unresolved contract root)
+  // ⇒ no action ⇒ fail-closed enforce: a resolution miss never clamps a gate off.
+  const action = events ? eventActionId(events, event, effTier) : null
+  if (action === 'block') return { token: 'enforce', hcTier, effTier }
+  if (action === 'warn' || action === 'inject') return { token: 'clamp-off', hcTier, effTier }
+  // Unknown / unsupported / '—' (unresolved events.json) ⇒ fail-closed enforce.
+  return { token: 'enforce', hcTier, effTier }
 }
 
 // ---------------------------------------------------------------------------
@@ -458,6 +523,59 @@ if (isMain) {
       process.exit(1)
     }
     runSessionStartSideEffects(resolveRepoRoot())
+    process.exit(0)
+  }
+
+  // RFC-008 P4a (R3/R5): --resolve-gate <plan_approval|pre_checkpoint|post_checkpoint>
+  // resolves the per-project effective disposition for ONE pre_tool_use gate and
+  // prints a CLOSED safe token to stdout (`silence` | `clamp-off`) — nothing else.
+  // The bash gate (plan-gate.sh / checkpoint-gate.sh) BLOCKS by default and skips
+  // its block ONLY on an exact-equality match of a safe token (F5). Therefore every
+  // failure path here — bad gate name, missing/relative --marker-root, unresolved
+  // contract, M8 duplicate, base-STRONG — prints NO token and the gate keeps
+  // blocking (fail-closed, B1). Dispatched BEFORE the --gate required-check (it has
+  // no --gate). --marker-root is passed EXPLICITLY by the bash gate (the REPO_ROOT
+  // it already resolved from hook-input .cwd); this mode NEVER calls resolveRepoRoot
+  // (F4 — no second resolution to diverge → the P3b-1 /var isMain fail-open class
+  // cannot recur). All diagnostics go to stderr; stdout is the token alone.
+  const resolveGate = flag('--resolve-gate')
+  if (resolveGate !== undefined) {
+    const VALID_RESOLVE_GATES = ['plan_approval', 'pre_checkpoint', 'post_checkpoint']
+    if (!VALID_RESOLVE_GATES.includes(resolveGate)) {
+      process.stderr.write(`enforce-contract: --resolve-gate "${resolveGate}" invalid (expected one of ${VALID_RESOLVE_GATES.join(', ')}); no token emitted → gate enforces.\n`)
+      process.exit(0)
+    }
+    const mr = flag('--marker-root')
+    if (mr === undefined || !path.isAbsolute(mr)) {
+      process.stderr.write(`enforce-contract: --resolve-gate requires an absolute --marker-root (got ${mr === undefined ? 'none' : `"${mr}"`}); no token emitted → gate enforces.\n`)
+      process.exit(0)
+    }
+    const event = GATE_EVENT_MAP[resolveGate] // 'pre_tool_use' (F8)
+    const cRoot = resolveContractRoot()
+    const reg = cRoot ? readJsonSafe(path.join(cRoot, 'plugins', '_index.json')) : null
+    const cDoc = cRoot ? readJsonSafe(path.join(cRoot, 'patterns', 'bp-001.json')) : null
+    const evs = cRoot ? readJsonSafe(path.join(cRoot, 'patterns', 'events.json')) : null
+    const cSchema = cRoot ? readJsonSafe(path.join(cRoot, 'patterns', 'enforce-config.schema.json')) : null
+    const hRes = reg ? resolveHarnessCap(reg, THIS_HARNESS, event) : { tier: null, duplicate: false }
+    const cfg = loadEnforceConfig(mr, cSchema)
+    const contractTier = dottedGet(cDoc, GATE_CONTRACT_KEY[resolveGate]) // gates.<gate>
+    const configTier = (cfg.bps[BP_ID] && typeof cfg.bps[BP_ID][resolveGate] === 'string') ? cfg.bps[BP_ID][resolveGate] : null
+    const disp = gateDisposition({
+      duplicate: hRes.duplicate, harnessCap: hRes.tier, contractTier,
+      active: cfg.active, configTier, events: evs, event,
+    })
+    if (disp.token === 'silence') {
+      appendEnforceAudit(mr, `${resolveGate} gate silenced (active:false) for ${BP_ID} (R5)`)
+      process.stderr.write(`enforce-contract: notice — ${resolveGate} gate silenced for this project via .episodic-memory/enforce-config.json {"active":false} (R5).\n`)
+      console.log('silence')
+    } else if (disp.token === 'clamp-off') {
+      appendEnforceAudit(mr, `${resolveGate} gate degraded ${disp.hcTier}->${disp.effTier} for ${BP_ID} (deliberate operator clamp via enforce-config.json)`)
+      process.stderr.write(`enforce-contract: notice — ${resolveGate} gate degraded ${disp.hcTier}→${disp.effTier} for ${BP_ID} via .episodic-memory/enforce-config.json (M4 audit → .episodic-memory/enforce-audit.log).\n`)
+      console.log('clamp-off')
+    } else if (disp.token === 'block') {
+      process.stderr.write(`enforce-contract: >1 active enforcement plugin binds harness "${THIS_HARNESS}" (M8/R6); ${resolveGate} gate NOT silenceable by active:false — fix plugins/_index.json. No token emitted → gate enforces.\n`)
+    }
+    // token 'enforce' (or 'block'): no stdout → bash keeps blocking (fail-closed).
     process.exit(0)
   }
 

--- a/scripts/lib/effective-tier.mjs
+++ b/scripts/lib/effective-tier.mjs
@@ -55,13 +55,13 @@ export const GATE_CONTRACT_KEY = {
   stop: "stop.tier",
 };
 
-// Which gates P3b-2 LIVE-wires into a runtime decision. ONLY the stop gate this
-// slice (decideStop, the marker-state gate). The three pre_tool_use classification
-// gates are DEFERRED — they need the bash plan-gate.sh/checkpoint-gate.sh ↔ node
-// bridge, a later slice (§9). Exported so the Rule-14 mirror validator can assert
-// a `stop→` clamp degrades the live decision while a `post_checkpoint→` clamp does
-// not (it is inert until wired).
-export const LIVE_GATES = ["stop"];
+// Which gates are LIVE-wired into a runtime decision. P3b-2 wired the stop gate
+// (decideStop, the marker-state gate); RFC-008 P4a added the three pre_tool_use
+// classification gates via the bash plan-gate.sh/checkpoint-gate.sh ↔ node
+// `enforce-contract --resolve-gate` bridge. All four contract gates are now live.
+// Exported so the Rule-14 mirror validator can assert every contract/config gate
+// key maps to a wired runtime decision (no inert key remains).
+export const LIVE_GATES = ["stop", "plan_approval", "pre_checkpoint", "post_checkpoint"];
 
 /**
  * VALIDATOR-ONLY fold: min over the PRESENT tier sources, null on all-absent.

--- a/scripts/validate-plugin-registry.mjs
+++ b/scripts/validate-plugin-registry.mjs
@@ -39,7 +39,7 @@ import { contained, resolveContained, UsageError } from "./lib/path-contain.mjs"
 // scripts/lib/effective-tier.mjs (extracted P3b-2, R3) so this validator's Table B
 // rendering and enforce-contract's runtime stop decision share ONE algebra
 // (Rule 14). No behavior change here — the self-tests prove it byte-for-byte.
-import { TIER_RANK, effectiveTier, eventActionId } from "./lib/effective-tier.mjs";
+import { TIER_RANK, effectiveTier, eventActionId, GATE_CONTRACT_KEY } from "./lib/effective-tier.mjs";
 
 // --- closed vocabularies (re-asserted even where a schema already closes them) ---
 export const MAX_SUPPORTED = "1.0.0"; // byte-equal'd to _corpus-index.current_schema_version (a test asserts equality)
@@ -420,10 +420,15 @@ export function renderConfigBlock(manifest) {
   const emits = cls.emits_labels || [];
   const trans = manifest.event_translations || {};
   const consumes = Object.keys(manifest.capabilities || {});
+  // RFC-008 P4: enforce_config_keys derived from GATE_CONTRACT_KEY (Rule-14 single
+  // source — same gate set the runtime resolver clamps; a drift here vs the runbook
+  // fails M7f loud). `active` is the R5 project switch; the per-bp tier clamps are
+  // the four contract gates this plugin reads from enforce-config.json.
+  const ecGateKeys = Object.keys(GATE_CONTRACT_KEY).sort().join(",");
   const out = [
     "**10a — Configuration.**",
     "",
-    "- `enforce_config_keys`: none yet — the per-project `enforce-config.json` schema lands in P4; M7f 10a is present-and-parses until then.",
+    `- \`enforce_config_keys\`: \`active\` (R5 project switch) + \`bp-001.{${ecGateKeys}}\` per-bp tier clamps (RFC-008 P4; schema \`patterns/enforce-config.schema.json\`; clamp-DOWN only; resolved by \`enforce-contract --gate stop\` / \`--resolve-gate <gate>\`).`,
     "- `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.",
     "",
     "**10b — Taxonomies.**",

--- a/tests/test-effective-tier.mjs
+++ b/tests/test-effective-tier.mjs
@@ -70,7 +70,8 @@ eq('post_checkpoint contract key is gates.post_checkpoint', GATE_CONTRACT_KEY.po
 eq('plan_approval fires at pre_tool_use', GATE_EVENT_MAP.plan_approval, 'pre_tool_use')
 eq('pre_checkpoint fires at pre_tool_use', GATE_EVENT_MAP.pre_checkpoint, 'pre_tool_use')
 eq('the two maps cover the same four gates', Object.keys(GATE_EVENT_MAP).sort(), Object.keys(GATE_CONTRACT_KEY).sort())
-eq('only the stop gate is LIVE-wired this slice', LIVE_GATES, ['stop'])
+eq('all four contract gates are LIVE-wired (P4a)', LIVE_GATES.slice().sort(), ['plan_approval', 'post_checkpoint', 'pre_checkpoint', 'stop'])
+eq('every LIVE gate has an event + contract-key mapping', LIVE_GATES.every((g) => GATE_EVENT_MAP[g] && GATE_CONTRACT_KEY[g]), true)
 
 console.log('')
 console.log('=== eventActionId (events.json action lookup) ===')

--- a/tests/test-resolve-gate-bridge.sh
+++ b/tests/test-resolve-gate-bridge.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test-resolve-gate-bridge.sh — RFC-008 P4a.
+#
+# Drives the REAL plan-gate.sh against a STUB enforce-contract resolver to prove the
+# bash bridge's fail-closed matching contract (F5), independent of the resolver's
+# own logic (covered by test-resolve-gate.mjs) and of the classifier (plan-gate
+# invokes the classifier only for Bash; this test uses the Write tool, which reaches
+# the consult with no classifier dependency).
+#
+# F5 obligations under test:
+#   - a safe token is matched by EXACT STRING EQUALITY (a substring that merely
+#     CONTAINS "silence"/"clamp-off" must still BLOCK);
+#   - the `RESULT="$(node …)" || RESULT=""` envelope fails CLOSED on a non-zero
+#     exit even when the stub prints a safe token on stdout (the `local`-mask trap);
+#   - `silence` and `clamp-off` both ALLOW; anything else BLOCKS.
+#
+# The stub at $HOME/.episodic-memory/scripts/enforce-contract.mjs honors STUB_TOKEN
+# (stdout) + STUB_EXIT (exit code), inherited from this script's env through the
+# hook's `node` spawn.
+
+set -u
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLAN_GATE="$REPO/plugins/claude-code/hooks/plan-gate.sh"
+SID="11111111-2222-3333-4444-555555555555"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); echo "  ✓ $1"; }
+bad() { fail=$((fail+1)); echo "  ✗ $1: $2"; }
+
+# Isolated HOME carrying the stub resolver at the canonical global path.
+HOME_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rgbridge-home-XXXXXX")"
+mkdir -p "$HOME_DIR/.episodic-memory/scripts"
+cat > "$HOME_DIR/.episodic-memory/scripts/enforce-contract.mjs" <<'STUB'
+const t = process.env.STUB_TOKEN || ''
+if (t.length) process.stdout.write(t + '\n')
+process.exit(Number(process.env.STUB_EXIT || '0'))
+STUB
+
+# Marker-root: a git repo with an armed OWN-session plan-approval marker so
+# plan-gate reaches the consult + (absent a safe token) the block path.
+REPO_MR="$(mktemp -d "${TMPDIR:-/tmp}/rgbridge-mr-XXXXXX")"
+git -C "$REPO_MR" init -q
+mkdir -p "$REPO_MR/.checkpoints"
+: > "$REPO_MR/.checkpoints/.plan-approval-pending.$SID"
+
+INPUT='{"tool_name":"Write","cwd":"'"$REPO_MR"'","session_id":"'"$SID"'","tool_input":{"file_path":"'"$REPO_MR"'/src.txt"}}'
+
+# run_plan_gate <stub_token> <stub_exit> → echoes hook stdout; sets RC.
+run_plan_gate() {
+  STUB_TOKEN="$1" STUB_EXIT="$2" HOME="$HOME_DIR" \
+    bash "$PLAN_GATE" <<<"$INPUT"
+}
+
+echo "=== plan-gate.sh bridge — F5 fail-closed matching ==="
+
+# 1. Exact "silence" → allow (empty stdout, no block decision).
+out="$(run_plan_gate silence 0)"
+if [ -z "$out" ]; then ok "silence → allow (no block)"; else bad "silence → allow" "got [$out]"; fi
+
+# 2. Exact "clamp-off" → allow.
+out="$(run_plan_gate clamp-off 0)"
+if [ -z "$out" ]; then ok "clamp-off → allow (no block)"; else bad "clamp-off → allow" "got [$out]"; fi
+
+# 3. No token (enforce) → BLOCK.
+out="$(run_plan_gate '' 0)"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "empty token → block (enforce)"; else bad "empty → block" "got [$out]"; fi
+
+# 4. SUBSTRING containing "silence" → BLOCK (exact-equality, not substring).
+out="$(run_plan_gate 'please-silence-this-gate' 0)"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "substring 'silence' → block (exact-equality)"; else bad "substring → block" "got [$out]"; fi
+
+# 5. Multi-line stdout whose FIRST line is a safe token → BLOCK (command
+#    substitution yields a multi-line value != "silence").
+out="$(run_plan_gate 'silence
+extra-diagnostic-line' 0)"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "multi-line 'silence\\n…' → block"; else bad "multi-line → block" "got [$out]"; fi
+
+# 6. ||-envelope: stub prints "silence" but EXITS NON-ZERO → cleared → BLOCK.
+#    (The `local`-mask trap: a `local X=$(…)` would swallow this exit and wrongly allow.)
+out="$(run_plan_gate silence 1)"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "silence + non-zero exit → block (||-envelope fail-closed)"; else bad "non-zero exit → block" "got [$out]"; fi
+
+# 7. Missing resolver binary (stub absent) → node errors non-zero → BLOCK.
+out="$(STUB_TOKEN=silence STUB_EXIT=0 HOME="$(mktemp -d)" bash "$PLAN_GATE" <<<"$INPUT")"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "missing enforce-contract.mjs → block (fail-closed)"; else bad "missing binary → block" "got [$out]"; fi
+
+# 8. No plan marker at all → allow WITHOUT spawning the resolver (no marker → no gate).
+REPO_NM="$(mktemp -d "${TMPDIR:-/tmp}/rgbridge-nm-XXXXXX")"
+git -C "$REPO_NM" init -q
+INPUT_NM='{"tool_name":"Write","cwd":"'"$REPO_NM"'","session_id":"'"$SID"'","tool_input":{"file_path":"'"$REPO_NM"'/src.txt"}}'
+out="$(STUB_TOKEN='' STUB_EXIT=0 HOME="$HOME_DIR" bash "$PLAN_GATE" <<<"$INPUT_NM")"
+if [ -z "$out" ]; then ok "no plan marker → allow (consult not reached)"; else bad "no marker → allow" "got [$out]"; fi
+
+echo ""
+echo "=== checkpoint-gate.sh bridge — F10 (post_checkpoint silence runs cleanup) + pre_checkpoint ==="
+CKPT_GATE="$REPO/plugins/claude-code/hooks/checkpoint-gate.sh"
+
+# F10 deadlock guard: under a post_checkpoint clamp (POST_SILENCED), a `git push`
+# must (a) NOT block and (b) sweep .checkpoint-required so the subsequent stop gate
+# cannot deadlock — NOT a bare exit 0 that strands the marker.
+mk_armed_repo() {
+  local r; r="$(mktemp -d "${TMPDIR:-/tmp}/rgbridge-ck-XXXXXX")"
+  git -C "$r" init -q
+  mkdir -p "$r/.checkpoints"
+  : > "$r/.checkpoints/.checkpoint-required.$SID"   # armed, no post-done
+  printf '%s' "$r"
+}
+push_input() { printf '{"tool_name":"Bash","cwd":"%s","session_id":"%s","tool_input":{"command":"git push"}}' "$1" "$SID"; }
+
+# Case 9 — post_checkpoint clamp-off → push allowed AND .checkpoint-required swept.
+R9="$(mk_armed_repo)"
+out="$(STUB_TOKEN=clamp-off STUB_EXIT=0 HOME="$HOME_DIR" bash "$CKPT_GATE" <<<"$(push_input "$R9")")"
+if [ -z "$out" ] && [ ! -e "$R9/.checkpoints/.checkpoint-required.$SID" ]; then
+  ok "F10: post_checkpoint clamp → push allowed + .checkpoint-required swept (no deadlock)"
+else
+  bad "F10: silence runs cleanup" "stdout=[$out] marker_present=[$([ -e "$R9/.checkpoints/.checkpoint-required.$SID" ] && echo yes || echo no)]"
+fi
+
+# Case 10 — NON-vacuous control: no clamp → push BLOCKS + .checkpoint-required RETAINED.
+R10="$(mk_armed_repo)"
+out="$(STUB_TOKEN='' STUB_EXIT=0 HOME="$HOME_DIR" bash "$CKPT_GATE" <<<"$(push_input "$R10")")"
+if echo "$out" | grep -qE '"decision": ?"block"' && [ -e "$R10/.checkpoints/.checkpoint-required.$SID" ]; then
+  ok "F10 control: no clamp → push blocks + .checkpoint-required retained (clamp genuinely flips behavior)"
+else
+  bad "F10 control: no clamp blocks + retains" "stdout=[$out] marker_present=[$([ -e "$R10/.checkpoints/.checkpoint-required.$SID" ] && echo yes || echo no)]"
+fi
+
+# Case 11 — pre_checkpoint silence → repo-source Write allowed (consult exits 0).
+R11="$(mk_armed_repo)"
+write_input() { printf '{"tool_name":"Write","cwd":"%s","session_id":"%s","tool_input":{"file_path":"%s/src.txt"}}' "$1" "$SID" "$1"; }
+out="$(STUB_TOKEN=silence STUB_EXIT=0 HOME="$HOME_DIR" bash "$CKPT_GATE" <<<"$(write_input "$R11")")"
+if [ -z "$out" ]; then ok "pre_checkpoint silence → repo Write allowed"; else bad "pre_checkpoint silence → allow" "got [$out]"; fi
+
+# Case 12 — pre_checkpoint control: no token → repo-source Write BLOCKS (_block_pre*).
+R12="$(mk_armed_repo)"
+out="$(STUB_TOKEN='' STUB_EXIT=0 HOME="$HOME_DIR" bash "$CKPT_GATE" <<<"$(write_input "$R12")")"
+if echo "$out" | grep -qE '"decision": ?"block"'; then ok "pre_checkpoint control: no token → repo Write blocks"; else bad "pre_checkpoint control → block" "got [$out]"; fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "PASS — $pass checks"
+  exit 0
+else
+  echo "FAIL — $fail of $((pass+fail)) checks"
+  exit 1
+fi

--- a/tests/test-resolve-gate.mjs
+++ b/tests/test-resolve-gate.mjs
@@ -1,0 +1,211 @@
+// test-resolve-gate.mjs — RFC-008 P4a.
+//
+// Covers the per-project enforce-config consult for the three pre_tool_use gates:
+//   (A) gateDisposition() — the PURE per-gate resolution algebra (M8-before-active
+//       F7, event-threaded F8, closed token vocab F5). No I/O.
+//   (B) `enforce-contract --resolve-gate <gate> --marker-root <abs>` CLI — the
+//       closed-token contract: stdout is `silence` | `clamp-off` ALONE, or empty
+//       (→ the bash gate keeps blocking). HOME-isolated planted contract + a
+//       marker-root carrying enforce-config.json, mirroring test-enforce-contract D.
+//
+// Fail-closed is the load-bearing invariant: every failure branch (bad gate name,
+// missing/relative --marker-root, M8 duplicate, type-confused active, garbage
+// config, unknown tier, no config) emits NO token so the gate enforces (B1).
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { gateDisposition } from '../scripts/enforce-contract.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const ENFORCE = path.join(REPO, 'scripts', 'enforce-contract.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  if (actual === expected) ok(name)
+  else bad(name, `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
+
+// events.json pre_tool_use action grid: STRONG=block, MEDIUM=warn, WEAK=inject.
+const EVENTS = {
+  events: [
+    { id: 'pre_tool_use', actions: { STRONG: { id: 'block' }, MEDIUM: { id: 'warn' }, WEAK: { id: 'inject' } } },
+  ],
+}
+
+console.log('=== A: gateDisposition() pure algebra ===')
+// Baseline: STRONG harness ∩ STRONG contract, no clamp → enforce (gate blocks).
+eq('A1: STRONG cap + STRONG contract + no config → enforce',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: null, events: EVENTS, event: 'pre_tool_use' }).token, 'enforce')
+// active:false → silence.
+eq('A2: active:false → silence',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: false, configTier: null, events: EVENTS, event: 'pre_tool_use' }).token, 'silence')
+// WEAK config clamp → action inject → clamp-off.
+eq('A3: config WEAK → clamp-off',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: 'WEAK', events: EVENTS, event: 'pre_tool_use' }).token, 'clamp-off')
+// MEDIUM config clamp → action warn → clamp-off.
+eq('A4: config MEDIUM → clamp-off',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: 'MEDIUM', events: EVENTS, event: 'pre_tool_use' }).token, 'clamp-off')
+// F7 — M8 duplicate forces block BEFORE active:false (corrupt install not silenceable).
+eq('A5 (F7): duplicate + active:false → block (M8 precedes silence)',
+  gateDisposition({ duplicate: true, harnessCap: 'STRONG', contractTier: 'STRONG', active: false, configTier: 'WEAK', events: EVENTS, event: 'pre_tool_use' }).token, 'block')
+// Unknown tier never lowers (clampTier fail-closed) → STRONG → enforce.
+eq('A6: unknown tier config "LOOSE" → enforce (no lower)',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: 'LOOSE', events: EVENTS, event: 'pre_tool_use' }).token, 'enforce')
+// clamp-UP ignored: config STRONG when base STRONG → enforce.
+eq('A7: config STRONG (no-op, never raises) → enforce',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: 'STRONG', events: EVENTS, event: 'pre_tool_use' }).token, 'enforce')
+// events.json unresolved (null) → action '—' → fail-closed enforce even with a WEAK clamp.
+eq('A8: events null + WEAK clamp → enforce (fail-closed; clamp inert without events)',
+  gateDisposition({ duplicate: false, harnessCap: 'STRONG', contractTier: 'STRONG', active: true, configTier: 'WEAK', events: null, event: 'pre_tool_use' }).token, 'enforce')
+// B1: all sources null (resolution miss) + no config → base STRONG → enforce.
+eq('A9: all sources null + no config → enforce (B1 base-STRONG)',
+  gateDisposition({ duplicate: false, harnessCap: null, contractTier: null, active: true, configTier: null, events: EVENTS, event: 'pre_tool_use' }).token, 'enforce')
+// B1: contract STRONG + missing harness cap (null) + WEAK clamp → effTier WEAK → clamp-off
+// (a legit operator downgrade still works even when the registry cap is absent).
+eq('A10: null harnessCap + STRONG contract + WEAK clamp → clamp-off',
+  gateDisposition({ duplicate: false, harnessCap: null, contractTier: 'STRONG', active: true, configTier: 'WEAK', events: EVENTS, event: 'pre_tool_use' }).token, 'clamp-off')
+
+// ---------------------------------------------------------------------------
+// B: CLI closed-token contract. HOME-isolated planted global contract; marker-root
+// carries the enforce-config.json. stdout MUST be exactly the token or empty.
+// ---------------------------------------------------------------------------
+const REPO_BP001 = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'bp-001.json'), 'utf8'))
+const REPO_EVENTS = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'events.json'), 'utf8'))
+const REPO_CONFIG_SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'enforce-config.schema.json'), 'utf8'))
+const REPO_REGISTRY = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins', '_index.json'), 'utf8'))
+
+function plantGlobalContract(home, { registry, bp001, events, configSchema } = {}) {
+  const pat = path.join(home, '.episodic-memory', 'patterns')
+  const plug = path.join(home, '.episodic-memory', 'plugins')
+  fs.mkdirSync(pat, { recursive: true })
+  fs.mkdirSync(plug, { recursive: true })
+  if (bp001 !== null) fs.writeFileSync(path.join(pat, 'bp-001.json'), JSON.stringify(bp001 || REPO_BP001))
+  if (events !== null) fs.writeFileSync(path.join(pat, 'events.json'), JSON.stringify(events || REPO_EVENTS))
+  if (configSchema !== null) fs.writeFileSync(path.join(pat, 'enforce-config.schema.json'), JSON.stringify(configSchema || REPO_CONFIG_SCHEMA))
+  if (registry !== null) fs.writeFileSync(path.join(plug, '_index.json'), JSON.stringify(registry || REPO_REGISTRY))
+}
+function mkHome(label) { return fs.mkdtempSync(path.join(os.tmpdir(), `resolve-home-${label}-`)) }
+function mkMarkerRoot(label, config) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `resolve-mr-${label}-`))
+  if (config !== undefined) {
+    fs.mkdirSync(path.join(root, '.episodic-memory'), { recursive: true })
+    fs.writeFileSync(path.join(root, '.episodic-memory', 'enforce-config.json'),
+      typeof config === 'string' ? config : JSON.stringify(config))
+  }
+  return root
+}
+function resolve(gate, markerRoot, home, extraArgs = []) {
+  const args = [ENFORCE, '--resolve-gate', gate, ...(markerRoot !== null ? ['--marker-root', markerRoot] : []), ...extraArgs]
+  const r = spawnSync('node', args, { encoding: 'utf8', env: { ...process.env, HOME: home } })
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status }
+}
+
+console.log('')
+console.log('=== B: --resolve-gate CLI closed-token contract ===')
+// B1 — active:false → exactly "silence".
+{
+  const home = mkHome('b1'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b1', { active: false })
+  const r = resolve('pre_checkpoint', mr, home)
+  eq('B1: active:false → stdout "silence" (alone)', r.stdout.trim(), 'silence')
+  eq('B1: exit 0', r.status, 0)
+}
+// B2 — per-gate WEAK clamp → exactly "clamp-off".
+{
+  const home = mkHome('b2'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b2', { 'bp-001': { post_checkpoint: 'WEAK' } })
+  const r = resolve('post_checkpoint', mr, home)
+  eq('B2: post_checkpoint WEAK → stdout "clamp-off"', r.stdout.trim(), 'clamp-off')
+}
+// B3 — SPLICE (F8): the same WEAK post_checkpoint clamp leaves plan_approval enforcing.
+{
+  const home = mkHome('b3'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b3', { 'bp-001': { post_checkpoint: 'WEAK' } })
+  const r = resolve('plan_approval', mr, home)
+  eq('B3 (splice): plan_approval under post_checkpoint clamp → empty (enforce)', r.stdout.trim(), '')
+}
+// B4 — no config → empty (enforce).
+{
+  const home = mkHome('b4'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b4') // no config file
+  const r = resolve('plan_approval', mr, home)
+  eq('B4: no enforce-config.json → empty (enforce)', r.stdout.trim(), '')
+}
+// B5 — invalid gate name → empty + exit 0 (fail-closed).
+{
+  const home = mkHome('b5'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b5', { active: false })
+  const r = resolve('bogus_gate', mr, home)
+  eq('B5: invalid gate name → empty stdout', r.stdout.trim(), '')
+  eq('B5: invalid gate name → exit 0', r.status, 0)
+}
+// B6 — missing --marker-root → empty (fail-closed).
+{
+  const home = mkHome('b6'); plantGlobalContract(home, {})
+  const r = resolve('plan_approval', null, home)
+  eq('B6: missing --marker-root → empty stdout', r.stdout.trim(), '')
+}
+// B7 — relative --marker-root → empty (fail-closed; must be absolute).
+{
+  const home = mkHome('b7'); plantGlobalContract(home, {})
+  const r = resolve('plan_approval', 'relative/path', home)
+  eq('B7: relative --marker-root → empty stdout', r.stdout.trim(), '')
+}
+// B8 (F7) — M8 duplicate registry + active:false config → empty (block, NOT silenceable).
+{
+  const home = mkHome('b8')
+  const dup = REPO_REGISTRY.plugins[0]
+  plantGlobalContract(home, { registry: { schema_version: '1.0.0', plugins: [dup, { ...dup }] } })
+  const mr = mkMarkerRoot('b8', { active: false })
+  const r = resolve('pre_checkpoint', mr, home)
+  eq('B8 (F7): M8 duplicate + active:false → empty (corrupt install not silenceable)', r.stdout.trim(), '')
+}
+// B9 — type-confused active values are schema-invalid → identity active:true → empty.
+for (const [label, raw] of [['string "false"', '{"active":"false"}'], ['number 0', '{"active":0}'], ['null', '{"active":null}']]) {
+  const home = mkHome('b9'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b9', raw)
+  const r = resolve('pre_checkpoint', mr, home)
+  eq(`B9: active ${label} → schema-invalid → empty (enforce, NOT silence)`, r.stdout.trim(), '')
+}
+// B10 — garbage config file → empty (enforce).
+{
+  const home = mkHome('b10'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b10', '{not json')
+  const r = resolve('plan_approval', mr, home)
+  eq('B10: garbage enforce-config.json → empty (enforce)', r.stdout.trim(), '')
+}
+// B11 — unknown tier string in config → never lowers → empty (enforce).
+{
+  const home = mkHome('b11'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b11', { 'bp-001': { plan_approval: 'LOOSE' } })
+  const r = resolve('plan_approval', mr, home)
+  // 'LOOSE' fails the schema tier enum → whole config schema-invalid → identity → enforce.
+  eq('B11: unknown tier "LOOSE" → schema-invalid → empty (enforce)', r.stdout.trim(), '')
+}
+// B12 — the token is emitted ALONE (no diagnostic on stdout). Guards the bash
+// exact-equality match: a multi-line / decorated stdout would break it.
+{
+  const home = mkHome('b12'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b12', { active: false })
+  const r = resolve('pre_checkpoint', mr, home)
+  eq('B12: stdout is exactly "silence\\n" (token alone, diagnostics on stderr)', r.stdout, 'silence\n')
+  if (r.stderr.length > 0) ok('B12: notice present on stderr (not stdout)')
+  else bad('B12: notice present on stderr', 'expected a stderr notice')
+}
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## RFC-008 P4a — per-project `enforce-config.json` wired into the 3 pre_tool_use gates

Extends per-project `enforce-config.json` (stop-gate-only since P3b-2 #393) to the three
`pre_tool_use` classification gates — `plan_approval`, `pre_checkpoint`, `post_checkpoint`.
Serves **R3** (`effective_tier = min(harness, contract, project_config)`, clamp DOWN only),
**R5** (`active:false` → silence), **R6** (M8 one-harness-one-plugin parity).

### Design — consult-before-block
- `enforce-contract.mjs`: new `--resolve-gate <gate> --marker-root <abs>` mode + pure
  `gateDisposition()`. Emits a CLOSED token vocab to stdout — `silence` | `clamp-off` — and
  nothing else; the bash gate BLOCKS by default and skips its block ONLY on an exact-equality
  safe token. `--marker-root` is passed explicitly by the hook (no re-resolve → the P3b-1
  `/var` isMain fail-open class cannot recur).
- `effective-tier.mjs`: `LIVE_GATES` → all four gates.
- `plan-gate.sh` / `checkpoint-gate.sh`: a single early consult per gate (spawns only when a
  block is imminent). `LABEL → gate` selection (push → `post_checkpoint`, else `pre_checkpoint`);
  `post_checkpoint` silence routes through the existing marker-cleanup sweep so
  `.checkpoint-required` is never stranded → **no stop-gate deadlock**; integrity +
  marker_write blocks stay **non-silenceable**.
- `validate-plugin-registry.mjs` + `runbooks/enforcement.md`: `enforce_config_keys` derived
  from `GATE_CONTRACT_KEY` (Rule-14 single source, M7f byte-match).

### Fail-closed (B1)
`node` absent / non-zero exit / empty / garbage / substring-not-equal → the gate keeps
blocking. M8 duplicate-plugin and integrity blocks are non-silenceable even under `active:false`.

### Reviews
- **Plan:** 2-round second-opinion (claude-subagent) — HOLD→HOLD→converged (F1–F12).
- **Code:** `negative-scenario-reviewer` → **ACCEPT-with-FU**, 0 blockers / 0 major. Every
  fail-open axis verified fail-**closed** with real shell traces. All 3 findings resolved in-PR:
  MINOR-1 (checkpoint-gate bridge test) **added** rather than deferred; MINOR-2 + NIT inline.

### Tests (all green; new CI steps in `plan-marker-validate.yml`)
- `test-resolve-gate.mjs` — 27 (pure `gateDisposition` + CLI closed-token contract;
  caught + fixed a null-events fail-open during authoring).
- `test-resolve-gate-bridge.sh` — 12 (real `plan-gate.sh` F5 matching + `checkpoint-gate.sh`
  F10 deadlock guard **with a non-vacuous control** + pre_checkpoint consult).
- Regression: checkpoint-gate 373, stop-gate 25, enforce-contract 25, enforce-config 27,
  effective-tier 32, plugin-registry 200.

### Scoped to P4b (not in this slice)
- **F1** — SessionStart `active:false` silence (the remaining R5 "no token cost" surface).
- Full live-hook SessionStart→Stop E2E with a real `enforce-config.json`.
- Cutover + RFC index sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
