### PR TITLE
docs(rfc-008): fill P6 DONE PR/commit refs (#431)

### DIFF
--- a/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
+++ b/docs/rfcs/RFC-008/P5-P7-tool-plugins.md
@@ -3,7 +3,7 @@
 > Part of [RFC-008](../RFC-008-decouple-enforcement-from-substrate.md). Index:
 > [RFC-008/README.md](README.md).
 
-**Status:** P5 **DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425 `a7f66c9`). **P6 DONE** (Codex plugin `plugins/codex/`, `feat/rfc-008-p6-codex-enforcement`; PR/commit ref added on merge). P7 queued. *(Legacy "Phase 6 / 7 / 8".)*
+**Status:** P5 **DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425 `a7f66c9`). **P6 DONE** (Codex plugin `plugins/codex/`, #431 `3b91f9b`). P7 queued. *(Legacy "Phase 6 / 7 / 8".)*
 **Serves:** R6 (plugin-to-harness binding), R10 (enforcement runbooks).
 **Depends on:** P3.
 **Estimate:** P5 ~45K · P6 ~40K · P7 ~35K.

--- a/docs/rfcs/RFC-008/README.md
+++ b/docs/rfcs/RFC-008/README.md
@@ -19,7 +19,7 @@ requirement parent. Each phase file carries its own R-anchors and back-links to 
 | **P2** | [P2-bp-contracts.md](P2-bp-contracts.md) | R2, R3, R4 | P0 | **DONE** — P2a #381 + P2b #384 + P2c #388 |
 | **P3** | [P3-thin-waist.md](P3-thin-waist.md) | R1, R2, R3, R4, R5, R9 | P0, P2 | **DONE** — P3a #389 + P3b-1 #391 + P3c #392 + P3b-2 #393 (P4 schema folded in) + P3d #395 |
 | **P4** | [P4-enforce-config.md](P4-enforce-config.md) | R3, R5 | P3 | **DONE**: P4a #397 (per-project loader, 3 pre_tool_use gates) + P4c #398 (`active:false` kill switch); **P4d** per-project enforcement re-architecture (Principle 12: enforcement per-project, substrate global) S1-S8 + ESC merged (slice detail in workplan). Original P4b superseded by the P4d re-architecture. |
-| **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | **P5 DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425); **P6 DONE** (Codex enforcement plugin `plugins/codex/`, MEDIUM-honest `pre_tool_use` tier; S0-S5, `feat/rfc-008-p6-codex-enforcement`; PR/commit ref added on merge); **P7 queued** (Pi Agent) |
+| **P5–P7** | [P5-P7-tool-plugins.md](P5-P7-tool-plugins.md) | R6, R10 | P3 | **P5 DONE** (OpenCode plugin #424 `f5dbaef`, doc fix #425); **P6 DONE** (Codex enforcement plugin `plugins/codex/`, MEDIUM-honest `pre_tool_use` tier; S0-S5, #431 `3b91f9b`); **P7 queued** (Pi Agent) |
 | **P8** | [P8-cursor-windsurf.md](P8-cursor-windsurf.md) | R6, R10 | P3 | queued |
 | **P9** | [P9-recall-strategies.md](P9-recall-strategies.md) | R7 | — | **DEFERRED** — own RFC |
 


### PR DESCRIPTION
Post-merge cleanup: the P6-S5 commit left `PR/commit ref added on merge` placeholders in the RFC-008 phase status (the PR number/merge commit weren't known until #431 merged). This fills them with #431 `3b91f9b`.

- `docs/rfcs/RFC-008/README.md:22` — P5-P7 phase row.
- `docs/rfcs/RFC-008/P5-P7-tool-plugins.md:6` — status line.

Docs-only; no code or runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)