### PR TITLE
fix(preflight): resolve hook deps co-located first — foreign-project edits no longer denied (#441, #442)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Run preflight-marker reapers (F4 SessionEnd reap + SessionStart 7d orphan sweep)
         run: node tests/test-preflight-marker-reapers.mjs
 
+      - name: Run preflight-gate foreign-project regression (#441 — real install, no scripts/ tree, edits allowed)
+        run: bash tests/test-preflight-gate-foreign-project.sh
+
+      - name: Run hook-body repo-relative-scripts class-check (#441 — no fail-closed sole $REPO_ROOT/scripts dep)
+        run: node tests/test-hook-bodies-no-repo-relative-scripts.mjs
+
       - name: Run no-legacy-plan-marker-writes detector (Rule 13)
         run: node tests/test-no-legacy-plan-marker-writes.mjs
 

--- a/plugins/claude-code/hooks/preflight-gate.sh
+++ b/plugins/claude-code/hooks/preflight-gate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# episodic-memory-hook-version: 2026-05-16.1
+# episodic-memory-hook-version: 2026-07-04.1
 # preflight-gate.sh — Layer D narrow PreToolUse gate.
 #
 # Closes the bp-010 cluster: codex/Agent/em-store review handoffs (and
@@ -66,8 +66,33 @@ PRIMARY_DIR="$REPO_ROOT/$PRIMARY_MARKER_DIR"
 PREFLIGHT_MARKER_LEGACY="$PRIMARY_DIR/.preflight-done"
 PREFLIGHT_MARKER_SID=""   # set after SESSION_ID validation if present
 LAST_PROMPT_MARKER="$PRIMARY_DIR/.last-user-prompt.json"
-HELPER_PATH="$REPO_ROOT/scripts/preflight-marker-write.mjs"
-CANON_LIB="$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs"
+# #441: resolve the canon lib + marker-write helper CO-LOCATED first (enforcement
+# installs together per-project — Principle 12), then in-repo scripts/ (development),
+# then the legacy global install. Mirrors preflight-prompt-helper.sh:113-126. The gate
+# stays FAIL-CLOSED: if no candidate resolves, CANON_LIB stays empty and
+# _canonicalize_one returns 99 → deny. Before this fix both constants were
+# $REPO_ROOT/scripts/... ONLY, which resolves solely inside the episodic-memory repo,
+# so in any foreign project the missing canon lib hard-denied EVERY Write/Edit
+# (before any target/active check), with no in-session self-recovery.
+CANON_LIB=""
+for cand in \
+  "$LIB_DIR/canonicalize-path-tolerant.mjs" \
+  "$REPO_ROOT/scripts/lib/canonicalize-path-tolerant.mjs" \
+  "${HOME:-/}/.episodic-memory/scripts/lib/canonicalize-path-tolerant.mjs"
+do
+  if [ -f "$cand" ]; then CANON_LIB="$cand"; break; fi
+done
+HELPER_PATH=""
+for cand in \
+  "$HOOK_DIR/preflight-marker-write.mjs" \
+  "$REPO_ROOT/scripts/preflight-marker-write.mjs" \
+  "${HOME:-/}/.episodic-memory/scripts/preflight-marker-write.mjs"
+do
+  if [ -f "$cand" ]; then HELPER_PATH="$cand"; break; fi
+done
+# HELPER_PATH is used only in actionable deny hints (never existence-checked); default
+# to the co-located path so the hint is well-formed even in the unresolved case.
+[ -z "$HELPER_PATH" ] && HELPER_PATH="$HOOK_DIR/preflight-marker-write.mjs"
 BUNDLE_PATH="$REPO_ROOT/bundles/codex-review-channel-current.md"
 
 # ---------------------------------------------------------------------------
@@ -123,7 +148,13 @@ _canonicalize_one() {
   fi
   # Use top-level await via async IIFE so import-rejection propagates as
   # a non-zero exit deterministically.
-  node -e "(async () => { try { const m = await import('$CANON_LIB'); process.stdout.write(m.canonicalizePathTolerant(process.argv[1], process.argv[2])) } catch (e) { process.stderr.write(e.message || String(e)); process.exit(2) } })()" "$input" "$hookcwd" 2>&1
+  # #441 code-review (codex 2026-07-04): pass CANON_LIB as an argv value
+  # (process.argv[3]) and import it via pathToFileURL — NEVER interpolate it into
+  # the JS source. A resolved path containing a single quote / space / shell-
+  # special char (e.g. a project dir named "proj-with-'quote", which the co-located
+  # CANON_LIB now inherits) would otherwise break the import string and hard-deny
+  # every write — the exact #441 symptom via a quoting vector.
+  node -e "(async () => { try { const { pathToFileURL } = await import('url'); const m = await import(pathToFileURL(process.argv[3]).href); process.stdout.write(m.canonicalizePathTolerant(process.argv[1], process.argv[2])) } catch (e) { process.stderr.write(e.message || String(e)); process.exit(2) } })()" "$input" "$hookcwd" "$CANON_LIB" 2>&1
   return $?
 }
 

--- a/plugins/claude-code/hooks/preflight-prompt-helper.sh
+++ b/plugins/claude-code/hooks/preflight-prompt-helper.sh
@@ -133,8 +133,13 @@ done
 # We hand the lib the entire stdin so it does the JSON.parse + .prompt
 # extract + utf-8 byte encode itself — keeping the binding logic in one
 # place. The lib exits non-zero on bad input; treat that as fail-safe.
+# #442: pass CANON_LIB as process.argv[1] + pathToFileURL — NEVER interpolate it into
+# the JS source. A resolved path with a single quote / space / shell-special char (the
+# co-located path inherits the project dir's name) would otherwise SyntaxError the
+# import string. Here that only fail-SAFES (skip), but the shape matches the #441 gate
+# bug so it gets the same treatment.
 PROMPT_SHA="$(printf '%s' "$INPUT" | node -e \
-  "import('$CANON_LIB').then(m => { let s=''; process.stdin.setEncoding('utf8'); process.stdin.on('data', d => s+=d); process.stdin.on('end', () => { try { process.stdout.write(m.canonicalPromptSha256(s)) } catch (e) { process.stderr.write(e.message); process.exit(2) } }) })" \
+  "(async () => { const { pathToFileURL } = await import('url'); const m = await import(pathToFileURL(process.argv[1]).href); let s=''; process.stdin.setEncoding('utf8'); process.stdin.on('data', d => s+=d); process.stdin.on('end', () => { try { process.stdout.write(m.canonicalPromptSha256(s)) } catch (e) { process.stderr.write(e.message); process.exit(2) } }) })()" "$CANON_LIB" \
   2>/dev/null)"
 if [ -z "$PROMPT_SHA" ] || [ "${#PROMPT_SHA}" -ne 64 ]; then
   _log_and_exit_safe "canonical sha computation returned empty or wrong length; skipping"

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -277,12 +277,32 @@ export function globalScriptLibs(repoDir) {
   return computeLibClosure(repoDir, globalEntryScripts(repoDir))
 }
 
+// Shell-loaded hook-runtime libs (#442): scripts/lib/*.mjs that a hook SHELL script
+// imports DYNAMICALLY at runtime (node -e "import(<path>)"), NOT via a JS import in
+// any .mjs entry script. computeLibClosure only follows JS imports, so it cannot see
+// these — they must be listed explicitly or they never deploy co-located into
+// <project>/.claude/hooks/lib/, and the hook falls back to $REPO_ROOT/scripts (absent
+// in foreign projects). preflight-prompt-helper.sh loads preflight-prompt-canon.mjs
+// this way.
+export const SHELL_LOADED_HOOK_LIBS = ['preflight-prompt-canon.mjs']
+
 // Lib closure that travels INTO the per-project enforcement bundle — every
 // scripts/lib/*.mjs the enforcement entries (incl. the SessionEnd hook script)
-// import. Includes shared substrate libs (local-dir.mjs, …) so the relocated
-// scripts resolve all imports co-located, never reaching into global.
+// import, PLUS the shell-loaded hook libs and their own transitive closure.
+// Includes shared substrate libs (local-dir.mjs, …) so the relocated scripts resolve
+// all imports co-located, never reaching into global.
 export function enforcementBundleLibs(repoDir) {
-  return computeLibClosure(repoDir, [...enforcementEntryScripts(repoDir), SESSION_END_SCRIPT])
+  const closure = computeLibClosure(repoDir, [...enforcementEntryScripts(repoDir), SESSION_END_SCRIPT])
+  const libDir = path.join(repoDir, 'scripts', 'lib')
+  for (const f of SHELL_LOADED_HOOK_LIBS) {
+    if (fs.existsSync(path.join(libDir, f))) closure.add(f)
+  }
+  // Their own transitive relative-import closure (empty today; defensive for future
+  // shell-loaded libs that import sibling libs).
+  for (const f of computeLibClosure(repoDir, SHELL_LOADED_HOOK_LIBS.map((f) => path.join('lib', f)))) {
+    closure.add(f)
+  }
+  return closure
 }
 
 // Libs that move OUT of global (enforcement-only): in the enforcement bundle and

--- a/tests/test-hook-bodies-no-repo-relative-scripts.mjs
+++ b/tests/test-hook-bodies-no-repo-relative-scripts.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// tests/test-hook-bodies-no-repo-relative-scripts.mjs
+//
+// CI class-check for issue #441 (and its siblings). A PreToolUse/UserPromptSubmit
+// gate hook installs PER-PROJECT into arbitrary repos. If it resolves a runtime
+// .mjs dependency SOLELY from `$REPO_ROOT/scripts/...`, that path exists only
+// inside the episodic-memory repo, so the hook breaks (or, for a fail-closed gate,
+// hard-denies every edit) in every foreign project. #441 was exactly this in
+// preflight-gate.sh.
+//
+// The correct pattern (already used by preflight-prompt-helper.sh) resolves the
+// dep CO-LOCATED first — `$HOOK_DIR/...` or `$LIB_DIR/...`, which the installer
+// deploys into <project>/.claude/hooks{,/lib}/ — and only THEN falls back to
+// `$REPO_ROOT/scripts/...` for in-repo development.
+//
+// This check is deliberately PRECISE, not a blunt grep (codex review 2026-07-04):
+// a bare `$REPO_ROOT/scripts/` grep would false-positive on the LEGITIMATE
+// co-located-first fallback. Rule: for every non-comment reference to
+// `$REPO_ROOT/scripts/.../<basename>.mjs`, the SAME file must contain an EARLIER
+// non-comment reference to the same <basename> via `$HOOK_DIR` or `$LIB_DIR`.
+// A fail-closed sole dependency (no prior co-located candidate) is the bug.
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const HOOKS_DIR = path.join(REPO_ROOT, 'plugins', 'claude-code', 'hooks')
+
+const isComment = (line) => /^\s*#/.test(line)
+// $REPO_ROOT/scripts/[optional/dirs/]<basename>.mjs
+const REPO_SCRIPTS_RE = /\$REPO_ROOT\/scripts\/(?:[^\s"'\\]*\/)?([A-Za-z0-9._-]+\.mjs)/g
+// A co-located reference to a basename via $HOOK_DIR or $LIB_DIR.
+const coLocatedRe = (basename) =>
+  new RegExp('\\$(?:HOOK_DIR|LIB_DIR)\\/(?:[^\\s"\'\\\\]*\\/)?' +
+    basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+
+const violations = []
+let refsChecked = 0
+
+const shFiles = fs.readdirSync(HOOKS_DIR).filter((f) => f.endsWith('.sh')).sort()
+for (const file of shFiles) {
+  const abs = path.join(HOOKS_DIR, file)
+  const lines = fs.readFileSync(abs, 'utf8').split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (isComment(line)) continue
+    let m
+    REPO_SCRIPTS_RE.lastIndex = 0
+    while ((m = REPO_SCRIPTS_RE.exec(line)) !== null) {
+      const basename = m[1]
+      refsChecked++
+      const re = coLocatedRe(basename)
+      // Require an EARLIER non-comment co-located reference to the same basename.
+      let coLocatedFirst = false
+      for (let j = 0; j < i; j++) {
+        if (!isComment(lines[j]) && re.test(lines[j])) { coLocatedFirst = true; break }
+      }
+      if (!coLocatedFirst) {
+        violations.push({
+          file: `plugins/claude-code/hooks/${file}`,
+          line: i + 1,
+          basename,
+          text: line.trim(),
+        })
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('FAIL: hook(s) resolve a runtime .mjs dep from $REPO_ROOT/scripts/ with')
+  console.error('no prior co-located ($HOOK_DIR/$LIB_DIR) candidate — breaks in foreign')
+  console.error('projects (issue #441 class). Resolve co-located FIRST, then fall back.\n')
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  (${v.basename})`)
+    console.error(`    ${v.text}`)
+  }
+  process.exit(1)
+}
+
+console.log(`OK: ${shFiles.length} hook file(s), ${refsChecked} $REPO_ROOT/scripts ref(s) checked — all co-located-first.`)
+process.exit(0)

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -629,6 +629,14 @@ assert_eq "T17c UserPromptSubmit entry has no matcher" "absent" "$ups_matcher"
 ups_timeout=$(jq -r '.hooks.UserPromptSubmit[]?.hooks[]? | select(.command|test("preflight-prompt-helper")) | .timeout' "$TEST_PROJECT/.claude/settings.json" 2>/dev/null)
 assert_eq "T17d UserPromptSubmit entry timeout=5s" "5" "$ups_timeout"
 
+# T17e (#442): preflight-prompt-helper.sh dynamically imports preflight-prompt-canon.mjs
+# from $HOOK_DIR/lib via `node -e import(...)`. That shell-only load is invisible to the
+# JS import-closure, so the lib must be deployed co-located via SHELL_LOADED_HOOK_LIBS
+# in install-manifest.mjs — otherwise the helper falls back to $REPO_ROOT/scripts (absent
+# in foreign projects). Regression guard for that manifest entry.
+[ -f "$TEST_PROJECT/.claude/hooks/lib/preflight-prompt-canon.mjs" ] && r=true || r=false
+assert_eq "T17e preflight-prompt-canon.mjs deployed co-located (shell-loaded hook lib)" "true" "$r"
+
 # ---------------------------------------------------------------------------
 # T18: #238 plan-v2 C6 — --bootstrap-last-prompt sentinel write
 # ---------------------------------------------------------------------------

--- a/tests/test-preflight-gate-foreign-project.sh
+++ b/tests/test-preflight-gate-foreign-project.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# tests/test-preflight-gate-foreign-project.sh — regression for issue #441.
+#
+# BUG (#441): preflight-gate.sh resolved CANON_LIB / HELPER_PATH SOLELY from
+# $REPO_ROOT/scripts/... . That path exists only inside the episodic-memory repo,
+# so in ANY foreign project the canon lib was missing → _canonicalize_one returned
+# 99 → the marker-write block hard-DENIED every Write|Edit|MultiEdit|NotebookEdit,
+# before any target/active check, with no in-session self-recovery (the fix itself
+# is an Edit). See plugins/claude-code/hooks/preflight-gate.sh.
+#
+# FIX: resolve both constants CO-LOCATED first ($HOOK_DIR / $LIB_DIR), which the
+# installer deploys into <project>/.claude/hooks{,/lib}/ for every project.
+#
+# This test deliberately does NOT stage a fake scripts/ tree under the target (the
+# pattern in tests/test-preflight-gate.sh masks the foreign layout — codex review
+# 2026-07-04). It drives the REAL installer into an isolated foreign project and
+# exercises the INSTALLED gate against the INSTALLED layout, then asserts the
+# co-located deps are what makes it pass (bidirectional: present→allow, removed→deny).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALLER="$REPO_ROOT/install.mjs"
+
+passed=0
+failed=0
+TEST_HOME=""
+TEST_PROJECT=""
+SESSION_ID="foreign-441-$$"
+
+cleanup() { [ -n "$TEST_HOME" ] && rm -rf "$TEST_HOME"; [ -n "$TEST_PROJECT" ] && rm -rf "$TEST_PROJECT"; }
+trap cleanup EXIT
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  ✓ $name"
+    passed=$((passed+1))
+  else
+    echo "  ✗ $name (expected '$expected', got '$actual')"
+    failed=$((failed+1))
+  fi
+}
+
+# Pipe a Write payload (foreign cwd) at the installed gate; echo "allow" (empty
+# output) or "deny:<reason-substring-match>".
+run_gate() {
+  local cwd="$1" file_path="$2"
+  local payload
+  payload="$(jq -nc --arg fp "$file_path" --arg cwd "$cwd" --arg sid "$SESSION_ID" \
+    '{tool_name:"Write", tool_input:{file_path:$fp, content:"x"}, cwd:$cwd, session_id:$sid, transcript_path:"/tmp/x"}')"
+  printf '%s' "$payload" | bash "$TEST_PROJECT/.claude/hooks/preflight-gate.sh" 2>&1 || true
+}
+
+echo "[T1] Real install into an isolated FOREIGN project (no scripts/ tree)"
+TEST_HOME=$(mktemp -d)
+TEST_PROJECT=$(mktemp -d)
+# A foreign project is a git repo (so resolve_repo_root works) with NO scripts/.
+( cd "$TEST_PROJECT" && git init -q 2>/dev/null ) || true
+HOME="$TEST_HOME" node "$INSTALLER" --tool claude-code --project "$TEST_PROJECT" --install-enforcement >/dev/null 2>&1
+
+[ -x "$TEST_PROJECT/.claude/hooks/preflight-gate.sh" ] && r=true || r=false
+assert_eq "T1a preflight-gate.sh installed + executable" "true" "$r"
+
+# The defining property of a foreign project: it has NO repo scripts/ dir. This is
+# exactly the condition the old code assumed away. (codex F4: assert it explicitly.)
+[ -e "$TEST_PROJECT/scripts" ] && r=true || r=false
+assert_eq "T1b foreign project has NO scripts/ tree" "false" "$r"
+
+# Co-located deps the fix relies on must be present in the installed layout.
+[ -f "$TEST_PROJECT/.claude/hooks/lib/canonicalize-path-tolerant.mjs" ] && r=true || r=false
+assert_eq "T1c canonicalize-path-tolerant.mjs deployed co-located (hooks/lib/)" "true" "$r"
+[ -f "$TEST_PROJECT/.claude/hooks/preflight-marker-write.mjs" ] && r=true || r=false
+assert_eq "T1d preflight-marker-write.mjs deployed co-located (hooks/)" "true" "$r"
+
+echo "[T2] The #441 blocking bug is gone: a Write is ALLOWED in the foreign project"
+out="$(run_gate "$TEST_PROJECT" "$TEST_PROJECT/src/foo.txt")"
+assert_eq "T2a Write allowed (gate emits no deny)" "" "$out"
+# Belt-and-suspenders: the specific old failure reason must not appear.
+if printf '%s' "$out" | grep -q "canonicalize-path-tolerant lib missing"; then r=true; else r=false; fi
+assert_eq "T2b old canon-lib-missing deny reason absent" "false" "$r"
+
+echo "[T3] Non-vacuity: removing the co-located canon lib re-introduces the deny"
+# Prove the gate genuinely depends on the resolved lib (so the test would catch a
+# regression). Remove ALL three resolution candidates: co-located (present), the
+# repo fallback (absent — no scripts/), and the global fallback (remove if present).
+rm -f "$TEST_PROJECT/.claude/hooks/lib/canonicalize-path-tolerant.mjs"
+rm -f "$TEST_HOME/.episodic-memory/scripts/lib/canonicalize-path-tolerant.mjs" 2>/dev/null || true
+out="$(run_gate "$TEST_PROJECT" "$TEST_PROJECT/src/foo.txt")"
+if printf '%s' "$out" | grep -q '"permissionDecision":"deny"'; then r=true; else r=false; fi
+assert_eq "T3a with all canon-lib candidates removed, gate denies (fail-closed)" "true" "$r"
+if printf '%s' "$out" | grep -q "canonicalize-path-tolerant lib missing"; then r=true; else r=false; fi
+assert_eq "T3b deny reason names the missing canon lib" "true" "$r"
+
+echo "[T4] Path-quoting: an apostrophe in the project path still ALLOWS edits (#441 code-review)"
+# codex 2026-07-04: _canonicalize_one must pass CANON_LIB as an argv value, not
+# interpolate it into node -e JS source. A project dir named with an apostrophe would
+# otherwise SyntaxError the import string → hard-deny every write (the #441 symptom via
+# a quoting vector). Uses a fresh isolated install so the co-located CANON_LIB inherits
+# the apostrophe-bearing path.
+Q_HOME=$(mktemp -d)
+Q_BASE=$(mktemp -d)
+Q_PROJECT="$Q_BASE/proj-with-'quote"
+mkdir -p "$Q_PROJECT"
+( cd "$Q_PROJECT" && git init -q 2>/dev/null ) || true
+HOME="$Q_HOME" node "$INSTALLER" --tool claude-code --project "$Q_PROJECT" --install-enforcement >/dev/null 2>&1
+q_payload="$(jq -nc --arg fp "$Q_PROJECT/src/foo.txt" --arg cwd "$Q_PROJECT" --arg sid "$SESSION_ID" \
+  '{tool_name:"Write", tool_input:{file_path:$fp, content:"x"}, cwd:$cwd, session_id:$sid, transcript_path:"/tmp/x"}')"
+q_out="$(printf '%s' "$q_payload" | bash "$Q_PROJECT/.claude/hooks/preflight-gate.sh" 2>&1 || true)"
+assert_eq "T4a Write allowed despite apostrophe in project path" "" "$q_out"
+if printf '%s' "$q_out" | grep -qi "SyntaxError"; then r=true; else r=false; fi
+assert_eq "T4b no JS SyntaxError leaked from the canon-lib import" "false" "$r"
+rm -rf "$Q_HOME" "$Q_BASE"
+
+echo ""
+echo "Passed: $passed"
+echo "Failed: $failed"
+[ $failed -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes the foreign-project preflight gate blocker (#441) and a co-located-deploy sibling (#442).

### #441 — every edit denied in foreign projects (BLOCKING)
`preflight-gate.sh` resolved `CANON_LIB` / `HELPER_PATH` solely from `$REPO_ROOT/scripts/...`, which exists only inside this repo. In any other project the canon lib was missing → `_canonicalize_one` returned 99 → the marker-write block hard-denied every `Write|Edit|MultiEdit|NotebookEdit`, before any target/active check, with no in-session self-recovery.

- Resolve `CANON_LIB` / `HELPER_PATH` **co-located first** (`$HOOK_DIR` / `$LIB_DIR`), then `$REPO_ROOT/scripts` (in-repo dev), then global. Mirrors the pattern already in `preflight-prompt-helper.sh`. Gate stays **fail-closed**: no candidate → empty `CANON_LIB` → `_canonicalize_one` returns 99 → deny.
- `_canonicalize_one` now passes `CANON_LIB` as `node` argv + `pathToFileURL` instead of interpolating it into the `node -e` JS source, so a project path containing an apostrophe no longer `SyntaxError`s into a deny (found in code review).

### #442 — `preflight-prompt-canon.mjs` deployed nowhere co-located
`preflight-prompt-helper.sh` loads `preflight-prompt-canon.mjs` via a shell `node -e import(...)`, invisible to the JS import-closure, so it deployed nowhere co-located and always used the `$REPO_ROOT` fallback.

- New `SHELL_LOADED_HOOK_LIBS` in `install-manifest.mjs` unions such libs into the per-project enforcement bundle → deploys to `<project>/.claude/hooks/lib/` (enforcement-only; **not** global, P12-clean).
- Same argv/`pathToFileURL` quote-safety applied to the helper's `node -e import`.

### Intentionally out of scope
`BUNDLE_PATH` / the `codex-review-handoff` channel is **not** made foreign-portable: it resolves `MEMORY_ROOT` from `${HOME}/.claude/projects/<sanitized>/memory` and hashes bundle components under it (`preflight-prompt-helper.sh:213-250`) — em-user-specific by design, and it already fail-safes (denies only `codex-review-handoff`) in foreign projects. Not a portability bug.

## Tests
New:
- `tests/test-preflight-gate-foreign-project.sh` — real install into an isolated foreign project (asserts no `scripts/` tree), drives the installed gate (allow), non-vacuity (canon-lib removal → deny), apostrophe-path case.
- `tests/test-hook-bodies-no-repo-relative-scripts.mjs` — CI class-check: every non-comment `$REPO_ROOT/scripts/<basename>.mjs` ref in a hook must have a prior co-located `$HOOK_DIR`/`$LIB_DIR` ref (precise; does not false-positive the legit fail-safe fallback).
- `tests/test-install-hooks.sh` T17e — asserts `preflight-prompt-canon.mjs` deploys co-located.

Both new tests registered in `.github/workflows/plan-marker-validate.yml`.

Verified: foreign-project 10/0, class-check OK, existing preflight-gate 107/0, prompt-helper 24/0, install-hooks 94/0, P12 6/0, uninstall 14/0. Reviewed via codex (cmux) across plan + both implementation passes.

Closes #441
Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
