### PR TITLE
feat(rfc-008): P4d S6 seed-identity coupling guard (REQ-7)

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'url'
 import { eventsVersion } from './scripts/lib/version-hash.mjs'
 import { findEnforcementTokens } from './scripts/lib/em-recall-purity.mjs'
 import {
-  HOOK_SPECS, SESSION_END_SCRIPT, ENFORCEMENT_HOOK_SCRIPTS,
+  HOOK_SPECS, SESSION_END_SCRIPT, ENFORCEMENT_HOOK_SCRIPTS, ENFORCE_CONFIG_SEED,
   enforcementHookFileBasenames, enforcementRegistrations, enforcementHookLibBasenames,
   isEnforcementEntryScript, isSubstrateScript, enforcementEntryScripts, enforcementBundleLibs,
   globalScriptLibs, relocatedOnlyLibs, bp1EntryScripts, bp1ClosureLibs,
@@ -1723,11 +1723,15 @@ if (installHooks || installEnforcement) {
     // (.episodic-memory/ ignore at §2 above) — a per-checkout switch, not committed
     // team policy. Seeded instances pin an explicit active:true and do NOT auto-track
     // the absent-file identity default; a future change to the safe default would need
-    // an S6 migration of seeded files.
+    // a migration of EXISTING seeded files (out of S6 scope). The seed↔identity
+    // coupling for NEW seeds is single-sourced as ENFORCE_CONFIG_SEED and guarded by
+    // tests/test-enforce-config-seed-identity.mjs (RFC-008 P4d S6, REQ-7): the seeded
+    // literal normalizes to the SAME `active` disposition as loadEnforceConfig's
+    // absent-file identity, so the two can never silently diverge.
     const enforceConfigPath = path.join(localDir, 'enforce-config.json')
     // localDir already exists (created unconditionally at §2, alongside episodes/).
     try {
-      fs.writeFileSync(enforceConfigPath, '{\n  "active": true\n}\n', { flag: 'wx' })
+      fs.writeFileSync(enforceConfigPath, ENFORCE_CONFIG_SEED, { flag: 'wx' })
       console.log(`Provisioned per-project enforcement switch: ${enforceConfigPath} (active:true)`)
       touched.hooks.push(enforceConfigPath)
     } catch (e) {

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -142,6 +142,17 @@ export function enforcementHookLibBasenames(repoDir) {
   return fs.existsSync(d) ? fs.readdirSync(d).filter((f) => f.endsWith('.sh')) : []
 }
 
+// ENFORCE_CONFIG_SEED — the EXACT bytes install.mjs seeds into a new
+// <project>/.episodic-memory/enforce-config.json (RFC-008 P4d S4, install.mjs
+// "5b-ec-cfg"). Single-sourced here (Rule 14) so install's write and the S6
+// coupling guard bind the SAME literal: the guard would be a tautology if the
+// test kept its own copy. RFC-008 P4d S6 (REQ-7) asserts this seed, run through
+// loadEnforceConfig's normalization, yields the SAME `active` disposition as the
+// absent-file identity {active:true} — so the seed can never silently diverge
+// from the fail-closed default. Coupling enforced by
+// tests/test-enforce-config-seed-identity.mjs.
+export const ENFORCE_CONFIG_SEED = '{\n  "active": true\n}\n'
+
 // ───────────────────────────────────────────────────────────────────────────
 // RFC-008 P4d / Principle 12 — enforcement SCRIPTS + their lib closure relocate
 // per-project; global holds ONLY substrate + dev/CI tooling.

--- a/tests/test-enforce-config-seed-identity.mjs
+++ b/tests/test-enforce-config-seed-identity.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// test-enforce-config-seed-identity.mjs — RFC-008 P4d S6 (REQ-7; parents R5, R3).
+//
+// COUPLING GUARD. The install seed (ENFORCE_CONFIG_SEED — the EXACT bytes
+// install.mjs writes into a new <project>/.episodic-memory/enforce-config.json)
+// must normalize, through loadEnforceConfig, to the SAME load-bearing `active`
+// disposition as the absent-file IDENTITY {active:true,bps:{}}. If the seed and
+// the fail-closed default ever silently diverge — someone flips the seed to
+// active:false, or changes the identity default — enforcement would mean
+// different things for a freshly-seeded project than for one with no file at all,
+// exactly the drift Rule 14 forbids. The seed is single-sourced in
+// install-manifest.mjs so this test and install.mjs bind the SAME literal (a test
+// holding its own copy would be a tautology).
+//
+// SEMANTIC, not byte: the seed bytes `{active:true}` can never byte-equal the
+// object {active:true,bps:{}}, so the compare is on the `active` field that
+// actually decides enforce-ON vs OFF (F4/BL-2). The normalizer is not
+// reimplemented here — the guard rides the real loadEnforceConfig. No migration
+// of existing seeded files (non-goal); this covers NEW seeds only.
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { loadEnforceConfig } from '../scripts/enforce-contract.mjs'
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs'
+import { ENFORCE_CONFIG_SEED } from '../scripts/lib/install-manifest.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'patterns', 'enforce-config.schema.json'), 'utf8'))
+
+let pass = 0
+let fail = 0
+const failures = []
+function ok(name) { pass++; console.log(`  ✓ ${name}`) }
+function bad(name, detail) { fail++; failures.push(`${name}: ${detail}`); console.log(`  ✗ ${name}: ${detail}`) }
+function eq(name, actual, expected) {
+  const a = JSON.stringify(actual), e = JSON.stringify(expected)
+  if (a === e) ok(name); else bad(name, `expected ${e}, got ${a}`)
+}
+function truthy(name, v, detail) { if (v) ok(name); else bad(name, detail || 'expected truthy') }
+
+// Write `raw` to <root>/.episodic-memory/enforce-config.json (undefined ⇒ absent),
+// then read it back through the REAL loadEnforceConfig — the exact write+read+
+// normalize path install.mjs (write side) and the runtime gate (read side)
+// traverse. resolveSeed(undefined) reproduces the absent-file fail-closed default.
+function resolveSeed(raw) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-identity-'))
+  fs.mkdirSync(path.join(root, '.episodic-memory'), { recursive: true })
+  if (raw !== undefined) fs.writeFileSync(path.join(root, '.episodic-memory', 'enforce-config.json'), raw)
+  return loadEnforceConfig(root, SCHEMA)
+}
+
+console.log('=== RFC-008 P4d S6 — seed↔identity coupling guard (REQ-7) ===')
+
+// The absent-file identity: the fail-closed default every miss resolves to. Pin it
+// explicitly — if THIS drifts, the whole guard is comparing against the wrong thing.
+const IDENTITY = resolveSeed(undefined)
+eq('identity (absent file) is {active:true,bps:{}}', IDENTITY, { active: true, bps: {} })
+
+// (a) The seed must be HONOR-ABLE, not silently fail-closed. A malformed or schema-
+// invalid seed resolves to identity {active:true} INSIDE loadEnforceConfig, which
+// would make the `active` compare in (b) pass for the WRONG reason. This pin proves
+// the seed satisfies the same predicates loadEnforceConfig's honored branch needs
+// (well-formed JSON + plain object + schema-valid). It does NOT by itself observe
+// that the loader took the honored branch — the negative control (c) does that, by
+// proving the load path actually READS `active`. Pin + (c) together rule out the
+// "both fell through to identity" false pass.
+{
+  let parsed = null
+  let parseOk = true
+  try { parsed = JSON.parse(ENFORCE_CONFIG_SEED) } catch { parseOk = false }
+  truthy('seed is well-formed JSON', parseOk, `not parseable: ${JSON.stringify(ENFORCE_CONFIG_SEED)}`)
+  truthy('seed is a plain object', parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed), 'seed is not a plain object')
+  truthy('seed is schema-valid (honored, not fail-closed)', parseOk && validateInstance(parsed, SCHEMA).valid, 'seed fails the enforce-config schema → would fail-closed to identity')
+}
+
+// (b) t_seed_matches_identity (PRIMARY): the real seed, normalized through the SAME
+// loadEnforceConfig path, has the same `active` disposition as the absent-file
+// identity. Compare on `active` only (REQ-7: ignore the bps shape).
+{
+  const seeded = resolveSeed(ENFORCE_CONFIG_SEED)
+  eq('t_seed_matches_identity: seeded.active === identity.active', seeded.active, IDENTITY.active)
+}
+
+// (c) t_guard_red_on_divergence (NEGATIVE CONTROL): a seed whose `active` diverges
+// from the identity MUST be distinguished — the guard predicate goes red. This
+// doubles as proof the load path actually READS `active`: if loadEnforceConfig
+// always returned identity, a flipped seed would still report active:true and this
+// assertion would fail. Red-then-green.
+{
+  const divergent = resolveSeed('{\n  "active": false\n}\n')
+  truthy('t_guard_red_on_divergence: active:false seed distinguished from identity', divergent.active !== IDENTITY.active, 'a divergent seed was NOT distinguished from identity — the guard is blind')
+}
+
+console.log('')
+if (fail > 0) {
+  console.log(`FAIL — ${pass} passed, ${fail} failed`)
+  for (const f of failures) console.log(`  - ${f}`)
+  process.exit(1)
+}
+console.log(`PASS — ${pass}/${pass} checks passed`)

--- a/tests/test-s4-gate-e2e.mjs
+++ b/tests/test-s4-gate-e2e.mjs
@@ -20,6 +20,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { mkMock, runInstall, runHook } from './lib/activation-scoping-harness.mjs'
+import { ENFORCE_CONFIG_SEED } from '../scripts/lib/install-manifest.mjs'
 
 let pass = 0, fail = 0
 const ok = (n) => { pass++; console.log(`  ✓ ${n}`) }
@@ -57,7 +58,9 @@ if (!isBlock(b) && (b.stdout || '').trim() === '') ok('active:false (seed) → s
 else bad('active:false → allow', `stdout="${(b.stdout || '').trim()}" stderr=${(b.stderr || '').slice(-300)}`)
 
 // 3. Restore active:true → BLOCK again (control: the toggle, not state drift, is the cause).
-fs.writeFileSync(cfgPath, '{\n  "active": true\n}\n')
+// Use the canonical install seed (single-sourced in install-manifest.mjs) so a future
+// seed reflow can't leave a stale hand-typed copy here (RFC-008 P4d S6, Rule 14).
+fs.writeFileSync(cfgPath, ENFORCE_CONFIG_SEED)
 const c = fireStop()
 if (isBlock(c)) ok('restore active:true → stop-gate BLOCKS again (toggle is the cause)')
 else bad('restore → block', `stdout="${(c.stdout || '').trim()}" stderr=${(c.stderr || '').slice(-300)}`)


### PR DESCRIPTION
## RFC-008 P4d S6: seed-identity coupling guard (REQ-7)

Closes the S6 slice of `docs/plans/p4d-s5-s8.md`. Parents: R5 (per-project enforcement switch), R3 (effective-tier).

### What

A coupling guard so the install seed can never silently diverge from `loadEnforceConfig`'s absent-file identity. No data migration and no default change (both still resolve to enforce-ON); the guard turns a future divergence into a loud test failure rather than a silent one (Rule 14).

- `scripts/lib/install-manifest.mjs`: new `ENFORCE_CONFIG_SEED` single-source const (the exact bytes install seeds).
- `install.mjs`: imports and writes the const at the `5b-ec-cfg` seed block (was an inline literal); comment updated.
- `tests/test-enforce-config-seed-identity.mjs` (new): the guard.
- `tests/test-s4-gate-e2e.mjs`: the `active:true` restore step now binds the const (was a second hand-typed copy; review F3).

### How the guard works (semantic, not byte)

The seed bytes `{active:true}` can never byte-equal the object `{active:true,bps:{}}`, so the compare is on the load-bearing `active` field (F4/BL-2). Three composing assertions rule out a false pass:

- a schema-valid pin proves the seed is honor-able (would not hit a fail-closed branch of `loadEnforceConfig`);
- the negative control (`active:false`) proves `loadEnforceConfig` actually reads `active` on the honored branch;
- the primary asserts the seed's `active` equals the identity's `active`.

### Verification

| Test | Result |
| --- | --- |
| test-enforce-config-seed-identity.mjs (new guard) | 6/6 |
| test-s4-gate-e2e.mjs (real install + real deployed stop-gate) | 5/5 |
| test-install-contract-deploy.mjs (T4 seed content + schema) | 36/36 |
| test-enforce-config.mjs (loadEnforceConfig regression) | 27/27 |
| test-uninstall-enforcement.mjs | 14/14 |
| test-enforcement-scope.mjs | 17/17 |
| test-activation-scoping-e2e.mjs | 13/13 |
| test-p12-global-clean.mjs | 6/6 |

Rule-14 check: a repo-wide grep confirms the only remaining copy of the seed bytes is the const definition.

### Review (Rule 18 step 6)

Adversarial 3-lens review (test false-pass / Rule-14 drift / REQ-7 conformance), each finding independently verified. 0 blockers.

- F1 (nit): comment overstated the schema-valid pin. Fixed inline (now credits the negative control).
- F3 (low): a second hand-typed seed copy in the s4 test. Fixed inline (binds the const).
- F2 (low): the guard is not wired into CI until S8 (by design; S8 step 8.1 already names this test in the P12 EXPLICIT set). No new issue.

### Out of scope

CI wiring of this guard is S8 (hard dep S6 then S8). No data migration of existing seeded files; no default change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
