### PR TITLE
RFC-008 P5: OpenCode enforcement plugin (R6, R10)

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -50,6 +50,30 @@ jobs:
       - name: Run plugin-registry conformance tests (path-contain regression lock)
         run: node tests/test-plugin-registry.mjs
 
+      - name: Run claude-code plugin gauntlet (REQ-1 regression lock)
+        run: node tests/test-plugin-gauntlet.mjs
+
+      - name: Run opencode plugin gauntlet (RFC-008 P5, REQ-1/REQ-12)
+        run: node scripts/test-plugin.mjs --project "$GITHUB_WORKSPACE" --harness opencode
+
+      - name: Run opencode translation tests (RFC-008 P5 S2, R3/R4)
+        run: node tests/test-opencode-translations.mjs
+
+      - name: Run repo-source parity tests (RFC-008 P5 S4, REQ-7 — bash/node single source)
+        run: node tests/test-repo-source-parity.mjs
+
+      - name: Run repo-source bash gate tests (RFC-008 P5 S4)
+        run: bash tests/test-repo-source.sh
+
+      - name: Run opencode enforce-bridge tests (RFC-008 P5 S5)
+        run: node tests/test-enforce-bridge.mjs
+
+      - name: Run opencode adapter tests (RFC-008 P5 S5, R1-R3 carve-out gate)
+        run: node tests/test-opencode-adapter.mjs
+
+      - name: Run opencode install/uninstall E2E (RFC-008 P5 S6, REQ-11)
+        run: node tests/test-install-opencode-enforcement.mjs
+
       - name: Run effective-tier algebra tests (RFC-008 P3b-2, R3 — shared min() fold)
         run: node tests/test-effective-tier.mjs
 

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -33,7 +33,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Node 24 (not the repo-standard 20): the OpenCode adapter is
+          # TypeScript and test-opencode-adapter-conformance.mjs LOADS it as a
+          # module. TS type-stripping is default-on from Node 23.6, so the
+          # conformance test (PR-level review BLOCKER-2 fix) needs >=23.6. All
+          # other steps here are stdlib .mjs/.sh and run unchanged on 24.
+          node-version: '24'
 
       - name: Validate schema docs + shared negative corpus (M1/M2, #368)
         run: node scripts/validate-schemas.mjs --project "$GITHUB_WORKSPACE"
@@ -70,6 +75,9 @@ jobs:
 
       - name: Run opencode adapter tests (RFC-008 P5 S5, R1-R3 carve-out gate)
         run: node tests/test-opencode-adapter.mjs
+
+      - name: Run opencode adapter conformance tests (PR-level BLOCKER-1/2 — loads enforcement.ts, asserts flat-key Hooks shape + STRONG block)
+        run: node tests/test-opencode-adapter-conformance.mjs
 
       - name: Run opencode install/uninstall E2E (RFC-008 P5 S6, REQ-11)
         run: node tests/test-install-opencode-enforcement.mjs

--- a/docs/plans/p5-opencode-plugin.md
+++ b/docs/plans/p5-opencode-plugin.md
@@ -1,0 +1,724 @@
+# P5 — OpenCode enforcement plugin Plan
+
+## §1 Status
+
+`Planning only.` Do not implement until this plan, the plan review, and the adversarial
+review are accepted (Rule 18). Current stage: **review-consensus ACCEPT (round 3); awaiting user Rule 18 step-4 approval.**
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-008` |
+| Parent requirements | `R6` (plugin-to-harness binding), `R10` (enforcement runbooks); principle anchors P4, P9, P11 |
+| Workplan episode | `20260622-095311-workplan-v147-rfc-008-p4d-complete-s8-me-e996` |
+| Target branch | `feat/rfc-008-p5-opencode-plugin` |
+| **Executor altitude (§0.1)** | **`low`** — target executor is **Haiku** or **DeepSeek V4 Flash**. Appendix A (A.1-A.9) is **mandatory** and is the build path. Every step names one file, a verbatim anchor or full CREATE contents, and a falsifiable (behavioral) verify. |
+
+**Rounds 1+2 adversarial review folded (§19.1, §19.2).** Round 1 (HOLD, 2B+4M): tool_result→MEDIUM
+(B1); decision surface re-architected onto the real `repo-source.sh` carve-outs + a new S4 (B2/M3);
+fixture-dir param (M1); synchronous turn_index (M2); unsound E2E branch deleted (M4); cwd-divergence
+fixture (axis-9). Round 2 (HOLD, 1B+1M+2m; B1/M1 cleared): the round-1 decision-surface fix was still
+mis-modeled as a pipe — round-2 **corrects the boundary** to the live gate's real two-layer **AND**
+(`toolTargetsRepoSource` AND `gateDisposition.token∈{enforce,block}`), resolves the disposition wiring
+inline (B-NEW-2/4), mandates exact-segment carve-out matching + boundary parity corpus (B-NEW-1),
+deploy-safe JSON with bash fallback (B-NEW-3), and scopes the bp-001 marker lifecycle out as OD-4.
+
+**Executor-readiness by slice:** S1 and S2 are fully mechanical now. S3 (runbook byte-derivation),
+S4 (repo-source extraction), S5 (adapter+bridge), and S6 (install) carry `<READ-PIN>` cells closed by
+the §A.0 pre-authoring reads; do not hand those to a weak executor until §A.0 is discharged.
+
+## §2 Episode Search Summary
+
+```bash
+node scripts/em-search.mjs --tag rfc-008 --tag workplan --scope all --limit 10 --full --no-track
+```
+
+Key active memories constraining this plan:
+
+- `…e996` (workplan v147): next = P5-P8 tool breadth; P5 = `plugins/opencode/`. This plan is that work.
+- `…7918` verify-the-strong-claim: E2E drives the **real deployed hook**, not the engine CLI token; review PR-level. → §14,§15,§19.
+- `…540d` unfiltered deploy audit: `tools/deploy-audit.mjs`, never `diff | grep differ` — S6 touches `install.mjs`. → §15.
+- `…16c4` isMain fail-open under symlink; `…937a` lstat-before-realpath. → §7,§13.
+- `feedback_enforcement_gate_only_repo_src` (R1-R3, LOCKED): gate ONLY repo-source writes; never episodes/plan-files/non-repo/`.git`. The carve-out set is `repo-source.sh` (single source). → §7,§12,§14.
+- `feedback_plan_template_first` (2026-06-23): default altitude = **low**; full appendix; behavioral verifies.
+- KB `opencode-plugin-api.md` (2026-06-23): OpenCode hook API ground truth (installed `@opencode-ai/plugin@1.14.50`). Resolves OD-1/OD-2 (§17).
+
+Verified against disk at `9ab5663`; re-verify in §A.4 per slice.
+
+## §3 Objective
+
+Ship the first non-Claude-Code enforcement plugin, `plugins/opencode/`, binding the contract to
+OpenCode at its **honest** tiers (`pre_tool_use: STRONG`, `tool_result: MEDIUM`, `session_start:
+MEDIUM`, `stop: MEDIUM` — all verified against the installed OpenCode types; tool_result is MEDIUM
+because OpenCode's after-hook has no proven result-re-read, §17). "Done" is provable by: the
+`test-plugin.mjs` 9-step gauntlet passing for the `opencode` entry (steps 1-4,7,8,9; 5-6 stay
+`deferred-P3`); a **real-OpenCode-runtime** mock-project E2E where the deployed adapter throws on a
+repo-source write and allows every carve-out (episode/plan/`.git`/`.checkpoints`/`.review-store`/
+git-ignored/non-repo); and a clean unfiltered deploy audit after `install.mjs`.
+
+## §4 Requirements (Ground Truth)
+
+| ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes |
+|---|---|---|---|---|---|
+| REQ-1 | `test-plugin.mjs` accepts `--harness <id>`, defaulting to `claude-code`; the registry lookup **and the harness-event fixture dir** (`test-plugin.mjs:143`) are both parameterized by it. | R6 | `testHarnessDefault/Opencode/UnknownThrows`; `manual: node scripts/test-plugin.mjs --harness opencode --json` | MUST | M1: fixture dir was hardcoded `claude-code/`. |
+| REQ-2 | `_index.json` has an `opencode` entry; `opencode/manifest.json` validates vs `manifest.schema.json`; the two `capabilities` blocks **deep-equal**. | R6,R8 | gauntlet 1-2; `test-plugin-registry.mjs` | MUST | tiers `pre_tool_use:STRONG, tool_result:MEDIUM, session_start:MEDIUM, stop:MEDIUM`. |
+| REQ-3 | The manifest declares `event_translations` for all 4 events; each replayed against its `opencode/<event>.json` fixture yields a payload valid vs `schemas/events/event-*.schema.json`. | R6 | gauntlet 8 | MUST | Fixtures are the post-normalize object (§8.3). |
+| REQ-4 | `tests/fixtures/harness-events/opencode/{pre-tool-use,tool-result,session-start,stop}.json` exist in post-normalize shape. | R6 | gauntlet 8 | MUST | Exact contents §A.7 S2. |
+| REQ-5 | `opencode/runbooks/enforcement.md` (+ `.quickref.md`) passes M7/M7a/M7c/M7d/M7e/M7f. | R10 | gauntlet 3,9; `validate-plugin-registry.mjs` | MUST | Byte-derived (§A.0 read #2). |
+| REQ-6 | `bypass_known.json` has an honest record per `{opencode,event}` pair; `tool_result` records the MEDIUM observe ceiling honestly. | R6 | gauntlet 7 (M4a) | MUST | §A.7 S2. |
+| REQ-7 | The carve-out set is defined **once** in a machine-readable form read by BOTH `repo-source.sh` and a new node classifier `scripts/lib/repo-source.mjs`; a parity test proves they agree. | R1-R3,R5 | `test-repo-source-parity.mjs` | MUST | B2/M3: today carve-outs live only in `repo-source.sh:75-85`. Rule 14. |
+| REQ-8 | `opencode/capabilities/enforcement.ts` normalizes a raw OpenCode hook event → canonical payload → decision via `repo-source.mjs` + `enforce-contract.gateDisposition` → OpenCode effect (`throw` on block; observe/log on tool_result; `return` on allow). | R6 | `test-opencode-adapter.mjs` + real-runtime E2E | MUST | First `capabilities/` adapter. Gates ONLY repo-source writes. |
+| REQ-9 | A zero-dep node bridge `enforce-bridge.mjs` does field_bindings → schema-validate → classify (`repo-source.mjs`) → `gateDisposition` → decision JSON; it resolves repo root from the payload's `cwd`, **never its own process cwd**. | R5,R6 | `test-enforce-bridge.mjs` incl. cwd-divergence | MUST | Axis-9: bridge cwd ≠ target repo. |
+| REQ-10 | The adapter synthesizes `cwd` (from `realpath(PluginInput.directory)`) and `turn_index` (per-`sessionID` monotonic counter incremented **synchronously before any await**). | R6 | `testCwdFromContext`, `testTurnIndexMonotonic` | MUST | M2: sync increment; reset-on-reload accepted (ordering-only). |
+| REQ-11 | `install.mjs --tool opencode --install-enforcement` deploys adapter+bridge+runbook+registry+repo-source.mjs+carve-out JSON + registers the plugin in `opencode.json[c]`; `--uninstall-enforcement` removes them. | R6 | `test-install-opencode-enforcement.mjs` (mock) | MUST | Today only the substrate skill installs. |
+| REQ-12 | The OpenCode gauntlet run is a CI gate in `plugin-validate.yml`. | R10 | CI green; `manual: gh run view` | SHOULD | Rule 13; references #377; may defer (OD-3). |
+| REQ-13 | The adapter never blocks a carve-out write: `.episodic-memory/`, `docs/plans/`, `.git/`, `.checkpoints/`, `.review-store/`, a `git check-ignore` match, or any non-repo target. | R5,R1-R3 | `test-opencode-adapter.mjs` negative controls (§14 Group 4) | MUST | M3: carve-out set = `repo-source.sh`. |
+| REQ-14 | The adapter/bridge fail **closed**: malformed event, schema-invalid payload, bridge non-zero exit, bridge timeout, or unparseable decision → **throw** (block). | R5 | `testMalformedFailsClosed`, `testBridgeErrorFailsClosed` | MUST | No uncertainty→allow path. |
+
+**Priority:** MUST = first-merge blocker; SHOULD = before phase complete (defer w/ issue); MAY = nice-to-have.
+
+## §5 Non-Goals
+
+- P6 (Codex) / P7 (Pi) plugins.
+- A general multi-contract refactor of `THIS_HARNESS`/`BP_ID` — S5 reaches the opencode decision via `gateDisposition` + a `harness` param at the **minimum**.
+- Promoting `tool_result` to STRONG — blocked on a real-runtime re-read proof (§17 B1); ships MEDIUM.
+- Promoting gauntlet steps 5/6 out of `deferred-P3`.
+- OpenCode substrate-skill authoring (already shipped).
+- Any claude-code behavior change — S1's `--harness`/fixture-dir defaults preserve it byte-for-byte.
+
+## §6 Token Budget (Rule 12)
+
+| File | `wc -l` | Reads (×5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/test-plugin.mjs` | 361 | ~1.8k | S1 edits | param harness + fixture dir |
+| `.claude/hooks/lib/repo-source.sh` | ~104 | ~0.5k | S4 edit (read carve-outs from JSON) | §A.0 read #3 |
+| `scripts/enforce-contract.mjs` | 789 | ~3.9k | S5 read (gateDisposition surface) | §A.0 read #1 |
+| `.claude/hooks/lib/command-classifier.sh` | (read) | ~1.5k | S4/S5 label logic | §A.0 read #3 |
+| `install.mjs` | 2246 | ~11k | S6 edits | scope to opencode + enforcement regions |
+| `scripts/validate-plugin-registry.mjs` | 680 | ~3.4k | read-only | §A.0 read #2 (runbook derivation) |
+| New: manifest, enforcement.ts, enforce-bridge.mjs, repo-source.mjs, carve-out JSON, runbook+quickref, 4 fixtures, 4 bypass records, 6 test files | — | — | writes | net-new |
+
+**Baseline (single session):** ~130-150k → autocompact risk. **Optimized, by dep layer (§10.1):**
+S1+S2 (~45k); §A.0 reads + S3 (~35k); S4 extraction (~30k); S5 adapter+bridge (~45k); S6 install+CI (~30k). Slice across ≥5 sessions.
+
+## §7 Safety / Security
+
+Dispatch `negative-scenario-planner` again on the **revised** S5 adapter design before building S5
+(round-2). Draft seed (round-1 findings already folded):
+
+| Concern | Sev | Scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| Over-block (R1-R3) | High | Adapter throws on episode/plan/`.git`/`.checkpoints`/`.review-store`/git-ignored/non-repo write. | Classify via `repo-source.mjs` reading the SHARED carve-out set (= `repo-source.sh`). | Group 4: each carve-out → allow (negative controls). |
+| Fail-open under degrade | High | Bridge error/timeout swallowed → allow. | Bridge exit≠0 / bad JSON / timeout → adapter **throws**. | `testBridgeErrorFailsClosed`. |
+| cwd divergence (axis-9) | High | Bridge resolves repo root from its own cwd (= OpenCode launch dir), not the target. | Bridge uses `payload.cwd` only; `realpath` it; `repo-source.mjs` takes repo_root as an arg. | `testBridgeCwdDivergence` (bridge cwd=tmpdir, payload.cwd=mock repo; assert decision + any marker land under mock repo on disk). |
+| Capability dishonesty | Med | Declaring STRONG where OpenCode can't enforce. | tool_result = MEDIUM (no proven re-read); honest `bypass_known`. | gauntlet 7. |
+| turn_index race | Low | post-await increment → two calls share an index. | Increment synchronously at normalize entry. | `testTurnIndexMonotonic`. |
+
+**8-axis symlink matrix:** symlinked repo root; symlinked `directory`; `/var`→`/private/var`
+(`realpath`/`pwd -P`, not `path.resolve`); marker-path symlink (lstat before realpath, `…937a`);
+linked worktree; `.git/` carve-out; isMain under symlink (`…16c4`); nested project root. Each → a
+row in §A.7 S5 fixtures or explicit N/A.
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/** OpenCode hooks (from @opencode-ai/plugin@1.14.50 dist/index.d.ts):
+ *   tool.execute.before(input{tool,sessionID,callID}, output{args})  — block by throw
+ *   tool.execute.after(input{tool,sessionID,callID,args}, output{title,output:string,metadata}) — returns void; result re-read NOT proven ⇒ observe/MEDIUM
+ *   experimental.chat.system.transform(input{sessionID?,model}, output{system:string[]}) — best-effort inject
+ *   event(input{event}) — observe-only; session.idle ⇒ "stop"
+ * cwd from PluginInput.directory (NOT events). turn_index NOT provided.
+ * @typedef {Object} NormalizedEvent
+ * @property {string} tool @property {object|null} args @property {string} [result]
+ * @property {string} sessionID @property {string} cwd  // realpath(ctx.directory)
+ * @property {number} turn_index @property {string} [harness] @property {boolean} [is_subagent] */
+```
+
+### 8.2 Key invariants
+
+- The opencode manifest `capabilities` block **deep-equals** the `_index.json` opencode entry's (validator uses `deepEqualJson`).
+- `event_translations` are near-identity `$.field` + `$$now`; all harness-specific work (context merge, turn_index, typed constants) is in the adapter **normalize** step (no `$$const` type coercion).
+- Adapter/bridge fail **closed** (REQ-14).
+- Gate scope = repo-source writes only; the carve-out set is `repo-source.sh` via the shared JSON (REQ-7).
+- The bridge resolves repo root from `payload.cwd` only, never its own process cwd (REQ-9, axis-9).
+- **Cross-platform:** `path`/`os.tmpdir()`; `cwd` = `realpath` (handles `/var`→`/private/var`); no GNU-only flags. Adapter TS (Bun); bridge + `repo-source.mjs` zero-dep node `.mjs`.
+- **Atomicity:** marker writes temp+rename.
+
+### 8.3 Resolution / flow
+
+```text
+OpenCode hook (input, output)
+  → enforcement.ts NORMALIZE: cwd=realpath(ctx.directory), turn_index++ (sync, pre-await), typed consts → NormalizedEvent
+  → spawn `node enforce-bridge.mjs`, stdin {harness:"opencode", event:<id>, normalized}
+  → bridge: field_bindings → canonical payload (validate vs schema; exit 2 on fail)
+          → TWO INDEPENDENT LAYERS, composed by AND (mirrors checkpoint-gate.sh):
+            (L1) label = classifyLabel(tool,args); gatedWrite = repoSource.toolTargetsRepoSource(realpath(payload.cwd), tool, targetPath, label)  // is this a gated repo-source write?
+            (L2) disp  = gateDisposition({duplicate, harnessCap:"STRONG", contractTier, active, configTier, events, event:"pre_tool_use"})  // is the gate enforcing at all?
+            → action = (gatedWrite===GATED && disp.token∈{enforce,block}) ? "block" : "allow"
+          → {action, effective_tier:disp.effTier, reason, label} on stdout (exit 0); ANY error → exit≠0
+  → enforcement.ts apply: block→throw(reason) | allow→return | (tool_result/session_start/stop MEDIUM)→observe/log, return
+  Note (scope): P5 enforces the repo-source-write × disposition AND. The bp-001 checkpoint/plan-approval
+  MARKER lifecycle (checkpoint-gate.sh's armed/approval-token state) is NOT replicated for OpenCode in
+  P5 — documented capability boundary; tracked as a follow-up (OD-4).
+```
+
+```mermaid
+sequenceDiagram
+    actor OC as OpenCode (Bun)
+    participant ADP as enforcement.ts
+    participant BR as enforce-bridge.mjs (node)
+    participant RS as repo-source.mjs
+    participant EC as enforce-contract.gateDisposition
+    OC->>ADP: hook(input, output)
+    ADP->>ADP: normalize → cwd=realpath(ctx.directory), turn_index++ (sync)
+    ADP->>BR: spawn, stdin {harness,event,normalized}
+    BR->>BR: field_bindings → payload (validate; exit 2 on fail)
+    BR->>RS: toolTargetsRepoSource(realpath(payload.cwd), tool, target, label)
+    RS-->>BR: gatedWrite (GATED | ALLOW)
+    BR->>EC: gateDisposition({harnessCap:"STRONG", contractTier, active, configTier, events, event})
+    EC-->>BR: {token: enforce|block|silence|clamp-off, effTier}
+    BR-->>ADP: action = (gatedWrite=GATED AND token∈{enforce,block}) ? block : allow ; any error → exit≠0
+    ADP-->>OC: block→throw | allow→return | tool_result→observe+return
+    Note over ADP: bridge exit≠0 / bad JSON / timeout ⇒ throw (fail-closed)
+```
+
+## §9 Existing Hook Points
+
+| File | Line(s) | Today | Impact |
+|---|---|---|---|
+| `scripts/test-plugin.mjs` | L55 | `runGauntlet({projectRoot,now,cwd})` | S1: add `harness` param. |
+| `scripts/test-plugin.mjs` | L66 | `…p.id==="claude-code"` | S1: `p.id === harness`. |
+| `scripts/test-plugin.mjs` | L143 | `tests/fixtures/harness-events/claude-code/${dash}.json` (hardcoded) | **S1 (M1): parameterize dir by harness.** |
+| `scripts/test-plugin.mjs` | L318,321,343 | argv parse + dispatch | S1: `--harness` arg threaded. |
+| `.claude/hooks/lib/repo-source.sh` | L53-104 (carve-outs L75-85) | `_path_is_repo_source` + carve-outs in bash | **S4 (B2/M3): read carve-outs from shared JSON; node `repo-source.mjs` mirrors it.** |
+| `.claude/hooks/lib/command-classifier.sh` | (read) | tool/command → label | S4/S5 (§A.0 read #3): label logic the bridge needs. |
+| `scripts/enforce-contract.mjs` | L365 `gateDisposition`, L110 `decideStop` | closed-token disposition over tiers (no path/label) | **S5 (§A.0 read #1): the bridge calls `gateDisposition`; there is NO `{action}` write-decision fn (B2).** |
+| `plugins/_index.json` | L3-18 | claude-code entry | S2: append opencode entry. |
+| `plugins/bypass_known.json` | L2-37 | codex+claude-code | S2: append 4 opencode records. |
+| `install.mjs` | L877-893 / L1640-1706 | skill-only / claude-code deploy | S6: add opencode enforcement deploy. |
+| `.github/workflows/plugin-validate.yml` | job `validate` | gauntlet not wired (#377) | S6: add opencode gauntlet step. |
+
+**Re-verify every line in §A.4 — they drift.**
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Tests | Hard stops |
+|---|---|---|---|---|
+| `P5-S1` | Gauntlet `--harness` + fixture-dir param (pure refactor) | `scripts/test-plugin.mjs`, `tests/test-plugin-gauntlet.mjs` | `testHarness*` | No opencode authoring; don't touch steps 5/6. |
+| `P5-S2` | Declarative opencode plugin (gauntlet 1,2,4,7,8) | `_index.json`, `opencode/manifest.json`, 4 fixtures, `bypass_known.json` | gauntlet 1,2,4,7,8 + `test-opencode-translations.mjs` | No runbook/adapter. tool_result MEDIUM. |
+| `P5-S3` | Runbook (3,9) | `opencode/runbooks/enforcement.md`+`.quickref.md` | gauntlet 3,9; validator | §A.0 read #2. focused-review. |
+| `P5-S4` | Shared carve-out JSON + node `repo-source.mjs` (pure extraction, parity-tested) | `patterns/repo-source-carveouts.json`, `scripts/lib/repo-source.mjs`, `.claude/hooks/lib/repo-source.sh` | `test-repo-source-parity.mjs` | §A.0 read #3. Zero behavior change to the bash gate. focused-review. |
+| `P5-S5` | TS adapter + node bridge (uses S4 + gateDisposition) | `opencode/capabilities/enforcement.ts`, `…/enforce-bridge.mjs`, `scripts/enforce-contract.mjs` | `test-opencode-adapter.mjs`, `test-enforce-bridge.mjs`, real-runtime E2E | §A.0 read #1. Gate ONLY repo-src. focused-review (security core). |
+| `P5-S6` | Install deploy + CI | `install.mjs`, `plugin-validate.yml` | `test-install-opencode-enforcement.mjs`; CI; `deploy-audit.mjs` | Unfiltered deploy audit. |
+
+### 10.1 Dependency graph
+
+```text
+S1 ──┬── S2 ──┬── S3 ──────────┐
+     │        └── S5 ──┐       │
+S4 ──────────────┘     ├───────┼── S6
+                       (S5 needs S2 + S4)
+```
+
+S1 hard-deps S2. S4 is independent (depends only on the current repo) — can start in parallel with S1/S2.
+S5 needs S2 (manifest/translations) + S4 (`repo-source.mjs`). S6 needs S2+S3+S5.
+
+## §11 Cut Order
+
+1. REQ-12 CI wiring → follow-up issue (#377).
+2. tool_result observe hook → ship `pre_tool_use` block first.
+
+Do **not** cut: REQ-1; REQ-7 (shared carve-out source); REQ-8/13/14 (repo-src-only, fail-closed — security core); REQ-2/3.
+
+## §12 Contracts
+
+### `runGauntlet({projectRoot, harness, now, cwd}) → result` (S1)
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A | `harness` absent | claude-code entry + `claude-code/` fixtures (byte-identical to today) | none |
+| B | `harness="opencode"` | opencode entry + `opencode/` fixtures | none |
+| C | `harness="zzz"` | throw `UsageError` naming `zzz` | exit 2 |
+
+### `repo-source.mjs` — node mirror of `repo-source.sh` (S4)
+
+Mirrors BOTH bash predicates verbatim (parity-tested). **Path matching is exact-segment** (`<root>/.git` or `<root>/.git/*`), NEVER substring — else `.github/` / `.gitignore` would be wrongly carved (B-NEW-1). Canonicalize via `realpath`/`pwd -P` equivalent (handles `/var`→`/private/var`).
+
+`isRepoSource(repoRoot, targetPath) → {isRepoSource, carveout}` (mirrors `_path_is_repo_source`, sh:54):
+
+| State | Condition | Output |
+|---|---|---|
+| A | target exact-segment under repoRoot, not a carve-out | `{isRepoSource:true, carveout:null}` |
+| B | target under a carve-out dir (shared JSON: `.episodic-memory/.checkpoints/.review-store/.git/docs/plans`) | `{isRepoSource:false, carveout:<name>}` |
+| C | `git -C repoRoot check-ignore` matches | `{isRepoSource:false, carveout:"gitignore"}` |
+| D | target not under repoRoot | `{isRepoSource:false, carveout:"outside-repo"}` |
+| E | **empty/whitespace targetPath** | `{isRepoSource:true}` (**fail-closed**, sh:56 `return 0`) |
+| F | `..`-traversal path | canonicalize first, then A-D (sh:67-73; off-repo `..` → allow, R3) |
+
+`toolTargetsRepoSource(repoRoot, tool, path, label) → GATED|ALLOW` (mirrors `_tool_targets_repo_source_shared`, sh:90): for `tool==="Bash"` (OpenCode `bash`): `read_only|nonsrc_write`→ALLOW; `shared_write|unsafe_complex|push_or_pr_create`→`isRepoSource(repoRoot,path)`; else GATED. For non-Bash tools (write/edit)→`isRepoSource(repoRoot,path)`.
+
+Parity: `test-repo-source-parity.mjs` runs a corpus (repo-src file; each carve-out; `.github/` and `.gitignore` adjacent-name; empty path; `..`-traversal; git-ignored) through BOTH `repo-source.mjs` and `repo-source.sh`, asserts identical verdicts — **with the carve-out JSON present AND absent** (the bash fallback path, B-NEW-3).
+
+### `enforce-bridge.mjs` (stdin JSON → stdout decision) (S5) — the AND composition (B-NEW-2 resolved inline)
+
+**Input:** stdin `{harness:"opencode", event, normalized}`. **Output:** stdout `{action, effective_tier, reason, label}` exit 0; ANY error → exit≠0 (adapter blocks). **Repo root = `realpath(payload.cwd)` only; never process cwd.**
+
+The decision is an **AND of two independent layers** (mirrors how `checkpoint-gate.sh:862` + `plan-gate.sh:192` compose them — NOT a pipe where one consumes the other):
+
+```js
+// pre_tool_use only (the sole blocking event; STRONG):
+const label = classifyLabel(tool, args)                 // L1a: node port of command-classifier subset (§A.0 read #3)
+const gatedWrite = toolTargetsRepoSource(repoRoot, tool, targetPath, label)  // L1b: repo-source.mjs → GATED|ALLOW
+const disp = gateDisposition({                           // L2: enforce-contract.mjs:365 — reuse its loaders for the inputs
+  duplicate,          // registry: >1 active enforcement plugin binds opencode → token "block"
+  harnessCap: "STRONG",   // opencode manifest cap for pre_tool_use
+  contractTier,       // bp-001 contract tier (loaded via the same reader the gates use)
+  active,             // loadEnforceConfig(repoRoot).active  (operator kill switch → "silence")
+  configTier,         // operator tier clamp → "clamp-off"
+  events,             // patterns/events.json
+  event: "pre_tool_use",
+})
+const action = (gatedWrite === "GATED" && (disp.token === "enforce" || disp.token === "block")) ? "block" : "allow"
+```
+
+| State | Condition | stdout / exit |
+|---|---|---|
+| A | pre_tool_use, gatedWrite=GATED, disp.token∈{enforce,block} | `{action:"block"}` exit 0 |
+| B | pre_tool_use, gatedWrite=ALLOW (read / carve-out / non-repo) | `{action:"allow"}` exit 0 |
+| C | pre_tool_use, gatedWrite=GATED but disp.token∈{silence,clamp-off} (operator kill/clamp) | `{action:"allow"}` exit 0 |
+| D | tool_result / session_start / stop (all MEDIUM) | `{action:"allow"}` exit 0 (adapter observes/logs; no mutation) |
+| E | schema-invalid payload | exit 2 |
+| F | classify / gateDisposition / loader throws | exit 3 |
+
+`gateDisposition` token semantics (verified `enforce-contract.mjs:365-378`): `duplicate→"block"`;
+`active===false→"silence"`; `pre_tool_use action==="block"→"enforce"`; `warn/inject→"clamp-off"`;
+unknown/unresolved→`"enforce"` (fail-closed). Only `enforce`/`block` keep the gate blocking.
+The gateDisposition input loaders (`loadEnforceConfig`, the contract-tier reader, the registry
+duplicate check) are reused from `enforce-contract.mjs`, not re-implemented (§A.0 read #1 — DONE inline).
+
+### adapter apply (enforcement.ts) (S5)
+
+| decision.action | OpenCode effect |
+|---|---|
+| `block` | `throw new Error(decision.reason)` |
+| `allow` | `return` |
+| (tool_result event) | observe/log, `return` (result unchanged — MEDIUM) |
+| (bridge exit≠0 / bad JSON / timeout) | `throw new Error("opencode-enforce: fail-closed: " + detail)` |
+
+## §13 Edge Cases
+
+| # | Scenario | Expected | Test |
+|---|---|---|---|
+| EC1 | empty/missing event fields | normalize throws → block | `testMalformedFailsClosed` |
+| EC2 | symlinked `directory` / `/var`→`/private/var` / isMain under symlink | realpath both sides; repo-root stable; gate fires | `testSymlinkRepoRoot` |
+| EC3 | concurrent `tool.execute.before` same session | turn_index incremented **synchronously before any await**; no shared index | `testTurnIndexMonotonic` |
+| EC4 | bridge spawn aborts / times out | adapter throws (no partial allow) | `testBridgeErrorFailsClosed` |
+| EC5 | bridge cwd ≠ target repo (axis-9) | decision uses `payload.cwd`; marker lands under target repo on disk | `testBridgeCwdDivergence` |
+| EC6 | validate-then-write ordering | schema-validate before any marker/alert side effect | `testValidateBeforeSideEffect` |
+| EC7 | carve-out writes (`.git/`,`.checkpoints/`,`.review-store/`,`.episodic-memory/`,`docs/plans/`,git-ignored) | allow | Group 4 negative controls |
+
+## §14 Test Case Catalog
+
+```text
+Group 1: gauntlet param (S1) — node tests/test-plugin-gauntlet.mjs
+  testHarnessDefault       — runGauntlet({projectRoot}); read_trace includes plugins/claude-code/manifest.json AND a claude-code/ fixture path
+  testHarnessOpencode      — harness:"opencode"; read_trace includes plugins/opencode/manifest.json AND an opencode/ fixture path
+  testHarnessUnknownThrows — harness:"zzz" throws, /zzz/.test(err.message)
+
+Group 2: declarative plugin (S2) — node scripts/test-plugin.mjs --harness opencode --json + node tests/test-opencode-translations.mjs
+  testPreToolUse/ToolResult/SessionStart/StopTranslation — replay fixture → payload valid vs schema; sentinel session_id flows through
+  (negative) testEmptySessionIdRejected — fixture sessionID:"" → payload invalid
+
+Group 3: runbook (S3) — gauntlet 3,9 + validator M7a/M7c/M7d/M7e/M7f
+
+Group 4: adapter repo-src gate, fail-closed (S5) — node tests/test-opencode-adapter.mjs
+  testRepoSrcWriteBlocks    — write under repoRoot/src/SENTINEL.mjs → throws (message===bridge reason)
+  testReadAllows            — read_only → no throw
+  testNonRepoWriteAllows / testEpisodeWriteAllows / testPlanFileWriteAllows / testGitWriteAllows /
+  testCheckpointsWriteAllows / testReviewStoreWriteAllows / testGitIgnoredWriteAllows  — each a negative control: no throw on the carve-out sentinel path
+  testMalformedFailsClosed  — normalized missing tool → throw
+  testBridgeErrorFailsClosed— bridge stub exits 1 → throw
+  testTurnIndexMonotonic    — two before-calls → 0 then 1
+  testCwdFromContext        — normalized.cwd === realpath(ctx.directory)
+  testToolResultObserveNoMutate — tool_result → no throw, output.output UNCHANGED (MEDIUM)
+
+Group 5: bridge (S5) — node tests/test-enforce-bridge.mjs
+  testBridgeRepoSrcBlock / testBridgeReadAllow / testBridgeInvalidPayloadExit2 / testBridgeEngineThrowExit3 /
+  testBridgeCwdDivergence — bridge process cwd=os.tmpdir(), payload.cwd=mock repo; decision uses mock repo carve-outs; any marker on disk under mock repo
+
+Group 6: repo-source parity (S4) — node tests/test-repo-source-parity.mjs
+  testParityCorpus     — repo-src + each carve-out + non-repo + git-ignored: identical verdict repo-source.mjs vs repo-source.sh
+  testAdjacentNameNotCarved — .github/x AND .gitignore → GATED (isRepoSource:true) in BOTH (exact-segment, not substring)
+  testEmptyPathFailsClosed  — "" → GATED in both
+  testTraversalAllows       — ../outside → ALLOW in both (R3)
+  testToolTargetsParity     — toolTargetsRepoSource(Bash, read_only|shared_write,…) matches _tool_targets_repo_source_shared
+  testFallbackMode          — JSON hidden → bash fallback verdicts still ≡ mjs (B-NEW-3)
+  testDeployedPathResolution — "JSON present" mode exercises the $HOME/.episodic-memory/patterns/ path the deployed copy uses (NEW-R3-1), not only the repo-relative path
+
+Group 7: install + deploy (S6) mock-project E2E — node tests/test-install-opencode-enforcement.mjs
+  testInstallDeploysAll / testUninstallRemoves / testDeployAuditClean
+```
+
+Total: ~33 named tests + 5 gauntlet steps × opencode.
+
+> **No aspirational output:** every assertion is on real captured output (thrown error/stdout/exit/file/return), never a typed constant. Negative controls inject a unique sentinel path and assert on THAT path.
+> **Real-runtime E2E, never mental-trace:** S5/S6 drive the **deployed** adapter under the real OpenCode runtime via real `install.mjs` (M4 — no node-call OR-branch).
+
+## §15 Verification Ledger (verify by artifact)
+
+| Claim | Command (strong layer) | Observed artifact |
+|---|---|---|
+| Gauntlet param green (claude-code unaffected) | `node tests/test-plugin-gauntlet.mjs` | `<fill: N/N pass>` |
+| Opencode gauntlet | `node scripts/test-plugin.mjs --harness opencode --json` | `<fill: 1-4,7,8,9 pass; 5,6 deferred>` |
+| repo-source.mjs ≡ repo-source.sh | `node tests/test-repo-source-parity.mjs` | `<fill: N/N identical>` |
+| Adapter gates repo-src only (real-runtime E2E) | mock-project: real `install.mjs`, drive deployed OpenCode adapter on repo-src vs carve-out write | `<fill: throw vs return>` |
+| Deploys clean | `node tools/deploy-audit.mjs` (unfiltered) | `<fill: clean>` |
+| Registry valid | `node scripts/validate-plugin-registry.mjs --project .` | `<fill: PASS>` |
+
+**Order + strong-layer rules** as in the template (artifact precedes claim; E2E = deployed adapter; deploy = unfiltered audit; review = 3 layers).
+
+## §16 Risk Analysis
+
+| Risk | Sev | Lik | Mitigation |
+|---|---|---|---|
+| tool_result MEDIUM is over-cautious (OpenCode DOES re-read output.output) | Low | Med | Promote to STRONG only after a real-runtime E2E proves re-read; until then MEDIUM is the honest floor (B1). |
+| Bun(adapter)/node(bridge) spawn fragility | Med | Med | Bridge plain node `.mjs`; adapter spawns `node` by abs path resolved at install; real-runtime E2E covers it. |
+| repo-source.mjs drifts from repo-source.sh | High | Med | Single shared carve-out JSON (Rule 14) + parity test (REQ-7). |
+| gateDisposition token→action mapping mis-pinned | High | Med | §A.0 read #1 pins it; bridge unit tests (Group 5) assert each branch. |
+| `.opencode/plugins/` dir / config shape varies by version | Med | Med | Register via config `plugin` array + plural dir; install E2E probes installed opencode. |
+
+## §17 Open Decisions
+
+**RESOLVED (ground truth: KB `opencode-plugin-api.md`, `@opencode-ai/plugin@1.14.50`):**
+
+- **OD-1 (hook-event shapes) — RESOLVED.** `tool.execute.before`→pre_tool_use STRONG (throw). `tool.execute.after`→tool_result; the after-hook returns `void` with **no proven result re-read**, so **MEDIUM (observe)**, NOT STRONG (round-1 B1; web docs were wrong both ways). `experimental.chat.system.transform`→session_start MEDIUM. `event`→session.idle observe→stop MEDIUM (no refuse hook). Events omit `cwd` (use `PluginInput.directory`) and `turn_index` (adapter synthesizes, sync).
+- **OD-2 (TS vs zero-dep) — RESOLVED.** `enforcement.ts` with a type-only import of `@opencode-ai/plugin` (erased → zero runtime dep), loaded by OpenCode (Bun); spawns zero-dep node `enforce-bridge.mjs`. Registered via the config `plugin` array + `.opencode/plugins/` fallback.
+
+**Still deferrable:**
+
+- **OD-3: REQ-12 CI wiring** → may defer to a follow-up issue referencing #377.
+- **OD-4: bp-001 marker lifecycle for OpenCode (round-2 scope boundary).** P5 enforces the repo-source-write × disposition AND (§12). The checkpoint/plan-approval MARKER lifecycle (checkpoint-gate.sh's armed/approval-token state) is claude-code-specific bp-001 machinery and is NOT replicated for OpenCode in P5. Tracked as a follow-up issue.
+
+| Field | OD-4 |
+|---|---|
+| 1. Run scenario | An OpenCode session writes repo source without a plan-approval/checkpoint marker; P5 blocks it iff the contract is enforcing, but does not additionally require the bp-001 lifecycle markers. |
+| 2. Spec | R5/R6 require harness binding + per-project enforcement; the bp-001 LIFECYCLE is a behavior pattern (decoupled layer per CAPABILITIES.md), not required for the first OpenCode binding. |
+| 3. History | Round-2 review (`…3fdb`) surfaced the marker-lifecycle depth; reviewer's prescribed AND model excludes it. |
+| 4. Same-class | P6/P7 share the same boundary; resolve the lifecycle-port once, later, for all non-claude harnesses. |
+| 5. Residual | If deferred: OpenCode gets repo-source-write gating (honest STRONG) but not the full plan/checkpoint workflow. Graceful; recover by a follow-up lifecycle-port slice. |
+
+| Field | OD-3 |
+|---|---|
+| 1. Run scenario | Without CI the gauntlet runs only locally; a regression merges green. |
+| 2. Spec | R10 + Rule 13 → SHOULD, defer allowed with a tracked issue. |
+| 3. History | #377 tracks the same for claude-code. |
+| 4. Same-class | claude-code gauntlet also uncovered; wire both. |
+| 5. Residual | Local run still exists; recover by wiring the follow-up. Graceful. |
+
+## §18 Done Criteria
+
+- [ ] REQ-1..11, REQ-13, REQ-14 passing with §15 artifacts.
+- [ ] `node scripts/test-plugin.mjs --harness opencode` → 1-4,7,8,9 pass, 5-6 deferred.
+- [ ] claude-code gauntlet byte-identical to pre-S1.
+- [ ] `repo-source.mjs` ≡ `repo-source.sh` (parity test green).
+- [ ] Real-runtime mock-project E2E: deployed adapter throws on a repo-src write; allows every carve-out.
+- [ ] `tools/deploy-audit.mjs` clean after S6.
+- [ ] Every deferred finding (OD-3, any round-2 DEFER) has an issue/comment/violation (Rule 18 step 9).
+
+## §19 Review Consensus (Rule 18)
+
+```bash
+node scripts/second-opinion.mjs request --provider claude-subagent --project . \
+  --storage episodic --body-file docs/plans/p5-opencode-plugin.md \
+  --summary "P5 OpenCode plugin plan review (round 2)" --dispatch
+```
+
+| Pass | Reviewer | Provider | Blockers | Verdict | Reply episode |
+|---|---|---|---|---|---|
+| 1 | `negative-scenario-planner` | (Agent subagent) | 2 + 4 major | **HOLD** | `20260623-063907-hold-p5-opencode-plan-tool-result-strong-13d5` |
+| 2 | `negative-scenario-planner` (revised) | (Agent subagent) | 1 + 1 major + 2 minor | **HOLD** (B1/M1 cleared) | `20260623-083618-hold-round-2-p5-opencode-plan-b2-re-arch-3fdb` |
+| 3 | `negative-scenario-planner` (boundary-corrected) | (Agent subagent) | 0 blocker, 1 minor (NEW-R3-1, fixed) | **ACCEPT** | `20260623-084701-accept-round-3-final-p5-opencode-plan-b--0da3` |
+
+**Consensus reached at round 3 (ACCEPT).** B-NEW-1/2/3/4 all verified adequate against the real repo
+(the two-layer AND is byte-accurate to `enforce-contract.mjs:365-378`; exact-segment mirrors
+`repo-source.sh:75-85`; repo copy is the right edit target, diffed identical to deployed). The one new
+minor (NEW-R3-1, JSON resolution order for the deployed copy) is applied to S4 4.2 + the parity test.
+Reviewer flagged its ACCEPT is a technical verdict, NOT a substitute for the user's Rule 18 step-4 approval.
+
+### 19.1 Resolved blockers (round 1)
+
+| # | Finding (R) | Verdict | Resolution + evidence |
+|---|---|---|---|
+| B1 | tool_result STRONG dishonest (R6) | ACCEPT (MODIFY) | → MEDIUM (observe) everywhere; promotion gated on real-runtime re-read E2E. `index.d.ts:248-257` returns `void`, no re-read contract. |
+| B2 | bridge "decision fn" absent (R5/R6/R1-R3) | ACCEPT | Decision = `repo-source.mjs` (carve-outs) + `gateDisposition` (`enforce-contract.mjs:365`); new pure-extraction slice S4; bridge spec rewritten (§12). |
+| M1 | gauntlet step 8 reads claude-code fixtures (R6) | ACCEPT | S1 now parameterizes the fixture dir (`test-plugin.mjs:143`); `testHarnessOpencode` asserts an `opencode/` fixture path in read_trace. |
+| M2 | turn_index fixture-vs-live + race (R6) | ACCEPT (MODIFY) | Sync pre-await increment (REQ-10, EC3); reset-on-reload accepted (ordering-only). |
+| M3 | §A.5 carve-out list incomplete → over-block (R1-R3) | ACCEPT | Carve-out set = `repo-source.sh` via shared JSON (REQ-7); Group-4 controls for `.checkpoints/`,`.review-store/`,git-ignored. |
+| M4 | unsound E2E OR-branch (R5/R6) | ACCEPT | OR-branch deleted; real-runtime E2E required or `deferred-unverified` + issue. |
+| axis-9 | bridge cwd divergence | ACCEPT | Bridge uses `payload.cwd` only (REQ-9); `testBridgeCwdDivergence`. |
+| OD-3 | CI wiring (R10) | DEFER | 5-field block (§17); references #377. |
+
+### 19.2 Resolved blockers (round 2)
+
+| # | Finding (R) | Verdict | Resolution + evidence |
+|---|---|---|---|
+| B-NEW-2 | bridge sequences classify→gateDisposition as a pipe; the real decision is a two-layer AND (R5/R6/R1-R3) | ACCEPT | §8.3/§12/mermaid rewritten to the explicit AND: `toolTargetsRepoSource` (`repo-source.sh:90`) AND `gateDisposition.token∈{enforce,block}` (`enforce-contract.mjs:365`). READ-PIN A.0#1 resolved inline. |
+| B-NEW-1 | "zero behavior change" to the live bash gate unverified; substring carve-out would catch `.github` (R1-R3) | ACCEPT | §12 + S4 mandate **exact-segment** match; parity corpus adds `.github`/`.gitignore`/empty/`..`/git-ignored, run JSON-present AND fallback. |
+| B-NEW-3 | half-migrated gate: JSON read at runtime but deployed only in S6 (R5) | ACCEPT | S4 4.2: JSON path resolved relative to the script + install-fallback; **bash falls back to inline literals if JSON unreadable** (never fail-open); parity test runs both modes. |
+| B-NEW-4 | A.0#1 READ-PIN re-buried the B2 decision (R5/R6) | ACCEPT | A.0#1 resolved inline in §12; only #2 (runbook) + #3 (label map) remain pinned (reviewer agreed those are mechanical). |
+| marker-lifecycle | the bp-001 checkpoint/approval lifecycle is deeper than P5 models | ACCEPT (scope) | Documented as OD-4 (out of P5 scope; follow-up); P5 = repo-source-write × disposition AND only. |
+
+Three layers (per-artifact → cross-file → PR-level). The round-1/2 cap is exceeded by explicit user
+direction ("reach consensus"); round-2's B-NEW-2 was same-class as B1's B2, so this revision **changes
+the boundary** (models the real two-layer AND from the live gate) rather than re-spelling the patch —
+the reviewer's prescribed fix, which it predicted "clears." Round-3 confirms.
+
+## §20 Lessons Encoded
+
+| Lesson | Rule | Enforced in |
+|---|---|---|
+| `…7918` verify-strong-claim | E2E = deployed adapter; review PR-level | §14,§15,§19 |
+| `…540d` unfiltered deploy audit | `deploy-audit.mjs`, never `diff\|grep differ` | §15 |
+| `…16c4`/`…937a` symlink/isMain | realpath both sides; lstat before realpath | §7,§13 |
+| enforcement-gate-only-repo-src (R1-R3) | gate ONLY repo-src; carve-out set = `repo-source.sh` | §7,§12,§14 |
+| Rule 14 single source | carve-outs in one JSON read by bash + node | REQ-7, §A.7 S4 |
+| mock-project-not-mental-trace | install/hook proven by real `install.mjs` E2E | §14, §A.7 S5/S6 |
+| model-scratch-I/O | carve `.git/` out | §13 EC7 |
+| canonical-agent dispatch | `negative-scenario-planner` before self-walk | §7,§19 |
+| pure-extraction-first | S1 + S4 ship before new callers | §10 |
+| plan-template low-altitude | low executor; full appendix; behavioral verifies | §1, App A |
+| Rule 4 / Rule 7 | probe installed types; distil to KB | §2,§17 |
+
+---
+
+# Appendix A: Mechanical Execution Spec (target executor: Haiku / DeepSeek V4 Flash)
+
+## A.0 Pre-authoring reads (plan author completes before S3/S4/S5/S6 handoff; fills `<READ-PIN>` cells)
+
+1. **~~enforce-contract decision surface~~ — DONE inline (B-NEW-4).** Read `enforce-contract.mjs:365-378` (`gateDisposition`) + the composition at `checkpoint-gate.sh:862` / `plan-gate.sh:192`. The exact AND composition + token semantics are now in §12 (no READ-PIN remains). S5 wires the reused loaders named there.
+2. **runbook derivation** — read `scripts/validate-plugin-registry.mjs:297-446` (M7a/M7c/M7d/M7e/M7f). Pin: byte-derivation of §7/§8/§9/§10. Fills S3 3.x. (`…2f5d`: reading pass, not phrase-grep.)
+3. **classifier label map** — read `.claude/hooks/lib/command-classifier.sh`. Pin: the tool/command→label mapping `classifyLabel(tool,args)` mirrors for OpenCode tools (write/edit/bash/read). Fills S5 step 5.1's `classifyLabel`. (Carve-out set is already pinned: `repo-source.sh:75-85` → §A.7 4.1.)
+
+## A.1 Forbidden-phrase lint
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/p5-opencode-plugin.md
+```
+
+Expected: **no matches inside Appendix A step tables.** Matches in §17/§19 (decision/disposition prose), the mermaid `gateDisposition`, and A.0 are excluded. Plus a reading pass (`…2f5d`).
+
+## A.2 Executor contract (copy verbatim into the handoff)
+
+1. Steps in numeric order; no skip/reorder/batch.
+2. Each step = one file, exact change, a verify.
+3. **No design decisions.** Ambiguity, missing verbatim anchor, or an unfilled `<READ-PIN>` → STOP (§A.3).
+4. Run the verify after each step; fix only that step before proceeding.
+5. **One file per step** (the `File` column). Read-only refs: §A.5.
+6. Each verify is a **single** command — no `;`/`&&`/`||`/pipes/subshells (compound-bash-gate blocks them).
+7. One slice = one commit `P5-S<n>: <title>` + `Co-Authored-By` trailer.
+8. No commit/push/PR until the slice's §18 criteria are green AND the human approved.
+9. **No aspirational output** — every printed check has a backing assertion.
+
+## A.3 STOP-and-ask protocol
+
+```text
+STOP — step <n.m> blocked.
+Reason: <anchor not found | ambiguous | verify failed after fix | READ-PIN unfilled>.
+File: <path> ; Expected anchor (verbatim): <text> ; Found instead: <±3 lines>
+Question: <the single decision the plan owner must make>
+```
+
+## A.4 Pre-flight (step 0 of every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| Branch | `git branch --show-current` | `feat/rfc-008-p5-opencode-plugin` |
+| Clean tree | `git status --porcelain` | empty |
+| Baseline gauntlet | `node tests/test-plugin-gauntlet.mjs` | `<N>/<N> pass` |
+| Anchor live | `grep -n 'claude-code/' scripts/test-plugin.mjs` | matches L143 (S1) |
+
+## A.5 Shared constants / types
+
+```js
+// Tiers (manifest + _index, deep-equal):
+//   pre_tool_use:"STRONG", tool_result:"MEDIUM", session_start:"MEDIUM", stop:"MEDIUM"
+// Version hashes (reuse current — same taxonomy/events files):
+//   taxonomy_version:"sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4"
+//   events_version:"sha256:13f01e5a599272b349eabd66694b7898e68438e8aad6497e80a9b780bea34ab0"
+// emits_labels (default classifier): ["read_only","nonsrc_write","shared_write","push_or_pr_create","marker_write","unsafe_complex","unknown"]
+// invocation_modality:"agent"
+// Carve-outs: DO NOT hardcode a list here — read patterns/repo-source-carveouts.json (S4), the single source mirrored from repo-source.sh:75-85 (Rule 14).
+```
+**Read-only refs:** `plugins/claude-code/manifest.json`, `schemas/events/event-*.schema.json`,
+`patterns/events.json`, `patterns/taxonomy.json`, `scripts/validate-plugin-registry.mjs`,
+`.claude/hooks/lib/repo-source.sh`, `scripts/lib/field-bindings.mjs`, KB `opencode-plugin-api.md`.
+
+## A.6 Anchor format
+
+EDIT = verbatim unique `ANCHOR`→`REPLACE`, smallest span, no reflow. CREATE = whole-file `Write`, full verbatim contents. APPEND = end-of-file add. Anchor not found verbatim → STOP.
+
+## A.6b Falsifiable Verify
+
+Every verify FAILS if intent is absent/stubbed, visible in the command. **Deny-list:** grep for the
+literal the step just wrote (self-fulfilling); tolerant exit (`|| true`); happy-path only with no
+negative control; a MUST/Safety row guarded only by a `command -v`-skippable smoke w/o `UNGUARDED-IN-CI`.
+**Obligation:** name the observed value (captured stdout/exit/return/file) + the expected concrete value.
+One command per verify.
+
+## A.7 Per-slice step tables
+
+### `P5-S1` — Gauntlet `--harness` + fixture-dir param (REQ-1) — FULLY SPECIFIED
+
+**May touch:** `scripts/test-plugin.mjs`, `tests/test-plugin-gauntlet.mjs`. **Read-only:** `plugins/_index.json`.
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4. | passes |
+| 1.1 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `export function runGauntlet({ projectRoot, now = NOW, cwd = process.cwd() } = {}) {` → `REPLACE:` `export function runGauntlet({ projectRoot, harness = "claude-code", now = NOW, cwd = process.cwd() } = {}) {` | `node -e "import('./scripts/test-plugin.mjs').then(m=>m.runGauntlet({projectRoot:process.cwd(),harness:'zzz'})).catch(e=>{if(!/zzz/.test(e.message))process.exit(1)})"` → exit 0 |
+| 1.2 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `(p) => p.type === "enforcement" && p.id === "claude-code"` → `REPLACE:` `(p) => p.type === "enforcement" && p.id === harness` | covered by 1.8 |
+| 1.3 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `no enforcement entry 'claude-code' in plugins/_index.json` → `REPLACE:` `` `no enforcement entry '${harness}' in plugins/_index.json` `` (template literal) | covered by 1.8 testHarnessUnknownThrows |
+| 1.4 | `scripts/test-plugin.mjs` | EDIT | `<READ-PIN: confirm L143 exact text + `stepEventReplay` signature at slice start>` `ANCHOR:` the `tests/fixtures/harness-events/claude-code/` literal at L143 → `REPLACE:` `tests/fixtures/harness-events/${harness}/`. The READ-PIN resolves how `harness` reaches L143: add `harness` as a parameter to `stepEventReplay(...)` and pass `entry.id` (the resolved registry id) at its call site (~L99). Smallest diff; no other line changes. | `node scripts/test-plugin.mjs --harness opencode --json` (after S2) → step 8 read_trace contains `harness-events/opencode/` |
+| 1.5 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `const args = { project: null, json: false, help: false };` → `REPLACE:` `const args = { project: null, harness: "claude-code", json: false, help: false };` | `node scripts/test-plugin.mjs --harness claude-code --json` → not "unknown argument" |
+| 1.6 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `if (a === "--project") args.project = argv[++i];` → `REPLACE:` `if (a === "--project") args.project = argv[++i];\n    else if (a === "--harness") args.harness = argv[++i];` | covered by 1.5 |
+| 1.7 | `scripts/test-plugin.mjs` | EDIT | `ANCHOR:` `runGauntlet({ projectRoot: args.project })` → `REPLACE:` `runGauntlet({ projectRoot: args.project, harness: args.harness })` | covered by 1.5 |
+| 1.8 | `tests/test-plugin-gauntlet.mjs` | EDIT | Add `testHarnessDefault` (read_trace has `claude-code/manifest.json` and a `harness-events/claude-code/` path), `testHarnessUnknownThrows` (`harness:"zzz"` throws, `/zzz/`). `testHarnessOpencode` after S2 (until then a skip-guard comment referencing S2). Full verbatim at slice start. | `node tests/test-plugin-gauntlet.mjs` → all pass incl. `testHarnessUnknownThrows` |
+| 1.9 | — | — | Commit `P5-S1: parameterize gauntlet by harness` + trailer. | `git log -1 --oneline` shows `P5-S1` |
+
+**Red-then-green:** `testHarnessUnknownThrows` goes RED on un-refactored code (hardwired claude-code ignores `harness:"zzz"`).
+
+### `P5-S2` — Declarative opencode plugin (REQ-2,3,4,6) — FULLY SPECIFIED
+
+**May touch:** `plugins/_index.json`, `plugins/opencode/manifest.json` (new), 4 fixtures (new), `plugins/bypass_known.json`, `tests/test-opencode-translations.mjs` (new). **Read-only:** `plugins/claude-code/manifest.json`, event schemas.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 2.0 | — | — | Pre-flight §A.4. | passes |
+| 2.1 | `plugins/_index.json` | EDIT | `ANCHOR:` `      "status": "active"\n    }\n  ]\n}` → `REPLACE:` (append a second entry) `      "status": "active"\n    },\n    {\n      "type": "enforcement",\n      "id": "opencode",\n      "harness": "opencode",\n      "directory": "plugins/opencode",\n      "capabilities": {\n        "pre_tool_use": "STRONG",\n        "tool_result": "MEDIUM",\n        "session_start": "MEDIUM",\n        "stop": "MEDIUM"\n      },\n      "classifier": "default",\n      "manifest": "plugins/opencode/manifest.json",\n      "status": "active"\n    }\n  ]\n}` | `node -e "const i=require('./plugins/_index.json');process.exit(i.plugins.some(p=>p.id==='opencode'&&p.capabilities.tool_result==='MEDIUM')?0:1)"` exit 0 |
+| 2.2 | `plugins/opencode/manifest.json` | CREATE | Full contents = §A.7-S2-manifest block below. | `node scripts/validate-plugin-registry.mjs --project .` → no M2 violation for opencode |
+| 2.3 | `tests/fixtures/harness-events/opencode/pre-tool-use.json` | CREATE | `{"tool":"write","args":{"filePath":"/Users/juan.delacruz/repo/src/x.mjs","content":"x"},"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":3}` | gauntlet step 8 (after S1) → pre_tool_use payload valid |
+| 2.4 | `tests/fixtures/harness-events/opencode/tool-result.json` | CREATE | `{"tool":"bash","args":{"command":"ls"},"result":"a.txt\nb.txt","sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":4}` | step 8 → tool_result payload valid |
+| 2.5 | `tests/fixtures/harness-events/opencode/session-start.json` | CREATE | `{"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","harness":"opencode"}` | step 8 → session_start payload valid |
+| 2.6 | `tests/fixtures/harness-events/opencode/stop.json` | CREATE | `{"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":5,"is_subagent":false}` | step 8 → stop payload valid |
+| 2.7 | `plugins/bypass_known.json` | EDIT | `ANCHOR:` `      "auditor": "rfc008-p1b-capability-audit"\n    }\n  ]\n}` → `REPLACE:` append 4 records `{harness:"opencode", event:<pre_tool_use|tool_result|session_start|stop>, no_known_bypass_evidence:true, last_audited_iso8601:"2026-06-23T00:00:00Z", auditor:"rfc008-p5-opencode-capability-audit"}` (full JSON, comma-joined, closing `]}`). | gauntlet step 7 → clean (M4a) |
+| 2.8 | `tests/test-opencode-translations.mjs` | CREATE | Full verbatim: for each event, read the fixture, run the manifest field_bindings via the interpreter `scripts/lib/field-bindings.mjs` (import it), validate the payload vs `schemas/events/event-<event>.schema.json` with the repo instance validator; assert `valid===true` AND `payload.session_id==="ses_abc"`. Plus `testEmptySessionIdRejected` (clone the pre-tool-use fixture with `sessionID:""` → assert invalid). | `node tests/test-opencode-translations.mjs` → 5/5 (4 valid + 1 negative) |
+| 2.9 | — | — | Commit `P5-S2: declarative opencode plugin` + trailer. | `node scripts/test-plugin.mjs --harness opencode --json` → steps 1,2,4,7,8 pass |
+
+**§A.7-S2-manifest block — full verbatim `plugins/opencode/manifest.json`:**
+
+```json
+{
+  "type": "enforcement",
+  "schema_version": "1.0.0",
+  "id": "opencode",
+  "harness": "opencode",
+  "version": "1.0.0",
+  "invocation_modality": "agent",
+  "capabilities": {
+    "pre_tool_use": "STRONG",
+    "tool_result": "MEDIUM",
+    "session_start": "MEDIUM",
+    "stop": "MEDIUM"
+  },
+  "classifier": {
+    "mode": "default",
+    "emits_labels": ["read_only","nonsrc_write","shared_write","push_or_pr_create","marker_write","unsafe_complex","unknown"]
+  },
+  "taxonomy_ref": "patterns/taxonomy.json",
+  "taxonomy_version": "sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4",
+  "events_version": "sha256:13f01e5a599272b349eabd66694b7898e68438e8aad6497e80a9b780bea34ab0",
+  "event_translations": {
+    "pre_tool_use": { "source_format": "opencode-tool-execute-before-normalized",
+      "field_bindings": { "tool":"$.tool","tool_args":"$.args","cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","timestamp_iso8601":"$$now" } },
+    "tool_result": { "source_format": "opencode-tool-execute-after-normalized",
+      "field_bindings": { "tool":"$.tool","tool_args":"$.args","result":"$.result","cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","timestamp_iso8601":"$$now" } },
+    "session_start": { "source_format": "opencode-system-transform-normalized",
+      "field_bindings": { "cwd":"$.cwd","session_id":"$.sessionID","harness":"$.harness","timestamp_iso8601":"$$now" } },
+    "stop": { "source_format": "opencode-session-idle-normalized",
+      "field_bindings": { "cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","is_subagent":"$.is_subagent","timestamp_iso8601":"$$now" } }
+  },
+  "runbook": { "full": "plugins/opencode/runbooks/enforcement.md", "quickref": "plugins/opencode/runbooks/enforcement.quickref.md" }
+}
+```
+
+### `P5-S3` — Runbook (REQ-5) — NEEDS §A.0 read #2; focused-review
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 3.0 | — | — | Pre-flight; confirm §A.0 read #2 done else STOP. | passes |
+| 3.1 | `plugins/opencode/runbooks/enforcement.md` | CREATE | sentinel `## ⚠️ Self-trigger checklist` + COMMON block byte-copied from `scripts/scaffold-plugin/templates/common-rows.md` + `## §1`…`## §10` headers (mirror claude-code runbook). | `grep -c '^## §' plugins/opencode/runbooks/enforcement.md` → 10 |
+| 3.2 | `plugins/opencode/runbooks/enforcement.md` | EDIT | `<READ-PIN A.0#2>` §7 resolution matrix from opencode caps×taxonomy×events R3 ternary (tool_result row = MEDIUM/observe). | validator → no M7c |
+| 3.3 | same | EDIT | §8 `**Invocation modality:** agent`. | no M7d |
+| 3.4 | same | EDIT | `<READ-PIN A.0#2>` §9 agent-manifest JSON: `command_shapes`=`["node","plugins/opencode/capabilities/enforce-bridge.mjs"]`, `expected_outputs.shape:"json-object"`, `return_codes` {0:ok,2:invalid,3:engine-error}. | no M7e; gauntlet step 9 dispatches in sandbox → marker armed in sandbox only |
+| 3.5 | same | EDIT | `<READ-PIN A.0#2>` §10 config cross-binding (values byte-equal manifest). | no M7f |
+| 3.6 | `plugins/opencode/runbooks/enforcement.quickref.md` | CREATE | quickref mirroring claude-code's. | gauntlet step 3 → present + sentinel + COMMON byte-match |
+| 3.7 | — | — | Commit `P5-S3: opencode enforcement runbook` + trailer. | `node scripts/test-plugin.mjs --harness opencode` → steps 3,9 pass |
+
+### `P5-S4` — Shared carve-out JSON + node `repo-source.mjs` (REQ-7) — NEEDS §A.0 read #3; pure extraction; focused-review
+
+**May touch (one per step):** `patterns/repo-source-carveouts.json`, `scripts/lib/repo-source.mjs`, `.claude/hooks/lib/repo-source.sh`, `tests/test-repo-source-parity.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 4.0 | — | — | Pre-flight; confirm carve-out set = `repo-source.sh:75-85` (exact list: `.episodic-memory`,`.checkpoints`,`.review-store`,`.git`,`docs/plans` + `git check-ignore`). | passes |
+| 4.1 | `patterns/repo-source-carveouts.json` | CREATE | Full JSON of the exact set: `{"exact_segment_dirs":[".episodic-memory",".checkpoints",".review-store",".git","docs/plans"],"git_check_ignore":true}`. (Comment in-file: dirs match by **exact segment** under repo root, never substring — `.github`/`.gitignore` must NOT match.) | `node -e "const c=require('./patterns/repo-source-carveouts.json');process.exit(c.exact_segment_dirs.length===5&&c.git_check_ignore?0:1)"` exit 0 |
+| 4.2 | `plugins/claude-code/hooks/lib/repo-source.sh` | EDIT | `ANCHOR:` the 5 inline carve-out `case` lines (`"$repo_canon"/.episodic-memory\|...` block, sh:76-80) → `REPLACE:` a loop reading `exact_segment_dirs` from the JSON, resolved in this **exact order (NEW-R3-1)**: (1) `$HOME/.episodic-memory/patterns/repo-source-carveouts.json` — the **deployed canonical** path the live `~/.claude/hooks/lib/` copy actually uses (the script-relative form overshoots above `$HOME` for the deployed copy: `~/.claude/hooks/lib/` + `../../../../` = `/Users/`, wrong); (2) `${BASH_SOURCE[0]%/*}/../../../../patterns/repo-source-carveouts.json` — in-repo dev/test only; (3) **inline 5-dir literals** if both are unreadable (fail-safe: a deploy-lag never opens the gate; zero behavior change). Keep exact-segment `case` semantics; never substring. | `bash tests/test-repo-source.sh` green; **negative:** hide BOTH JSON locations → the inline fallback still gates `.git/` (one-shot bash assert) |
+| 4.3 | `scripts/lib/repo-source.mjs` | CREATE | Full verbatim node mirror per §12: `isRepoSource(repoRoot,targetPath)` + `toolTargetsRepoSource(repoRoot,tool,path,label)`. **Exact-segment** match (`p===root+"/"+d || p.startsWith(root+"/"+d+"/")`), realpath canonicalize, empty-path→fail-closed gated, `..`-traversal→canonicalize-first, `git -C repoRoot check-ignore`. Reads the same JSON with the same fallback. | imported in 4.4 |
+| 4.4 | `tests/test-repo-source-parity.mjs` | CREATE | Full verbatim corpus run through BOTH `repo-source.sh` AND `repo-source.mjs`, asserting identical verdict per path, **twice — JSON present and JSON hidden (fallback)**. Corpus MUST include: a repo-src file (GATED); each carve-out dir; **`.github/x` and `.gitignore` (adjacent-name → GATED, NOT carved)**; empty path (→ fail-closed GATED); a `../outside` traversal (→ ALLOW); a `git check-ignore` match (→ ALLOW). | `node tests/test-repo-source-parity.mjs` → all identical in BOTH JSON modes; **negative row:** `.github/x` returns isRepoSource:true (GATED) in both impls |
+| 4.5 | — | — | Commit `P5-S4: shared repo-source carve-outs (bash+node, parity)` + trailer. | parity green (both modes); bash gate tests green |
+
+### `P5-S5` — TS adapter + node bridge (REQ-8,9,10,13,14) — NEEDS §A.0 read #1+#3; focused-review (security core)
+
+**May touch (one per step):** `plugins/opencode/capabilities/enforce-bridge.mjs`, `tests/test-enforce-bridge.mjs`, `plugins/opencode/capabilities/enforcement.ts`, `tests/test-opencode-adapter.mjs`, `scripts/enforce-contract.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 5.0 | — | — | Pre-flight; confirm §A.0 read #3 (classifyLabel map) done. (Read #1 is resolved inline in §12.) | passes |
+| 5.1 | `plugins/opencode/capabilities/enforce-bridge.mjs` | CREATE | Zero-dep node CLI = the §12 AND composition verbatim: stdin `{harness,event,normalized}`; `field-bindings.mjs` → payload; validate vs event schema (exit 2); for `event!=="pre_tool_use"` → `{action:"allow"}` (MEDIUM observe); for `pre_tool_use`: `label=classifyLabel(tool,args)` (§A.0#3 map), `gatedWrite=toolTargetsRepoSource(realpath(payload.cwd),tool,target,label)`, `disp=gateDisposition({...})` reusing `loadEnforceConfig`+contract-tier+duplicate from enforce-contract, `action=(gatedWrite==="GATED"&&disp.token∈{enforce,block})?block:allow`; print `{action,effective_tier:disp.effTier,reason,label}`; any throw → exit 3. Repo root = `realpath(payload.cwd)` ONLY. | `node tests/test-enforce-bridge.mjs` → all pass (incl. State-C operator-kill → allow even on a gated write) |
+| 5.2 | `tests/test-enforce-bridge.mjs` | CREATE | Full verbatim Group 5 incl. `testBridgeCwdDivergence` (process cwd=`os.tmpdir()`, payload.cwd=mock repo → decision uses mock repo carve-outs; marker on disk under mock repo) + `testBridgeInvalidPayloadExit2` + `testBridgeEngineThrowExit3`. Assert captured stdout/exit; sentinel path flows through. | `node tests/test-enforce-bridge.mjs` → 5/5 |
+| 5.3 | `plugins/opencode/capabilities/enforcement.ts` | CREATE | Full verbatim TS: `export const EpisodicEnforcement: Plugin = async (ctx) => ({...})` with `tool.execute.before`/`tool.execute.after`/`experimental.chat.system.transform`/`event`. Each: NORMALIZE (cwd=`realpath(ctx.directory)`, per-session turn_index Map incremented **synchronously before any await**, typed consts), spawn bridge (`node` abs path), apply §12 (throw on block; tool_result observe/log + return; allow return; bridge exit≠0/bad JSON/timeout → throw). Type-only import of `@opencode-ai/plugin`. | `node tests/test-opencode-adapter.mjs` → all pass |
+| 5.4 | `tests/test-opencode-adapter.mjs` | CREATE | Full verbatim Group 4 (§14): repo-src→throw; read→allow; ALL carve-out negative controls (episode/plan/git/checkpoints/review-store/git-ignored/non-repo)→no throw; malformed→throw; bridge-error→throw; turn_index 0→1; cwd from ctx; tool_result no-mutate. Unique sentinel path per case. | `node tests/test-opencode-adapter.mjs` → all pass; each negative control asserted on its sentinel path |
+| 5.5 | `scripts/enforce-contract.mjs` | EDIT | Add thin `export` for any loader the bridge imports but that is currently module-private (`gateDisposition` is already exported, L365; confirm `loadEnforceConfig` + the contract-tier reader + the registry duplicate check are exported, else APPEND thin re-export wrappers). NO logic change; claude-code path untouched (smallest diff). | existing `node tests/test-*enforce*` green; `node -e "import('./scripts/enforce-contract.mjs').then(m=>process.exit(typeof m.gateDisposition==='function'&&typeof m.loadEnforceConfig==='function'?0:1))"` exit 0 |
+| 5.6 | — | — | Commit `P5-S5: opencode adapter + bridge` + trailer; run the real-runtime E2E (§A.7-S5-E2E). | E2E: deployed adapter throws on repo-src write |
+
+**§A.7-S5-E2E (real OpenCode runtime, no OR-branch — M4):** isolated-`HOME` mock project; install the
+plugin via real `install.mjs --tool opencode --install-enforcement` (S6) into the mock; run OpenCode
+against a `write` to a repo-source path → assert the tool is refused (hook threw); run a `write` to
+`.episodic-memory/` → assert it proceeds. If the real runtime cannot be driven in CI, mark
+`deferred-unverified` + file an issue (do NOT substitute a node-call).
+
+### `P5-S6` — Install deploy + CI (REQ-11,12) — anchored
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 6.0 | — | — | Pre-flight. | passes |
+| 6.1 | `install.mjs` | EDIT | `<READ-PIN: opencode install region L877-893 + enforcement deploy L1640-1706>` extend `--install-enforcement` to deploy `plugins/opencode/{manifest.json,capabilities/,runbooks/}` + `_index.json` + `scripts/lib/repo-source.mjs` + `patterns/repo-source-carveouts.json` + register the plugin in the project `opencode.json[c]` `plugin` array. | `node tests/test-install-opencode-enforcement.mjs` → `testInstallDeploysAll` pass |
+| 6.2 | `install.mjs` | EDIT | `<READ-PIN>` extend `--uninstall-enforcement` to remove the opencode artifacts + config entry. | `testUninstallRemoves` pass |
+| 6.3 | `tests/test-install-opencode-enforcement.mjs` | CREATE | Full verbatim mock-project E2E: install → assert files on disk + config `plugin` entry; uninstall → assert gone; `tools/deploy-audit.mjs` → clean. | `node tests/test-install-opencode-enforcement.mjs` → 3/3 |
+| 6.4 | `.github/workflows/plugin-validate.yml` | EDIT | `ANCHOR:` the `validate` step running `test-plugin-registry.mjs` → add `node scripts/test-plugin.mjs --harness opencode --json`. (If OD-3 deferred, file the issue + skip 6.4.) | `gh run view <id>` → opencode gauntlet step present + green |
+| 6.5 | — | — | Commit `P5-S6: install + CI for opencode plugin` + trailer; run `node tools/deploy-audit.mjs`. | deploy-audit clean |
+
+## A.8 Definition of done (mechanical)
+
+```bash
+node tests/test-plugin-gauntlet.mjs               # claude-code unaffected: all pass
+node scripts/test-plugin.mjs --harness opencode   # 1-4,7,8,9 pass, 5-6 deferred
+node tests/test-opencode-translations.mjs         # 5/5
+node tests/test-repo-source-parity.mjs            # N/N identical
+node tests/test-enforce-bridge.mjs                # 5/5 incl. cwd-divergence
+node tests/test-opencode-adapter.mjs              # all incl. carve-out negative controls
+node tests/test-install-opencode-enforcement.mjs  # 3/3 (mock-project E2E)
+node scripts/validate-plugin-registry.mjs --project .  # PASS
+node tools/deploy-audit.mjs                       # clean (S6 touched install.mjs)
+```
+
+## A.9 Blast-radius patterns (applied)
+
+- **Red-then-green:** every Group-4/5/6 negative control (each carve-out→allow; malformed/bridge-error→throw; parity repo-src→isRepoSource:true) is a discriminating row going RED on broken input. Break is inline (sentinel path / bridge-exit fixture / cwd flag), never an added-then-removed fixture.
+- **Pure-extraction first:** S1 (param) and S4 (carve-out extraction) ship before any opencode caller; the enforce-contract edit (5.5) is the **minimum** reach to `gateDisposition`, not a refactor; the bridge is a thin wrapper.
+- **Single source (Rule 14):** carve-outs in `patterns/repo-source-carveouts.json` read by bash + node; parity test guards drift.
+- **Discriminating sentinel:** adapter/bridge tests inject a unique path and assert the action on THAT path.
+- **Flag high-blast-radius:** S3, S4, S5 are `focused-review-before-build`.
+- **Real-runtime E2E for install/hook:** S5/S6 drive the deployed adapter under real OpenCode + real `install.mjs`; no node-call substitute (M4).
+- **Two-runtime caveat:** adapter (Bun) spawns bridge (`node`); only the real-runtime E2E proves OpenCode honors the thrown error and that the bridge resolves the target repo from `payload.cwd`.
+```

--- a/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
+++ b/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
@@ -44,13 +44,20 @@ graph TB
 
 | Phase | Dir | Language | Declared capabilities |
 |-------|-----|----------|-----------------------|
-| **P5** | `plugins/opencode/` | TypeScript | `pre_tool_use: STRONG, tool_result: STRONG, session_start: MEDIUM, stop: MEDIUM` |
+| **P5** | `plugins/opencode/` | TypeScript | `pre_tool_use: STRONG, tool_result: MEDIUM` *(honesty downgrade, see note)*`, session_start: MEDIUM, stop: MEDIUM` |
 | **P6** | `plugins/codex/` | Python hooks | `pre_tool_use: MEDIUM` *(multi-edit bypass documented)*, `stop: STRONG, session_start: STRONG` |
 | **P7** | `plugins/pi-agent/` | `tool_call` + `session_shutdown`/`turn_end` | `pre_tool_use: STRONG, stop: MEDIUM, session_start: STRONG` |
 
 **Honesty note (P5 principle):** Codex `pre_tool_use` is declared **MEDIUM**, not STRONG —
 its PreToolUse has a known multi-edit bypass. Push-gate + stop-gate are the hard enforcement
 for Codex.
+
+**Honesty note (OpenCode `tool_result`):** declared **MEDIUM**, not STRONG. The installed
+`tool.execute.after` hook output (`output.output`) IS mutable, so result rewrite is mechanically
+possible — but that the OpenCode model actually re-reads the mutated output has not been
+end-to-end proven, so MEDIUM (observe) is the honest ceiling pending that proof (P5 OD-1, round-1
+B1). The adapter therefore observes `tool_result` without mutating. `bypass_known.json` records
+the same rationale.
 
 ## Done when ✓
 

--- a/install.mjs
+++ b/install.mjs
@@ -64,6 +64,8 @@ const installSecondOpinion = argv.includes('--install-second-opinion')
 const bootstrapLastPrompt = argv.includes('--bootstrap-last-prompt')
 const REPO_HOOKS = path.join(REPO_DIR, 'plugins', 'claude-code', 'hooks')
 const REPO_SECOND_OPINION = path.join(REPO_SCRIPTS, 'second-opinion')
+// RFC-008 P5 S6: OpenCode enforcement plugin source (adapter + bridge + runbooks).
+const REPO_PLUGIN_OPENCODE = path.join(REPO_DIR, 'plugins', 'opencode')
 
 // I-NEW-C: --install-second-opinion is atomic w.r.t. its own validation.
 // installFailed is tracked across all sub-steps so the final "Done!" banner
@@ -1442,6 +1444,154 @@ function runUninstallEnforcement(projectDir, { purgeConfig = false } = {}) {
   return report
 }
 
+// ---------------------------------------------------------------------------
+// RFC-008 P5 S6 — OpenCode enforcement deploy (REQ-11). The OpenCode model is
+// NOT the claude-code hook+settings.json model: the TS adapter is registered in
+// the project `opencode.json` `plugin` array (version-independent path; KB
+// opencode-plugin-api.md), and it spawns the co-located node bridge per tool
+// call. The bridge resolves its repo-script deps (`enforce-contract.mjs` +
+// `scripts/lib/`) via `../../scripts/...` relative to its capabilities/ dir, so
+// the full transitive closure co-deploys under `.opencode/plugins/scripts/`
+// (decision A — co-deploy the closure). Everything is per-project under
+// <project>/.opencode/ — NEVER global (P12).
+//
+// Deployed layout (resolution-critical — verified by the deployed-bridge E2E):
+//   <proj>/.opencode/plugins/episodic-memory/capabilities/{enforcement.ts,enforce-bridge.mjs}
+//   <proj>/.opencode/plugins/episodic-memory/{manifest.json,runbooks/*}
+//   <proj>/.opencode/plugins/scripts/enforce-contract.mjs   (bridge ../../scripts/..)
+//   <proj>/.opencode/plugins/scripts/lib/*.mjs              (closure incl. repo-source.mjs)
+//   <proj>/.opencode/plugins/patterns/repo-source-carveouts.json (repo-source.mjs cand-2)
+//   <proj>/.opencode/plugins/_index.json                    (audit only; see note)
+//   <proj>/opencode.json  plugin[] += "./.opencode/plugins/episodic-memory/capabilities/enforcement.ts"
+//
+// resolveContractRoot() finds no `patterns/bp-001.json` beside the deployed
+// enforce-contract.mjs (OD-4 ships no bp-001 for opencode), so it returns null:
+// registry/events stay null, gateDisposition fail-closes the pre_tool_use gate to
+// STRONG `enforce`, and the R5 kill switch is still read from the PROJECT's
+// .episodic-memory/enforce-config.json. Net: GATED write -> block, carve-out ->
+// allow, read -> allow, active:false -> allow. _index.json is decorative here.
+function opencodeEnforcementPaths(projectDir) {
+  const deployRoot = path.join(projectDir, '.opencode', 'plugins')
+  const pluginDir = path.join(deployRoot, 'episodic-memory')
+  return {
+    opencodeDir: path.join(projectDir, '.opencode'),
+    deployRoot,
+    pluginDir,
+    capabilitiesDir: path.join(pluginDir, 'capabilities'),
+    runbooksDir: path.join(pluginDir, 'runbooks'),
+    scriptsDir: path.join(deployRoot, 'scripts'),
+    scriptsLibDir: path.join(deployRoot, 'scripts', 'lib'),
+    patternsDir: path.join(deployRoot, 'patterns'),
+    indexPath: path.join(deployRoot, '_index.json'),
+    // Adapter spec registered in opencode.json — always forward-slash (config is
+    // OS-portable JSON, not a host path).
+    adapterSpec: './.opencode/plugins/episodic-memory/capabilities/enforcement.ts',
+    configPath: path.join(projectDir, 'opencode.json'),
+  }
+}
+
+function installOpenCodeEnforcement(projectDir) {
+  const report = { deployedFiles: [], registration: null, warnings: [] }
+  const P = opencodeEnforcementPaths(projectDir)
+
+  // 1. adapter + bridge (co-located) + manifest + runbooks.
+  fs.mkdirSync(P.capabilitiesDir, { recursive: true })
+  for (const f of ['enforcement.ts', 'enforce-bridge.mjs']) {
+    const dst = path.join(P.capabilitiesDir, f)
+    fs.copyFileSync(path.join(REPO_PLUGIN_OPENCODE, 'capabilities', f), dst)
+    report.deployedFiles.push(dst)
+  }
+  const manDst = path.join(P.pluginDir, 'manifest.json')
+  fs.copyFileSync(path.join(REPO_PLUGIN_OPENCODE, 'manifest.json'), manDst)
+  report.deployedFiles.push(manDst)
+  const rbSrc = path.join(REPO_PLUGIN_OPENCODE, 'runbooks')
+  if (fs.existsSync(rbSrc)) { copyDirRecursive(rbSrc, P.runbooksDir); report.deployedFiles.push(P.runbooksDir) }
+
+  // 2. bridge transitive closure: enforce-contract.mjs + ALL of scripts/lib/*.mjs.
+  fs.mkdirSync(P.scriptsLibDir, { recursive: true })
+  const ecDst = path.join(P.scriptsDir, 'enforce-contract.mjs')
+  fs.copyFileSync(path.join(REPO_SCRIPTS, 'enforce-contract.mjs'), ecDst)
+  report.deployedFiles.push(ecDst)
+  const repoLib = path.join(REPO_SCRIPTS, 'lib')
+  for (const f of fs.readdirSync(repoLib).filter((f) => f.endsWith('.mjs')).sort()) {
+    const dst = path.join(P.scriptsLibDir, f)
+    fs.copyFileSync(path.join(repoLib, f), dst)
+    report.deployedFiles.push(dst)
+  }
+
+  // 3. carve-out JSON (repo-source.mjs candidate-2; inline fallback exists, deploy for fidelity).
+  const coSrc = path.join(REPO_DIR, 'patterns', 'repo-source-carveouts.json')
+  if (fs.existsSync(coSrc)) {
+    fs.mkdirSync(P.patternsDir, { recursive: true })
+    const coDst = path.join(P.patternsDir, 'repo-source-carveouts.json')
+    fs.copyFileSync(coSrc, coDst)
+    report.deployedFiles.push(coDst)
+  }
+
+  // 4. registry index (audit only — not runtime-load-bearing under OD-4).
+  const idxSrc = path.join(REPO_DIR, 'plugins', '_index.json')
+  if (fs.existsSync(idxSrc)) {
+    fs.copyFileSync(idxSrc, P.indexPath)
+    report.deployedFiles.push(P.indexPath)
+  }
+
+  // 5. register the adapter in opencode.json `plugin` array (parse-or-abort).
+  let config = {}
+  if (fs.existsSync(P.configPath)) {
+    try { config = JSON.parse(fs.readFileSync(P.configPath, 'utf8')) }
+    catch (e) {
+      report.warnings.push(`opencode.json is not valid JSON (${e.message}); left unchanged — files deployed, register the plugin manually`)
+      return report
+    }
+  } else {
+    config = { $schema: 'https://opencode.ai/config.json' }
+  }
+  if (!Array.isArray(config.plugin)) config.plugin = []
+  if (!config.plugin.includes(P.adapterSpec)) {
+    config.plugin.push(P.adapterSpec)
+    writeJSONAtomic(P.configPath, config)
+    report.registration = P.adapterSpec
+  } else {
+    report.registration = `${P.adapterSpec} (already present)`
+  }
+  return report
+}
+
+function uninstallOpenCodeEnforcement(projectDir) {
+  const report = { removedFiles: [], removedRegistration: null, warnings: [] }
+  const P = opencodeEnforcementPaths(projectDir)
+
+  // (a) config FIRST — parse-or-abort (atomic on malformed; F-C parity with claude-code).
+  if (fs.existsSync(P.configPath)) {
+    let config
+    try { config = JSON.parse(fs.readFileSync(P.configPath, 'utf8')) }
+    catch (e) { report.warnings.push(`opencode.json not valid JSON (${e.message}); aborted — nothing changed`); return report }
+    if (Array.isArray(config.plugin)) {
+      const before = config.plugin.length
+      config.plugin = config.plugin.filter((p) => p !== P.adapterSpec)
+      if (config.plugin.length !== before) {
+        if (config.plugin.length === 0) delete config.plugin
+        writeJSONAtomic(P.configPath, config)
+        report.removedRegistration = P.adapterSpec
+      }
+    }
+  }
+
+  // (b) remove ONLY what we deployed, each contained under <project>/.opencode (BL-B).
+  for (const target of [P.pluginDir, P.scriptsDir, P.patternsDir, P.indexPath]) {
+    if (!fs.existsSync(target)) continue
+    assertContained(target, P.opencodeDir)
+    fs.rmSync(target, { recursive: true, force: true })
+    report.removedFiles.push(target)
+  }
+
+  // (c) prune now-empty deploy dirs (leave dirs that still hold other plugins).
+  for (const d of [P.deployRoot, P.opencodeDir]) {
+    try { if (fs.existsSync(d) && fs.readdirSync(d).length === 0) { fs.rmdirSync(d); report.removedFiles.push(d) } } catch {}
+  }
+  return report
+}
+
 if (installHooks && !installEnforcement) {
   // P12 (RFC-008 P4d) transitional honesty (review F2): post-S2 ALL enforcement
   // (gates, libs, taxonomy/contract config, registrations) installs PER-PROJECT
@@ -1452,13 +1602,22 @@ if (installHooks && !installEnforcement) {
 }
 
 if (uninstallEnforcement) {
-  // RFC-008 P4d S5: mutually exclusive with install in one run — reverse the
-  // per-project enforcement set and report what was removed/preserved.
-  const rep = runUninstallEnforcement(projectDir, { purgeConfig })
+  // RFC-008 P4d S5 / P5 S6: mutually exclusive with install in one run — reverse
+  // the per-project enforcement set and report what was removed/preserved. The
+  // OpenCode layer (S6) lives under .opencode/ + opencode.json, not .claude/.
+  const rep = tool === 'opencode'
+    ? uninstallOpenCodeEnforcement(projectDir)
+    : runUninstallEnforcement(projectDir, { purgeConfig })
   console.log(JSON.stringify(rep, null, 2))
 }
 
-if (installHooks || installEnforcement) {
+if (installEnforcement && tool === 'opencode') {
+  // RFC-008 P5 S6: the OpenCode enforcement layer deploys under .opencode/ +
+  // opencode.json (NOT the claude-code .claude/hooks model) — handled wholly by
+  // installOpenCodeEnforcement, so it pre-empts the claude-code block below.
+  const rep = installOpenCodeEnforcement(projectDir)
+  console.log(JSON.stringify(rep, null, 2))
+} else if (installHooks || installEnforcement) {
   // P12 (RFC-008 P4d): enforcement artifacts (hook files, libs, taxonomy/contract
   // config, registrations) install PER-PROJECT under <project>/.claude/ — NEVER
   // global — and ONLY under --install-enforcement (every substantive inner block

--- a/install.mjs
+++ b/install.mjs
@@ -1460,29 +1460,44 @@ function runUninstallEnforcement(projectDir, { purgeConfig = false } = {}) {
 //   <proj>/.opencode/plugins/episodic-memory/{manifest.json,runbooks/*}
 //   <proj>/.opencode/plugins/scripts/enforce-contract.mjs   (bridge ../../scripts/..)
 //   <proj>/.opencode/plugins/scripts/lib/*.mjs              (closure incl. repo-source.mjs)
+//   <proj>/.opencode/plugins/scripts/patterns/{bp-001,events,enforce-config.schema}.json
+//   <proj>/.opencode/plugins/scripts/plugins/_index.json    (project-local registry)
 //   <proj>/.opencode/plugins/patterns/repo-source-carveouts.json (repo-source.mjs cand-2)
-//   <proj>/.opencode/plugins/_index.json                    (audit only; see note)
 //   <proj>/opencode.json  plugin[] += "./.opencode/plugins/episodic-memory/capabilities/enforcement.ts"
 //
-// resolveContractRoot() finds no `patterns/bp-001.json` beside the deployed
-// enforce-contract.mjs (OD-4 ships no bp-001 for opencode), so it returns null:
-// registry/events stay null, gateDisposition fail-closes the pre_tool_use gate to
-// STRONG `enforce`, and the R5 kill switch is still read from the PROJECT's
-// .episodic-memory/enforce-config.json. Net: GATED write -> block, carve-out ->
-// allow, read -> allow, active:false -> allow. _index.json is decorative here.
+// PROJECT-LOCAL contract source (round-2 BLOCKER-1 fix). The contract set is
+// deployed BESIDE the deployed enforce-contract.mjs (under scripts/), so
+// resolveContractRoot() accepts candidate-0 (the `patterns/bp-001.json` sentinel)
+// and returns the deployed scripts/ dir — it NEVER falls through to the legacy
+// GLOBAL candidate-1 (~/.episodic-memory), so a project's enforcement decision is
+// owned entirely by the project (P12), deterministic across machines. Deploying
+// enforce-config.schema.json is what makes loadEnforceConfig able to VALIDATE the
+// operator's .episodic-memory/enforce-config.json, so the R5 kill switch
+// (active:false -> allow) actually works; without the schema it silently
+// fail-closed to active:true. bp-001.json is the resolve sentinel only — the
+// bridge passes contractTier/configTier=null (OD-4: no bp-001 lifecycle for
+// opencode). Net: GATED write -> block, carve-out -> allow, read -> allow,
+// active:false -> allow, no global ambient state consulted.
 function opencodeEnforcementPaths(projectDir) {
   const deployRoot = path.join(projectDir, '.opencode', 'plugins')
   const pluginDir = path.join(deployRoot, 'episodic-memory')
+  const scriptsDir = path.join(deployRoot, 'scripts')
   return {
     opencodeDir: path.join(projectDir, '.opencode'),
     deployRoot,
     pluginDir,
     capabilitiesDir: path.join(pluginDir, 'capabilities'),
     runbooksDir: path.join(pluginDir, 'runbooks'),
-    scriptsDir: path.join(deployRoot, 'scripts'),
-    scriptsLibDir: path.join(deployRoot, 'scripts', 'lib'),
-    patternsDir: path.join(deployRoot, 'patterns'),
-    indexPath: path.join(deployRoot, '_index.json'),
+    scriptsDir,
+    scriptsLibDir: path.join(scriptsDir, 'lib'),
+    // repo-source.mjs candidate-2 carve-out JSON: <deployRoot>/patterns (computed
+    // from repo-source.mjs's own ../../patterns).
+    carveoutPatternsDir: path.join(deployRoot, 'patterns'),
+    // Contract source BESIDE the deployed engine: resolveContractRoot candidate-0
+    // (bp-001.json sentinel) + the bridge's events.json / enforce-config.schema.json.
+    contractPatternsDir: path.join(scriptsDir, 'patterns'),
+    // Bridge registry: path.join(contractRoot='scriptsDir', 'plugins', '_index.json').
+    contractIndexPath: path.join(scriptsDir, 'plugins', '_index.json'),
     // Adapter spec registered in opencode.json — always forward-slash (config is
     // OS-portable JSON, not a host path).
     adapterSpec: './.opencode/plugins/episodic-memory/capabilities/enforcement.ts',
@@ -1493,6 +1508,20 @@ function opencodeEnforcementPaths(projectDir) {
 function installOpenCodeEnforcement(projectDir) {
   const report = { deployedFiles: [], registration: null, warnings: [] }
   const P = opencodeEnforcementPaths(projectDir)
+
+  // 0. PARSE the existing opencode.json FIRST — abort the WHOLE deploy on malformed
+  //    config (MAJOR-1 fix: symmetric with uninstall's parse-or-abort; never leave
+  //    unregistered files on disk that the agent then silently fails to enforce with).
+  let config
+  if (fs.existsSync(P.configPath)) {
+    try { config = JSON.parse(fs.readFileSync(P.configPath, 'utf8')) }
+    catch (e) {
+      report.warnings.push(`opencode.json is not valid JSON (${e.message}); aborted — nothing deployed`)
+      return report
+    }
+  } else {
+    config = { $schema: 'https://opencode.ai/config.json' }
+  }
 
   // 1. adapter + bridge (co-located) + manifest + runbooks.
   fs.mkdirSync(P.capabilitiesDir, { recursive: true })
@@ -1522,30 +1551,35 @@ function installOpenCodeEnforcement(projectDir) {
   // 3. carve-out JSON (repo-source.mjs candidate-2; inline fallback exists, deploy for fidelity).
   const coSrc = path.join(REPO_DIR, 'patterns', 'repo-source-carveouts.json')
   if (fs.existsSync(coSrc)) {
-    fs.mkdirSync(P.patternsDir, { recursive: true })
-    const coDst = path.join(P.patternsDir, 'repo-source-carveouts.json')
+    fs.mkdirSync(P.carveoutPatternsDir, { recursive: true })
+    const coDst = path.join(P.carveoutPatternsDir, 'repo-source-carveouts.json')
     fs.copyFileSync(coSrc, coDst)
     report.deployedFiles.push(coDst)
   }
 
-  // 4. registry index (audit only — not runtime-load-bearing under OD-4).
+  // 4. PROJECT-LOCAL contract set (BLOCKER-1 fix). bp-001.json is the
+  //    resolveContractRoot candidate-0 sentinel; events.json + enforce-config.schema.json
+  //    are read by the bridge's L2; _index.json is the project-local registry
+  //    (harnessCap). Deployed BESIDE the engine so resolution is project-local, never
+  //    the global candidate-1. enforce-config.schema.json presence is what lets the
+  //    R5 kill switch (active:false) be honored.
+  fs.mkdirSync(P.contractPatternsDir, { recursive: true })
+  for (const f of ['bp-001.json', 'events.json', 'enforce-config.schema.json']) {
+    const src = path.join(REPO_DIR, 'patterns', f)
+    if (fs.existsSync(src)) {
+      const dst = path.join(P.contractPatternsDir, f)
+      fs.copyFileSync(src, dst)
+      report.deployedFiles.push(dst)
+    }
+  }
   const idxSrc = path.join(REPO_DIR, 'plugins', '_index.json')
   if (fs.existsSync(idxSrc)) {
-    fs.copyFileSync(idxSrc, P.indexPath)
-    report.deployedFiles.push(P.indexPath)
+    fs.mkdirSync(path.dirname(P.contractIndexPath), { recursive: true })
+    fs.copyFileSync(idxSrc, P.contractIndexPath)
+    report.deployedFiles.push(P.contractIndexPath)
   }
 
-  // 5. register the adapter in opencode.json `plugin` array (parse-or-abort).
-  let config = {}
-  if (fs.existsSync(P.configPath)) {
-    try { config = JSON.parse(fs.readFileSync(P.configPath, 'utf8')) }
-    catch (e) {
-      report.warnings.push(`opencode.json is not valid JSON (${e.message}); left unchanged — files deployed, register the plugin manually`)
-      return report
-    }
-  } else {
-    config = { $schema: 'https://opencode.ai/config.json' }
-  }
+  // 5. register the adapter in opencode.json `plugin` array (config parsed in step 0).
   if (!Array.isArray(config.plugin)) config.plugin = []
   if (!config.plugin.includes(P.adapterSpec)) {
     config.plugin.push(P.adapterSpec)
@@ -1578,7 +1612,8 @@ function uninstallOpenCodeEnforcement(projectDir) {
   }
 
   // (b) remove ONLY what we deployed, each contained under <project>/.opencode (BL-B).
-  for (const target of [P.pluginDir, P.scriptsDir, P.patternsDir, P.indexPath]) {
+  //     scriptsDir is recursive, so it covers scripts/{lib,patterns,plugins,*.mjs}.
+  for (const target of [P.pluginDir, P.scriptsDir, P.carveoutPatternsDir]) {
     if (!fs.existsSync(target)) continue
     assertContained(target, P.opencodeDir)
     fs.rmSync(target, { recursive: true, force: true })

--- a/memory/knowledge_base/index.md
+++ b/memory/knowledge_base/index.md
@@ -5,4 +5,5 @@ Distilled web-research cache (per global Rule 7). Each entry has frontmatter `ur
 | Topic | File | Fetched | Summary |
 |---|---|---|---|
 | Cursor hooks | [cursor-hooks.md](cursor-hooks.md) | 2026-05-28 | Cursor exposes 16+ programmatic hooks (blocking + observational) — STRONG-capable, NOT WEAK. Source for RFC-008 F43 capability-matrix correction. |
+| OpenCode plugin API | [opencode-plugin-api.md](opencode-plugin-api.md) | 2026-06-23 | OpenCode hook API from installed @opencode-ai/plugin@1.14.50 types (web docs wrong on tool.execute.after — it IS mutable). pre_tool_use/tool_result STRONG, session_start/stop MEDIUM. Source for RFC-008 P5. |
 | Windsurf rules/memories | [windsurf-rules.md](windsurf-rules.md) | 2026-05-28 | Windsurf exposes no programmatic hooks — file-based rules only. Confirms WEAK tier. Source for RFC-008 F43. |

--- a/memory/knowledge_base/opencode-plugin-api.md
+++ b/memory/knowledge_base/opencode-plugin-api.md
@@ -1,0 +1,47 @@
+---
+url: https://opencode.ai/docs/plugins/ + https://opencode.ai/docs/config/ + probed @opencode-ai/plugin@1.14.50 dist/index.d.ts
+fetched: 2026-06-23
+summary: OpenCode plugin hook API (ground truth from installed types, not web docs). Source for RFC-008 P5 OpenCode plugin OD-1/OD-2. Web docs were WRONG on tool.execute.after (it IS mutable) — installed types are authoritative.
+---
+
+# OpenCode plugin/hook API (RFC-008 P5)
+
+**Authoritative source:** the installed `@opencode-ai/plugin@1.14.50`
+`dist/index.d.ts` (`~/.opencode/node_modules/@opencode-ai/plugin/`). Web docs
+conflict with it and were wrong in one material place (see tool.execute.after).
+Probe the installed version, do not trust the web docs.
+
+## Plugin shape & loading
+- A plugin is an ESM TS/JS module: `Plugin = (input: PluginInput, options?) => Promise<Hooks>`.
+- `PluginInput` context: `{ client, project, directory, worktree, $, serverUrl, experimental_workspace }`.
+  - `directory` (string) = current working directory. `worktree` (string) = git worktree path.
+  - **cwd is NOT in any event payload — it comes from this context.**
+- Loaded from `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global) — **plural** per docs/config.
+  Also registerable via the config `plugin` array in `opencode.json[c]`: `"plugin": ["pkg-name", "./path"]` (robust, version-independent — prefer this for install).
+- Runs under OpenCode's runtime (Bun). External npm deps allowed via `.opencode/package.json`, but a type-only import of `@opencode-ai/plugin` is erased at runtime → zero runtime dep is achievable.
+
+## Hooks (from `interface Hooks`, dist/index.d.ts:173-316)
+| Hook | input | output (mutable) | Enforcement use |
+|---|---|---|---|
+| `tool.execute.before` | `{tool:string, sessionID:string, callID:string}` | `{args:any}` | **pre_tool_use STRONG.** Block by `throw`. Mutate `output.args`. |
+| `tool.execute.after` | `{tool, sessionID, callID, args}` | `{title:string, output:string, metadata:any}` | **tool_result STRONG (modify).** `output.output` IS mutable → result mutation before model sees it. (Web docs wrongly said observe-only.) |
+| `experimental.chat.system.transform` | `{sessionID?, model}` | `{system:string[]}` | **session_start MEDIUM.** `output.system.push(ctx)` — experimental, best-effort inject. |
+| `event` | `{event: Event}` | — (void) | **observe only.** Sees `session.idle`/`session.created`/etc. Only path for "stop". |
+| `permission.ask` | `Permission` | `{status:"ask"|"deny"|"allow"}` | could deny permissions (not used by P5). |
+| `chat.params` / `chat.headers` / `chat.message` | per-message | various | not used by P5. |
+
+## Capability honesty (P5 declared tiers — all verified against types)
+- `pre_tool_use: STRONG` — `tool.execute.before` + throw. ✓
+- `tool_result: STRONG` — `tool.execute.after` mutable `output.output`. ✓ (must E2E-confirm OpenCode re-reads mutated output).
+- `session_start: MEDIUM` — only experimental transform, best-effort. ✓
+- `stop: MEDIUM` — **no refuse-stop hook exists.** Only `event`→`session.idle` observe → warn/log. Cannot block a stop. STRONG is impossible. ✓ (maps events.json stop MEDIUM=warn).
+
+## Translation gaps (OpenCode event → canonical payload)
+The canonical event schemas (`schemas/events/event-*.schema.json`) require fields OpenCode does not put in the event:
+- **`cwd`** — not in event; adapter injects from `PluginInput.directory`.
+- **`turn_index`** — not provided anywhere; adapter synthesizes a per-`sessionID` monotonic counter (Map), incremented on each `tool.execute.before`. The canonical contract uses turn_index only for ordering/monotonicity, so an adapter-maintained counter satisfies it.
+- So the OpenCode adapter has a **normalize step** (merge context + synthesize turn_index) BEFORE the declarative `field_bindings`. The harness-event fixtures represent the post-normalize object the field_bindings consume; the normalize step is covered by the adapter unit test, not the gauntlet.
+
+## Blocking semantics
+- Block = `throw new Error(msg)` inside the hook (verified: `.env` example throws to refuse a read).
+- Modify result = mutate `output.output` in `tool.execute.after`.

--- a/patterns/repo-source-carveouts.json
+++ b/patterns/repo-source-carveouts.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Carve-out dirs matched by EXACT SEGMENT under repo root — never substring. .github/ and .gitignore must NOT match. Read by repo-source.sh (bash fallback) and scripts/lib/repo-source.mjs (node). Rule 14 single source.",
+  "exact_segment_dirs": [".episodic-memory", ".checkpoints", ".review-store", ".git", "docs/plans"],
+  "git_check_ignore": true
+}

--- a/plugins/_index.json
+++ b/plugins/_index.json
@@ -27,7 +27,7 @@
         "session_start": "MEDIUM",
         "stop": "MEDIUM"
       },
-      "classifier": "default",
+      "classifier": "override",
       "manifest": "plugins/opencode/manifest.json",
       "status": "active"
     }

--- a/plugins/_index.json
+++ b/plugins/_index.json
@@ -15,6 +15,21 @@
       "classifier": "default",
       "manifest": "plugins/claude-code/manifest.json",
       "status": "active"
+    },
+    {
+      "type": "enforcement",
+      "id": "opencode",
+      "harness": "opencode",
+      "directory": "plugins/opencode",
+      "capabilities": {
+        "pre_tool_use": "STRONG",
+        "tool_result": "MEDIUM",
+        "session_start": "MEDIUM",
+        "stop": "MEDIUM"
+      },
+      "classifier": "default",
+      "manifest": "plugins/opencode/manifest.json",
+      "status": "active"
     }
   ]
 }

--- a/plugins/bypass_known.json
+++ b/plugins/bypass_known.json
@@ -33,6 +33,35 @@
       "no_known_bypass_evidence": true,
       "last_audited_iso8601": "2026-06-06T00:00:00Z",
       "auditor": "rfc008-p1b-capability-audit"
+    },
+    {
+      "harness": "opencode",
+      "event": "pre_tool_use",
+      "no_known_bypass_evidence": true,
+      "last_audited_iso8601": "2026-06-23T00:00:00Z",
+      "auditor": "rfc008-p5-opencode-capability-audit"
+    },
+    {
+      "harness": "opencode",
+      "event": "tool_result",
+      "ceiling": "MEDIUM",
+      "citation": "tool.execute.after returns void; no proven result re-read; MEDIUM (observe) is the honest ceiling (RFC-008 P5 OD-1, B1)",
+      "last_audited_iso8601": "2026-06-23T00:00:00Z",
+      "auditor": "rfc008-p5-opencode-capability-audit"
+    },
+    {
+      "harness": "opencode",
+      "event": "session_start",
+      "no_known_bypass_evidence": true,
+      "last_audited_iso8601": "2026-06-23T00:00:00Z",
+      "auditor": "rfc008-p5-opencode-capability-audit"
+    },
+    {
+      "harness": "opencode",
+      "event": "stop",
+      "no_known_bypass_evidence": true,
+      "last_audited_iso8601": "2026-06-23T00:00:00Z",
+      "auditor": "rfc008-p5-opencode-capability-audit"
     }
   ]
 }

--- a/plugins/bypass_known.json
+++ b/plugins/bypass_known.json
@@ -45,7 +45,7 @@
       "harness": "opencode",
       "event": "tool_result",
       "ceiling": "MEDIUM",
-      "citation": "tool.execute.after returns void; no proven result re-read; MEDIUM (observe) is the honest ceiling (RFC-008 P5 OD-1, B1)",
+      "citation": "tool.execute.after output.output IS mutable (result rewrite mechanically possible), but model re-read of mutated output is not E2E-proven; MEDIUM (observe) is the honest ceiling pending that proof (RFC-008 P5 OD-1, B1)",
       "last_audited_iso8601": "2026-06-23T00:00:00Z",
       "auditor": "rfc008-p5-opencode-capability-audit"
     },

--- a/plugins/claude-code/hooks/lib/repo-source.sh
+++ b/plugins/claude-code/hooks/lib/repo-source.sh
@@ -72,13 +72,38 @@ _path_is_repo_source() {
     case "$fp_canon" in "$repo_canon"/*|"$repo_canon") in_repo=0 ;; esac
   fi
   [ "$in_repo" = 0 ] || return 1
-  case "$fp_canon" in
-    "$repo_canon"/.episodic-memory|"$repo_canon"/.episodic-memory/*) return 1 ;;
-    "$repo_canon"/.checkpoints|"$repo_canon"/.checkpoints/*)         return 1 ;;
-    "$repo_canon"/.review-store|"$repo_canon"/.review-store/*)       return 1 ;;
-    "$repo_canon"/.git|"$repo_canon"/.git/*)                         return 1 ;;
-    "$repo_canon"/docs/plans|"$repo_canon"/docs/plans/*)             return 1 ;;
-  esac
+  # Load carve-out dirs from the shared JSON (Rule 14 single source).
+  # Resolution order (NEW-R3-1): (1) deployed canonical path used by the live
+  # ~/.claude/hooks/ copy; (2) in-repo dev/test relative path; (3) inline
+  # literals if both are unreadable (fail-safe — a deploy-lag never opens gate).
+  # Matching is EXACT SEGMENT: "<repo>/<dir>" or "<repo>/<dir>/*" only.
+  # Never substring — .github/ and .gitignore must NOT be carved.
+  local _co_json="" _co_json1 _co_json2
+  _co_json1="$HOME/.episodic-memory/patterns/repo-source-carveouts.json"
+  _co_json2="${BASH_SOURCE[0]%/*}/../../../../patterns/repo-source-carveouts.json"
+  if [ -f "$_co_json1" ] && _co_dirs="$(node -e "try{const c=require(process.argv[1]);process.stdout.write(c.exact_segment_dirs.join('\n'))}catch(e){process.exit(1)}" "$_co_json1" 2>/dev/null)"; then
+    _co_json="$_co_json1"
+  elif [ -f "$_co_json2" ] && _co_dirs="$(node -e "try{const c=require(process.argv[1]);process.stdout.write(c.exact_segment_dirs.join('\n'))}catch(e){process.exit(1)}" "$_co_json2" 2>/dev/null)"; then
+    _co_json="$_co_json2"
+  fi
+  if [ -n "$_co_json" ]; then
+    local _d
+    while IFS= read -r _d; do
+      [ -z "$_d" ] && continue
+      case "$fp_canon" in
+        "$repo_canon/$_d"|"$repo_canon/$_d"/*) return 1 ;;
+      esac
+    done <<< "$_co_dirs"
+  else
+    # Inline fallback — exact-segment match, never substring.
+    case "$fp_canon" in
+      "$repo_canon"/.episodic-memory|"$repo_canon"/.episodic-memory/*) return 1 ;;
+      "$repo_canon"/.checkpoints|"$repo_canon"/.checkpoints/*)         return 1 ;;
+      "$repo_canon"/.review-store|"$repo_canon"/.review-store/*)       return 1 ;;
+      "$repo_canon"/.git|"$repo_canon"/.git/*)                         return 1 ;;
+      "$repo_canon"/docs/plans|"$repo_canon"/docs/plans/*)             return 1 ;;
+    esac
+  fi
   if command -v git >/dev/null 2>&1 \
      && git -C "$repo_canon" check-ignore -q -- "$fp_canon" 2>/dev/null; then
     return 1

--- a/plugins/opencode/capabilities/enforce-bridge.mjs
+++ b/plugins/opencode/capabilities/enforce-bridge.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * enforce-bridge.mjs — OpenCode enforcement bridge (RFC-008 P5 S5, REQ-8/9/10/13/14).
+ *
+ * Zero external dependencies. Node.js stdlib + repo scripts only.
+ *
+ * Protocol:
+ *   stdin  — JSON: {harness:"opencode", event:"pre_tool_use"|..., normalized:{...}}
+ *   stdout — JSON: {action:"block"|"allow", effective_tier, reason, label}
+ *   exit 0 — ok
+ *   exit 2 — invalid input (schema / parse error)
+ *   exit 3 — engine error (threw during decision)
+ *
+ * The decision is the §12 two-layer AND (B-NEW-2):
+ *   L1: toolTargetsRepoSource(repoRoot, tool, target, label) → GATED|ALLOW
+ *   L2: gateDisposition({...}) → token ∈ {enforce, block, allow, silence, clamp-off}
+ * block only when BOTH L1=GATED AND L2.token ∈ {enforce, block}.
+ *
+ * Repo root = realpath(payload.cwd) ONLY. Never process.cwd().
+ * Non-pre_tool_use events → {action:"allow"} immediately (MEDIUM observe).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BRIDGE_ROOT = path.resolve(__dirname, "..", "..", ".."); // repo root relative to plugin dir
+
+// ---------------------------------------------------------------------------
+// Resolve script paths — bridge is installed alongside the repo scripts.
+// Priority: co-located (deployed) → in-repo dev path.
+// ---------------------------------------------------------------------------
+function resolveScriptPath(relativeToBridge, relativeToRepo) {
+  const deployed = path.resolve(__dirname, relativeToBridge);
+  if (fs.existsSync(deployed)) return deployed;
+  return path.resolve(BRIDGE_ROOT, relativeToRepo);
+}
+
+const REPO_SOURCE_MJS = resolveScriptPath(
+  "../../scripts/lib/repo-source.mjs",
+  "scripts/lib/repo-source.mjs"
+);
+const ENFORCE_CONTRACT_MJS = resolveScriptPath(
+  "../../scripts/enforce-contract.mjs",
+  "scripts/enforce-contract.mjs"
+);
+
+// ---------------------------------------------------------------------------
+// classifyLabel — node port of command-classifier.sh tool→label mapping (§A.0 #3).
+// Minimal subset: covers the OpenCode tool names (write/edit/bash/read) + bash
+// command heuristic (read-only bash vs shared_write). Maps to
+// _tool_targets_repo_source_shared's label-based branch for bash.
+// ---------------------------------------------------------------------------
+const READ_ONLY_BASH_RE = /^\s*(cat|head|tail|grep|find|ls|echo|printf|wc|du|df|pwd|which|type|file|stat|diff|sort|uniq|tr|cut|awk|sed|jq|git\s+(status|log|diff|show|branch|tag|remote|describe|rev-parse|ls-files|ls-tree|cat-file|shortlog|stash list|blame)|curl\s+(-[^>]*\s)?(--head|-I)\b|wget\s+(-[^>]*)?(--spider|-q)\b|node\s+--version|npm\s+(ls|list|outdated|audit)\b|which\s|test\s|true|false)\b/;
+
+function classifyLabel(tool, args) {
+  const t = (tool || "").toLowerCase();
+  if (t === "read") return "read_only";
+  if (t === "write" || t === "edit" || t === "multiedit") return "shared_write";
+  if (t === "bash") {
+    const cmd = (args && (args.command || args.cmd)) || "";
+    if (READ_ONLY_BASH_RE.test(cmd)) return "read_only";
+    // git push / gh pr → push_or_pr_create
+    if (/\bgit\s+push\b|\bgh\s+(pr|release)\s+(create|push)\b/.test(cmd)) return "push_or_pr_create";
+    return "shared_write";
+  }
+  // Unknown tool: fail-closed
+  return "shared_write";
+}
+
+// ---------------------------------------------------------------------------
+// Decision entry point.
+// ---------------------------------------------------------------------------
+async function decide(envelope) {
+  const { toolTargetsRepoSource } = await import(REPO_SOURCE_MJS);
+  const {
+    gateDisposition,
+    loadEnforceConfig,
+    resolveContractRoot,
+    resolveHarnessCap,
+  } = await import(ENFORCE_CONTRACT_MJS);
+
+  const { event, normalized } = envelope;
+  const payload = normalized || {};
+
+  // Non-pre_tool_use events are MEDIUM observe — always allow.
+  if (event !== "pre_tool_use") {
+    return { action: "allow", effective_tier: "MEDIUM", reason: "observe: non-blocking event", label: null };
+  }
+
+  // Resolve repo root from payload.cwd (ONLY source — never process.cwd()).
+  const cwdRaw = payload.cwd;
+  if (!cwdRaw || typeof cwdRaw !== "string") {
+    throw new Error("enforce-bridge: payload.cwd is required and must be a string");
+  }
+  let repoRoot;
+  try {
+    repoRoot = fs.realpathSync(cwdRaw);
+  } catch (e) {
+    throw new Error(`enforce-bridge: cannot realpath payload.cwd ${JSON.stringify(cwdRaw)}: ${e.message}`);
+  }
+
+  const tool = payload.tool || "";
+  const args = payload.tool_args || {};
+  // Target path: for write/edit it's args.filePath; for bash it's empty (command text).
+  const targetPath = args.filePath || args.file_path || "";
+  const label = classifyLabel(tool, args);
+
+  // Short-circuit: read_only / nonsrc_write labels never gate (regardless of path).
+  // This extends the bash _tool_targets_repo_source_shared bash-branch logic to all
+  // tools: a `read` tool with a repo-source path is not a write and must be allowed.
+  if (label === "read_only" || label === "nonsrc_write") {
+    return { action: "allow", effective_tier: null, reason: `allow: label=${label} (non-write)`, label };
+  }
+
+  // L1: repo-source check.
+  const gatedWrite = toolTargetsRepoSource(repoRoot, tool, targetPath, label);
+
+  // L2: gate disposition (reuse enforce-contract loaders; no logic re-impl).
+  const contractRoot = resolveContractRoot();
+  let registry = null, enforceConfigSchema = null, eventsJson = null;
+  if (contractRoot) {
+    try {
+      const regPath = path.join(contractRoot, "plugins", "_index.json");
+      registry = JSON.parse(fs.readFileSync(regPath, "utf8"));
+    } catch { /* null → fail-closed */ }
+    try {
+      const schemaPath = path.join(contractRoot, "patterns", "enforce-config.schema.json");
+      enforceConfigSchema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+    } catch { /* null → identity config */ }
+    try {
+      const evPath = path.join(contractRoot, "patterns", "events.json");
+      eventsJson = JSON.parse(fs.readFileSync(evPath, "utf8"));
+    } catch { /* null → fail-closed */ }
+  }
+
+  const { tier: harnessCap, duplicate } = resolveHarnessCap(registry, "opencode", "pre_tool_use");
+  const enforceConfig = loadEnforceConfig(repoRoot, enforceConfigSchema);
+  const { active } = enforceConfig;
+
+  // contractTier: bp-001 opencode gates not wired in P5 (OD-4) — null (no clamp).
+  const contractTier = null;
+  // configTier: operator per-gate clamp from enforce-config.json bp-001 — opencode
+  // doesn't share the bp-001 lifecycle in P5, so no gate-specific clamp.
+  const configTier = null;
+
+  const disp = gateDisposition({
+    duplicate,
+    harnessCap,
+    contractTier,
+    active,
+    configTier,
+    events: eventsJson,
+    event: "pre_tool_use",
+  });
+
+  const block = gatedWrite === "GATED" && (disp.token === "enforce" || disp.token === "block");
+  const action = block ? "block" : "allow";
+  const reason = block
+    ? `repo-source write gated: ${targetPath || tool} (label:${label}, tier:${disp.effTier})`
+    : `allow: gatedWrite=${gatedWrite}, disp.token=${disp.token}`;
+
+  return { action, effective_tier: disp.effTier, reason, label };
+}
+
+// ---------------------------------------------------------------------------
+// Validate the incoming envelope against a minimal schema.
+// ---------------------------------------------------------------------------
+function validateEnvelope(envelope) {
+  if (typeof envelope !== "object" || envelope === null) throw new Error("envelope must be a JSON object");
+  if (envelope.harness !== "opencode") throw new Error(`harness must be "opencode", got ${JSON.stringify(envelope.harness)}`);
+  const validEvents = ["pre_tool_use", "tool_result", "session_start", "stop"];
+  if (!validEvents.includes(envelope.event)) throw new Error(`event must be one of ${validEvents.join("|")}, got ${JSON.stringify(envelope.event)}`);
+  if (typeof envelope.normalized !== "object" || envelope.normalized === null) throw new Error("normalized must be a JSON object");
+}
+
+// ---------------------------------------------------------------------------
+// Main — read stdin, decide, emit stdout.
+// ---------------------------------------------------------------------------
+async function main() {
+  let raw = "";
+  try {
+    const chunks = [];
+    for await (const chunk of process.stdin) chunks.push(chunk);
+    raw = Buffer.concat(chunks).toString("utf8");
+  } catch (e) {
+    process.stderr.write(`enforce-bridge: stdin read error: ${e.message}\n`);
+    process.exit(3);
+  }
+
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch (e) {
+    process.stderr.write(`enforce-bridge: JSON parse error: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  try {
+    validateEnvelope(envelope);
+  } catch (e) {
+    process.stderr.write(`enforce-bridge: validation error: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  let result;
+  try {
+    result = await decide(envelope);
+  } catch (e) {
+    process.stderr.write(`enforce-bridge: engine error: ${e.message}\n`);
+    process.exit(3);
+  }
+
+  try {
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } catch (e) {
+    process.stderr.write(`enforce-bridge: stdout write error: ${e.message}\n`);
+    process.exit(3);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  process.stderr.write(`enforce-bridge: unhandled error: ${e.message}\n`);
+  process.exit(3);
+});

--- a/plugins/opencode/capabilities/enforcement.ts
+++ b/plugins/opencode/capabilities/enforcement.ts
@@ -11,6 +11,18 @@
  * Non-blocking events (tool_result, session_start, stop) are MEDIUM observe:
  * the bridge is invoked for audit/logging but never throws.
  *
+ * Hook surface is pinned to the INSTALLED @opencode-ai/plugin `interface Hooks`
+ * (dist/index.d.ts:173-316), NOT web docs. The host indexes hooks by FLAT
+ * DOTTED keys ("tool.execute.before") and calls them with TWO args
+ * (input, output); a nested object or single-arg signature is silently never
+ * invoked (fails OPEN). Ground truth:
+ *   "tool.execute.before"(input:{tool,sessionID,callID}, output:{args})
+ *   "tool.execute.after"(input:{tool,sessionID,callID,args}, output:{title,output,metadata})
+ *   "experimental.chat.system.transform"(input:{sessionID?,model}, output:{system})
+ *   event(input:{event})  — Event union; session end = type "session.idle"
+ * PluginInput carries `directory` (cwd source) but NO sessionId — sessionID
+ * comes from each hook's `input`.
+ *
  * Type-only import of @opencode-ai/plugin — no runtime dependency.
  *
  * OD-4 note: the bp-001 checkpoint/plan-approval MARKER lifecycle is NOT
@@ -58,132 +70,143 @@ function callBridge(envelope: Record<string, unknown>): { action: string; reason
   return parsed;
 }
 
-export const EpisodicEnforcement: Plugin = async (ctx) => ({
-  /**
-   * tool.execute.before — pre_tool_use (STRONG block).
-   * Invokes the bridge; throws on "block" or bridge failure.
-   */
-  tool: {
-    execute: {
-      before: async (params: { tool: string; args: Record<string, unknown> }) => {
-        const sessionId = ctx.sessionId as string ?? "unknown";
-        // EC3: synchronous increment before any await.
-        const turnIndex = nextTurnIndex(sessionId);
-        const cwd = realpathSync(ctx.directory as string);
+export const EpisodicEnforcement: Plugin = async (ctx) => {
+  // cwd source: PluginInput.directory. Resolved per-call (worktree can change).
+  const directoryOf = (): string => realpathSync(ctx.directory);
 
-        const envelope = {
-          harness: "opencode",
-          event: "pre_tool_use",
-          normalized: {
-            tool: params.tool,
-            tool_args: params.args,
-            cwd,
-            session_id: sessionId,
-            turn_index: turnIndex,
-            timestamp_iso8601: new Date().toISOString(),
-          },
-        };
+  return {
+    /**
+     * tool.execute.before — pre_tool_use (STRONG block).
+     * Real signature: (input:{tool,sessionID,callID}, output:{args}).
+     * tool_args live in `output.args`; sessionID in `input.sessionID`.
+     * Block by throwing; allow by returning.
+     */
+    "tool.execute.before": async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: unknown },
+    ): Promise<void> => {
+      const sessionId = input.sessionID || "unknown";
+      // EC3: synchronous increment before any await.
+      const turnIndex = nextTurnIndex(sessionId);
+      const cwd = directoryOf();
 
-        const decision = callBridge(envelope);
-        if (decision.action === "block") {
-          throw new Error(decision.reason || "opencode-enforce: write blocked by enforcement gate");
-        }
-        // allow → return (no-op)
-      },
-
-      /**
-       * tool.execute.after — tool_result (MEDIUM observe).
-       * Invokes bridge for logging; never throws; never mutates result.
-       */
-      after: async (params: { tool: string; args: Record<string, unknown>; result: unknown }) => {
-        const sessionId = ctx.sessionId as string ?? "unknown";
-        const turnIndex = nextTurnIndex(sessionId);
-        const cwd = realpathSync(ctx.directory as string);
-
-        const envelope = {
-          harness: "opencode",
-          event: "tool_result",
-          normalized: {
-            tool: params.tool,
-            tool_args: params.args,
-            result: params.result,
-            cwd,
-            session_id: sessionId,
-            turn_index: turnIndex,
-            timestamp_iso8601: new Date().toISOString(),
-          },
-        };
-
-        try {
-          callBridge(envelope);
-        } catch {
-          // MEDIUM: observe only — log but do NOT rethrow.
-          // A bridge failure on tool_result must not interrupt the agent.
-        }
-        // return result UNCHANGED (MEDIUM — no mutation)
-      },
-    },
-  },
-
-  /**
-   * experimental.chat.system.transform — session_start (MEDIUM observe).
-   * Records session context; does not inject anything.
-   */
-  experimental: {
-    chat: {
-      system: {
-        transform: async (messages: unknown[]) => {
-          const sessionId = ctx.sessionId as string ?? "unknown";
-          const cwd = realpathSync(ctx.directory as string);
-
-          const envelope = {
-            harness: "opencode",
-            event: "session_start",
-            normalized: {
-              cwd,
-              session_id: sessionId,
-              harness: "opencode",
-              timestamp_iso8601: new Date().toISOString(),
-            },
-          };
-
-          try {
-            callBridge(envelope);
-          } catch {
-            // MEDIUM: observe only.
-          }
-          return messages; // unmodified
+      const envelope = {
+        harness: "opencode",
+        event: "pre_tool_use",
+        normalized: {
+          tool: input.tool,
+          tool_args: output.args ?? {},
+          cwd,
+          session_id: sessionId,
+          turn_index: turnIndex,
+          timestamp_iso8601: new Date().toISOString(),
         },
-      },
+      };
+
+      const decision = callBridge(envelope);
+      if (decision.action === "block") {
+        throw new Error(decision.reason || "opencode-enforce: write blocked by enforcement gate");
+      }
+      // allow → return (no-op)
     },
-  },
 
-  /**
-   * event — stop (MEDIUM observe).
-   * Records session end; does not refuse.
-   */
-  event: async (type: string, data: unknown) => {
-    if (type !== "session:stop") return;
-    const sessionId = ctx.sessionId as string ?? "unknown";
-    const cwd = realpathSync(ctx.directory as string);
-    const turnIndex = _turnIndex.get(sessionId) ?? 0;
+    /**
+     * tool.execute.after — tool_result (MEDIUM observe).
+     * Real signature: (input:{tool,sessionID,callID,args}, output:{title,output,metadata}).
+     * args live in `input.args`; the tool result text in `output.output`.
+     * Invokes bridge for audit; never throws; never mutates output.
+     */
+    "tool.execute.after": async (
+      input: { tool: string; sessionID: string; callID: string; args: unknown },
+      output: { title: string; output: string; metadata: unknown },
+    ): Promise<void> => {
+      const sessionId = input.sessionID || "unknown";
+      const turnIndex = nextTurnIndex(sessionId);
+      const cwd = directoryOf();
 
-    const envelope = {
-      harness: "opencode",
-      event: "stop",
-      normalized: {
-        cwd,
-        session_id: sessionId,
-        turn_index: turnIndex,
-        is_subagent: false,
-        timestamp_iso8601: new Date().toISOString(),
-      },
-    };
+      const envelope = {
+        harness: "opencode",
+        event: "tool_result",
+        normalized: {
+          tool: input.tool,
+          tool_args: input.args ?? {},
+          result: output.output,
+          cwd,
+          session_id: sessionId,
+          turn_index: turnIndex,
+          timestamp_iso8601: new Date().toISOString(),
+        },
+      };
 
-    try {
-      callBridge(envelope);
-    } catch {
-      // MEDIUM: observe only.
-    }
-  },
-});
+      try {
+        callBridge(envelope);
+      } catch {
+        // MEDIUM: observe only — log but do NOT rethrow.
+        // A bridge failure on tool_result must not interrupt the agent.
+      }
+      // output left UNCHANGED (MEDIUM — no mutation)
+    },
+
+    /**
+     * experimental.chat.system.transform — session_start (MEDIUM observe).
+     * Real signature: (input:{sessionID?,model}, output:{system:string[]}).
+     * Records session context; does not inject anything.
+     */
+    "experimental.chat.system.transform": async (
+      input: { sessionID?: string; model: unknown },
+      _output: { system: string[] },
+    ): Promise<void> => {
+      const sessionId = input.sessionID || "unknown";
+      const cwd = directoryOf();
+
+      const envelope = {
+        harness: "opencode",
+        event: "session_start",
+        normalized: {
+          cwd,
+          session_id: sessionId,
+          harness: "opencode",
+          timestamp_iso8601: new Date().toISOString(),
+        },
+      };
+
+      try {
+        callBridge(envelope);
+      } catch {
+        // MEDIUM: observe only.
+      }
+      // output.system left unmodified
+    },
+
+    /**
+     * event — stop (MEDIUM observe).
+     * Real signature: (input:{event}). The Event union carries `.type`;
+     * session end is "session.idle" with `.properties.sessionID`.
+     * No refuse-stop hook exists in OpenCode (stop is MEDIUM by construction).
+     */
+    event: async (input: { event: { type: string; properties?: { sessionID?: string } } }): Promise<void> => {
+      if (!input.event || input.event.type !== "session.idle") return;
+      const sessionId = input.event.properties?.sessionID || "unknown";
+      const cwd = directoryOf();
+      const turnIndex = _turnIndex.get(sessionId) ?? 0;
+
+      const envelope = {
+        harness: "opencode",
+        event: "stop",
+        normalized: {
+          cwd,
+          session_id: sessionId,
+          turn_index: turnIndex,
+          is_subagent: false,
+          timestamp_iso8601: new Date().toISOString(),
+        },
+      };
+
+      try {
+        callBridge(envelope);
+      } catch {
+        // MEDIUM: observe only.
+      }
+    },
+  };
+};

--- a/plugins/opencode/capabilities/enforcement.ts
+++ b/plugins/opencode/capabilities/enforcement.ts
@@ -1,0 +1,189 @@
+/**
+ * enforcement.ts — OpenCode enforcement plugin (RFC-008 P5 S5, REQ-8/9/10/13/14).
+ *
+ * TypeScript adapter registered as an OpenCode plugin. Spawns the node bridge
+ * (enforce-bridge.mjs) for each tool.execute.before event and applies the
+ * §12 action semantics:
+ *   block  → throw (refuses the tool call)
+ *   allow  → return (proceeds)
+ *   bridge exit≠0 / bad JSON / timeout → throw fail-closed
+ *
+ * Non-blocking events (tool_result, session_start, stop) are MEDIUM observe:
+ * the bridge is invoked for audit/logging but never throws.
+ *
+ * Type-only import of @opencode-ai/plugin — no runtime dependency.
+ *
+ * OD-4 note: the bp-001 checkpoint/plan-approval MARKER lifecycle is NOT
+ * replicated here. P5 enforces the repo-source-write × disposition AND only.
+ * The full bp-001 lifecycle port is deferred to a follow-up slice.
+ */
+
+// @ts-ignore — type-only; not compiled in this repo (zero-dep policy for test harness)
+import type { Plugin } from "@opencode-ai/plugin";
+import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRIDGE = resolve(__dirname, "enforce-bridge.mjs");
+
+// Per-session turn_index counters. Incremented synchronously BEFORE any await
+// (EC3: no shared mutable state that a concurrent call could race on).
+const _turnIndex = new Map<string, number>();
+
+function nextTurnIndex(sessionId: string): number {
+  const n = (_turnIndex.get(sessionId) ?? -1) + 1;
+  _turnIndex.set(sessionId, n);
+  return n;
+}
+
+/** Spawn the bridge, return parsed stdout decision. Throws on any error. */
+function callBridge(envelope: Record<string, unknown>): { action: string; reason: string; label: string | null; effective_tier: string | null } {
+  const input = JSON.stringify(envelope);
+  const r = spawnSync(process.execPath, [BRIDGE], {
+    input,
+    encoding: "utf8",
+    timeout: 10000,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (r.error) throw new Error(`opencode-enforce: bridge spawn error: ${r.error.message}`);
+  if (r.status !== 0) throw new Error(`opencode-enforce: fail-closed: bridge exited ${r.status}: ${(r.stderr || "").slice(0, 200)}`);
+  let parsed: { action: string; reason: string; label: string | null; effective_tier: string | null };
+  try {
+    parsed = JSON.parse(r.stdout.trim());
+  } catch {
+    throw new Error(`opencode-enforce: fail-closed: bridge stdout not valid JSON: ${(r.stdout || "").slice(0, 200)}`);
+  }
+  return parsed;
+}
+
+export const EpisodicEnforcement: Plugin = async (ctx) => ({
+  /**
+   * tool.execute.before — pre_tool_use (STRONG block).
+   * Invokes the bridge; throws on "block" or bridge failure.
+   */
+  tool: {
+    execute: {
+      before: async (params: { tool: string; args: Record<string, unknown> }) => {
+        const sessionId = ctx.sessionId as string ?? "unknown";
+        // EC3: synchronous increment before any await.
+        const turnIndex = nextTurnIndex(sessionId);
+        const cwd = realpathSync(ctx.directory as string);
+
+        const envelope = {
+          harness: "opencode",
+          event: "pre_tool_use",
+          normalized: {
+            tool: params.tool,
+            tool_args: params.args,
+            cwd,
+            session_id: sessionId,
+            turn_index: turnIndex,
+            timestamp_iso8601: new Date().toISOString(),
+          },
+        };
+
+        const decision = callBridge(envelope);
+        if (decision.action === "block") {
+          throw new Error(decision.reason || "opencode-enforce: write blocked by enforcement gate");
+        }
+        // allow → return (no-op)
+      },
+
+      /**
+       * tool.execute.after — tool_result (MEDIUM observe).
+       * Invokes bridge for logging; never throws; never mutates result.
+       */
+      after: async (params: { tool: string; args: Record<string, unknown>; result: unknown }) => {
+        const sessionId = ctx.sessionId as string ?? "unknown";
+        const turnIndex = nextTurnIndex(sessionId);
+        const cwd = realpathSync(ctx.directory as string);
+
+        const envelope = {
+          harness: "opencode",
+          event: "tool_result",
+          normalized: {
+            tool: params.tool,
+            tool_args: params.args,
+            result: params.result,
+            cwd,
+            session_id: sessionId,
+            turn_index: turnIndex,
+            timestamp_iso8601: new Date().toISOString(),
+          },
+        };
+
+        try {
+          callBridge(envelope);
+        } catch {
+          // MEDIUM: observe only — log but do NOT rethrow.
+          // A bridge failure on tool_result must not interrupt the agent.
+        }
+        // return result UNCHANGED (MEDIUM — no mutation)
+      },
+    },
+  },
+
+  /**
+   * experimental.chat.system.transform — session_start (MEDIUM observe).
+   * Records session context; does not inject anything.
+   */
+  experimental: {
+    chat: {
+      system: {
+        transform: async (messages: unknown[]) => {
+          const sessionId = ctx.sessionId as string ?? "unknown";
+          const cwd = realpathSync(ctx.directory as string);
+
+          const envelope = {
+            harness: "opencode",
+            event: "session_start",
+            normalized: {
+              cwd,
+              session_id: sessionId,
+              harness: "opencode",
+              timestamp_iso8601: new Date().toISOString(),
+            },
+          };
+
+          try {
+            callBridge(envelope);
+          } catch {
+            // MEDIUM: observe only.
+          }
+          return messages; // unmodified
+        },
+      },
+    },
+  },
+
+  /**
+   * event — stop (MEDIUM observe).
+   * Records session end; does not refuse.
+   */
+  event: async (type: string, data: unknown) => {
+    if (type !== "session:stop") return;
+    const sessionId = ctx.sessionId as string ?? "unknown";
+    const cwd = realpathSync(ctx.directory as string);
+    const turnIndex = _turnIndex.get(sessionId) ?? 0;
+
+    const envelope = {
+      harness: "opencode",
+      event: "stop",
+      normalized: {
+        cwd,
+        session_id: sessionId,
+        turn_index: turnIndex,
+        is_subagent: false,
+        timestamp_iso8601: new Date().toISOString(),
+      },
+    };
+
+    try {
+      callBridge(envelope);
+    } catch {
+      // MEDIUM: observe only.
+    }
+  },
+});

--- a/plugins/opencode/manifest.json
+++ b/plugins/opencode/manifest.json
@@ -1,0 +1,32 @@
+{
+  "type": "enforcement",
+  "schema_version": "1.0.0",
+  "id": "opencode",
+  "harness": "opencode",
+  "version": "1.0.0",
+  "invocation_modality": "agent",
+  "capabilities": {
+    "pre_tool_use": "STRONG",
+    "tool_result": "MEDIUM",
+    "session_start": "MEDIUM",
+    "stop": "MEDIUM"
+  },
+  "classifier": {
+    "mode": "default",
+    "emits_labels": ["read_only","nonsrc_write","shared_write","push_or_pr_create","marker_write","unsafe_complex","unknown"]
+  },
+  "taxonomy_ref": "patterns/taxonomy.json",
+  "taxonomy_version": "sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4",
+  "events_version": "sha256:13f01e5a599272b349eabd66694b7898e68438e8aad6497e80a9b780bea34ab0",
+  "event_translations": {
+    "pre_tool_use": { "source_format": "opencode-tool-execute-before-normalized",
+      "field_bindings": { "tool":"$.tool","tool_args":"$.args","cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","timestamp_iso8601":"$$now" } },
+    "tool_result": { "source_format": "opencode-tool-execute-after-normalized",
+      "field_bindings": { "tool":"$.tool","tool_args":"$.args","result":"$.result","cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","timestamp_iso8601":"$$now" } },
+    "session_start": { "source_format": "opencode-system-transform-normalized",
+      "field_bindings": { "cwd":"$.cwd","session_id":"$.sessionID","harness":"$.harness","timestamp_iso8601":"$$now" } },
+    "stop": { "source_format": "opencode-session-idle-normalized",
+      "field_bindings": { "cwd":"$.cwd","session_id":"$.sessionID","turn_index":"$.turn_index","is_subagent":"$.is_subagent","timestamp_iso8601":"$$now" } }
+  },
+  "runbook": { "full": "plugins/opencode/runbooks/enforcement.md", "quickref": "plugins/opencode/runbooks/enforcement.quickref.md" }
+}

--- a/plugins/opencode/manifest.json
+++ b/plugins/opencode/manifest.json
@@ -12,8 +12,9 @@
     "stop": "MEDIUM"
   },
   "classifier": {
-    "mode": "default",
-    "emits_labels": ["read_only","nonsrc_write","shared_write","push_or_pr_create","marker_write","unsafe_complex","unknown"]
+    "mode": "override",
+    "emits_labels": ["read_only","shared_write","push_or_pr_create","marker_write","unsafe_complex"],
+    "override_path": "plugins/opencode/capabilities/enforce-bridge.mjs"
   },
   "taxonomy_ref": "patterns/taxonomy.json",
   "taxonomy_version": "sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4",

--- a/plugins/opencode/runbooks/enforcement.md
+++ b/plugins/opencode/runbooks/enforcement.md
@@ -46,12 +46,21 @@ logs/records these events but does not block or modify the response.
 
 ## §3 — Classifier mode & emitted labels
 
-Mode is `default`: the plugin emits the full canonical taxonomy vocabulary and
-performs no override remapping. The seven labels are `read_only`,
-`nonsrc_write`, `shared_write`, `push_or_pr_create`, `marker_write`,
-`unsafe_complex`, and `unknown`. The two non-overridable labels — `marker_write`
-and `unsafe_complex` — are safety/deadlock-critical and may never be remapped by
-an override classifier (M5a).
+Mode is `override`: the OpenCode plugin ships its own harness-native classifier
+(`enforce-bridge.mjs` `classifyLabel`, declared via `classifier.override_path`)
+that maps OpenCode tool calls to a subset of the canonical taxonomy —
+`read_only`, `shared_write`, and `push_or_pr_create` — and fail-closes any
+unrecognized tool to `shared_write` (gated). It is not the canonical bash
+default classifier (`command-classifier.sh`); it is a node port covering the
+OpenCode tool surface. The two non-overridable labels — `marker_write` and
+`unsafe_complex` — are safety/deadlock-critical: they are DECLARED in the
+vocabulary (required by M5a) so the substrate keeps routing them and no override
+classifier can remap or drop them. `classifyLabel` does not itself emit
+`marker_write` yet — opencode's marker lifecycle is deferred (OD-4), so markers
+under `.checkpoints/` are handled by the repo-source carve-out, not by label
+routing. The runtime declared-vs-emitted check (M5b) that would assert emission
+lands in P3; until then the declaration is a static safety floor, not a claim of
+runtime emission.
 
 ## §4 — Repo-source gate scope
 
@@ -98,12 +107,10 @@ embedded markdown; drift = fail (same enforcement boundary as the §1 COMMON row
 | Label | plan_approval | pre_checkpoint | post_checkpoint | stop |
 |---|---|---|---|---|
 | `read_only` | allow | allow | allow | warn |
-| `nonsrc_write` | block | allow | allow | warn |
 | `shared_write` | block | block | allow | warn |
 | `push_or_pr_create` | block | allow | block | warn |
 | `marker_write` † | allow | allow | allow | warn |
 | `unsafe_complex` † | block | block | block | warn |
-| `unknown` | block | block | block | warn |
 
 `†` non-overridable label — cells immutable regardless of plugin (`taxonomy.non_overridable`).
 `stop` is label-independent: `effective_tier(stop) = min(harness_cap.stop, …)` reads marker state, not the command label (F10).
@@ -169,7 +176,7 @@ derived source-of-truth.
 
 - `taxonomy_ref`: `patterns/taxonomy.json`
 - `taxonomy_version`: `sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4`
-- `emits_labels`: `read_only`, `nonsrc_write`, `shared_write`, `push_or_pr_create`, `marker_write`, `unsafe_complex`, `unknown`
+- `emits_labels`: `read_only`, `shared_write`, `push_or_pr_create`, `marker_write`, `unsafe_complex`
 - `consumes_events`: `pre_tool_use`, `tool_result`, `session_start`, `stop`
 - `event_translations_summary`:
   - `pre_tool_use`: `opencode-tool-execute-before-normalized`

--- a/plugins/opencode/runbooks/enforcement.md
+++ b/plugins/opencode/runbooks/enforcement.md
@@ -1,0 +1,179 @@
+# opencode — enforcement runbook
+
+> RFC-008 enforcement plugin. Manifest: `plugins/opencode/manifest.json`;
+> registry entry: `plugins/_index.json`. This runbook is the human + agent
+> contract for how the opencode enforcement plugin classifies commands and
+> gates the agent lifecycle. It is validated structurally by
+> `scripts/validate-plugin-registry.mjs` (M7/M7a/M7b in P1b; M7c–M7f content
+> derivation in P1c).
+
+## ⚠️ Self-trigger checklist
+
+Before acting under this plugin, confirm each of the following — this is the
+fail-closed self-check the agent runs at the moment a gated tool call forms:
+
+- The manifest validates against `plugins/manifest.schema.json` (M2).
+- The command classifies to a taxonomy label in `patterns/taxonomy.json` (M5).
+- The non-overridable labels (`marker_write`, `unsafe_complex`) are never remapped (§3).
+
+## §1 — Capability summary
+
+The opencode plugin declares **STRONG** enforcement on `pre_tool_use` and
+**MEDIUM** (observe) on `tool_result`, `session_start`, and `stop`. The
+harness-agnostic event → action semantics are the COMMON rows shared by every
+enforcement plugin (byte-sourced from `scripts/scaffold-plugin/templates/common-rows.md`, M7a):
+
+<!-- COMMON:BEGIN -->
+| Event | STRONG | MEDIUM | WEAK |
+|---|---|---|---|
+| `pre_tool_use` | block | warn (marker) | inject |
+| `tool_result` | modify | observe | unsupported |
+| `stop` | refuse_stop | warn | unsupported |
+| `session_start` | inject_context | inject_context (best-effort) | inject_static |
+| `session_end` | write_artifact | write_artifact (best-effort) | unsupported |
+<!-- COMMON:END -->
+
+opencode declares `tool_result` at MEDIUM (observe) because `tool.execute.after`
+returns void — no result-mutation contract exists. The `pre_tool_use` hook
+(`tool.execute.before`) is STRONG: the adapter throws to block the call.
+
+## §2 — Event tiers (opencode)
+
+`pre_tool_use` is STRONG: the TypeScript adapter throws from `tool.execute.before`
+to refuse a gated write, and OpenCode surfaces this as a tool refusal to the user.
+`tool_result`, `session_start`, and `stop` are MEDIUM (observe): the adapter
+logs/records these events but does not block or modify the response.
+
+## §3 — Classifier mode & emitted labels
+
+Mode is `default`: the plugin emits the full canonical taxonomy vocabulary and
+performs no override remapping. The seven labels are `read_only`,
+`nonsrc_write`, `shared_write`, `push_or_pr_create`, `marker_write`,
+`unsafe_complex`, and `unknown`. The two non-overridable labels — `marker_write`
+and `unsafe_complex` — are safety/deadlock-critical and may never be remapped by
+an override classifier (M5a).
+
+## §4 — Repo-source gate scope
+
+The opencode plugin gates ONLY repo-source writes (R1-R3). Carve-outs are defined
+in `patterns/repo-source-carveouts.json` (Rule 14 single source, shared with
+`plugins/claude-code/hooks/lib/repo-source.sh` via `scripts/lib/repo-source.mjs`).
+Non-repo writes, episode store writes, and git-ignored paths are always allowed.
+
+## §5 — Gate lifecycle
+
+The gate decision is a two-layer AND:
+1. `toolTargetsRepoSource(repoRoot, tool, path, label)` from `scripts/lib/repo-source.mjs` — returns `"GATED"` or `"ALLOW"`.
+2. `gateDisposition({...})` from `scripts/enforce-contract.mjs` — returns a disposition with `token ∈ {enforce, block, allow}`.
+
+Only when BOTH layers return block/enforce AND the write is repo-source does the
+adapter throw. The COMMON event-tier table in §1 defines what each event does at
+each enforcement tier.
+
+## §6 — Bridge protocol
+
+The `plugins/opencode/capabilities/enforce-bridge.mjs` node bridge reads a JSON
+envelope from stdin (`{harness, event, normalized}`) and writes a decision JSON
+object to stdout (`{action, effective_tier, reason, label}`). The TypeScript
+adapter (`enforcement.ts`) spawns the bridge via `node`, captures stdout, and acts
+on the `action` field. Bridge exit codes: 0 = ok, 2 = invalid input (schema
+error), 3 = engine error (threw during decision). Any non-zero exit or malformed
+JSON from the bridge causes the adapter to throw fail-closed.
+
+## §7 — Resolution matrix
+
+Auto-derived from `manifest.capabilities` × `patterns/taxonomy.json` × the R3
+`effective_tier` ternary. M7c regenerates the two tables below and byte-diffs the
+embedded markdown; drift = fail (same enforcement boundary as the §1 COMMON rows).
+
+<!-- RESOLUTION:BEGIN -->
+**Table A — Per-event capability declaration.**
+
+| `pre_tool_use` | `tool_result` | `stop` | `session_start` | `session_end` |
+|---|---|---|---|---|
+| STRONG | MEDIUM | MEDIUM | MEDIUM | — |
+
+**Table B — Resolved gate × label action grid** (cell = taxonomy policy degraded by `effective_tier`).
+
+| Label | plan_approval | pre_checkpoint | post_checkpoint | stop |
+|---|---|---|---|---|
+| `read_only` | allow | allow | allow | warn |
+| `nonsrc_write` | block | allow | allow | warn |
+| `shared_write` | block | block | allow | warn |
+| `push_or_pr_create` | block | allow | block | warn |
+| `marker_write` † | allow | allow | allow | warn |
+| `unsafe_complex` † | block | block | block | warn |
+| `unknown` | block | block | block | warn |
+
+`†` non-overridable label — cells immutable regardless of plugin (`taxonomy.non_overridable`).
+`stop` is label-independent: `effective_tier(stop) = min(harness_cap.stop, …)` reads marker state, not the command label (F10).
+<!-- RESOLUTION:END -->
+
+## §8 — Invocation modality
+
+**Invocation modality:** agent
+
+The TypeScript adapter is registered as an OpenCode plugin
+(`plugins/opencode/capabilities/enforcement.ts`). OpenCode loads it via
+`plugin` config in the project's `opencode.json`. The adapter spawns the
+node bridge (`enforce-bridge.mjs`) as a subprocess for each `tool.execute.before`
+event. M7d asserts this line byte-equals `manifest.invocation_modality`.
+
+## §9 — Agent manifest
+
+A harness agent reads the machine-parseable block below — sentinel
+`## 🤖 Agent invocation manifest` (column 1) followed by one fenced JSON block —
+and learns how to invoke the plugin without a `--help` round-trip. M7e parses it,
+schema-validates against `schemas/runbook-agent-manifest.schema.json`, and
+cross-checks `invocation_modality` against §8 and the manifest.
+
+## 🤖 Agent invocation manifest
+
+```json
+{
+  "invocation_modality": "agent",
+  "command_shapes": [
+    ["node", "{plugin_dir}/capabilities/enforce-bridge.mjs"]
+  ],
+  "required_args": [],
+  "optional_args": [],
+  "expected_outputs": { "shape": "json-object" },
+  "env_requirements": [],
+  "return_codes": {
+    "0": "ok — decision emitted to stdout",
+    "2": "invalid — malformed input (schema error)",
+    "3": "engine-error — threw during decision"
+  },
+  "dispatch_examples": [
+    {
+      "description": "pre_tool_use repo-source write resolves to block (exit 0, action:block in stdout)",
+      "argv": ["node", "{plugin_dir}/capabilities/enforce-bridge.mjs"]
+    }
+  ]
+}
+```
+
+## §10 — Config / taxonomy cross-binding
+
+Auto-derived from `manifest.json` + the per-project `enforce-config.json` schema
+(`patterns/enforce-config.schema.json`). M7f byte-diffs the block below against the
+derived source-of-truth.
+
+<!-- CONFIG:BEGIN -->
+**10a — Configuration.**
+
+- `enforce_config_keys`: `active` (R5 project switch) + `bp-001.{plan_approval,post_checkpoint,pre_checkpoint,stop}` per-bp tier clamps (RFC-008 P4; schema `patterns/enforce-config.schema.json`; clamp-DOWN only; resolved by `enforce-contract --gate stop` / `--resolve-gate <gate>`).
+- `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.
+
+**10b — Taxonomies.**
+
+- `taxonomy_ref`: `patterns/taxonomy.json`
+- `taxonomy_version`: `sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4`
+- `emits_labels`: `read_only`, `nonsrc_write`, `shared_write`, `push_or_pr_create`, `marker_write`, `unsafe_complex`, `unknown`
+- `consumes_events`: `pre_tool_use`, `tool_result`, `session_start`, `stop`
+- `event_translations_summary`:
+  - `pre_tool_use`: `opencode-tool-execute-before-normalized`
+  - `tool_result`: `opencode-tool-execute-after-normalized`
+  - `session_start`: `opencode-system-transform-normalized`
+  - `stop`: `opencode-session-idle-normalized`
+<!-- CONFIG:END -->

--- a/plugins/opencode/runbooks/enforcement.quickref.md
+++ b/plugins/opencode/runbooks/enforcement.quickref.md
@@ -1,0 +1,8 @@
+# opencode enforcement — quickref
+
+STRONG on `pre_tool_use` (block on repo-source write). MEDIUM (observe) on
+`tool_result`, `session_start`, `stop`. Classifier mode `default`, emits the 7
+canonical taxonomy labels. Non-overridable: `marker_write`, `unsafe_complex`.
+Gate scope: repo-source writes only (R1-R3); carve-outs via
+`patterns/repo-source-carveouts.json`. Bridge: `node {plugin_dir}/capabilities/enforce-bridge.mjs`.
+Full contract: `plugins/opencode/runbooks/enforcement.md`.

--- a/scripts/lib/repo-source.mjs
+++ b/scripts/lib/repo-source.mjs
@@ -1,0 +1,168 @@
+/**
+ * repo-source.mjs — Node mirror of plugins/claude-code/hooks/lib/repo-source.sh.
+ * Rule 14 single source: carve-out dirs from patterns/repo-source-carveouts.json,
+ * read with the same resolution order as the bash script (NEW-R3-1):
+ *   1. $HOME/.episodic-memory/patterns/repo-source-carveouts.json (deployed canonical)
+ *   2. <this-script>/../../../patterns/repo-source-carveouts.json (in-repo dev/test)
+ *   3. Inline 5-dir fallback literals (deploy-lag safety; never fail-open)
+ *
+ * Exact-segment matching: <root>/<dir> or <root>/<dir>/* only.
+ * NEVER substring — .github/ and .gitignore must NOT be carved.
+ *
+ * Zero external dependencies. Node.js stdlib only.
+ *
+ * Exports:
+ *   isRepoSource(repoRoot, targetPath) → {isRepoSource:bool, carveout:string|null}
+ *   toolTargetsRepoSource(repoRoot, tool, path, label) → "GATED"|"ALLOW"
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Carve-out loader (NEW-R3-1 resolution order)
+// ---------------------------------------------------------------------------
+const INLINE_CARVEOUT_DIRS = [".episodic-memory", ".checkpoints", ".review-store", ".git", "docs/plans"];
+
+function loadCarveouts() {
+  const candidates = [
+    path.join(os.homedir(), ".episodic-memory", "patterns", "repo-source-carveouts.json"),
+    path.join(__dirname, "..", "..", "patterns", "repo-source-carveouts.json"),
+  ];
+  for (const jsonPath of candidates) {
+    try {
+      const raw = fs.readFileSync(jsonPath, "utf8");
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed.exact_segment_dirs) && parsed.exact_segment_dirs.length > 0) {
+        return { dirs: parsed.exact_segment_dirs, gitCheckIgnore: !!parsed.git_check_ignore, source: jsonPath };
+      }
+    } catch {
+      // try next
+    }
+  }
+  return { dirs: INLINE_CARVEOUT_DIRS, gitCheckIgnore: true, source: "inline-fallback" };
+}
+
+// Lazy-load once per process.
+let _carveouts = null;
+function getCarveouts() {
+  if (!_carveouts) _carveouts = loadCarveouts();
+  return _carveouts;
+}
+
+// ---------------------------------------------------------------------------
+// Canonicalization (mirrors _canonicalize_possibly_nonexistent in bash).
+// Uses fs.realpathSync when the path exists; otherwise walks up to the
+// nearest existing ancestor, canonicalizes that, and reappends the tail.
+// Handles /var → /private/var on macOS.
+// ---------------------------------------------------------------------------
+function canonicalizePossiblyNonexistent(p) {
+  // Make absolute if relative
+  if (!path.isAbsolute(p)) p = path.join(process.cwd(), p);
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    // Path does not exist: walk up to first existing ancestor
+    let cur = p;
+    let tail = "";
+    while (cur !== path.dirname(cur)) {
+      try {
+        const realCur = fs.realpathSync(cur);
+        return path.join(realCur, tail);
+      } catch {
+        tail = path.basename(cur) + (tail ? path.sep + tail : "");
+        cur = path.dirname(cur);
+      }
+    }
+    // Reached filesystem root without resolving; return as-is
+    return p;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isRepoSource — mirrors _path_is_repo_source (bash §12.1 contract)
+// Returns {isRepoSource:bool, carveout:string|null}
+// Fail-closed: empty/whitespace path → {isRepoSource:true, carveout:null}
+// ---------------------------------------------------------------------------
+export function isRepoSource(repoRoot, targetPath) {
+  // Empty/whitespace → fail-closed (gated), mirrors bash `[ -n "$file_path" ] || return 0`
+  if (!targetPath || !targetPath.trim()) {
+    return { isRepoSource: true, carveout: null };
+  }
+
+  const repoCanon = canonicalizePossiblyNonexistent(repoRoot);
+  const fpCanon = canonicalizePossiblyNonexistent(targetPath);
+
+  // Check if under repo root (raw-prefix or canonical)
+  let inRepo = false;
+  // Raw check (catches symlink-OUT author intent), BUT skip for .. traversals
+  if (!/(?:^|[/\\])\.\.(?:[/\\]|$)/.test(targetPath)) {
+    if (targetPath === repoRoot || targetPath.startsWith(repoRoot + "/") || targetPath.startsWith(repoRoot + path.sep)) {
+      inRepo = true;
+    }
+  }
+  // Canonical check
+  if (!inRepo) {
+    if (fpCanon === repoCanon || fpCanon.startsWith(repoCanon + "/") || fpCanon.startsWith(repoCanon + path.sep)) {
+      inRepo = true;
+    }
+  }
+
+  if (!inRepo) {
+    return { isRepoSource: false, carveout: "outside-repo" };
+  }
+
+  // Carve-out check — exact-segment matching
+  const carveouts = getCarveouts();
+  for (const dir of carveouts.dirs) {
+    const dirPath = repoCanon + "/" + dir;
+    if (fpCanon === dirPath || fpCanon.startsWith(dirPath + "/")) {
+      return { isRepoSource: false, carveout: dir };
+    }
+  }
+
+  // git check-ignore
+  if (carveouts.gitCheckIgnore) {
+    try {
+      execFileSync("git", ["-C", repoCanon, "check-ignore", "-q", "--", fpCanon], {
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      // exit 0 means ignored
+      return { isRepoSource: false, carveout: "gitignore" };
+    } catch {
+      // exit 1 = not ignored; other errors = treat as not ignored
+    }
+  }
+
+  return { isRepoSource: true, carveout: null };
+}
+
+// ---------------------------------------------------------------------------
+// toolTargetsRepoSource — mirrors _tool_targets_repo_source_shared (bash §12.2)
+// Returns "GATED" | "ALLOW"
+// ---------------------------------------------------------------------------
+export function toolTargetsRepoSource(repoRoot, tool, targetPath, label) {
+  if (tool === "Bash" || tool === "bash") {
+    switch (label) {
+      case "read_only":
+      case "nonsrc_write":
+        return "ALLOW";
+      case "shared_write":
+      case "unsafe_complex":
+      case "push_or_pr_create":
+        if (targetPath) {
+          return isRepoSource(repoRoot, targetPath).isRepoSource ? "GATED" : "ALLOW";
+        }
+        return "GATED";
+      default:
+        return "GATED";
+    }
+  }
+  // Non-bash tools (write/edit): always check path
+  return isRepoSource(repoRoot, targetPath).isRepoSource ? "GATED" : "ALLOW";
+}

--- a/scripts/test-plugin.mjs
+++ b/scripts/test-plugin.mjs
@@ -266,7 +266,7 @@ function stepInvocationParity(root, readText, manifest, read_trace) {
       if (!iso.isolationHeld) problems.push(`N1 isolation breach: a .checkpoints/.* marker appeared under the live --project after a stateless-bridge dispatch (${iso.liveLeak})`);
       if (!iso.cwdHeld) problems.push(`N1 root-source breach: a .checkpoints/.* marker appeared under the divergent process cwd (${iso.procLeak})`);
     }
-    passDetail = `§9 surface-truth ok; stdout-decision bridge emitted action:${iso.decision && iso.decision.action} (exit ${iso.exit}); no marker mutated live or divergent-process-cwd (N1: root from input cwd)`;
+    passDetail = `§9 surface-truth ok; stdout-decision bridge emitted action:${iso.decision && iso.decision.action} (exit ${iso.exit}); stateless (no marker mutated anywhere); root-from-input-cwd proven by test-enforce-bridge cwd-divergence`;
   } else {
     problems.push(`unsupported expected_outputs.shape ${JSON.stringify(modality)} — step 9 cannot prove invocation parity`);
   }

--- a/scripts/test-plugin.mjs
+++ b/scripts/test-plugin.mjs
@@ -52,7 +52,7 @@ function resolveRoot(argProject, cwd) {
 // ---------------------------------------------------------------------------
 // The gauntlet. Each step returns { n, title, status: pass|deferred-P3|fail, detail }.
 // ---------------------------------------------------------------------------
-export function runGauntlet({ projectRoot, now = NOW, cwd = process.cwd() } = {}) {
+export function runGauntlet({ projectRoot, harness = "claude-code", now = NOW, cwd = process.cwd() } = {}) {
   const read_trace = [];
   const root = resolveRoot(projectRoot, cwd);
   const readJson = (rel) => { const abs = path.join(root, rel); const t = fs.readFileSync(abs, "utf8"); read_trace.push(abs); return JSON.parse(t); };
@@ -63,8 +63,8 @@ export function runGauntlet({ projectRoot, now = NOW, cwd = process.cwd() } = {}
 
   // Resolve the claude-code enforcement entry from the registry.
   const index = readJson("plugins/_index.json");
-  const entry = (index.plugins || []).find((p) => p.type === "enforcement" && p.id === "claude-code");
-  if (!entry) throw new UsageError("no enforcement entry 'claude-code' in plugins/_index.json");
+  const entry = (index.plugins || []).find((p) => p.type === "enforcement" && p.id === harness);
+  if (!entry) throw new UsageError(`no enforcement entry '${harness}' in plugins/_index.json`);
   const manifest = readJson(entry.manifest);
   const taxonomy = readJson("patterns/taxonomy.json");
   const events = readJson("patterns/events.json");
@@ -96,7 +96,7 @@ export function runGauntlet({ projectRoot, now = NOW, cwd = process.cwd() } = {}
   step(7, "capability honesty (M4a)", clean("M4a") ? "pass" : "fail", clean("M4a") ? "every declared {harness,event} has an honest bypass record" : why("M4a"));
 
   // Step 8 — event replay (F39) through the field_bindings interpreter (C1).
-  steps.push(stepEventReplay(root, readJson, readText, manifest, events, now, read_trace));
+  steps.push(stepEventReplay(root, readJson, readText, manifest, events, now, read_trace, entry.id));
 
   // Step 9 — runbook-derived invocation parity (F47) + N1 sandbox isolation.
   steps.push(stepInvocationParity(root, readText, manifest, read_trace));
@@ -130,7 +130,7 @@ function stepGoldenInputs(readJson, manifest, taxonomy) {
     : { n, title, status: "fail", detail: bad.slice(0, 3).join("; ") };
 }
 
-function stepEventReplay(root, readJson, readText, manifest, events, now, read_trace) {
+function stepEventReplay(root, readJson, readText, manifest, events, now, read_trace, harness = "claude-code") {
   const n = 8, title = "event replay (F39) — field_bindings → canonical payload";
   const trans = manifest.event_translations || {};
   const caps = manifest.capabilities || {};
@@ -140,7 +140,7 @@ function stepEventReplay(root, readJson, readText, manifest, events, now, read_t
   for (const [eventId, t] of Object.entries(trans)) {
     const dash = eventId.replace(/_/g, "-");
     let raw, schema;
-    try { raw = readJson(`tests/fixtures/harness-events/claude-code/${dash}.json`); }
+    try { raw = readJson(`tests/fixtures/harness-events/${harness}/${dash}.json`); }
     catch (e) { problems.push(`${eventId}: no harness-event fixture (${e.message})`); continue; }
     try { schema = readJson(`schemas/events/event-${dash}.schema.json`); }
     catch (e) { problems.push(`${eventId}: no event schema (${e.message})`); continue; }
@@ -315,10 +315,11 @@ function sandboxDispatch(root, manifest, am) {
 // CLI.
 // ---------------------------------------------------------------------------
 function parseArgs(argv) {
-  const args = { project: null, json: false, help: false };
+  const args = { project: null, harness: "claude-code", json: false, help: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--project") args.project = argv[++i];
+    else if (a === "--harness") args.harness = argv[++i];
     else if (a === "--json") args.json = true;
     else if (a === "--help" || a === "-h") args.help = true;
     else throw new UsageError(`unknown argument ${JSON.stringify(a)}`);
@@ -340,7 +341,7 @@ function main() {
   if (args.help) { process.stdout.write(HELP + "\n"); process.exit(0); }
 
   let result;
-  try { result = runGauntlet({ projectRoot: args.project }); }
+  try { result = runGauntlet({ projectRoot: args.project, harness: args.harness }); }
   catch (e) {
     process.stdout.write(JSON.stringify({ status: "usage_error", project_root: null, summary: { pass: 0, deferred: 0, fail: 0 }, steps: [], read_trace: [], violations: [{ detail: e.message }] }) + "\n");
     process.exit(2);

--- a/scripts/test-plugin.mjs
+++ b/scripts/test-plugin.mjs
@@ -22,7 +22,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { validateRegistry } from "./validate-plugin-registry.mjs";
 import { validateInstance } from "./lib/json-instance-validate.mjs";
@@ -215,28 +215,64 @@ function stepInvocationParity(root, readText, manifest, read_trace) {
     }
   }
 
-  // N1 — exercise the gate dispatch in an ISOLATED tmpdir+git-init sandbox with
-  // hook stdin `.cwd` = absolute sandbox root, and assert NO new `.checkpoints/.*`
-  // marker appears under the live --project root (the gate resolves its root from
-  // stdin .cwd, not process cwd/env, so markers land in the sandbox by construction).
-  const iso = sandboxDispatch(root, manifest, am);
-  read_trace.push(...iso.read_trace);
-  if (iso.error) problems.push(`N1 sandbox: ${iso.error}`);
-  else {
-    // The dispatch must ACTUALLY produce a marker (else the absence-assertions
-    // below are vacuous — claude-subagent F1). A push_or_pr_create command
-    // self-arms `.post-checkpoint-required` under the gate's resolved REPO_ROOT.
-    if (!iso.markerArmedInSandbox) problems.push(`N1: dispatch armed no marker in the sandbox — the isolation assertion would be vacuous (expected push self-arm)`);
-    // N1 proper: the marker landed in the sandbox (stdin .cwd), NOT the live repo.
-    if (!iso.isolationHeld) problems.push(`N1 isolation breach: a .checkpoints/.* marker appeared under the live --project after dispatch (${iso.liveLeak})`);
-    // Root-source proof: process cwd is DIVERGENT from stdin .cwd; a gate that
-    // resolved its root from process cwd would have leaked here instead.
-    if (!iso.cwdHeld) problems.push(`N1 root-source breach: a marker appeared under the divergent process cwd (${iso.procLeak}) — gate used process cwd, not stdin .cwd`);
-    if (iso.exit != null && !(String(iso.exit) in am.return_codes)) problems.push(`dispatched gate exit ${iso.exit} not in §9 return_codes ${JSON.stringify(Object.keys(am.return_codes))}`);
+  // N1 — exercise the documented §9 invocation in an ISOLATED git-init sandbox and
+  // prove (non-vacuously) that the gate's root-source is the INPUT cwd, not the
+  // process cwd. The proof SHAPE depends on the harness enforcement modality the
+  // runbook declares in expected_outputs.shape (S1 parameterization — the two
+  // enforcement models differ and a single assertion cannot fit both):
+  //   "exit-code-only" — a marker-arming gate (claude-code checkpoint-gate.sh):
+  //       a push self-arms a `.checkpoints/.*` marker under the gate's resolved
+  //       REPO_ROOT; assert it lands in the sandbox (stdin .cwd) and NONE leaks to
+  //       the live --project or the divergent process cwd.
+  //   "json-object"   — a stateless stdout-decision bridge (opencode
+  //       enforce-bridge.mjs, OD-4): it writes NO marker by design and enforces by
+  //       emitting a decision to stdout. Assert the documented dispatch (a
+  //       pre_tool_use repo-source WRITE) actually resolves to action:block with an
+  //       exit in return_codes, and that NO `.checkpoints/.*` marker is mutated
+  //       under the live --project or the divergent process cwd.
+  const modality = (am.expected_outputs && am.expected_outputs.shape) || "";
+  let passDetail = "";
+  if (modality === "exit-code-only") {
+    const iso = sandboxDispatch(root, manifest, am);
+    read_trace.push(...iso.read_trace);
+    if (iso.error) problems.push(`N1 sandbox: ${iso.error}`);
+    else {
+      // The dispatch must ACTUALLY produce a marker (else the absence-assertions
+      // below are vacuous — claude-subagent F1). A push_or_pr_create command
+      // self-arms `.post-checkpoint-required` under the gate's resolved REPO_ROOT.
+      if (!iso.markerArmedInSandbox) problems.push(`N1: dispatch armed no marker in the sandbox — the isolation assertion would be vacuous (expected push self-arm)`);
+      // N1 proper: the marker landed in the sandbox (stdin .cwd), NOT the live repo.
+      if (!iso.isolationHeld) problems.push(`N1 isolation breach: a .checkpoints/.* marker appeared under the live --project after dispatch (${iso.liveLeak})`);
+      // Root-source proof: process cwd is DIVERGENT from stdin .cwd; a gate that
+      // resolved its root from process cwd would have leaked here instead.
+      if (!iso.cwdHeld) problems.push(`N1 root-source breach: a marker appeared under the divergent process cwd (${iso.procLeak}) — gate used process cwd, not stdin .cwd`);
+      if (iso.exit != null && !(String(iso.exit) in am.return_codes)) problems.push(`dispatched gate exit ${iso.exit} not in §9 return_codes ${JSON.stringify(Object.keys(am.return_codes))}`);
+    }
+    passDetail = `§9 surface-truth ok; gate self-armed in sandbox (${iso.sandboxMarkers}); live + divergent-process-cwd untouched (N1: root from stdin .cwd)`;
+  } else if (modality === "json-object") {
+    const iso = bridgeDispatch(root, manifest, am);
+    read_trace.push(...iso.read_trace);
+    if (iso.error) problems.push(`N1 bridge: ${iso.error}`);
+    else {
+      // Surface-truth (stdout-decision form): the documented dispatch must emit the
+      // documented decision. A repo-source write resolves to action:block (else the
+      // §9 dispatch_example lies about the invocation surface).
+      if (iso.exit == null || !(String(iso.exit) in am.return_codes)) problems.push(`dispatched bridge exit ${iso.exit} not in §9 return_codes ${JSON.stringify(Object.keys(am.return_codes))}`);
+      if (!iso.decision || typeof iso.decision !== "object") problems.push(`N1: bridge stdout did not parse as a json-object decision (expected_outputs.shape=json-object)`);
+      else if (iso.decision.action !== "block") problems.push(`N1 surface-truth: documented dispatch (repo-source write) did not resolve to action:block (got ${JSON.stringify(iso.decision.action)})`);
+      // Isolation: a stateless bridge mutates NO marker anywhere (live or divergent
+      // process cwd). Root-source is independently proven by the bridge's own
+      // cwd-divergence unit test (test-enforce-bridge.mjs::testBridgeCwdDivergence).
+      if (!iso.isolationHeld) problems.push(`N1 isolation breach: a .checkpoints/.* marker appeared under the live --project after a stateless-bridge dispatch (${iso.liveLeak})`);
+      if (!iso.cwdHeld) problems.push(`N1 root-source breach: a .checkpoints/.* marker appeared under the divergent process cwd (${iso.procLeak})`);
+    }
+    passDetail = `§9 surface-truth ok; stdout-decision bridge emitted action:${iso.decision && iso.decision.action} (exit ${iso.exit}); no marker mutated live or divergent-process-cwd (N1: root from input cwd)`;
+  } else {
+    problems.push(`unsupported expected_outputs.shape ${JSON.stringify(modality)} — step 9 cannot prove invocation parity`);
   }
 
   return problems.length === 0
-    ? { n, title, status: "pass", detail: `§9 surface-truth ok; gate self-armed in sandbox (${iso.sandboxMarkers}); live + divergent-process-cwd untouched (N1: root from stdin .cwd)` }
+    ? { n, title, status: "pass", detail: passDetail }
     : { n, title, status: "fail", detail: problems.slice(0, 3).join("; ") };
 }
 
@@ -307,6 +343,80 @@ function sandboxDispatch(root, manifest, am) {
     isolationHeld: liveLeak.length === 0, // N1: no marker under the live --project
     liveLeak: liveLeak.join(","),
     cwdHeld: procLeak.length === 0, //       gate used stdin .cwd, not the divergent process cwd
+    procLeak: procLeak.join(","),
+  };
+}
+
+// Dispatch a stateless stdout-decision bridge (opencode enforce-bridge.mjs, OD-4)
+// in a throwaway git-init sandbox and PROVE the json-object invocation surface is
+// truthful + isolated. Two deliberate design points mirror sandboxDispatch:
+//   1. The dispatch is the DOCUMENTED one — a pre_tool_use repo-source WRITE, which
+//      the bridge resolves to {action:"block"} on stdout (§9 dispatch_example). The
+//      sandbox holds a real src/ file so the L1 repo-source check is non-vacuous.
+//   2. The process cwd is a SEPARATE throwaway dir, DIVERGENT from the bridge's
+//      input cwd (normalized.cwd). The bridge resolves repo root from normalized.cwd
+//      ONLY (enforce-bridge.mjs:94-104), never process.cwd().
+// Asserts (in stepInvocationParity): decision.action === "block"; exit in
+// return_codes; NO `.checkpoints/.*` marker mutated under the live --project or the
+// divergent process cwd (a stateless bridge writes none).
+function bridgeDispatch(root, manifest, am) {
+  const read_trace = [];
+  const shape = (am.command_shapes || [])[0];
+  if (!Array.isArray(shape) || shape.length === 0) return { error: "no command_shape to dispatch", read_trace };
+  const pluginDir = path.join(root, "plugins", manifest.harness);
+  const argv = shape.map((tok) => (typeof tok === "string" ? tok.replace("{plugin_dir}", pluginDir) : tok));
+
+  const SID = "00000000-0000-4000-8000-000000000000";
+  const snapshot = (base) => { try { return new Set(fs.readdirSync(path.join(base, ".checkpoints"))); } catch { return new Set(); } };
+  const newMarkers = (base, before) => [...snapshot(base)].filter((f) => !before.has(f));
+
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), "tp-bridge-sbx-"));
+  const procCwd = fs.mkdtempSync(path.join(os.tmpdir(), "tp-bridge-cwd-")); // divergent process cwd
+  const liveBefore = snapshot(root);
+  const procBefore = snapshot(procCwd);
+
+  let exit = null, err = null, decision = null;
+  try {
+    execFileSync("git", ["init", "-q"], { cwd: sandbox });
+    const sandboxRoot = fs.realpathSync(sandbox); // ABSOLUTE input cwd — bridge's authoritative root
+    fs.mkdirSync(path.join(sandboxRoot, "src"), { recursive: true });
+    const target = path.join(sandboxRoot, "src", "SENTINEL.mjs");
+    fs.writeFileSync(target, "// sentinel\n");
+    const stdin = JSON.stringify({
+      harness: manifest.harness,
+      event: "pre_tool_use",
+      normalized: {
+        tool: "write",
+        tool_args: { filePath: target, content: "x" }, // repo-source write → action:block
+        cwd: sandboxRoot,
+        session_id: SID,
+        turn_index: 1,
+        timestamp_iso8601: "2026-01-01T00:00:00Z",
+      },
+    });
+    const r = spawnSync(argv[0], argv.slice(1), {
+      cwd: procCwd, // DIVERGENT from input cwd: a bridge reading process cwd resolves HERE
+      input: stdin,
+      encoding: "utf8",
+      timeout: 15000,
+      env: { ...process.env },
+    });
+    exit = typeof r.status === "number" ? r.status : null;
+    try { if (r.stdout) decision = JSON.parse(r.stdout.trim()); } catch { /* decision stays null */ }
+    if (exit == null && r.error) err = r.error.message;
+  } catch (e) { err = `bridge setup failed: ${e.message}`; }
+  finally {
+    try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(procCwd, { recursive: true, force: true }); } catch {}
+  }
+
+  const liveLeak = newMarkers(root, liveBefore);
+  const procLeak = newMarkers(procCwd, procBefore);
+  return {
+    exit, error: err, read_trace, decision,
+    isolationHeld: liveLeak.length === 0, // N1: no marker under the live --project
+    liveLeak: liveLeak.join(","),
+    cwdHeld: procLeak.length === 0, //       bridge used input cwd, not divergent process cwd
     procLeak: procLeak.join(","),
   };
 }

--- a/tests/fixtures/harness-events/opencode/pre-tool-use.json
+++ b/tests/fixtures/harness-events/opencode/pre-tool-use.json
@@ -1,0 +1,1 @@
+{"tool":"write","args":{"filePath":"/Users/juan.delacruz/repo/src/x.mjs","content":"x"},"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":3}

--- a/tests/fixtures/harness-events/opencode/session-start.json
+++ b/tests/fixtures/harness-events/opencode/session-start.json
@@ -1,0 +1,1 @@
+{"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","harness":"opencode"}

--- a/tests/fixtures/harness-events/opencode/stop.json
+++ b/tests/fixtures/harness-events/opencode/stop.json
@@ -1,0 +1,1 @@
+{"sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":5,"is_subagent":false}

--- a/tests/fixtures/harness-events/opencode/tool-result.json
+++ b/tests/fixtures/harness-events/opencode/tool-result.json
@@ -1,0 +1,1 @@
+{"tool":"bash","args":{"command":"ls"},"result":"a.txt\nb.txt","sessionID":"ses_abc","cwd":"/Users/juan.delacruz/repo","turn_index":4}

--- a/tests/fixtures/plugins/bad-missing-bypass-record.json
+++ b/tests/fixtures/plugins/bad-missing-bypass-record.json
@@ -5,7 +5,7 @@
   "harness": "opencode",
   "version": "1.0.0",
   "invocation_modality": "agent",
-  "capabilities": { "pre_tool_use": "STRONG", "tool_result": "STRONG" },
+  "capabilities": { "pre_tool_use": "STRONG", "session_end": "STRONG" },
   "classifier": { "mode": "default", "emits_labels": ["read_only", "nonsrc_write", "shared_write", "push_or_pr_create", "marker_write", "unsafe_complex", "unknown"] },
   "taxonomy_ref": "patterns/taxonomy.json",
   "taxonomy_version": "sha256:7ea41ed82edef968baee6880f040008080afd962fec9120336ee336796013cc4",

--- a/tests/fixtures/plugins/bad-missing-bypass-record.json
+++ b/tests/fixtures/plugins/bad-missing-bypass-record.json
@@ -12,7 +12,7 @@
   "events_version": "sha256:13f01e5a599272b349eabd66694b7898e68438e8aad6497e80a9b780bea34ab0",
   "event_translations": {
     "pre_tool_use": { "source_format": "opencode-tool-call", "field_bindings": { "tool": "$.tool" } },
-    "tool_result": { "source_format": "opencode-tool-result", "field_bindings": { "tool": "$.tool", "result": "$.result" } }
+    "session_end": { "source_format": "opencode-session-end", "field_bindings": { "session_id": "$.sessionID" } }
   },
   "runbook": { "full": "plugins/opencode/runbooks/enforcement.md", "quickref": "plugins/opencode/runbooks/enforcement.quickref.md" }
 }

--- a/tests/test-enforce-bridge.mjs
+++ b/tests/test-enforce-bridge.mjs
@@ -1,0 +1,195 @@
+/**
+ * test-enforce-bridge.mjs — Group 5 tests for the OpenCode enforce bridge
+ * (RFC-008 P5 S5, REQ-8/9/10/13/14).
+ *
+ * Tests spawn the bridge as a subprocess, send JSON to stdin, and assert
+ * on stdout + exit code. No global state mutation.
+ *
+ * Run: node tests/test-enforce-bridge.mjs
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+const BRIDGE = path.join(REPO, "plugins", "opencode", "capabilities", "enforce-bridge.mjs");
+
+let pass = 0, fail = 0;
+const failures = [];
+function assert(cond, name, detail = "") {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: spawn the bridge with a given envelope, capture stdout/exit.
+// ---------------------------------------------------------------------------
+function runBridge(envelope, opts = {}) {
+  const { cwd = REPO } = opts;
+  const input = JSON.stringify(envelope);
+  const r = spawnSync(process.execPath, [BRIDGE], {
+    cwd,
+    input,
+    encoding: "utf8",
+    timeout: 15000,
+    env: process.env,
+  });
+  let parsed = null;
+  try { if (r.stdout) parsed = JSON.parse(r.stdout.trim()); } catch {}
+  return { exit: r.status, stdout: r.stdout, stderr: r.stderr, parsed };
+}
+
+// ---------------------------------------------------------------------------
+// Set up a mock git repo for path-resolution tests.
+// ---------------------------------------------------------------------------
+function makeMockRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bridge-test-"));
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  // Create a src file to represent a repo-source target
+  fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "src", "SENTINEL.mjs"), "// sentinel\n");
+  // .episodic-memory carve-out
+  fs.mkdirSync(path.join(dir, ".episodic-memory"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".episodic-memory", "ep.json"), "{}");
+  return fs.realpathSync(dir);
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeRepoSrcBlock — pre_tool_use write to repo-source → action:block
+// ---------------------------------------------------------------------------
+{
+  const mockRepo = makeMockRepo();
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const envelope = {
+    harness: "opencode",
+    event: "pre_tool_use",
+    normalized: {
+      tool: "write",
+      tool_args: { filePath: sentinelPath, content: "x" },
+      cwd: mockRepo,
+      session_id: "test-block-ses",
+      turn_index: 1,
+      timestamp_iso8601: "2026-01-01T00:00:00Z",
+    },
+  };
+  const r = runBridge(envelope);
+  assert(r.exit === 0, "testBridgeRepoSrcBlock: exit 0", String(r.exit));
+  assert(r.parsed && r.parsed.action === "block", "testBridgeRepoSrcBlock: action=block",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+  assert(r.parsed && typeof r.parsed.reason === "string" && r.parsed.reason.length > 0,
+    "testBridgeRepoSrcBlock: reason is non-empty string");
+  fs.rmSync(mockRepo, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeReadAllow — read_only tool → action:allow
+// ---------------------------------------------------------------------------
+{
+  const mockRepo = makeMockRepo();
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const envelope = {
+    harness: "opencode",
+    event: "pre_tool_use",
+    normalized: {
+      tool: "read",
+      tool_args: { filePath: sentinelPath },
+      cwd: mockRepo,
+      session_id: "test-read-ses",
+      turn_index: 1,
+      timestamp_iso8601: "2026-01-01T00:00:00Z",
+    },
+  };
+  const r = runBridge(envelope);
+  assert(r.exit === 0, "testBridgeReadAllow: exit 0", String(r.exit));
+  assert(r.parsed && r.parsed.action === "allow", "testBridgeReadAllow: action=allow",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+  fs.rmSync(mockRepo, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeInvalidPayloadExit2 — malformed envelope → exit 2
+// ---------------------------------------------------------------------------
+{
+  // Missing event field
+  const r1 = runBridge({ harness: "opencode", normalized: {} });
+  assert(r1.exit === 2, "testBridgeInvalidPayloadExit2 (missing event): exit 2", String(r1.exit));
+
+  // Wrong harness
+  const r2 = runBridge({ harness: "claude-code", event: "pre_tool_use", normalized: {} });
+  assert(r2.exit === 2, "testBridgeInvalidPayloadExit2 (wrong harness): exit 2", String(r2.exit));
+
+  // Non-JSON input via raw stdin
+  const rBad = spawnSync(process.execPath, [BRIDGE], {
+    cwd: REPO,
+    input: "NOT JSON",
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  assert(rBad.status === 2, "testBridgeInvalidPayloadExit2 (non-JSON): exit 2", String(rBad.status));
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeEngineThrowExit3 — unresolvable cwd → engine throws → exit 3
+// ---------------------------------------------------------------------------
+{
+  const envelope = {
+    harness: "opencode",
+    event: "pre_tool_use",
+    normalized: {
+      tool: "write",
+      tool_args: { filePath: "/nonexistent/SENTINEL.mjs" },
+      cwd: "/nonexistent-bridge-test-xyz-123456",
+      session_id: "test-eng-ses",
+      turn_index: 1,
+      timestamp_iso8601: "2026-01-01T00:00:00Z",
+    },
+  };
+  const r = runBridge(envelope);
+  assert(r.exit === 3, "testBridgeEngineThrowExit3: exit 3 on unresolvable cwd", String(r.exit));
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeCwdDivergence — process cwd=os.tmpdir(), payload.cwd=mock repo.
+// Decision uses mock repo carve-outs (repo-source write blocks using mock
+// repo as root), NOT the process cwd.
+// ---------------------------------------------------------------------------
+{
+  const mockRepo = makeMockRepo();
+  const procCwd = os.tmpdir();
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const envelope = {
+    harness: "opencode",
+    event: "pre_tool_use",
+    normalized: {
+      tool: "write",
+      tool_args: { filePath: sentinelPath },
+      cwd: mockRepo,
+      session_id: "test-cwd-div-ses",
+      turn_index: 1,
+      timestamp_iso8601: "2026-01-01T00:00:00Z",
+    },
+  };
+  // Run with process cwd=tmpdir (divergent from payload.cwd=mockRepo)
+  const r = runBridge(envelope, { cwd: procCwd });
+  assert(r.exit === 0, "testBridgeCwdDivergence: exit 0", String(r.exit));
+  // Should still block (uses payload.cwd=mockRepo as repo root, not procCwd)
+  assert(r.parsed && r.parsed.action === "block",
+    "testBridgeCwdDivergence: action=block (repo-root from payload.cwd, not process cwd)",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+  fs.rmSync(mockRepo, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log(`\ntest-enforce-bridge: ${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.error("\nFAILURES:");
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log("✓ all enforce-bridge tests passed");

--- a/tests/test-install-opencode-enforcement.mjs
+++ b/tests/test-install-opencode-enforcement.mjs
@@ -1,0 +1,172 @@
+/**
+ * test-install-opencode-enforcement.mjs — Group 7 mock-project E2E for the
+ * OpenCode enforcement install/uninstall (RFC-008 P5 S6, REQ-11).
+ *
+ * Runs the REAL install.mjs under an isolated HOME + throwaway project, then
+ * DRIVES THE DEPLOYED bridge (not the in-repo one — M4: no node-call substitute
+ * for the deployed artifact). Proves the co-deployed dependency closure
+ * (enforce-contract.mjs + scripts/lib/*) actually resolves and the deployed gate
+ * decides correctly: repo-source write -> block, carve-out -> allow, read ->
+ * allow. Then uninstalls and asserts removal + no global leak (P12 per-project).
+ *
+ * Run: node tests/test-install-opencode-enforcement.mjs
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+const INSTALL = path.join(REPO, "install.mjs");
+
+let pass = 0, fail = 0;
+const failures = [];
+function assert(cond, name, detail = "") {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+}
+
+// Deployed paths under a project root (mirror opencodeEnforcementPaths in install.mjs).
+function deployed(projectDir) {
+  const deployRoot = path.join(projectDir, ".opencode", "plugins");
+  const pluginDir = path.join(deployRoot, "episodic-memory");
+  return {
+    deployRoot, pluginDir,
+    adapter: path.join(pluginDir, "capabilities", "enforcement.ts"),
+    bridge: path.join(pluginDir, "capabilities", "enforce-bridge.mjs"),
+    manifest: path.join(pluginDir, "manifest.json"),
+    runbook: path.join(pluginDir, "runbooks", "enforcement.md"),
+    enforceContract: path.join(deployRoot, "scripts", "enforce-contract.mjs"),
+    repoSource: path.join(deployRoot, "scripts", "lib", "repo-source.mjs"),
+    carveouts: path.join(deployRoot, "patterns", "repo-source-carveouts.json"),
+    config: path.join(projectDir, "opencode.json"),
+  };
+}
+
+// Spawn the DEPLOYED bridge with an envelope; return {exit, parsed}.
+function runDeployedBridge(bridgePath, envelope) {
+  const r = spawnSync(process.execPath, [bridgePath], {
+    input: JSON.stringify(envelope),
+    encoding: "utf8",
+    timeout: 15000,
+  });
+  let parsed = null;
+  try { if (r.stdout) parsed = JSON.parse(r.stdout.trim()); } catch {}
+  return { exit: r.status, parsed, stderr: r.stderr };
+}
+
+// ---------------------------------------------------------------------------
+// Isolated sandbox: a fake HOME + a git-init project. The real install.mjs
+// writes its global substrate under HOME/.episodic-memory, so overriding HOME
+// keeps the test off the developer's real global store.
+// ---------------------------------------------------------------------------
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "oc-install-home-"));
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oc-install-proj-"));
+execFileSync("git", ["init", "-q"], { cwd: project });
+const projectReal = fs.realpathSync(project);
+const D = deployed(projectReal);
+const env = { ...process.env, HOME: sandboxHome };
+
+function runInstaller(extraArgs) {
+  return spawnSync(process.execPath, [INSTALL, "--tool", "opencode", "--project", projectReal, ...extraArgs], {
+    encoding: "utf8", timeout: 120000, env,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// testInstallDeploysAll — install, assert files + registration, DRIVE the bridge.
+// ---------------------------------------------------------------------------
+{
+  const r = runInstaller(["--install-enforcement"]);
+  assert(r.status === 0, "install: exit 0", `${r.status}: ${(r.stderr || "").slice(0, 300)}`);
+
+  for (const [k, p] of Object.entries({
+    adapter: D.adapter, bridge: D.bridge, manifest: D.manifest, runbook: D.runbook,
+    enforceContract: D.enforceContract, repoSource: D.repoSource, carveouts: D.carveouts,
+  })) {
+    assert(fs.existsSync(p), `install deploys ${k}`, p);
+  }
+
+  // opencode.json registration.
+  let cfg = null;
+  try { cfg = JSON.parse(fs.readFileSync(D.config, "utf8")); } catch {}
+  const spec = "./.opencode/plugins/episodic-memory/capabilities/enforcement.ts";
+  assert(cfg && Array.isArray(cfg.plugin) && cfg.plugin.includes(spec),
+    "install registers adapter in opencode.json plugin[]", cfg ? JSON.stringify(cfg.plugin) : "no config");
+
+  // DEPLOYED-BRIDGE E2E (M4): the co-deployed closure must resolve + decide right.
+  fs.mkdirSync(path.join(projectReal, "src"), { recursive: true });
+  const srcWrite = {
+    harness: "opencode", event: "pre_tool_use",
+    normalized: { tool: "write", tool_args: { filePath: path.join(projectReal, "src", "app.mjs"), content: "x" },
+      cwd: projectReal, session_id: "s", turn_index: 1, timestamp_iso8601: "2026-01-01T00:00:00Z" },
+  };
+  const rb1 = runDeployedBridge(D.bridge, srcWrite);
+  assert(rb1.exit === 0, "deployed bridge: repo-src write exit 0", `${rb1.exit}: ${(rb1.stderr || "").slice(0, 300)}`);
+  assert(rb1.parsed && rb1.parsed.action === "block", "deployed bridge: repo-src write -> block",
+    rb1.parsed ? JSON.stringify(rb1.parsed) : (rb1.stderr || "").slice(0, 300));
+
+  const carveWrite = {
+    harness: "opencode", event: "pre_tool_use",
+    normalized: { tool: "write", tool_args: { filePath: path.join(projectReal, ".episodic-memory", "ep.json"), content: "{}" },
+      cwd: projectReal, session_id: "s", turn_index: 2, timestamp_iso8601: "2026-01-01T00:00:00Z" },
+  };
+  const rb2 = runDeployedBridge(D.bridge, carveWrite);
+  assert(rb2.parsed && rb2.parsed.action === "allow", "deployed bridge: carve-out (.episodic-memory) -> allow",
+    rb2.parsed ? JSON.stringify(rb2.parsed) : (rb2.stderr || "").slice(0, 300));
+
+  const readCall = {
+    harness: "opencode", event: "pre_tool_use",
+    normalized: { tool: "read", tool_args: { filePath: path.join(projectReal, "src", "app.mjs") },
+      cwd: projectReal, session_id: "s", turn_index: 3, timestamp_iso8601: "2026-01-01T00:00:00Z" },
+  };
+  const rb3 = runDeployedBridge(D.bridge, readCall);
+  assert(rb3.parsed && rb3.parsed.action === "allow", "deployed bridge: read -> allow",
+    rb3.parsed ? JSON.stringify(rb3.parsed) : (rb3.stderr || "").slice(0, 300));
+}
+
+// ---------------------------------------------------------------------------
+// testNoGlobalLeak (P12) — the install wrote NOTHING under the developer's real
+// HOME; everything global landed under the sandbox HOME instead.
+// ---------------------------------------------------------------------------
+{
+  // The sandbox HOME received the global substrate (proof the override took).
+  assert(fs.existsSync(path.join(sandboxHome, ".episodic-memory")),
+    "no-global-leak: global substrate landed under sandbox HOME (override honored)");
+}
+
+// ---------------------------------------------------------------------------
+// testUninstallRemoves — uninstall, assert files gone + registration removed.
+// ---------------------------------------------------------------------------
+{
+  const r = runInstaller(["--uninstall-enforcement"]);
+  assert(r.status === 0, "uninstall: exit 0", `${r.status}: ${(r.stderr || "").slice(0, 300)}`);
+
+  assert(!fs.existsSync(D.pluginDir), "uninstall removes pluginDir", D.pluginDir);
+  assert(!fs.existsSync(path.join(D.deployRoot, "scripts")), "uninstall removes deployed scripts");
+  assert(!fs.existsSync(path.join(D.deployRoot, "patterns")), "uninstall removes deployed patterns");
+
+  let cfg = null;
+  try { cfg = JSON.parse(fs.readFileSync(D.config, "utf8")); } catch {}
+  const spec = "./.opencode/plugins/episodic-memory/capabilities/enforcement.ts";
+  const stillRegistered = cfg && Array.isArray(cfg.plugin) && cfg.plugin.includes(spec);
+  assert(!stillRegistered, "uninstall removes adapter from opencode.json plugin[]",
+    cfg ? JSON.stringify(cfg.plugin || null) : "no config");
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup + report.
+// ---------------------------------------------------------------------------
+try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}
+try { fs.rmSync(project, { recursive: true, force: true }); } catch {}
+
+console.log(`\ntest-install-opencode-enforcement: ${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.error("\nFAILURES:");
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log("✓ all opencode install/uninstall E2E tests passed");

--- a/tests/test-install-opencode-enforcement.mjs
+++ b/tests/test-install-opencode-enforcement.mjs
@@ -158,6 +158,98 @@ function runInstaller(extraArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: a fresh isolated (home, project) pair + an installer bound to them.
+// ---------------------------------------------------------------------------
+function freshSandbox() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-install-home-"));
+  const proj = fs.mkdtempSync(path.join(os.tmpdir(), "oc-install-proj-"));
+  execFileSync("git", ["init", "-q"], { cwd: proj });
+  const projReal = fs.realpathSync(proj);
+  return {
+    home, proj, projReal, D: deployed(projReal),
+    install: (extra) => spawnSync(process.execPath,
+      [INSTALL, "--tool", "opencode", "--project", projReal, ...extra],
+      { encoding: "utf8", timeout: 120000, env: { ...process.env, HOME: home } }),
+    cleanup: () => { try { fs.rmSync(home, { recursive: true, force: true }); } catch {}
+                     try { fs.rmSync(proj, { recursive: true, force: true }); } catch {} },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// testKillSwitchHonored (BLOCKER-1) — with the project enforce-config set to
+// {active:false}, the DEPLOYED bridge must ALLOW a repo-source write (R5). The
+// sandbox HOME carries NO global contract, so this cannot pass via a leaked
+// global — it proves the project-local enforce-config.schema.json is read.
+// ---------------------------------------------------------------------------
+{
+  const S = freshSandbox();
+  try {
+    const r = S.install(["--install-enforcement"]);
+    assert(r.status === 0, "killswitch: install exit 0", `${r.status}: ${(r.stderr || "").slice(0, 200)}`);
+    fs.mkdirSync(path.join(S.projReal, ".episodic-memory"), { recursive: true });
+    fs.writeFileSync(path.join(S.projReal, ".episodic-memory", "enforce-config.json"), JSON.stringify({ active: false }));
+    fs.mkdirSync(path.join(S.projReal, "src"), { recursive: true });
+    const env = {
+      harness: "opencode", event: "pre_tool_use",
+      normalized: { tool: "write", tool_args: { filePath: path.join(S.projReal, "src", "app.mjs"), content: "x" },
+        cwd: S.projReal, session_id: "ks", turn_index: 1, timestamp_iso8601: "2026-01-01T00:00:00Z" },
+    };
+    const rb = runDeployedBridge(S.D.bridge, env);
+    assert(rb.parsed && rb.parsed.action === "allow", "killswitch: active:false -> repo-src write ALLOWED (R5 honored)",
+      rb.parsed ? JSON.stringify(rb.parsed) : (rb.stderr || "").slice(0, 300));
+  } finally { S.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// testNoGlobalContractLeak (BLOCKER-1 / P12) — plant a POISON global contract
+// (bp-001 sentinel + a schema that rejects active:false) under the sandbox HOME.
+// resolveContractRoot must still pick the PROJECT-local candidate-0, so the
+// project's {active:false} validates against the PROJECT schema and the write is
+// allowed. If the bridge leaked to the global candidate-1, the poison schema
+// would reject active:false -> identity active:true -> BLOCK.
+// ---------------------------------------------------------------------------
+{
+  const S = freshSandbox();
+  try {
+    S.install(["--install-enforcement"]);
+    // Poison global contract under HOME/.episodic-memory.
+    const gPat = path.join(S.home, ".episodic-memory", "patterns");
+    fs.mkdirSync(gPat, { recursive: true });
+    fs.writeFileSync(path.join(gPat, "bp-001.json"), JSON.stringify({ schema_version: "1.0.0", gates: {} }));
+    fs.writeFileSync(path.join(gPat, "enforce-config.schema.json"),
+      JSON.stringify({ type: "object", properties: { active: { const: true } }, required: ["active"], additionalProperties: false }));
+    // Project opts out.
+    fs.mkdirSync(path.join(S.projReal, ".episodic-memory"), { recursive: true });
+    fs.writeFileSync(path.join(S.projReal, ".episodic-memory", "enforce-config.json"), JSON.stringify({ active: false }));
+    fs.mkdirSync(path.join(S.projReal, "src"), { recursive: true });
+    const env = {
+      harness: "opencode", event: "pre_tool_use",
+      normalized: { tool: "write", tool_args: { filePath: path.join(S.projReal, "src", "app.mjs"), content: "x" },
+        cwd: S.projReal, session_id: "gl", turn_index: 1, timestamp_iso8601: "2026-01-01T00:00:00Z" },
+    };
+    const rb = runDeployedBridge(S.D.bridge, env);
+    assert(rb.parsed && rb.parsed.action === "allow",
+      "no-global-leak: project-local contract wins over planted global poison (P12)",
+      rb.parsed ? JSON.stringify(rb.parsed) : (rb.stderr || "").slice(0, 300));
+  } finally { S.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
+// testMalformedConfigAbortsInstall (MAJOR-1) — a malformed opencode.json aborts
+// the WHOLE deploy: NO files land on disk (symmetry with uninstall's abort).
+// ---------------------------------------------------------------------------
+{
+  const S = freshSandbox();
+  try {
+    fs.writeFileSync(S.D.config, "{ this is : not json ]");
+    const r = S.install(["--install-enforcement"]);
+    assert(r.status === 0, "malformed-config: install still exits 0 (warns, no throw)", String(r.status));
+    assert(!fs.existsSync(S.D.bridge), "malformed-config: NO bridge deployed (deploy aborted, not orphaned)", S.D.bridge);
+    assert(!fs.existsSync(S.D.pluginDir), "malformed-config: NO pluginDir deployed", S.D.pluginDir);
+  } finally { S.cleanup(); }
+}
+
+// ---------------------------------------------------------------------------
 // Cleanup + report.
 // ---------------------------------------------------------------------------
 try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}

--- a/tests/test-opencode-adapter-conformance.mjs
+++ b/tests/test-opencode-adapter-conformance.mjs
@@ -1,0 +1,154 @@
+/**
+ * test-opencode-adapter-conformance.mjs — RFC-008 P5 (PR-level review BLOCKER-1/2 fix).
+ *
+ * The sibling test-opencode-adapter.mjs drives enforce-bridge.mjs directly; it
+ * never loads enforcement.ts, so a broken adapter hook surface passed every
+ * green suite. This test closes that gap: it LOADS the deployed adapter module
+ * and asserts it conforms to the INSTALLED @opencode-ai/plugin `interface Hooks`
+ * (dist/index.d.ts) — flat dotted hook keys, two-arg (input, output) calling
+ * convention — and that its STRONG `tool.execute.before` hook actually throws on
+ * a gated repo-source write (block) and returns on a carve-out (allow).
+ *
+ * BLOCKER-1 regression guard: the host indexes hooks by flat keys
+ * (hooks["tool.execute.before"]). A nested {tool:{execute:{before}}} object —
+ * the original bug — leaves that key undefined and the blocking hook never
+ * fires (fails OPEN). This test fails RED on the nested shape.
+ *
+ * Adapter is TypeScript; loading it needs a type-stripping runtime (Node >=22.6
+ * with --experimental-strip-types, default-on >=23.6). If the runtime cannot
+ * strip types we FAIL LOUDLY rather than skip — an un-runnable conformance test
+ * is the BLOCKER-2 gap, not an acceptable pass. CI pins this job to Node 24.
+ *
+ * Run: node tests/test-opencode-adapter-conformance.mjs
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+const INSTALL = path.join(REPO, "install.mjs");
+
+let pass = 0, fail = 0;
+const failures = [];
+function assert(cond, name, detail = "") {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+}
+
+// --- Isolated install (mirror test-install-opencode-enforcement.mjs) ---------
+const sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "oc-conf-home-"));
+const project = fs.mkdtempSync(path.join(os.tmpdir(), "oc-conf-proj-"));
+execFileSync("git", ["init", "-q"], { cwd: project });
+const projectReal = fs.realpathSync(project);
+const env = { ...process.env, HOME: sandboxHome };
+
+const installRes = spawnSync(
+  process.execPath,
+  [INSTALL, "--tool", "opencode", "--project", projectReal, "--install-enforcement"],
+  { encoding: "utf8", timeout: 120000, env },
+);
+assert(installRes.status === 0, "install: exit 0", `${installRes.status}: ${(installRes.stderr || "").slice(0, 300)}`);
+
+const deployedAdapter = path.join(
+  projectReal, ".opencode", "plugins", "episodic-memory", "capabilities", "enforcement.ts",
+);
+assert(fs.existsSync(deployedAdapter), "deployed adapter exists", deployedAdapter);
+
+// --- Load the deployed adapter as a module (TS type-stripping required) -------
+let mod = null;
+let loadErr = null;
+try {
+  mod = await import(pathToFileURL(deployedAdapter).href);
+} catch (e) {
+  loadErr = e;
+}
+assert(
+  mod !== null,
+  "deployed adapter loads as a module (TS strip)",
+  loadErr
+    ? `import failed (${loadErr.code || ""}): ${String(loadErr.message).slice(0, 200)} — needs Node >=23.6 or --experimental-strip-types; CI pins Node 24`
+    : "",
+);
+
+// Everything below depends on a loaded module + a callable plugin factory.
+if (mod && typeof mod.EpisodicEnforcement === "function") {
+  assert(true, "exports EpisodicEnforcement as a function");
+
+  const hooks = await mod.EpisodicEnforcement({ directory: projectReal });
+  assert(hooks && typeof hooks === "object", "plugin factory returns a hooks object");
+
+  // --- BLOCKER-1 regression: flat dotted keys present, nested shape absent ----
+  assert(typeof hooks["tool.execute.before"] === "function",
+    'hooks["tool.execute.before"] is a function (flat key)');
+  assert(typeof hooks["tool.execute.after"] === "function",
+    'hooks["tool.execute.after"] is a function (flat key)');
+  assert(typeof hooks["experimental.chat.system.transform"] === "function",
+    'hooks["experimental.chat.system.transform"] is a function (flat key)');
+  assert(typeof hooks.event === "function", "hooks.event is a function");
+
+  // The original bug: a nested tool.execute.before. `hooks.tool`, if present, is
+  // the ToolDefinition map per the Hooks interface — it must NOT carry an
+  // execute.before hook (that would mean the adapter regressed to nesting).
+  const nestedRegressed = !!(hooks.tool && hooks.tool.execute && typeof hooks.tool.execute.before === "function");
+  assert(!nestedRegressed, "no nested tool.execute.before (BLOCKER-1 regression guard)");
+
+  // --- before-hook actually BLOCKS a gated repo-source write (throws) ---------
+  fs.mkdirSync(path.join(projectReal, "src"), { recursive: true });
+  let threw = false, throwMsg = "";
+  try {
+    await hooks["tool.execute.before"](
+      { tool: "write", sessionID: "s1", callID: "c1" },
+      { args: { filePath: path.join(projectReal, "src", "app.mjs"), content: "x" } },
+    );
+  } catch (e) { threw = true; throwMsg = String(e.message || e); }
+  assert(threw, "before-hook THROWS on gated repo-source write (STRONG block)", throwMsg ? "" : "did not throw");
+
+  // --- before-hook ALLOWS a carve-out write (no throw) ------------------------
+  let carveThrew = false, carveMsg = "";
+  try {
+    await hooks["tool.execute.before"](
+      { tool: "write", sessionID: "s1", callID: "c2" },
+      { args: { filePath: path.join(projectReal, ".episodic-memory", "ep.json"), content: "{}" } },
+    );
+  } catch (e) { carveThrew = true; carveMsg = String(e.message || e); }
+  assert(!carveThrew, "before-hook does NOT throw on carve-out (.episodic-memory) write", carveMsg);
+
+  // --- before-hook ALLOWS a read (no throw) -----------------------------------
+  let readThrew = false, readMsg = "";
+  try {
+    await hooks["tool.execute.before"](
+      { tool: "read", sessionID: "s1", callID: "c3" },
+      { args: { filePath: path.join(projectReal, "src", "app.mjs") } },
+    );
+  } catch (e) { readThrew = true; readMsg = String(e.message || e); }
+  assert(!readThrew, "before-hook does NOT throw on read tool", readMsg);
+
+  // --- observe hooks never throw ----------------------------------------------
+  let observeThrew = false;
+  try {
+    await hooks["tool.execute.after"](
+      { tool: "write", sessionID: "s1", callID: "c4", args: { filePath: path.join(projectReal, "src", "app.mjs") } },
+      { title: "t", output: "done", metadata: {} },
+    );
+    await hooks.event({ event: { type: "session.idle", properties: { sessionID: "s1" } } });
+  } catch { observeThrew = true; }
+  assert(!observeThrew, "observe hooks (tool_result, stop) never throw");
+} else {
+  assert(false, "exports EpisodicEnforcement as a function",
+    mod ? `got ${typeof (mod && mod.EpisodicEnforcement)}` : "module did not load");
+}
+
+// --- cleanup -----------------------------------------------------------------
+try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}
+try { fs.rmSync(project, { recursive: true, force: true }); } catch {}
+
+// --- report ------------------------------------------------------------------
+console.log(`\ntest-opencode-adapter-conformance: ${pass} pass / ${fail} fail`);
+if (fail > 0) {
+  console.error("FAILURES:\n  - " + failures.join("\n  - "));
+  process.exit(1);
+}

--- a/tests/test-opencode-adapter.mjs
+++ b/tests/test-opencode-adapter.mjs
@@ -1,0 +1,322 @@
+/**
+ * test-opencode-adapter.mjs — Group 4 tests for the OpenCode adapter
+ * (RFC-008 P5 S5, REQ-8/9/10/13/14).
+ *
+ * These tests drive the enforce-bridge.mjs directly (the same protocol the
+ * TypeScript adapter uses) to verify the end-to-end enforcement behavior.
+ * The adapter spawns the bridge; these tests do the same. This is the
+ * strongest testable form before OpenCode runtime integration.
+ *
+ * Run: node tests/test-opencode-adapter.mjs
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync, spawnSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+const BRIDGE = path.join(REPO, "plugins", "opencode", "capabilities", "enforce-bridge.mjs");
+
+let pass = 0, fail = 0;
+const failures = [];
+function assert(cond, name, detail = "") {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: invoke bridge with a pre-normalized payload (mirrors adapter behavior)
+// Returns {threw:bool, action:string|null, exit:number, stdout:string}
+// ---------------------------------------------------------------------------
+function invokeAdapter(mockRepo, event, normalized) {
+  const envelope = { harness: "opencode", event, normalized };
+  const input = JSON.stringify(envelope);
+  const r = spawnSync(process.execPath, [BRIDGE], {
+    cwd: REPO,
+    input,
+    encoding: "utf8",
+    timeout: 15000,
+    env: process.env,
+  });
+  let parsed = null;
+  try { if (r.stdout) parsed = JSON.parse(r.stdout.trim()); } catch {}
+  const threw = r.status !== 0;
+  const action = parsed ? parsed.action : null;
+  return { threw, action, exit: r.status, stdout: r.stdout, stderr: r.stderr, parsed };
+}
+
+// ---------------------------------------------------------------------------
+// Set up a mock git repo.
+// ---------------------------------------------------------------------------
+function makeMockRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "adapter-test-"));
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "src", "SENTINEL.mjs"), "// sentinel\n");
+  // Carve-out directories
+  fs.mkdirSync(path.join(dir, ".episodic-memory", "episodes"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "docs", "plans"), { recursive: true });
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true }); // already created by git init
+  fs.mkdirSync(path.join(dir, ".checkpoints"), { recursive: true });
+  fs.mkdirSync(path.join(dir, ".review-store"), { recursive: true });
+  return fs.realpathSync(dir);
+}
+
+const mockRepo = makeMockRepo();
+
+// ---------------------------------------------------------------------------
+// testRepoSrcWriteBlocks — write under repoRoot/src/SENTINEL.mjs → action:block
+// ---------------------------------------------------------------------------
+{
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "x" },
+    cwd: mockRepo,
+    session_id: "test-ses-001",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.exit === 0, "testRepoSrcWriteBlocks: bridge exits 0", String(r.exit));
+  assert(r.action === "block", "testRepoSrcWriteBlocks: action=block",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// testReadAllows — read_only → action:allow
+// ---------------------------------------------------------------------------
+{
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "read",
+    tool_args: { filePath: sentinelPath },
+    cwd: mockRepo,
+    session_id: "test-ses-002",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testReadAllows: action=allow (read is not a write)",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// Carve-out negative controls: each must NOT block (action:allow)
+// ---------------------------------------------------------------------------
+
+// testEpisodeWriteAllows — .episodic-memory/ carve-out
+{
+  const sentinelPath = path.join(mockRepo, ".episodic-memory", "episodes", "SENTINEL.json");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "{}" },
+    cwd: mockRepo,
+    session_id: "test-ses-003",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testEpisodeWriteAllows: .episodic-memory/ is carved out",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// testPlanFileWriteAllows — docs/plans/ carve-out
+{
+  const sentinelPath = path.join(mockRepo, "docs", "plans", "SENTINEL.md");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "plan" },
+    cwd: mockRepo,
+    session_id: "test-ses-004",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testPlanFileWriteAllows: docs/plans/ is carved out",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// testGitWriteAllows — .git/ carve-out
+{
+  const sentinelPath = path.join(mockRepo, ".git", "SENTINEL_MSG");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "x" },
+    cwd: mockRepo,
+    session_id: "test-ses-005",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testGitWriteAllows: .git/ is carved out",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// testCheckpointsWriteAllows — .checkpoints/ carve-out
+{
+  const sentinelPath = path.join(mockRepo, ".checkpoints", "SENTINEL.marker");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "x" },
+    cwd: mockRepo,
+    session_id: "test-ses-006",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testCheckpointsWriteAllows: .checkpoints/ is carved out",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// testReviewStoreWriteAllows — .review-store/ carve-out
+{
+  const sentinelPath = path.join(mockRepo, ".review-store", "SENTINEL.json");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "{}" },
+    cwd: mockRepo,
+    session_id: "test-ses-007",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testReviewStoreWriteAllows: .review-store/ is carved out",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// testNonRepoWriteAllows — write outside repo root → allow (outside-repo)
+{
+  const sentinelPath = path.join(os.tmpdir(), "SENTINEL_outside_repo.txt");
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "x" },
+    cwd: mockRepo,
+    session_id: "test-ses-008",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow", "testNonRepoWriteAllows: outside-repo write is allowed",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// testMalformedFailsClosed — normalized missing tool → bridge exits 2 (schema error)
+// ---------------------------------------------------------------------------
+{
+  const r = invokeAdapter(mockRepo, "pre_tool_use", {
+    // missing required fields; bridge should validate and exit 2 or 3
+    session_id: "test-ses-009",
+  });
+  // Malformed = exit 2 (validation) or 3 (engine throw). Either counts as "fail-closed"
+  // since the adapter (enforcement.ts) would throw on any non-zero exit.
+  assert(r.exit !== 0 || r.action === "block",
+    "testMalformedFailsClosed: malformed payload causes bridge failure or block",
+    `exit=${r.exit}, action=${r.action}`);
+}
+
+// ---------------------------------------------------------------------------
+// testBridgeErrorFailsClosed — simulate bridge error by sending garbage JSON
+// (the adapter throws on bridge non-zero exit; this is the gateway to fail-closed)
+// ---------------------------------------------------------------------------
+{
+  const r = spawnSync(process.execPath, [BRIDGE], {
+    cwd: REPO,
+    input: '{"harness":"opencode","event":"pre_tool_use","normalized":null}',
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  // null normalized should fail schema validation (exit 2)
+  assert(r.status === 2, "testBridgeErrorFailsClosed: null normalized → exit 2 (adapter would throw fail-closed)",
+    String(r.status));
+}
+
+// ---------------------------------------------------------------------------
+// testTurnIndexMonotonic — two calls with incrementing turn_index
+// (turn_index is managed by the adapter; bridge just passes it through)
+// ---------------------------------------------------------------------------
+{
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const r0 = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "x" },
+    cwd: mockRepo,
+    session_id: "test-ses-010",
+    turn_index: 0,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  const r1 = invokeAdapter(mockRepo, "pre_tool_use", {
+    tool: "write",
+    tool_args: { filePath: sentinelPath, content: "y" },
+    cwd: mockRepo,
+    session_id: "test-ses-010",
+    turn_index: 1,
+    timestamp_iso8601: "2026-01-01T00:00:01Z",
+  });
+  // Both should block (same path, both gated). The turn_index flows through.
+  assert(r0.action === "block" && r1.action === "block",
+    "testTurnIndexMonotonic: both calls block (turn_index 0 then 1)",
+    `r0.action=${r0.action}, r1.action=${r1.action}`);
+}
+
+// ---------------------------------------------------------------------------
+// testCwdFromContext — bridge uses payload.cwd as repo root
+// (even when process.cwd() differs — mirrors testBridgeCwdDivergence)
+// ---------------------------------------------------------------------------
+{
+  const sentinelPath = path.join(mockRepo, "src", "SENTINEL.mjs");
+  const envelope = {
+    harness: "opencode",
+    event: "pre_tool_use",
+    normalized: {
+      tool: "write",
+      tool_args: { filePath: sentinelPath, content: "x" },
+      cwd: mockRepo,
+      session_id: "test-ses-011",
+      turn_index: 1,
+      timestamp_iso8601: "2026-01-01T00:00:00Z",
+    },
+  };
+  const r = spawnSync(process.execPath, [BRIDGE], {
+    cwd: os.tmpdir(), // divergent process cwd
+    input: JSON.stringify(envelope),
+    encoding: "utf8",
+    timeout: 15000,
+    env: process.env,
+  });
+  let parsed = null;
+  try { if (r.stdout) parsed = JSON.parse(r.stdout.trim()); } catch {}
+  assert(parsed && parsed.action === "block",
+    "testCwdFromContext: bridge uses payload.cwd (not process.cwd) → still blocks",
+    parsed ? JSON.stringify(parsed) : r.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// testToolResultObserveNoMutate — tool_result event → action:allow (MEDIUM observe)
+// ---------------------------------------------------------------------------
+{
+  const r = invokeAdapter(mockRepo, "tool_result", {
+    tool: "write",
+    tool_args: { filePath: path.join(mockRepo, "src", "SENTINEL.mjs") },
+    result: "written",
+    cwd: mockRepo,
+    session_id: "test-ses-012",
+    turn_index: 2,
+    timestamp_iso8601: "2026-01-01T00:00:00Z",
+  });
+  assert(r.action === "allow",
+    "testToolResultObserveNoMutate: tool_result event always allows (MEDIUM observe)",
+    r.parsed ? JSON.stringify(r.parsed) : r.stderr);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+fs.rmSync(mockRepo, { recursive: true, force: true });
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+console.log(`\ntest-opencode-adapter: ${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.error("\nFAILURES:");
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log("✓ all opencode adapter tests passed");

--- a/tests/test-opencode-translations.mjs
+++ b/tests/test-opencode-translations.mjs
@@ -1,0 +1,103 @@
+/**
+ * test-opencode-translations.mjs — S2 REQ-3 translation tests.
+ * For each of the 4 opencode events, reads the fixture from
+ * tests/fixtures/harness-events/opencode/<event>.json, runs the manifest
+ * field_bindings via interpretBindings, validates the payload vs
+ * schemas/events/event-<event>.schema.json, and asserts:
+ *   - valid === true
+ *   - payload.session_id === "ses_abc" (sentinel flows through)
+ *
+ * Plus testEmptySessionIdRejected: clones the pre-tool-use fixture with
+ * sessionID:"" → assert invalid (the schema requires minLength:1).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { interpretBindings } from "../scripts/lib/field-bindings.mjs";
+import { validateInstance } from "../scripts/lib/json-instance-validate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+
+let pass = 0, fail = 0;
+const failures = [];
+const assert = (cond, name, detail = "") => {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+};
+
+const NOW = "2026-01-01T00:00:00Z";
+const SENTINEL_SESSION = "ses_abc";
+
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(REPO, rel), "utf8"));
+}
+
+const manifest = readJson("plugins/opencode/manifest.json");
+const trans = manifest.event_translations;
+
+// Events to test
+const events = ["pre_tool_use", "tool_result", "session_start", "stop"];
+
+for (const eventId of events) {
+  const dash = eventId.replace(/_/g, "-");
+  const fixturePath = `tests/fixtures/harness-events/opencode/${dash}.json`;
+  const schemaPath = `schemas/events/event-${dash}.schema.json`;
+
+  let fixture, schema;
+  try { fixture = readJson(fixturePath); }
+  catch (e) { assert(false, `${eventId}: fixture readable`, e.message); continue; }
+  try { schema = readJson(schemaPath); }
+  catch (e) { assert(false, `${eventId}: schema readable`, e.message); continue; }
+
+  const bindings = trans[eventId] && trans[eventId].field_bindings;
+  if (!bindings) { assert(false, `${eventId}: field_bindings present in manifest`); continue; }
+
+  let payload;
+  try {
+    payload = interpretBindings(bindings, fixture, { now: NOW });
+  } catch (e) {
+    assert(false, `${eventId}: interpretBindings succeeds`, e.message);
+    continue;
+  }
+
+  const v = validateInstance(payload, schema);
+  assert(v.valid === true, `${eventId}: payload valid vs event schema`, v.valid ? "" : JSON.stringify((v.errors || []).slice(0, 2)));
+
+  // Sentinel: session_id flows through
+  assert(payload.session_id === SENTINEL_SESSION,
+    `${eventId}: session_id === "${SENTINEL_SESSION}"`,
+    `got: ${JSON.stringify(payload.session_id)}`);
+}
+
+// testEmptySessionIdRejected — sessionID:"" → payload invalid (schema minLength:1)
+{
+  const fixture = readJson("tests/fixtures/harness-events/opencode/pre-tool-use.json");
+  const modifiedFixture = { ...fixture, sessionID: "" };
+  const bindings = trans.pre_tool_use.field_bindings;
+  let payload, didThrow = false;
+  try {
+    payload = interpretBindings(bindings, modifiedFixture, { now: NOW });
+  } catch {
+    // interpretBindings doesn't validate length; the schema does
+    didThrow = true;
+  }
+  if (!didThrow) {
+    const schema = readJson("schemas/events/event-pre-tool-use.schema.json");
+    const v = validateInstance(payload, schema);
+    assert(v.valid === false, "testEmptySessionIdRejected: empty sessionID → schema invalid",
+      v.valid ? "incorrectly passed schema validation" : "");
+  } else {
+    // If interpretBindings threw on empty string (possible for non-$.path directives), that's fine too
+    assert(true, "testEmptySessionIdRejected: empty sessionID rejected (threw at binding)");
+  }
+}
+
+console.log(`\ntest-opencode-translations: ${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.error("\nFAILURES:");
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log("✓ all opencode translation tests passed");

--- a/tests/test-plugin-gauntlet.mjs
+++ b/tests/test-plugin-gauntlet.mjs
@@ -61,8 +61,17 @@ try { runGauntlet({ projectRoot: REPO, harness: "zzz" }); } catch (e) { harnessT
 assert(harnessThrew, "testHarnessUnknownThrows: harness:zzz throws");
 assert(/zzz/.test(harnessErrMsg), "testHarnessUnknownThrows: error message contains harness name 'zzz'", harnessErrMsg);
 
-// testHarnessOpencode — added after P5-S2 ships the opencode fixtures.
-// (skip guard: opencode manifest + fixtures not yet authored; see S2)
+// testHarnessOpencode — opencode fixture-dir is parameterized (S1) + opencode plugin
+// shipped (S2). Steps 1,2,4,7,8 pass; steps 3+9 require the runbook (S3).
+const rOC = runGauntlet({ projectRoot: REPO, harness: "opencode" });
+assert(rOC.read_trace.some((p) => p.includes("plugins/opencode/manifest.json")), "testHarnessOpencode: read_trace includes plugins/opencode/manifest.json");
+assert(rOC.read_trace.some((p) => p.includes("harness-events/opencode/")), "testHarnessOpencode: read_trace includes harness-events/opencode/ fixture path");
+// Steps that must pass in S2 (1,2,4,7,8); 3+9 are expected to fail until S3.
+const ocPassRequired = [1, 2, 4, 7, 8];
+for (const n of ocPassRequired) {
+  const s = rOC.steps.find((st) => st.n === n);
+  assert(s && s.status === "pass", `testHarnessOpencode: step ${n} passes`, s ? s.detail : "step not found");
+}
 
 console.log(`\ntest-plugin-gauntlet: ${pass} passed, ${fail} failed`);
 if (fail > 0) {

--- a/tests/test-plugin-gauntlet.mjs
+++ b/tests/test-plugin-gauntlet.mjs
@@ -50,6 +50,20 @@ let threw = false;
 try { runGauntlet({ projectRoot: "/nonexistent-xyz-123-tp" }); } catch { threw = true; }
 assert(threw, "non-resolving --project throws (usage-error path)");
 
+// testHarnessDefault — default (no harness arg) resolves claude-code entry + claude-code/ fixture path.
+const rDefault = runGauntlet({ projectRoot: REPO });
+assert(rDefault.read_trace.some((p) => p.includes("plugins/claude-code/manifest.json")), "testHarnessDefault: read_trace includes plugins/claude-code/manifest.json");
+assert(rDefault.read_trace.some((p) => p.includes("harness-events/claude-code/")), "testHarnessDefault: read_trace includes harness-events/claude-code/ fixture path");
+
+// testHarnessUnknownThrows — harness:"zzz" throws with zzz in the error message.
+let harnessThrew = false, harnessErrMsg = "";
+try { runGauntlet({ projectRoot: REPO, harness: "zzz" }); } catch (e) { harnessThrew = true; harnessErrMsg = e.message || ""; }
+assert(harnessThrew, "testHarnessUnknownThrows: harness:zzz throws");
+assert(/zzz/.test(harnessErrMsg), "testHarnessUnknownThrows: error message contains harness name 'zzz'", harnessErrMsg);
+
+// testHarnessOpencode — added after P5-S2 ships the opencode fixtures.
+// (skip guard: opencode manifest + fixtures not yet authored; see S2)
+
 console.log(`\ntest-plugin-gauntlet: ${pass} passed, ${fail} failed`);
 if (fail > 0) {
   console.error("\nFAILURES:");

--- a/tests/test-plugin-registry.mjs
+++ b/tests/test-plugin-registry.mjs
@@ -412,6 +412,11 @@ function buildLiveProject() {
     "plugins/claude-code/manifest.json",
     "plugins/claude-code/runbooks/enforcement.md",
     "plugins/claude-code/runbooks/enforcement.quickref.md",
+    // RFC-008 P5 S2/S3: opencode is now a live _index.json entry — its manifest +
+    // runbooks must be on disk too, else M2/M8 fire (entry dir/manifest missing).
+    "plugins/opencode/manifest.json",
+    "plugins/opencode/runbooks/enforcement.md",
+    "plugins/opencode/runbooks/enforcement.quickref.md",
     "scripts/scaffold-plugin/templates/common-rows.md",
   ];
   for (const rel of LIVE_FILES) {

--- a/tests/test-repo-source-parity.mjs
+++ b/tests/test-repo-source-parity.mjs
@@ -1,0 +1,319 @@
+/**
+ * test-repo-source-parity.mjs — Parity test for S4 (REQ-7).
+ * Runs a corpus through BOTH repo-source.sh (bash) AND repo-source.mjs (node),
+ * asserts identical verdicts for EACH case, in BOTH JSON-present AND JSON-hidden
+ * (fallback) modes (B-NEW-1, B-NEW-3).
+ *
+ * Corpus MUST include (per plan §12 + §A.7 S4):
+ *   - A repo-src file → GATED
+ *   - Each carve-out dir → ALLOW (carved)
+ *   - .github/x and .gitignore (adjacent-name, exact-segment → GATED, NOT carved)
+ *   - Empty path → fail-closed GATED in both
+ *   - ../outside traversal → ALLOW in both (R3)
+ *   - A git check-ignore match → ALLOW in both
+ *
+ * testAdjacentNameNotCarved (B-NEW-1): .github/x and .gitignore return isRepoSource:true
+ *   (GATED) in BOTH impls.
+ *
+ * testFallbackMode (B-NEW-3): JSON hidden → bash fallback inline literals still agree
+ *   with the node module's inline fallback.
+ *
+ * testDeployedPathResolution (NEW-R3-1): "JSON present" exercises the $HOME path the
+ *   deployed copy uses, not only the repo-relative path.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { isRepoSource, toolTargetsRepoSource } from "../scripts/lib/repo-source.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = fs.realpathSync(path.join(__dirname, ".."));
+const REPO_SH = path.join(REPO, "plugins/claude-code/hooks/lib/repo-source.sh");
+const CARVEOUTS_JSON = path.join(REPO, "patterns/repo-source-carveouts.json");
+
+let pass = 0, fail = 0;
+const failures = [];
+const assert = (cond, name, detail = "") => {
+  if (cond) { pass++; }
+  else { fail++; failures.push(`${name}${detail ? " — " + detail : ""}`); }
+};
+
+// ---------------------------------------------------------------------------
+// Helper: call _path_is_repo_source from bash, return {isRepoSource:bool}
+// exit 0 = gated (isRepoSource:true), exit 1 = ALLOW (isRepoSource:false)
+// ---------------------------------------------------------------------------
+function bashIsRepoSource(repoRoot, filePath) {
+  const script = `
+    source '${REPO_SH}'
+    _path_is_repo_source '${repoRoot.replace(/'/g, "'\\''")}' '${filePath.replace(/'/g, "'\\''")}' && exit 0 || exit 1
+  `;
+  try {
+    execSync(`bash -c "${script.replace(/"/g, '\\"')}"`, { stdio: ["ignore", "ignore", "ignore"] });
+    return { isRepoSource: true };
+  } catch (e) {
+    if (e.status === 1) return { isRepoSource: false };
+    return { isRepoSource: true }; // other errors → fail-closed
+  }
+}
+
+// Alternative: use bash -c with single-quoted heredoc approach
+function bashIsRepoSourceV2(repoRoot, filePath, envOverrides = {}) {
+  const script = [
+    `source '${REPO_SH}'`,
+    `_path_is_repo_source '${repoRoot.replace(/'/g, "'\\''")}' '${filePath.replace(/'/g, "'\\''")}'`,
+  ].join("\n");
+  try {
+    execFileSync("bash", ["-c", script], {
+      stdio: ["ignore", "ignore", "ignore"],
+      env: { ...process.env, ...envOverrides },
+    });
+    return { isRepoSource: true };
+  } catch (e) {
+    if (e && (e.status === 1 || e.status === undefined)) return { isRepoSource: false };
+    return { isRepoSource: true };
+  }
+}
+
+// Setup: create a mock repo for tests
+const mockRepo = fs.mkdtempSync(path.join(os.tmpdir(), "rs-parity-"));
+try {
+  execFileSync("git", ["init", "-q"], { cwd: mockRepo, stdio: ["ignore", "ignore", "ignore"] });
+} catch {}
+
+// Create a .gitignore to test gitignore match
+fs.writeFileSync(path.join(mockRepo, ".gitignore"), "*.log\n");
+
+// ---------------------------------------------------------------------------
+// Corpus definition
+// ---------------------------------------------------------------------------
+const corpus = [
+  {
+    name: "repo-src file is GATED",
+    path: path.join(mockRepo, "src", "app.mjs"),
+    expectedIsRepo: true,
+    expectedCarveout: null,
+  },
+  {
+    name: ".episodic-memory is carved out",
+    path: path.join(mockRepo, ".episodic-memory", "index.json"),
+    expectedIsRepo: false,
+    expectedCarveout: ".episodic-memory",
+  },
+  {
+    name: ".checkpoints is carved out",
+    path: path.join(mockRepo, ".checkpoints", ".pre-checkpoint-done"),
+    expectedIsRepo: false,
+    expectedCarveout: ".checkpoints",
+  },
+  {
+    name: ".review-store is carved out",
+    path: path.join(mockRepo, ".review-store", "review.json"),
+    expectedIsRepo: false,
+    expectedCarveout: ".review-store",
+  },
+  {
+    name: ".git is carved out",
+    path: path.join(mockRepo, ".git", "COMMIT_EDITMSG"),
+    expectedIsRepo: false,
+    expectedCarveout: ".git",
+  },
+  {
+    name: "docs/plans is carved out",
+    path: path.join(mockRepo, "docs", "plans", "plan.md"),
+    expectedIsRepo: false,
+    expectedCarveout: "docs/plans",
+  },
+  // testAdjacentNameNotCarved (B-NEW-1) — these MUST be GATED (not carved)
+  {
+    name: ".github/ is NOT carved (adjacent-name, exact-segment)",
+    path: path.join(mockRepo, ".github", "workflows", "ci.yml"),
+    expectedIsRepo: true,
+    expectedCarveout: null,
+    tag: "adjacent-name",
+  },
+  {
+    name: ".gitignore is NOT carved (adjacent-name, exact-segment)",
+    path: path.join(mockRepo, ".gitignore"),
+    expectedIsRepo: true,
+    expectedCarveout: null,
+    tag: "adjacent-name",
+  },
+  // testTraversalAllows — ../outside-repo path → ALLOW (R3)
+  {
+    name: "../outside traversal is ALLOW (R3)",
+    path: path.join(mockRepo, "..", "outside-file.txt"),
+    expectedIsRepo: false,
+    expectedCarveout: "outside-repo",
+  },
+  // Outside repo path
+  {
+    name: "/tmp path is outside-repo (ALLOW)",
+    path: path.join(os.tmpdir(), "not-in-repo.txt"),
+    expectedIsRepo: false,
+    expectedCarveout: "outside-repo",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// testParityCorpus — both modes
+// ---------------------------------------------------------------------------
+function runParityCorpus(mode) {
+  let envOverrides = {};
+  let jsonBackup = null;
+  let homeJsonBackup = null;
+  const homeJson = path.join(os.homedir(), ".episodic-memory", "patterns", "repo-source-carveouts.json");
+
+  if (mode === "fallback") {
+    // Hide JSON files
+    if (fs.existsSync(CARVEOUTS_JSON)) {
+      jsonBackup = CARVEOUTS_JSON + ".bak";
+      fs.renameSync(CARVEOUTS_JSON, jsonBackup);
+    }
+    if (fs.existsSync(homeJson)) {
+      homeJsonBackup = homeJson + ".bak";
+      fs.renameSync(homeJson, homeJsonBackup);
+    }
+    // Override HOME to a temp dir so no JSON is reachable
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "rs-parity-home-"));
+    envOverrides = { HOME: fakeHome };
+  }
+
+  try {
+    for (const c of corpus) {
+      const nodeResult = isRepoSource(mockRepo, c.path);
+      const bashResult = bashIsRepoSourceV2(mockRepo, c.path, envOverrides);
+
+      const nodeGated = nodeResult.isRepoSource;
+      const bashGated = bashResult.isRepoSource;
+      const expectedGated = c.expectedIsRepo;
+
+      // Parity check
+      assert(nodeGated === bashGated,
+        `[${mode}] parity: ${c.name}`,
+        `node=${nodeGated} bash=${bashGated}`);
+
+      // Contract check (node vs expected)
+      assert(nodeGated === expectedGated,
+        `[${mode}] contract: ${c.name}`,
+        `got=${nodeGated} expected=${expectedGated}`);
+
+      // Specific adjacent-name check (B-NEW-1): must be GATED in both
+      if (c.tag === "adjacent-name") {
+        assert(nodeGated === true, `[${mode}] B-NEW-1 adjacent-name GATED (node): ${c.name}`, String(nodeGated));
+        assert(bashGated === true, `[${mode}] B-NEW-1 adjacent-name GATED (bash): ${c.name}`, String(bashGated));
+      }
+    }
+  } finally {
+    // Restore JSON files
+    if (jsonBackup && fs.existsSync(jsonBackup)) fs.renameSync(jsonBackup, CARVEOUTS_JSON);
+    if (homeJsonBackup && fs.existsSync(homeJsonBackup)) fs.renameSync(homeJsonBackup, homeJson);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// testEmptyPathFailsClosed — "" → GATED in both
+// ---------------------------------------------------------------------------
+function testEmptyPathFailsClosed() {
+  const nodeResult = isRepoSource(mockRepo, "");
+  const bashResult = bashIsRepoSourceV2(mockRepo, "");
+  assert(nodeResult.isRepoSource === true, "testEmptyPathFailsClosed: node empty→GATED", String(nodeResult.isRepoSource));
+  assert(bashResult.isRepoSource === true, "testEmptyPathFailsClosed: bash empty→GATED", String(bashResult.isRepoSource));
+  assert(nodeResult.isRepoSource === bashResult.isRepoSource, "testEmptyPathFailsClosed: parity");
+}
+
+// ---------------------------------------------------------------------------
+// testToolTargetsParity — toolTargetsRepoSource vs _tool_targets_repo_source_shared
+// ---------------------------------------------------------------------------
+function bashToolTargets(repoRoot, tool, filePath, label, envOverrides = {}) {
+  const script = [
+    `source '${REPO_SH}'`,
+    `_tool_targets_repo_source_shared '${repoRoot.replace(/'/g, "'\\''")}' '${tool}' '${filePath.replace(/'/g, "'\\''")}' '${label}'`,
+  ].join("\n");
+  try {
+    execFileSync("bash", ["-c", script], {
+      stdio: ["ignore", "ignore", "ignore"],
+      env: { ...process.env, ...envOverrides },
+    });
+    return "GATED"; // exit 0 = gated
+  } catch (e) {
+    return "ALLOW"; // exit 1 = allow
+  }
+}
+
+function testToolTargetsParity() {
+  const cases = [
+    { tool: "Bash", path: path.join(mockRepo, "src", "app.mjs"), label: "read_only", expected: "ALLOW" },
+    { tool: "Bash", path: path.join(mockRepo, "src", "app.mjs"), label: "nonsrc_write", expected: "ALLOW" },
+    { tool: "Bash", path: path.join(mockRepo, "src", "app.mjs"), label: "shared_write", expected: "GATED" },
+    { tool: "Bash", path: path.join(mockRepo, ".git", "x"), label: "shared_write", expected: "ALLOW" },
+    { tool: "write", path: path.join(mockRepo, "src", "x.mjs"), label: "", expected: "GATED" },
+    { tool: "write", path: path.join(mockRepo, ".episodic-memory", "x"), label: "", expected: "ALLOW" },
+  ];
+  for (const c of cases) {
+    const nodeResult = toolTargetsRepoSource(mockRepo, c.tool, c.path, c.label);
+    const bashResult = bashToolTargets(mockRepo, c.tool, c.path, c.label);
+    assert(nodeResult === bashResult,
+      `testToolTargetsParity: ${c.tool} ${c.label || "(no label)"} → ${c.expected}`,
+      `node=${nodeResult} bash=${bashResult}`);
+    assert(nodeResult === c.expected,
+      `testToolTargetsParity contract: ${c.tool} ${c.label || "(no label)"} → ${c.expected}`,
+      `got=${nodeResult}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// testDeployedPathResolution (NEW-R3-1) — JSON-present mode explicitly
+// exercises both candidate paths (we note which source was used).
+// ---------------------------------------------------------------------------
+function testDeployedPathResolution() {
+  // The module caches carveouts lazily — force a fresh load to check the source
+  // by reading the JSON directly and verifying correctness.
+  const inRepoPath = path.join(REPO, "patterns", "repo-source-carveouts.json");
+  const homePath = path.join(os.homedir(), ".episodic-memory", "patterns", "repo-source-carveouts.json");
+  let resolvedPath = null;
+  for (const p of [homePath, inRepoPath]) {
+    try {
+      const c = JSON.parse(fs.readFileSync(p, "utf8"));
+      if (Array.isArray(c.exact_segment_dirs) && c.exact_segment_dirs.length === 5) {
+        resolvedPath = p;
+        break;
+      }
+    } catch {}
+  }
+  assert(resolvedPath !== null, "testDeployedPathResolution: at least one JSON path resolves", "none found");
+  // The resolved JSON agrees with inline fallback dirs (5 entries)
+  if (resolvedPath) {
+    const c = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
+    assert(c.exact_segment_dirs.length === 5, "testDeployedPathResolution: JSON has 5 dirs", String(c.exact_segment_dirs.length));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run all tests
+// ---------------------------------------------------------------------------
+console.log("\n=== test-repo-source-parity.mjs ===");
+
+console.log("\n-- JSON-present mode --");
+runParityCorpus("present");
+
+console.log("\n-- JSON-fallback (hidden) mode --");
+runParityCorpus("fallback");
+
+console.log("\n-- Edge cases --");
+testEmptyPathFailsClosed();
+testToolTargetsParity();
+testDeployedPathResolution();
+
+// Cleanup mock repo
+try { fs.rmSync(mockRepo, { recursive: true, force: true }); } catch {}
+
+console.log(`\ntest-repo-source-parity: ${pass} passed, ${fail} failed`);
+if (fail > 0) {
+  console.error("\nFAILURES:");
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  process.exit(1);
+}
+console.log("✓ all parity tests passed (JSON-present and fallback modes, both impls)");

--- a/tests/test-repo-source.sh
+++ b/tests/test-repo-source.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# test-repo-source.sh — Tests for plugins/claude-code/hooks/lib/repo-source.sh
+# Verifies the carve-out logic with both JSON-present and JSON-fallback modes.
+# Usage: bash tests/test-repo-source.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$REPO_ROOT/plugins/claude-code/hooks/lib/repo-source.sh"
+CARVEOUTS_JSON="$REPO_ROOT/patterns/repo-source-carveouts.json"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: $LIB not found"
+  exit 1
+fi
+
+passed=0
+failed=0
+
+# Use a tmpdir as mock repo root so tests don't depend on actual repo state
+MOCK_REPO="$(mktemp -d)"
+trap 'rm -rf "$MOCK_REPO"' EXIT
+
+# Create a minimal git repo in mock dir so git check-ignore works
+git -C "$MOCK_REPO" init -q 2>/dev/null || true
+
+assert_repo_source() {
+  local desc="$1"
+  local file_path="$2"
+  local expect_gated="$3"  # 0=gated(repo-source), 1=ALLOW(carveout/non-repo)
+
+  # shellcheck disable=SC1090
+  source "$LIB"
+  _path_is_repo_source "$MOCK_REPO" "$file_path"
+  local got=$?
+
+  if [ "$got" = "$expect_gated" ]; then
+    echo "  ✓ $desc"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $desc (expected exit=$expect_gated, got=$got)"
+    failed=$((failed+1))
+  fi
+}
+
+echo "=== test-repo-source.sh (JSON-present mode) ==="
+echo "  Carve-out JSON: $CARVEOUTS_JSON"
+
+# Normal repo-source file — must be GATED (exit 0)
+assert_repo_source "src/app.mjs is gated (repo source)" "$MOCK_REPO/src/app.mjs" 0
+
+# Carve-out dirs — must ALLOW (exit 1)
+assert_repo_source ".episodic-memory is carved out" "$MOCK_REPO/.episodic-memory/index.json" 1
+assert_repo_source ".checkpoints is carved out" "$MOCK_REPO/.checkpoints/.pre-checkpoint-done" 1
+assert_repo_source ".review-store is carved out" "$MOCK_REPO/.review-store/foo.json" 1
+assert_repo_source ".git is carved out" "$MOCK_REPO/.git/COMMIT_EDITMSG" 1
+assert_repo_source "docs/plans is carved out" "$MOCK_REPO/docs/plans/myplan.md" 1
+
+# Adjacent names that must NOT be carved (exact-segment check, not substring)
+assert_repo_source ".github/ is NOT carved out (exact-segment)" "$MOCK_REPO/.github/workflows/ci.yml" 0
+assert_repo_source ".gitignore is NOT carved out (exact-segment)" "$MOCK_REPO/.gitignore" 0
+
+# Non-repo path — must ALLOW (exit 1)
+assert_repo_source "outside-repo path is allowed" "/tmp/some-file.txt" 1
+
+echo ""
+echo "=== test-repo-source.sh (JSON-fallback/hidden mode) ==="
+
+# Hide the JSON by temporarily renaming (test fallback inline literals)
+mv "$CARVEOUTS_JSON" "${CARVEOUTS_JSON}.bak" 2>/dev/null || true
+# Also clear HOME-based JSON (won't exist in test unless deployed)
+_HIDDEN_HOME_JSON="$HOME/.episodic-memory/patterns/repo-source-carveouts.json"
+_ORIG_HOME_JSON_EXISTS=0
+if [ -f "$_HIDDEN_HOME_JSON" ]; then
+  mv "$_HIDDEN_HOME_JSON" "${_HIDDEN_HOME_JSON}.bak"
+  _ORIG_HOME_JSON_EXISTS=1
+fi
+
+assert_repo_source "(fallback) src/app.mjs is gated" "$MOCK_REPO/src/app.mjs" 0
+assert_repo_source "(fallback) .git is carved out" "$MOCK_REPO/.git/COMMIT_EDITMSG" 1
+assert_repo_source "(fallback) .episodic-memory is carved out" "$MOCK_REPO/.episodic-memory/index.json" 1
+assert_repo_source "(fallback) .github/ NOT carved (exact-segment)" "$MOCK_REPO/.github/workflows/ci.yml" 0
+
+# Negative: hide JSON still gates .git (the key invariant)
+echo "  (negative) JSON hidden → .git/ still gated (inline fallback active)"
+
+# Restore
+mv "${CARVEOUTS_JSON}.bak" "$CARVEOUTS_JSON" 2>/dev/null || true
+if [ "$_ORIG_HOME_JSON_EXISTS" = "1" ]; then
+  mv "${_HIDDEN_HOME_JSON}.bak" "$_HIDDEN_HOME_JSON"
+fi
+
+echo ""
+echo "test-repo-source: $passed passed, $failed failed"
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi
+echo "✓ all repo-source tests passed"

--- a/tests/test-validate-bp-contract.mjs
+++ b/tests/test-validate-bp-contract.mjs
@@ -404,13 +404,19 @@ classifierCase("7c: typo'd emit-site label literal (GAP-2)", () => {
   assert(s.exit === 0 && s.payload && s.payload.updated.length === 11, "stable-ID (c): scaffold refreshes all 11 contracts after taxonomy add", `exit=${s.exit} updated=${s.payload && s.payload.updated.length}`);
   const clsAbs = path.join(root, CLASSIFIER_REL);
   fs.writeFileSync(clsAbs, fs.readFileSync(clsAbs, "utf8").replace(/^(\s*)read_only\)(\s*)printf '1' ;;$/m, "$1new_label)$2printf '1' ;;\n$1read_only)$2printf '1' ;;"));
-  // A taxonomy change also stales the plugin manifest's hash binding (assertion
-  // 15 covers manifests; scaffold refreshes contracts only) — refresh it as the
-  // manifest author would.
-  const manRel = path.join("plugins", "claude-code", "manifest.json");
-  const man = readJsonAt(root, manRel);
-  man.taxonomy_version = taxonomyVersion(readJsonAt(root, path.join("patterns", "taxonomy.json")));
-  writeJsonAt(root, manRel, man);
+  // A taxonomy change also stales EVERY plugin manifest's hash binding (assertion
+  // 15 covers ALL manifests; scaffold refreshes contracts only) — refresh each as
+  // the manifest author would. (opencode added in P5: a single-manifest refresh
+  // here silently passed only while opencode failed an earlier assertion.)
+  const newTaxVer = taxonomyVersion(readJsonAt(root, path.join("patterns", "taxonomy.json")));
+  for (const manRel of [
+    path.join("plugins", "claude-code", "manifest.json"),
+    path.join("plugins", "opencode", "manifest.json"),
+  ]) {
+    const man = readJsonAt(root, manRel);
+    man.taxonomy_version = newTaxVer;
+    writeJsonAt(root, manRel, man);
+  }
   const r = run(["--project", root, "--json"]);
   assert(r.exit === 0, "stable-ID (c): pure add + scaffold refresh + classifier arm + manifest hash refresh = exit 0 (FP control)", `exit=${r.exit} violations=${JSON.stringify((r.payload && r.payload.violations || []).map((v) => v.check + ":" + v.detail.slice(0, 60)))}`);
 }


### PR DESCRIPTION
## RFC-008 P5 — OpenCode enforcement plugin (R6, R10)

Adds the OpenCode enforcement plugin: a TypeScript adapter + node bridge that gate repo-source writes per the shared `enforce-contract.mjs` thin waist, deployed per-project (Principle 12), with install/uninstall, CI, and a runbook. Maps to RFC-008 R6 (per-tool plugins) and R10 (enforcement runbooks).

### What ships (slices S1-S6)
- S1: gauntlet parameterized by harness (REQ-1).
- S2: declarative opencode plugin (manifest, `_index` entry, event translations).
- S3: enforcement runbook (§1-§10, agent manifest).
- S4: shared repo-source carve-outs, bash + node at parity (REQ-7).
- S5: TypeScript adapter (`enforcement.ts`) + node bridge (`enforce-bridge.mjs`).
- S6: `install.mjs --tool opencode --install-enforcement` + CI gating the opencode suites (REQ-11/REQ-12). Deploys the contract set project-local beside the engine so the kill switch and project-local resolution work in a clean deploy (R5/P12).

### Pre-PR whole-branch review fixes (last two commits)
A PR-level review of the full `main..HEAD` diff (the layer the per-slice reviews could not provide) found issues no single-slice review saw:

- **Adapter was inert (failed open).** `enforcement.ts` returned a nested hooks object, but the installed `@opencode-ai/plugin` `interface Hooks` uses flat dotted keys (`"tool.execute.before"`) with two-arg `(input, output)` signatures. The host found `undefined` and the only STRONG blocking hook never fired. Rewritten to the installed shape; args read from `output.args`/`input.args`, sessionID from `input.sessionID`, stop via the `session.idle` event.
- **No test loaded the adapter.** Every test drove the bridge directly, so the broken adapter passed every green suite. Added `test-opencode-adapter-conformance.mjs` that loads the deployed `.ts` and drives the real `tool.execute.before` hook to a block on a gated write / allow on a carve-out; it fails loud (not skip) if the runtime cannot strip TS. `plugin-validate.yml` pinned to Node 24 for that step.
- **Honest classifier mode.** opencode declared `classifier.mode: "default"` but ships no canonical bash `command-classifier.sh` — its classifier is the node `classifyLabel` subset port. Reclassified to `override` (the truthful declaration) with `override_path`, the honest emitted subset + the non-overridable labels M5a requires; `_index.json` and runbook §3/§7/§10 reconciled (derived blocks regenerated from the canonical generators). A latent FP-control bug in `test-validate-bp-contract.mjs` (refreshed only claude-code's manifest hash) was fixed.
- RFC matrix `tool_result` STRONG→MEDIUM honesty note; `bypass_known` citation corrected.

### Verification
All green: `validate-bp-contract` OK (79 checks) + self-tests 103/0; plugin-registry 200/0; opencode gauntlet 7 pass/2 deferred-P3/0; claude-code gauntlet 25/0; install E2E 25/0; adapter conformance 14/0; opencode adapter 14/0; enforce-bridge 11/0; repo-source parity 65/0; translations 9/0.

Reviewed by `negative-scenario-reviewer` across two rounds to ACCEPT (round 3 specifically adjudicated and confirmed the classifier-mode change is an honest solve, not a disguised bypass; NS1/NS2/NS4 reproduced).

### Post-merge (tracked, not in this PR)
Global hook deploy (`install.mjs --install-hooks --install-hooks-force`) to clear the SessionStart deploy-audit MISSING (S4-origin `repo-source.mjs` stale-local-global), then unfiltered audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
