### PR TITLE
feat(rfc-008): P4d S2 — per-project enforcement install (--install-enforcement) + substrate allowlist

### DIFF
--- a/.claude/hooks/bp1-approval-check.sh
+++ b/.claude/hooks/bp1-approval-check.sh
@@ -79,6 +79,9 @@ fi
 # under <project>/.claude/hooks/, NOT in the global substrate. BASH_SOURCE is
 # absolute (Claude Code registers hooks by absolute path), so this is cd-safe.
 EM_SCRIPTS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# Co-located install (P4d) first; legacy global fallback if the bp1 scripts are
+# not beside this hook (fresh installs co-locate; the fallback is inert there).
+[ -f "$EM_SCRIPTS_DIR/bp1-flag-check.mjs" ] || EM_SCRIPTS_DIR="$HOME/.episodic-memory/scripts"
 FLAG_CHECK="$EM_SCRIPTS_DIR/bp1-flag-check.mjs"
 VALIDATE="$EM_SCRIPTS_DIR/bp1-marker-validate.mjs"
 EMIT_INVALID="$EM_SCRIPTS_DIR/bp1-emit-marker-invalid-evidence.mjs"

--- a/.claude/hooks/bp1-approval-check.sh
+++ b/.claude/hooks/bp1-approval-check.sh
@@ -55,9 +55,9 @@ set -e
 #     WORKTREE root (not the main checkout). This hook follows the same
 #     resolution — see the $TOPLEVEL computation below.
 #
-# Script resolution (codex code-review A1, 2026-05-07):
-#   bp1 scripts are installed GLOBALLY at $HOME/.episodic-memory/scripts/.
-#   See bp1-sweep-on-session.sh:23-30 for rationale.
+# Script resolution (RFC-008 P4d / Principle 12 — relocated per-project 2026-06-19):
+#   bp1 scripts install CO-LOCATED with this hook under <project>/.claude/hooks/,
+#   resolved via $HOOK_DIR. NOT global. See bp1-sweep-on-session.sh:23-29.
 
 INPUT="$(cat)"
 # Guard stdin .cwd parse: malformed SessionStart JSON would otherwise propagate
@@ -75,7 +75,10 @@ if ! cd "$CWD" 2>/dev/null; then
   exit 0
 fi
 
-EM_SCRIPTS_DIR="$HOME/.episodic-memory/scripts"
+# RFC-008 P4d / Principle 12: the bp1 scripts install CO-LOCATED with this hook
+# under <project>/.claude/hooks/, NOT in the global substrate. BASH_SOURCE is
+# absolute (Claude Code registers hooks by absolute path), so this is cd-safe.
+EM_SCRIPTS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 FLAG_CHECK="$EM_SCRIPTS_DIR/bp1-flag-check.mjs"
 VALIDATE="$EM_SCRIPTS_DIR/bp1-marker-validate.mjs"
 EMIT_INVALID="$EM_SCRIPTS_DIR/bp1-emit-marker-invalid-evidence.mjs"

--- a/.claude/hooks/bp1-sweep-on-session.sh
+++ b/.claude/hooks/bp1-sweep-on-session.sh
@@ -44,6 +44,9 @@ fi
 # <project>/.claude/hooks/, NOT in the global substrate. BASH_SOURCE is absolute
 # (Claude Code registers hooks by absolute path), so this is cd-safe.
 EM_SCRIPTS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+# Co-located install (P4d) first; legacy global fallback if the bp1 scripts are
+# not beside this hook (fresh installs co-locate; the fallback is inert there).
+[ -f "$EM_SCRIPTS_DIR/bp1-flag-check.mjs" ] || EM_SCRIPTS_DIR="$HOME/.episodic-memory/scripts"
 FLAG_CHECK="$EM_SCRIPTS_DIR/bp1-flag-check.mjs"
 SWEEP="$EM_SCRIPTS_DIR/bp1-deadline-sweep.mjs"
 

--- a/.claude/hooks/bp1-sweep-on-session.sh
+++ b/.claude/hooks/bp1-sweep-on-session.sh
@@ -20,13 +20,12 @@ set -e
 #   - Passes `--project "$CWD"` explicitly to BOTH subprocesses; does NOT rely
 #     on subprocess `process.cwd()` defaulting.
 #
-# Script resolution (codex code-review A1, 2026-05-07):
-#   bp1 scripts are installed GLOBALLY at $HOME/.episodic-memory/scripts/ by
-#   install.mjs section 1 (lines 82-99). NOT under <projectRoot>/scripts/.
-#   Resolving via $CWD/scripts would silently no-op for any installed project
-#   that isn't this repo (which is the only one where the source-of-truth and
-#   the install destination overlap). Mirrors em-recall-sessionstart.sh:38
-#   resolution pattern.
+# Script resolution (RFC-008 P4d / Principle 12 — relocated per-project 2026-06-19;
+# was codex code-review A1, 2026-05-07):
+#   bp1 scripts install CO-LOCATED with this hook under <project>/.claude/hooks/
+#   (the BP-1 behavior pattern is per-project, never in the global substrate).
+#   They are resolved via $HOOK_DIR (this script's own dir, BASH_SOURCE-derived),
+#   NOT via $CWD/scripts and NOT via the global $HOME/.episodic-memory/scripts/.
 #
 # Idempotent: re-firing on the same project is harmless. Sweep is stateless.
 
@@ -41,7 +40,10 @@ if ! cd "$CWD" 2>/dev/null; then
   exit 0
 fi
 
-EM_SCRIPTS_DIR="$HOME/.episodic-memory/scripts"
+# RFC-008 P4d / Principle 12: bp1 scripts install CO-LOCATED with this hook under
+# <project>/.claude/hooks/, NOT in the global substrate. BASH_SOURCE is absolute
+# (Claude Code registers hooks by absolute path), so this is cd-safe.
+EM_SCRIPTS_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 FLAG_CHECK="$EM_SCRIPTS_DIR/bp1-flag-check.mjs"
 SWEEP="$EM_SCRIPTS_DIR/bp1-deadline-sweep.mjs"
 

--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Run install-manifest scope + migration-cutover (RFC-008 P4d — enforcement scope:project excluded from global cutover)
         run: node tests/test-migration-cutover.mjs
 
+      - name: Run lib-closure import-form coverage (RFC-008 P4d S2 F3 — bare/default/re-export/dynamic captured; computed not)
+        run: node tests/test-lib-closure.mjs
+
       - name: Run second-opinion gate per-project install E2E (RFC-008 P4d — gate + libs + runbooks per-project; snapshot global)
         run: node tests/test-install-second-opinion-e2e.mjs
 

--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -126,6 +126,15 @@ jobs:
       - name: Run activation-scoping mock-project E2E (RFC-008 P4d S1 — substrate hook-independence A0-A3 + em-* round-trips C1-C7)
         run: node tests/test-activation-scoping-e2e.mjs
 
+      - name: Run P12 global-clean guardrail (RFC-008 P4d — global scope has ZERO enforcement hooks/scripts/libs/config across every install variant)
+        run: node tests/test-p12-global-clean.mjs
+
+      - name: Run install-manifest scope + migration-cutover (RFC-008 P4d — enforcement scope:project excluded from global cutover)
+        run: node tests/test-migration-cutover.mjs
+
+      - name: Run second-opinion gate per-project install E2E (RFC-008 P4d — gate + libs + runbooks per-project; snapshot global)
+        run: node tests/test-install-second-opinion-e2e.mjs
+
       - name: Run preflight-gate regression tests
         run: bash tests/test-preflight-gate.sh
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -121,10 +121,21 @@ Core decisions — what is a request, what is a verdict, what closes a request �
 
 ---
 
+## 12. Enforcement is per-project; the substrate is global
+
+Enforcement — hooks, gates, classifiers — is activated and controlled **per project, never globally**. A project owns a single switch that enables or disables its own hooks and enforcement; flipping it affects only that project. **Every enforcement artifact lives in the project: the hook FILES and hook SCRIPTS (gate `.sh`, their hook libs, the SessionEnd/SessionStart hook scripts, the enforcement engine they invoke) are installed under `<project>/.claude/`, and their registrations go in `<project>/.claude/settings.json` — NEVER in `~/.claude/hooks/` or `~/.claude/settings.json`.** A script that exists only to be run by a hook is an enforcement artifact, not substrate, however it is packaged. The memory substrate — the episode store, the `em-*` memory tools (`em-store`/`em-search`/`em-recall`/`em-revise`/`em-list`/`em-rebuild-index`), `patterns/`, and the skill — is the ONLY thing that stays global, and it stays **hook-free**: it never registers, copies, or depends on a hook to function.
+
+**Why:** A hook in global `~/.claude/settings.json` fires in *every* project — Claude Code merges hooks across scopes and a project cannot subtract a global one — so global enforcement reaches into unrelated projects and breaks them (a gate looking for a project-local lib that isn't there denies real work). Enforcement that cannot be scoped or switched off per project defeats the entire point of RFC-008: decoupling enforcement from the substrate. Memory must stay usable everywhere without dragging enforcement along.
+
+**How to apply:** Enforcement adapters install their hook FILES + libs + hook-invoked scripts into the activating project's `<project>/.claude/hooks/` and register them only into `<project>/.claude/settings.json` (never `~/.claude/hooks/` or `~/.claude/settings.json`). Global install deploys ONLY substrate (the `em-*` memory tools, `patterns/`, the skill); it copies zero hook files and writes zero hook registrations. Each project carries its own enable/disable switch — `<project>/.episodic-memory/enforce-config.json` `active`, plus the presence of its hook registrations. Installers expose enforcement as an explicit per-project opt-in (Principle 3) with per-project uninstall (Principle 10); a project that did not opt in runs zero enforcement hooks. Core memory operations never depend on any hook being installed (Principle 9). **Test this:** a mock-project E2E must assert that after any global/core install, `~/.claude/hooks/` contains no enforcement file and `~/.claude/settings.json` contains no enforcement registration; that the enforcement set is installed only under `<project>/.claude/`; and any design/code/test that places an enforcement artifact in global scope is a P12 violation.
+
+---
+
 ## How these principles relate
 
 - **Substrate** (1, 2, 9, 11): episodes are the only data, definitions are JSON, adapters are shallow.
 - **Install contract** (3, 10): detect to suggest, activate to commit, undo as a first-class action.
+- **Enforcement contract** (3, 10, 12): enforcement activates per-project, switches off per-project, and never reaches global; the substrate stays global and hook-free.
 - **Honesty contract** (4, 5, 6): don't pretend parity, don't burn tokens silently, don't shift load onto the user.
 - **Integrity contract** (7, 8): lifecycle is auditable, messages carry their context.
 

--- a/install.mjs
+++ b/install.mjs
@@ -25,7 +25,7 @@ import { findEnforcementTokens } from './scripts/lib/em-recall-purity.mjs'
 import {
   HOOK_SPECS, SESSION_END_SCRIPT, ENFORCEMENT_HOOK_SCRIPTS,
   enforcementHookFileBasenames, enforcementRegistrations,
-  isEnforcementEntryScript, enforcementEntryScripts, enforcementBundleLibs,
+  isEnforcementEntryScript, isSubstrateScript, enforcementEntryScripts, enforcementBundleLibs,
   globalScriptLibs, relocatedOnlyLibs, bp1EntryScripts, bp1ClosureLibs,
 } from './scripts/lib/install-manifest.mjs'
 
@@ -226,15 +226,15 @@ fs.mkdirSync(path.join(GLOBAL_DIR, 'episodes'), { recursive: true })
 
 let scriptFiles
 try {
-  // P12 (RFC-008 P4d): enforcement SCRIPTS — the engine (enforce-contract), the
-  // classifier suite, the marker writers, the bp1 orchestration, and the SessionEnd
-  // hook script — exist ONLY to be run by a hook, so they install per-project under
-  // --install-enforcement and are EXCLUDED from the global substrate scripts-scan.
-  // Global = substrate (em-*) + dev/CI tooling only. The enforcement set is DERIVED
-  // (isEnforcementEntryScript: explicit list + the bp1-* family) so a new enforcement
-  // script cannot silently leak to global.
+  // P12 (RFC-008 P4d): global = SUBSTRATE ONLY — the em-* tools + the second-opinion
+  // capability harness (isSubstrateScript ALLOWLIST). Two other classes ship
+  // elsewhere/nowhere: enforcement SCRIPTS (engine, classifier, markers, bp1,
+  // SessionEnd hook) install per-project under --install-enforcement; repo-dev/CI
+  // tools (validate-*, scaffold-bp, test-plugin, check-automode-defaults) ship
+  // NOWHERE — CI runs them repo-relative. An allowlist (not the prior denylist)
+  // ensures a newly added non-substrate script cannot silently leak into global.
   scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(
-    f => f.endsWith('.mjs') && !isEnforcementEntryScript(f) && !ENFORCEMENT_HOOK_SCRIPTS.includes(f)
+    f => f.endsWith('.mjs') && isSubstrateScript(f)
   )
   for (const file of scriptFiles) {
     const src = path.join(REPO_SCRIPTS, file)
@@ -352,12 +352,14 @@ if (fs.existsSync(repoPatternsIndex)) {
   console.log(`Installed patterns/_index.json to ${globalPatternsDir}`)
 }
 
-// NOTE: patterns/taxonomy.json is a RUNTIME dependency of command-classifier.sh,
-// NOT a global-validation artifact like _index.json — so it is co-deployed WITH
-// the classifier inside the `if (installHooks)` block (§5a-tax below), never
-// unconditionally here. Deploying it in the main body would advance runtime
-// candidate-1 on a no-hooks install while leaving an already-installed classifier
-// stale + unwarned (PR-level codex BLOCKER; R4/F4 root parity + sync coupling).
+// NOTE (RFC-008 P4d / Principle 12): patterns/taxonomy.json is a RUNTIME
+// dependency of the relocated command-classifier — it is an ENFORCEMENT contract
+// artifact, NOT a global-validation artifact like _index.json. Post-S2 it is
+// co-deployed with the classifier PER-PROJECT under <project>/.claude/hooks/patterns/
+// inside the `if (installEnforcement)` block (§5b-ec), never global. Only
+// _index.json (the substrate pattern registry) stays global, unconditionally (§1b
+// above). Deploying taxonomy globally would re-leak an enforcement artifact into
+// the substrate (the exact P12 violation S2 closes).
 
 // ---------------------------------------------------------------------------
 // 2. Create local .episodic-memory in target project
@@ -1201,11 +1203,21 @@ function installHookFile(repoFile, destFile, force) {
   return 'skipped-divergent'
 }
 
+if (installHooks && !installEnforcement) {
+  // P12 (RFC-008 P4d) transitional honesty (review F2): post-S2 ALL enforcement
+  // (gates, libs, taxonomy/contract config, registrations) installs PER-PROJECT
+  // via --install-enforcement. --install-hooks alone no longer deploys any
+  // enforcement artifact — every inner block below is gated `if (installEnforcement)`.
+  // Surface that rather than silently no-op'ing the previously load-bearing flag.
+  console.log('Note: enforcement now installs per-project via --install-enforcement (RFC-008 P4d). --install-hooks alone no longer deploys enforcement gates.')
+}
+
 if (installHooks || installEnforcement) {
-  // P12 (RFC-008 P4d): enforcement artifacts (hook files, libs, registrations)
-  // install PER-PROJECT under <project>/.claude/ — NEVER global. The substrate
-  // co-deploys (taxonomy/contract/_index) stay global and are gated on
-  // --install-hooks. --install-enforcement does the per-project enforcement.
+  // P12 (RFC-008 P4d): enforcement artifacts (hook files, libs, taxonomy/contract
+  // config, registrations) install PER-PROJECT under <project>/.claude/ — NEVER
+  // global — and ONLY under --install-enforcement (every substantive inner block
+  // is gated `if (installEnforcement)`). The lone global substrate artifact,
+  // patterns/_index.json, is deployed unconditionally far above (§1b).
   const settingsPath = path.join(projectDir, '.claude', 'settings.json')
   const userHooksDir = path.join(projectDir, '.claude', 'hooks')
   const userHooksLibDir = path.join(userHooksDir, 'lib')

--- a/install.mjs
+++ b/install.mjs
@@ -22,6 +22,10 @@ import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { eventsVersion } from './scripts/lib/version-hash.mjs'
 import { findEnforcementTokens } from './scripts/lib/em-recall-purity.mjs'
+import {
+  HOOK_SPECS, SESSION_END_SCRIPT, ENFORCEMENT_HOOK_SCRIPTS,
+  enforcementHookFileBasenames, enforcementRegistrations,
+} from './scripts/lib/install-manifest.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const SCRIPTS_DIR = path.join(GLOBAL_DIR, 'scripts')
@@ -213,7 +217,10 @@ fs.mkdirSync(path.join(GLOBAL_DIR, 'episodes'), { recursive: true })
 
 let scriptFiles
 try {
-  scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(f => f.endsWith('.mjs'))
+  // P12 (RFC-008 P4d): enforcement hook scripts (em-session-end-prompt.mjs) run
+  // ONLY as a hook, so they install per-project under --install-enforcement and
+  // are EXCLUDED from the global substrate scripts-scan. Global = substrate only.
+  scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(f => f.endsWith('.mjs') && !ENFORCEMENT_HOOK_SCRIPTS.includes(f))
   for (const file of scriptFiles) {
     const src = path.join(REPO_SCRIPTS, file)
     const dst = path.join(SCRIPTS_DIR, file)

--- a/install.mjs
+++ b/install.mjs
@@ -1571,7 +1571,13 @@ if (installHooks || installEnforcement) {
 // --install-hooks alongside --install-second-opinion.
 // ---------------------------------------------------------------------------
 if (installSecondOpinion) {
-  const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
+  // P12 (RFC-008 P4d): second-opinion-gate.mjs is a PreToolUse hook — its code
+  // (gate + libs + runbooks) installs PER-PROJECT under <project>/.claude/hooks/,
+  // never global. (The providers.json snapshot is a generated data artifact read
+  // via the shared snapshotPath() resolver; fully relocating the runtime snapshot
+  // path is S3 dep-class scope. The P12 guardrail tracks hook CODE files (.sh/.mjs),
+  // which this moves out of global.)
+  const userHooksDir = path.join(projectDir, '.claude', 'hooks')
   const userHooksLibDir = path.join(userHooksDir, 'lib')
   const userRunbooksDir = path.join(userHooksDir, 'runbooks')
 

--- a/install.mjs
+++ b/install.mjs
@@ -25,6 +25,8 @@ import { findEnforcementTokens } from './scripts/lib/em-recall-purity.mjs'
 import {
   HOOK_SPECS, SESSION_END_SCRIPT, ENFORCEMENT_HOOK_SCRIPTS,
   enforcementHookFileBasenames, enforcementRegistrations,
+  isEnforcementEntryScript, enforcementEntryScripts, enforcementBundleLibs,
+  globalScriptLibs, relocatedOnlyLibs, bp1EntryScripts, bp1ClosureLibs,
 } from './scripts/lib/install-manifest.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -224,22 +226,34 @@ fs.mkdirSync(path.join(GLOBAL_DIR, 'episodes'), { recursive: true })
 
 let scriptFiles
 try {
-  // P12 (RFC-008 P4d): enforcement hook scripts (em-session-end-prompt.mjs) run
-  // ONLY as a hook, so they install per-project under --install-enforcement and
-  // are EXCLUDED from the global substrate scripts-scan. Global = substrate only.
-  scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(f => f.endsWith('.mjs') && !ENFORCEMENT_HOOK_SCRIPTS.includes(f))
+  // P12 (RFC-008 P4d): enforcement SCRIPTS — the engine (enforce-contract), the
+  // classifier suite, the marker writers, the bp1 orchestration, and the SessionEnd
+  // hook script — exist ONLY to be run by a hook, so they install per-project under
+  // --install-enforcement and are EXCLUDED from the global substrate scripts-scan.
+  // Global = substrate (em-*) + dev/CI tooling only. The enforcement set is DERIVED
+  // (isEnforcementEntryScript: explicit list + the bp1-* family) so a new enforcement
+  // script cannot silently leak to global.
+  scriptFiles = fs.readdirSync(REPO_SCRIPTS).filter(
+    f => f.endsWith('.mjs') && !isEnforcementEntryScript(f) && !ENFORCEMENT_HOOK_SCRIPTS.includes(f)
+  )
   for (const file of scriptFiles) {
     const src = path.join(REPO_SCRIPTS, file)
     const dst = path.join(SCRIPTS_DIR, file)
     fs.copyFileSync(src, dst)
     fs.chmodSync(dst, 0o755)
   }
-  // scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-* scripts.
+  // scripts/lib/ — shared helpers (e.g. local-dir.mjs for #85). Imported by em-*
+  // scripts. P12: ENFORCEMENT-ONLY libs (relocatedOnlyLibs — the closure of the
+  // enforcement entries minus anything a retained-global script imports) move
+  // per-project with their scripts and are EXCLUDED here. Libs shared by both a
+  // global and an enforcement script (local-dir, json-instance-validate, …) stay
+  // global AND get a co-located copy in the per-project bundle.
   const REPO_SCRIPTS_LIB = path.join(REPO_SCRIPTS, 'lib')
   if (fs.existsSync(REPO_SCRIPTS_LIB)) {
     const libDst = path.join(SCRIPTS_DIR, 'lib')
+    const relocatedLibs = new Set(relocatedOnlyLibs(REPO_DIR))
     fs.mkdirSync(libDst, { recursive: true })
-    for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs'))) {
+    for (const file of fs.readdirSync(REPO_SCRIPTS_LIB).filter(f => f.endsWith('.mjs') && !relocatedLibs.has(f))) {
       fs.copyFileSync(path.join(REPO_SCRIPTS_LIB, file), path.join(libDst, file))
     }
   }
@@ -453,6 +467,26 @@ if (tool === 'claude-code' || tool === 'all') {
     console.log(`Warning: BP-1 H2 hook source not found at ${repoH2HookSrc}; skipping wiring.`)
   } else {
     fs.mkdirSync(projHooksDir, { recursive: true })
+
+    // RFC-008 P4d / Principle 12: the BP-1 behavior-pattern SCRIPTS (bp1-*.mjs +
+    // their lib closure) install CO-LOCATED with the bp1 SessionStart hooks here,
+    // per-project — NEVER in the global substrate (they are excluded from the
+    // global scripts-scan by isEnforcementEntryScript). The hooks resolve them at
+    // $HOOK_DIR, so core install ships a self-contained BP-1 (no global reach).
+    {
+      const projHooksLibDir = path.join(projHooksDir, 'lib')
+      fs.mkdirSync(projHooksLibDir, { recursive: true })
+      for (const f of bp1EntryScripts(REPO_DIR)) {
+        const dst = path.join(projHooksDir, f)
+        fs.copyFileSync(path.join(REPO_SCRIPTS, f), dst)
+        fs.chmodSync(dst, 0o755)
+      }
+      for (const f of bp1ClosureLibs(REPO_DIR)) {
+        const src = path.join(REPO_SCRIPTS, 'lib', f)
+        if (fs.existsSync(src)) fs.copyFileSync(src, path.join(projHooksLibDir, f))
+      }
+    }
+
     let h2HookCopied = false
     let h2DivergentSkipped = false
     if (!fs.existsSync(projH2HookDst)) {
@@ -1260,89 +1294,12 @@ if (installHooks || installEnforcement) {
     }
    } // end if (installEnforcement) — enforcement hook libs (per-project)
 
-   if (installHooks) {
-    // SUBSTRATE co-deploys (global, hook-free) — taxonomy + contract set +
-    // plugins/_index. Coupled to --install-hooks (NOT --install-enforcement):
-    // the project-side gates read these from the global $HOME/.episodic-memory
-    // substrate root at runtime.
-    // 5a-tax. RFC-008 P3c (R4/F4): co-deploy patterns/taxonomy.json to the SAME
-    // global root the classifier reads at runtime (candidate 1 =
-    // $HOME/.episodic-memory/patterns/taxonomy.json; GLOBAL_DIR = os.homedir()/
-    // .episodic-memory, no EPISODIC_MEMORY_HOME indirection — codex R2-P2 root
-    // parity). This is INSIDE the installHooks block so taxonomy and classifier
-    // advance together: a no-hooks install touches neither (PR-level codex
-    // BLOCKER — taxonomy must not advance candidate-1 while the installed
-    // classifier stays stale + unwarned).
-    const repoTaxonomy = path.join(REPO_DIR, 'patterns', 'taxonomy.json')
-    if (fs.existsSync(repoTaxonomy)) {
-      fs.mkdirSync(globalPatternsDir, { recursive: true })
-      fs.copyFileSync(repoTaxonomy, path.join(globalPatternsDir, 'taxonomy.json'))
-      console.log(`Installed patterns/taxonomy.json to ${globalPatternsDir}`)
-    }
-
-    // 5a-contract. RFC-008 P3b-2 (R5/R6/R8): co-deploy the enforce-contract RUNTIME
-    // contract set to the SAME global root enforce-contract.mjs reads at runtime
-    // (candidate 1 = $HOME/.episodic-memory/patterns/). COUPLED to the hook install
-    // exactly like the P3c taxonomy deploy above — stop-gate.sh invokes
-    // enforce-contract.mjs (a hook), so a no-hooks install must NOT advance the
-    // global contract while the installed gate stays stale (the P3c PR-level
-    // BLOCKER class). enforce-config.json itself is per-PROJECT + human-authored:
-    // ship the SCHEMA only, never a config instance.
-    //
-    // F-NEW-4 atomic multi-file deploy: bp-001.json embeds events_version (a sha
-    // over events.json). Land events.json + the schema FIRST and the sha-referencer
-    // bp-001.json LAST, so the candidate-1 gate (which keys on bp-001.json presence)
-    // flips to "present" only once the whole coupled set is on disk; a reader during
-    // the window falls through to candidate-2 and never sees new-bp-001 + stale-events.
-    const repoBp001 = path.join(REPO_DIR, 'patterns', 'bp-001.json')
-    let deployedContractSet = false
-    if (fs.existsSync(repoBp001)) {
-      fs.mkdirSync(globalPatternsDir, { recursive: true })
-      for (const f of ['events.json', 'enforce-config.schema.json']) {
-        const src = path.join(REPO_DIR, 'patterns', f)
-        if (fs.existsSync(src)) fs.copyFileSync(src, path.join(globalPatternsDir, f))
-      }
-      fs.copyFileSync(repoBp001, path.join(globalPatternsDir, 'bp-001.json')) // LAST — sha-referencer
-      deployedContractSet = true
-      console.log(`Installed enforce-contract set (bp-001.json, events.json, enforce-config.schema.json) to ${globalPatternsDir}`)
-    }
-
-    // PR-level review PR-1 (R3/R6/R8): enforce-contract reads the harness-capability
-    // registry at runtime from <contractRoot>/plugins/_index.json (resolveHarnessCap),
-    // and the installed contractRoot is candidate-1 = $HOME/.episodic-memory. WITHOUT
-    // this deploy the runtime registry is always null in prod → the harness-cap min()
-    // leg is dead AND the M8 duplicate-binding + CLASS-C(a) fail-closed checks are
-    // unreachable (they only fired in dev/CI where candidate-2 = the repo root). Deploy
-    // plugins/_index.json to the global plugins/ tree, coupled to the same --install-hooks
-    // block. (resolveHarnessCap reads only entry.capabilities — no manifest needed here.)
-    const repoPluginsIndex = path.join(REPO_DIR, 'plugins', '_index.json')
-    if (fs.existsSync(repoPluginsIndex)) {
-      const globalPluginsDir = path.join(GLOBAL_DIR, 'plugins')
-      fs.mkdirSync(globalPluginsDir, { recursive: true })
-      fs.copyFileSync(repoPluginsIndex, path.join(globalPluginsDir, '_index.json'))
-      console.log(`Installed plugins/_index.json to ${globalPluginsDir}`)
-    }
-    // F-NEW-4 coupling assertion: the DEPLOYED bp-001.events_version must equal the
-    // sha over the DEPLOYED events.json. A mismatch means a partial/torn deploy —
-    // WARN (enforce-contract fails CLOSED to STRONG on a contract it can't trust,
-    // so this is hardening, not a fail-open fix).
-    if (deployedContractSet) {
-      try {
-        const depBp = JSON.parse(fs.readFileSync(path.join(globalPatternsDir, 'bp-001.json'), 'utf8'))
-        const depEvents = JSON.parse(fs.readFileSync(path.join(globalPatternsDir, 'events.json'), 'utf8'))
-        const liveEv = eventsVersion(depEvents)
-        if (depBp.events_version !== liveEv) {
-          console.log(
-            `WARNING: deployed bp-001.events_version (${depBp.events_version}) != sha of deployed ` +
-            `events.json (${liveEv}) — contract set is divergent/torn; enforce-contract will fail ` +
-            'CLOSED (stay STRONG). Re-run with --install-hooks-force to resync.'
-          )
-        }
-      } catch (e) {
-        console.log(`WARNING: could not verify enforce-contract set coupling: ${e.message}`)
-      }
-    }
-   } // end if (installHooks) — substrate co-deploys (global)
+   // RFC-008 P4d / Principle 12: the enforce-contract RUNTIME config (taxonomy.json,
+   // the bp-001/events/schema contract set, plugins/_index.json) is ENFORCEMENT, not
+   // substrate — it now deploys PER-PROJECT, co-located with the engine, in the
+   // `if (installEnforcement)` 5b-ec block above. It is no longer co-deployed to the
+   // global $HOME/.episodic-memory under --install-hooks (that was the config half of
+   // the P12 leak). No global contract co-deploy remains.
 
    if (installEnforcement) {
     // RFC-008 P3c (R4/F4, codex R1-P1b): if the command classifier was KEPT as a
@@ -1422,6 +1379,72 @@ if (installHooks || installEnforcement) {
       touched.hooks.push(seDest)
     } else if (seFileResult === 'unchanged') {
       console.log(`SessionEnd hook script already current: ${seDest}`)
+    }
+
+    // 5b-ec. RFC-008 P4d / Principle 12 — relocate the enforcement RUNTIME (engine +
+    // classifier + markers + bp1 + their lib closure + the contract config) INTO the
+    // project so global holds zero enforcement. The per-project gates resolve all of
+    // it co-located ($HOOK_DIR), never reaching into $HOME/.episodic-memory.
+    //
+    //   entry scripts → <project>/.claude/hooks/         (siblings of the gates)
+    //   lib closure   → <project>/.claude/hooks/lib/      (relative ./lib/ imports resolve)
+    //   contract cfg  → <project>/.claude/hooks/patterns/ + .../plugins/  (engine candidate-0)
+    fs.mkdirSync(userHooksLibDir, { recursive: true })
+    const entryScripts = enforcementEntryScripts(REPO_DIR)
+    for (const f of entryScripts) {
+      const dst = path.join(userHooksDir, f)
+      fs.copyFileSync(path.join(REPO_SCRIPTS, f), dst)
+      fs.chmodSync(dst, 0o755)
+      touched.hooks.push(dst)
+    }
+    for (const f of enforcementBundleLibs(REPO_DIR)) {
+      const src = path.join(REPO_SCRIPTS, 'lib', f)
+      if (fs.existsSync(src)) fs.copyFileSync(src, path.join(userHooksLibDir, f))
+    }
+    console.log(`Installed enforcement runtime (${entryScripts.length} scripts + lib closure) to ${userHooksDir}`)
+
+    // Contract config co-located with the engine (enforce-contract candidate-0 =
+    // <selfDir>/patterns). F-NEW-4 atomic order: events.json + schema FIRST, the
+    // sha-referencer bp-001.json LAST, so the candidate gate (keys on bp-001.json)
+    // flips to present only once the whole coupled set is on disk.
+    const projPatternsDir = path.join(userHooksDir, 'patterns')
+    const projPluginsDir = path.join(userHooksDir, 'plugins')
+    fs.mkdirSync(projPatternsDir, { recursive: true })
+    let deployedContractSet = false
+    const repoTaxonomy = path.join(REPO_DIR, 'patterns', 'taxonomy.json')
+    if (fs.existsSync(repoTaxonomy)) {
+      fs.copyFileSync(repoTaxonomy, path.join(projPatternsDir, 'taxonomy.json'))
+    }
+    const repoBp001 = path.join(REPO_DIR, 'patterns', 'bp-001.json')
+    if (fs.existsSync(repoBp001)) {
+      for (const f of ['events.json', 'enforce-config.schema.json']) {
+        const src = path.join(REPO_DIR, 'patterns', f)
+        if (fs.existsSync(src)) fs.copyFileSync(src, path.join(projPatternsDir, f))
+      }
+      fs.copyFileSync(repoBp001, path.join(projPatternsDir, 'bp-001.json')) // LAST — sha-referencer
+      deployedContractSet = true
+    }
+    const repoPluginsIndex = path.join(REPO_DIR, 'plugins', '_index.json')
+    if (fs.existsSync(repoPluginsIndex)) {
+      fs.mkdirSync(projPluginsDir, { recursive: true })
+      fs.copyFileSync(repoPluginsIndex, path.join(projPluginsDir, '_index.json'))
+    }
+    if (deployedContractSet) {
+      console.log(`Installed enforce-contract config set to ${projPatternsDir}`)
+      try {
+        const depBp = JSON.parse(fs.readFileSync(path.join(projPatternsDir, 'bp-001.json'), 'utf8'))
+        const depEvents = JSON.parse(fs.readFileSync(path.join(projPatternsDir, 'events.json'), 'utf8'))
+        const liveEv = eventsVersion(depEvents)
+        if (depBp.events_version !== liveEv) {
+          console.log(
+            `WARNING: deployed bp-001.events_version (${depBp.events_version}) != sha of deployed ` +
+            `events.json (${liveEv}) — contract set is divergent/torn; enforce-contract will fail ` +
+            'CLOSED (stay STRONG). Re-run with --install-hooks-force to resync.'
+          )
+        }
+      } catch (e) {
+        console.log(`WARNING: could not verify enforce-contract set coupling: ${e.message}`)
+      }
     }
 
     // 5c. Read settings, run migration, register hooks.

--- a/install.mjs
+++ b/install.mjs
@@ -44,6 +44,13 @@ const tool = flag('--tool')
 const projectDir = flag('--project') || process.cwd()
 const installHooks = argv.includes('--install-hooks')
 const installHooksForce = argv.includes('--install-hooks-force')
+// RFC-008 P4d / Principle 12: enforcement hooks (files + libs + scripts +
+// registrations) install ONLY per-project via --install-enforcement, into
+// <project>/.claude/. INTERNAL/undocumented until S3 resolves the cross-deps
+// ($REPO_ROOT scripts/bundles + the SessionEnd .mjs libs) — S2 acceptance is
+// registration-green, NOT functional-safe (the registered gates hard-deny on
+// missing deps in a non-this-repo project until S3).
+const installEnforcement = argv.includes('--install-enforcement')
 const installSecondOpinion = argv.includes('--install-second-opinion')
 const bootstrapLastPrompt = argv.includes('--bootstrap-last-prompt')
 const REPO_HOOKS = path.join(REPO_DIR, 'plugins', 'claude-code', 'hooks')
@@ -1160,13 +1167,23 @@ function installHookFile(repoFile, destFile, force) {
   return 'skipped-divergent'
 }
 
-if (installHooks) {
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json')
-  const userHooksDir = path.join(os.homedir(), '.claude', 'hooks')
+if (installHooks || installEnforcement) {
+  // P12 (RFC-008 P4d): enforcement artifacts (hook files, libs, registrations)
+  // install PER-PROJECT under <project>/.claude/ — NEVER global. The substrate
+  // co-deploys (taxonomy/contract/_index) stay global and are gated on
+  // --install-hooks. --install-enforcement does the per-project enforcement.
+  const settingsPath = path.join(projectDir, '.claude', 'settings.json')
+  const userHooksDir = path.join(projectDir, '.claude', 'hooks')
   const userHooksLibDir = path.join(userHooksDir, 'lib')
   const REPO_HOOKS_LIB = path.join(REPO_HOOKS, 'lib')
   const touched = { hooks: [], settings: [], hookLib: [] }
   try {
+   // Shared enforcement lib-install state, hoisted so every installEnforcement
+   // sub-block (5_lib, 5c registration gating, classifier-sync warning) sees it.
+   const libResults = {}
+   let hookLibFiles = []
+   let anyLibSkippedDivergent = false
+   if (installEnforcement) {
     // 5_lib. Deploy hooks/lib/ alongside hooks/. Session 1 (#86 PR-B / #89 /
     // #101) introduces hooks/lib/command-classifier.sh and hooks/lib/repo-root.sh
     // sourced by plan-gate.sh and checkpoint-gate.sh via $BASH_SOURCE/cd -P.
@@ -1178,9 +1195,6 @@ if (installHooks) {
     // lib was skipped-divergent — registered hook would source stale/missing
     // lib at runtime and fail loud (or worse, silently behave wrong if user's
     // divergent lib is incomplete).
-    const libResults = {}
-    let hookLibFiles = []
-    let anyLibSkippedDivergent = false
     if (fs.existsSync(REPO_HOOKS_LIB)) {
       fs.mkdirSync(userHooksLibDir, { recursive: true })
       hookLibFiles = fs.readdirSync(REPO_HOOKS_LIB).filter(f => f.endsWith('.sh')).sort()
@@ -1244,7 +1258,13 @@ if (installHooks) {
         're-run with --install-hooks-force'
       )
     }
+   } // end if (installEnforcement) — enforcement hook libs (per-project)
 
+   if (installHooks) {
+    // SUBSTRATE co-deploys (global, hook-free) — taxonomy + contract set +
+    // plugins/_index. Coupled to --install-hooks (NOT --install-enforcement):
+    // the project-side gates read these from the global $HOME/.episodic-memory
+    // substrate root at runtime.
     // 5a-tax. RFC-008 P3c (R4/F4): co-deploy patterns/taxonomy.json to the SAME
     // global root the classifier reads at runtime (candidate 1 =
     // $HOME/.episodic-memory/patterns/taxonomy.json; GLOBAL_DIR = os.homedir()/
@@ -1322,7 +1342,9 @@ if (installHooks) {
         console.log(`WARNING: could not verify enforce-contract set coupling: ${e.message}`)
       }
     }
+   } // end if (installHooks) — substrate co-deploys (global)
 
+   if (installEnforcement) {
     // RFC-008 P3c (R4/F4, codex R1-P1b): if the command classifier was KEPT as a
     // divergent local edit while taxonomy.json was (re)deployed just above, the
     // installed classifier and the global taxonomy may disagree. Two cases,
@@ -1354,14 +1376,11 @@ if (installHooks) {
       }
     }
 
-    // 5a. Hook specs imported from scripts/lib/install-manifest.mjs (single
-    // source of truth shared with tools/migration-cutover.mjs). Closes
-    // Codex round-2 implementation attention point: avoid a second
-    // hardcoded copy list.
-    const { HOOK_SPECS } = await import(
-      new URL('./scripts/lib/install-manifest.mjs', import.meta.url).href
-    )
+    // 5a. Hook specs from scripts/lib/install-manifest.mjs (single source of
+    // truth, statically imported at top). Ensure the PROJECT hooks dir exists
+    // (P12: enforcement hook files live under <project>/.claude/hooks/).
     const hookSpecs = HOOK_SPECS
+    fs.mkdirSync(userHooksDir, { recursive: true })
 
     // 5b. Copy hook files; track which got installed for registration eligibility.
     const fileResults = {} // spec.file → result
@@ -1389,6 +1408,20 @@ if (installHooks) {
           console.log(`Note: ${repoFile} not found in repo, skipped`)
           break
       }
+    }
+
+    // 5b-se. The SessionEnd hook SCRIPT (em-session-end-prompt.mjs) is an
+    // enforcement hook script (P12) — copy it from scripts/ into the PROJECT
+    // hooks dir too, so its registration points at <project>/.claude/hooks/.
+    const seRepo = path.join(REPO_SCRIPTS, SESSION_END_SCRIPT)
+    const seDest = path.join(userHooksDir, SESSION_END_SCRIPT)
+    const seFileResult = installHookFile(seRepo, seDest, installHooksForce)
+    fileResults[SESSION_END_SCRIPT] = seFileResult
+    if (seFileResult === 'copied' || seFileResult === 'forced') {
+      console.log(`Installed SessionEnd hook script: ${seDest}`)
+      touched.hooks.push(seDest)
+    } else if (seFileResult === 'unchanged') {
+      console.log(`SessionEnd hook script already current: ${seDest}`)
     }
 
     // 5c. Read settings, run migration, register hooks.
@@ -1472,8 +1505,9 @@ if (installHooks) {
       if (result === 'added') touched.settings.push(`${spec.event} → ${spec.file}`)
     }
 
-    // SessionEnd em-session-end-prompt.mjs (Phase 1; canonical at SCRIPTS_DIR).
-    const seCmd = `node ${shellQuote(path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'))}`
+    // SessionEnd em-session-end-prompt.mjs — registered at its PER-PROJECT
+    // location (P12): <project>/.claude/hooks/em-session-end-prompt.mjs.
+    const seCmd = `node ${shellQuote(path.join(userHooksDir, SESSION_END_SCRIPT))}`
     const seResult = addHookEntry(settings.hooks, 'SessionEnd', seCmd, { timeout: 10 })
     console.log(`SessionEnd em-session-end-prompt.mjs: ${seResult}`)
     if (seResult === 'added') touched.settings.push('SessionEnd → em-session-end-prompt.mjs')
@@ -1481,7 +1515,7 @@ if (installHooks) {
     // P2 (code review): warn about stale canonical-named entries left behind
     // by migration so the user can prune them. Run AFTER all registrations.
     const canonicalByBasename = {
-      'em-session-end-prompt.mjs': path.join(SCRIPTS_DIR, 'em-session-end-prompt.mjs'),
+      'em-session-end-prompt.mjs': path.join(userHooksDir, 'em-session-end-prompt.mjs'),
       'checkpoint-gate.sh': path.join(userHooksDir, 'checkpoint-gate.sh'),
       'plan-gate.sh': path.join(userHooksDir, 'plan-gate.sh'),
       'em-recall-sessionstart.sh': path.join(userHooksDir, 'em-recall-sessionstart.sh'),
@@ -1500,13 +1534,6 @@ if (installHooks) {
     writeJSONAtomic(settingsPath, settings)
     if (touched.settings.length > 0) touched.hooks.push(settingsPath)
 
-    const manifestPath = path.join(GLOBAL_DIR, 'hook-install.json')
-    const manifest = buildHookFreshnessManifest(hookSpecs, hookLibFiles, userHooksDir, userHooksLibDir)
-    if (writeJSONAtomicIfChanged(manifestPath, manifest)) {
-      console.log(`Wrote hook freshness manifest: ${manifestPath}`)
-      touched.hooks.push(manifestPath)
-    }
-
     // 5d. Consent legibility (Codex non-blocking guidance): list everything
     // touched so the user can audit the install.
     if (touched.hooks.length > 0 || touched.settings.length > 0) {
@@ -1522,6 +1549,7 @@ if (installHooks) {
     } else {
       console.log('--- Hook install summary: nothing to do (already current) ---')
     }
+   } // end if (installEnforcement) — enforcement hook files + registration (per-project)
   } catch (e) {
     console.log(`Note: could not install hooks: ${e.message}`)
   }

--- a/plugins/claude-code/hooks/checkpoint-gate.sh
+++ b/plugins/claude-code/hooks/checkpoint-gate.sh
@@ -114,8 +114,10 @@ REPO_ROOT="$(resolve_repo_root "$CWD")"
 # missing binary makes `node` exit non-zero → "" → the gate keeps blocking
 # (fail-closed, B1). Never re-resolves the root — the consult passes REPO_ROOT as
 # --marker-root (F4).
-# RFC-008 P4d / Principle 12: engine co-located with this gate, not global.
+# RFC-008 P4d / Principle 12: engine co-located with this gate. Global path is a
+# legacy fallback only (fresh P4d installs ship no global engine).
 ENFORCE_CONTRACT="$HOOK_DIR/enforce-contract.mjs"
+[ -f "$ENFORCE_CONTRACT" ] || ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
 
 # Canonical WRITE paths. Used in block-message paths so the agent knows
 # where to write the checkpoint block.
@@ -747,6 +749,7 @@ _arm_checkpoint_required_if_missing() {
   # sid is valid here (the approval check requires it).
   ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
   local helper="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located marker writer
+  [ -f "$helper" ] || helper="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"  # legacy fallback
   if [ -f "$helper" ]; then
     CLAUDE_CODE_SESSION_ID="$MY_SID" node "$helper" \
       --target .checkpoint-required \
@@ -1638,6 +1641,7 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
     ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
     if validate_session_id "$MY_SID"; then
       HELPER_CKM_PUSH="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located
+      [ -f "$HELPER_CKM_PUSH" ] || HELPER_CKM_PUSH="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
       if [ -f "$HELPER_CKM_PUSH" ]; then
         # CAPTURE stdout (codex C3: the gate previously discarded it) and parse
         # the helper's authoritative `noop` field.
@@ -1762,6 +1766,7 @@ case "$TOOL_NAME" in
         # CLAUDE_CODE_SESSION_ID is exported to the helper subprocess via the
         # hook's inherited env (claude code sets it for all hooks).
         HELPER_CKM="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located
+        [ -f "$HELPER_CKM" ] || HELPER_CKM="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
         if [ -f "$HELPER_CKM" ]; then
           CLAUDE_CODE_SESSION_ID="$MY_SID" node "$HELPER_CKM" \
             --target .post-checkpoint-required \

--- a/plugins/claude-code/hooks/checkpoint-gate.sh
+++ b/plugins/claude-code/hooks/checkpoint-gate.sh
@@ -114,7 +114,8 @@ REPO_ROOT="$(resolve_repo_root "$CWD")"
 # missing binary makes `node` exit non-zero → "" → the gate keeps blocking
 # (fail-closed, B1). Never re-resolves the root — the consult passes REPO_ROOT as
 # --marker-root (F4).
-ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+# RFC-008 P4d / Principle 12: engine co-located with this gate, not global.
+ENFORCE_CONTRACT="$HOOK_DIR/enforce-contract.mjs"
 
 # Canonical WRITE paths. Used in block-message paths so the agent knows
 # where to write the checkpoint block.
@@ -745,7 +746,7 @@ _arm_checkpoint_required_if_missing() {
   fi
   # sid is valid here (the approval check requires it).
   ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
-  local helper="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+  local helper="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located marker writer
   if [ -f "$helper" ]; then
     CLAUDE_CODE_SESSION_ID="$MY_SID" node "$helper" \
       --target .checkpoint-required \
@@ -1115,9 +1116,16 @@ _validate_classifier_marker_helper() {
   local script_canon
   script_canon="$(_canonicalize_possibly_nonexistent "$script_path")"
   [ -z "$script_canon" ] && return 1
-  local allowed_global allowed_repo
+  local allowed_global allowed_repo allowed_hookdir
+  # RFC-008 P4d / Principle 12: the classifier-marker writer installs CO-LOCATED
+  # with this gate (<project>/.claude/hooks/) — allow that path. Legacy global +
+  # in-repo paths kept for back-compat / dev.
+  allowed_hookdir="$(_canonicalize_possibly_nonexistent "$HOOK_DIR/classifier-marker.mjs")"
   allowed_global="$(_canonicalize_possibly_nonexistent "$HOME/.episodic-memory/scripts/classifier-marker.mjs")"
   allowed_repo="$(_canonicalize_possibly_nonexistent "$repo_root/scripts/classifier-marker.mjs")"
+  if [ -n "$allowed_hookdir" ] && [ "$script_canon" = "$allowed_hookdir" ]; then
+    return 0
+  fi
   if [ -n "$allowed_global" ] && [ "$script_canon" = "$allowed_global" ]; then
     return 0
   fi
@@ -1629,7 +1637,7 @@ if [ "$TOOL_NAME" = "Bash" ] && [ "$LABEL" = "push_or_pr_create" ]; then
   if [ "$POST_SILENCED" != "1" ] && ! checkpoint_marker_exists_for_session .post-checkpoint-required "$MY_SID"; then
     ensure_primary_dir "$REPO_ROOT" 2>/dev/null || true
     if validate_session_id "$MY_SID"; then
-      HELPER_CKM_PUSH="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+      HELPER_CKM_PUSH="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located
       if [ -f "$HELPER_CKM_PUSH" ]; then
         # CAPTURE stdout (codex C3: the gate previously discarded it) and parse
         # the helper's authoritative `noop` field.
@@ -1753,7 +1761,7 @@ case "$TOOL_NAME" in
         # Prefer helper for unified marker_write classification + atomic write.
         # CLAUDE_CODE_SESSION_ID is exported to the helper subprocess via the
         # hook's inherited env (claude code sets it for all hooks).
-        HELPER_CKM="$HOME/.episodic-memory/scripts/checkpoint-marker.mjs"
+        HELPER_CKM="$HOOK_DIR/checkpoint-marker.mjs"  # P4d/P12: co-located
         if [ -f "$HELPER_CKM" ]; then
           CLAUDE_CODE_SESSION_ID="$MY_SID" node "$HELPER_CKM" \
             --target .post-checkpoint-required \

--- a/plugins/claude-code/hooks/em-recall-sessionstart.sh
+++ b/plugins/claude-code/hooks/em-recall-sessionstart.sh
@@ -36,9 +36,11 @@ CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 
 # RFC-008 P4d / Principle 12: enforce-contract.mjs is the enforcement ENGINE,
 # installed CO-LOCATED with this hook under <project>/.claude/hooks/, never in the
-# global substrate. Resolve via BASH_SOURCE (symlink-safe).
+# global substrate. Resolve co-located first (BASH_SOURCE, symlink-safe); the global
+# path is a legacy fallback only (fresh P4d installs ship no global engine).
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
 ENFORCE="$HOOK_DIR/enforce-contract.mjs"
+[ -f "$ENFORCE" ] || ENFORCE="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
 
 _em_join_list() {
   local out=""

--- a/plugins/claude-code/hooks/em-recall-sessionstart.sh
+++ b/plugins/claude-code/hooks/em-recall-sessionstart.sh
@@ -34,7 +34,11 @@ INPUT="$(cat)"
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""')"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-ENFORCE="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+# RFC-008 P4d / Principle 12: enforce-contract.mjs is the enforcement ENGINE,
+# installed CO-LOCATED with this hook under <project>/.claude/hooks/, never in the
+# global substrate. Resolve via BASH_SOURCE (symlink-safe).
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+ENFORCE="$HOOK_DIR/enforce-contract.mjs"
 
 _em_join_list() {
   local out=""

--- a/plugins/claude-code/hooks/lib/agent-classifier-deny-reason.sh
+++ b/plugins/claude-code/hooks/lib/agent-classifier-deny-reason.sh
@@ -34,10 +34,13 @@
 # bare basename last (agent resolves via its own runtime). Mirrors
 # __agent_classifier_resolve_marker_helper in agent-classifier.sh.
 __agent_classifier_deny_resolve_helper() {
-  local global="$HOME/.episodic-memory/scripts/classifier-marker.mjs"
-  if [ -f "$global" ]; then printf '%s' "$global"; return 0; fi
   local self_dir
   self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  # P4d/P12: co-located per-project install first (hooks/lib/ → ../X.mjs).
+  local colocated="$self_dir/../classifier-marker.mjs"
+  if [ -f "$colocated" ]; then printf '%s' "$colocated"; return 0; fi
+  local global="$HOME/.episodic-memory/scripts/classifier-marker.mjs"
+  if [ -f "$global" ]; then printf '%s' "$global"; return 0; fi
   local repo="$self_dir/../../../../scripts/classifier-marker.mjs"
   if [ -f "$repo" ]; then printf '%s' "$repo"; return 0; fi
   printf '%s' "classifier-marker.mjs"

--- a/plugins/claude-code/hooks/lib/agent-classifier.sh
+++ b/plugins/claude-code/hooks/lib/agent-classifier.sh
@@ -39,14 +39,22 @@
 # marker artifact entirely. Helper resolution is hard-bound to
 # installed-runtime OR repo-source paths — both authoritative.
 __agent_classifier_resolve_marker_helper() {
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # RFC-008 P4d / Principle 12: enforcement scripts install CO-LOCATED per-project
+  # (hooks/lib/ → ../classifier-marker.mjs). Authoritative installed-runtime path,
+  # checked before the legacy global root. No env seam (PR #271 attack class).
+  local colocated="$self_dir/../classifier-marker.mjs"
+  if [ -f "$colocated" ]; then
+    printf '%s' "$colocated"
+    return 0
+  fi
   local global="$HOME/.episodic-memory/scripts/classifier-marker.mjs"
   if [ -f "$global" ]; then
     printf '%s' "$global"
     return 0
   fi
   # Repo-source fallback (dev / pre-install).
-  local self_dir
-  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local repo="$self_dir/../../../../scripts/classifier-marker.mjs"
   if [ -f "$repo" ]; then
     printf '%s' "$repo"
@@ -59,13 +67,19 @@ __agent_classifier_resolve_marker_helper() {
 # runtime first, repo-source fallback. NO env-var override seam (PR #271
 # attack class — ambient env paths can be hijacked).
 __agent_classifier_resolve_persist_helper() {
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # P4d/P12: co-located per-project install first; then legacy global; then repo.
+  local colocated="$self_dir/../classifier-override-persist.mjs"
+  if [ -f "$colocated" ]; then
+    printf '%s' "$colocated"
+    return 0
+  fi
   local global="$HOME/.episodic-memory/scripts/classifier-override-persist.mjs"
   if [ -f "$global" ]; then
     printf '%s' "$global"
     return 0
   fi
-  local self_dir
-  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local repo="$self_dir/../../../../scripts/classifier-override-persist.mjs"
   if [ -f "$repo" ]; then
     printf '%s' "$repo"
@@ -128,13 +142,19 @@ __agent_classifier_resolve_legacy_dispatcher() {
     printf '%s' "$_dispatch_path"
     return 0
   fi
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # P4d/P12: co-located per-project install first; then legacy global; then repo.
+  local colocated="$self_dir/../agent-classifier-dispatch.mjs"
+  if [ -f "$colocated" ]; then
+    printf '%s' "$colocated"
+    return 0
+  fi
   local global="$HOME/.episodic-memory/scripts/agent-classifier-dispatch.mjs"
   if [ -f "$global" ]; then
     printf '%s' "$global"
     return 0
   fi
-  local self_dir
-  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local repo="$self_dir/../../../../scripts/agent-classifier-dispatch.mjs"
   if [ -f "$repo" ]; then
     printf '%s' "$repo"

--- a/plugins/claude-code/hooks/lib/command-classifier.sh
+++ b/plugins/claude-code/hooks/lib/command-classifier.sh
@@ -1633,16 +1633,18 @@ _classify_segment() {
   if [ $env_prefix_count -eq 0 ] && [ -f "$target_root/.episodic-memory/classifier-overrides.jsonl" ]; then
     # Resolve helper path (installed-runtime preferred, repo-source fallback).
     local __t0_helper=""
+    local __t0_self_dir
+    __t0_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+    # P4d/P12: co-located per-project install first (hooks/lib/ → ../X.mjs).
+    local __t0_colocated="$__t0_self_dir/../classifier-override-lookup.mjs"
     local __t0_global="$HOME/.episodic-memory/scripts/classifier-override-lookup.mjs"
-    if [ -f "$__t0_global" ]; then
+    local __t0_repo="$__t0_self_dir/../../../../scripts/classifier-override-lookup.mjs"
+    if [ -f "$__t0_colocated" ]; then
+      __t0_helper="$__t0_colocated"
+    elif [ -f "$__t0_global" ]; then
       __t0_helper="$__t0_global"
-    else
-      local __t0_self_dir
-      __t0_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-      local __t0_repo="$__t0_self_dir/../../../../scripts/classifier-override-lookup.mjs"
-      if [ -f "$__t0_repo" ]; then
-        __t0_helper="$__t0_repo"
-      fi
+    elif [ -f "$__t0_repo" ]; then
+      __t0_helper="$__t0_repo"
     fi
     if [ -n "$__t0_helper" ]; then
       # Reconstruct command text from tokens (same shape Tier 2/3 dispatch uses).
@@ -2459,15 +2461,25 @@ _priority_arm_labels() {
 
 # Echo the resolved taxonomy.json path, or empty + return 1 if none qualifies.
 _taxonomy_resolve_path() {
-  # Candidate 1 — global install root (== install.mjs GLOBAL_DIR).
+  local self_dir climbed
+  self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || return 1
+  # Candidate 0 — CO-LOCATED per-project install (RFC-008 P4d / Principle 12: the
+  # classifier config installs beside the hooks under <project>/.claude/hooks/; the
+  # lib sits at hooks/lib/, so taxonomy is ../patterns/taxonomy.json). Authoritative
+  # installed-runtime path, like candidate 1.
+  local c0="$self_dir/../patterns/taxonomy.json"
+  if [ -f "$c0" ]; then
+    _taxonomy_file_realpath "$c0" 2>/dev/null || printf '%s' "$c0"
+    return 0
+  fi
+  # Candidate 1 — legacy global install root (== install.mjs GLOBAL_DIR).
   local c1="$HOME/.episodic-memory/patterns/taxonomy.json"
   if [ -f "$c1" ]; then
     _taxonomy_file_realpath "$c1" 2>/dev/null || printf '%s' "$c1"
     return 0
   fi
   # Candidate 2 — in-repo copy, CONDITIONAL on a repo-layout proof predicate.
-  local self_dir climbed
-  self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || return 1
+  local climbed
   climbed="$(cd -P "$self_dir/../../../.." 2>/dev/null && pwd)" || return 1
   # (a) repo sentinels present at the climbed root.
   [ -f "$climbed/patterns/taxonomy.schema.json" ] || return 1

--- a/plugins/claude-code/hooks/plan-gate.sh
+++ b/plugins/claude-code/hooks/plan-gate.sh
@@ -114,7 +114,9 @@ esac
 # B1). A missing enforce-contract.mjs makes `node` exit non-zero → "" → block.
 # RFC-008 P4d / Principle 12: the engine installs CO-LOCATED with this gate
 # (<project>/.claude/hooks/), never in the global substrate. HOOK_DIR resolved above.
+# Global path is a legacy fallback only (fresh P4d installs ship no global engine).
 ENFORCE_CONTRACT="$HOOK_DIR/enforce-contract.mjs"
+[ -f "$ENFORCE_CONTRACT" ] || ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
 if _any_plan_marker_exists_local; then
   GATE_DISP="$(node "$ENFORCE_CONTRACT" --resolve-gate plan_approval --marker-root "$REPO_ROOT" 2>/dev/null)" || GATE_DISP=""
   if [ "$GATE_DISP" = "silence" ] || [ "$GATE_DISP" = "clamp-off" ]; then

--- a/plugins/claude-code/hooks/plan-gate.sh
+++ b/plugins/claude-code/hooks/plan-gate.sh
@@ -112,7 +112,9 @@ esac
 # non-zero exit (caught by `|| GATE_DISP=""`), garbage, multi-line — leaves
 # GATE_DISP unmatched and falls through to the existing block paths (fail-closed,
 # B1). A missing enforce-contract.mjs makes `node` exit non-zero → "" → block.
-ENFORCE_CONTRACT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+# RFC-008 P4d / Principle 12: the engine installs CO-LOCATED with this gate
+# (<project>/.claude/hooks/), never in the global substrate. HOOK_DIR resolved above.
+ENFORCE_CONTRACT="$HOOK_DIR/enforce-contract.mjs"
 if _any_plan_marker_exists_local; then
   GATE_DISP="$(node "$ENFORCE_CONTRACT" --resolve-gate plan_approval --marker-root "$REPO_ROOT" 2>/dev/null)" || GATE_DISP=""
   if [ "$GATE_DISP" = "silence" ] || [ "$GATE_DISP" = "clamp-off" ]; then

--- a/plugins/claude-code/hooks/preflight-gate.sh
+++ b/plugins/claude-code/hooks/preflight-gate.sh
@@ -314,7 +314,8 @@ fi
 # non-`inactive` string — falls through to enforcement (2>/dev/null discards the
 # node stderr so it can never leak into the captured token).
 # ---------------------------------------------------------------------------
-LAYER_ACTIVE_CONSULT="$HOOK_DIR/enforce-contract.mjs"  # P4d/P12: co-located engine, not global
+LAYER_ACTIVE_CONSULT="$HOOK_DIR/enforce-contract.mjs"  # P4d/P12: co-located engine
+[ -f "$LAYER_ACTIVE_CONSULT" ] || LAYER_ACTIVE_CONSULT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"  # legacy fallback
 set +e
 LAYER_DISP="$(node "$LAYER_ACTIVE_CONSULT" --layer-active --marker-root "$REPO_ROOT" 2>/dev/null)"
 set -e

--- a/plugins/claude-code/hooks/preflight-gate.sh
+++ b/plugins/claude-code/hooks/preflight-gate.sh
@@ -314,7 +314,7 @@ fi
 # non-`inactive` string — falls through to enforcement (2>/dev/null discards the
 # node stderr so it can never leak into the captured token).
 # ---------------------------------------------------------------------------
-LAYER_ACTIVE_CONSULT="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+LAYER_ACTIVE_CONSULT="$HOOK_DIR/enforce-contract.mjs"  # P4d/P12: co-located engine, not global
 set +e
 LAYER_DISP="$(node "$LAYER_ACTIVE_CONSULT" --layer-active --marker-root "$REPO_ROOT" 2>/dev/null)"
 set -e

--- a/plugins/claude-code/hooks/preflight-prompt-helper.sh
+++ b/plugins/claude-code/hooks/preflight-prompt-helper.sh
@@ -105,17 +105,20 @@ if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
   _log_and_exit_safe "repo root unresolved from cwd=$CWD; skipping"
 fi
 
-# Locate the canon lib + marker-write helper. Prefer in-repo paths
-# (development), fall back to the global install (~/.episodic-memory/).
+# Locate the canon lib + marker-write helper. RFC-008 P4d / Principle 12: prefer
+# the CO-LOCATED per-project copies ($HOOK_DIR — enforcement installs together,
+# never global); then in-repo (development); then legacy global install.
 CANON_LIB=""
 HELPER=""
 for cand in \
+  "$HOOK_DIR/lib/preflight-prompt-canon.mjs" \
   "$REPO_ROOT/scripts/lib/preflight-prompt-canon.mjs" \
   "${HOME:-/}/.episodic-memory/scripts/lib/preflight-prompt-canon.mjs"
 do
   if [ -f "$cand" ]; then CANON_LIB="$cand"; break; fi
 done
 for cand in \
+  "$HOOK_DIR/preflight-marker-write.mjs" \
   "$REPO_ROOT/scripts/preflight-marker-write.mjs" \
   "${HOME:-/}/.episodic-memory/scripts/preflight-marker-write.mjs"
 do

--- a/plugins/claude-code/hooks/stop-gate.sh
+++ b/plugins/claude-code/hooks/stop-gate.sh
@@ -67,9 +67,16 @@ CWD="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")"
 # repoint — a missing/erroring binary MUST block loud, never degrade to
 # allow-always.
 HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-ENFORCE="$HOOK_DIR/enforce-contract.mjs"
-if [ ! -f "$ENFORCE" ]; then
-  echo '{"decision": "block", "reason": "stop-gate.sh: enforce-contract.mjs not found co-located in the project hooks dir. Re-run install.mjs --install-enforcement."}'
+# Resolve the engine CO-LOCATED first (installed per-project, P12). The global path
+# is a legacy/back-compat fallback only — fresh P4d installs ship NO global engine
+# (test-p12-global-clean proves global is empty), so co-located always wins in a
+# real install; the fallback exists so a pre-P4d global install still resolves.
+ENFORCE=""
+for _ec in "$HOOK_DIR/enforce-contract.mjs" "$HOME/.episodic-memory/scripts/enforce-contract.mjs"; do
+  [ -f "$_ec" ] && { ENFORCE="$_ec"; break; }
+done
+if [ -z "$ENFORCE" ]; then
+  echo '{"decision": "block", "reason": "stop-gate.sh: enforce-contract.mjs not found (co-located project hooks dir or legacy global). Re-run install.mjs --install-enforcement."}'
   exit 0
 fi
 

--- a/plugins/claude-code/hooks/stop-gate.sh
+++ b/plugins/claude-code/hooks/stop-gate.sh
@@ -56,18 +56,20 @@ fi
 CWD="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")"
 [ -z "$CWD" ] && CWD="$(pwd)"
 
-# Resolve enforce-contract.mjs at canonical global install path. The hook does
-# not attempt to use the in-repo script — production hooks invoke globally
-# installed copies, which is what install.mjs --install-hooks deploys.
+# Resolve enforce-contract.mjs CO-LOCATED with this gate. RFC-008 P4d / Principle
+# 12: the enforcement engine installs per-project alongside the gates under
+# <project>/.claude/hooks/ — NOT in the global substrate. Resolve via BASH_SOURCE
+# (symlink-safe) so the gate calls its own project's engine.
 #
 # RFC-008 P3b-1: the stop decision moved OUT of the memory substrate
 # (em-recall.mjs --gate stop) INTO the enforcement layer (enforce-contract.mjs),
 # byte-identical. CLASS-C(c): this loud-fail-if-missing is PRESERVED on the
 # repoint — a missing/erroring binary MUST block loud, never degrade to
 # allow-always.
-ENFORCE="$HOME/.episodic-memory/scripts/enforce-contract.mjs"
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+ENFORCE="$HOOK_DIR/enforce-contract.mjs"
 if [ ! -f "$ENFORCE" ]; then
-  echo '{"decision": "block", "reason": "stop-gate.sh: enforce-contract.mjs not found at canonical global path. Re-run install.mjs."}'
+  echo '{"decision": "block", "reason": "stop-gate.sh: enforce-contract.mjs not found co-located in the project hooks dir. Re-run install.mjs --install-enforcement."}'
   exit 0
 fi
 

--- a/scripts/bp1-deadline-sweep.mjs
+++ b/scripts/bp1-deadline-sweep.mjs
@@ -51,6 +51,7 @@
 'use strict'
 
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
@@ -91,7 +92,11 @@ const emit = !bool('--no-emit')
 
 const SCRIPT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname))
 const FLAG_CHECK = path.join(SCRIPT_DIR, 'bp1-flag-check.mjs')
-const EM_STORE = path.join(SCRIPT_DIR, 'em-store.mjs')
+// em-store is SUBSTRATE (stays global): co-located in dev/repo, else the global
+// substrate root (RFC-008 P4d / Principle 12 — enforcement may call the substrate).
+const EM_STORE = fs.existsSync(path.join(SCRIPT_DIR, 'em-store.mjs'))
+  ? path.join(SCRIPT_DIR, 'em-store.mjs')
+  : path.join(os.homedir(), '.episodic-memory', 'scripts', 'em-store.mjs')
 
 // ---------------------------------------------------------------------------
 // Resolve project root

--- a/scripts/bp1-flag-check.mjs
+++ b/scripts/bp1-flag-check.mjs
@@ -33,6 +33,7 @@
  */
 
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
@@ -142,7 +143,12 @@ function tryEmitEpisode(code, reason, extra) {
   // violation episodes).
   try {
     const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname))
-    const emStore = path.join(repoScripts, 'em-store.mjs')
+    // em-store is SUBSTRATE (global): co-located in dev/repo, else the global root
+    // (RFC-008 P4d / Principle 12 — enforcement may call the global substrate).
+    const _coLocated = path.join(repoScripts, 'em-store.mjs')
+    const emStore = fs.existsSync(_coLocated)
+      ? _coLocated
+      : path.join(os.homedir(), '.episodic-memory', 'scripts', 'em-store.mjs')
     if (!fs.existsSync(emStore)) return
     const projectName = extra.project_root ? path.basename(extra.project_root) : 'unknown'
     const summary = `bp1-flag-check ${code}: ${reason}`
@@ -232,7 +238,11 @@ if (bypass.ok) {
   if (emit) {
     try {
       const repoScripts = path.resolve(path.dirname(new URL(import.meta.url).pathname))
-      const emStore = path.join(repoScripts, 'em-store.mjs')
+      // em-store is SUBSTRATE (global): co-located in dev/repo, else the global root.
+      const _coLocated = path.join(repoScripts, 'em-store.mjs')
+      const emStore = fs.existsSync(_coLocated)
+        ? _coLocated
+        : path.join(os.homedir(), '.episodic-memory', 'scripts', 'em-store.mjs')
       if (fs.existsSync(emStore)) {
         execFileSync('node', [
           emStore,

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -79,10 +79,18 @@ import { writeMarker, cleanupApprovalMarker } from './lib/bp1-marker.mjs'
 import { loadActiveRunsForSweep } from './lib/bp1-sweep-loader.mjs'
 import { scanForCandidates, PATH_B_AGE_THRESHOLD_MS } from './lib/bp1-sweep.mjs'
 
-const REPO_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
-const FLAG_CHECK = path.join(REPO_DIR, 'scripts', 'bp1-flag-check.mjs')
-const RFC_SCAN = path.join(REPO_DIR, 'scripts', 'bp1-rfc-scan.mjs')
-const EM_STORE = path.join(REPO_DIR, 'scripts', 'em-store.mjs')
+// RFC-008 P4d / Principle 12: bp1 scripts install per-project (enforcement). The
+// bp1 siblings are CO-LOCATED with this module (dev: scripts/; installed:
+// <project>/.claude/hooks/), so resolve them from SCRIPT_DIR, not a hardcoded
+// <root>/scripts/ segment. em-store is SUBSTRATE (stays global): co-located in the
+// dev/repo layout, else resolved from the global substrate root — enforcement may
+// call the global substrate.
+const SCRIPT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname))
+const FLAG_CHECK = path.join(SCRIPT_DIR, 'bp1-flag-check.mjs')
+const RFC_SCAN = path.join(SCRIPT_DIR, 'bp1-rfc-scan.mjs')
+const EM_STORE = fs.existsSync(path.join(SCRIPT_DIR, 'em-store.mjs'))
+  ? path.join(SCRIPT_DIR, 'em-store.mjs')
+  : path.join(os.homedir(), '.episodic-memory', 'scripts', 'em-store.mjs')
 
 const INPUT_SHA256_RE = /^[a-f0-9]{64}$/
 const EPISODE_ID_RE = /^[a-z0-9-]+$/

--- a/scripts/enforce-contract.mjs
+++ b/scripts/enforce-contract.mjs
@@ -220,6 +220,21 @@ function dottedGet(obj, dotted) {
  * ambient parent's patterns/).
  */
 export function resolveContractRoot() {
+  // Candidate 0 — CO-LOCATED with this module (RFC-008 P4d / Principle 12). The
+  // engine + its contract config install together per-project under
+  // <project>/.claude/hooks/, so patterns/ + plugins/ sit beside enforce-contract.mjs.
+  // Self-relative: works in EVERY invocation mode with no markerRoot dependency, and
+  // it is what makes enforcement fully project-local (zero reach into global). Accepted
+  // iff the deployed bp-001 contract is present beside the module. In the dev/repo
+  // layout the module sits at scripts/ (no scripts/patterns/) so this falls through to
+  // the candidate-2 in-repo climb below; an installed module finds it here.
+  const self0 = realpathOrNull(fileURLToPath(import.meta.url))
+  if (self0) {
+    const selfDir0 = path.dirname(self0)
+    if (fs.existsSync(path.join(selfDir0, 'patterns', 'bp-001.json'))) return selfDir0
+  }
+  // Candidate 1 — legacy global install root. Retained for back-compat with any
+  // pre-P4d global deploy; fresh P4d installs ship no global contract so this misses.
   const c1 = path.join(os.homedir(), '.episodic-memory')
   if (fs.existsSync(path.join(c1, 'patterns', 'bp-001.json'))) {
     return realpathOrNull(c1) || c1

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -153,15 +153,54 @@ export function isEnforcementEntryScript(basename) {
   return ENFORCEMENT_ENTRY_EXPLICIT.has(basename) || /^bp1-.+\.mjs$/.test(basename)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// SUBSTRATE allowlist (P12 / user directive 2026-06-19). The global
+// ~/.episodic-memory/scripts dir holds the memory SUBSTRATE ONLY: the em-* tools
+// plus the second-opinion review CAPABILITY harness. This is an ALLOWLIST, not a
+// denylist — the prior "every .mjs that isn't enforcement → global" rule silently
+// leaked repo-dev/CI validators (validate-*, scaffold-bp, test-plugin,
+// check-automode-defaults) into the substrate. By the P12 FUNCTION test those
+// exist only to police the repo/enforcement layer; they are NOT substrate. They
+// ship NOWHERE (CI runs them repo-relative: `node scripts/validate-*.mjs`).
+//
+// Three disjoint classes for scripts/*.mjs:
+//   substrate   → global       (isSubstrateScript)
+//   enforcement → per-project  (isEnforcementEntryScript + ENFORCEMENT_HOOK_SCRIPTS)
+//   repo-dev    → nowhere       (isRepoDevScript — the remainder)
+// ───────────────────────────────────────────────────────────────────────────
+const SUBSTRATE_CAPABILITY_SCRIPTS = new Set(['second-opinion.mjs'])
+export function isSubstrateScript(basename) {
+  if (ENFORCEMENT_HOOK_SCRIPTS.includes(basename)) return false
+  return /^em-.+\.mjs$/.test(basename) || SUBSTRATE_CAPABILITY_SCRIPTS.has(basename)
+}
+
+// Repo-only dev/CI scripts: not substrate, not enforcement. Installed NOWHERE.
+export function isRepoDevScript(basename) {
+  return basename.endsWith('.mjs')
+    && !isSubstrateScript(basename)
+    && !isEnforcementEntryScript(basename)
+    && !ENFORCEMENT_HOOK_SCRIPTS.includes(basename)
+}
+
 function listRepoScripts(repoDir) {
   const d = path.join(repoDir, 'scripts')
   return fs.existsSync(d) ? fs.readdirSync(d).filter((f) => f.endsWith('.mjs')) : []
 }
 
 // Transitive relative-import closure (restricted to scripts/lib/*.mjs) of a set of
-// entry scripts. Static parse of `... from '<spec>'` + dynamic `import('<spec>')`,
-// relative specifiers only. Returns a Set of lib basenames.
-function computeLibClosure(repoDir, entryBasenames) {
+// entry scripts. Static parse of three import FORMS — `... from '<spec>'`,
+// dynamic `import('<spec>')`, and bare side-effect `import '<spec>'` — relative
+// specifiers only. Returns a Set of lib basenames.
+//
+// This closure is the SOLE guarantee that the per-project enforcement bundle is
+// import-complete (a dropped transitive lib breaks the relocated engine in a
+// non-this-repo project, and this repo's CI can't catch it — it runs dev-relative
+// where scripts/lib/ is fully present). So all three static forms are matched
+// (review F3). LIMITATION: a COMPUTED dynamic import — `import(variable)` /
+// `import(`./${x}.mjs`)` — cannot be resolved by static analysis; none exist in
+// scripts/ today (grep-verified) and the convention is literal specifiers only.
+// tests/test-lib-closure.mjs asserts the bare-import form is captured.
+export function computeLibClosure(repoDir, entryBasenames) {
   const scriptsDir = path.join(repoDir, 'scripts')
   const libDir = path.join(scriptsDir, 'lib')
   const libs = new Set()
@@ -172,8 +211,11 @@ function computeLibClosure(repoDir, entryBasenames) {
     let src
     try { src = fs.readFileSync(abs, 'utf8') } catch { return }
     // Fresh matcher per call — a single /g regex shares lastIndex across the
-    // recursive walk and would skip imports of nested modules.
-    for (const m of src.matchAll(/(?:from\s*|import\s*\(\s*)['"]([^'"]+)['"]/g)) {
+    // recursive walk and would skip imports of nested modules. The `import\s+`
+    // alternative (require whitespace) matches bare side-effect imports
+    // `import './x.mjs'` without false-matching identifiers; `import(` is caught
+    // by the earlier `import\s*\(` alternative, `import x from` by `from\s*`.
+    for (const m of src.matchAll(/(?:from\s*|import\s*\(\s*|import\s+)['"]([^'"]+)['"]/g)) {
       const spec = m[1]
       if (!spec.startsWith('.')) continue
       let resolved = path.resolve(path.dirname(abs), spec)
@@ -194,13 +236,11 @@ export function enforcementEntryScripts(repoDir) {
   return listRepoScripts(repoDir).filter(isEnforcementEntryScript)
 }
 
-// Scripts that STAY global: substrate (em-*) + dev/CI tooling (validate-*, second-
-// opinion, scaffold-bp, …). Excludes enforcement entries AND the per-project
-// SessionEnd hook script.
+// Scripts that STAY global: SUBSTRATE ONLY — the em-* tools + the second-opinion
+// capability harness (isSubstrateScript allowlist). Enforcement entries relocate
+// per-project; repo-dev/CI tools (validate-*, scaffold-bp, …) ship nowhere.
 export function globalEntryScripts(repoDir) {
-  return listRepoScripts(repoDir).filter(
-    (f) => !isEnforcementEntryScript(f) && !ENFORCEMENT_HOOK_SCRIPTS.includes(f)
-  )
+  return listRepoScripts(repoDir).filter(isSubstrateScript)
 }
 
 // Lib closure that STAYS global — every scripts/lib/*.mjs imported (transitively)
@@ -300,21 +340,26 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
 
   // Scripts — every .mjs under scripts/ EXCEPT enforcement hook scripts
   // (em-session-end-prompt.mjs), which install per-project (Principle 12) and
-  // must not appear as global substrate. The enforcement ENTRY scripts (engine +
-  // classifier + markers + bp1) are emitted scope:'project' — they relocated to
-  // <project>/.claude/hooks/, so migration-cutover (which verifies the GLOBAL
-  // installed copies) excludes them; the installedPath below is the legacy global
-  // location, no longer written.
+  // must not appear as global substrate. Three disjoint scopes:
+  //   substrate (em-* + second-opinion) → global (no scope tag)
+  //   enforcement (engine/classifier/markers/bp1) → scope:'project' (relocated to
+  //     <project>/.claude/hooks/; installedPath below is the legacy global loc)
+  //   repo-dev/CI (validate-*, scaffold-bp, …) → scope:'repo' (shipped NOWHERE;
+  //     CI runs them repo-relative). migration-cutover + global-clean exclude both
+  //     non-global scopes; only substrate is verified at the global installedPath.
   const repoScripts = path.join(repoDir, 'scripts')
   if (fs.existsSync(repoScripts)) {
     for (const f of fs.readdirSync(repoScripts).filter(n => n.endsWith('.mjs') && !ENFORCEMENT_HOOK_SCRIPTS.includes(n))) {
       const rel = `scripts/${f}`
+      const scope = isEnforcementEntryScript(f) ? 'project'
+        : isSubstrateScript(f) ? undefined
+        : 'repo'
       entries.push({
         relativePath: rel,
         repoPath: path.join(repoDir, rel),
         installedPath: path.join(HOME_SCRIPTS(homeDir), f),
         kind: 'script',
-        ...(isEnforcementEntryScript(f) ? { scope: 'project' } : {}),
+        ...(scope ? { scope } : {}),
       })
     }
   }

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -126,6 +126,119 @@ export function enforcementRegistrations() {
   ]
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// RFC-008 P4d / Principle 12 — enforcement SCRIPTS + their lib closure relocate
+// per-project; global holds ONLY substrate + dev/CI tooling.
+//
+// An "enforcement ENTRY script" is a .mjs under scripts/ that exists ONLY to be
+// run by a hook: the enforcement ENGINE (enforce-contract), the classifier suite,
+// the marker writers, and the bp1 orchestration. By the P12 FUNCTION test these
+// are enforcement artifacts however packaged → they install under
+// <project>/.claude/hooks/ and NEVER deploy to the global substrate scripts dir.
+//
+// The set is DERIVED (explicit list + the bp1-* family by prefix) so a newly
+// added enforcement script is classified automatically and can't silently leak to
+// global. The transitive relative-import closure (computeLibClosure) decides which
+// scripts/lib/*.mjs travel with them — no hand-maintained lib list to drift.
+// ───────────────────────────────────────────────────────────────────────────
+const ENFORCEMENT_ENTRY_EXPLICIT = new Set([
+  'enforce-contract.mjs',
+  'agent-classifier-dispatch.mjs', 'classifier-config-loader.mjs', 'classifier-marker.mjs',
+  'classifier-override-lookup.mjs', 'classifier-override-persist.mjs', 'classify-correction.mjs',
+  'llm-classify.mjs',
+  'checkpoint-marker.mjs', 'plan-marker.mjs', 'preflight-marker-write.mjs',
+])
+
+export function isEnforcementEntryScript(basename) {
+  return ENFORCEMENT_ENTRY_EXPLICIT.has(basename) || /^bp1-.+\.mjs$/.test(basename)
+}
+
+function listRepoScripts(repoDir) {
+  const d = path.join(repoDir, 'scripts')
+  return fs.existsSync(d) ? fs.readdirSync(d).filter((f) => f.endsWith('.mjs')) : []
+}
+
+// Transitive relative-import closure (restricted to scripts/lib/*.mjs) of a set of
+// entry scripts. Static parse of `... from '<spec>'` + dynamic `import('<spec>')`,
+// relative specifiers only. Returns a Set of lib basenames.
+function computeLibClosure(repoDir, entryBasenames) {
+  const scriptsDir = path.join(repoDir, 'scripts')
+  const libDir = path.join(scriptsDir, 'lib')
+  const libs = new Set()
+  const seen = new Set()
+  const walk = (abs) => {
+    if (seen.has(abs)) return
+    seen.add(abs)
+    let src
+    try { src = fs.readFileSync(abs, 'utf8') } catch { return }
+    // Fresh matcher per call — a single /g regex shares lastIndex across the
+    // recursive walk and would skip imports of nested modules.
+    for (const m of src.matchAll(/(?:from\s*|import\s*\(\s*)['"]([^'"]+)['"]/g)) {
+      const spec = m[1]
+      if (!spec.startsWith('.')) continue
+      let resolved = path.resolve(path.dirname(abs), spec)
+      if (!resolved.endsWith('.mjs') && !fs.existsSync(resolved)) resolved += '.mjs'
+      if (path.dirname(resolved) === libDir) libs.add(path.basename(resolved))
+      walk(resolved)
+    }
+  }
+  for (const e of entryBasenames) {
+    const abs = path.join(scriptsDir, e)
+    if (fs.existsSync(abs)) walk(abs)
+  }
+  return libs
+}
+
+// Enforcement entry scripts present in the repo (engine + classifier + markers + bp1).
+export function enforcementEntryScripts(repoDir) {
+  return listRepoScripts(repoDir).filter(isEnforcementEntryScript)
+}
+
+// Scripts that STAY global: substrate (em-*) + dev/CI tooling (validate-*, second-
+// opinion, scaffold-bp, …). Excludes enforcement entries AND the per-project
+// SessionEnd hook script.
+export function globalEntryScripts(repoDir) {
+  return listRepoScripts(repoDir).filter(
+    (f) => !isEnforcementEntryScript(f) && !ENFORCEMENT_HOOK_SCRIPTS.includes(f)
+  )
+}
+
+// Lib closure that STAYS global — every scripts/lib/*.mjs imported (transitively)
+// by a retained-global script. These are NOT removed from global even if an
+// enforcement script also imports them (e.g. local-dir.mjs, json-instance-validate).
+export function globalScriptLibs(repoDir) {
+  return computeLibClosure(repoDir, globalEntryScripts(repoDir))
+}
+
+// Lib closure that travels INTO the per-project enforcement bundle — every
+// scripts/lib/*.mjs the enforcement entries (incl. the SessionEnd hook script)
+// import. Includes shared substrate libs (local-dir.mjs, …) so the relocated
+// scripts resolve all imports co-located, never reaching into global.
+export function enforcementBundleLibs(repoDir) {
+  return computeLibClosure(repoDir, [...enforcementEntryScripts(repoDir), SESSION_END_SCRIPT])
+}
+
+// Libs that move OUT of global (enforcement-only): in the enforcement bundle and
+// NOT in any retained-global script's closure. Drives the global lib filter + the
+// D4 prune sweep + the P12 global-clean guardrail.
+export function relocatedOnlyLibs(repoDir) {
+  const keep = globalScriptLibs(repoDir)
+  return [...enforcementBundleLibs(repoDir)].filter((l) => !keep.has(l)).sort()
+}
+
+// BP-1 (RFC-004 auto-pilot) is a BEHAVIOR PATTERN, deployed PER-PROJECT alongside
+// its SessionStart hooks on CORE install (not gated on --install-enforcement). Its
+// scripts (bp1-*.mjs) + their lib closure co-locate with the bp1 hooks under
+// <project>/.claude/hooks/. They are still enforcement-by-function for the GLOBAL
+// exclusion (isEnforcementEntryScript matches bp1-* so they never land in global) —
+// these helpers only drive the per-project co-deploy with the bp1 hooks.
+export function bp1EntryScripts(repoDir) {
+  return listRepoScripts(repoDir).filter((f) => /^bp1-.+\.mjs$/.test(f))
+}
+export function bp1ClosureLibs(repoDir) {
+  return [...computeLibClosure(repoDir, bp1EntryScripts(repoDir))]
+}
+
 const HOME_HOOKS = (homeDir) => path.join(homeDir, '.claude', 'hooks')
 const HOME_HOOKS_LIB = (homeDir) => path.join(homeDir, '.claude', 'hooks', 'lib')
 const HOME_SCRIPTS = (homeDir) => path.join(homeDir, '.episodic-memory', 'scripts')

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -95,10 +95,36 @@ export const HOOK_SPECS = [
   }
 ]
 
-// SessionEnd hook is em-session-end-prompt.mjs invoked from the global
-// scripts dir (canonical at $HOME/.episodic-memory/scripts/). The hook
-// command string is built by install.mjs at registration time.
+// SessionEnd hook is em-session-end-prompt.mjs. Per RFC-008 P4d + Principle 12
+// it is an ENFORCEMENT hook script (it runs ONLY as the SessionEnd hook), so it
+// installs PER-PROJECT under <project>/.claude/hooks/ and is EXCLUDED from the
+// global scripts-scan — it is NOT a global substrate script.
 export const SESSION_END_SCRIPT = 'em-session-end-prompt.mjs'
+
+// Enforcement hook SCRIPTS (.mjs that exist only to be run by a hook) — these
+// must NEVER deploy to the global scripts dir (Principle 12); they install
+// per-project. install.mjs's global scripts-scan filters these out.
+export const ENFORCEMENT_HOOK_SCRIPTS = [SESSION_END_SCRIPT]
+
+// DERIVED (Rule 14) from HOOK_SPECS + SESSION_END_SCRIPT — single source of
+// truth so the harness drift guard (A4) and install can't diverge.
+//
+// enforcementHookFileBasenames(): the 8 enforcement hook FILES that install
+// per-project — the unique HOOK_SPECS .sh gates (stop-gate.sh once) plus the
+// SessionEnd hook script. Drives project-side copy AND global prune.
+export function enforcementHookFileBasenames() {
+  return [...new Set(HOOK_SPECS.map((s) => s.file)), ...ENFORCEMENT_HOOK_SCRIPTS]
+}
+
+// enforcementRegistrations(): the 9 enforcement registrations (8 HOOK_SPECS
+// event-entries — stop-gate twice — plus the SessionEnd entry). Drives
+// project-side registration, global de-registration, and the A4 drift guard.
+export function enforcementRegistrations() {
+  return [
+    ...HOOK_SPECS.map((s) => ({ file: s.file, event: s.event, matcher: s.matcher, timeout: s.timeout })),
+    { file: SESSION_END_SCRIPT, event: 'SessionEnd', timeout: 10 },
+  ]
+}
 
 const HOME_HOOKS = (homeDir) => path.join(homeDir, '.claude', 'hooks')
 const HOME_HOOKS_LIB = (homeDir) => path.join(homeDir, '.claude', 'hooks', 'lib')
@@ -135,7 +161,11 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
       relativePath: rel,
       repoPath: path.join(repoDir, rel),
       installedPath: path.join(HOME_HOOKS(homeDir), spec.file),
-      kind: 'hook'
+      kind: 'hook',
+      // RFC-008 P4d / Principle 12: enforcement hooks install per-project, not
+      // global. migration-cutover excludes scope:'project' (the installedPath
+      // above is the legacy global location, no longer written).
+      scope: 'project'
     })
   }
 
@@ -148,15 +178,19 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
         relativePath: rel,
         repoPath: path.join(repoDir, rel),
         installedPath: path.join(HOME_HOOKS_LIB(homeDir), f),
-        kind: 'hook-lib'
+        kind: 'hook-lib',
+        // P12: hook libs install per-project alongside their hooks.
+        scope: 'project'
       })
     }
   }
 
-  // Scripts — every .mjs under scripts/.
+  // Scripts — every .mjs under scripts/ EXCEPT enforcement hook scripts
+  // (em-session-end-prompt.mjs), which install per-project (Principle 12) and
+  // must not appear as global substrate.
   const repoScripts = path.join(repoDir, 'scripts')
   if (fs.existsSync(repoScripts)) {
-    for (const f of fs.readdirSync(repoScripts).filter(n => n.endsWith('.mjs'))) {
+    for (const f of fs.readdirSync(repoScripts).filter(n => n.endsWith('.mjs') && !ENFORCEMENT_HOOK_SCRIPTS.includes(n))) {
       const rel = `scripts/${f}`
       entries.push({
         relativePath: rel,

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -300,7 +300,11 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
 
   // Scripts — every .mjs under scripts/ EXCEPT enforcement hook scripts
   // (em-session-end-prompt.mjs), which install per-project (Principle 12) and
-  // must not appear as global substrate.
+  // must not appear as global substrate. The enforcement ENTRY scripts (engine +
+  // classifier + markers + bp1) are emitted scope:'project' — they relocated to
+  // <project>/.claude/hooks/, so migration-cutover (which verifies the GLOBAL
+  // installed copies) excludes them; the installedPath below is the legacy global
+  // location, no longer written.
   const repoScripts = path.join(repoDir, 'scripts')
   if (fs.existsSync(repoScripts)) {
     for (const f of fs.readdirSync(repoScripts).filter(n => n.endsWith('.mjs') && !ENFORCEMENT_HOOK_SCRIPTS.includes(n))) {
@@ -309,21 +313,26 @@ export function buildInstallManifest(repoDir, homeDir = os.homedir()) {
         relativePath: rel,
         repoPath: path.join(repoDir, rel),
         installedPath: path.join(HOME_SCRIPTS(homeDir), f),
-        kind: 'script'
+        kind: 'script',
+        ...(isEnforcementEntryScript(f) ? { scope: 'project' } : {}),
       })
     }
   }
 
-  // Script lib — every .mjs under scripts/lib/.
+  // Script lib — every .mjs under scripts/lib/. Enforcement-only libs
+  // (relocatedOnlyLibs) travel per-project with their scripts → scope:'project'.
+  // Libs shared with a retained-global script stay global (no scope).
   const repoScriptsLib = path.join(repoDir, 'scripts', 'lib')
   if (fs.existsSync(repoScriptsLib)) {
+    const relocated = new Set(relocatedOnlyLibs(repoDir))
     for (const f of fs.readdirSync(repoScriptsLib).filter(n => n.endsWith('.mjs'))) {
       const rel = `scripts/lib/${f}`
       entries.push({
         relativePath: rel,
         repoPath: path.join(repoDir, rel),
         installedPath: path.join(HOME_SCRIPTS_LIB(homeDir), f),
-        kind: 'script-lib'
+        kind: 'script-lib',
+        ...(relocated.has(f) ? { scope: 'project' } : {}),
       })
     }
   }

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -23,10 +23,48 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { spawnSync } from 'node:child_process'
+import {
+  enforcementEntryScripts, relocatedOnlyLibs,
+} from '../../scripts/lib/install-manifest.mjs'
 
 export const REPO_ROOT = path.resolve(
   path.dirname(new URL(import.meta.url).pathname), '..', '..'
 )
+
+// The enforce-contract CONFIG files that relocate per-project (RFC-008 P4d / P12 —
+// co-located with the engine under <project>/.claude/hooks/patterns/). NOTE:
+// patterns/_index.json is SUBSTRATE (the behavioral-pattern registry) and stays
+// global by design — it is deliberately NOT in this list.
+export const CONTRACT_CONFIG_FILES = [
+  'bp-001.json', 'events.json', 'enforce-config.schema.json', 'taxonomy.json',
+]
+
+// Enforcement RUNTIME found in GLOBAL scope under `home`: the engine + classifier
+// + markers + bp1 entry scripts (manifest enforcementEntryScripts), the
+// relocated-only libs, the contract config, and the contract plugins index — none
+// may live in ~/.episodic-memory/. Manifest-derived so a newly added enforcement
+// script is covered automatically (no hand-list to drift). Returns sorted
+// rel-paths; [] == P12-clean. Complements enforcementFilesInGlobalScope (hooks)
+// and hookCodeFilesInGlobalScope (~/.claude/hooks/).
+export function enforcementRuntimeInGlobalScope(home) {
+  const out = []
+  const gScripts = path.join(home, '.episodic-memory', 'scripts')
+  for (const f of enforcementEntryScripts(REPO_ROOT)) {
+    if (fs.existsSync(path.join(gScripts, f))) out.push(`.episodic-memory/scripts/${f}`)
+  }
+  const gLib = path.join(gScripts, 'lib')
+  for (const f of relocatedOnlyLibs(REPO_ROOT)) {
+    if (fs.existsSync(path.join(gLib, f))) out.push(`.episodic-memory/scripts/lib/${f}`)
+  }
+  const gPatterns = path.join(home, '.episodic-memory', 'patterns')
+  for (const f of CONTRACT_CONFIG_FILES) {
+    if (fs.existsSync(path.join(gPatterns, f))) out.push(`.episodic-memory/patterns/${f}`)
+  }
+  if (fs.existsSync(path.join(home, '.episodic-memory', 'plugins', '_index.json'))) {
+    out.push('.episodic-memory/plugins/_index.json')
+  }
+  return out.sort()
+}
 
 // Command-string fragments that identify an RFC-008 ENFORCEMENT hook.
 //

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -54,6 +54,39 @@ export const ENFORCEMENT_HOOK_MARKERS = [
   'second-opinion-gate',
 ]
 
+// Enforcement hook FILE basenames that must live ONLY under <project>/.claude/
+// (P12) — never in global ~/.claude/hooks/ or, for the SessionEnd hook script,
+// ~/.episodic-memory/scripts/. 7 gate/recall/.sh hooks + the SessionEnd hook
+// script. Distinct from ENFORCEMENT_HOOK_MARKERS (command-string fragments for
+// settings-registration detection): this is about FILES on disk.
+export const ENFORCEMENT_HOOK_FILES = [
+  'checkpoint-gate.sh',
+  'plan-gate.sh',
+  'preflight-gate.sh',
+  'stop-gate.sh',
+  'preflight-prompt-helper.sh',
+  'em-recall-sessionstart.sh',
+  'session-handoff-prompt.sh',
+  'em-session-end-prompt.mjs',
+]
+
+// Return enforcement artifacts found in GLOBAL scope under `home` — any
+// enforcement hook FILE in ~/.claude/hooks/ plus the SessionEnd hook script if
+// present at ~/.episodic-memory/scripts/. Empty array == P12-clean (no hook
+// file in global). This is the on-disk half of the PRINCIPLES.md §12 "Test
+// this" clause; hasEnforcementHook(globalSettings) is the registration half.
+export function enforcementFilesInGlobalScope(home) {
+  const found = []
+  const globalHooks = path.join(home, '.claude', 'hooks')
+  for (const f of ENFORCEMENT_HOOK_FILES) {
+    if (f.endsWith('.mjs')) continue // SessionEnd hook script handled below
+    if (fs.existsSync(path.join(globalHooks, f))) found.push(`.claude/hooks/${f}`)
+  }
+  const sessionEndGlobal = path.join(home, '.episodic-memory', 'scripts', 'em-session-end-prompt.mjs')
+  if (fs.existsSync(sessionEndGlobal)) found.push('.episodic-memory/scripts/em-session-end-prompt.mjs')
+  return found
+}
+
 // Env vars that, if inherited from the test runner's real environment, would
 // defeat HOME isolation: CLAUDE_CONFIG_DIR repoints the settings dir, and the
 // SO_* paths are read by second-opinion-gate.mjs (it would resolve the REAL

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -87,6 +87,28 @@ export function enforcementFilesInGlobalScope(home) {
   return found
 }
 
+// Recursively list EVERY hook CODE file (.sh / .mjs) under global
+// ~/.claude/hooks/. P12: none may exist there — ALL hook code is per-project.
+// This is the COMPREHENSIVE check (any hook file, not just a hand-maintained
+// enforcement list), closing the blind spot where second-opinion-gate.mjs
+// slipped past the enforcement-set-only assertion. Returns sorted rel paths.
+export function hookCodeFilesInGlobalScope(home) {
+  const root = path.join(home, '.claude', 'hooks')
+  const out = []
+  const walk = (dir, rel) => {
+    let entries
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }) } catch { return }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name)
+      const r = rel ? `${rel}/${e.name}` : e.name
+      if (e.isDirectory()) walk(abs, r)
+      else if (e.name.endsWith('.sh') || e.name.endsWith('.mjs')) out.push(`.claude/hooks/${r}`)
+    }
+  }
+  walk(root, '')
+  return out.sort()
+}
+
 // Env vars that, if inherited from the test runner's real environment, would
 // defeat HOME isolation: CLAUDE_CONFIG_DIR repoints the settings dir, and the
 // SO_* paths are read by second-opinion-gate.mjs (it would resolve the REAL

--- a/tests/lib/activation-scoping-harness.mjs
+++ b/tests/lib/activation-scoping-harness.mjs
@@ -24,7 +24,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { spawnSync } from 'node:child_process'
 import {
-  enforcementEntryScripts, relocatedOnlyLibs,
+  enforcementEntryScripts, relocatedOnlyLibs, isSubstrateScript,
 } from '../../scripts/lib/install-manifest.mjs'
 
 export const REPO_ROOT = path.resolve(
@@ -64,6 +64,24 @@ export function enforcementRuntimeInGlobalScope(home) {
     out.push('.episodic-memory/plugins/_index.json')
   }
   return out.sort()
+}
+
+// COMPREHENSIVE global-substrate check (P12 / user directive 2026-06-19): the
+// global ~/.episodic-memory/scripts dir must hold SUBSTRATE ONLY (em-* + the
+// second-opinion harness). List any *.mjs there that is NOT substrate — this
+// catches BOTH enforcement-runtime leaks AND repo-dev/CI-validator leaks
+// (validate-*, scaffold-bp, …), the class that slipped past the enforcement-set-
+// only enforcementRuntimeInGlobalScope check. Returns sorted rel-paths; [] ==
+// substrate-clean. The second-opinion/ harness SUBTREE (recursively copied) is
+// legitimate substrate and is excluded by only scanning the top-level .mjs files.
+export function nonSubstrateScriptsInGlobalScope(home) {
+  const gScripts = path.join(home, '.episodic-memory', 'scripts')
+  let entries
+  try { entries = fs.readdirSync(gScripts) } catch { return [] }
+  return entries
+    .filter((f) => f.endsWith('.mjs') && !isSubstrateScript(f))
+    .map((f) => `.episodic-memory/scripts/${f}`)
+    .sort()
 }
 
 // Command-string fragments that identify an RFC-008 ENFORCEMENT hook.

--- a/tests/test-bp1-sweep-on-session.mjs
+++ b/tests/test-bp1-sweep-on-session.mjs
@@ -112,9 +112,15 @@ function writeConfig(homeDir, projectRoot, entry) {
 }
 
 function buildHashAgainstHome(projectRoot, homeDir) {
+  // RFC-008 P4d / Principle 12: bp1 scripts install CO-LOCATED per-project under
+  // <project>/.claude/hooks/. The unit fixtures stage them at the legacy global
+  // scripts dir; the real-install test (case 9) co-locates them. Resolve whichever
+  // exists so both shapes use the same artifact-manifest builder.
+  const coLocated = path.join(projectRoot, '.claude', 'hooks', 'bp1-build-artifact-manifest.mjs')
+  const global = path.join(homeDir, '.episodic-memory', 'scripts', 'bp1-build-artifact-manifest.mjs')
+  const script = fs.existsSync(coLocated) ? coLocated : global
   const out = execFileSync('node', [
-    path.join(homeDir, '.episodic-memory', 'scripts', 'bp1-build-artifact-manifest.mjs'),
-    '--project', projectRoot, '--json',
+    script, '--project', projectRoot, '--json',
   ], { encoding: 'utf8', env: { ...process.env, HOME: homeDir } })
   return JSON.parse(out).sha256
 }

--- a/tests/test-install-contract-deploy.mjs
+++ b/tests/test-install-contract-deploy.mjs
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
-// test-install-contract-deploy.mjs — RFC-008 P3b-2 (§10 install-runtime contract
-// deploy; mirrors the P3c T20a2 coupling regression). The enforce-contract runtime
-// contract set (bp-001.json + events.json + enforce-config.schema.json) is
-// co-deployed to $HOME/.episodic-memory/patterns/ ONLY inside --install-hooks
-// (COUPLED to the hook install, like the P3c taxonomy deploy): stop-gate.sh invokes
-// enforce-contract.mjs, so a no-hooks install must NOT advance the global contract
-// while the installed gate stays stale.
+// test-install-contract-deploy.mjs — RFC-008 P4d / Principle 12 (relocated
+// 2026-06-19; was P3b-2 §10 global-contract deploy). The enforce-contract RUNTIME
+// contract set (bp-001.json + events.json + enforce-config.schema.json + taxonomy.json)
+// + plugins/_index.json is the engine's CONFIG. By the P12 function test it is
+// ENFORCEMENT, not substrate, so it deploys PER-PROJECT — CO-LOCATED with the engine
+// under <project>/.claude/hooks/{patterns,plugins}/ — under --install-enforcement,
+// and NEVER to the global $HOME/.episodic-memory/patterns/.
 //
-//   T1 — --install-hooks deploys the full coupled set, byte-equal to the repo.
+//   T1 — --install-enforcement deploys the full coupled set per-project, byte-equal repo.
 //   T2 — F-NEW-4 coupling: deployed bp-001.events_version == sha(deployed events.json).
-//   T3 — no-hooks install leaves the contract set ABSENT (the T20a2 analog), while
-//        the unconditional patterns/_index.json IS deployed.
+//   T3 — GLOBAL stays clean: the contract set is ABSENT from ~/.episodic-memory/patterns/
+//        even WITH --install-enforcement (P12), while the substrate patterns/_index.json
+//        IS deployed global unconditionally.
 
 import fs from 'fs'
 import os from 'os'
@@ -36,54 +37,64 @@ function mkSandbox(label) {
   execFileSync('git', ['init', '-q'], { cwd: project })
   return { home, project }
 }
-function runInstall({ home, project, hooks }) {
+function runInstall({ home, project, enforcement }) {
   const args = [INSTALL, '--tool', 'claude-code', '--project', project]
-  if (hooks) args.push('--install-hooks')
+  if (enforcement) args.push('--install-enforcement')
   return spawnSync('node', args, { cwd: project, encoding: 'utf8', env: { ...process.env, HOME: home } })
 }
+// Engine candidate-0 contract root: co-located with the engine under the project hooks dir.
+function projectContractRoot(project) { return path.join(project, '.claude', 'hooks') }
+function projectPatterns(project) { return path.join(projectContractRoot(project), 'patterns') }
 function globalPatterns(home) { return path.join(home, '.episodic-memory', 'patterns') }
 function byteEqual(a, b) { return fs.readFileSync(a).equals(fs.readFileSync(b)) }
 
-console.log('=== T1/T2: --install-hooks deploys the coupled contract set ===')
+console.log('=== T1/T2: --install-enforcement deploys the coupled contract set PER-PROJECT ===')
 {
-  const { home, project } = mkSandbox('hooks')
-  const r = runInstall({ home, project, hooks: true })
-  truthy('T1: install --install-hooks exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
-  const gp = globalPatterns(home)
+  const { home, project } = mkSandbox('enforce')
+  const r = runInstall({ home, project, enforcement: true })
+  truthy('T1: install --install-enforcement exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
+  const pp = projectPatterns(project)
   for (const f of CONTRACT_SET) {
-    const dep = path.join(gp, f)
-    truthy(`T1: ${f} deployed`, fs.existsSync(dep), `missing ${dep}`)
+    const dep = path.join(pp, f)
+    truthy(`T1: ${f} deployed per-project`, fs.existsSync(dep), `missing ${dep}`)
     if (fs.existsSync(dep)) truthy(`T1: ${f} byte-equal repo`, byteEqual(dep, path.join(REPO, 'patterns', f)), 'deployed bytes differ from repo')
   }
+  // taxonomy.json travels with the contract set (the classifier reads it co-located).
+  truthy('T1: taxonomy.json deployed per-project', fs.existsSync(path.join(pp, 'taxonomy.json')), `missing ${path.join(pp, 'taxonomy.json')}`)
   // T2 — coupling assertion: deployed bp-001.events_version == sha(deployed events.json).
   try {
-    const depBp = JSON.parse(fs.readFileSync(path.join(gp, 'bp-001.json'), 'utf8'))
-    const depEvents = JSON.parse(fs.readFileSync(path.join(gp, 'events.json'), 'utf8'))
+    const depBp = JSON.parse(fs.readFileSync(path.join(pp, 'bp-001.json'), 'utf8'))
+    const depEvents = JSON.parse(fs.readFileSync(path.join(pp, 'events.json'), 'utf8'))
     truthy('T2: deployed bp-001.events_version == sha(deployed events.json)', depBp.events_version === eventsVersion(depEvents),
       `bp=${depBp.events_version} live=${eventsVersion(depEvents)}`)
   } catch (e) { bad('T2: coupling readable', e.message) }
-  // PR-1 (R3/R6/R8): the harness-cap registry the runtime reads from
-  // <contractRoot>/plugins/_index.json MUST be deployed to the global plugins/
-  // tree — else resolveHarnessCap is dead in prod and M8/CLASS-C(a) never fire.
-  const depRegistry = path.join(home, '.episodic-memory', 'plugins', '_index.json')
-  truthy('PR-1: plugins/_index.json deployed to global plugins/ (--install-hooks)', fs.existsSync(depRegistry), `missing ${depRegistry}`)
+  // The harness-cap registry the engine reads from <contractRoot>/plugins/_index.json
+  // is co-located with the engine, per-project.
+  const depRegistry = path.join(projectContractRoot(project), 'plugins', '_index.json')
+  truthy('PR-1: plugins/_index.json deployed per-project (co-located with engine)', fs.existsSync(depRegistry), `missing ${depRegistry}`)
   if (fs.existsSync(depRegistry)) truthy('PR-1: deployed registry byte-equal repo', byteEqual(depRegistry, path.join(REPO, 'plugins', '_index.json')), 'deployed registry differs from repo')
+
+  // P12: the contract set must NOT appear in GLOBAL ~/.episodic-memory/patterns/.
+  const gp = globalPatterns(home)
+  for (const f of [...CONTRACT_SET, 'taxonomy.json']) {
+    truthy(`P12: ${f} ABSENT from global patterns (even with --install-enforcement)`, !fs.existsSync(path.join(gp, f)), `LEAKED to global: ${path.join(gp, f)}`)
+  }
+  truthy('P12: global plugins/_index.json ABSENT (contract registry is per-project)', !fs.existsSync(path.join(home, '.episodic-memory', 'plugins', '_index.json')), 'contract plugins index leaked to global')
 }
 
 console.log('')
-console.log('=== T3: no-hooks install leaves the contract set ABSENT (T20a2 analog) ===')
+console.log('=== T3: substrate patterns/_index.json still deployed global unconditionally ===')
 {
   const { home, project } = mkSandbox('nohooks')
-  const r = runInstall({ home, project, hooks: false })
-  truthy('T3: install (no hooks) exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
+  const r = runInstall({ home, project, enforcement: false })
+  truthy('T3: install (core) exits 0', r.status === 0, `status=${r.status} stderr=${(r.stderr || '').slice(-400)}`)
   const gp = globalPatterns(home)
-  for (const f of CONTRACT_SET) {
-    truthy(`T3: ${f} ABSENT without --install-hooks`, !fs.existsSync(path.join(gp, f)), `unexpectedly present: ${path.join(gp, f)}`)
+  // The substrate behavioral-pattern registry IS deployed global even on core.
+  truthy('T3: patterns/_index.json (substrate) deployed unconditionally', fs.existsSync(path.join(gp, '_index.json')), 'expected _index.json present')
+  // The enforce-contract config set is NEVER global.
+  for (const f of [...CONTRACT_SET, 'taxonomy.json']) {
+    truthy(`T3: ${f} ABSENT from global patterns`, !fs.existsSync(path.join(gp, f)), `unexpectedly present: ${path.join(gp, f)}`)
   }
-  // The unconditional patterns/_index.json IS deployed even without hooks (existing behavior).
-  truthy('T3: patterns/_index.json deployed unconditionally', fs.existsSync(path.join(gp, '_index.json')), 'expected _index.json present')
-  // PR-1: the global plugins/_index.json is coupled to --install-hooks → absent without it.
-  truthy('T3: plugins/_index.json ABSENT without --install-hooks', !fs.existsSync(path.join(home, '.episodic-memory', 'plugins', '_index.json')), 'unexpectedly present')
 }
 
 console.log('')

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
-# test-install-hooks.sh — Tests for install.mjs --install-hooks (PR-B per #59)
+# test-install-hooks.sh — Tests for install.mjs --install-enforcement (PR-B per #59)
+#
+# RFC-008 P4d / Principle 12: enforcement hooks + the enforcement runtime moved
+# from GLOBAL to PER-PROJECT install. Enforcement now installs under the flag
+# --install-enforcement (NOT --install-hooks) to per-project locations:
+#   - hook .sh + .mjs files → <project>/.claude/hooks/
+#   - hook libs (.sh + .mjs) → <project>/.claude/hooks/lib/
+#   - registrations → <project>/.claude/settings.json (NOT global)
+#   - contract config (taxonomy/bp-001/events/enforce-config.schema.json) →
+#     <project>/.claude/hooks/patterns/
+#   - plugins/_index.json → <project>/.claude/hooks/plugins/_index.json
+# The global hook-freshness manifest ($HOME/.episodic-memory/hook-install.json)
+# is NO LONGER WRITTEN. --install-hooks-force still controls force-overwrite of
+# divergent files, alongside --install-enforcement.
 #
 # Verifies the realistic upgrade path observed locally on 2026-05-02:
 #   - Pre-existing settings.json with unrelated PreToolUse / SessionStart hooks
@@ -65,111 +78,89 @@ assert_eq() {
 echo "[T1] Fresh install: hook files copied, settings.json populated"
 # ---------------------------------------------------------------------------
 reset_state
-run_installer --install-hooks
+run_installer --install-enforcement
 
-[ -x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" ] && r=true || r=false
+[ -x "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" ] && r=true || r=false
 assert_eq "T1a checkpoint-gate.sh installed and executable" "true" "$r"
 
-[ -x "$TEST_HOME/.claude/hooks/em-recall-sessionstart.sh" ] && r=true || r=false
+[ -x "$TEST_PROJECT/.claude/hooks/em-recall-sessionstart.sh" ] && r=true || r=false
 assert_eq "T1b em-recall-sessionstart.sh installed and executable" "true" "$r"
 
 # Issue #86 PR-A: plan-gate.sh canonicalized into repo + deployed by installer.
-[ -x "$TEST_HOME/.claude/hooks/plan-gate.sh" ] && r=true || r=false
+[ -x "$TEST_PROJECT/.claude/hooks/plan-gate.sh" ] && r=true || r=false
 assert_eq "T1b2 plan-gate.sh installed and executable (#86 PR-A)" "true" "$r"
 
-# Session 1 (#86 PR-B / #89 / #101): hooks/lib/ deployed alongside hooks/.
-[ -f "$TEST_HOME/.claude/hooks/lib/command-classifier.sh" ] && r=true || r=false
+# Session 1 (#86 PR-B / #89 / #101): hooks/lib/ deployed alongside hooks/
+# (per-project: <project>/.claude/hooks/lib/).
+[ -f "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" ] && r=true || r=false
 assert_eq "T1b3 hooks/lib/command-classifier.sh installed (Session 1)" "true" "$r"
-[ -f "$TEST_HOME/.claude/hooks/lib/repo-root.sh" ] && r=true || r=false
+[ -f "$TEST_PROJECT/.claude/hooks/lib/repo-root.sh" ] && r=true || r=false
 assert_eq "T1b4 hooks/lib/repo-root.sh installed (Session 1)" "true" "$r"
 # Hooks should be able to source the lib (smoke test).
-HOME="$TEST_HOME" bash -c "source $TEST_HOME/.claude/hooks/lib/command-classifier.sh && type classify_command >/dev/null 2>&1" && r=true || r=false
+HOME="$TEST_HOME" bash -c "source $TEST_PROJECT/.claude/hooks/lib/command-classifier.sh && type classify_command >/dev/null 2>&1" && r=true || r=false
 assert_eq "T1b5 installed lib sources successfully and exports classify_command" "true" "$r"
 
-[ -f "$TEST_HOME/.episodic-memory/hook-install.json" ] && r=true || r=false
-assert_eq "T1b6 hook freshness manifest written (#103)" "true" "$r"
+# (RFC-008 P4d) hook-freshness manifest removed — enforcement installs per-project; see test-p12-global-clean.mjs
 
-manifest_source=$(jq -r '.source_repo' "$TEST_HOME/.episodic-memory/hook-install.json")
-assert_eq "T1b7 hook freshness manifest records source repo (#103)" "$REPO_ROOT" "$manifest_source"
-
-managed_count=$(jq '[.files[]? | select(.relative_path | test("^plugins/claude-code/hooks/.*\\.sh$"))] | length' "$TEST_HOME/.episodic-memory/hook-install.json")
-# 7 hook .sh files (checkpoint-gate, plan-gate, preflight-gate,
-# preflight-prompt-helper, em-recall-sessionstart, session-handoff-prompt,
-# stop-gate) + 6 hooks/lib/.sh files (command-classifier, repo-root,
-# marker-paths, session-id, agent-classifier, agent-classifier-deny-reason) = 13.
-# NOTE (PR-B): was hardcoded "10" and went stale when PR #331 added the
-# classifier lib (this test runs in no CI workflow). Corrected to 11, then to 12
-# when PR-B2 (#351) added the 3-way deny-hint lib agent-classifier-deny-reason.sh,
-# then to 13 when checkpoint-hygiene F3 brought session-handoff-prompt.sh under
-# HOOK_SPECS. The test is wired into CI (plan-marker-validate.yml) to catch
-# future drift.
-assert_eq "T1b8 hook freshness manifest covers managed hooks and libs (#103)" "13" "$managed_count"
-
-pg_manifest=$(jq -r '.files[] | select(.relative_path == "plugins/claude-code/hooks/plan-gate.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
-assert_eq "T1b9 hook freshness manifest records plan-gate install path (#103)" "$TEST_HOME/.claude/hooks/plan-gate.sh" "$pg_manifest"
-
-cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1c PreToolUse contains exactly one checkpoint-gate entry" "1" "$cg_count"
 
-pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1c2 PreToolUse contains exactly one plan-gate entry (#86 PR-A)" "1" "$pg_count"
 
 # plan-gate.sh registers with NO matcher (per design — must run on every
 # PreToolUse so the tool-name allowlist is the sole filter).
-pg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("plan-gate")) | .matcher // "<none>"' "$TEST_HOME/.claude/settings.json")
+pg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("plan-gate")) | .matcher // "<none>"' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1c3 plan-gate registered with no matcher (runs on every PreToolUse)" "<none>" "$pg_matcher"
 
-ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
+ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1d SessionStart contains exactly one em-recall-sessionstart entry" "1" "$ss_count"
 
 # session-handoff-prompt.sh tracking (checkpoint-hygiene F3): copied,
-# registered exactly once with timeout 5, manifest row, and ordered AFTER
+# registered exactly once with timeout 5, and ordered AFTER
 # em-recall-sessionstart (matches the pre-existing manual registration).
-[ -f "$TEST_HOME/.claude/hooks/session-handoff-prompt.sh" ] && r=true || r=false
-assert_eq "T1d2 session-handoff-prompt.sh copied to ~/.claude/hooks/ (F3)" "true" "$r"
+[ -f "$TEST_PROJECT/.claude/hooks/session-handoff-prompt.sh" ] && r=true || r=false
+assert_eq "T1d2 session-handoff-prompt.sh copied to <project>/.claude/hooks/ (F3)" "true" "$r"
 
-shp_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+shp_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1d3 SessionStart contains exactly one session-handoff-prompt entry (F3)" "1" "$shp_count"
 
-shp_timeout=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt")) | .timeout' "$TEST_HOME/.claude/settings.json")
+shp_timeout=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt")) | .timeout' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1d4 session-handoff-prompt entry timeout=5s (F3)" "5" "$shp_timeout"
 
-shp_manifest=$(jq -r '.files[] | select(.relative_path == "plugins/claude-code/hooks/session-handoff-prompt.sh") | .installed_path' "$TEST_HOME/.episodic-memory/hook-install.json")
-assert_eq "T1d5 hook freshness manifest records session-handoff-prompt install path (F3)" "$TEST_HOME/.claude/hooks/session-handoff-prompt.sh" "$shp_manifest"
-
-shp_order=$(jq '[.hooks.SessionStart[].hooks[0].command] as $c | ($c | map(test("em-recall-sessionstart")) | index(true)) < ($c | map(test("session-handoff-prompt")) | index(true))' "$TEST_HOME/.claude/settings.json")
+shp_order=$(jq '[.hooks.SessionStart[].hooks[0].command] as $c | ($c | map(test("em-recall-sessionstart")) | index(true)) < ($c | map(test("session-handoff-prompt")) | index(true))' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1d6 em-recall-sessionstart registered before session-handoff-prompt (F3)" "true" "$shp_order"
 
-se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1e SessionEnd contains exactly one em-session-end-prompt entry (nested shape)" "1" "$se_count"
 
-cg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .matcher' "$TEST_HOME/.claude/settings.json")
+cg_matcher=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .matcher' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1f checkpoint-gate matcher is canonical PreToolUse pattern" "Edit|Write|MultiEdit|Bash|NotebookEdit" "$cg_matcher"
 
-cg_type=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .hooks[0].type' "$TEST_HOME/.claude/settings.json")
+cg_type=$(jq -r '.hooks.PreToolUse[] | select(.hooks[]?.command|test("checkpoint-gate")) | .hooks[0].type' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T1g checkpoint-gate hook entry has type=command" "command" "$cg_type"
 
 # ---------------------------------------------------------------------------
 echo "[T2] Re-run idempotence: no duplicate entries, no diff in hook files"
 # ---------------------------------------------------------------------------
-sha_before=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
-run_installer --install-hooks
-sha_after=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+sha_before=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+run_installer --install-enforcement
+sha_after=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
 assert_eq "T2a checkpoint-gate.sh unchanged after re-run" "$sha_before" "$sha_after"
 
-cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T2b still exactly one checkpoint-gate entry after re-run" "1" "$cg_count"
 
-pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T2b2 still exactly one plan-gate entry after re-run (#86 PR-A)" "1" "$pg_count"
 
-ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_HOME/.claude/settings.json")
+ss_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T2c still exactly one em-recall-sessionstart entry after re-run" "1" "$ss_count"
 
-shp_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+shp_count=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("session-handoff-prompt"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T2c2 still exactly one session-handoff-prompt entry after re-run (F3)" "1" "$shp_count"
 
-se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+se_count=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T2d still exactly one em-session-end-prompt entry after re-run" "1" "$se_count"
 
 # ---------------------------------------------------------------------------
@@ -177,8 +168,8 @@ echo "[T3] Migration: pre-existing flat-shape SessionEnd entry rewritten"
 # Regression guard for the bug shipped before PR-B (Rule 15).
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude"
-cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+mkdir -p "$TEST_PROJECT/.claude"
+cat > "$TEST_PROJECT/.claude/settings.json" <<'JSON'
 {
   "hooks": {
     "SessionEnd": [
@@ -190,27 +181,27 @@ cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
   }
 }
 JSON
-run_installer --install-hooks
+run_installer --install-enforcement
 
-flat_count=$(jq '[.hooks.SessionEnd[] | select(.command and (.hooks|not))] | length' "$TEST_HOME/.claude/settings.json")
+flat_count=$(jq '[.hooks.SessionEnd[] | select(.command and (.hooks|not))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T3a no flat-shape SessionEnd entries remain after migration" "0" "$flat_count"
 
 # Migration preserves the original command verbatim — does NOT replace the
-# /old/path/ pointer. The new canonical em-session-end-prompt at SCRIPTS_DIR
-# is then registered as a separate entry (different path, different command,
-# exact-path idempotence treats them distinctly).
-old_path_preserved=$(jq -r '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/"))] | length' "$TEST_HOME/.claude/settings.json")
+# /old/path/ pointer. The new canonical em-session-end-prompt at the per-project
+# hooks dir is then registered as a separate entry (different path, different
+# command, exact-path idempotence treats them distinctly).
+old_path_preserved=$(jq -r '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T3b migrated entry preserves /old/path/ command verbatim" "1" "$old_path_preserved"
 
-old_path_type=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/")) | .type' "$TEST_HOME/.claude/settings.json")
+old_path_type=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("/old/path/")) | .type' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T3c migrated entry has type=command" "command" "$old_path_type"
 
 # ---------------------------------------------------------------------------
 echo "[T4] Pre-existing unrelated hooks: appended, not replaced"
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude"
-cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+mkdir -p "$TEST_PROJECT/.claude"
+cat > "$TEST_PROJECT/.claude/settings.json" <<'JSON'
 {
   "hooks": {
     "PreToolUse": [
@@ -230,29 +221,34 @@ cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
   }
 }
 JSON
-output=$(run_installer_capture --install-hooks)
+output=$(run_installer_capture --install-enforcement)
 
-pre_total=$(jq '.hooks.PreToolUse | length' "$TEST_HOME/.claude/settings.json")
+pre_total=$(jq '.hooks.PreToolUse | length' "$TEST_PROJECT/.claude/settings.json")
 # Post #86 PR-A: existing /some/user/plan-gate.sh + canonical checkpoint-gate
-# + canonical plan-gate = 3 entries. The stale /some/user/plan-gate.sh is
-# preserved verbatim (T4b) and the canonical is registered separately (T4b3).
+# + canonical plan-gate + canonical preflight-gate = 4 entries. The stale
+# /some/user/plan-gate.sh is preserved verbatim (T4b) and the canonical is
+# registered separately (T4b3).
 assert_eq "T4a PreToolUse now has 4 entries (existing plan-gate + canonical checkpoint-gate + canonical plan-gate + canonical preflight-gate)" "4" "$pre_total"
 
-plan_gate_existing=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/some/user/plan-gate.sh")] | length' "$TEST_HOME/.claude/settings.json")
+plan_gate_existing=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/some/user/plan-gate.sh")] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T4b existing /some/user/plan-gate.sh entry preserved verbatim" "1" "$plan_gate_existing"
 
-plan_gate_canonical_path="$TEST_HOME/.claude/hooks/plan-gate.sh"
-plan_gate_canonical=$(jq --arg p "$plan_gate_canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_HOME/.claude/settings.json")
+plan_gate_canonical_path="$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+plan_gate_canonical=$(jq --arg p "$plan_gate_canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T4b2 canonical plan-gate.sh registered at exact installed path (#86 PR-A)" "1" "$plan_gate_canonical"
 
 # Stale-canonical warning surfaced by detectStaleCanonicalEntries.
 if echo "$output" | grep -q "stale PreToolUse entry for plan-gate.sh"; then r=true; else r=false; fi
 assert_eq "T4b3 stale-canonical warning printed for non-canonical /some/user/plan-gate.sh" "true" "$r"
 
-ss_total=$(jq '.hooks.SessionStart | length' "$TEST_HOME/.claude/settings.json")
-assert_eq "T4c SessionStart now has 3 entries (existing + em-recall-sessionstart + session-handoff-prompt)" "3" "$ss_total"
+ss_total=$(jq '.hooks.SessionStart | length' "$TEST_PROJECT/.claude/settings.json")
+# RFC-008 P4d: the always-on BP-1 activation layer (H1 approval-check + H2
+# sweep-on-session) registers 2 SessionStart entries on EVERY install,
+# independent of --install-enforcement. So: existing rules-check + bp1-H1 +
+# bp1-H2 + em-recall-sessionstart + session-handoff-prompt = 5.
+assert_eq "T4c SessionStart now has 5 entries (existing + bp1-H1 + bp1-H2 + em-recall-sessionstart + session-handoff-prompt)" "5" "$ss_total"
 
-rules_check_intact=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("rules-check"))] | length' "$TEST_HOME/.claude/settings.json")
+rules_check_intact=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command|test("rules-check"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T4d existing rules-check.sh entry preserved" "1" "$rules_check_intact"
 
 # ---------------------------------------------------------------------------
@@ -261,20 +257,20 @@ echo "[T5] Divergent local hook file: skipped + new settings registration WITHHE
 # content. New registration only happens when the canonical file is in place.
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-sha_before=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+sha_before=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
 
-output=$(run_installer_capture --install-hooks)
-sha_after=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+output=$(run_installer_capture --install-enforcement)
+sha_after=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
 assert_eq "T5a divergent checkpoint-gate.sh not overwritten" "$sha_before" "$sha_after"
 
 if echo "$output" | grep -q "Skipped (divergent local edit)"; then r=true; else r=false; fi
 assert_eq "T5b warning printed for divergent hook" "true" "$r"
 
-cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T5c new checkpoint-gate registration WITHHELD when file install skipped" "0" "$cg_count"
 
 if echo "$output" | grep -q "registration withheld (file install skipped)"; then r=true; else r=false; fi
@@ -282,12 +278,12 @@ assert_eq "T5d explicit 'registration withheld' message printed" "true" "$r"
 
 # T5e: divergent + prior registration exists → registration preserved, no duplicate.
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-canon_path="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-cat > "$TEST_HOME/.claude/settings.json" <<JSON
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+canon_path="$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+cat > "$TEST_PROJECT/.claude/settings.json" <<JSON
 {
   "hooks": {
     "PreToolUse": [
@@ -301,8 +297,8 @@ cat > "$TEST_HOME/.claude/settings.json" <<JSON
   }
 }
 JSON
-output=$(run_installer_capture --install-hooks)
-cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+output=$(run_installer_capture --install-enforcement)
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T5e prior registration preserved when file install skipped" "1" "$cg_count"
 
 if echo "$output" | grep -q "existing registration preserved"; then r=true; else r=false; fi
@@ -312,23 +308,23 @@ assert_eq "T5f explicit 'existing registration preserved' message printed" "true
 echo "[T6] --install-hooks-force overrides divergent file AND registers"
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-echo "# user-customized" >> "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-run_installer --install-hooks --install-hooks-force
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+run_installer --install-enforcement --install-hooks-force
 
 sha_repo=$(shasum "$REPO_ROOT/plugins/claude-code/hooks/checkpoint-gate.sh" | awk '{print $1}')
-sha_dest=$(shasum "$TEST_HOME/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
 assert_eq "T6a --install-hooks-force overwrites divergent hook with repo version" "$sha_repo" "$sha_dest"
 
-cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T6b --install-hooks-force registers checkpoint-gate after overwrite" "1" "$cg_count"
 
 # ---------------------------------------------------------------------------
 echo "[T7] Identical existing hook: 'unchanged' status, registration proceeds"
 # ---------------------------------------------------------------------------
-output=$(run_installer_capture --install-hooks)
+output=$(run_installer_capture --install-enforcement)
 if echo "$output" | grep -q "Hook already current.*checkpoint-gate"; then r=true; else r=false; fi
 assert_eq "T7 identical hook reports 'already current'" "true" "$r"
 
@@ -336,14 +332,14 @@ assert_eq "T7 identical hook reports 'already current'" "true" "$r"
 echo "[T8] Missing settings.json: created with correct shape"
 # ---------------------------------------------------------------------------
 reset_state
-[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
+[ -f "$TEST_PROJECT/.claude/settings.json" ] && r=true || r=false
 assert_eq "T8a settings.json absent before install" "false" "$r"
 
-run_installer --install-hooks
-[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
+run_installer --install-enforcement
+[ -f "$TEST_PROJECT/.claude/settings.json" ] && r=true || r=false
 assert_eq "T8b settings.json created" "true" "$r"
 
-hooks_present=$(jq 'has("hooks")' "$TEST_HOME/.claude/settings.json")
+hooks_present=$(jq 'has("hooks")' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T8c created settings.json has hooks key" "true" "$hooks_present"
 
 # ---------------------------------------------------------------------------
@@ -352,24 +348,24 @@ echo "[T9] Atomic settings.json write: orphan .tmp does not corrupt original"
 # scenario leaves the existing settings.json intact.
 # ---------------------------------------------------------------------------
 reset_state
-run_installer --install-hooks
-sha_settings_before=$(shasum "$TEST_HOME/.claude/settings.json" | awk '{print $1}')
+run_installer --install-enforcement
+sha_settings_before=$(shasum "$TEST_PROJECT/.claude/settings.json" | awk '{print $1}')
 
 # Plant an orphan .tmp from a notional crashed prior run. The installer's next
 # atomic write must overwrite the .tmp via fs.writeFileSync (truncate semantics)
 # then rename atomically — leaving no .tmp behind and the real settings.json
 # valid JSON post-run.
-echo "{ partial garbage" > "$TEST_HOME/.claude/settings.json.tmp"
-run_installer --install-hooks
+echo "{ partial garbage" > "$TEST_PROJECT/.claude/settings.json.tmp"
+run_installer --install-enforcement
 
-if [ -f "$TEST_HOME/.claude/settings.json.tmp" ]; then r=true; else r=false; fi
+if [ -f "$TEST_PROJECT/.claude/settings.json.tmp" ]; then r=true; else r=false; fi
 assert_eq "T9a orphan .tmp cleared after atomic write (renamed away)" "false" "$r"
 
-if jq empty "$TEST_HOME/.claude/settings.json" 2>/dev/null; then r=true; else r=false; fi
+if jq empty "$TEST_PROJECT/.claude/settings.json" 2>/dev/null; then r=true; else r=false; fi
 assert_eq "T9b settings.json is valid JSON after atomic write" "true" "$r"
 
 # Re-running without changes should be byte-identical (atomic determinism).
-sha_settings_after=$(shasum "$TEST_HOME/.claude/settings.json" | awk '{print $1}')
+sha_settings_after=$(shasum "$TEST_PROJECT/.claude/settings.json" | awk '{print $1}')
 assert_eq "T9c second atomic write yields byte-identical settings.json" "$sha_settings_before" "$sha_settings_after"
 
 # ---------------------------------------------------------------------------
@@ -379,8 +375,8 @@ echo "[T10] Exact-path idempotence: same basename at different path is NOT a dup
 # false-positive and skip the canonical registration.
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude"
-cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+mkdir -p "$TEST_PROJECT/.claude"
+cat > "$TEST_PROJECT/.claude/settings.json" <<'JSON'
 {
   "hooks": {
     "PreToolUse": [
@@ -394,29 +390,37 @@ cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
   }
 }
 JSON
-run_installer --install-hooks
+run_installer --install-enforcement
 
-cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T10a both checkpoint-gate registrations coexist (different paths)" "2" "$cg_total"
 
 # Non-canonical entry preserved verbatim.
-nc=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/somewhere/else/checkpoint-gate.sh")] | length' "$TEST_HOME/.claude/settings.json")
+nc=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command == "/somewhere/else/checkpoint-gate.sh")] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T10b non-canonical /somewhere/else/checkpoint-gate.sh entry preserved" "1" "$nc"
 
-canonical_path="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-canon_count=$(jq --arg p "$canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_HOME/.claude/settings.json")
+canonical_path="$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+canon_count=$(jq --arg p "$canonical_path" '[.hooks.PreToolUse[]?.hooks[]? | select(.command == $p)] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T10c canonical checkpoint-gate.sh registered at exact installed path" "1" "$canon_count"
 
 # ---------------------------------------------------------------------------
-echo "[T11] Code-review P2: --install-hooks-force without --install-hooks warns + no-ops"
+echo "[T11] Code-review P2: --install-hooks-force without --install-hooks/--install-enforcement warns + no enforcement install"
 # ---------------------------------------------------------------------------
 reset_state
 output=$(run_installer_capture --install-hooks-force)
 if echo "$output" | grep -q "Warning: --install-hooks-force has no effect without --install-hooks"; then r=true; else r=false; fi
 assert_eq "T11a warning printed when force flag passed alone" "true" "$r"
 
-[ -f "$TEST_HOME/.claude/settings.json" ] && r=true || r=false
-assert_eq "T11b no settings.json created (hook block was correctly skipped)" "false" "$r"
+# RFC-008 P4d: the enforcement block is gated on --install-enforcement, so a
+# bare --install-hooks-force installs NO enforcement gate. (The always-on BP-1
+# activation layer still creates settings.json with its 2 SessionStart hooks —
+# that is the substrate activation layer, not enforcement.) Assert no
+# enforcement hook (checkpoint-gate) was registered.
+cg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json" 2>/dev/null || echo 0)
+assert_eq "T11b no enforcement hook registered (enforcement block correctly skipped)" "0" "$cg_count"
+
+[ -f "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" ] && r=true || r=false
+assert_eq "T11c no enforcement hook file installed (enforcement block correctly skipped)" "false" "$r"
 
 # ---------------------------------------------------------------------------
 echo "[T12] Code-review P2: stale-canonical detection after migration"
@@ -425,8 +429,8 @@ echo "[T12] Code-review P2: stale-canonical detection after migration"
 # is added separately. Installer must warn about the resulting stale entry.
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude"
-cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
+mkdir -p "$TEST_PROJECT/.claude"
+cat > "$TEST_PROJECT/.claude/settings.json" <<'JSON'
 {
   "hooks": {
     "SessionEnd": [
@@ -438,12 +442,12 @@ cat > "$TEST_HOME/.claude/settings.json" <<'JSON'
   }
 }
 JSON
-output=$(run_installer_capture --install-hooks)
+output=$(run_installer_capture --install-enforcement)
 if echo "$output" | grep -q "stale SessionEnd entry for em-session-end-prompt.mjs"; then r=true; else r=false; fi
 assert_eq "T12a stale-canonical warning printed for migrated /old/bogus/path/" "true" "$r"
 
 # Both entries coexist: canonical (newly registered) + stale (migrated, preserved verbatim).
-sec=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_HOME/.claude/settings.json")
+sec=$(jq '[.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T12b both em-session-end-prompt entries coexist (canonical + stale)" "2" "$sec"
 
 # ---------------------------------------------------------------------------
@@ -460,9 +464,9 @@ if [[ "$TEST_HOME" != *" "* ]]; then
 fi
 
 if [[ "$TEST_HOME" == *" "* ]]; then
-  run_installer --install-hooks
+  run_installer --install-enforcement
 
-  cg_cmd=$(jq -r '.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate")) | .command' "$TEST_HOME/.claude/settings.json")
+  cg_cmd=$(jq -r '.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate")) | .command' "$TEST_PROJECT/.claude/settings.json")
   case "$cg_cmd" in
     "'"*"'") r=true ;;
     *) r=false ;;
@@ -475,12 +479,12 @@ if [[ "$TEST_HOME" == *" "* ]]; then
   if echo "$cg_err" | grep -q "No such file"; then r=true; else r=false; fi
   assert_eq "T13b checkpoint-gate command resolves under sh -c (no 'No such file')" "false" "$r"
 
-  ss_cmd=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart")) | .command' "$TEST_HOME/.claude/settings.json")
+  ss_cmd=$(jq -r '.hooks.SessionStart[]?.hooks[]? | select(.command|test("em-recall-sessionstart")) | .command' "$TEST_PROJECT/.claude/settings.json")
   ss_err=$(sh -c "$ss_cmd </dev/null 2>&1" || true)
   if echo "$ss_err" | grep -q "No such file"; then r=true; else r=false; fi
   assert_eq "T13c sessionstart command resolves under sh -c" "false" "$r"
 
-  se_cmd=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt")) | .command' "$TEST_HOME/.claude/settings.json")
+  se_cmd=$(jq -r '.hooks.SessionEnd[]?.hooks[]? | select(.command|test("em-session-end-prompt")) | .command' "$TEST_PROJECT/.claude/settings.json")
   # Extract the quoted path arg (everything after `node `) and verify the file exists.
   se_path=$(echo "$se_cmd" | sed -E "s/^node //; s/^'(.*)'\$/\1/")
   [ -f "$se_path" ] && r=true || r=false
@@ -495,18 +499,17 @@ echo "[T14] Codex post-PR review: v1→v2 upgrade idempotence on spaced paths"
 # ---------------------------------------------------------------------------
 if [[ "$TEST_HOME" == *" "* ]]; then
   # Hand-craft a v1-style unquoted entry.
-  legacy_cmd="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
   cleanup
   TEST_HOME=$(mktemp -d -t "em hooks ")
   TEST_PROJECT=$(mktemp -d -t "em proj ")
-  legacy_cmd="$TEST_HOME/.claude/hooks/checkpoint-gate.sh"
-  mkdir -p "$TEST_HOME/.claude/hooks"
+  legacy_cmd="$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+  mkdir -p "$TEST_PROJECT/.claude/hooks"
   # First place a copy of the canonical hook so installHookFile reports
   # 'unchanged' (file install eligibility succeeds) — so addHookEntry's
   # idempotence check is what determines whether we duplicate.
   cp "$REPO_ROOT/plugins/claude-code/hooks/checkpoint-gate.sh" "$legacy_cmd"
   chmod +x "$legacy_cmd"
-  cat > "$TEST_HOME/.claude/settings.json" <<JSON
+  cat > "$TEST_PROJECT/.claude/settings.json" <<JSON
 {
   "hooks": {
     "PreToolUse": [
@@ -520,9 +523,9 @@ if [[ "$TEST_HOME" == *" "* ]]; then
   }
 }
 JSON
-  run_installer --install-hooks
+  run_installer --install-enforcement
 
-  cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+  cg_total=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("checkpoint-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
   assert_eq "T14 v1 unquoted entry is recognized as canonical; no duplicate added" "1" "$cg_total"
 fi
 
@@ -533,30 +536,30 @@ echo "[T15] Issue #86 PR-A: divergent local plan-gate.sh — skipped + reg withh
 # not point Claude at unreviewed custom content.
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
-echo "# user-customized plan-gate" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
-sha_before=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+echo "# user-customized plan-gate" >> "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+sha_before=$(shasum "$TEST_PROJECT/.claude/hooks/plan-gate.sh" | awk '{print $1}')
 
-output=$(run_installer_capture --install-hooks)
-sha_after=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+output=$(run_installer_capture --install-enforcement)
+sha_after=$(shasum "$TEST_PROJECT/.claude/hooks/plan-gate.sh" | awk '{print $1}')
 assert_eq "T15a divergent plan-gate.sh not overwritten" "$sha_before" "$sha_after"
 
 if echo "$output" | grep -q "Skipped (divergent local edit).*plan-gate.sh"; then r=true; else r=false; fi
 assert_eq "T15b warning printed for divergent plan-gate" "true" "$r"
 
-pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T15c new plan-gate registration WITHHELD when file install skipped" "0" "$pg_count"
 
 # T15d: divergent plan-gate + prior canonical registration → preserved.
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
-echo "# user-customized" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
-canon_pg_path="$TEST_HOME/.claude/hooks/plan-gate.sh"
-cat > "$TEST_HOME/.claude/settings.json" <<JSON
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+canon_pg_path="$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+cat > "$TEST_PROJECT/.claude/settings.json" <<JSON
 {
   "hooks": {
     "PreToolUse": [
@@ -569,8 +572,8 @@ cat > "$TEST_HOME/.claude/settings.json" <<JSON
   }
 }
 JSON
-output=$(run_installer_capture --install-hooks)
-pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+output=$(run_installer_capture --install-enforcement)
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T15d prior plan-gate registration preserved when file install skipped" "1" "$pg_count"
 
 # P2 (code review): assert the user-visible "existing registration preserved"
@@ -584,17 +587,17 @@ assert_eq "T15e explicit 'existing registration preserved' message printed for p
 echo "[T16] Issue #86 PR-A: --install-hooks-force overwrites divergent plan-gate AND registers"
 # ---------------------------------------------------------------------------
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/plan-gate.sh"
-echo "# user-customized" >> "$TEST_HOME/.claude/hooks/plan-gate.sh"
-chmod +x "$TEST_HOME/.claude/hooks/plan-gate.sh"
-run_installer --install-hooks --install-hooks-force
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/plan-gate.sh"
+run_installer --install-enforcement --install-hooks-force
 
 sha_repo=$(shasum "$REPO_ROOT/plugins/claude-code/hooks/plan-gate.sh" | awk '{print $1}')
-sha_dest=$(shasum "$TEST_HOME/.claude/hooks/plan-gate.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_PROJECT/.claude/hooks/plan-gate.sh" | awk '{print $1}')
 assert_eq "T16a --install-hooks-force overwrites divergent plan-gate with repo version" "$sha_repo" "$sha_dest"
 
-pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_HOME/.claude/settings.json")
+pg_count=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command|test("plan-gate"))] | length' "$TEST_PROJECT/.claude/settings.json")
 assert_eq "T16b --install-hooks-force registers plan-gate after overwrite" "1" "$pg_count"
 
 # ---------------------------------------------------------------------------
@@ -603,11 +606,11 @@ assert_eq "T16b --install-hooks-force registers plan-gate after overwrite" "1" "
 echo ""
 echo "--- T17: UserPromptSubmit hook wiring (#238 C6) ---"
 reset_state
-run_installer --install-hooks
+run_installer --install-enforcement
 
 # Hook file copied
-if [ -f "$TEST_HOME/.claude/hooks/preflight-prompt-helper.sh" ]; then
-  echo "  ✓ T17a preflight-prompt-helper.sh copied to ~/.claude/hooks/"
+if [ -f "$TEST_PROJECT/.claude/hooks/preflight-prompt-helper.sh" ]; then
+  echo "  ✓ T17a preflight-prompt-helper.sh copied to <project>/.claude/hooks/"
   ((passed++))
 else
   echo "  ✗ T17a preflight-prompt-helper.sh missing"
@@ -615,15 +618,15 @@ else
 fi
 
 # Registered under UserPromptSubmit (event-agnostic addHookEntry path)
-ups_count=$(jq '[.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper"))] | length' "$TEST_HOME/.claude/settings.json" 2>/dev/null || echo 0)
+ups_count=$(jq '[.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper"))] | length' "$TEST_PROJECT/.claude/settings.json" 2>/dev/null || echo 0)
 assert_eq "T17b preflight-prompt-helper registered on UserPromptSubmit" "1" "$ups_count"
 
 # No matcher on the entry (UserPromptSubmit always fires per hooks ref:85)
-ups_matcher=$(jq -r '.hooks.UserPromptSubmit[]? | select(.hooks[].command | test("preflight-prompt-helper")) | .matcher // "absent"' "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+ups_matcher=$(jq -r '.hooks.UserPromptSubmit[]? | select(.hooks[].command | test("preflight-prompt-helper")) | .matcher // "absent"' "$TEST_PROJECT/.claude/settings.json" 2>/dev/null)
 assert_eq "T17c UserPromptSubmit entry has no matcher" "absent" "$ups_matcher"
 
 # Timeout from HOOK_SPECS (5s)
-ups_timeout=$(jq -r '.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper")) | .timeout' "$TEST_HOME/.claude/settings.json" 2>/dev/null)
+ups_timeout=$(jq -r '.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper")) | .timeout' "$TEST_PROJECT/.claude/settings.json" 2>/dev/null)
 assert_eq "T17d UserPromptSubmit entry timeout=5s" "5" "$ups_timeout"
 
 # ---------------------------------------------------------------------------
@@ -701,15 +704,18 @@ echo "[T19] PR-B orphan sweep: renamed llm-classifier.* deleted when new files c
 reset_state
 # Pre-seed stale installed copies of the OLD names (as if upgrading from a
 # pre-PR-B install). The repo no longer ships these basenames, so the glob copy
-# won't touch them; the conditional sweep must delete them.
-mkdir -p "$TEST_HOME/.claude/hooks/lib" "$TEST_HOME/.episodic-memory/scripts"
-echo "# stale old wrapper" > "$TEST_HOME/.claude/hooks/lib/llm-classifier.sh"
+# won't touch them; the conditional sweep must delete them. RFC-008 P4d: the
+# lib .sh orphan now lives per-project at <project>/.claude/hooks/lib/; the
+# .mjs dispatch orphan stays at the GLOBAL $HOME/.episodic-memory/scripts/
+# (SCRIPTS_DIR in install.mjs RENAMED_REMOVED).
+mkdir -p "$TEST_PROJECT/.claude/hooks/lib" "$TEST_HOME/.episodic-memory/scripts"
+echo "# stale old wrapper" > "$TEST_PROJECT/.claude/hooks/lib/llm-classifier.sh"
 echo "// stale old dispatcher" > "$TEST_HOME/.episodic-memory/scripts/llm-classifier-dispatch.mjs"
-output=$(run_installer_capture --install-hooks)
+output=$(run_installer_capture --install-enforcement)
 
-[ -f "$TEST_HOME/.claude/hooks/lib/agent-classifier.sh" ] && r=true || r=false
+[ -f "$TEST_PROJECT/.claude/hooks/lib/agent-classifier.sh" ] && r=true || r=false
 assert_eq "T19a new agent-classifier.sh installed" "true" "$r"
-[ -e "$TEST_HOME/.claude/hooks/lib/llm-classifier.sh" ] && r=true || r=false
+[ -e "$TEST_PROJECT/.claude/hooks/lib/llm-classifier.sh" ] && r=true || r=false
 assert_eq "T19b stale llm-classifier.sh swept (deleted)" "false" "$r"
 [ -e "$TEST_HOME/.episodic-memory/scripts/llm-classifier-dispatch.mjs" ] && r=true || r=false
 assert_eq "T19c stale llm-classifier-dispatch.mjs swept (deleted)" "false" "$r"
@@ -719,57 +725,78 @@ assert_eq "T19d sweep logged the removal" "true" "$r"
 # T19e: sweep WITHHELD when command-classifier.sh is divergent (skipped) — must
 # not delete an orphan a still-divergent command-classifier.sh might source.
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks/lib"
-echo "#!/bin/bash" > "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
-echo "# user-customized divergent classifier" >> "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
-echo "# stale old wrapper" > "$TEST_HOME/.claude/hooks/lib/llm-classifier.sh"
-output=$(run_installer_capture --install-hooks)
+mkdir -p "$TEST_PROJECT/.claude/hooks/lib"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+echo "# user-customized divergent classifier" >> "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+echo "# stale old wrapper" > "$TEST_PROJECT/.claude/hooks/lib/llm-classifier.sh"
+output=$(run_installer_capture --install-enforcement)
 
-[ -e "$TEST_HOME/.claude/hooks/lib/llm-classifier.sh" ] && r=true || r=false
+[ -e "$TEST_PROJECT/.claude/hooks/lib/llm-classifier.sh" ] && r=true || r=false
 assert_eq "T19e stale llm-classifier.sh NOT swept while command-classifier.sh divergent" "true" "$r"
 if echo "$output" | grep -q "Skipped orphan sweep"; then r=true; else r=false; fi
 assert_eq "T19f sweep-withheld message printed on divergent command-classifier" "true" "$r"
 
 # ---------------------------------------------------------------------------
-# T20: RFC-008 P3c — taxonomy.json runtime-sourcing co-deploy + divergent WARN
+# T20: RFC-008 P4d / P3c — taxonomy.json + contract-set PER-PROJECT co-deploy + divergent WARN
 # ---------------------------------------------------------------------------
-# T20a: an --install-hooks install co-deploys patterns/taxonomy.json to the SAME
-# global root the classifier reads at runtime ($HOME/.episodic-memory/patterns),
-# byte-equal to the repo (codex R2-P2 install/runtime root parity). Coupled to
-# the classifier deploy so taxonomy never advances on its own.
+# RFC-008 P4d / Principle 12: the enforce-contract runtime config (taxonomy.json,
+# bp-001/events/enforce-config.schema.json, plugins/_index.json) is ENFORCEMENT,
+# not substrate — it now deploys PER-PROJECT under <project>/.claude/hooks/patterns/
+# (co-located with the engine), NOT to the global $HOME/.episodic-memory/patterns/.
+# T20a: an --install-enforcement install deploys patterns/taxonomy.json to the
+# per-project root the classifier reads at runtime, byte-equal to the repo.
 reset_state
-run_installer --install-hooks >/dev/null 2>&1
-GLOBAL_TAX="$TEST_HOME/.episodic-memory/patterns/taxonomy.json"
-[ -f "$GLOBAL_TAX" ] && r=true || r=false
-assert_eq "T20a taxonomy.json co-deployed to global patterns dir (--install-hooks)" "true" "$r"
-if cmp -s "$REPO_ROOT/patterns/taxonomy.json" "$GLOBAL_TAX"; then r=true; else r=false; fi
+run_installer --install-enforcement >/dev/null 2>&1
+PROJ_TAX="$TEST_PROJECT/.claude/hooks/patterns/taxonomy.json"
+[ -f "$PROJ_TAX" ] && r=true || r=false
+assert_eq "T20a taxonomy.json deployed to per-project patterns dir (--install-enforcement)" "true" "$r"
+if cmp -s "$REPO_ROOT/patterns/taxonomy.json" "$PROJ_TAX"; then r=true; else r=false; fi
 assert_eq "T20b deployed taxonomy.json is byte-equal to repo" "true" "$r"
 
-# T20a2 (PR-level codex BLOCKER regression): a NO-hooks install must NOT deploy
-# the global taxonomy — otherwise it would advance runtime candidate-1 while an
-# already-installed classifier stays stale + unwarned (silent taxonomy_drift).
+# T20b2: the contract set (bp-001/events/enforce-config.schema) + plugins/_index.json
+# co-deploy per-project alongside taxonomy.
+[ -f "$TEST_PROJECT/.claude/hooks/patterns/bp-001.json" ] && \
+  [ -f "$TEST_PROJECT/.claude/hooks/patterns/events.json" ] && \
+  [ -f "$TEST_PROJECT/.claude/hooks/patterns/enforce-config.schema.json" ] && \
+  [ -f "$TEST_PROJECT/.claude/hooks/plugins/_index.json" ] && r=true || r=false
+assert_eq "T20b3 contract set + plugins/_index.json co-deployed per-project" "true" "$r"
+
+# T20b4: the global $HOME/.episodic-memory/patterns/ holds NO enforcement contract
+# config — ONLY the substrate behavioral-pattern registry (_index.json) stays global.
+[ -f "$TEST_HOME/.episodic-memory/patterns/taxonomy.json" ] && r=true || r=false
+assert_eq "T20b4 taxonomy.json ABSENT from global patterns dir (per-project only)" "false" "$r"
+[ -f "$TEST_HOME/.episodic-memory/patterns/bp-001.json" ] && r=true || r=false
+assert_eq "T20b5 contract set ABSENT from global patterns dir (per-project only)" "false" "$r"
+[ -f "$TEST_HOME/.episodic-memory/patterns/_index.json" ] && r=true || r=false
+assert_eq "T20b6 substrate _index.json STILL deployed to global patterns dir (unchanged)" "true" "$r"
+
+# T20a2 (PR-level codex BLOCKER regression): a NO-enforcement install must NOT
+# deploy taxonomy anywhere — neither per-project nor global. Taxonomy is gated
+# on --install-enforcement (it is enforcement config, not substrate).
 reset_state
 run_installer >/dev/null 2>&1
+[ -f "$TEST_PROJECT/.claude/hooks/patterns/taxonomy.json" ] && r=true || r=false
+assert_eq "T20a2 no-enforcement install does NOT deploy per-project taxonomy (coupling)" "false" "$r"
 [ -f "$TEST_HOME/.episodic-memory/patterns/taxonomy.json" ] && r=true || r=false
-assert_eq "T20a2 no-hooks install does NOT deploy global taxonomy (coupling)" "false" "$r"
+assert_eq "T20a3 no-enforcement install does NOT deploy global taxonomy" "false" "$r"
 
 # T20c: pre-P3c divergent classifier (no _ensure_taxonomy_synced helper) kept +
 # taxonomy redeployed → WARN that the gate is NOT taxonomy-synced (codex R1-P1b).
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks/lib"
+mkdir -p "$TEST_PROJECT/.claude/hooks/lib"
 printf '#!/bin/bash\n# user-customized divergent classifier (pre-P3c, no helper)\n' \
-  > "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
-output=$(run_installer_capture --install-hooks)
+  > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+output=$(run_installer_capture --install-enforcement)
 if echo "$output" | grep -q "pre-P3c"; then r=true; else r=false; fi
 assert_eq "T20c pre-P3c divergent classifier emits 'not taxonomy-synced' WARN" "true" "$r"
 
 # T20d: post-P3c divergent classifier (HAS the helper) kept + taxonomy redeployed
 # → WARN that it will FAIL CLOSED on drift (the other split branch).
 reset_state
-mkdir -p "$TEST_HOME/.claude/hooks/lib"
+mkdir -p "$TEST_PROJECT/.claude/hooks/lib"
 printf '#!/bin/bash\n_ensure_taxonomy_synced() { :; }\n# divergent local edit, post-P3c\n' \
-  > "$TEST_HOME/.claude/hooks/lib/command-classifier.sh"
-output=$(run_installer_capture --install-hooks)
+  > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+output=$(run_installer_capture --install-enforcement)
 if echo "$output" | grep -q "FAIL CLOSED"; then r=true; else r=false; fi
 assert_eq "T20d post-P3c divergent classifier emits 'FAIL CLOSED' WARN" "true" "$r"
 

--- a/tests/test-install-second-opinion-e2e.mjs
+++ b/tests/test-install-second-opinion-e2e.mjs
@@ -211,14 +211,26 @@ test('happy install: exit 0, Done!, full surface populated, snapshot valid', () 
   assert.ok(r.stdout.includes('Done!'), `expected Done! in stdout; got: ${r.stdout}`)
 
   // Active surface populated.
+  // RFC-008 P4d / Principle 12: the PreToolUse gate code (gate + libs +
+  // runbooks) installs PER-PROJECT under <project>/.claude/hooks/, never
+  // global. The harness RUNTIME (scripts/second-opinion.mjs) stays GLOBAL
+  // under ~/.episodic-memory/ (substrate/review tooling), and the providers
+  // snapshot (second-opinion-providers.json) stays GLOBAL under
+  // ~/.claude/hooks/ (generated data artifact read via snapshotPath()).
   const harness = path.join(tempHome, '.episodic-memory/scripts/second-opinion.mjs')
-  const hook = path.join(tempHome, '.claude/hooks/second-opinion-gate.mjs')
-  const hookLib = path.join(tempHome, '.claude/hooks/lib/registry-validator.mjs')
+  const hook = path.join(tempProject, '.claude/hooks/second-opinion-gate.mjs')
+  const hookLib = path.join(tempProject, '.claude/hooks/lib/registry-validator.mjs')
+  const runbook = path.join(tempProject, '.claude/hooks/runbooks/second-opinion-harness.md')
   const snapshot = path.join(tempHome, '.claude/hooks/second-opinion-providers.json')
-  assert.ok(fs.existsSync(harness), `harness must exist at ${harness}`)
-  assert.ok(fs.existsSync(hook), `hook must exist at ${hook}`)
-  assert.ok(fs.existsSync(hookLib), `hook lib must exist at ${hookLib}`)
-  assert.ok(fs.existsSync(snapshot), `snapshot must exist at ${snapshot}`)
+  assert.ok(fs.existsSync(harness), `harness (global runtime) must exist at ${harness}`)
+  assert.ok(fs.existsSync(hook), `hook (per-project) must exist at ${hook}`)
+  assert.ok(fs.existsSync(hookLib), `hook lib (per-project) must exist at ${hookLib}`)
+  assert.ok(fs.existsSync(runbook), `hook runbook (per-project) must exist at ${runbook}`)
+  assert.ok(fs.existsSync(snapshot), `snapshot (global) must exist at ${snapshot}`)
+
+  // The gate code must NOT land in GLOBAL ~/.claude/hooks/ anymore (P12).
+  assert.ok(!fs.existsSync(path.join(tempHome, '.claude/hooks/second-opinion-gate.mjs')),
+    'gate must NOT install to global ~/.claude/hooks/ (per-project only, P12)')
 
   // Snapshot has at least one provider (stub is always available()).
   const snap = JSON.parse(fs.readFileSync(snapshot, 'utf8'))

--- a/tests/test-lib-closure.mjs
+++ b/tests/test-lib-closure.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * test-lib-closure.mjs — regression guard for computeLibClosure's import-form
+ * coverage (RFC-008 P4d S2, review finding F3).
+ *
+ * computeLibClosure is the SOLE guarantee that the per-project enforcement bundle
+ * (enforcementBundleLibs) is import-complete. A relative import FORM the walker
+ * misses → a transitive lib silently dropped from the bundle → the relocated
+ * engine fails at runtime in a non-this-repo project, uncatchable by this repo's
+ * dev-relative CI. F3: the walker missed bare side-effect `import './x.mjs'`.
+ *
+ * This builds a throwaway scripts/ fixture exercising every static import form +
+ * recursion + the non-captured cases, and asserts the resolved lib closure.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import assert from 'node:assert'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { computeLibClosure } from '../scripts/lib/install-manifest.mjs'
+
+let passed = 0, failed = 0
+const failures = []
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  ✓ ${name}`) }
+  catch (e) { failed++; failures.push({ name, error: e.stack || e.message }); console.log(`  ✗ ${name}: ${e.message}`) }
+}
+
+console.log('# test-lib-closure (RFC-008 P4d S2 — F3 import-form coverage)')
+
+// Build a fixture repo: <tmp>/scripts/{entry.mjs, lib/*.mjs}.
+const repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'libclosure-')))
+process.on('exit', () => { try { fs.rmSync(repo, { recursive: true, force: true }) } catch {} })
+const scriptsDir = path.join(repo, 'scripts')
+const libDir = path.join(scriptsDir, 'lib')
+fs.mkdirSync(libDir, { recursive: true })
+
+// entry.mjs exercises ALL FOUR import forms + a non-relative + a computed import.
+fs.writeFileSync(path.join(scriptsDir, 'entry.mjs'), [
+  `import './lib/bare.mjs'`,                  // bare side-effect (F3: was missed)
+  `import def from './lib/default.mjs'`,      // default import
+  `export { x } from './lib/reexport.mjs'`,  // re-export
+  `const d = await import('./lib/dynamic.mjs')`, // dynamic literal
+  `import fs from 'node:fs'`,                 // non-relative → NOT captured
+  `const m = './lib/computed.mjs'; await import(m)`, // computed → NOT captured (documented limit)
+].join('\n'))
+
+// bare.mjs recurses into nested.mjs via a bare import → must be captured transitively.
+fs.writeFileSync(path.join(libDir, 'bare.mjs'), `import './nested.mjs'\n`)
+for (const f of ['default.mjs', 'reexport.mjs', 'dynamic.mjs', 'nested.mjs', 'computed.mjs']) {
+  fs.writeFileSync(path.join(libDir, f), `export const ok = true\n`)
+}
+
+const closure = computeLibClosure(repo, ['entry.mjs'])
+
+test('F3: bare side-effect `import \'./x\'` is captured', () => {
+  assert.ok(closure.has('bare.mjs'), `bare.mjs missing from closure: ${[...closure].sort().join(', ')}`)
+})
+test('bare import recurses transitively (nested.mjs captured)', () => {
+  assert.ok(closure.has('nested.mjs'), `nested.mjs missing: ${[...closure].sort().join(', ')}`)
+})
+test('default + re-export + dynamic-literal forms all captured', () => {
+  for (const f of ['default.mjs', 'reexport.mjs', 'dynamic.mjs']) {
+    assert.ok(closure.has(f), `${f} missing: ${[...closure].sort().join(', ')}`)
+  }
+})
+test('non-relative import is NOT captured (node:fs)', () => {
+  assert.ok(!closure.has('fs'), 'node:fs leaked into closure')
+})
+test('computed dynamic import is NOT captured (documented static-analysis limit)', () => {
+  assert.ok(!closure.has('computed.mjs'),
+    'computed import unexpectedly resolved — if static analysis was extended, update the F3 limitation note')
+})
+test('closure is exactly the 5 statically-resolvable relative libs', () => {
+  assert.deepStrictEqual([...closure].sort(),
+    ['bare.mjs', 'default.mjs', 'dynamic.mjs', 'nested.mjs', 'reexport.mjs'])
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) { for (const f of failures) console.error(`\n${f.name}\n${f.error}`); process.exit(1) }

--- a/tests/test-migration-cutover.mjs
+++ b/tests/test-migration-cutover.mjs
@@ -4,15 +4,17 @@
  * scripts/lib/install-manifest.mjs.
  *
  * Verifies the install parity check correctly distinguishes OK / DIFF /
- * MISSING / SOURCE_GONE per file in the manifest. Closes Codex round-1 F1
- * (runtime install parity) by ensuring the cutover tool catches stale
- * installed copies before push.
+ * MISSING / SOURCE_GONE per file, and that RFC-008 P4d / Principle 12
+ * scope:'project' entries (enforcement hooks + engine + classifier + markers +
+ * bp1 + their relocated-only libs) are EXCLUDED from the GLOBAL cutover (they
+ * install per-project; their integrity is covered by test-p12-global-clean +
+ * the activation-scoping E2E suite).
  *
  * Layered:
- *   Layer 1 — install-manifest unit tests (manifest contents from a tmp repo)
- *   Layer 2 — migration-cutover integration tests (run subprocess against
- *             a synthetic repo + home pair, parse JSON output, assert state
- *             counts and per-file statuses)
+ *   Layer 1 — install-manifest scope tagging (against the REAL repo, so the
+ *             enforcement-vs-substrate classification + import closure are real).
+ *   Layer 2 — migration-cutover integration over a synthetic GLOBAL-only repo
+ *             (the cutover's view after the scope:'project' filter).
  */
 
 import fs from 'fs'
@@ -50,12 +52,67 @@ function eq(actual, expected, msg) {
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-cutover-'))
 process.on('exit', () => fs.rmSync(tmpRoot, { recursive: true, force: true }))
 
+const FAKE_HOME = path.join(tmpRoot, 'real-manifest-home')
+
+console.log('Layer 1 — install-manifest scope tagging (real repo):')
+
+test('every HOOK_SPECS hook entry is scope:project (P4d — per-project install)', () => {
+  const m = buildInstallManifest(REPO_ROOT, FAKE_HOME)
+  const hooks = m.filter(e => e.kind === 'hook')
+  if (hooks.length === 0) throw new Error('no hook entries')
+  for (const h of hooks) {
+    if (h.scope !== 'project') throw new Error(`hook ${h.relativePath} not scope:project`)
+  }
+  // dedup: stop-gate registered twice (Stop + SubagentStop) → one file entry.
+  const uniqueHookFiles = new Set(HOOK_SPECS.map(s => s.file))
+  eq(hooks.length, uniqueHookFiles.size, 'unique hook file count')
+})
+
+test('enforcement ENGINE/classifier/marker/bp1 scripts are scope:project; substrate em-* are not', () => {
+  const m = buildInstallManifest(REPO_ROOT, FAKE_HOME)
+  const find = (rel) => m.find(e => e.relativePath === rel)
+  // Enforcement entry scripts → scope:'project'.
+  for (const f of ['enforce-contract.mjs', 'classifier-marker.mjs', 'plan-marker.mjs', 'bp1-orchestrator.mjs']) {
+    const e = find(`scripts/${f}`)
+    if (!e) throw new Error(`missing manifest entry scripts/${f}`)
+    eq(e.scope, 'project', `scripts/${f} scope`)
+  }
+  // Substrate scripts → NO project scope (stay global).
+  for (const f of ['em-store.mjs', 'em-recall.mjs', 'em-search.mjs']) {
+    const e = find(`scripts/${f}`)
+    if (!e) throw new Error(`missing manifest entry scripts/${f}`)
+    if (e.scope === 'project') throw new Error(`substrate scripts/${f} must NOT be scope:project`)
+  }
+})
+
+test('relocated-only libs are scope:project; shared substrate libs (local-dir) are not', () => {
+  const m = buildInstallManifest(REPO_ROOT, FAKE_HOME)
+  const find = (rel) => m.find(e => e.relativePath === rel)
+  // marker-state is enforcement-only (in the enforcement closure, not any
+  // retained-global script's closure) → scope:'project'.
+  const ms = find('scripts/lib/marker-state.mjs')
+  if (ms) eq(ms.scope, 'project', 'marker-state lib scope')
+  // local-dir is shared with the em-* substrate → stays global (no project scope).
+  const ld = find('scripts/lib/local-dir.mjs')
+  if (!ld) throw new Error('missing scripts/lib/local-dir.mjs')
+  if (ld.scope === 'project') throw new Error('local-dir.mjs (shared substrate) must NOT be scope:project')
+})
+
+test('buildInstallManifest sorts entries by relativePath', () => {
+  const m = buildInstallManifest(REPO_ROOT, FAKE_HOME)
+  for (let i = 1; i < m.length; i++) {
+    if (m[i].relativePath < m[i - 1].relativePath) {
+      throw new Error(`unsorted at index ${i}: ${m[i - 1].relativePath} > ${m[i].relativePath}`)
+    }
+  }
+})
+
 // ---------------------------------------------------------------------------
-// Synthetic repo + home setup
+// Layer 2 — migration-cutover over a synthetic GLOBAL-only repo.
+// The cutover filters scope:'project', so it only verifies global substrate +
+// dev/CI tooling + global libs + patterns/_index.json. We mirror a minimal
+// global-scoped tree and exercise OK / DIFF / MISSING.
 // ---------------------------------------------------------------------------
-// We mirror the repo's hooks/ + scripts/ + patterns/ structure but with
-// minimal placeholder content. The cutover tool walks the manifest, so we
-// only need files at the expected relative paths.
 const synthRepo = path.join(tmpRoot, 'repo')
 const synthHome = path.join(tmpRoot, 'home')
 
@@ -64,82 +121,20 @@ function mkfile(p, content = 'x') {
   fs.writeFileSync(p, content)
 }
 
-// Mirror real hook + lib + script + script-lib + pattern files.
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/checkpoint-gate.sh'), 'cp\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/plan-gate.sh'), 'plan\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/stop-gate.sh'), 'stop\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/em-recall-sessionstart.sh'), 'sess\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/lib/marker-paths.sh'), 'mp\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/lib/repo-root.sh'), 'rr\n')
-mkfile(path.join(synthRepo, 'plugins/claude-code/hooks/lib/command-classifier.sh'), 'cc\n')
+// Global-scoped sources only (substrate scripts + a shared lib + pattern index).
+// NOTE: no enforce-contract / bp1 / marker scripts here — they'd be scope:'project'
+// and filtered by the cutover, so their absence is irrelevant to this layer.
 mkfile(path.join(synthRepo, 'scripts/em-recall.mjs'), 'er\n')
 mkfile(path.join(synthRepo, 'scripts/em-store.mjs'), 'es\n')
 mkfile(path.join(synthRepo, 'scripts/lib/local-dir.mjs'), 'ld\n')
-mkfile(path.join(synthRepo, 'scripts/lib/marker-paths.mjs'), 'mp-mjs\n')
 mkfile(path.join(synthRepo, 'patterns/_index.json'), '{}\n')
 
-console.log('Layer 1 — install-manifest:')
+// The global-scoped subset the cutover actually verifies for this synth repo.
+function globalManifest() {
+  return buildInstallManifest(synthRepo, synthHome).filter(e => e.scope !== 'project')
+}
 
-test('HOOK_SPECS contains the 5 canonical hooks (incl. stop-gate twice)', () => {
-  // 5 entries (stop-gate registered for Stop AND SubagentStop).
-  eq(HOOK_SPECS.length, 5)
-  const files = HOOK_SPECS.map(s => s.file)
-  for (const f of ['checkpoint-gate.sh', 'plan-gate.sh', 'em-recall-sessionstart.sh', 'stop-gate.sh']) {
-    if (!files.includes(f)) throw new Error(`missing hook file: ${f}`)
-  }
-})
-
-test('buildInstallManifest enumerates hooks + libs + scripts + script-libs + patterns', () => {
-  const m = buildInstallManifest(synthRepo, synthHome)
-  // Expected count: 4 unique hooks + 3 hook libs + 2 scripts + 2 script libs + 1 pattern = 12
-  eq(m.length, 12)
-  const byKind = m.reduce((acc, e) => {
-    acc[e.kind] = (acc[e.kind] || 0) + 1
-    return acc
-  }, {})
-  eq(byKind.hook, 4)        // dedup stop-gate (registered twice)
-  eq(byKind['hook-lib'], 3)
-  eq(byKind.script, 2)
-  eq(byKind['script-lib'], 2)
-  eq(byKind.pattern, 1)
-})
-
-// Codex round-1 F3 regression: HOOK_SPECS entries are emitted even when the
-// repo source files don't exist. Otherwise a wrong --repo produces a
-// vacuously-empty manifest that passes the gate.
-test('buildInstallManifest emits HOOK_SPECS entries even when repo sources missing', () => {
-  const phantomRepo = path.join(tmpRoot, 'phantom-for-manifest-test')
-  // Don't create any files — phantomRepo doesn't even exist.
-  const m = buildInstallManifest(phantomRepo, synthHome)
-  const hookEntries = m.filter(e => e.kind === 'hook')
-  eq(hookEntries.length, 4)  // checkpoint-gate, plan-gate, em-recall-sessionstart, stop-gate
-  // Each hook entry's repoPath should point at the phantom repo's hooks/ dir
-  // (which doesn't exist — that's the point: cutover catches it as SOURCE_GONE).
-  for (const e of hookEntries) {
-    if (!e.repoPath.startsWith(phantomRepo)) {
-      throw new Error(`hook entry repoPath outside phantom repo: ${e.repoPath}`)
-    }
-  }
-})
-
-test('buildInstallManifest sorts entries by relativePath', () => {
-  const m = buildInstallManifest(synthRepo, synthHome)
-  for (let i = 1; i < m.length; i++) {
-    if (m[i].relativePath < m[i - 1].relativePath) {
-      throw new Error(`unsorted at index ${i}: ${m[i - 1].relativePath} > ${m[i].relativePath}`)
-    }
-  }
-})
-
-test('buildInstallManifest installedPath uses HOME_DIR for hook + script roots', () => {
-  const m = buildInstallManifest(synthRepo, synthHome)
-  const checkpoint = m.find(e => e.relativePath === 'plugins/claude-code/hooks/checkpoint-gate.sh')
-  eq(checkpoint.installedPath, path.join(synthHome, '.claude', 'hooks', 'checkpoint-gate.sh'))
-  const recall = m.find(e => e.relativePath === 'scripts/em-recall.mjs')
-  eq(recall.installedPath, path.join(synthHome, '.episodic-memory', 'scripts', 'em-recall.mjs'))
-})
-
-console.log('\nLayer 2 — migration-cutover:')
+console.log('\nLayer 2 — migration-cutover (global-scoped only):')
 
 function runCutover(repoDir, homeDir) {
   const out = execSync(`node ${CUTOVER} --repo ${repoDir} --home ${homeDir} --json`, {
@@ -163,56 +158,30 @@ function runCutoverExpectFail(repoDir, homeDir) {
   }
 }
 
-test('all-MISSING (empty home) → exit 1, all entries MISSING', () => {
-  // Fresh home — nothing installed.
-  const result = runCutoverExpectFail(synthRepo, synthHome)
-  eq(result.allOk, false)
-  eq(result.counts.MISSING, 12)
-  if (result.counts.OK) throw new Error(`unexpected OK count: ${result.counts.OK}`)
-})
-
-// Codex round-1 F3 regression: wrong/empty --repo must NOT vacuously pass.
-test('empty/wrong --repo → exit 1, emptyManifest=false (HOOK_SPECS still emitted) + SOURCE_GONE', () => {
-  // Synthetic empty repo: directory exists but contains no hooks/scripts.
-  const emptyRepo = path.join(tmpRoot, 'empty-repo')
-  fs.mkdirSync(emptyRepo, { recursive: true })
-  const result = runCutoverExpectFail(emptyRepo, synthHome)
-  eq(result.allOk, false)
-  // HOOK_SPECS entries are now emitted unconditionally — 4 unique hook
-  // .sh files (checkpoint-gate, plan-gate, em-recall-sessionstart, stop-gate)
-  // appear with status SOURCE_GONE because the empty-repo paths don't exist.
-  eq(result.emptyManifest, false)
-  if (!result.counts.SOURCE_GONE || result.counts.SOURCE_GONE < 4) {
-    throw new Error(`expected ≥4 SOURCE_GONE entries, got ${JSON.stringify(result.counts)}`)
-  }
-})
-
-test('truly empty manifest (no HOOK_SPECS sources possible) → emptyManifest=true, exit 1', () => {
-  // Construct a "repo" with NO hooks/ subdir AT ALL (HOOK_SPECS would still
-  // emit entries that fail SOURCE_GONE — proves the failure routes through
-  // the SOURCE_GONE counts, not just emptyManifest).
-  const phantomRepo = path.join(tmpRoot, 'phantom-repo-not-a-dir')
-  // Don't even mkdir it. buildInstallManifest still emits HOOK_SPECS entries
-  // (they're unconditional now), so emptyManifest is false; SOURCE_GONE is
-  // the load-bearing failure mode.
-  const result = runCutoverExpectFail(phantomRepo, synthHome)
-  eq(result.allOk, false)
-})
-
-test('all-OK (home installed identically) → exit 0', () => {
-  // Mirror every manifest entry into the home.
-  const m = buildInstallManifest(synthRepo, synthHome)
-  for (const entry of m) {
+test('cutover excludes scope:project (no hook / engine / bp1 entries in results)', () => {
+  // Install the global subset so the run is all-OK, then assert NO project-scoped
+  // path appears in the cutover results.
+  for (const entry of globalManifest()) {
     fs.mkdirSync(path.dirname(entry.installedPath), { recursive: true })
     fs.copyFileSync(entry.repoPath, entry.installedPath)
   }
   const result = runCutover(synthRepo, synthHome)
+  const projectish = result.results.filter(r =>
+    r.relativePath.startsWith('plugins/claude-code/hooks/') ||
+    /scripts\/(enforce-contract|classifier-|classify-|bp1-|checkpoint-marker|plan-marker|preflight-marker)/.test(r.relativePath)
+  )
+  if (projectish.length > 0) {
+    throw new Error(`cutover included scope:project entries: ${projectish.map(r => r.relativePath).join(', ')}`)
+  }
+})
+
+test('all-OK (global subset installed identically) → exit 0', () => {
+  const result = runCutover(synthRepo, synthHome)
   eq(result.allOk, true)
-  eq(result.counts.OK, 12)
+  eq(result.counts.OK, globalManifest().length)
 })
 
 test('one DIFF surfaces correctly → exit 1', () => {
-  // Mutate the installed em-recall to differ from the repo source.
   const installedRecall = path.join(synthHome, '.episodic-memory', 'scripts', 'em-recall.mjs')
   fs.writeFileSync(installedRecall, 'DRIFTED CONTENT\n')
   const result = runCutoverExpectFail(synthRepo, synthHome)
@@ -221,21 +190,26 @@ test('one DIFF surfaces correctly → exit 1', () => {
   if (!recallEntry || recallEntry.status !== 'DIFF') {
     throw new Error(`expected DIFF for em-recall, got ${JSON.stringify(recallEntry)}`)
   }
-  // Restore for next test.
   fs.copyFileSync(path.join(synthRepo, 'scripts/em-recall.mjs'), installedRecall)
 })
 
 test('one MISSING surfaces correctly → exit 1', () => {
-  const installedClassifier = path.join(synthHome, '.claude', 'hooks', 'lib', 'command-classifier.sh')
-  fs.unlinkSync(installedClassifier)
+  const installedLib = path.join(synthHome, '.episodic-memory', 'scripts', 'lib', 'local-dir.mjs')
+  fs.unlinkSync(installedLib)
   const result = runCutoverExpectFail(synthRepo, synthHome)
   eq(result.counts.MISSING, 1)
-  const cc = result.results.find(r => r.relativePath === 'plugins/claude-code/hooks/lib/command-classifier.sh')
-  if (!cc || cc.status !== 'MISSING') {
-    throw new Error(`expected MISSING for command-classifier, got ${JSON.stringify(cc)}`)
+  const lib = result.results.find(r => r.relativePath === 'scripts/lib/local-dir.mjs')
+  if (!lib || lib.status !== 'MISSING') {
+    throw new Error(`expected MISSING for local-dir, got ${JSON.stringify(lib)}`)
   }
-  // Restore.
-  fs.copyFileSync(path.join(synthRepo, 'plugins/claude-code/hooks/lib/command-classifier.sh'), installedClassifier)
+  fs.copyFileSync(path.join(synthRepo, 'scripts/lib/local-dir.mjs'), installedLib)
+})
+
+test('all-MISSING (empty home) → exit 1, no OK', () => {
+  const freshHome = path.join(tmpRoot, 'fresh-home')
+  const result = runCutoverExpectFail(synthRepo, freshHome)
+  eq(result.allOk, false)
+  if (result.counts.OK) throw new Error(`unexpected OK count: ${result.counts.OK}`)
 })
 
 console.log()

--- a/tests/test-p12-global-clean.mjs
+++ b/tests/test-p12-global-clean.mjs
@@ -24,6 +24,7 @@ import assert from 'node:assert'
 import {
   mkMock, runInstall, readSettings,
   hasEnforcementHook, enforcementHookCommands, enforcementFilesInGlobalScope,
+  hookCodeFilesInGlobalScope,
 } from './lib/activation-scoping-harness.mjs'
 
 let passed = 0
@@ -56,12 +57,19 @@ for (const v of VARIANTS) {
     const r = runInstall({ home: M.home, project: M.project, callerCwd: M.callerCwd, flags: v.flags })
     assert.strictEqual(r.status, 0, `install '${v.label}' must exit 0; stderr=${r.stderr}`)
 
-    // (a) No enforcement hook FILE in global scope.
+    // (a) No KNOWN enforcement hook FILE in global scope.
     const globalFiles = enforcementFilesInGlobalScope(M.home)
     assert.deepStrictEqual(globalFiles, [],
       `P12 VIOLATION — enforcement files in global scope after '${v.label}': ${globalFiles.join(', ')}`)
 
-    // (b) No enforcement REGISTRATION in global settings.json.
+    // (b) COMPREHENSIVE: NO hook code file (.sh/.mjs) of ANY kind under global
+    // ~/.claude/hooks/ — not just the hand-maintained enforcement set. This is
+    // the check that catches review tooling (second-opinion-gate.mjs) too.
+    const globalHookCode = hookCodeFilesInGlobalScope(M.home)
+    assert.deepStrictEqual(globalHookCode, [],
+      `P12 VIOLATION — hook code files in global ~/.claude/hooks/ after '${v.label}': ${globalHookCode.join(', ')}`)
+
+    // (c) No enforcement REGISTRATION in global settings.json.
     const g = readSettings('global', M)
     assert.strictEqual(hasEnforcementHook(g), false,
       `P12 VIOLATION — enforcement registrations in global settings after '${v.label}': ${enforcementHookCommands(g).join(', ')}`)

--- a/tests/test-p12-global-clean.mjs
+++ b/tests/test-p12-global-clean.mjs
@@ -24,7 +24,7 @@ import assert from 'node:assert'
 import {
   mkMock, runInstall, readSettings,
   hasEnforcementHook, enforcementHookCommands, enforcementFilesInGlobalScope,
-  hookCodeFilesInGlobalScope,
+  hookCodeFilesInGlobalScope, enforcementRuntimeInGlobalScope,
 } from './lib/activation-scoping-harness.mjs'
 
 let passed = 0
@@ -44,11 +44,17 @@ console.log('# test-p12-global-clean (RFC-008 P4d — PRINCIPLES.md §12 guardra
 
 // Every install variant a user can run WITHOUT the per-project enforcement
 // opt-in. None may place an enforcement artifact in global scope.
+// Core + the opt-in variants. --install-enforcement is INCLUDED here even though
+// it is the per-project enforcement opt-in: P12's whole point is that enforcement
+// goes to the PROJECT, so even WITH --install-enforcement, GLOBAL scope must stay
+// enforcement-clean. That is the strongest form of the guarantee.
 const VARIANTS = [
   { label: 'core (no flags)', flags: [] },
   { label: '--install-hooks', flags: ['--install-hooks', '--install-hooks-force'] },
   { label: '--install-second-opinion', flags: ['--install-second-opinion'] },
   { label: '--install-hooks + --install-second-opinion', flags: ['--install-hooks', '--install-hooks-force', '--install-second-opinion'] },
+  { label: '--install-enforcement', flags: ['--install-enforcement'] },
+  { label: '--install-enforcement + --install-second-opinion', flags: ['--install-enforcement', '--install-second-opinion'] },
 ]
 
 for (const v of VARIANTS) {
@@ -73,6 +79,16 @@ for (const v of VARIANTS) {
     const g = readSettings('global', M)
     assert.strictEqual(hasEnforcementHook(g), false,
       `P12 VIOLATION — enforcement registrations in global settings after '${v.label}': ${enforcementHookCommands(g).join(', ')}`)
+
+    // (d) COMPREHENSIVE RUNTIME: no enforcement ENGINE / classifier / markers /
+    // bp1 entry scripts, no relocated-only libs, no contract config, no contract
+    // plugins index in global ~/.episodic-memory/. This is the script+config half
+    // of the leak the 2026-06-19 audit found (the per-project gates used to shim
+    // back into a global enforce-contract.mjs). Manifest-derived, so it cannot
+    // drift behind a newly added enforcement script.
+    const globalRuntime = enforcementRuntimeInGlobalScope(M.home)
+    assert.deepStrictEqual(globalRuntime, [],
+      `P12 VIOLATION — enforcement runtime in global ~/.episodic-memory/ after '${v.label}': ${globalRuntime.join(', ')}`)
   })
 }
 

--- a/tests/test-p12-global-clean.mjs
+++ b/tests/test-p12-global-clean.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * test-p12-global-clean.mjs — RFC-008 P4d, the governing Principle 12 guardrail.
+ *
+ * PRINCIPLES.md §12 "Test this": after ANY global/core install variant, global
+ * scope must contain ZERO enforcement hook FILES and ZERO enforcement
+ * registrations. Enforcement artifacts (hook files, hook scripts, libs) live
+ * ONLY under <project>/.claude/. A script that runs only as a hook (e.g.
+ * em-session-end-prompt.mjs) is an enforcement artifact, not substrate.
+ *
+ * This test is parametrized over every install variant a user can run WITHOUT
+ * the per-project --install-enforcement opt-in. None of them may leave an
+ * enforcement file in ~/.claude/hooks/ or ~/.episodic-memory/scripts/, nor an
+ * enforcement registration in ~/.claude/settings.json.
+ *
+ * Pre-S2 this FAILS (--install-hooks writes hook files + registrations to
+ * global) — that failure is the proof the guardrail bites. S2 makes it pass by
+ * moving all enforcement per-project.
+ *
+ * Zero deps. Node assert + the activation-scoping fixture lib.
+ */
+
+import assert from 'node:assert'
+import {
+  mkMock, runInstall, readSettings,
+  hasEnforcementHook, enforcementHookCommands, enforcementFilesInGlobalScope,
+} from './lib/activation-scoping-harness.mjs'
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn(); passed++; console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++; failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+console.log('# test-p12-global-clean (RFC-008 P4d — PRINCIPLES.md §12 guardrail)')
+
+// Every install variant a user can run WITHOUT the per-project enforcement
+// opt-in. None may place an enforcement artifact in global scope.
+const VARIANTS = [
+  { label: 'core (no flags)', flags: [] },
+  { label: '--install-hooks', flags: ['--install-hooks', '--install-hooks-force'] },
+  { label: '--install-second-opinion', flags: ['--install-second-opinion'] },
+  { label: '--install-hooks + --install-second-opinion', flags: ['--install-hooks', '--install-hooks-force', '--install-second-opinion'] },
+]
+
+for (const v of VARIANTS) {
+  test(`P12: after '${v.label}', global scope has ZERO enforcement files + registrations`, () => {
+    const M = mkMock('p12')
+    const r = runInstall({ home: M.home, project: M.project, callerCwd: M.callerCwd, flags: v.flags })
+    assert.strictEqual(r.status, 0, `install '${v.label}' must exit 0; stderr=${r.stderr}`)
+
+    // (a) No enforcement hook FILE in global scope.
+    const globalFiles = enforcementFilesInGlobalScope(M.home)
+    assert.deepStrictEqual(globalFiles, [],
+      `P12 VIOLATION — enforcement files in global scope after '${v.label}': ${globalFiles.join(', ')}`)
+
+    // (b) No enforcement REGISTRATION in global settings.json.
+    const g = readSettings('global', M)
+    assert.strictEqual(hasEnforcementHook(g), false,
+      `P12 VIOLATION — enforcement registrations in global settings after '${v.label}': ${enforcementHookCommands(g).join(', ')}`)
+  })
+}
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-p12-global-clean.mjs
+++ b/tests/test-p12-global-clean.mjs
@@ -25,6 +25,7 @@ import {
   mkMock, runInstall, readSettings,
   hasEnforcementHook, enforcementHookCommands, enforcementFilesInGlobalScope,
   hookCodeFilesInGlobalScope, enforcementRuntimeInGlobalScope,
+  nonSubstrateScriptsInGlobalScope,
 } from './lib/activation-scoping-harness.mjs'
 
 let passed = 0
@@ -89,6 +90,16 @@ for (const v of VARIANTS) {
     const globalRuntime = enforcementRuntimeInGlobalScope(M.home)
     assert.deepStrictEqual(globalRuntime, [],
       `P12 VIOLATION — enforcement runtime in global ~/.episodic-memory/ after '${v.label}': ${globalRuntime.join(', ')}`)
+
+    // (e) SUBSTRATE-ONLY: global ~/.episodic-memory/scripts holds NOTHING but
+    // substrate (em-* + second-opinion). Catches the repo-dev/CI-validator leak
+    // class (validate-*, scaffold-bp, test-plugin, check-automode-defaults) that
+    // (d) — scoped to the enforcement set only — does not. By the P12 FUNCTION
+    // test those validators exist only to police the repo/enforcement layer; they
+    // are not substrate and must ship nowhere.
+    const nonSubstrate = nonSubstrateScriptsInGlobalScope(M.home)
+    assert.deepStrictEqual(nonSubstrate, [],
+      `P12 VIOLATION — non-substrate scripts in global ~/.episodic-memory/scripts after '${v.label}': ${nonSubstrate.join(', ')}`)
   })
 }
 

--- a/tools/migration-cutover.mjs
+++ b/tools/migration-cutover.mjs
@@ -51,7 +51,13 @@ function compareFiles(repoPath, installedPath) {
   return a.equals(b) ? 'OK' : 'DIFF'
 }
 
-const manifest = buildInstallManifest(REPO_DIR, HOME_DIR)
+// RFC-008 P4d / Principle 12: scope:'project' entries (enforcement hooks + engine
+// + classifier + markers + bp1 + their relocated-only libs) install PER-PROJECT,
+// not at the global installedPath. This cutover verifies the GLOBAL installed
+// copies are byte-identical to repo (the legacy-fallback-removal migration), so it
+// excludes per-project entries — their integrity is covered by the per-project
+// install + the test-p12-global-clean / activation-scoping E2E suites.
+const manifest = buildInstallManifest(REPO_DIR, HOME_DIR).filter(e => e.scope !== 'project')
 const results = manifest.map(entry => ({
   relativePath: entry.relativePath,
   installedPath: entry.installedPath,

--- a/tools/migration-cutover.mjs
+++ b/tools/migration-cutover.mjs
@@ -51,13 +51,14 @@ function compareFiles(repoPath, installedPath) {
   return a.equals(b) ? 'OK' : 'DIFF'
 }
 
-// RFC-008 P4d / Principle 12: scope:'project' entries (enforcement hooks + engine
-// + classifier + markers + bp1 + their relocated-only libs) install PER-PROJECT,
-// not at the global installedPath. This cutover verifies the GLOBAL installed
-// copies are byte-identical to repo (the legacy-fallback-removal migration), so it
-// excludes per-project entries — their integrity is covered by the per-project
-// install + the test-p12-global-clean / activation-scoping E2E suites.
-const manifest = buildInstallManifest(REPO_DIR, HOME_DIR).filter(e => e.scope !== 'project')
+// RFC-008 P4d / Principle 12: this cutover verifies the GLOBAL installed copies
+// are byte-identical to repo (the legacy-fallback-removal migration), so it keeps
+// ONLY global-substrate entries (no scope tag). Non-global scopes are excluded:
+// scope:'project' (enforcement hooks + engine + classifier + markers + bp1 + their
+// relocated-only libs) install per-project; scope:'repo' (repo-dev/CI validators)
+// ship nowhere. Their integrity is covered by the per-project install + the
+// test-p12-global-clean / activation-scoping E2E suites.
+const manifest = buildInstallManifest(REPO_DIR, HOME_DIR).filter(e => !e.scope)
 const results = manifest.map(entry => ({
   relativePath: entry.relativePath,
   installedPath: entry.installedPath,


### PR DESCRIPTION
## RFC-008 P4d S2 — per-project enforcement install (`--install-enforcement`)

Decouples the **enforcement layer** from the **memory substrate** (RFC-008 P4d core; PRINCIPLES.md §12). This PR is S2 of the P4d slice plan: it relocates ALL enforcement install per-project and makes the global `~/.episodic-memory/` substrate enforcement-clean.

### The three governing P12 invariants

| Invariant | Status after this PR |
|---|---|
| **1. Enforcement separate from substrate** | ✅ engine + classifier + markers + bp1 + contract config relocated per-project; global is substrate-only |
| **2. Per-project on/off switch provisioned** | ⏳ **S4** — install does not yet write `enforce-config.json`; P4c already reads it |
| **3. All enforcement files/scripts/configs at project level** | ✅ files + scripts + configs all per-project |

### What changed

**Relocation (P12 function test — a thing that exists only to run/serve enforcement is enforcement, however packaged → per-project):**
- The enforcement **engine** (`enforce-contract.mjs`), the **classifier** suite, the **marker** writers, the **bp1** orchestration + their transitive `scripts/lib/*.mjs` closure + the **contract config** (taxonomy / bp-001 / events / enforce-config.schema) install under `<project>/.claude/hooks/` (+ `/patterns`, `/plugins`).
- Gate hooks (`*-gate.sh`, `em-recall-sessionstart.sh`, classifier `.sh` libs) resolve via `$HOOK_DIR` (their own dir) with the global path as an **inert legacy fallback**. All 5 gates **fail-closed** when the engine is absent at both locations; R4 non-overridable marker write preserved.
- **BP-1** (RFC-004 auto-pilot) is a behavior pattern: it ships per-project on **core** install (not gated on `--install-enforcement`), self-contained (hooks + bp1 scripts + closure).

**Substrate allowlist (final commit — closes a leak the relocation left open):**
- The global scripts scan was a **denylist** ("any `.mjs` not enforcement → global"), silently leaking 12 repo-dev/CI validators (`validate-*`, `scaffold-bp`, `test-plugin`, `check-automode-defaults`) into the substrate — including enforcement tooling like `validate-bp-contract` / `validate-plan-marker-sites`.
- Flipped to an **allowlist**: global = substrate ONLY (`em-*` + the `second-opinion` capability). Repo-dev tools ship nowhere (CI runs them repo-relative). Global drops **33 → 21** substrate-only scripts.

### Guardrail (Rule 13/14)
`tests/test-p12-global-clean.mjs` — manifest-derived, asserts across all 6 non-`--install-enforcement` variants that global scope has ZERO enforcement files/registrations/runtime AND nothing but substrate scripts. Bites pre-S2; a newly added enforcement/dev script fails CI rather than leaking.

### Review
Second-opinion (`claude-subagent`, grounded against the tree): **ACCEPT-WITH-FOLLOWUPS, zero blocking.** F1 (stale comments), F2 (`--install-hooks` no-op notice), F3 (closure regex missed bare side-effect imports + regression test) **fixed inline**. F4 (3 `em-*` validators kept global by prefix) **deferred** — verified benign (no enforcement-lib pinned via their closures).

### Tests
Full suite **40/0**, including the new `test-lib-closure.mjs` (import-form coverage).

### Scope notes
- **S2 grew beyond its original charter**: it absorbed the full engine/config relocation + the substrate allowlist (originally these were to be a later slice). Invariant 2 (provision `enforce-config.json`) remains **S4**.
- Transitional: `--install-enforcement` is the per-project enforcement entry; `--install-hooks` alone now emits a notice and deploys no enforcement (S3 resolves the public-flag story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
