### PR TITLE
feat(scripts): --help/-h short-circuit on all 21 installed substrate scripts

### DIFF
--- a/scripts/em-audit-compliance.mjs
+++ b/scripts/em-audit-compliance.mjs
@@ -44,6 +44,12 @@ import { walkTranscripts, groupBySession } from './lib/transcript-walker.mjs'
 // ---------------------------------------------------------------------------
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-audit-compliance.mjs', usage: 'node em-audit-compliance.mjs [--since <ISO>] [--slug <substring>] [--exclude-worktrees] [--format json|markdown] [--prior-since <ISO>]' }))
+  process.exit(0)
+}
+
 function flag(name, def = undefined) {
   const i = argv.indexOf(name)
   if (i === -1) return def

--- a/scripts/em-backup.mjs
+++ b/scripts/em-backup.mjs
@@ -1675,6 +1675,11 @@ function selfTest() {
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-backup.mjs', usage: 'node em-backup.mjs (--audit | --init | --sync | --self-test | --show-config) [--sample <n>]' }))
+  process.exit(0)
+}
+
 // Codex PR-#137 round-5: every CLI JSON output (success OR error) must pass
 // through artifact redaction at the output boundary. Patching individual
 // return objects + error strings was whack-a-mole. This is the LAST line of

--- a/scripts/em-check-stale.mjs
+++ b/scripts/em-check-stale.mjs
@@ -21,6 +21,11 @@ const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-check-stale.mjs', usage: 'node em-check-stale.mjs [--days <n>] [--project <name>] [--scope local|global|all]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-list.mjs
+++ b/scripts/em-list.mjs
@@ -19,6 +19,11 @@ const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-list.mjs', usage: 'node em-list.mjs [--project <name>] [--limit <n>] [--scope local|global|all] [--include-superseded]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-lock.mjs
+++ b/scripts/em-lock.mjs
@@ -27,6 +27,16 @@ import fs from 'node:fs'
 import { spawn } from 'node:child_process'
 
 const args = process.argv.slice(2)
+
+// Scan only the flags before the `--` separator so a wrapped command's own
+// --help/-h is not intercepted here.
+const helpSep = args.indexOf('--')
+const helpScan = helpSep === -1 ? args : args.slice(0, helpSep)
+if (helpScan.includes('--help') || helpScan.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-lock.mjs', usage: 'node em-lock.mjs --file <lockpath> --timeout <seconds> -- <cmd> [args...]' }))
+  process.exit(0)
+}
+
 const dashDash = args.indexOf('--')
 if (dashDash === -1 || dashDash === args.length - 1) {
   console.error(JSON.stringify({ status: 'error', code: 'usage', message: 'Usage: em-lock.mjs --file <path> --timeout <seconds> -- <cmd> [args...]' }))

--- a/scripts/em-mine-transcripts.mjs
+++ b/scripts/em-mine-transcripts.mjs
@@ -52,6 +52,12 @@ const TRIGGERS = [
 // ---------------------------------------------------------------------------
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-mine-transcripts.mjs', usage: 'node em-mine-transcripts.mjs [--since <ISO>] [--slug <substring>] [--exclude-worktrees] [--output <path>] [--dry-run]' }))
+  process.exit(0)
+}
+
 function flag(name, def = undefined) {
   const i = argv.indexOf(name)
   if (i === -1) return def

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -31,6 +31,11 @@ const LOCAL_DIR = resolveLocalDir(CWD)
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-pattern-health.mjs', usage: 'node em-pattern-health.mjs [--pattern <id>] [--scope local|global|all] [--window-days <N>] [--min-violations <N>] [--has-enforcement <id>] [--check] [--json] [--summary]' }))
+  process.exit(0)
+}
+
 // Reject `--something` as a value for another flag — protects against
 // `--has-enforcement --check` silently registering "--check" as a pattern.
 function isFlagToken(s) {

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -30,6 +30,12 @@ const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-prune.mjs', usage: 'node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -19,6 +19,12 @@ const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-rebuild-index.mjs', usage: 'node em-rebuild-index.mjs [--scope local|global|all]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -30,6 +30,11 @@ const REPO_ROOT = resolveRepoRoot()
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-recall.mjs', usage: 'node em-recall.mjs [--project <name>] [--scope local|global|all] [--limit <n>] [--days <n>] [--no-track] [--task-type implementation|push|rule|general] [--warn-time-ms <n>] [--warn-count <n>]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -2394,7 +2394,7 @@ try {
     out({ status: r.fail === 0 ? 'ok' : 'fail', ...r })
     process.exit(r.fail === 0 ? 0 : 1)
   } else if (bool('--help') || bool('-h')) {
-    out({ status: 'ok', usage: usage() })
+    out({ status: 'help', usage: usage() })
   } else {
     const backupDir = expandHome(flag('--from'))
     if (!backupDir) {

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -2394,7 +2394,7 @@ try {
     out({ status: r.fail === 0 ? 'ok' : 'fail', ...r })
     process.exit(r.fail === 0 ? 0 : 1)
   } else if (bool('--help') || bool('-h')) {
-    out({ status: 'help', usage: usage() })
+    out({ status: 'help', script: 'em-restore.mjs', usage: usage() })
   } else {
     const backupDir = expandHome(flag('--from'))
     if (!backupDir) {

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -55,6 +55,12 @@ const LOCAL_DIR = resolveLocalDir()
 // CLI
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-review-request.mjs', usage: 'node em-review-request.mjs --task <id> --plan-ref <ref> --approval-ref <ep> --pre-checkpoint-ref <ep> --post-checkpoint-ref <ep> --tests-ref <ref> --code-review-ref <ep> [--bug-log-ref <url>]... [--no-new-bugs] [--command-inventory-ref <ref>] [--triggered-by <ep>] [--head <sha>] [--branch <name>] [--worktree <path>] [--project <name>] [--tags <t1,t2>] [--scope inherit|local|global] [--verifications-file <path>] [--pattern-id <id>] [--dry-run]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -37,6 +37,11 @@ const LOCAL_DIR = resolveLocalDir()
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-revise.mjs', usage: 'node em-revise.mjs --original <id> --project <name> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-rfc-validate.mjs
+++ b/scripts/em-rfc-validate.mjs
@@ -30,6 +30,12 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-rfc-validate.mjs', usage: 'node em-rfc-validate.mjs [--json] [--rfcs-dir <path>]' }))
+  process.exit(0)
+}
+
 const jsonMode = argv.includes('--json')
 const dirIdx = argv.indexOf('--rfcs-dir')
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -28,6 +28,11 @@ const LOCAL_DIR = resolveLocalDir()
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-search.mjs', usage: 'node em-search.mjs [--project <name>] [--tag <tag>] [--category <cat>] [--query <text>] [--since <YYYY-MM-DD>] [--limit <n>] [--scope local|global|all] [--include-superseded] [--history <id>] [--full] [--no-score] [--no-track] [--warn-time-ms <n>] [--warn-count <n>]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -20,6 +20,12 @@ import crypto from 'crypto'
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-seed-patterns.mjs', usage: 'node em-seed-patterns.mjs [--dir <patterns-dir>] [--dry-run]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -37,6 +37,11 @@ const LOCAL_DIR = resolveLocalDir()
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-store.mjs', usage: 'node em-store.mjs --project <name> --category <cat> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope local|global]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-violation.mjs
+++ b/scripts/em-violation.mjs
@@ -33,6 +33,11 @@ const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-violation.mjs', usage: 'node em-violation.mjs --pattern <pattern_id> --summary <text> (--body <text> | --body-file <path>) [--sequence <a,b>] [--correct <a,b>] [--project <name>] [--tags <extra>] [--scope global|local]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/em-watch-codex.mjs
+++ b/scripts/em-watch-codex.mjs
@@ -35,6 +35,11 @@ const VALID_SCOPES = ['local', 'global', 'all']
 
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-watch-codex.mjs', usage: 'node em-watch-codex.mjs [--scope local|global|all] [--since <id>] [--no-update] [--project-root <path>] [--limit <n>]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1) return undefined

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -39,6 +39,12 @@ const LOCAL_DIR = resolveLocalDir()
 // CLI args
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-workflow-validate.mjs', usage: 'node em-workflow-validate.mjs --task <task> --gate <pre-checkpoint|post-checkpoint|push-allowed> [--pattern-id <id>] [--worktree <path>] [--branch <branch>] [--head <sha>] [--scope local|global|all] [--strict]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/scripts/second-opinion.mjs
+++ b/scripts/second-opinion.mjs
@@ -47,6 +47,11 @@ const PROVIDERS_REGISTRY = path.join(HARNESS_ROOT, 'scripts', 'second-opinion', 
 // ---------------------------------------------------------------------------
 const argv = process.argv.slice(2)
 
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'second-opinion.mjs', usage: 'node second-opinion.mjs <request|list-replies|rebuild-index> [options]. request: --provider <p> --project <path> --storage <files|episodic> --body <text> --summary <text> [--dispatch] [--consensus --max-rounds <n> --rebuttal-cb <script>] [--preamble <id>]' }))
+  process.exit(0)
+}
+
 function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined

--- a/tests/test-em-help-flags.mjs
+++ b/tests/test-em-help-flags.mjs
@@ -202,8 +202,17 @@ test('em-lock.mjs wrapped command owns --help after the -- separator', () => {
   const s = makeSandbox()
   try {
     const lockFile = path.join(s.root, 'lockfile')
-    const r = run('em-lock.mjs', ['--file', lockFile, '--timeout', '2', '--', process.execPath, '-e', 'console.log("wrapped-ran")', '--help'], s)
+    // node's own `--` ends node's option parsing, so the trailing --help lands
+    // in the wrapped script's process.argv instead of triggering node's help
+    // (codex PR #449 round-2 P2: the previous spelling made node print its own
+    // help and the assertion passed vacuously).
+    const r = run('em-lock.mjs', [
+      '--file', lockFile, '--timeout', '2', '--',
+      process.execPath, '-e', 'console.log("wrapped-ran " + process.argv.slice(1).join(" "))', '--', '--help',
+    ], s)
     assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+    assert.ok(r.stdout.includes('wrapped-ran'), `wrapped command did not run: ${r.stdout}`)
+    assert.ok(r.stdout.includes('wrapped-ran --help'), `wrapped command did not receive its --help arg: ${r.stdout}`)
     assert.ok(!r.stdout.includes('"status":"help"'), `em-lock intercepted the wrapped command's --help: ${r.stdout}`)
   } finally { s.cleanup() }
 })

--- a/tests/test-em-help-flags.mjs
+++ b/tests/test-em-help-flags.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * test-em-help-flags.mjs - Regression tests for the --help / -h short-circuit
+ * on the installed substrate scripts.
+ *
+ * Bug context: most substrate scripts had no --help handler, so an unknown flag
+ * was silently ignored and the script ran its DEFAULT behavior. Probing
+ * `em-prune --help` actually executed a real prune pass; em-rebuild-index
+ * rewrote the index; em-seed-patterns would seed. Every AI harness probes CLIs
+ * with --help, so this was an agent footgun.
+ *
+ * Fix: each script short-circuits on --help / -h with a single JSON object
+ * ({ status: 'help', script, usage }) on stdout, exit 0, BEFORE any filesystem,
+ * store, or subprocess side effect. This test pins:
+ *   1. --help returns exit 0, JSON, status 'help', non-empty usage string.
+ *   2. No .episodic-memory store gets created under the sandbox HOME or cwd
+ *      (proves the short-circuit fires before store creation).
+ *   3. em-list also honors the -h alias.
+ *   4. Negative control: em-store WITHOUT --help DOES create the store, so the
+ *      step-2 assertion actually discriminates.
+ *   5. Belt-and-braces: prune/seed/rebuild --help emit no work-result keys.
+ *
+ * Usage: node tests/test-em-help-flags.mjs
+ * Zero deps - Node stdlib only.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+import assert from 'assert'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const SCRIPTS = path.join(REPO, 'scripts')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ok ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  FAIL ${name}: ${e.message}`)
+  }
+}
+
+function makeSandbox() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'em-help-flags-test-')))
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  return {
+    root, home, cwd,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+function run(script, args, sandbox) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], {
+    cwd: sandbox.cwd,
+    env: { ...process.env, HOME: sandbox.home },
+    encoding: 'utf8',
+  })
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr }
+}
+
+function parseJSON(stdout) {
+  return JSON.parse(stdout.trim())
+}
+
+// Recursively test whether any file named `name` exists anywhere under `dir`.
+function existsAnywhere(dir, name) {
+  let found = false
+  const stack = [dir]
+  while (stack.length) {
+    const cur = stack.pop()
+    let entries
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true })
+    } catch { continue }
+    for (const ent of entries) {
+      const full = path.join(cur, ent.name)
+      if (ent.name === name) { found = true; return found }
+      if (ent.isDirectory()) stack.push(full)
+    }
+  }
+  return found
+}
+
+// Assert no .episodic-memory store leaked into the sandbox after a --help run.
+function assertNoStore(sandbox, label) {
+  assert.strictEqual(
+    fs.existsSync(path.join(sandbox.home, '.episodic-memory')), false,
+    `${label}: .episodic-memory created under sandbox HOME (short-circuit fired too late)`)
+  assert.strictEqual(
+    fs.existsSync(path.join(sandbox.cwd, '.episodic-memory')), false,
+    `${label}: .episodic-memory created under sandbox cwd (short-circuit fired too late)`)
+}
+
+// ---------------------------------------------------------------------------
+// The installed substrate set: every script that got a --help handler.
+// ---------------------------------------------------------------------------
+const SUBSTRATE = [
+  'em-audit-compliance.mjs', 'em-backup.mjs', 'em-check-stale.mjs', 'em-list.mjs',
+  'em-lock.mjs', 'em-mine-transcripts.mjs', 'em-pattern-health.mjs', 'em-prune.mjs',
+  'em-rebuild-index.mjs', 'em-recall.mjs', 'em-restore.mjs', 'em-review-request.mjs',
+  'em-revise.mjs', 'em-rfc-validate.mjs', 'em-search.mjs', 'em-seed-patterns.mjs',
+  'em-store.mjs', 'em-violation.mjs', 'em-watch-codex.mjs', 'em-workflow-validate.mjs',
+  'second-opinion.mjs',
+]
+
+console.log('--help contract (every substrate script):')
+
+for (const script of SUBSTRATE) {
+  test(`${script} --help -> status help, exit 0, no store`, () => {
+    const s = makeSandbox()
+    try {
+      const r = run(script, ['--help'], s)
+      assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+      const json = parseJSON(r.stdout)
+      assert.strictEqual(json.status, 'help', `status was ${JSON.stringify(json.status)}`)
+      assert.strictEqual(typeof json.usage, 'string', 'usage is not a string')
+      assert.ok(json.usage.length > 0, 'usage is empty')
+      assertNoStore(s, `${script} --help`)
+    } finally { s.cleanup() }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// -h short alias (covered at least once via em-list)
+// ---------------------------------------------------------------------------
+console.log('-h short alias:')
+
+test('em-list.mjs -h -> status help, exit 0, no store', () => {
+  const s = makeSandbox()
+  try {
+    const r = run('em-list.mjs', ['-h'], s)
+    assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+    const json = parseJSON(r.stdout)
+    assert.strictEqual(json.status, 'help', `status was ${JSON.stringify(json.status)}`)
+    assert.ok(typeof json.usage === 'string' && json.usage.length > 0, 'usage missing/empty')
+    assertNoStore(s, 'em-list.mjs -h')
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// Negative control: proves the no-store assertion discriminates.
+// ---------------------------------------------------------------------------
+console.log('negative controls (discrimination):')
+
+test('em-list.mjs WITHOUT --help -> status ok, exit 0', () => {
+  const s = makeSandbox()
+  try {
+    const r = run('em-list.mjs', [], s)
+    assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+    const json = parseJSON(r.stdout)
+    assert.strictEqual(json.status, 'ok', `status was ${JSON.stringify(json.status)}`)
+  } finally { s.cleanup() }
+})
+
+test('em-store.mjs WITHOUT --help DOES create the store under HOME', () => {
+  const s = makeSandbox()
+  try {
+    const r = run('em-store.mjs', [
+      '--project', 't', '--category', 'decision',
+      '--summary', 's', '--body', 'b', '--scope', 'global',
+    ], s)
+    assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+    const json = parseJSON(r.stdout)
+    assert.strictEqual(json.status, 'ok', `status was ${JSON.stringify(json.status)}`)
+    assert.strictEqual(
+      fs.existsSync(path.join(s.home, '.episodic-memory')), true,
+      'em-store did NOT create .episodic-memory under HOME; the step-2 assertion would not discriminate')
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// Belt-and-braces: destructive/mutating scripts must emit no work-result keys.
+// ---------------------------------------------------------------------------
+console.log('belt-and-braces (no work performed on --help):')
+
+test('em-prune.mjs --help emits no pruned/results key', () => {
+  const s = makeSandbox()
+  try {
+    const json = parseJSON(run('em-prune.mjs', ['--help'], s).stdout)
+    assert.strictEqual(json.status, 'help')
+    assert.ok(!('results' in json), 'unexpected results key')
+    assert.ok(!('pruned' in json), 'unexpected pruned key')
+  } finally { s.cleanup() }
+})
+
+test('em-seed-patterns.mjs --help emits no seeded key', () => {
+  const s = makeSandbox()
+  try {
+    const json = parseJSON(run('em-seed-patterns.mjs', ['--help'], s).stdout)
+    assert.strictEqual(json.status, 'help')
+    assert.ok(!('seeded' in json), 'unexpected seeded key')
+  } finally { s.cleanup() }
+})
+
+test('em-rebuild-index.mjs --help emits no rebuilt key and writes no index.jsonl', () => {
+  const s = makeSandbox()
+  try {
+    const json = parseJSON(run('em-rebuild-index.mjs', ['--help'], s).stdout)
+    assert.strictEqual(json.status, 'help')
+    assert.ok(!('rebuilt' in json), 'unexpected rebuilt key')
+    assert.strictEqual(existsAnywhere(s.root, 'index.jsonl'), false, 'index.jsonl was written under sandbox')
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-em-help-flags.mjs
+++ b/tests/test-em-help-flags.mjs
@@ -12,13 +12,26 @@
  * Fix: each script short-circuits on --help / -h with a single JSON object
  * ({ status: 'help', script, usage }) on stdout, exit 0, BEFORE any filesystem,
  * store, or subprocess side effect. This test pins:
- *   1. --help returns exit 0, JSON, status 'help', non-empty usage string.
+ *   1. --help returns exit 0, EXACTLY one JSON object on stdout with EXACTLY
+ *      the keys {script, status, usage}, script matching the invoked basename,
+ *      status 'help', non-empty usage string, and empty stderr (codex PR #449
+ *      round-1 B1/B2: em-restore shipped without the script key and the loose
+ *      assertions let it pass).
  *   2. No .episodic-memory store gets created under the sandbox HOME or cwd
  *      (proves the short-circuit fires before store creation).
  *   3. em-list also honors the -h alias.
  *   4. Negative control: em-store WITHOUT --help DOES create the store, so the
  *      step-2 assertion actually discriminates.
  *   5. Belt-and-braces: prune/seed/rebuild --help emit no work-result keys.
+ *   6. Pinned token semantics (codex round-1 B3, invariant narrowed by design):
+ *      a STANDALONE --help/-h argv token triggers help wherever it appears,
+ *      INCLUDING in value position of another flag (em-store --summary --help
+ *      prints help and stores nothing). Detecting value-position help tokens
+ *      would require mirroring each script's parser; the pre-existing flag()
+ *      parsers share the same token-collision class, and a literal '--help'
+ *      value is the same argv token even when quoted. em-lock is the one
+ *      deliberate exception: tokens after its -- separator belong to the
+ *      wrapped command and never trigger help.
  *
  * Usage: node tests/test-em-help-flags.mjs
  * Zero deps - Node stdlib only.
@@ -74,6 +87,30 @@ function parseJSON(stdout) {
   return JSON.parse(stdout.trim())
 }
 
+// Exact help-contract assertion (codex PR #449 round-1 B1/B2): exactly one
+// JSON object on stdout, exactly the keys {script, status, usage}, script
+// matching the invoked basename, empty stderr.
+function assertHelpContract(r, script, label) {
+  assert.strictEqual(r.code, 0, `${label}: exit code ${r.code} (stderr: ${r.stderr})`)
+  assert.strictEqual(r.stderr, '', `${label}: stderr not empty: ${r.stderr}`)
+  // Exactly ONE JSON value on stdout: JSON.parse of the whole trimmed stream
+  // throws on trailing content, so concatenated objects or extra prose fail.
+  // (em-restore pretty-prints its object over multiple lines; that is fine.)
+  let json
+  try {
+    json = JSON.parse(r.stdout.trim())
+  } catch (e) {
+    throw new Error(`${label}: stdout is not exactly one JSON value: ${e.message}\n${r.stdout}`)
+  }
+  assert.deepStrictEqual(
+    Object.keys(json).sort(), ['script', 'status', 'usage'],
+    `${label}: keys were ${JSON.stringify(Object.keys(json).sort())}`)
+  assert.strictEqual(json.status, 'help', `${label}: status was ${JSON.stringify(json.status)}`)
+  assert.strictEqual(json.script, script, `${label}: script was ${JSON.stringify(json.script)}`)
+  assert.ok(typeof json.usage === 'string' && json.usage.length > 0, `${label}: usage missing/empty`)
+  return json
+}
+
 // Recursively test whether any file named `name` exists anywhere under `dir`.
 function existsAnywhere(dir, name) {
   let found = false
@@ -118,15 +155,11 @@ const SUBSTRATE = [
 console.log('--help contract (every substrate script):')
 
 for (const script of SUBSTRATE) {
-  test(`${script} --help -> status help, exit 0, no store`, () => {
+  test(`${script} --help -> exact help contract, exit 0, no store`, () => {
     const s = makeSandbox()
     try {
       const r = run(script, ['--help'], s)
-      assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
-      const json = parseJSON(r.stdout)
-      assert.strictEqual(json.status, 'help', `status was ${JSON.stringify(json.status)}`)
-      assert.strictEqual(typeof json.usage, 'string', 'usage is not a string')
-      assert.ok(json.usage.length > 0, 'usage is empty')
+      assertHelpContract(r, script, `${script} --help`)
       assertNoStore(s, `${script} --help`)
     } finally { s.cleanup() }
   })
@@ -137,15 +170,41 @@ for (const script of SUBSTRATE) {
 // ---------------------------------------------------------------------------
 console.log('-h short alias:')
 
-test('em-list.mjs -h -> status help, exit 0, no store', () => {
+test('em-list.mjs -h -> exact help contract, exit 0, no store', () => {
   const s = makeSandbox()
   try {
     const r = run('em-list.mjs', ['-h'], s)
-    assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
-    const json = parseJSON(r.stdout)
-    assert.strictEqual(json.status, 'help', `status was ${JSON.stringify(json.status)}`)
-    assert.ok(typeof json.usage === 'string' && json.usage.length > 0, 'usage missing/empty')
+    assertHelpContract(r, 'em-list.mjs', 'em-list.mjs -h')
     assertNoStore(s, 'em-list.mjs -h')
+  } finally { s.cleanup() }
+})
+
+// ---------------------------------------------------------------------------
+// Pinned token semantics (codex round-1 B3, narrowed invariant): a standalone
+// --help token triggers help even in value position of another flag. Chosen by
+// design over parser-mirroring; see header comment item 6.
+// ---------------------------------------------------------------------------
+console.log('pinned token semantics (value-position --help):')
+
+test('em-store.mjs --summary --help -> help output, nothing stored', () => {
+  const s = makeSandbox()
+  try {
+    const r = run('em-store.mjs', [
+      '--project', 't', '--category', 'decision',
+      '--summary', '--help', '--body', 'b', '--scope', 'global',
+    ], s)
+    assertHelpContract(r, 'em-store.mjs', 'em-store.mjs --summary --help')
+    assertNoStore(s, 'em-store.mjs --summary --help')
+  } finally { s.cleanup() }
+})
+
+test('em-lock.mjs wrapped command owns --help after the -- separator', () => {
+  const s = makeSandbox()
+  try {
+    const lockFile = path.join(s.root, 'lockfile')
+    const r = run('em-lock.mjs', ['--file', lockFile, '--timeout', '2', '--', process.execPath, '-e', 'console.log("wrapped-ran")', '--help'], s)
+    assert.strictEqual(r.code, 0, `exit code ${r.code} (stderr: ${r.stderr})`)
+    assert.ok(!r.stdout.includes('"status":"help"'), `em-lock intercepted the wrapped command's --help: ${r.stdout}`)
   } finally { s.cleanup() }
 })
 


### PR DESCRIPTION
## Summary

Most substrate scripts had no `--help` handler: an unknown flag was silently ignored and the script ran its default behavior. During the install-guide work (2026-07-04) an agent probing `em-prune --help` executed a **real prune pass** (em-prune is destructive without `--dry-run`), `em-rebuild-index --help` rewrote the index, and `em-seed-patterns --help` would have seeded. Every AI harness probes CLIs with `--help`, so this was a standing footgun. Requested by the operator as an implementation, not an issue.

## Change

Each of the 21 installed substrate scripts (all `em-*.mjs` + `second-opinion.mjs`) now short-circuits on `--help`/`-h` as the first executable logic after `argv`, before any filesystem, store, or subprocess side effect:

```json
{"status":"help","script":"em-prune.mjs","usage":"node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check]"}
```

- Usage strings derive from each script's Usage header or its actual argv parser; flag audit confirmed no invented flags (spot-checked `em-watch-codex --limit`, `em-recall --warn-time-ms/--warn-count`).
- `em-restore` already had a handler; aligned its `status` from `ok` to `help`.
- `em-lock` scans only tokens before the `--` separator so a wrapped command's own `--help` is not intercepted.
- No other behavior changed; unknown non-help flags keep their current semantics.

## Verification

- `tests/test-em-help-flags.mjs`: 27/27. All 21 scripts on `--help` (exit 0, JSON `status: help`, non-empty usage, **no** `.episodic-memory` store created in the sandbox), the `-h` alias, two discrimination controls (default `em-list` runs; default `em-store` DOES create the store, proving the no-store assertion bites), and belt-and-braces checks that prune/seed/rebuild emit no work keys on `--help`.
- Regression suites green: tag-flags 11/11, sort-missing-datetime 5/5, body-file 20/20, revise-scope-inherit 18/18, watch-codex 25/25, restore self-test 120/120, seed-patterns 15/15, mine-transcripts 9/9, audit-compliance 7/7.
- Live E2E of the original footgun: `em-prune --help` against the real environment prints the help JSON and performs no prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)