### PR TITLE
fix(p12): runbook install_time_config wrongly claimed hooks deploy to ~/.claude/hooks/

### DIFF
--- a/plugins/claude-code/runbooks/enforcement.md
+++ b/plugins/claude-code/runbooks/enforcement.md
@@ -176,7 +176,7 @@ same consult.
 **10a — Configuration.**
 
 - `enforce_config_keys`: `active` (R5 project switch) + `bp-001.{plan_approval,post_checkpoint,pre_checkpoint,stop}` per-bp tier clamps (RFC-008 P4; schema `patterns/enforce-config.schema.json`; clamp-DOWN only; resolved by `enforce-contract --gate stop` / `--resolve-gate <gate>`).
-- `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.
+- `install_time_config`: enforcement hooks deployed per-project under `<project>/.claude/` (or `<project>/.opencode/`), NEVER `~/.claude/` (Principle 12), by `install.mjs --install-hooks` / `--install-enforcement`.
 
 **10b — Taxonomies.**
 

--- a/plugins/opencode/runbooks/enforcement.md
+++ b/plugins/opencode/runbooks/enforcement.md
@@ -170,7 +170,7 @@ derived source-of-truth.
 **10a — Configuration.**
 
 - `enforce_config_keys`: `active` (R5 project switch) + `bp-001.{plan_approval,post_checkpoint,pre_checkpoint,stop}` per-bp tier clamps (RFC-008 P4; schema `patterns/enforce-config.schema.json`; clamp-DOWN only; resolved by `enforce-contract --gate stop` / `--resolve-gate <gate>`).
-- `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.
+- `install_time_config`: enforcement hooks deployed per-project under `<project>/.claude/` (or `<project>/.opencode/`), NEVER `~/.claude/` (Principle 12), by `install.mjs --install-hooks` / `--install-enforcement`.
 
 **10b — Taxonomies.**
 

--- a/scripts/validate-plugin-registry.mjs
+++ b/scripts/validate-plugin-registry.mjs
@@ -429,7 +429,7 @@ export function renderConfigBlock(manifest) {
     "**10a — Configuration.**",
     "",
     `- \`enforce_config_keys\`: \`active\` (R5 project switch) + \`bp-001.{${ecGateKeys}}\` per-bp tier clamps (RFC-008 P4; schema \`patterns/enforce-config.schema.json\`; clamp-DOWN only; resolved by \`enforce-contract --gate stop\` / \`--resolve-gate <gate>\`).`,
-    "- `install_time_config`: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks`.",
+    "- `install_time_config`: enforcement hooks deployed per-project under `<project>/.claude/` (or `<project>/.opencode/`), NEVER `~/.claude/` (Principle 12), by `install.mjs --install-hooks` / `--install-enforcement`.",
     "",
     "**10b — Taxonomies.**",
     "",


### PR DESCRIPTION
## Problem

The shared `renderConfigBlock` generator hardcoded `install_time_config: hooks deployed under `~/.claude/hooks/` by `install.mjs --install-hooks``, emitted into **every** plugin runbook §10 (claude-code + opencode). That contradicts **Principle 12** (enforcement is per-project, never global) and the actual installer: `install.mjs:1336` roots `userHooksDir` at `<project>/.claude/hooks` (not `os.homedir()`), and enforcement deploys per-project under `<project>/.claude/` or `<project>/.opencode/`, never `~/.claude/`.

Caught during the P5 post-merge review when the deploy scope was being audited.

## Fix
- `scripts/validate-plugin-registry.mjs` `renderConfigBlock`: corrected the line to state the per-project / never-global truth, citing Principle 12.
- Regenerated the §10 CONFIG block in `plugins/claude-code/runbooks/enforcement.md` and `plugins/opencode/runbooks/enforcement.md` to byte-match the generator (M7f).

## Verification
`node tests/test-plugin-registry.mjs` -> 200/0 (M7f byte-match holds for both runbooks). Old `~/.claude/hooks/` string removed everywhere; corrected line present in generator + both runbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)