### PR TITLE
fix(rfc-008): P4d — prune superseded relative-path hook duplicate on re-install

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -84,8 +84,14 @@ jobs:
       - name: Run checkpoint-gate regression (incl. F1 Bash re-gate + .review-store carve-out, PR-B)
         run: bash tests/test-checkpoint-gate.sh
 
+      - name: Run plan-gate regression (incl. P4a/P4d session_id fail-closed guard)
+        run: bash tests/test-plan-gate.sh
+
       - name: Run install-hooks regression (incl. PR-B orphan sweep + manifest count)
         run: bash tests/test-install-hooks.sh
+
+      - name: Run install dedup regression (RFC-008 P4d double-registration prune)
+        run: node tests/test-install-dedup.mjs
 
       - name: Run stop-gate regression
         run: bash tests/test-stop-gate.sh

--- a/install.mjs
+++ b/install.mjs
@@ -114,7 +114,7 @@ if (bootstrapLastPrompt) {
 }
 
 if (!tool) {
-  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|opencode|pi-agent|windsurf|all> [--project <path>] [--install-hooks] [--install-hooks-force]
+  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|opencode|pi-agent|windsurf|all> [--project <path>] [--install-hooks] [--install-enforcement] [--install-hooks-force] [--install-second-opinion] [--bootstrap-last-prompt]
 
 Tools:
   claude-code  Install SKILL.md + plugin structure
@@ -125,15 +125,31 @@ Tools:
   windsurf     Install .windsurfrules (or append to existing)
   all          Install for all supported tools except opencode (avoids duplicate OpenCode-visible skills)
 
-Hook flags (claude-code / Phase 3b):
-  --install-hooks         Copy plugins/claude-code/hooks/*.sh into ~/.claude/hooks/ and register
-                          checkpoint-gate + plan-gate (PreToolUse),
-                          em-recall-sessionstart (SessionStart), and
-                          em-session-end-prompt (SessionEnd) in
-                          ~/.claude/settings.json. Skips divergent local
-                          hook files AND withholds new settings registration
-                          for them (re-run with --install-hooks-force to
+Hook flags (claude-code / RFC-008 P4d — enforcement is PER-PROJECT, never global):
+  --install-hooks         Install the NON-enforcement hooks into
+                          <project>/.claude/ and register them in
+                          <project>/.claude/settings.json: em-recall
+                          (SessionStart), session-handoff (SessionStart), and
+                          em-session-end-prompt (SessionEnd). Post-P4d this
+                          flag alone NO LONGER deploys the enforcement gates
+                          (checkpoint/plan/preflight/stop) — use
+                          --install-enforcement for those. Skips divergent
+                          local hook files AND withholds their settings
+                          registration (re-run with --install-hooks-force to
                           accept). Atomic settings.json write (temp+rename).
+  --install-enforcement   Install the PER-PROJECT enforcement layer under
+                          <project>/.claude/ (NEVER ~/.claude): the gate hooks
+                          (checkpoint-gate, plan-gate, preflight-gate,
+                          stop-gate) + their hooks/lib closure + the
+                          enforce-contract runtime config set
+                          (taxonomy.json, events.json, schema), register them
+                          in <project>/.claude/settings.json, and SEED a
+                          discoverable on/off switch at
+                          <project>/.episodic-memory/enforce-config.json
+                          ({active:true}, create-if-absent — never overwritten,
+                          even with --install-hooks-force). This is the only
+                          flag that arms enforcement, and it arms it for THIS
+                          project only.
   --install-hooks-force   Overwrite divergent hook files with repo versions
                           and proceed with registration.
 
@@ -1184,6 +1200,37 @@ function detectStaleCanonicalEntries(hooks, canonicalByBasename) {
   return stale
 }
 
+// Resolve the filesystem target a hook command points at: strip a leading
+// `bash`/`node`/`sh` runner and any surrounding shell quotes, take the first
+// path token (the script; flags follow), and resolve it to an absolute path.
+// Project-relative entries (e.g. `.claude/hooks/X.sh`) resolve against the
+// project dir — that is how Claude Code runs project-relative hook commands.
+// Returns null if no path token is recoverable.
+function hookCommandTargetPath(cmd, projectDir) {
+  if (typeof cmd !== 'string') return null
+  const stripped = cmd.trim().replace(/^(?:bash|node|sh)\s+/, '')
+  let tok = stripped.split(/\s+/)[0] || ''
+  if (tok.length > 1 &&
+      ((tok.startsWith("'") && tok.endsWith("'")) ||
+       (tok.startsWith('"') && tok.endsWith('"')))) {
+    tok = tok.slice(1, -1)
+  }
+  if (!tok) return null
+  return path.resolve(projectDir, tok)
+}
+
+// Remove every hook ENTRY in <event> whose hook list contains a command exactly
+// equal to <command>. Returns the count removed. Used to prune superseded
+// path-spelling duplicates (relative vs absolute) of an already-canonical hook.
+function removeHookEntryByCommand(hooks, event, command) {
+  const arr = hooks[event]
+  if (!Array.isArray(arr)) return 0
+  const before = arr.length
+  hooks[event] = arr.filter(e =>
+    !(e && Array.isArray(e.hooks) && e.hooks.some(h => h && h.command === command)))
+  return before - hooks[event].length
+}
+
 function installHookFile(repoFile, destFile, force) {
   if (!fs.existsSync(repoFile)) return 'missing-source'
   if (!fs.existsSync(destFile)) {
@@ -1595,9 +1642,27 @@ if (installHooks || installEnforcement) {
       'preflight-gate.sh': path.join(userHooksDir, 'preflight-gate.sh'),
       'preflight-prompt-helper.sh': path.join(userHooksDir, 'preflight-prompt-helper.sh')
     }
+    // RFC-008 P4d double-registration fix. A prior installer version registered
+    // hooks by PROJECT-RELATIVE path (`.claude/hooks/X`); this version registers
+    // the canonical ABSOLUTE path. addHookEntry's idempotence keys on the EXACT
+    // command string, so the two spellings don't unify — the absolute entry is
+    // ADDED beside the stale relative one and every hook fires twice. Resolve
+    // each stale entry's path: if it points at the SAME canonical file, it is a
+    // superseded spelling → auto-remove it (the canonical absolute entry stays).
+    // If it only shares the BASENAME but resolves elsewhere, it may be the
+    // operator's own hook → warn only, never auto-remove (original safety intent).
     const staleEntries = detectStaleCanonicalEntries(settings.hooks, canonicalByBasename)
     for (const { event, basename, command } of staleEntries) {
-      console.log(`Warning: stale ${event} entry for ${basename} at ${command} — canonical also registered; remove the stale entry manually if it never resolves.`)
+      const canonicalResolved = path.resolve(canonicalByBasename[basename])
+      if (hookCommandTargetPath(command, projectDir) === canonicalResolved) {
+        const removed = removeHookEntryByCommand(settings.hooks, event, command)
+        if (removed > 0) {
+          console.log(`Removed superseded duplicate ${event} registration: ${command} (canonical absolute entry kept)`)
+          touched.settings.push(`removed duplicate ${event} → ${basename}`)
+        }
+      } else {
+        console.log(`Warning: stale ${event} entry for ${basename} at ${command} — resolves to a non-canonical path; left in place. Remove manually if unintended.`)
+      }
     }
 
     writeJSONAtomic(settingsPath, settings)

--- a/tests/test-install-dedup.mjs
+++ b/tests/test-install-dedup.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * test-install-dedup.mjs — regression for the double-registration fix
+ * (RFC-008 P4d). A prior installer version registered hooks by PROJECT-RELATIVE
+ * path; the current version registers the canonical ABSOLUTE path. Because
+ * addHookEntry keys idempotence on the exact command STRING, re-installing left
+ * BOTH spellings and every hook fired twice.
+ *
+ * This test drives the REAL install.mjs against an isolated HOME + mock project
+ * (feedback_mock_project_test_not_mental_trace) and asserts:
+ *   1. a superseded project-relative spelling of a canonical hook is AUTO-REMOVED
+ *      on re-install (resolves to the same file), and
+ *   2. a same-basename entry at a DIFFERENT path (an operator's own hook) is
+ *      PRESERVED (warn-only) — the original safety intent is kept.
+ *
+ * Zero deps. Node stdlib only.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+import {
+  mkMock, runInstall, readSettings, flattenHookCommands,
+} from './lib/activation-scoping-harness.mjs'
+
+let passed = 0, failed = 0
+function check(name, cond) {
+  if (cond) { console.log(`  ✓ ${name}`); passed++ }
+  else { console.log(`  ✗ ${name}`); failed++ }
+}
+const count = (cmds, sub) => cmds.filter((c) => c.includes(sub)).length
+
+const INSTALL_FLAGS = ['--install-hooks', '--install-enforcement', '--install-hooks-force']
+const { home, project, callerCwd } = mkMock('dedup')
+const settingsPath = path.join(project, '.claude', 'settings.json')
+const canonicalCG = path.join(project, '.claude', 'hooks', 'checkpoint-gate.sh')
+const RELATIVE_CG = '.claude/hooks/checkpoint-gate.sh'
+const CUSTOM_CG = '/tmp/operator-custom-hooks/checkpoint-gate.sh'
+
+console.log('--- First enforcement install (canonical absolute registration) ---')
+const r1 = runInstall({ home, project, callerCwd, flags: INSTALL_FLAGS })
+assert(r1.status === 0, `first install failed (status ${r1.status}): ${r1.stderr}`)
+const cg1 = count(flattenHookCommands(readSettings('project', { home, project })), 'checkpoint-gate.sh')
+check(`baseline: exactly one checkpoint-gate after first install (got ${cg1})`, cg1 === 1)
+
+console.log('--- Inject a superseded relative dup + a different-path custom entry ---')
+const seeded = JSON.parse(fs.readFileSync(settingsPath, 'utf8'))
+seeded.hooks.PreToolUse.unshift(
+  { hooks: [{ type: 'command', command: RELATIVE_CG, timeout: 5 }], matcher: 'Edit|Write|MultiEdit|Bash|NotebookEdit' },
+)
+seeded.hooks.PreToolUse.unshift(
+  { hooks: [{ type: 'command', command: CUSTOM_CG, timeout: 5 }], matcher: 'Edit' },
+)
+fs.writeFileSync(settingsPath, JSON.stringify(seeded, null, 2))
+const before = count(flattenHookCommands(readSettings('project', { home, project })), 'checkpoint-gate.sh')
+check(`seeded: 3 checkpoint-gate entries before re-install (got ${before})`, before === 3)
+
+console.log('--- Re-install (prune superseded spelling, preserve custom) ---')
+const r2 = runInstall({ home, project, callerCwd, flags: INSTALL_FLAGS })
+assert(r2.status === 0, `re-install failed (status ${r2.status}): ${r2.stderr}`)
+const cmds2 = flattenHookCommands(readSettings('project', { home, project }))
+
+check('relative spelling AUTO-REMOVED', !cmds2.includes(RELATIVE_CG))
+check('canonical absolute entry KEPT', cmds2.includes(canonicalCG))
+check('exactly one canonical checkpoint-gate remains', cmds2.filter((c) => c === canonicalCG).length === 1)
+check('different-path custom entry PRESERVED (warn-only)', cmds2.includes(CUSTOM_CG))
+check('re-install reported the removal', /Removed superseded duplicate/.test(r2.stdout))
+check('re-install warned (not removed) about the custom entry', /resolves to a non-canonical path/.test(r2.stdout))
+
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed > 0 ? 1 : 0)

--- a/tests/test-plan-gate.sh
+++ b/tests/test-plan-gate.sh
@@ -28,6 +28,13 @@ TEST_DIR="$(cd -P "$TEST_DIR" && pwd)"
 # TEST_DIR as a git repo so resolve_repo_root returns TEST_DIR.
 git -C "$TEST_DIR" init -q 2>/dev/null
 MARKER="$TEST_DIR/.claude/.plan-approval-pending"
+# P4a/P4d (#397/#401) hardened plan-gate to resolve per-session markers from the
+# PreToolUse stdin .session_id and to FAIL CLOSED when it is missing/invalid.
+# The mock JSON must therefore carry a valid session_id, else every read-only
+# "allow" case fails closed (blocks). A fixed UUID suffices — the gate checks
+# presence/shape, not membership. (Before this fix the test omitted session_id
+# and 8 read-only assertions fail-closed-blocked; it was also never wired into CI.)
+SID="11111111-1111-1111-1111-111111111111"
 passed=0
 failed=0
 
@@ -39,11 +46,11 @@ mock_json() {
   local tool_name="$1"
   local command="${2:-}"
   if [ -n "$command" ]; then
-    jq -n --arg tn "$tool_name" --arg cmd "$command" --arg cwd "$TEST_DIR" \
-      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd}'
+    jq -n --arg tn "$tool_name" --arg cmd "$command" --arg cwd "$TEST_DIR" --arg sid "$SID" \
+      '{tool_name: $tn, tool_input: {command: $cmd}, cwd: $cwd, session_id: $sid}'
   else
-    jq -n --arg tn "$tool_name" --arg cwd "$TEST_DIR" \
-      '{tool_name: $tn, tool_input: {}, cwd: $cwd}'
+    jq -n --arg tn "$tool_name" --arg cwd "$TEST_DIR" --arg sid "$SID" \
+      '{tool_name: $tn, tool_input: {}, cwd: $cwd, session_id: $sid}'
   fi
 }
 
@@ -208,6 +215,29 @@ assert_allowed "9. Edit allowed without marker" \
 
 assert_allowed "10. Write allowed without marker" \
   "$(mock_json 'Write')"
+
+# ===========================================================================
+echo ""
+echo "--- Missing session_id (P4a/P4d #397/#401 fail-closed regression) ---"
+# With the marker armed, a read-only op that WOULD be allowed when a valid
+# session_id is present MUST fail closed (block) when .session_id is absent
+# from stdin — the gate cannot resolve the per-session marker namespace and
+# must never fail open. Guards the exact regression this test fix addresses.
+# ===========================================================================
+mkdir -p "$(dirname "$MARKER")"
+touch "$MARKER"
+
+assert_blocked "11. read-only Bash, marker armed, NO session_id → fail closed" \
+  "$(jq -n --arg cwd "$TEST_DIR" '{tool_name: "Bash", tool_input: {command: "ls -la"}, cwd: $cwd}')"
+
+# Read-only TOOLS (Read/Glob/etc.) sit on the unconditional allowlist checked
+# BEFORE session resolution, so they are allowed even without a session_id —
+# only classification-dependent Bash fails closed (test 11). Documents the
+# boundary so the fail-closed guard isn't over-read as "blocks everything".
+assert_allowed "12. Read tool, marker armed, NO session_id → still ALLOWED (read-only tools are session-independent)" \
+  "$(jq -n --arg cwd "$TEST_DIR" '{tool_name: "Read", tool_input: {}, cwd: $cwd}')"
+
+rm "$MARKER"
 
 # ===========================================================================
 echo ""


### PR DESCRIPTION
## Summary

RFC-008 P4d fix: a prior installer registered enforcement hooks by **project-relative** path (`.claude/hooks/X.sh`); the current installer registers the canonical **absolute** path. `addHookEntry` keys idempotence on the exact command *string*, so the two spellings never unify — re-installing left **both** entries and every gate hook fired **twice**.

## Changes

- **`install.mjs`** — add `hookCommandTargetPath()` (resolve a hook command's script to an absolute path, stripping the `bash`/`node` runner + quotes) and `removeHookEntryByCommand()`. On re-install, for each stale canonical-basename entry:
  - resolves to the **same canonical file** → **auto-remove** the superseded spelling (canonical absolute entry kept);
  - shares only the **basename** but resolves elsewhere → **warn only, never remove** (preserves the operator's own hook — original safety intent).

  Previously the code *only ever warned*, so duplicates were never pruned. Also refreshes `--help` for the P4d per-project model (`--install-enforcement`).
- **`tests/test-install-dedup.mjs`** (new) — real `install.mjs` + mock project; asserts the superseded relative spelling is auto-removed and a different-path custom entry is preserved.
- **`tests/test-plan-gate.sh`** — thread a valid `session_id` into the mock JSON (P4a/P4d #397/#401 made plan-gate fail-closed without one, which would have blocked 8 read-only assertions) + add tests 11/12 for the missing-session_id fail-closed boundary.
- **`.github/workflows/plan-marker-validate.yml`** — wire `test-plan-gate.sh` (was never in CI) + `test-install-dedup.mjs` into the validate job.

## Test plan

- `node tests/test-install-dedup.mjs` → **8/0** (real install, mock project, isolated HOME)
- `bash tests/test-plan-gate.sh` → **36/0** (hardened, session_id-bearing)
- Both now run in CI via `plan-marker-validate.yml`.

## Notes

Independent of the in-flight ESC (enforcement-scope-correction) work — touches `install.mjs` + the workflow, which ESC-S3 also touches, so whichever lands first, the other rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
