### PR TITLE
docs(rfc-008): mark P5 DONE, OpenCode plugin merged (#424/#425)

### DIFF
--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -1217,7 +1217,7 @@ Serves R3, R5 · depends on: P3 · **DONE (P4a #397, P4c #398, P4d S1-S8 + ESC).
 
 #### P5–P7 — Per-tool plugins (OpenCode / Codex / Pi Agent) → [RFC-008/P5-P7-tool-plugins.md](RFC-008/P5-P7-tool-plugins.md)
 
-Serves R6, R10 · depends on: P3 · queued *(legacy "Phase 6/7/8")*. Same template instantiated three times: `manifest.json` + adapter + 10-section runbook + fixtures, each at its declared capability tiers. Codex `pre_tool_use: MEDIUM` (multi-edit bypass documented).
+Serves R6, R10 · depends on: P3 · **P5 DONE (#424 `f5dbaef`, doc fix #425); P6 / P7 queued** *(legacy "Phase 6/7/8")*. Same template instantiated three times: `manifest.json` + adapter + 10-section runbook + fixtures, each at its declared capability tiers. Codex `pre_tool_use: MEDIUM` (multi-edit bypass documented).
 
 #### P8 — Cursor + Windsurf plugins → [RFC-008/P8-cursor-windsurf.md](RFC-008/P8-cursor-windsurf.md)
 

--- a/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
+++ b/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
@@ -3,7 +3,7 @@
 > Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
 > [RFC-008/README.md](README.md).
 
-**Status:** queued. *(Legacy "Phase 6 / 7 / 8".)*
+**Status:** P5 **DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425 `a7f66c9`). P6 / P7 queued. *(Legacy "Phase 6 / 7 / 8".)*
 **Serves:** R6 (plugin-to-harness binding), R10 (enforcement runbooks).
 **Depends on:** P3.
 **Estimate:** P5 ~45K · P6 ~40K · P7 ~35K.

--- a/docs/rfcs/RFC-008/README.md
+++ b/docs/rfcs/RFC-008/README.md
@@ -19,7 +19,7 @@ requirement parent. Each phase file carries its own R-anchors and back-links to 
 | **P2** | [P2-bp-contracts.md](P2-bp-contracts.md) | R2, R3, R4 | P0 | **DONE** — P2a #381 + P2b #384 + P2c #388 |
 | **P3** | [P3-thin-waist.md](P3-thin-waist.md) | R1, R2, R3, R4, R5, R9 | P0, P2 | **DONE** — P3a #389 + P3b-1 #391 + P3c #392 + P3b-2 #393 (P4 schema folded in) + P3d #395 |
 | **P4** | [P4-enforce-config.md](P4-enforce-config.md) | R3, R5 | P3 | **DONE**: P4a #397 (per-project loader, 3 pre_tool_use gates) + P4c #398 (`active:false` kill switch); **P4d** per-project enforcement re-architecture (Principle 12: enforcement per-project, substrate global) S1-S8 + ESC merged (slice detail in workplan). Original P4b superseded by the P4d re-architecture. |
-| **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | queued |
+| **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | **P5 DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425); **P6 / P7 queued** (Codex, Pi Agent) |
 | **P8** | [P8-cursor-windsurf.md](P8-cursor-windsurf.md) | R6, R10 | P3 | queued |
 | **P9** | [P9-recall-strategies.md](P9-recall-strategies.md) | R7 | — | **DEFERRED** — own RFC |
 


### PR DESCRIPTION
## What

Rule 10 doc-sync follow-up. P5 (OpenCode enforcement plugin) merged via #424 (`f5dbaef`) + doc fix #425 (`a7f66c9`), but the per-phase status still read `queued` in three places. This flips them, mirroring #423's P4-DONE sync.

## Changes

- **`docs/rfcs/RFC-008/README.md`** phase matrix: the shared P5-P7 row now reads **P5 DONE**; **P6 / P7 queued** (Codex, Pi Agent still pending).
- **`docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md`** phase-index stub (:1220): same split.
- **`docs/rfcs/RFC-008/P5-P7-tool-plugins.md`** status line: P5 DONE, P6/P7 queued.

P6/P7 stay `queued` because they share the row and the slice file with P5.

## Not changed (intentional)

`docs/rfcs/_index.json` and `docs/rfcs/README.md` track RFC-level status only. RFC-008 stays `accepted` (P6-P9 not shipped), so those are untouched. `em-rfc-validate.mjs` passes: 8 RFCs in `_index.json`, 8 canonical files, 8 README rows.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)