### PR TITLE
RFC-008 P4c: layer-wide active:false enforcement kill switch

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Run --resolve-gate bash bridge contract (RFC-008 P4a, F5 — exact-token match, ||-envelope fail-closed, plan-gate honors silence/clamp)
         run: bash tests/test-resolve-gate-bridge.sh
 
+      - name: Run --layer-active per-project kill switch (RFC-008 P4c, R5 — layerDisposition + closed-token CLI + F1 session-start fold)
+        run: node tests/test-layer-active.mjs
+
+      - name: Run --layer-active bash+node bridge (RFC-008 P4c, R5 — preflight + second-opinion honor inactive; F1 ENOENT fail-closed; G4 marker-write survives)
+        run: bash tests/test-layer-active-bridge.sh
+
       - name: Run enforce-contract --session-start side-effects relocation (RFC-008 P3d)
         run: node tests/test-enforce-contract-session-start.mjs
 

--- a/plugins/claude-code/hooks/preflight-gate.sh
+++ b/plugins/claude-code/hooks/preflight-gate.sh
@@ -296,6 +296,32 @@ if [ "$CLAIM_CLASS" != "codex-review-handoff" ]; then
   exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# RFC-008 P4c (R5): layer-wide enforcement kill switch.
+# Placed AFTER the claim-class early-exit (F-PERF-1) so it spawns the consult ONLY
+# for an actual codex-review-handoff — the one enforcement this gate applies and
+# the only thing the switch silences — never for the ~all non-handoff Write/Edit/
+# Bash/Agent calls. It also sits AFTER the non-overridable marker-write (:136-195)
+# + helper-invocation (:216-283) guards, which protect substrate trust (R4:
+# marker_write NON-overridable) and MUST survive active:false (planner G4).
+#
+# FAIL-CLOSED capture (reviewer F1): the script runs under `set -e` (line 2), so a
+# naive `OUT="$(node …)"` that ENOENTs (degraded install) would ABORT the gate →
+# exit 1 → PreToolUse non-blocking → tool proceeds UN-gated (the exact inverse of
+# the kill switch). Capture inside an explicit `set +e` block (mirror the
+# canonicalize pattern at :142-151) and skip enforcement ONLY on the exact string
+# `inactive`. Every other outcome — non-zero exit, ENOENT, empty, stderr-only, any
+# non-`inactive` string — falls through to enforcement (2>/dev/null discards the
+# node stderr so it can never leak into the captured token).
+# ---------------------------------------------------------------------------
+LAYER_ACTIVE_CONSULT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+set +e
+LAYER_DISP="$(node "$LAYER_ACTIVE_CONSULT" --layer-active --marker-root "$REPO_ROOT" 2>/dev/null)"
+set -e
+if [ "$LAYER_DISP" = "inactive" ]; then
+  exit 0
+fi
+
 # #279 fix: prefer per-session marker `.preflight-done.<SESSION_ID>`, fall
 # back to legacy `.preflight-done` during burn-in. Resolution is purely a
 # local file existence check; the cross-session-stomp bug occurs only on

--- a/plugins/claude-code/hooks/second-opinion-gate.mjs
+++ b/plugins/claude-code/hooks/second-opinion-gate.mjs
@@ -49,6 +49,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
 
 // resolveRepoRoot is dynamically imported inside checkRunbookGate so a
 // missing local-dir.mjs (orphan/partial install) cannot preempt the gate
@@ -75,7 +76,34 @@ const MIN_QUICKREF_BYTES = 64
 // Pure helpers — no side effects at module load.
 // ---------------------------------------------------------------------------
 
+// RFC-008 P4c (R5): the layer-wide enforcement kill switch is consulted LAZILY —
+// only when a block is IMMINENT (inside emitBlock), never on the allow path. The
+// marker-root is resolved ONCE in main() (the only async step) and stored here; the
+// consult spawn itself is sync. Consulting at the single block-emission chokepoint
+// gives three properties at once: (a) NO per-call node-spawn on the ~all allow paths
+// (F-PERF-2 / P6); (b) the `inactive` audit line is written only when a REAL block is
+// silenced (F-IO-1) — exactly when the operator wants the trail; (c) ALL block paths
+// (runbook, snapshot, timeout-floor, bash, agent) honor the switch uniformly.
+let _layerConsultMarkerRoot = null
+
+function layerInactiveConsult() {
+  // FAIL-CLOSED (reviewer G1): return true (→ silence) ONLY on an exact `inactive`
+  // from the SAME global enforce-contract --layer-active the bash gates use. An
+  // unresolved marker-root, spawn ENOENT (status===null), non-zero exit, stderr-only
+  // output, timeout, or any non-`inactive` stdout → false → keep enforcing. F-OBS-1:
+  // a bounded timeout so a hung consult can't stall the gated tool call (a timed-out
+  // spawn yields status===null / no stdout → already fail-closed).
+  if (!_layerConsultMarkerRoot) return false
+  const consult = path.join(os.homedir(), '.episodic-memory', 'scripts', 'enforce-contract.mjs')
+  const res = spawnSync(process.execPath, [consult, '--layer-active', '--marker-root', _layerConsultMarkerRoot], { encoding: 'utf8', timeout: 5000 })
+  return typeof res.stdout === 'string' && res.stdout.trim() === 'inactive'
+}
+
 function emitBlock(reason, extra = {}) {
+  // RFC-008 P4c: a project with enforce-config.json {"active":false} silences the
+  // WHOLE second-opinion gate — honored at this single block chokepoint. Inactive →
+  // allow instead of block; any non-`inactive` consult result still blocks (fail-closed).
+  if (layerInactiveConsult()) emitAllow()
   console.log(JSON.stringify({ decision: 'block', reason, ...extra }))
   process.exit(0)
 }
@@ -338,6 +366,18 @@ async function main() {
   const toolName = input.tool_name || ''
   const toolInput = input.tool_input || {}
   const cwd = input.cwd || process.cwd()
+
+  // ─── RFC-008 P4c (R5): resolve the kill-switch marker-root ONCE (async). ─
+  // The actual consult is LAZY — it fires inside emitBlock, only when a block is
+  // imminent (F-PERF-2). Here we only do the one async step: resolve the repo root
+  // from cwd via the SAME resolveRepoRoot the runbook gate uses, then realpath it
+  // (G2 — parity with bash `cd -P`; NO cross-resolution path-equality, so the P3b-1
+  // isMain fail-open class cannot recur). Unresolvable → stays null → emitBlock's
+  // consult fails CLOSED (keeps enforcing).
+  try {
+    const mod = await import(new URL('./lib/local-dir.mjs', import.meta.url).href)
+    _layerConsultMarkerRoot = fs.realpathSync(mod.resolveRepoRoot(cwd))
+  } catch { /* unresolved repo root → null → fail-closed at the emitBlock consult */ }
 
   // ─── Timeout-floor + runbook gate fire BEFORE validator/snapshot work. ─
   // Codex r2 P1: validator import failure / snapshot errors MUST NOT

--- a/plugins/claude-code/runbooks/enforcement.md
+++ b/plugins/claude-code/runbooks/enforcement.md
@@ -150,9 +150,27 @@ cross-checks `invocation_modality` against §8 and the manifest.
 
 ## §10 — Config / taxonomy cross-binding
 
-Auto-derived from `manifest.json` (the per-project `enforce-config.json` schema
-lands in P4 — until then M7f 10a is present-and-parses only). M7f byte-diffs the
+Auto-derived from `manifest.json` + the per-project `enforce-config.json` schema
+(`patterns/enforce-config.schema.json`, landed P3b-2 #393; the 4 bp-001 gates wired
+P4a / P3b-2; the layer-wide `active:false` consult added P4c). M7f byte-diffs the
 block below against the derived source-of-truth.
+
+**Layer-wide kill switch (R5, P4c).** Beyond the 4 bp-001 gates, EVERY ec enforcement
+hook honors the project-level `active:false` switch via one gate-agnostic consult:
+
+```
+node "$HOME/.episodic-memory/scripts/enforce-contract.mjs" --layer-active --marker-root <ABS_REPO_ROOT>
+```
+
+It prints exactly `inactive` to stdout when enforcement is OFF for the project, and
+NOTHING on every other outcome — active, an M8-duplicate registry (R6, non-silenceable),
+a missing/relative `--marker-root`, or any error — so the caller keeps enforcing
+(fail-closed). Consumers skip their enforcement ONLY on an exact-string `inactive`;
+any other result (incl. a non-zero exit / ENOENT from a degraded install) falls through
+to enforcement. The `marker_write` + helper-invocation substrate-trust guards (R4,
+NON-overridable) are NOT silenced by the switch. External hooks NOT shipped by ec
+(e.g. a user-global `compound-bash-gate.sh`) MAY opt in with a ~3-line read of this
+same consult.
 
 <!-- CONFIG:BEGIN -->
 **10a — Configuration.**

--- a/scripts/enforce-contract.mjs
+++ b/scripts/enforce-contract.mjs
@@ -362,6 +362,34 @@ export function gateDisposition({ duplicate, harnessCap, contractTier, active, c
   return { token: 'enforce', hcTier, effTier }
 }
 
+/**
+ * layerDisposition — pure LAYER-WIDE activation resolution (no I/O, no exit).
+ * The gate-AGNOSTIC sibling of gateDisposition (RFC-008 P4c, R5): serves the
+ * operator's project-wide enforcement kill switch (enforce-config.json
+ * {"active":false}) at the LAYER level, for every ec enforcement hook that is NOT
+ * one of the 4 bp-001 gates (preflight-gate.sh, second-opinion-gate.mjs, the
+ * SessionStart token-cost path, and any external opt-in hook).
+ *
+ * Precedence is byte-identical to gateDisposition (M8 duplicate REAL-blocks BEFORE
+ * the active:false silence): a corrupt/duplicate registry (R6/M8) is NEVER
+ * silenceable by an operator opt-out.
+ *
+ *   'block'    — M8: >1 active enforcement plugin binds this harness. Corrupt
+ *                install; non-silenceable (caller keeps enforcing).
+ *   'inactive' — operator set active:false (R5). The whole layer is OFF for this
+ *                project; the caller skips its enforcement.
+ *   'active'   — enforcement ON. The fail-closed default: every miss/garbage config
+ *                resolves here via loadEnforceConfig's identity {active:true}.
+ *
+ * @param {{duplicate:boolean, active:boolean}} o
+ * @returns {{token:'block'|'inactive'|'active'}}
+ */
+export function layerDisposition({ duplicate, active }) {
+  if (duplicate) return { token: 'block' }
+  if (active === false) return { token: 'inactive' }
+  return { token: 'active' }
+}
+
 // ---------------------------------------------------------------------------
 // CLI — the ONLY I/O + process.exit boundary. Invoked by hooks/stop-gate.sh as
 // `node enforce-contract.mjs --gate stop [--session-id <sid>]`. Empty stdout =
@@ -522,7 +550,32 @@ if (isMain) {
       console.log(JSON.stringify({ status: 'error', message: '--session-start cannot be combined with --gate' }))
       process.exit(1)
     }
-    runSessionStartSideEffects(resolveRepoRoot())
+    // M5/F2: resolve the marker root ONCE and thread it to BOTH the active-check
+    // and the side-effects — no second resolveRepoRoot() to diverge mid-invocation.
+    const ssRoot = resolveRepoRoot()
+    // RFC-008 P4c F1-fold (R5/P6): honor the layer-wide kill switch on the
+    // SessionStart token-cost path too — active:false skips the baseline write +
+    // sweeps + bp-001 advisory (the dominant SessionStart cost). A schema-
+    // resolution MISS yields loadEnforceConfig's identity {active:true} ⇒ RUN the
+    // side-effects (fail-closed to DOING the work; a resolution failure never skips
+    // baseline/sweeps).
+    const ssContractRoot = resolveContractRoot()
+    const ssSchema = ssContractRoot ? readJsonSafe(path.join(ssContractRoot, 'patterns', 'enforce-config.schema.json')) : null
+    const ssCfg = loadEnforceConfig(ssRoot, ssSchema)
+    // Deliberate asymmetry vs --layer-active (review observation): this checks raw
+    // cfg.active WITHOUT the M8-duplicate precedence. Safe + fail-closed — skipping
+    // the SessionStart baseline only REMOVES an allow-arming carve-out; the stop gate
+    // blocks independently on M8 (non-silenceable), so a skipped baseline under
+    // active:false+duplicate can only make enforcement stricter, never weaker.
+    if (!ssCfg.active) {
+      appendEnforceAudit(ssRoot, `${BP_ID} session-start side-effects skipped (active:false) — no baseline/sweeps/advisory (R5 layer silence)`)
+      process.stderr.write(
+        'enforce-contract: notice — enforcement disabled for this project via ' +
+        '.episodic-memory/enforce-config.json {"active":false}; session-start side-effects skipped (R5 layer silence).\n',
+      )
+      process.exit(0)
+    }
+    runSessionStartSideEffects(ssRoot)
     process.exit(0)
   }
 
@@ -576,6 +629,44 @@ if (isMain) {
       process.stderr.write(`enforce-contract: >1 active enforcement plugin binds harness "${THIS_HARNESS}" (M8/R6); ${resolveGate} gate NOT silenceable by active:false — fix plugins/_index.json. No token emitted → gate enforces.\n`)
     }
     // token 'enforce' (or 'block'): no stdout → bash keeps blocking (fail-closed).
+    process.exit(0)
+  }
+
+  // RFC-008 P4c (R5): --layer-active --marker-root <abs> resolves the LAYER-WIDE
+  // enforcement kill switch (enforce-config.json {"active":false}) for ONE project
+  // and prints a CLOSED safe token to stdout (`inactive`) — nothing else. Every ec
+  // enforcement hook that is NOT one of the 4 bp-001 gates (preflight-gate.sh,
+  // second-opinion-gate.mjs, and external opt-in hooks) calls this EARLY and skips
+  // its enforcement ONLY on an exact-equality `inactive`. Therefore every failure
+  // path here — missing/relative --marker-root, unresolved registry, M8 duplicate
+  // (NON-silenceable, R6), base-active — prints NO token and the caller keeps
+  // enforcing (fail-closed, B1). Precedence mirrors gateDisposition: M8 duplicate ⊐
+  // active:false. --marker-root is passed EXPLICITLY by the caller (the repo root it
+  // already resolved + realpath'd); this mode NEVER calls resolveRepoRoot (F4 — no
+  // second resolution to diverge → the P3b-1 /var isMain fail-open class cannot
+  // recur). All diagnostics go to stderr; stdout is the token alone.
+  if (argv.includes('--layer-active')) {
+    const mr = flag('--marker-root')
+    if (mr === undefined || !path.isAbsolute(mr)) {
+      process.stderr.write(`enforce-contract: --layer-active requires an absolute --marker-root (got ${mr === undefined ? 'none' : `"${mr}"`}); no token emitted → layer enforces.\n`)
+      process.exit(0)
+    }
+    const cRoot = resolveContractRoot()
+    const reg = cRoot ? readJsonSafe(path.join(cRoot, 'plugins', '_index.json')) : null
+    const cSchema = cRoot ? readJsonSafe(path.join(cRoot, 'patterns', 'enforce-config.schema.json')) : null
+    // event is immaterial to the duplicate flag (resolveHarnessCap filters by
+    // harness/type/status; only `tier` is event-scoped, and we read only duplicate).
+    const hRes = reg ? resolveHarnessCap(reg, THIS_HARNESS, 'pre_tool_use') : { tier: null, duplicate: false }
+    const cfg = loadEnforceConfig(mr, cSchema)
+    const disp = layerDisposition({ duplicate: hRes.duplicate, active: cfg.active })
+    if (disp.token === 'inactive') {
+      appendEnforceAudit(mr, `layer enforcement disabled (active:false) — all ec gates silenced for this project (R5)`)
+      process.stderr.write(`enforce-contract: notice — enforcement disabled for this project via .episodic-memory/enforce-config.json {"active":false}; ALL ec gates silenced (R5 layer silence).\n`)
+      console.log('inactive')
+    } else if (disp.token === 'block') {
+      process.stderr.write(`enforce-contract: >1 active enforcement plugin binds harness "${THIS_HARNESS}" (M8/R6); layer NOT silenceable by active:false — fix plugins/_index.json. No token emitted → layer enforces.\n`)
+    }
+    // token 'active' (or 'block'): no stdout → caller keeps enforcing (fail-closed).
     process.exit(0)
   }
 

--- a/tests/test-layer-active-bridge.sh
+++ b/tests/test-layer-active-bridge.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test-layer-active-bridge.sh — RFC-008 P4c.
+#
+# Drives the REAL preflight-gate.sh + second-opinion-gate.mjs against a STUB
+# `--layer-active` resolver to prove the layer-wide kill switch's fail-closed
+# bridge contract on BOTH non-bp-001 surfaces — independent of the resolver's own
+# logic (covered by test-layer-active.mjs):
+#
+#   preflight-gate.sh (bash, set -e):
+#     - inactive  → bp-010 codex-review-handoff enforcement SILENCED (allow);
+#     - active    → DENY (base behavior, non-vacuous control);
+#     - consult ENOENT (degraded install) → still DENY (reviewer F1: set -e must
+#       NOT abort the gate into a non-blocking exit 1 = un-gated tool);
+#     - marker-write to the preflight marker is DENIED even when inactive
+#       (planner G4: R4 marker_write is NON-overridable, survives the switch).
+#
+#   second-opinion-gate.mjs (node spawnSync):
+#     - inactive  → whole gate OFF (allow);
+#     - active    → block (base behavior);
+#     - consult ENOENT → block (reviewer G1: spawn failure is fail-closed, NOT allow).
+#
+# The stub at $HOME/.episodic-memory/scripts/enforce-contract.mjs honors STUB_TOKEN
+# (stdout) + STUB_EXIT (exit), inherited through each hook's `node` spawn.
+
+set -u
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT_SRC="$REPO/plugins/claude-code/hooks/preflight-gate.sh"
+SECOND_OPINION="$REPO/plugins/claude-code/hooks/second-opinion-gate.mjs"
+SID="11111111-2222-3333-4444-555555555555"
+
+pass=0; fail=0
+ok()  { pass=$((pass+1)); echo "  ✓ $1"; }
+bad() { fail=$((fail+1)); echo "  ✗ $1: $2"; }
+decision_of() { printf '%s' "$1" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo ""; }
+
+# Isolated HOME carrying the stub resolver at the canonical global path.
+mk_stub_home() {
+  local h; h="$(mktemp -d "${TMPDIR:-/tmp}/layerbridge-home-XXXXXX")"
+  mkdir -p "$h/.episodic-memory/scripts"
+  cat > "$h/.episodic-memory/scripts/enforce-contract.mjs" <<'STUB'
+const t = process.env.STUB_TOKEN || ''
+if (t.length) process.stdout.write(t + '\n')
+process.exit(Number(process.env.STUB_EXIT || '0'))
+STUB
+  printf '%s' "$h"
+}
+
+# stage_fixture <tmp-root> — minimal project hosting the gate + its libs (mirrors
+# test-preflight-gate.sh so the staged preflight-gate.sh resolves CANON_LIB etc.).
+stage_fixture() {
+  local tmp="$1"
+  mkdir -p "$tmp/scripts/lib" "$tmp/hooks/lib" "$tmp/.checkpoints" "$tmp/bundles"
+  (cd "$tmp" && git init -q 2>/dev/null) || true
+  cp "$REPO/scripts/preflight-marker-write.mjs" "$tmp/scripts/"
+  cp "$REPO/scripts/lib/canonicalize-path-tolerant.mjs" "$tmp/scripts/lib/"
+  cp "$REPO/scripts/lib/local-dir.mjs" "$tmp/scripts/lib/"
+  cp "$REPO/scripts/lib/marker-paths.mjs" "$tmp/scripts/lib/"
+  cp "$REPO/scripts/lib/session-id.mjs" "$tmp/scripts/lib/"
+  cp "$REPO/scripts/lib/marker-root-validation.mjs" "$tmp/scripts/lib/"
+  cp "$PREFLIGHT_SRC" "$tmp/hooks/"
+  cp "$REPO/plugins/claude-code/hooks/lib/command-classifier.sh" "$tmp/hooks/lib/"
+  cp "$REPO/plugins/claude-code/hooks/lib/repo-root.sh" "$tmp/hooks/lib/"
+  cp "$REPO/plugins/claude-code/hooks/lib/marker-paths.sh" "$tmp/hooks/lib/"
+  cp "$REPO/bundles/codex-review-channel-current.md" "$tmp/bundles/"
+}
+
+STUB_HOME="$(mk_stub_home)"
+EMPTY_HOME="$(mktemp -d "${TMPDIR:-/tmp}/layerbridge-empty-XXXXXX")"  # no stub → consult ENOENT
+PF="$(mktemp -d "${TMPDIR:-/tmp}/layerbridge-pf-XXXXXX")"
+stage_fixture "$PF"
+PF_GATE="$PF/hooks/preflight-gate.sh"
+PF_INPUT='{"tool_name":"Bash","cwd":"'"$PF"'","session_id":"'"$SID"'","tool_input":{"command":"codex exec foo"}}'
+
+echo "=== preflight-gate.sh — layer kill switch (codex-review-handoff, no marker) ==="
+
+# 1. active (empty token) → DENY (base behavior; non-vacuous control).
+out="$(STUB_TOKEN='' STUB_EXIT=0 HOME="$STUB_HOME" bash "$PF_GATE" <<<"$PF_INPUT" 2>/dev/null)"
+if [ "$(decision_of "$out")" = "deny" ]; then ok "active → codex-review-handoff DENIED (base behavior)"; else bad "active → deny" "got [$out]"; fi
+
+# 2. inactive → ALLOW (kill switch silences bp-010 enforcement).
+out="$(STUB_TOKEN=inactive STUB_EXIT=0 HOME="$STUB_HOME" bash "$PF_GATE" <<<"$PF_INPUT" 2>/dev/null)"
+if [ -z "$out" ]; then ok "inactive → codex-review-handoff ALLOWED (silenced)"; else bad "inactive → allow" "got [$out]"; fi
+
+# 3. F1 — consult ENOENT (stub absent) under set -e → still DENY (degraded install
+#    cannot disable the gate; the set +e capture must not abort into exit 1).
+out="$(STUB_TOKEN=inactive STUB_EXIT=0 HOME="$EMPTY_HOME" bash "$PF_GATE" <<<"$PF_INPUT" 2>/dev/null)"
+if [ "$(decision_of "$out")" = "deny" ]; then ok "F1: consult ENOENT → DENY (fail-closed under set -e)"; else bad "F1 ENOENT → deny" "got [$out]"; fi
+
+# 4. inactive + stub EXITS NON-ZERO but prints "inactive" → still DENY? No: the
+#    consult discards stderr only; a non-zero exit with stdout "inactive" is the
+#    real CLI's allow shape too (it exit(0)s). The genuine fail-closed lever is a
+#    NON-inactive stdout. Assert a stub printing a DIFFERENT token → DENY.
+out="$(STUB_TOKEN='please-inactivate' STUB_EXIT=0 HOME="$STUB_HOME" bash "$PF_GATE" <<<"$PF_INPUT" 2>/dev/null)"
+if [ "$(decision_of "$out")" = "deny" ]; then ok "non-'inactive' token → DENY (exact-match, not substring)"; else bad "substring token → deny" "got [$out]"; fi
+
+# 5. G4 — direct Write to the preflight marker is DENIED even when inactive
+#    (R4 marker_write NON-overridable; the consult sits AFTER this guard).
+G4_INPUT='{"tool_name":"Write","cwd":"'"$PF"'","session_id":"'"$SID"'","tool_input":{"file_path":"'"$PF"'/.checkpoints/.preflight-done","content":"x"}}'
+out="$(STUB_TOKEN=inactive STUB_EXIT=0 HOME="$STUB_HOME" bash "$PF_GATE" <<<"$G4_INPUT" 2>/dev/null)"
+reason="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecisionReason // ""' 2>/dev/null)"
+if [ "$(decision_of "$out")" = "deny" ] && printf '%s' "$reason" | grep -qE 'forbidden|helper'; then
+  ok "G4: direct marker Write DENIED even when inactive (R4 non-overridable, survives switch)"
+else
+  bad "G4 marker-write survives" "got [$out]"
+fi
+
+echo ""
+echo "=== second-opinion-gate.mjs — layer kill switch (direct provider Bash) ==="
+SO_REPO="$(mktemp -d "${TMPDIR:-/tmp}/layerbridge-so-XXXXXX")"
+git -C "$SO_REPO" init -q
+SO_INPUT='{"tool_name":"Bash","cwd":"'"$SO_REPO"'","session_id":"'"$SID"'","tool_input":{"command":"codex exec foo"}}'
+
+# 6. active (empty token) → block (no install snapshot under STUB_HOME → snapshot error).
+out="$(STUB_TOKEN='' STUB_EXIT=0 HOME="$STUB_HOME" node "$SECOND_OPINION" <<<"$SO_INPUT" 2>/dev/null)"
+if printf '%s' "$out" | grep -qE '"decision": ?"block"'; then ok "active → second-opinion BLOCK (base behavior)"; else bad "active → block" "got [$out]"; fi
+
+# 7. inactive → ALLOW (whole gate off; consult precedes runbook/snapshot work).
+out="$(STUB_TOKEN=inactive STUB_EXIT=0 HOME="$STUB_HOME" node "$SECOND_OPINION" <<<"$SO_INPUT" 2>/dev/null)"
+if [ -z "$out" ]; then ok "inactive → second-opinion ALLOWED (gate off)"; else bad "inactive → allow" "got [$out]"; fi
+
+# 8. G1 — consult ENOENT (stub absent) → fall through → BLOCK (spawn failure is
+#    fail-closed, NOT allow).
+out="$(STUB_TOKEN=inactive STUB_EXIT=0 HOME="$EMPTY_HOME" node "$SECOND_OPINION" <<<"$SO_INPUT" 2>/dev/null)"
+if printf '%s' "$out" | grep -qE '"decision": ?"block"'; then ok "G1: consult ENOENT → BLOCK (spawn failure fail-closed)"; else bad "G1 ENOENT → block" "got [$out]"; fi
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "PASS — $pass checks"
+  exit 0
+else
+  echo "FAIL — $fail of $((pass+fail)) checks"
+  exit 1
+fi

--- a/tests/test-layer-active.mjs
+++ b/tests/test-layer-active.mjs
@@ -1,0 +1,198 @@
+// test-layer-active.mjs — RFC-008 P4c.
+//
+// Covers the LAYER-WIDE enforcement kill switch (enforce-config.json
+// {"active":false}) that every ec hook outside the 4 bp-001 gates honors:
+//   (A) layerDisposition() — the PURE precedence algebra (M8 duplicate ⊐ active:false).
+//   (B) `enforce-contract --layer-active --marker-root <abs>` CLI — the closed-token
+//       contract: stdout is `inactive` ALONE, or empty (→ the caller keeps enforcing).
+//       HOME-isolated planted contract + a marker-root carrying enforce-config.json,
+//       mirroring test-resolve-gate.mjs B.
+//   (C) F1 fold: `--session-start` skips ALL side-effects (baseline/sweeps/advisory)
+//       on active:false; a schema-miss / active:true still RUNS them (fail-closed to
+//       doing the work).
+//
+// Fail-closed is the load-bearing invariant: every failure branch (missing/relative
+// --marker-root, M8 duplicate, type-confused active, garbage config, no config)
+// emits NO token so the caller enforces (B1).
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { layerDisposition } from '../scripts/enforce-contract.mjs'
+import { BASELINE_NAME, PRIMARY_MARKER_DIR } from '../scripts/lib/marker-paths.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const ENFORCE = path.join(REPO, 'scripts', 'enforce-contract.mjs')
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  if (actual === expected) ok(name)
+  else bad(name, `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
+
+console.log('=== A: layerDisposition() pure precedence algebra ===')
+// Baseline: enforcement on (the fail-closed default reached by loadEnforceConfig's identity).
+eq('A1: active:true, no duplicate → active',
+  layerDisposition({ duplicate: false, active: true }).token, 'active')
+// Operator opt-out → inactive (the whole layer off).
+eq('A2: active:false → inactive',
+  layerDisposition({ duplicate: false, active: false }).token, 'inactive')
+// M8 duplicate ⊐ active:false — a corrupt registry is NOT silenceable (byte-identical
+// precedence to gateDisposition: duplicate REAL-blocks BEFORE the active:false silence).
+eq('A3 (M8 ⊐ active): duplicate + active:false → block (NOT inactive)',
+  layerDisposition({ duplicate: true, active: false }).token, 'block')
+eq('A4: duplicate + active:true → block',
+  layerDisposition({ duplicate: true, active: true }).token, 'block')
+
+// ---------------------------------------------------------------------------
+// B: CLI closed-token contract. HOME-isolated planted global contract; marker-root
+// carries the enforce-config.json. stdout MUST be exactly `inactive` or empty.
+// ---------------------------------------------------------------------------
+const REPO_BP001 = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'bp-001.json'), 'utf8'))
+const REPO_EVENTS = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'events.json'), 'utf8'))
+const REPO_CONFIG_SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'enforce-config.schema.json'), 'utf8'))
+const REPO_REGISTRY = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins', '_index.json'), 'utf8'))
+
+function plantGlobalContract(home, { registry, bp001, events, configSchema } = {}) {
+  const pat = path.join(home, '.episodic-memory', 'patterns')
+  const plug = path.join(home, '.episodic-memory', 'plugins')
+  fs.mkdirSync(pat, { recursive: true })
+  fs.mkdirSync(plug, { recursive: true })
+  if (bp001 !== null) fs.writeFileSync(path.join(pat, 'bp-001.json'), JSON.stringify(bp001 || REPO_BP001))
+  if (events !== null) fs.writeFileSync(path.join(pat, 'events.json'), JSON.stringify(events || REPO_EVENTS))
+  if (configSchema !== null) fs.writeFileSync(path.join(pat, 'enforce-config.schema.json'), JSON.stringify(configSchema || REPO_CONFIG_SCHEMA))
+  if (registry !== null) fs.writeFileSync(path.join(plug, '_index.json'), JSON.stringify(registry || REPO_REGISTRY))
+}
+function mkHome(label) { return fs.mkdtempSync(path.join(os.tmpdir(), `layer-home-${label}-`)) }
+function mkMarkerRoot(label, config) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `layer-mr-${label}-`))
+  if (config !== undefined) {
+    fs.mkdirSync(path.join(root, '.episodic-memory'), { recursive: true })
+    fs.writeFileSync(path.join(root, '.episodic-memory', 'enforce-config.json'),
+      typeof config === 'string' ? config : JSON.stringify(config))
+  }
+  return root
+}
+function layerActive(markerRoot, home, extraArgs = []) {
+  const args = [ENFORCE, '--layer-active', ...(markerRoot !== null ? ['--marker-root', markerRoot] : []), ...extraArgs]
+  const r = spawnSync('node', args, { encoding: 'utf8', env: { ...process.env, HOME: home } })
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status }
+}
+
+console.log('')
+console.log('=== B: --layer-active CLI closed-token contract ===')
+// B1 (D4) — active:false → exactly "inactive".
+{
+  const home = mkHome('b1'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b1', { active: false })
+  const r = layerActive(mr, home)
+  eq('B1 (D4): active:false → stdout "inactive" (alone)', r.stdout.trim(), 'inactive')
+  eq('B1: exit 0', r.status, 0)
+}
+// B2 — anti-vacuous: active:true → empty (enforce). Proves "inactive" is not always emitted.
+{
+  const home = mkHome('b2'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b2', { active: true })
+  const r = layerActive(mr, home)
+  eq('B2 (anti-vacuous): active:true → empty (enforce)', r.stdout.trim(), '')
+}
+// B3 (D1) — no config → empty (enforce).
+{
+  const home = mkHome('b3'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b3') // no config file
+  const r = layerActive(mr, home)
+  eq('B3 (D1): no enforce-config.json → empty (enforce)', r.stdout.trim(), '')
+}
+// B4 (D2) — garbage config → empty (enforce).
+{
+  const home = mkHome('b4'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b4', '{not json')
+  const r = layerActive(mr, home)
+  eq('B4 (D2): garbage enforce-config.json → empty (enforce)', r.stdout.trim(), '')
+}
+// B5 (D3) — type-confused active values are schema-invalid → identity active:true → empty.
+for (const [label, raw] of [['string "false"', '{"active":"false"}'], ['number 0', '{"active":0}'], ['null', '{"active":null}']]) {
+  const home = mkHome('b5'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b5', raw)
+  const r = layerActive(mr, home)
+  eq(`B5 (D3): active ${label} → schema-invalid → empty (enforce, NOT inactive)`, r.stdout.trim(), '')
+}
+// B6 (D6) — missing --marker-root → empty + exit 0 (fail-closed).
+{
+  const home = mkHome('b6'); plantGlobalContract(home, {})
+  const r = layerActive(null, home)
+  eq('B6 (D6): missing --marker-root → empty stdout', r.stdout.trim(), '')
+  eq('B6: exit 0', r.status, 0)
+}
+// B7 (D6) — relative --marker-root → empty (must be absolute).
+{
+  const home = mkHome('b7'); plantGlobalContract(home, {})
+  const r = layerActive('relative/path', home)
+  eq('B7 (D6): relative --marker-root → empty stdout', r.stdout.trim(), '')
+}
+// B8 (D5) — M8 duplicate registry + active:false → empty (block, NOT silenceable).
+{
+  const home = mkHome('b8')
+  const dup = REPO_REGISTRY.plugins[0]
+  plantGlobalContract(home, { registry: { schema_version: '1.0.0', plugins: [dup, { ...dup }] } })
+  const mr = mkMarkerRoot('b8', { active: false })
+  const r = layerActive(mr, home)
+  eq('B8 (D5): M8 duplicate + active:false → empty (corrupt install not silenceable)', r.stdout.trim(), '')
+}
+// B9 — the token is emitted ALONE (no diagnostic on stdout). Guards the exact-equality
+// match used by the bash + node callers: a multi-line / decorated stdout would break it.
+{
+  const home = mkHome('b9'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('b9', { active: false })
+  const r = layerActive(mr, home)
+  eq('B9: stdout is exactly "inactive\\n" (token alone, diagnostics on stderr)', r.stdout, 'inactive\n')
+  if (r.stderr.length > 0) ok('B9: notice present on stderr (not stdout)')
+  else bad('B9: notice present on stderr', 'expected a stderr notice')
+}
+
+// ---------------------------------------------------------------------------
+// C: F1 fold — `--session-start` honors the kill switch. active:false skips the
+// baseline write (the dominant SessionStart cost); active:true RUNS it. Asserts the
+// on-disk DIRECTION (baseline file presence), not an emission counter (D8).
+// ---------------------------------------------------------------------------
+console.log('')
+console.log('=== C: --session-start F1 fold (D8) ===')
+function gitInit(dir) { spawnSync('git', ['-C', dir, 'init', '-q'], { encoding: 'utf8' }) }
+function sessionStart(cwd, home) {
+  return spawnSync('node', [ENFORCE, '--session-start'], { encoding: 'utf8', cwd, env: { ...process.env, HOME: home } })
+}
+function baselinePath(root) { return path.join(root, PRIMARY_MARKER_DIR, BASELINE_NAME) }
+
+// C1 (D8) — active:false → NO baseline write + exit 0.
+{
+  const home = mkHome('c1'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('c1', { active: false }); gitInit(mr)
+  const r = sessionStart(mr, home)
+  eq('C1 (D8): --session-start active:false → exit 0', r.status, 0)
+  eq('C1 (D8): active:false → baseline NOT written (side-effects skipped)', fs.existsSync(baselinePath(mr)), false)
+}
+// C2 — non-vacuous control: active:true (no config) → baseline IS written (proves the
+// skip is genuine, not a fixture that never writes a baseline).
+{
+  const home = mkHome('c2'); plantGlobalContract(home, {})
+  const mr = mkMarkerRoot('c2'); gitInit(mr) // no config → identity active:true
+  const r = sessionStart(mr, home)
+  eq('C2 (control): active:true → exit 0', r.status, 0)
+  eq('C2 (control): active:true → baseline IS written (skip is non-vacuous)', fs.existsSync(baselinePath(mr)), true)
+}
+
+console.log('')
+if (fail === 0) {
+  console.log(`PASS — ${pass} checks`)
+  process.exit(0)
+} else {
+  console.log(`FAIL — ${fail} of ${pass + fail} checks`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## RFC-008 P4c — layer-wide `active:false` enforcement kill switch (serves R5)

Closes the R5 gap: after P4a, `enforce-config.json {"active":false}` silenced only
the 4 bp-001 gates, but **not** the other ec enforcement surfaces. R5 is layer-wide —
"no enforcement plugin active → classifier silent, no hook spawns, no token cost."
P4c adds one shared, fail-closed *"is the layer active?"* consult that every
non-bp-001 ec surface honors.

### Changes
- **`enforce-contract.mjs`** — pure `layerDisposition({duplicate,active})` (M8 duplicate ⊐ `active:false`, byte-identical precedence to `gateDisposition`); new `--layer-active --marker-root <abs>` CLI (mirrors `--resolve-gate`: prints `inactive` alone or **nothing**; fail-closed on every miss/garbage/relative-root/M8/error). **F1-fold:** `--session-start` skips baseline/sweeps/advisory on `active:false` (single `resolveRepoRoot`); a schema-miss still runs them (fail-closed to *doing* the work).
- **`preflight-gate.sh`** — consult **after** the non-overridable `marker_write` + helper guards (R4 substrate-trust survives the switch) and **only** for an actual `codex-review-handoff` (no node-spawn on the ~all non-handoff tool calls). `set +e`-wrapped capture so a degraded-install ENOENT can't abort the gate into a non-blocking exit 1.
- **`second-opinion-gate.mjs`** — lazy consult at the single `emitBlock` chokepoint (fires only when a block is imminent → no spawn on allow paths, audit only on real silenced blocks). Realpath'd marker-root (no cross-resolution equality → P3b-1 isMain class can't recur); bounded spawn timeout; fail-closed on spawn failure / non-`inactive`.
- **`enforcement.md`** — §10 stale-prose fix (schema landed P3b-2 #393, not "lands in P4") + documents the `--layer-active` convention so external hooks (e.g. a user-global `compound-bash-gate.sh`) can opt in with a ~3-line read.

### Fail-closed invariant
A missing/garbage/hostile config, an M8-duplicate registry, a symlinked cwd, a
degraded install (consult ENOENT), or any resolution miss **all keep enforcement ON**.
Only an exact-string `inactive` silences a surface. `marker_write`/helper guards (R4)
survive the switch.

### Tests (CI-wired in `plan-marker-validate.yml`)
- `test-layer-active.mjs` (22) — pure algebra + closed-token CLI D1–D8 + F1 session-start fold.
- `test-layer-active-bridge.sh` (8) — preflight + second-opinion honor `inactive`; F1 ENOENT fail-closed; G4 marker-write survives; G1 spawn-fail fail-closed.
- Full regression green: preflight 107, second-opinion 23, enforce-contract 25, session-start 20, resolve-gate 27+12; `validate-bp-contract` 76 checks OK.

### Review trail
- **Plan** (2 rounds): `negative-scenario-planner` HOLD (G1–G6) → folded; `negative-scenario-reviewer` ACCEPT-WITH-FU (reproduced the `set -e` fail-open F1) → folded.
- **Code**: `negative-scenario-reviewer` ACCEPT-WITH-FU, **no required-before-merge**. All FUs (F-PERF-1/2, F-IO-1, F-OBS-1, F1-fold asymmetry) fixed inline via the lazy block-gated consult — the original F3 caching FU is obsoleted by that design.

### Post-merge follow-ups (separate)
- Deploy to global hooks: `install.mjs --tool claude-code --install-hooks --install-hooks-force`.
- RFC-008 `README.md` phase-index + workplan update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
