### PR TITLE
test(rfc-008): P4d S1 — mock-project activation-scoping E2E harness

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Run install-runtime contract-set deploy coupling (RFC-008 P3b-2, §10)
         run: node tests/test-install-contract-deploy.mjs
 
+      - name: Run activation-scoping mock-project E2E (RFC-008 P4d S1 — substrate hook-independence A0-A3 + em-* round-trips C1-C7)
+        run: node tests/test-activation-scoping-e2e.mjs
+
       - name: Run preflight-gate regression tests
         run: bash tests/test-preflight-gate.sh
 

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -73,6 +73,9 @@ process.on('exit', () => {
     try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
   }
 })
+// 'exit' doesn't fire on a forced signal (local SIGINT, CI timeout SIGTERM);
+// re-exit through process.exit so the cleanup above runs (S1 PR-review F3).
+for (const sig of ['SIGINT', 'SIGTERM']) process.on(sig, () => process.exit(130))
 
 /**
  * Create an isolated fixture: a fresh HOME, a mock git project, and a separate

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -28,20 +28,44 @@ export const REPO_ROOT = path.resolve(
   path.dirname(new URL(import.meta.url).pathname), '..', '..'
 )
 
-// Command-string fragments that identify an RFC-008 ENFORCEMENT gate (the
-// --install-hooks / --install-second-opinion bundle). BP-1 SessionStart hooks
-// (bp1-approval-check / bp1-sweep-on-session) are SUBSTRATE hygiene
-// (activation-gated, RFC-004) and are deliberately NOT in this set — their
+// Command-string fragments that identify an RFC-008 ENFORCEMENT hook.
+//
+// Rule (one unambiguous definition, S1 review F1): a marker names EVERY hook
+// that `--install-hooks` / `--install-second-opinion` registers — i.e. the
+// install-manifest `HOOK_SPECS` bundle (all of which are enforcement; no
+// substrate hook lives in HOOK_SPECS) + the SessionEnd script + the
+// second-opinion gate (registered by --install-second-opinion, outside
+// HOOK_SPECS). The BP-1 SessionStart hooks (bp1-approval-check /
+// bp1-sweep-on-session) are wired by a SEPARATE install path, are SUBSTRATE
+// hygiene (activation-gated, RFC-004), and are deliberately absent here — their
 // project-scoped presence is expected and correct.
+//
+// test-activation-scoping-e2e.mjs (A4) asserts this set covers every HOOK_SPECS
+// file + SESSION_END_SCRIPT, so it cannot silently drift behind install (Rule 14).
 export const ENFORCEMENT_HOOK_MARKERS = [
   'plan-gate',
   'checkpoint-gate',
   'preflight-gate',
   'stop-gate',
-  'second-opinion-gate',
   'em-recall-sessionstart',
+  'preflight-prompt-helper',
+  'session-handoff-prompt',
   'em-session-end-prompt',
+  'second-opinion-gate',
 ]
+
+// Env vars that, if inherited from the test runner's real environment, would
+// defeat HOME isolation: CLAUDE_CONFIG_DIR repoints the settings dir, and the
+// SO_* paths are read by second-opinion-gate.mjs (it would resolve the REAL
+// snapshot/runbook instead of the mock). One source so the three runners can't
+// drift (S1 review F2). Mutates `env` in place and returns it.
+function scrubEnv(env) {
+  delete env.CLAUDE_CONFIG_DIR
+  delete env.SO_INSTALL_SNAPSHOT_PATH
+  delete env.SO_RUNBOOK_PATH
+  delete env.SO_QUICKREF_PATH
+  return env
+}
 
 const _tmpDirs = []
 process.on('exit', () => {
@@ -75,10 +99,7 @@ export function mkMock(label = 'mock') {
  * the mock's caller dir (kept distinct from --project).
  */
 export function runInstall({ home, project, callerCwd, flags = [], tool = 'claude-code', extraEnv = {} }) {
-  const env = { ...process.env, HOME: home, ...extraEnv }
-  // Scrub inherited overrides that would break HOME isolation.
-  delete env.SO_INSTALL_SNAPSHOT_PATH
-  delete env.CLAUDE_CONFIG_DIR
+  const env = scrubEnv({ ...process.env, HOME: home, ...extraEnv })
   return spawnSync('node', [
     path.join(REPO_ROOT, 'install.mjs'),
     '--tool', tool,
@@ -103,8 +124,7 @@ export function deployedScript(home, name) {
  * json } — json is the parsed last JSON line, or null if unparseable.
  */
 export function runScript(home, name, args = [], { cwd, extraEnv = {} } = {}) {
-  const env = { ...process.env, HOME: home, ...extraEnv }
-  delete env.CLAUDE_CONFIG_DIR
+  const env = scrubEnv({ ...process.env, HOME: home, ...extraEnv })
   const r = spawnSync('node', [deployedScript(home, name), ...args], {
     cwd: cwd || home,
     env,
@@ -120,10 +140,9 @@ export function runScript(home, name, args = [], { cwd, extraEnv = {} } = {}) {
  * stderr }.
  */
 export function runHook(hookPath, event, { home, project, extraEnv = {} } = {}) {
-  const env = { ...process.env, ...extraEnv }
+  const env = scrubEnv({ ...process.env, ...extraEnv })
   if (home) env.HOME = home
   if (project) env.CLAUDE_PROJECT_DIR = project
-  delete env.CLAUDE_CONFIG_DIR
   const input = typeof event === 'string' ? event : JSON.stringify(event)
   const r = spawnSync('bash', [hookPath], {
     cwd: project || home || process.cwd(),

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -1,0 +1,193 @@
+/**
+ * activation-scoping-harness.mjs — mock-project E2E fixture lib for the
+ * RFC-008 P4d enforcement-activation-scoping suite.
+ *
+ * Built S1; reused by S2–S8. Every helper runs the REAL install.mjs / REAL
+ * deployed scripts / REAL hooks against an isolated HOME + mock git project —
+ * NO mental tracing (feedback_mock_project_test_not_mental_trace).
+ *
+ * Empirically grounded against current code (2026-06-19):
+ *   - `--project` is a NAMESPACE LABEL, not a path; local scope resolves to
+ *     the process cwd's repo root. So local-scope round-trips MUST set
+ *     cwd = mock project (not pass --project <path>).
+ *   - macOS canonicalizes /tmp → /private/tmp; mkMock realpaths the base so
+ *     path comparisons against script-reported paths hold.
+ *   - A core install (no --install-hooks) writes NO global settings.json and
+ *     wires ONLY BP-1 H1/H2 SessionStart (activation-gated) project-scoped —
+ *     ZERO enforcement gates anywhere.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { spawnSync } from 'node:child_process'
+
+export const REPO_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname), '..', '..'
+)
+
+// Command-string fragments that identify an RFC-008 ENFORCEMENT gate (the
+// --install-hooks / --install-second-opinion bundle). BP-1 SessionStart hooks
+// (bp1-approval-check / bp1-sweep-on-session) are SUBSTRATE hygiene
+// (activation-gated, RFC-004) and are deliberately NOT in this set — their
+// project-scoped presence is expected and correct.
+export const ENFORCEMENT_HOOK_MARKERS = [
+  'plan-gate',
+  'checkpoint-gate',
+  'preflight-gate',
+  'stop-gate',
+  'second-opinion-gate',
+  'em-recall-sessionstart',
+  'em-session-end-prompt',
+]
+
+const _tmpDirs = []
+process.on('exit', () => {
+  for (const d of _tmpDirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }) } catch {}
+  }
+})
+
+/**
+ * Create an isolated fixture: a fresh HOME, a mock git project, and a separate
+ * caller cwd (so caller-cwd != --project leakage is detectable). Returns
+ * absolute, realpath-canonicalized paths.
+ */
+export function mkMock(label = 'mock') {
+  const base = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), `p4d-${label}-`))
+  )
+  _tmpDirs.push(base)
+  const home = path.join(base, 'home')
+  const project = path.join(base, 'project')
+  const callerCwd = path.join(base, 'caller')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(path.join(project, '.git'), { recursive: true }) // mark git root
+  fs.mkdirSync(callerCwd, { recursive: true })
+  return { base, home, project, callerCwd }
+}
+
+/**
+ * Run the real install.mjs with HOME overridden to the mock home. `flags`
+ * defaults to [] (core install — no enforcement hooks). Caller cwd defaults to
+ * the mock's caller dir (kept distinct from --project).
+ */
+export function runInstall({ home, project, callerCwd, flags = [], tool = 'claude-code', extraEnv = {} }) {
+  const env = { ...process.env, HOME: home, ...extraEnv }
+  // Scrub inherited overrides that would break HOME isolation.
+  delete env.SO_INSTALL_SNAPSHOT_PATH
+  delete env.CLAUDE_CONFIG_DIR
+  return spawnSync('node', [
+    path.join(REPO_ROOT, 'install.mjs'),
+    '--tool', tool,
+    '--project', project,
+    ...flags,
+  ], {
+    cwd: callerCwd || project,
+    env,
+    encoding: 'utf8',
+    timeout: 120000,
+  })
+}
+
+/** Absolute path of a deployed substrate script under the mock home. */
+export function deployedScript(home, name) {
+  return path.join(home, '.episodic-memory', 'scripts', name)
+}
+
+/**
+ * Run a deployed em-* script (by filename) under isolated HOME. For
+ * local-scope ops, pass cwd = mock project. Returns { status, stdout, stderr,
+ * json } — json is the parsed last JSON line, or null if unparseable.
+ */
+export function runScript(home, name, args = [], { cwd, extraEnv = {} } = {}) {
+  const env = { ...process.env, HOME: home, ...extraEnv }
+  delete env.CLAUDE_CONFIG_DIR
+  const r = spawnSync('node', [deployedScript(home, name), ...args], {
+    cwd: cwd || home,
+    env,
+    encoding: 'utf8',
+    timeout: 60000,
+  })
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, json: parseLastJson(r.stdout) }
+}
+
+/**
+ * Run a hook script (absolute path) with a JSON event on stdin. `event` may be
+ * an object (JSON.stringify'd) or a raw string. Returns { status, stdout,
+ * stderr }.
+ */
+export function runHook(hookPath, event, { home, project, extraEnv = {} } = {}) {
+  const env = { ...process.env, ...extraEnv }
+  if (home) env.HOME = home
+  if (project) env.CLAUDE_PROJECT_DIR = project
+  delete env.CLAUDE_CONFIG_DIR
+  const input = typeof event === 'string' ? event : JSON.stringify(event)
+  const r = spawnSync('bash', [hookPath], {
+    cwd: project || home || process.cwd(),
+    env,
+    input,
+    encoding: 'utf8',
+    timeout: 60000,
+  })
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr }
+}
+
+/**
+ * Read settings.json for a scope. scope='global' → <home>/.claude/settings.json;
+ * scope='project' → <project>/.claude/settings.json. Returns the parsed object,
+ * or null if the file is absent.
+ */
+export function readSettings(scope, { home, project }) {
+  const p = scope === 'global'
+    ? path.join(home, '.claude', 'settings.json')
+    : path.join(project, '.claude', 'settings.json')
+  if (!fs.existsSync(p)) return null
+  return JSON.parse(fs.readFileSync(p, 'utf8'))
+}
+
+/**
+ * Flatten every hook command string across all events in a settings object.
+ * Returns string[] (empty if settings is null or has no hooks).
+ */
+export function flattenHookCommands(settings) {
+  const out = []
+  if (!settings || !settings.hooks) return out
+  for (const event of Object.keys(settings.hooks)) {
+    const matchers = settings.hooks[event]
+    if (!Array.isArray(matchers)) continue
+    for (const m of matchers) {
+      const hooks = m && Array.isArray(m.hooks) ? m.hooks : []
+      for (const h of hooks) {
+        if (h && typeof h.command === 'string') out.push(h.command)
+      }
+    }
+  }
+  return out
+}
+
+/** True if any enforcement-gate marker appears in the settings' hook commands. */
+export function hasEnforcementHook(settings) {
+  const cmds = flattenHookCommands(settings)
+  return cmds.some((c) => ENFORCEMENT_HOOK_MARKERS.some((m) => c.includes(m)))
+}
+
+/** List enforcement-gate command strings found in a settings object. */
+export function enforcementHookCommands(settings) {
+  return flattenHookCommands(settings).filter(
+    (c) => ENFORCEMENT_HOOK_MARKERS.some((m) => c.includes(m))
+  )
+}
+
+function parseLastJson(stdout) {
+  if (!stdout) return null
+  const lines = stdout.trim().split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim()
+    if (!line.startsWith('{') && !line.startsWith('[')) continue
+    try { return JSON.parse(line) } catch { /* keep scanning up */ }
+  }
+  return null
+}

--- a/tests/test-activation-scoping-e2e.mjs
+++ b/tests/test-activation-scoping-e2e.mjs
@@ -36,7 +36,9 @@ import assert from 'node:assert'
 import {
   mkMock, runInstall, runScript, runHook, readSettings,
   hasEnforcementHook, enforcementHookCommands, flattenHookCommands, deployedScript,
+  ENFORCEMENT_HOOK_MARKERS,
 } from './lib/activation-scoping-harness.mjs'
+import { HOOK_SPECS, SESSION_END_SCRIPT } from '../scripts/lib/install-manifest.mjs'
 
 let passed = 0
 let failed = 0
@@ -111,6 +113,21 @@ test('A3: BP-1 SessionStart hook runs + exits 0 silently when not activated', ()
     { hook_event_name: 'SessionStart', session_id: 's1', cwd: M.project },
     { home: M.home, project: M.project })
   assert.strictEqual(r.status, 0, `BP-1 hook must exit 0 when not activated; stderr=${r.stderr}`)
+})
+
+test('A4: ENFORCEMENT_HOOK_MARKERS covers every HOOK_SPECS hook + SessionEnd (Rule 14 drift guard)', () => {
+  // Every hook --install-hooks registers (HOOK_SPECS) and the SessionEnd
+  // script must be detectable by a marker, so a future bundle hook can't slip
+  // past hasEnforcementHook — the helper S2 uses to prove "no enforcement leaks
+  // to global" (S1 review F1).
+  const bundleStems = [
+    ...HOOK_SPECS.map((s) => s.file.replace(/\.(sh|mjs)$/, '')),
+    SESSION_END_SCRIPT.replace(/\.(sh|mjs)$/, ''),
+  ]
+  for (const stem of bundleStems) {
+    assert.ok(ENFORCEMENT_HOOK_MARKERS.some((m) => stem.includes(m) || m === stem),
+      `HOOK_SPECS hook "${stem}" has no ENFORCEMENT_HOOK_MARKERS entry — marker set drifted behind install`)
+  }
 })
 
 console.log('\n## C — substrate round-trips with ZERO enforcement hooks (RQ3)')

--- a/tests/test-activation-scoping-e2e.mjs
+++ b/tests/test-activation-scoping-e2e.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * test-activation-scoping-e2e.mjs — RFC-008 P4d Slice S1.
+ *
+ * Mock-project E2E proving the SUBSTRATE is already hook-independent on
+ * current code (RQ3): a core install ships the em-* substrate + activation-
+ * gated BP-1 hygiene with ZERO enforcement gates, and every em-* round-trip
+ * works with no enforcement hook present.
+ *
+ * This file is GREEN ON TODAY'S CODE — it is the foundation every later slice
+ * (S2 project-scoped --install-enforcement, S3 dep-class fix, S4 switch, …)
+ * asserts against. It does NOT yet exercise --install-enforcement (S2's flag).
+ *
+ * Contracts:
+ *   A0  core install → exit 0, "Done!"
+ *   A1g global settings.json carries ZERO enforcement gates (file absent)
+ *   A1p project settings.json carries ZERO enforcement gates; SessionStart
+ *       holds ONLY the two BP-1 hygiene hooks (activation-gated)
+ *   A2  substrate scripts deployed under <home>/.episodic-memory/scripts
+ *   A3  BP-1 SessionStart hook runs + exits 0 silently when not activated
+ *       (substrate present but inert) — exercises runHook
+ *   C1  em-store (local) → ok, file under <project>/.episodic-memory
+ *   C2  em-search (local, by tag) → finds it
+ *   C3  em-revise (local) → supersedes the original
+ *   C4  em-rebuild-index (local) → ok
+ *   C5  em-list → revised present with supersedes set
+ *   C6  em-recall → revised surfaces, original suppressed, no preflight warnings
+ *   C7  em-store/search (global) → ok, file under <home>/.episodic-memory
+ *
+ * Zero deps. Node assert + the activation-scoping fixture lib.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+import {
+  mkMock, runInstall, runScript, runHook, readSettings,
+  hasEnforcementHook, enforcementHookCommands, flattenHookCommands, deployedScript,
+} from './lib/activation-scoping-harness.mjs'
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+console.log('# test-activation-scoping-e2e (RFC-008 P4d S1)')
+
+// ---------------------------------------------------------------------------
+// Single shared core install — exercised by both the A and C contract groups.
+// ---------------------------------------------------------------------------
+const M = mkMock('s1')
+const install = runInstall({ home: M.home, project: M.project, callerCwd: M.callerCwd })
+
+console.log('\n## A — install hook-scoping baseline (core install, no --install-hooks)')
+
+test('A0: core install exits 0 with Done!', () => {
+  assert.strictEqual(install.status, 0,
+    `expected exit 0; got ${install.status}; stderr=${install.stderr}`)
+  assert.ok(install.stdout.includes('Done!'),
+    `expected "Done!"; stdout tail: ${install.stdout.slice(-200)}`)
+})
+
+test('A1g: global settings.json carries ZERO enforcement gates', () => {
+  const g = readSettings('global', M)
+  // Core install must not even create a global settings.json.
+  assert.strictEqual(g, null,
+    `core install must not write global settings.json; found: ${JSON.stringify(g)}`)
+  assert.strictEqual(hasEnforcementHook(g), false)
+})
+
+test('A1p: project settings.json has ZERO enforcement gates; only BP-1 SessionStart', () => {
+  const p = readSettings('project', M)
+  assert.ok(p, 'project settings.json must exist after core install')
+  assert.strictEqual(hasEnforcementHook(p), false,
+    `enforcement gates leaked into project scope: ${enforcementHookCommands(p).join(', ')}`)
+  // Only SessionStart is wired, and only the two BP-1 hygiene hooks.
+  assert.deepStrictEqual(Object.keys(p.hooks), ['SessionStart'],
+    `core install must wire only SessionStart; got events: ${Object.keys(p.hooks)}`)
+  const cmds = flattenHookCommands(p)
+  assert.strictEqual(cmds.length, 2, `expected exactly 2 BP-1 hooks; got: ${cmds.join(', ')}`)
+  assert.ok(cmds.some((c) => c.includes('bp1-approval-check.sh')), 'BP-1 H1 must be wired')
+  assert.ok(cmds.some((c) => c.includes('bp1-sweep-on-session.sh')), 'BP-1 H2 must be wired')
+  // No PreToolUse / Stop / SessionEnd enforcement surfaces.
+  assert.ok(!('PreToolUse' in p.hooks), 'no PreToolUse gates in a core install')
+  assert.ok(!('Stop' in p.hooks), 'no Stop gate in a core install')
+  assert.ok(!('SessionEnd' in p.hooks), 'no SessionEnd prompt in a core install')
+})
+
+test('A2: substrate scripts deployed under <home>/.episodic-memory/scripts', () => {
+  for (const s of ['em-store.mjs', 'em-search.mjs', 'em-recall.mjs', 'em-list.mjs',
+    'em-revise.mjs', 'em-rebuild-index.mjs']) {
+    assert.ok(fs.existsSync(deployedScript(M.home, s)), `missing deployed substrate script: ${s}`)
+  }
+})
+
+test('A3: BP-1 SessionStart hook runs + exits 0 silently when not activated', () => {
+  const hook = path.join(M.project, '.claude', 'hooks', 'bp1-approval-check.sh')
+  assert.ok(fs.existsSync(hook), 'BP-1 H1 hook must be deployed project-scoped')
+  const r = runHook(hook,
+    { hook_event_name: 'SessionStart', session_id: 's1', cwd: M.project },
+    { home: M.home, project: M.project })
+  assert.strictEqual(r.status, 0, `BP-1 hook must exit 0 when not activated; stderr=${r.stderr}`)
+})
+
+console.log('\n## C — substrate round-trips with ZERO enforcement hooks (RQ3)')
+
+let originalId = null
+let revisedId = null
+
+test('C1: em-store (local) → ok, file under <project>/.episodic-memory', () => {
+  const r = runScript(M.home, 'em-store.mjs', [
+    '--project', 'mock', '--category', 'decision', '--tag', 's1rt',
+    '--summary', 's1 round-trip', '--body', 'substrate works hook-free',
+    '--scope', 'local',
+  ], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-store failed: ${r.stdout} ${r.stderr}`)
+  originalId = r.json.id
+  assert.ok(r.json.file.startsWith(path.join(M.project, '.episodic-memory')),
+    `local episode must land under the mock project; got ${r.json.file}`)
+})
+
+test('C2: em-search (local, by tag) → finds the stored episode', () => {
+  const r = runScript(M.home, 'em-search.mjs', [
+    '--project', 'mock', '--tag', 's1rt', '--scope', 'local', '--no-track',
+  ], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-search failed: ${r.stdout} ${r.stderr}`)
+  assert.ok(r.json.count >= 1, `expected >=1 hit; got ${r.json.count}`)
+  assert.ok(r.json.episodes.some((e) => e.id === originalId), 'stored episode must be found')
+})
+
+test('C3: em-revise (local) → supersedes the original', () => {
+  const r = runScript(M.home, 'em-revise.mjs', [
+    '--original', originalId, '--summary', 's1 revised', '--body', 'revision body',
+    '--scope', 'local',
+  ], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-revise failed: ${r.stdout} ${r.stderr}`)
+  assert.strictEqual(r.json.supersedes, originalId, 'revision must point at the original')
+  revisedId = r.json.id
+})
+
+test('C4: em-rebuild-index (local) → ok', () => {
+  const r = runScript(M.home, 'em-rebuild-index.mjs', ['--scope', 'local'], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-rebuild-index failed: ${r.stdout} ${r.stderr}`)
+})
+
+test('C5: em-list → revised present with supersedes set', () => {
+  const r = runScript(M.home, 'em-list.mjs', [], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-list failed: ${r.stdout} ${r.stderr}`)
+  const rev = r.json.episodes.find((e) => e.id === revisedId)
+  assert.ok(rev, 'revised episode must be listed')
+  assert.strictEqual(rev.supersedes, originalId, 'listed revision must carry supersedes')
+})
+
+test('C6: em-recall → revised surfaces, original suppressed, no preflight warnings', () => {
+  const r = runScript(M.home, 'em-recall.mjs', [], { cwd: M.project })
+  assert.ok(r.json && r.json.status === 'ok', `em-recall failed: ${r.stdout} ${r.stderr}`)
+  const ids = r.json.episodes.map((e) => e.id)
+  assert.ok(ids.includes(revisedId), 'revised episode must surface in recall')
+  assert.ok(!ids.includes(originalId), 'superseded original must NOT surface')
+  // Recall must produce no enforcement side-effects (purified substrate).
+  assert.deepStrictEqual(r.json.preflight_warnings, [],
+    `substrate recall must emit no preflight warnings; got ${JSON.stringify(r.json.preflight_warnings)}`)
+})
+
+test('C7: em-store/search (global) → ok, file under <home>/.episodic-memory', () => {
+  const s = runScript(M.home, 'em-store.mjs', [
+    '--project', 'mock', '--category', 'lesson', '--tag', 's1global',
+    '--summary', 'global rt', '--body', 'global substrate', '--scope', 'global',
+  ], { cwd: M.project })
+  assert.ok(s.json && s.json.status === 'ok', `global em-store failed: ${s.stdout} ${s.stderr}`)
+  assert.ok(s.json.file.startsWith(path.join(M.home, '.episodic-memory')),
+    `global episode must land under <home>/.episodic-memory; got ${s.json.file}`)
+  const q = runScript(M.home, 'em-search.mjs', [
+    '--project', 'mock', '--tag', 's1global', '--scope', 'global', '--no-track',
+  ], { cwd: M.project })
+  assert.ok(q.json && q.json.status === 'ok' && q.json.count >= 1,
+    `global em-search must find it; got ${q.stdout}`)
+})
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## RFC-008 P4d — Slice S1: mock-project activation-scoping E2E harness

First slice of **P4d** (decouple the enforcement layer from the memory substrate). Establishes the mock-project E2E fixture lib reused by S2–S8 and the first test, **green on current code** — the foundation later slices assert against.

### What this proves (RQ3, Principle 12)
A **core install ships the substrate + activation-gated BP-1 hygiene with ZERO enforcement gates**, and every em-* round-trip works with no enforcement hook present. Empirically verified by running the REAL `install.mjs` / REAL deployed scripts / REAL hooks against an isolated HOME + mock git project (no mental tracing).

### Contracts (13/13 green)
- **A0–A4** install hook-scoping baseline: core install writes **no global `settings.json`**; project `SessionStart` holds **only the two BP-1 hooks**; substrate scripts deployed; BP-1 hook exits 0 silently when not activated; **A4** is a Rule-14 drift guard asserting `ENFORCEMENT_HOOK_MARKERS` covers every `HOOK_SPECS` hook + `SESSION_END_SCRIPT`.
- **C1–C7** substrate round-trips hook-free: em-store / search / revise / rebuild / list / recall (local + global), supersession honored, recall side-effect-free.

### Files
- `tests/lib/activation-scoping-harness.mjs` — `mkMock`, `runInstall`, `runScript`, `runHook`, `readSettings` + enforcement-gate detection (one `scrubEnv` for HOME isolation).
- `tests/test-activation-scoping-e2e.mjs` — the S1 contracts.
- `.github/workflows/plan-marker-validate.yml` — one CI step.

### Review
Second-opinion (claude-subagent) code review: **ACCEPT, no blocking findings**. Two non-blocking foundation gaps (F1 marker completeness, F2 env scrub) folded **inline**; F3 (enforce-config writer + block-vs-allow gate-runner) tracked into the **S4** slice plan.

### Scope notes
Test-only — **no production code touched**. Does **not** yet exercise `--install-enforcement` (that is S2). Principle 12 + the RFC P4d doc land in later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
