### PR TITLE
fix(session-handoff): generalize Q2 for foreign projects (#440)

### DIFF
--- a/plugins/claude-code/hooks/session-handoff-prompt.sh
+++ b/plugins/claude-code/hooks/session-handoff-prompt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# episodic-memory-hook-version: 2026-05-12.rank10-slice
+# episodic-memory-hook-version: 2026-07-04.foreign-project-440
 # session-handoff-prompt.sh — SessionStart hook: two-phase blocking directive
 # with always-tier discipline load (rank-10 slice, codex consensus r1-r5).
 #
@@ -30,6 +30,13 @@
 # 6-file always-tier list (2026-05-16 demotions) + condensed Q1/Q2 directive —
 # which had drifted ahead of this source; file is now tracked in HOOK_SPECS /
 # the freshness manifest so future drift is reported at SessionStart.
+#
+# 2026-07-04 (#440): generalized for foreign projects. em-search.mjs resolves
+# in-repo dev copy first, then ~/.episodic-memory/scripts/ (global substrate);
+# always-tier list emits only files that exist at MEM_ROOT; directive degrades
+# to Q1-only / Q2-only / no emission when parts are absent. Previously the
+# emitted command hard-referenced <repo>/scripts/em-search.mjs (MODULE_NOT_FOUND
+# outside this repo) and 5 feedback files foreign memory dirs never have.
 #
 # Composes with:
 #   - hooks/lib/repo-root.sh (sourced for resolve_repo_root canonical helper)
@@ -72,6 +79,12 @@ fi
 
 if [ ! -d "$STDIN_CWD" ]; then
   _log_and_exit_safe "stdin.cwd '$STDIN_CWD' does not exist on disk"
+fi
+
+# Fail-safe under set -u: HOME feeds memory-root candidates and the substrate
+# em-search probe; unset HOME must degrade cleanly, not crash mid-script.
+if [ -z "${HOME:-}" ]; then
+  _log_and_exit_safe "HOME unset; cannot resolve memory root or substrate scripts"
 fi
 
 # ---------------------------------------------------------------------------
@@ -166,10 +179,17 @@ ALWAYS_TIER=(
   "feedback_canonical_agent_dispatch_trigger.md"
 )
 
-# Emit explicit absolute paths (codex F11).
+# Emit explicit absolute paths (codex F11), filtered to files that exist at
+# hook runtime (#440): foreign projects typically have MEMORY.md but none of
+# the feedback files; emitting absent paths made the agent issue 5 failing
+# Reads every session. Skip missing entries silently.
 _paths=""
+_n_files=0
 for f in "${ALWAYS_TIER[@]}"; do
-  _paths="${_paths}     - ${MEM_ROOT}/${f}"$'\n'
+  if [ -f "${MEM_ROOT}/${f}" ]; then
+    _paths="${_paths}     - ${MEM_ROOT}/${f}"$'\n'
+    _n_files=$((_n_files+1))
+  fi
 done
 
 # Shell-quote a path for safe inclusion in a command string. Mirrors
@@ -190,18 +210,51 @@ _shell_quote() {
   esac
 }
 
-# Mechanical em-search command (cd-bound; codex F11). Both REPO_ROOT uses
-# are shell-quoted for path-with-spaces / shell-metachar safety.
-_quoted_root="$(_shell_quote "${REPO_ROOT}")"
-_quoted_emsearch="$(_shell_quote "${REPO_ROOT}/scripts/em-search.mjs")"
-EM_SEARCH_CMD="cd ${_quoted_root} && node ${_quoted_emsearch} --category lesson --scope all --limit 10 --no-track --no-score"
+# Mechanical em-search command (cd-bound; codex F11). Both paths are
+# shell-quoted for path-with-spaces / shell-metachar safety.
+#
+# em-search.mjs resolution (#440): probe the in-repo dev copy first (resolves
+# only inside the episodic-memory repo itself), then the global substrate —
+# mirrors the gates' engine resolution pattern (#441). REPO_ROOT stays as the
+# cd target so --scope all picks up the project-local episode store. If no
+# candidate resolves, EM_SEARCH_CMD stays empty and the directive omits the
+# em-search step instead of emitting a MODULE_NOT_FOUND command.
+EM_SEARCH_SCRIPT=""
+for cand in \
+  "${REPO_ROOT}/scripts/em-search.mjs" \
+  "${HOME}/.episodic-memory/scripts/em-search.mjs"
+do
+  if [ -f "$cand" ]; then EM_SEARCH_SCRIPT="$cand"; break; fi
+done
+EM_SEARCH_CMD=""
+if [ -n "$EM_SEARCH_SCRIPT" ]; then
+  _quoted_root="$(_shell_quote "${REPO_ROOT}")"
+  _quoted_emsearch="$(_shell_quote "${EM_SEARCH_SCRIPT}")"
+  EM_SEARCH_CMD="cd ${_quoted_root} && node ${_quoted_emsearch} --category lesson --scope all --limit 10 --no-track --no-score"
+fi
+
+# Q2 payload (#440): compose from whichever parts resolved. Empty when there
+# is nothing to load — the directive then degrades to Q1-only or no emission.
+Q2_BODY=""
+_pathword="paths"
+[ "$_n_files" -eq 1 ] && _pathword="path"
+if [ "$_n_files" -gt 0 ] && [ -n "$EM_SEARCH_CMD" ]; then
+  Q2_BODY="batch-Read these ${_n_files} absolute ${_pathword}, then run the em-search command:
+${_paths}     ${EM_SEARCH_CMD}"
+elif [ "$_n_files" -gt 0 ]; then
+  Q2_BODY="batch-Read these ${_n_files} absolute ${_pathword}:
+${_paths%$'\n'}"
+elif [ -n "$EM_SEARCH_CMD" ]; then
+  Q2_BODY="run the em-search command:
+     ${EM_SEARCH_CMD}"
+fi
 
 # ---------------------------------------------------------------------------
 # Handoff (phase 1) — only if session_handoff.md exists at resolved memory_root.
 # ---------------------------------------------------------------------------
 HANDOFF="${MEM_ROOT}/session_handoff.md"
 
-if [ -f "${HANDOFF}" ]; then
+if [ -f "${HANDOFF}" ] && [ -n "$Q2_BODY" ]; then
   MTIME="$(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "${HANDOFF}" 2>/dev/null \
          || stat -c '%y' "${HANDOFF}" 2>/dev/null | cut -c1-16 \
          || echo unknown)"
@@ -218,16 +271,28 @@ Remember Q1's answer across Q2; do NOT drop it.
 
 After both answers, process in order:
   1. If Q1=y: Read ${HANDOFF}
-  2. If Q2=y: batch-Read these 6 absolute paths, then run the em-search command:
-${_paths}     ${EM_SEARCH_CMD}
+  2. If Q2=y: ${Q2_BODY}
   3. Then address the user's prompt."
-else
+elif [ -f "${HANDOFF}" ]; then
+  MTIME="$(stat -f '%Sm' -t '%Y-%m-%d %H:%M' "${HANDOFF}" 2>/dev/null \
+         || stat -c '%y' "${HANDOFF}" 2>/dev/null | cut -c1-16 \
+         || echo unknown)"
+
+  DIRECTIVE="BLOCKING: Ask this y/n question (verbatim) before responding, no preamble or tool calls:
+  Load session_handoff.md from ${MTIME}? (y/n)
+
+If y: Read ${HANDOFF}
+Then address the user's prompt."
+elif [ -n "$Q2_BODY" ]; then
   DIRECTIVE="BLOCKING: Ask this y/n question (verbatim) before responding, no preamble or tool calls:
   Load discipline + toolkit + recent lessons? (y/n)
 
-If y: batch-Read these 6 absolute paths, then run the em-search command:
-${_paths}     ${EM_SEARCH_CMD}
+If y: ${Q2_BODY}
 Then address the user's prompt."
+else
+  # Nothing to load at this project (#440): no handoff, no memory files, no
+  # resolvable em-search. Emit no directive rather than a no-op Q2.
+  _log_and_exit_safe "no handoff, no always-tier files, no em-search candidate at MEM_ROOT=${MEM_ROOT}; skipping directive"
 fi
 
 jq -n --arg ctx "${DIRECTIVE}" '{

--- a/tests/test-session-handoff-cwd-matrix.sh
+++ b/tests/test-session-handoff-cwd-matrix.sh
@@ -20,12 +20,31 @@
 #   T7  bounded resolver: pick non-empty variant, reject wrong sibling project
 #   T7a bounded resolver: deterministic tie-break (canonical first)
 #   T9  installed runtime sha matches committed source
+#
+# Foreign-project generalization (#440):
+#   T440-1 foreign repo + substrate em-search → global substrate path emitted,
+#          cd stays repo-bound, only existing memory files listed
+#   T440-2 in-repo scripts/em-search.mjs wins over substrate (probe order)
+#   T440-3 no em-search anywhere → directive omits the em-search step
+#   T440-4 nothing to load (no handoff/files/em-search) → NO directive + stderr
+#   T440-5 handoff only → Q1-only directive, no Q2
+#   T440-6 handoff + files, no em-search → two-question, files-only Q2
+#   T440-7 HOME unset → fail-safe exit 0 + stderr, no set -u crash
 
 set -u
 
 HOOK="$(cd "$(dirname "$0")/../plugins/claude-code/hooks" && pwd)/session-handoff-prompt.sh"
 INSTALLED_HOOK="${HOME}/.claude/hooks/session-handoff-prompt.sh"
-MAIN_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# Resolve to the MAIN repo via git common-dir, exactly as the hook does (#440):
+# when this suite runs from a linked worktree, stdin.cwd=<worktree> resolves to
+# MAIN, so repo-identity assertions must expect MAIN, not the worktree root.
+SUITE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+_suite_common="$(git -C "${SUITE_ROOT}" rev-parse --git-common-dir 2>/dev/null)"
+case "${_suite_common}" in
+  /*) : ;;
+  *)  _suite_common="${SUITE_ROOT}/${_suite_common}" ;;
+esac
+MAIN_REPO="$(dirname "$(cd -P "${_suite_common}" && pwd)")"
 
 PASS=0
 FAIL=0
@@ -43,7 +62,7 @@ _assert() {
 
 _assert_contains() {
   local name="$1" needle="$2" haystack="$3"
-  if printf '%s' "$haystack" | grep -qF "$needle"; then
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
     PASS=$((PASS+1))
   else
     FAIL=$((FAIL+1))
@@ -53,7 +72,7 @@ _assert_contains() {
 
 _assert_not_contains() {
   local name="$1" needle="$2" haystack="$3"
-  if printf '%s' "$haystack" | grep -qF "$needle"; then
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
     FAIL=$((FAIL+1))
     FAILED_TESTS+=("$name: unexpected presence of '$needle'")
   else
@@ -74,12 +93,26 @@ _run_hook_stderr() {
   printf '%s' "$stdin_json" | "$HOOK" 2>&1 >/dev/null
 }
 
+# #440: invoke with an overridden HOME so substrate-resolution cases are
+# hermetic (independent of whether this machine has ~/.episodic-memory).
+_run_hook_home() {
+  local fake_home="$1" caller_cwd="$2" stdin_json="$3"
+  cd "$caller_cwd" 2>/dev/null || { printf "caller_cwd_missing"; return 1; }
+  printf '%s' "$stdin_json" | HOME="$fake_home" "$HOOK" 2>/dev/null
+}
+
+_run_hook_home_stderr() {
+  local fake_home="$1" caller_cwd="$2" stdin_json="$3"
+  cd "$caller_cwd" 2>/dev/null || { printf "caller_cwd_missing"; return 1; }
+  printf '%s' "$stdin_json" | HOME="$fake_home" "$HOOK" 2>&1 >/dev/null
+}
+
 # ---------------------------------------------------------------------------
 # C1: stdin.cwd=<main>, caller=/private/tmp → resolved=<main>
 # ---------------------------------------------------------------------------
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${MAIN_REPO}\"}")
 _assert_contains "C1 emits main repo path" "${MAIN_REPO}" "$_out"
-_assert_contains "C1 emits BLOCKING DIRECTIVE" "BLOCKING DIRECTIVE" "$_out"
+_assert_contains "C1 emits BLOCKING directive" "BLOCKING:" "$_out"
 
 # ---------------------------------------------------------------------------
 # C2: stdin.cwd=<main>/scripts (nested), caller=/private/tmp → resolved=<main>
@@ -165,8 +198,12 @@ TMP_REPO="$(mktemp -d /tmp/em-rank10-c8.XXXXXX)"
 git -C "${TMP_REPO}" init -q >/dev/null 2>&1
 mkdir -p "${TMP_REPO}/.episodic-memory"
 echo '{"claude_memory_root":"/this/path/does/not/exist"}' > "${TMP_REPO}/.episodic-memory/config.json"
+# Plant an in-repo em-search so a directive is emitted regardless of whether
+# this machine has the global substrate (#440 made emission conditional).
+mkdir -p "${TMP_REPO}/scripts"
+: > "${TMP_REPO}/scripts/em-search.mjs"
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${TMP_REPO}\"}")
-_assert_contains "C8 malformed config falls back to canonical" "BLOCKING DIRECTIVE" "$_out"
+_assert_contains "C8 malformed config falls back to canonical" "BLOCKING:" "$_out"
 _assert_not_contains "C8 does NOT use the invalid config path" "/this/path/does/not/exist" "$_out"
 rm -rf "${TMP_REPO}"
 
@@ -179,13 +216,14 @@ TMP_REPO_T7="$(mktemp -d /tmp/em-rank10-t7.XXXXXX)"
 git -C "${TMP_REPO_T7}" init -q >/dev/null 2>&1
 # Realpath-normalize like the hook does (on macOS /tmp → /private/tmp via cd -P).
 TMP_REPO_T7_REAL="$(cd -P "${TMP_REPO_T7}" && pwd)"
+# Plant an in-repo em-search so a directive is emitted (#440); the orphan repo
+# has no memory files anywhere, so the always-tier list must be EMPTY — the
+# hook must NOT surface any ~/.claude/projects path (no sibling-project scan).
+mkdir -p "${TMP_REPO_T7_REAL}/scripts"
+: > "${TMP_REPO_T7_REAL}/scripts/em-search.mjs"
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${TMP_REPO_T7_REAL}\"}")
-# The canonical sanitization of TMP_REPO_T7_REAL won't match any real project memory.
-# Hook should emit the canonical (empty) path. It must NOT emit a path from
-# an unrelated project memory (e.g. user-preferences memory).
-_T7_canonical="$(printf '%s' "${TMP_REPO_T7_REAL}" | sed 's|/|-|g; s|\.|-|g')"
-_T7_expected_mem="${HOME}/.claude/projects/${_T7_canonical}/memory"
-_assert_contains "T7 bounded: emits canonical path for orphan repo" "${_T7_expected_mem}" "$_out"
+_assert_contains "T7 bounded: cd stays bound to orphan repo" "cd ${TMP_REPO_T7_REAL} && node" "$_out"
+_assert_not_contains "T7 bounded: no memory path leaks for orphan repo" "${HOME}/.claude/projects" "$_out"
 rm -rf "${TMP_REPO_T7}"
 
 # ---------------------------------------------------------------------------
@@ -198,6 +236,10 @@ TMP_REPO_T14="${TMP_REPO_T14_PARENT}/repo with spaces"
 mkdir -p "${TMP_REPO_T14}"
 git -C "${TMP_REPO_T14}" init -q >/dev/null 2>&1
 TMP_REPO_T14_REAL="$(cd -P "${TMP_REPO_T14}" && pwd)"
+# Plant an in-repo em-search so the spaced path is the one emitted (#440
+# made the in-repo copy a probe, not an assumption).
+mkdir -p "${TMP_REPO_T14_REAL}/scripts"
+: > "${TMP_REPO_T14_REAL}/scripts/em-search.mjs"
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${TMP_REPO_T14_REAL}\"}")
 # Emitted cd should be single-quoted (path has spaces).
 _assert_contains "T14 path-with-spaces: cd is single-quoted" "cd '${TMP_REPO_T14_REAL}'" "$_out"
@@ -222,6 +264,8 @@ TMP_REPO_T14B="${TMP_REPO_T14B_PARENT}/it's-mine"
 mkdir -p "${TMP_REPO_T14B}"
 git -C "${TMP_REPO_T14B}" init -q >/dev/null 2>&1
 TMP_REPO_T14B_REAL="$(cd -P "${TMP_REPO_T14B}" && pwd)"
+mkdir -p "${TMP_REPO_T14B_REAL}/scripts"
+: > "${TMP_REPO_T14B_REAL}/scripts/em-search.mjs"
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${TMP_REPO_T14B_REAL}\"}")
 # The POSIX escape sequence in the actual emitted command is `'\''` (4 chars:
 # quote, backslash, quote, quote). The hook returns its directive as a JSON
@@ -246,18 +290,105 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Always-tier emission check: directive must list all 8 files
+# Always-tier emission check: directive lists the 6-file set (2026-05-16
+# demotions), NOT the demoted pair.
 # ---------------------------------------------------------------------------
 _out=$(_run_hook /private/tmp "{\"cwd\":\"${MAIN_REPO}\"}")
 for f in MEMORY.md feedback_verify_by_artifact.md feedback_self_trigger_artifact_mode.md \
-         feedback_per_prompt_rule_preflight.md feedback_send_grep_artifact.md \
-         feedback_three_state_review_verdict.md feedback_bp1_step9_filing_trigger.md \
+         feedback_per_prompt_rule_preflight.md feedback_bp1_step9_filing_trigger.md \
          feedback_canonical_agent_dispatch_trigger.md; do
   _assert_contains "always-tier emits $f" "$f" "$_out"
 done
+for f in feedback_send_grep_artifact.md feedback_three_state_review_verdict.md; do
+  _assert_not_contains "demoted lazy-tier $f NOT emitted" "$f" "$_out"
+done
 
-# em-search emitted with mechanical cd-binding
+# em-search emitted with mechanical cd-binding (in-repo dev copy wins at MAIN)
 _assert_contains "em-search emitted with cd-binding" "cd ${MAIN_REPO} && node ${MAIN_REPO}/scripts/em-search.mjs" "$_out"
+
+# ---------------------------------------------------------------------------
+# T440-*: foreign-project generalization (issue #440). All hermetic via fake
+# HOME + config.json:claude_memory_root override.
+# ---------------------------------------------------------------------------
+T440_HOME="$(mktemp -d /tmp/em-440-home.XXXXXX)"
+T440_HOME_REAL="$(cd -P "${T440_HOME}" && pwd)"
+mkdir -p "${T440_HOME_REAL}/.episodic-memory/scripts"
+: > "${T440_HOME_REAL}/.episodic-memory/scripts/em-search.mjs"
+
+T440_REPO_PARENT="$(mktemp -d /tmp/em-440-repo.XXXXXX)"
+T440_REPO="${T440_REPO_PARENT}/foreign-project"
+mkdir -p "${T440_REPO}"
+git -C "${T440_REPO}" init -q >/dev/null 2>&1
+T440_REPO_REAL="$(cd -P "${T440_REPO}" && pwd)"
+T440_MEM="${T440_REPO_PARENT}/mem"
+mkdir -p "${T440_MEM}"
+T440_MEM_REAL="$(cd -P "${T440_MEM}" && pwd)"
+printf '# mem\n' > "${T440_MEM_REAL}/MEMORY.md"
+mkdir -p "${T440_REPO_REAL}/.episodic-memory"
+printf '{"claude_memory_root":"%s"}' "${T440_MEM_REAL}" > "${T440_REPO_REAL}/.episodic-memory/config.json"
+
+# T440-1: foreign repo (no in-repo em-search) → global substrate path, cd
+# stays repo-bound, only MEMORY.md listed, no absent feedback files.
+_out=$(_run_hook_home "${T440_HOME_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert_contains "T440-1 substrate em-search path emitted" \
+  "node ${T440_HOME_REAL}/.episodic-memory/scripts/em-search.mjs" "$_out"
+_assert_contains "T440-1 cd stays bound to foreign repo" "cd ${T440_REPO_REAL} && node" "$_out"
+_assert_not_contains "T440-1 repo-relative em-search NOT emitted" \
+  "${T440_REPO_REAL}/scripts/em-search.mjs" "$_out"
+_assert_contains "T440-1 existing MEMORY.md listed" "- ${T440_MEM_REAL}/MEMORY.md" "$_out"
+_assert_not_contains "T440-1 absent feedback file NOT listed" "feedback_verify_by_artifact.md" "$_out"
+_assert_contains "T440-1 count reflects filtered list" "these 1 absolute path" "$_out"
+
+# T440-2: in-repo copy wins over substrate (probe order).
+mkdir -p "${T440_REPO_REAL}/scripts"
+: > "${T440_REPO_REAL}/scripts/em-search.mjs"
+_out=$(_run_hook_home "${T440_HOME_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert_contains "T440-2 in-repo em-search wins" \
+  "node ${T440_REPO_REAL}/scripts/em-search.mjs" "$_out"
+rm -rf "${T440_REPO_REAL}/scripts"
+
+# T440-3: no em-search anywhere → directive still emitted, em-search omitted.
+T440_HOME_EMPTY="$(mktemp -d /tmp/em-440-home-empty.XXXXXX)"
+T440_HOME_EMPTY_REAL="$(cd -P "${T440_HOME_EMPTY}" && pwd)"
+_out=$(_run_hook_home "${T440_HOME_EMPTY_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert_contains "T440-3 files still listed without em-search" "- ${T440_MEM_REAL}/MEMORY.md" "$_out"
+_assert_not_contains "T440-3 no em-search command emitted" "em-search.mjs" "$_out"
+
+# T440-5: handoff only (no always-tier files, no em-search) → Q1-only.
+printf 'handoff\n' > "${T440_MEM_REAL}/session_handoff.md"
+rm -f "${T440_MEM_REAL}/MEMORY.md"
+_out=$(_run_hook_home "${T440_HOME_EMPTY_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert_contains "T440-5 Q1 handoff question emitted" "Load session_handoff.md" "$_out"
+_assert_contains "T440-5 handoff read instruction emitted" "If y: Read ${T440_MEM_REAL}/session_handoff.md" "$_out"
+_assert_not_contains "T440-5 no Q2 question emitted" "discipline + toolkit" "$_out"
+
+# T440-6: handoff + files, no em-search → two-question directive, files-only
+# Q2 (covers the handoff x files-only arm of the directive matrix).
+printf '# mem\n' > "${T440_MEM_REAL}/MEMORY.md"
+_out=$(_run_hook_home "${T440_HOME_EMPTY_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert_contains "T440-6 both questions emitted" "Q2 (verbatim, after Q1 is answered)" "$_out"
+_assert_contains "T440-6 files-only Q2 lists MEMORY.md" "- ${T440_MEM_REAL}/MEMORY.md" "$_out"
+_assert_not_contains "T440-6 no em-search command emitted" "em-search.mjs" "$_out"
+
+# T440-4: nothing to load at all → exit 0, NO directive, stderr log.
+rm -f "${T440_MEM_REAL}/session_handoff.md" "${T440_MEM_REAL}/MEMORY.md"
+_out=$(_run_hook_home "${T440_HOME_EMPTY_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_rc=$?
+_err=$(_run_hook_home_stderr "${T440_HOME_EMPTY_REAL}" /private/tmp "{\"cwd\":\"${T440_REPO_REAL}\"}")
+_assert "T440-4 nothing-to-load emits nothing on stdout" "" "$_out"
+_assert "T440-4 exits 0" "0" "$_rc"
+_assert_contains "T440-4 stderr explains skip" "skipping directive" "$_err"
+
+# T440-7: HOME unset → fail-safe (exit 0, stderr, no directive), not a
+# set -u crash mid-script.
+_out=$(cd /private/tmp && printf '%s' "{\"cwd\":\"${T440_REPO_REAL}\"}" | env -u HOME "$HOOK" 2>/dev/null)
+_rc=$?
+_err=$(cd /private/tmp && printf '%s' "{\"cwd\":\"${T440_REPO_REAL}\"}" | env -u HOME "$HOOK" 2>&1 >/dev/null)
+_assert "T440-7 HOME-unset emits nothing on stdout" "" "$_out"
+_assert "T440-7 HOME-unset exits 0" "0" "$_rc"
+_assert_contains "T440-7 stderr explains HOME skip" "HOME unset" "$_err"
+
+rm -rf "${T440_HOME}" "${T440_HOME_EMPTY}" "${T440_REPO_PARENT}"
 
 # ---------------------------------------------------------------------------
 # Results


### PR DESCRIPTION
Fixes #440.

`session-handoff-prompt.sh` is deployed per-project by `--install-enforcement` but its Q2 directive embedded two episodic-memory-repo-only assumptions: the em-search command hard-referenced `<repo>/scripts/em-search.mjs` (MODULE_NOT_FOUND in any foreign project) and the always-tier batch-Read list emitted 5 feedback files foreign memory dirs never have (5 failing Reads per session).

## Changes

- **em-search resolution by probe** (mirrors the #441 engine-resolution pattern): `<repo>/scripts/em-search.mjs` (in-repo dev copy) first, then `~/.episodic-memory/scripts/em-search.mjs` (global substrate). `REPO_ROOT` stays the `cd` target so `--scope all` still picks up the project-local episode store. No candidate → the em-search step is omitted from the directive.
- **Always-tier list filtered by existence**: only files present at `MEM_ROOT` are emitted; the directive states the actual count (MEMORY.md kept when present, missing entries skipped silently).
- **Directive degrades instead of misleading**: both-parts Q2 / files-only Q2 / em-search-only Q2 / Q1-only (handoff exists, Q2 empty) / no emission at all (stderr + exit 0) when nothing is loadable.
- **HOME-unset fail-safe**: previously a `set -u` crash at the memory-root candidates; now logs and exits 0 (review finding).

## Tests (`tests/test-session-handoff-cwd-matrix.sh`)

- Stale needles repaired so the suite runs green against the current source: `BLOCKING:` (was `BLOCKING DIRECTIVE`), 6-file always-tier list (was the pre-demotion 8) + negative asserts on the demoted pair, `grep -qF --` for dash-leading needles.
- Suite now runnable from a linked worktree (`MAIN_REPO` resolved via git common-dir, same as the hook).
- New hermetic regression cases T440-1..7 (fake `HOME` + `config.json:claude_memory_root` override): substrate resolution, probe order, em-search omission, nothing-to-load no-emission, Q1-only, handoff+files-only, HOME-unset.
- Suite result: 55 pass, 0 fail (T9 skips until the post-merge deploy refreshes the installed copy).

## Verification

- E2E on a real foreign project (`structure-discovery-lab`): directive now emits `node ~/.episodic-memory/scripts/em-search.mjs` with `cd` bound to the lab repo and lists only its existing `MEMORY.md`; the emitted command executed verbatim returns `status: ok, count: 10`.
- No regression for the episodic-memory repo itself: old vs new `additionalContext` byte-identical.
- Code review: `negative-scenario-reviewer` on the diff, verdict ACCEPT, 0 P1/P2, 5 P3 (reply episode `…203e`). P3-1 and P3-3 fixed in-branch; P3-2 (Q2 question wording in degraded variants) wontfix, since the verbatim question text is a stable contract; P3-4 accepted (local-only suite doubles as drift detection); P3-5 is the standard post-merge deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
