### PR TITLE
docs(rfc-008): mark P4 DONE (P4d S7+S8 merged)

### DIFF
--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -1213,7 +1213,7 @@ Serves R1, R2, R3, R4, R5, R9 (+ F38) · depends on: P0, P2 · **DONE (P3a #389,
 
 #### P4 — Per-project `enforce-config.json` → [RFC-008/P4-enforce-config.md](RFC-008/P4-enforce-config.md)
 
-Serves R3, R5 · depends on: P3 · **IN PROGRESS**: P4a #397 + P4c #398 done; **P4d** per-project enforcement re-architecture (Principle 12) S1-S6 + ESC merged, S7-S8 open *(legacy "Phase 5")*. `effective_tier = min(harness, contract, project_config)` clamps DOWN only; `active: false` makes the classifier silent (R5).
+Serves R3, R5 · depends on: P3 · **DONE (P4a #397, P4c #398, P4d S1-S8 + ESC).** **P4d** per-project enforcement re-architecture (Principle 12): S1-S8 + ESC all merged (uninstall #416, seed-identity #417, docs #418, P12 CI gate #419); legacy P4b superseded by the P4d re-architecture *(legacy "Phase 5")*. `effective_tier = min(harness, contract, project_config)` clamps DOWN only; `active: false` makes the classifier silent (R5).
 
 #### P5–P7 — Per-tool plugins (OpenCode / Codex / Pi Agent) → [RFC-008/P5-P7-tool-plugins.md](RFC-008/P5-P7-tool-plugins.md)
 

--- a/docs/rfcs/RFC-008/P4-enforce-config.md
+++ b/docs/rfcs/RFC-008/P4-enforce-config.md
@@ -3,7 +3,7 @@
 > Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
 > [RFC-008/README.md](README.md).
 
-**Status:** IN PROGRESS: schema landed P3b-2 #393; **P4a #397** (per-project loader, 3 pre_tool_use contract gates) + **P4c #398** (layer-wide `active:false` kill switch across preflight + second-opinion + SessionStart, R5) merged + deployed. **P4d** (per-project enforcement re-architecture, Principle 12) S1-S6 + ESC merged; S7-S8 open. Original P4b superseded by the P4d re-architecture. *(Legacy "Phase 5".)*
+**Status:** DONE: schema landed P3b-2 #393; **P4a #397** (per-project loader, 3 pre_tool_use contract gates) + **P4c #398** (layer-wide `active:false` kill switch across preflight + second-opinion + SessionStart, R5) merged + deployed. **P4d** (per-project enforcement re-architecture, Principle 12) S1-S8 + ESC merged. Original P4b superseded by the P4d re-architecture. *(Legacy "Phase 5".)*
 **Serves:** R3, R5.
 **Depends on:** P3.
 **Estimate:** ~25K.
@@ -59,5 +59,5 @@ Slice status (phase index; full slice and PR detail live in the workplan episode
 | ESC | gates block ONLY repo-source writes (R1-R3) | merged (#409) |
 | S5 | `--uninstall-enforcement [--purge-config]` | merged (#416) |
 | S6 | install seed matches `loadEnforceConfig` identity (coupling guard) | merged (#417) |
-| S7 | this phase-index + Principle 12 docs refresh | in progress (closes #403) |
-| S8 | the 3 P12 invariants as a required CI gate | open |
+| S7 | this phase-index + Principle 12 docs refresh | merged (#418, closed #403) |
+| S8 | the 3 P12 invariants as a required CI gate | merged (#419); required-check toggle tracked #420 |

--- a/docs/rfcs/RFC-008/README.md
+++ b/docs/rfcs/RFC-008/README.md
@@ -18,7 +18,7 @@ requirement parent. Each phase file carries its own R-anchors and back-links to 
 | **P1** | [P1-plugin-registry.md](P1-plugin-registry.md) | R1, R6, R8 | P0, R0b′ | **DONE** — P1a #373 + P1b #374 + P1c #376 + Follow #378 |
 | **P2** | [P2-bp-contracts.md](P2-bp-contracts.md) | R2, R3, R4 | P0 | **DONE** — P2a #381 + P2b #384 + P2c #388 |
 | **P3** | [P3-thin-waist.md](P3-thin-waist.md) | R1, R2, R3, R4, R5, R9 | P0, P2 | **DONE** — P3a #389 + P3b-1 #391 + P3c #392 + P3b-2 #393 (P4 schema folded in) + P3d #395 |
-| **P4** | [P4-enforce-config.md](P4-enforce-config.md) | R3, R5 | P3 | **IN PROGRESS**: P4a #397 (per-project loader, 3 pre_tool_use gates) + P4c #398 (`active:false` kill switch) DONE; **P4d** per-project enforcement re-architecture (Principle 12: enforcement per-project, substrate global) S1-S6 + ESC merged, S7-S8 open (slice detail in workplan). Original P4b superseded by the P4d re-architecture. |
+| **P4** | [P4-enforce-config.md](P4-enforce-config.md) | R3, R5 | P3 | **DONE**: P4a #397 (per-project loader, 3 pre_tool_use gates) + P4c #398 (`active:false` kill switch); **P4d** per-project enforcement re-architecture (Principle 12: enforcement per-project, substrate global) S1-S8 + ESC merged (slice detail in workplan). Original P4b superseded by the P4d re-architecture. |
 | **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | queued |
 | **P8** | [P8-cursor-windsurf.md](P8-cursor-windsurf.md) | R6, R10 | P3 | queued |
 | **P9** | [P9-recall-strategies.md](P9-recall-strategies.md) | R7 | — | **DEFERRED** — own RFC |


### PR DESCRIPTION
## RFC-008 P4d doc-sync: mark P4 DONE

S7 (#418) and S8 (#419) are merged, completing P4d and therefore P4. This flips the stale status the prior docs slice (S7) could not self-mark at authoring time.

### Changes (status flips only, no code)
- `RFC-008-decouple-enforcement-from-substrate.md` (body ledger): P4 row from "IN PROGRESS / S7-S8 open" to "DONE (P4a #397, P4c #398, P4d S1-S8 + ESC)".
- `RFC-008/README.md` (phase matrix): P4 row from "IN PROGRESS / S7-S8 open" to "DONE".
- `RFC-008/P4-enforce-config.md`: status line to DONE; slice table S7 to "merged (#418, closed #403)", S8 to "merged (#419); required-check toggle tracked #420".

### Verification
`grep -rnE "S7-S8|S8 .*open|IN PROGRESS|P4b.*(remains|reduced|cutover)"` over the RFC-008 docs returns only an unrelated historical "v11 review in progress" note; no stale P4 status remains and the S7 CI guard pattern is not tripped.

Rule 10 doc-sync. No code change, no deploy.
