### PR TITLE
RFC-009 P0: em-pattern-health --hermetic (R5a) + em-prune R6 protection set

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -162,6 +162,12 @@ jobs:
       - name: Run preflight-prompt-helper regression tests
         run: bash tests/test-preflight-prompt-helper.sh
 
+      - name: Run RFC-009 P0 hermetic pattern-health tests
+        run: node tests/test-pattern-health-hermetic.mjs
+
+      - name: Run RFC-009 P0 prune-protection tests
+        run: node tests/test-prune-protection.mjs
+
   p12-invariant-gate:
     # RFC-008 P4d S8 (REQ-10 / REQ-11): the three Principle-12 invariants as ONE
     # separately-named REQUIRED check. Membership is defined in code

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ node ~/.episodic-memory/scripts/em-recall.mjs --days 14 --no-track
 node ~/.episodic-memory/scripts/em-prune.mjs --dry-run
 node ~/.episodic-memory/scripts/em-prune.mjs --scope global --threshold 0.15
 node ~/.episodic-memory/scripts/em-prune.mjs --check  # exit 1 if prunable episodes exist
+# RFC-009 R6: evidence-linked violations, trigger-bearing lessons, consolidates
+# members, and the latest clerk run record are never archived — see the
+# protected / protected_episodes output fields in --dry-run.
 ```
 
 ### Backup (Mirror to Private Repo with Redaction)
@@ -442,6 +445,9 @@ node ~/.episodic-memory/scripts/em-pattern-health.mjs --window-days 7 --min-viol
 
 # Manual override when enforcement detection misses a hook
 node ~/.episodic-memory/scripts/em-pattern-health.mjs --has-enforcement bp-006-push-after-verify
+
+# Hermetic mode (RFC-009 R5a) — project-only reads, zero $HOME dependence
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --hermetic --check
 ```
 
 Searches `~/.claude/hooks/`, `<project>/.claude/hooks/`, `<project>/.git/hooks/`, and `<project>/.github/workflows/` for `pattern_id` references to detect mechanical enforcement. Patterns flagged `needs-enforcement` are violated repeatedly with no hook to stop them; `needs-attention` means an enforcement file exists but violations still occur (escalate to a human).

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -300,6 +300,17 @@ Output:
 `--check` exits 1 when prunable episodes exist (CI gate). `--dry-run` previews with
 no writes.
 
+**Protection set (RFC-009 R6).** Prune never archives, in any mode: violations
+evidence-linked to a valid lesson (either direction: the lesson's `evidence` array
+or the violation's `lessons` array); valid lessons carrying `triggers`; episodes
+named in a valid episode's `consolidates` array; supersession-chain members of any
+of those; and the latest `record_type: clerk-run` episode per store. "Valid" means
+not superseded and `review_by` absent or unexpired — protection lapses when the
+referencing episode is superseded or expires. Retained entries are counted in the
+`protected` output field; `--dry-run` lists them in `protected_episodes` as
+`{id, score, reason, via}` where `via` names the protecting episode. `remaining`
+includes protected entries; the `--check` exit code ignores them.
+
 ### em-pattern-health
 
 Aggregate violation episodes per behavioral pattern within a rolling window and flag
@@ -317,6 +328,18 @@ node ~/.episodic-memory/scripts/em-pattern-health.mjs --check    # exit 1 if att
 
 `needs-enforcement` means violated repeatedly with no hook found. `needs-attention`
 means a hook exists but violations continue (escalate to a human).
+
+**`--hermetic` (RFC-009 R5a).** Reads ONLY project surfaces: violations from the
+project-local store, the patterns registry from `<project>/.episodic-memory/patterns/`
+falling back to `<project>/patterns/_index.json`, and enforcement detection over
+`<project>/.claude/hooks`, `<project>/.git/hooks`, `<project>/.github/workflows` —
+zero `$HOME` reads, so output is identical under any HOME. Scope is forced to
+`local`; combining with an explicit `--scope global|all` errors. Output shape and
+the `--check` exit contract are unchanged.
+
+```
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --hermetic --check   # project-only CI gate (R5b wires this in Phase 3)
+```
 
 ### em-violation
 

--- a/docs/plans/rfc-009-p0.md
+++ b/docs/plans/rfc-009-p0.md
@@ -301,16 +301,20 @@ All fixtures are isolated non-git scratch dirs + controlled `HOME` env, driving 
 
 | Claim | Command (the strong-layer one) | Observed artifact |
 |---|---|---|
-| R5 group passes | `node tests/test-pattern-health-hermetic.mjs` | _fill at impl_ |
-| R6 group passes | `node tests/test-prune-protection.mjs` | _fill at impl_ |
-| Legacy suite green | `node tests/test-rfc002-phase2.mjs` (existing pattern-health coverage) | _fill at impl_ |
-| Hermetic acceptance (RFC gate) | re-run §3 probes A-D with `--hermetic`: A≡B, C rejected | _fill at impl_ |
-| Prune protection live | re-run §3 probe E post-impl: 3 protected, 0 prunable, reasons listed | _fill at impl_ |
-| No `$HOME` token behind the flag | reading pass over the two hermetic path-set constructs + broad-token `grep -n "HOME" scripts/em-pattern-health.mjs` disposition list | _fill at impl_ |
-| em-prune consumers unaffected | `grep -rn "em-prune" scripts plugins .claude/hooks docs` → per-site disposition | _fill at impl_ |
-| CI green | `gh pr checks <PR>` (never a local proxy) | _fill at impl_ |
-| Docs gate | grep `EM_SCRIPTS_GUIDE.md` for `--hermetic`, `protected_episodes` | _fill at impl_ |
+| R5 group passes | `node tests/test-pattern-health-hermetic.mjs` | `8/8 pass`, exit 0 (2026-07-06) |
+| R6 group passes | `node tests/test-prune-protection.mjs` | `14/14 pass`, exit 0 (incl. testDocsGrepGate) |
+| Legacy suite green | `node tests/test-rfc002-phase2.mjs` + `node tests/test-phase2.mjs` | `31 passed, 0 failed` and `24 passed, 0 failed` |
+| Hermetic acceptance (RFC gate) | re-run §3 probes with `--hermetic` (probe-run.mjs) | `IDENTITY A===B: true` (fakehome vs emptyhome, byte-identical stdout + exit); `--hermetic --scope all` → exit 1, `--hermetic is project-local only; omit --scope or pass --scope local` |
+| Prune protection live | re-run §3 probe E post-impl | `"prunable":0,"protected":3` — `…cccc` evidence-linked-violation via `…dddd`; `…dddd` trigger-bearing-lesson; `…eeee` consolidates-member via `…ffff` (pre-impl: prunable 3) |
+| No `$HOME` token behind the flag | `grep -n "HOME" scripts/em-pattern-health.mjs` + reading pass | 6 hits: L24/26 consts (GLOBAL_DIR unreachable under hermetic — effectiveScope forced local), L114 + L290 non-hermetic ternary branches only, L106/128 comment/message text |
+| em-prune consumers unaffected | `grep -rn "em-prune"` sweep (§7) | consumers pin only `status`/`prunable`/`pruned`/`remaining` (tests/test-phase2.mjs:301-346 green post-change); new fields additive |
+| Docs gate | `testDocsGrepGate` (in the 14/14 run) | both tokens present in EM_SCRIPTS_GUIDE.md |
+| CI green | `gh pr checks <PR>` (never a local proxy) | _fill after PR_ |
 | Merged | `gh pr view <n> --json state,mergeCommit` | _fill at merge_ |
+
+§A.1 lint final disposition (run 2026-07-06): 6 matches, all the token "decided/decides" as
+resolved-statement prose (I3, §8.3 flow, EC6, §17 lock, and two comment lines inside the S2-A2
+fenced artifact); none inside a step-table instruction cell — plan ready per the §A.1 acceptance rule.
 
 ## §16 Risk Analysis
 

--- a/docs/plans/rfc-009-p0.md
+++ b/docs/plans/rfc-009-p0.md
@@ -224,8 +224,8 @@ Do **not** cut:
 | B. violation back-link | row `category==='violation'` with `Array.isArray(lessons)`, any listed id resolving (in ANY store's rows) to a `category==='lesson'` valid-referencer row | row's own id → `evidence-linked-violation`, via=the matching lesson id | none |
 | C. trigger-bearing | row `category==='lesson'` + valid referencer + `Array.isArray(triggers) && triggers.filter(t => typeof t === 'string').length > 0` | own id → `trigger-bearing-lesson`, via=own id | none |
 | D. expired/superseded referencer | any A/B/C/E shape whose referencer fails the validity predicate | contributes nothing (lapse — may still protect via another valid referencer) | none |
-| E. consolidates member | any valid-referencer row with `Array.isArray(consolidates)` | each string item → `consolidates-member`, via=row.id | none |
-| F. latest run record | rows with `record_type==='clerk-run'` AND a string `id`, grouped by `_store`: lexicographically greatest id per group (ids are unique by construction; rows without `id` skipped) | that id → `latest-run-record`, via=own id | none |
+| E. consolidates member | any valid-referencer row with `Array.isArray(consolidates)` (NO id requirement on the referencer — symmetric with A; reviewer F1) | each string item → `consolidates-member`, via=row.id or `null` when the referencer has no string id (reviewer F2: `via` never dropped from JSON) | none |
+| F. latest run record | rows with `record_type==='clerk-run'` AND a string `id`, grouped by `_store`: greatest CANONICAL id (`^\d{8}-\d{6}-`) per group; non-canonical (hand-written) ids compete only against each other and never shadow a canonical one (reviewer F4); rows without `id` skipped | that id → `latest-run-record`, via=own id | none |
 | G. older run record | non-max clerk-run rows | not protected | none |
 | H. chain closure | ids reachable from any A/B/C/E-protected id via: (1) the row's own `supersedes` string, (2) DERIVED forward edges from inverting the `supersedes` map over the union rows, (3) `superseded_by` strings when present (never relied on — planner F1); transitive, visited-set cycle guard | each new id → `chain-member`, via=the anchor protected id | none |
 | I. malformed fields | `evidence`/`lessons`/`triggers`/`consolidates` present but non-array; array items non-string | field ignored (items skipped) | none |
@@ -274,7 +274,7 @@ Group R5 — tests/test-pattern-health-hermetic.mjs (8 tests)
   testHermeticHasEnforcementOverride — override flips has_enforcement true under --hermetic
   testNonHermeticUnchanged — without flag: fake-HOME hook detected + scope-all counts global store (pins legacy)
 
-Group R6 — tests/test-prune-protection.mjs (13 tests)
+Group R6 — tests/test-prune-protection.mjs (16 tests)
   testEvidenceLinkedViolationSurvives — aged violation + valid lesson evidence link survives dry-run AND real prune
   testViolationLessonsBacklinkSurvives — violation.lessons → valid lesson id protects the violation
   testTriggerBearingLessonSurvives — aged valid lesson with triggers survives
@@ -288,12 +288,15 @@ Group R6 — tests/test-prune-protection.mjs (13 tests)
   testCrossStoreProtection — global lesson evidence protects local violation under --scope local; missing global index degrades clean; stale local superseded copy does NOT shadow the active global referencer (planner F3)
   testMalformedFieldsTolerated — string evidence / numeric triggers / no-category row / NaN-date row: no crash, malformed fields don't protect, NaN-date row survives (pinned)
   testProtectedCountInOutput — protected count + partition invariant (remaining = kept + protected) in all three modes; protected_episodes {id, score, reason, via}; --check exit excludes protected; existing fields unchanged
+  testIdlessReferencerProtectsBothClasses — idless valid referencer protects via evidence AND consolidates; via renders null (reviewer F1/F2)
+  testNumericIdRowProtected — numeric-id row protected through String() lookup (reviewer F3)
+  testJunkRunRecordIdDoesNotShadow — non-canonical clerk-run id never shadows the canonical latest (reviewer F4)
 
 Group docs (1 test, S3)
   testDocsGrepGate — EM_SCRIPTS_GUIDE.md contains `--hermetic` and `protected_episodes`
 ```
 
-Total: 22 tests. Runners: `node tests/test-pattern-health-hermetic.mjs`, `node tests/test-prune-protection.mjs` (each prints `N/N pass`, exit non-zero on failure; docs grep folded into the prune test file as its final case to avoid a third CI step — named separately here for traceability).
+Total: 25 tests. Runners: `node tests/test-pattern-health-hermetic.mjs`, `node tests/test-prune-protection.mjs` (each prints `N/N pass`, exit non-zero on failure; docs grep folded into the prune test file as its final case to avoid a third CI step — named separately here for traceability).
 
 All fixtures are isolated non-git scratch dirs + controlled `HOME` env, driving the REAL scripts via `spawnSync` with explicit `cwd` (behavior-simulation convention; no mental-trace, no stubs).
 
@@ -336,7 +339,7 @@ fenced artifact); none inside a step-table instruction cell — plan ready per t
 
 ## §18 Done Criteria
 
-- [ ] All 22 §14 tests pass (artifact in §15).
+- [ ] All 25 §14 tests pass (artifact in §15).
 - [ ] §15 ledger fully populated with observed output.
 - [ ] RFC-009 P0 checklist rows marked done in the RFC's Implementation table in the same PR (Rule 10: never batch).
 - [ ] Workplan episode revised to v163 (P0 shipped) after merge.
@@ -352,6 +355,7 @@ Second-opinion review: codex, interactive cmux (standing directive 2026-06-28; c
 | 1 | codex (cmux interactive) | gpt-5.5 high | 0 BLOCKER, 2 MAJOR + 1 MINOR | HOLD (ran against the mid-rewrite plan; findings subsumed by r2) | n/a (cmux transcript) |
 | 2 | codex (cmux interactive) | gpt-5.5 high | 0 BLOCKER, 2 MAJOR + 2 MINOR | HOLD → all 4 fixed (r2-F1 §8.3/EC5 union wording; r2-F2 class-c lapse leg; r2-F3 I1 reword; r2-F4 §18 count). Positive evidence: codex instantiated the fenced artifacts in a temp copy — S1 tests 8/8, S2 tests 13/13; all anchors unique | n/a (cmux transcript) |
 | 3 | codex (cmux interactive) | gpt-5.5 high | 0 | ACCEPT — all r2 fixes verified at file:line + runtime probe re-run (temp-copy S1 8/8, S2 13/13 incl. the class-c lapse leg) | n/a (cmux transcript, 2026-07-06) |
+| 4 (post-impl, Rule 18 step 6) | negative-scenario-reviewer | claude subagent | 1 MAJOR + 4 MINOR + 1 NIT | HOLD → F1-F4 fixed same turn (class-c id-guard asymmetry, via-null normalization, String() lookup, canonical-id run-record ordering) + 3 regression tests; F5 pre-existing string-tags crash → issue at wrap-up; suites re-run 17/17 + 24/24 | n/a (agent transcript, 2026-07-06) |
 
 ### 19.1 Resolved blockers
 
@@ -1505,7 +1509,7 @@ let pass = 0
 
 ```bash
 node tests/test-pattern-health-hermetic.mjs   # → 8/8 pass
-node tests/test-prune-protection.mjs          # → 14/14 pass
+node tests/test-prune-protection.mjs          # → 17/17 pass
 node tests/test-rfc002-phase2.mjs             # → existing suite green
 node /private/tmp/.../probe-run.mjs           # → hermetic reruns: A≡B; prune rerun: protected 3, prunable 0
 ```

--- a/docs/plans/rfc-009-p0.md
+++ b/docs/plans/rfc-009-p0.md
@@ -1,0 +1,1515 @@
+# RFC009-P0 Hermetic Pattern-Health + Prune Protection Set Plan
+
+## §1 Status
+
+`Planning only.` Do not implement until this plan, the plan review, and the adversarial
+review are accepted (Rule 18). Current stage: **final — reviews accepted (planner merged,
+codex r3 ACCEPT 2026-07-06), awaiting operator approval**.
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-009` |
+| Parent requirements | `R5a, R6 (prune-protection half); R2 cited for chain-resolution rationale` |
+| Workplan episode | `20260705-125419-workplan-v162-pr-452-merged-eb6ac0a-rfc--c94c` |
+| Target branch | `feat/rfc-009-p0` |
+| Executor altitude (§0.1) | `low` (default; no high-capability implementer named) |
+
+## §2 Episode Search Summary
+
+Recall run (2026-07-06): `node scripts/em-search.mjs --tag rfc-009 --scope all --limit 5 --no-track --no-score` → 5 episodes:
+
+- `20260705-125400-…-1da6`: PR #452 merged, RFC-009 status ACCEPTED — phases implementable; this plan builds P0 exactly as sized in the RFC impl table (1 session, no hard deps).
+- `20260705-125419-…-c94c`: workplan v162 — P0 picked by operator 2026-07-06.
+- `20260705-102842-…-eaa1` / `20260705-094953-…-a945`: PR #451 strict event-plane boundary + behavior-simulation convention — constrains this plan to runtime-probed claims (probes recorded in §15).
+- `20260705-084023-…-f5e3`: violation — taxonomy conflation caught by user, not by planner/self-walk. Constraint honored here: `record_type` (typed scalar) identifies run records, never a tag (R10 T2).
+
+Verified against current code before relying on recalled facts: `em-pattern-health.mjs` `$HOME` reads exist at lines 26 (global store), 97 (global patterns fallback), 264 (`~/.claude/hooks`); `em-prune.mjs` scores age+access only (lines 55-62), no protection concept.
+
+## §3 Objective
+
+`em-pattern-health.mjs` gains `--hermetic`: with the flag, the script reads zero paths under `$HOME` — provable by a fixture where a populated fake HOME and an empty HOME produce byte-identical output (today they diverge: probe A/B below). `em-prune.mjs` gains the R6 protection set: aged below-threshold episodes that are load-bearing for the RFC-009 activation contracts (evidence-linked violations, active trigger-bearing lessons, `consolidates` members, the latest clerk run record) survive prune in every mode — provable by aged fixtures that today are listed prunable at score 0.1 (probe E below).
+
+Runtime evidence (2026-07-06 probes, isolated fixture store, real scripts, explicit cwd + controlled HOME):
+
+- Probe A vs B (`--scope local`, fake HOME with `.claude/hooks/enforce.sh` naming the pattern vs empty HOME): `"has_enforcement":true` vs `false` — the `~/.claude/hooks` read.
+- Probe C vs D (`--scope all`): `"violations":2` vs `1` — the global-store read.
+- Probe E (`em-prune --dry-run --scope local`): all three protected-class fixtures listed prunable at `"score":0.1` (`…cccc` evidence-linked violation, `…dddd` active trigger-bearing lesson, `…eeee` consolidates member).
+
+## §4 Requirements (Ground Truth)
+
+| ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes / edge cases |
+|---|---|---|---|---|---|
+| REQ-1 | `--hermetic` reads only project surfaces: violation episodes from `<LOCAL_DIR>` only; patterns from `<LOCAL_DIR>/patterns/_index.json` then `<PROJECT_ROOT>/patterns/_index.json`; enforcement scan over `<PROJECT_ROOT>/.claude/hooks` (`*.sh`), `<PROJECT_ROOT>/.git/hooks` (non-`.sample`), `<PROJECT_ROOT>/.github/workflows` (`*.ya?ml`). Zero `$HOME` filesystem reads. | R5a | `testHermeticHomeIsolation`, `testHermeticPatternsProjectOnly`, `testHermeticEnforcementProjectOnly` | MUST | PROJECT_ROOT = `path.dirname(LOCAL_DIR)`; non-git cwd degrades to cwd per `resolveLocalDir` |
+| REQ-2 | `--hermetic` output under an empty isolated HOME is byte-identical to a populated HOME (stdout and exit code), where the populated HOME plants ALL THREE read sites (`.claude/hooks/*.sh` naming the pattern id, `.episodic-memory/index.jsonl` violations, `.episodic-memory/patterns/_index.json` divergent registry) and the two homes DIVERGE without the flag. Fixture project lives OUTSIDE the fixture HOME; env sets both `HOME` and `USERPROFILE` (Windows). | R5a | `testHermeticHomeIsolation` (includes the no-flag divergence negative control) | MUST | Planner F4: a single-site fixture passes vacuously. Contract scope (planner F7/F9): "zero `$HOME` reads" means the script's OWN `fs` operations; `resolveLocalDir`'s git subprocess is outside the contract |
+| REQ-3 | `--hermetic` with explicit `--scope global` or `--scope all` exits 1 with `{"status":"error","message":"--hermetic is project-local only; omit --scope or pass --scope local"}`; with no explicit `--scope` the effective scope is `local`. | R5a | `testHermeticScopeConflict`, `testHermeticDefaultsLocal` | MUST | "explicit" = `argv.includes('--scope')` |
+| REQ-4 | `--hermetic --check` keeps the exit contract: exit 1 iff needs-attention + needs-enforcement > 0, else 0. Output JSON shape unchanged (`status/patterns/summary/warning?`). | R5a | `testHermeticCheckExit` | MUST | |
+| REQ-5 | Without `--hermetic`, behavior is byte-identical to today (all changes flag-gated), including the `~/.claude/hooks` scan and global-store reads. | R5a | `testNonHermeticUnchanged`; existing `tests/test-rfc002-phase2.mjs` stays green | MUST | Blast-radius rule: legacy path pinned by test, not assumed |
+| REQ-6 | `--has-enforcement <id>` override still honored under `--hermetic` (argv data, not a `$HOME` read). | R5a | `testHermeticHasEnforcementOverride` | MUST | |
+| REQ-7 | Prune never archives, in ANY mode (`--check` / `--dry-run` / real prune): (a) a violation named in a VALID referencing lesson's `evidence` array, or whose own `lessons` array names a valid lesson; (b) a valid lesson with non-empty `triggers`; (c) an id named in a valid episode's `consolidates` array. **Referencer validity (one predicate, all classes):** `status !== 'superseded'` (a MISSING status protects — the #447 hand-written class, planner F2) AND `review_by` absent/malformed/`>= today` (expiry lapses every class, RFC "lapses naturally" clause, planner F12). Aged (score < threshold) fixtures of all three classes survive. | R6 (fields defined in R1/R9) | `testEvidenceLinkedViolationSurvives`, `testViolationLessonsBacklinkSurvives`, `testTriggerBearingLessonSurvives`, `testConsolidatesMemberSurvives`, `testProtectedCountInOutput` (all-modes leg), `testMissingStatusReferencerProtects` | MUST | Protection computed once in the shared selection loop, before the mode branches (level-2 one-branch-only guard) |
+| REQ-8 | Protection lapses: the same class-a/b/c fixtures with the referencing episode `status: superseded`, or with valid `review_by < today`, become prunable again. | R6 | `testProtectionLapseOnSupersede`, `testExpiredTriggerLessonPrunable`, `testExpiredReferencerLapsesEvidence` | MUST | Lapse fires per the REQ-7 validity predicate uniformly, never per-class |
+| REQ-9 | Run records: among rows with `record_type === 'clerk-run'`, the lexicographically-greatest id PER STORE is protected; older run records age out under the normal score. | R6, R9/R10 (`record_type` typed scalar, never a tag) | `testLatestRunRecordSurvives` | MUST | Identification by `record_type` only; ids sort chronologically by construction |
+| REQ-10 | Supersession-chain closure: every id reachable from a class-a/b/c protected id via chain edges is protected while the anchor is. **Edges (planner F1): the ONLY writer-emitted edge is `supersedes` — forward edges are DERIVED by inverting the `supersedes` map over the union rows; `superseded_by` string fields are additionally honored when present (forward-compat with R9's P4 writes) but never relied on.** Transitive, cycle-safe via visited set. | R6; rationale R2 (chain-resolved effective-priority counting reads live index rows; an archived intermediate silently breaks the walk and demotes the earned band; planner probe PR1 archived a chain-mid row today) | `testChainMembersProtected` (includes cycle fixture + inverted-edge-only fixture with NO `superseded_by` field) | MUST | Design extension beyond R6's letter — flagged for the §19 review; fallback if rejected: direct refs only (§17) |
+| REQ-11 | Cross-store references protect: the reference scan loads BOTH stores' `index.jsonl` read-only regardless of `--scope`, and iterates the **UNION of all rows — no local-precedence id-dedupe** (planner F3: a stale local superseded copy must not shadow an active global referencer; an id is protected if ANY store's rows justify it). Missing/unreadable other-store index degrades to empty, never fatal. | R6 | `testCrossStoreProtection` (includes the shadowing-copy leg) | MUST | Real corpus shape: lessons global, violations local. Dedupe stays correct for SEARCH; it is wrong for protection |
+| REQ-12 | Malformed activation fields never crash and never protect: non-array `evidence`/`triggers`/`lessons`/`consolidates` ignored (non-string items skipped); malformed `review_by` treated as unexpired (protection-conservative). A malformed-`date` row (NaN score) survives prune — pinned as contract, no longer accidental (planner axis-4 probe: `NaN < threshold` is false). | R6; the #447 hand-written-row class | `testMalformedFieldsTolerated` (includes the NaN-date row) | MUST | Fail direction: tolerate + skip, matching read-tolerant matrix (R10c) |
+| REQ-13 | Output contract: every per-scope result gains `"protected": N` (count of below-threshold entries retained); `--dry-run` additionally lists `protected_episodes: [{id, score, reason, via}]` — reason ∈ `evidence-linked-violation` \| `trigger-bearing-lesson` \| `consolidates-member` \| `latest-run-record` \| `chain-member`, `via` = the protecting referencer episode id (self id for classes b/d) so prune starvation is diagnosable (planner F10). **Partition invariant (planner F5): `remaining` INCLUDES protected on all four surfaces (check / dry-run / real / the exit-code totals at em-prune.mjs:171): `rows = remaining + (pruned\|prunable)`, `remaining = kept + protected`.** `--check`'s prunable count and exit code exclude protected. Existing fields unchanged (consumers pin only `prunable/pruned/remaining`: tests/test-phase2.mjs:301-346). | R6 | `testProtectedCountInOutput` (asserts the partition in all three modes) | MUST | First-match reason precedence in the order listed |
+| REQ-14 | Docs ship in the same PR: `--hermetic` and the protection set documented in `docs/EM_SCRIPTS_GUIDE.md` (grep-gated), README script table row updated, `instructions/SKILL.md` untouched unless a listed flag table exists (verified: none). | RFC-009 "Documentation deliverable (every phase, normative)" | `testDocsGrepGate` (grep `EM_SCRIPTS_GUIDE.md` for `--hermetic` and `protected_episodes`) | MUST | Docs drift is CI-caught, not review-caught |
+| REQ-15 | Both new test files run in CI as explicit steps in `.github/workflows/plan-marker-validate.yml` (runs on every PR — no paths filter, by design per its header). | Rule 13; check-actual-CI memory | `manual: gh pr checks <PR>` shows the two steps | MUST | Curated-list workflow: unwired = never runs (see §17 for the pre-existing unwired-tests finding) |
+
+## §5 Non-Goals
+
+- R5b: the CI job + SessionStart advisory wiring for `--hermetic --check` (Phase 3).
+- R1 write-surface flags (`--trigger`, `--evidence`, `--lesson`, …) — Phase 1. P0 fixtures hand-plant index rows.
+- `em-trigger-index.mjs`, the `session_start` static blend, effective-priority computation — Phase 1. P0 only PRESERVES the rows those need.
+- Any change to the prune SCORE formula (RFC: "Prune SCORING stays unchanged").
+- Any change to `em-pattern-health` behavior without the flag (byte-identical legacy path).
+- Run-record WRITING (Phase 4); P0 only protects planted ones.
+- Consuming `last_accessed` in ranking (the blend half of R6 lands with R2 in P1).
+
+## §6 Token Budget (Rule 12)
+
+| File | `wc -l` | Reads (lines × ~5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/em-pattern-health.mjs` | 373 | ~1.9k | ~1k | flag + path-set gating |
+| `scripts/em-prune.mjs` | 178 | ~0.9k | ~2k | protection scan + output fields |
+| `tests/test-pattern-health-hermetic.mjs` | new | — | ~3k | ~8 tests |
+| `tests/test-prune-protection.mjs` | new | — | ~4k | ~11 tests |
+| `docs/EM_SCRIPTS_GUIDE.md` | 436 | ~0.5k (sections only) | ~0.5k | two script sections |
+| `README.md` | 631 | ~0.3k (table only) | ~0.2k | one row touch |
+| `.github/workflows/plan-marker-validate.yml` | ~185 | ~0.3k | ~0.2k | two steps |
+| this plan + RFC section re-reads | — | ~4k | — | |
+
+**Baseline (single session):** ~38k overhead + ~19k above + test-run/iteration slack ≈ **65-75k** — inside the 60-130k sweet spot; one PR, one session as the RFC sizing table states.
+**Optimized:** same (no split warranted).
+
+## §7 Safety / Security
+
+`negative-scenario-planner` ran on this design 2026-07-06: verdict **HOLD**, 3 design-level fail-opens (F1 phantom `superseded_by` edge, F2 over-strict ACTIVE predicate, F3 wrong cross-store dedupe) + 4 fixture-vacuity/contract findings (F4/F5/F10/F11) — ALL merged into §4/§12/§13/§14 (dispositions in §19.1). Planner probes preserved at the session scratchpad (`fix1`, `fix2`, `fix2-real`, `probe*.mjs`) for reuse as regression fixtures. Boundary check F14 PASS: both deliverables data-plane; no gate/marker/decision surface (RFC-008 R1, P12, CAPABILITIES). No new path-authority predicates (no realpath/lstat/isMain logic added; store resolution stays `resolveLocalDir`, already worktree-tested by `tests/test-em-local-dir-worktree.mjs`), so the 8-axis symlink matrix is not re-enumerated; the linked-worktree binding row is inherited via the existing lib.
+
+| Concern | Severity | Attack/abuse scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| Hermetic fail-open | High | `--hermetic` still reads `$HOME` via a missed path (patterns fallback, enforcement row, global store) → CI trusts a non-hermetic verdict in P3 | Single flag-gated path-set construction (one branch point per path set, §8.2 I2); acceptance fixture uses DIVERGENT homes | `testHermeticHomeIsolation` — negative control: same fixture WITHOUT the flag must diverge, proving the fixture would catch a leak |
+| Silent knowledge loss (prune) | High | Aged evidence-linked violation archived → earned band silently demotes at next R2 build (P1) | Protection set computed in the one shared selection loop; below-threshold protected entries retained in all modes | All REQ-7/8/9/10/11 tests; negative: `testProtectionLapseOnSupersede` proves the guard can go red (prunes when protection genuinely lapses) |
+| One-branch-only protection (level-2) | Med | Protection applied in `--dry-run` but not real prune (or vice versa) | Selection (score + protection) happens once, before `checkOnly`/`dryRun` branches | `testProtectedCountInOutput` — runs all three modes on identical fixtures, asserts identical partition counts |
+| Prune starvation (fail-closed abuse) | Med | A crafted row (self-referencing evidence, giant `consolidates`) protects everything forever | Protection requires the REFERENCING episode active; lapse-on-supersede keeps it reversible; `protected` count + `protected_episodes` reasons make retention visible, never silent | `testProtectedCountInOutput`; `testMalformedFieldsTolerated` (cycle fixture in `testChainMembersProtected` proves the walk terminates) |
+| Output-contract drift | Med | New JSON fields break existing consumers | Additive fields only; existing keys byte-compatible. Invocation-site sweep 2026-07-06: `grep -rn "em-prune" --include="*.mjs" --include="*.sh"` over scripts/, plugins/, .claude/hooks/, docs/ → consumers are docs + `em-session-end-prompt` advisory text (no JSON field parsing beyond `status`) — re-verify at impl time (§15 row) | `testProtectedCountInOutput` asserts existing fields untouched |
+| Enforcement leak into substrate | High (boundary) | Protection styled as a gate (blocking write, marker) | Protection is data-retention only: no exit-code change except the existing `--check` semantics, no marker, no hook | Code review checklist row; RFC-008 R1 / CAPABILITIES boundary cited in §19 dispatch body |
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/**
+ * @typedef {Object} ProtectedEntry
+ * @property {string} id — episode id
+ * @property {number} score — computed prune score (below threshold)
+ * @property {string} reason — 'evidence-linked-violation' | 'trigger-bearing-lesson'
+ *   | 'consolidates-member' | 'latest-run-record' | 'chain-member' (first match wins,
+ *   in that precedence order)
+ */
+// Zero-dep Node ESM; no new modules — both changes live inside the existing scripts.
+```
+
+### 8.2 Key invariants
+
+- **I1 (R5a):** under `--hermetic`, no `fs` call uses a `HOME`-DERIVED path (`GLOBAL_DIR`, the `$HOME` patterns fallback, `~/.claude/hooks`); project-root paths are allowed even when the project physically resides under `$HOME` (as this repo does). Enforced structurally: every `HOME`-derived path lives in exactly one of three constructs (SCOPE_DIRS, patterns candidates, ENFORCEMENT_PATHS), each built once behind the flag.
+- **I2 (R5a):** flag-off path-set construction is token-identical to current main (blast radius zero).
+- **I3 (R6):** protection is decided in the single entry-selection loop shared by check/dry-run/prune; mode branches only FORMAT the already-decided sets.
+- **I4 (R6):** protection never mutates rows or files; it only moves entries from `toPrune` to `toKeep` + counts them.
+- **Cross-platform:** `path.join` everywhere; date comparisons on `YYYY-MM-DD` strings (UTC, matching em-store's contract); no shell, no GNU flags.
+- **Atomicity:** unchanged — index rewrite stays temp+rename (existing code).
+
+### 8.3 Resolution / flow
+
+```text
+em-pattern-health --hermetic:
+  parse flags → conflict check (REQ-3) → effective scope = local
+  → SCOPE_DIRS = [LOCAL_DIR] ; patterns = [LOCAL_DIR/patterns, PROJECT_ROOT/patterns]
+  → ENFORCEMENT_PATHS = project trio (PROJECT_ROOT-based)
+  → existing count/detect/classify/output pipeline unchanged
+
+em-prune (all modes):
+  load prune-target store rows (existing)
+  → load BOTH stores' rows read-only (reference scan input: UNION, no id-dedupe — any row can justify protection)
+  → protectedIds = computeProtectedIds(referenceRows, today)
+  → selection loop: score < threshold ? (protected ? keep+count : prune) : keep
+  → mode branches format {check|dry-run|prune} from the decided sets
+```
+
+## §9 Existing Hook Points
+
+Line numbers verified 2026-07-06 on `eb6ac0a`.
+
+| File | Line(s) | What it does today | Impact of this change |
+|---|---|---|---|
+| `scripts/em-pattern-health.mjs` | 24-27 | `HOME`/`GLOBAL_DIR`/`LOCAL_DIR` consts | add `PROJECT_ROOT`, `hermeticMode` nearby |
+| | 35 | `--help` usage string | add `[--hermetic]` |
+| | 64-71 | flag parsing block | add hermetic + explicit-scope detection |
+| | 73-89 | scope/mode validation | add REQ-3 conflict error |
+| | 94-106 | `loadPatternsIndex()` candidates `[CWD, $HOME]` | hermetic candidate list |
+| | 122-124 | `SCOPE_DIRS` push local/global | effective-scope forcing covers it (no structural edit) |
+| | 263-268 | `ENFORCEMENT_PATHS` incl. `~/.claude/hooks` | hermetic project-trio variant |
+| `scripts/em-prune.mjs` | 29-30 | store dirs | reused by reference scan |
+| | 35 | `--help` usage string | add protection note |
+| | 55-62 | `computePruneScore` | untouched (RFC: scoring unchanged) |
+| | 83-98 | `pruneDir` load + selection loop | protection decision point (I3) |
+| | 100-113 | check/dry-run formatting | add `protected` / `protected_episodes` |
+| | 167-175 | scope loop + exit | pass protectedIds in; totals unchanged semantics |
+| `.github/workflows/plan-marker-validate.yml` | steps list end | curated CI battery, runs on every PR | append two test steps |
+| `docs/EM_SCRIPTS_GUIDE.md` | em-pattern-health + em-prune sections | per-script usage guide (#450) | document flag + protection + new fields |
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Key deliverables | Tests | Hard stops (do NOT do in this slice) |
+|---|---|---|---|---|---|
+| `P0-S1` | R5a `--hermetic` | `scripts/em-pattern-health.mjs`, `tests/test-pattern-health-hermetic.mjs` | flag, conflict error, hermetic path sets | R5 group (8) | no prune changes; no CI/doc edits |
+| `P0-S2` | R6 protection set | `scripts/em-prune.mjs`, `tests/test-prune-protection.mjs` | protected-id scan, selection-loop integration, output fields | R6 group (13) | no scoring change; no pattern-health edits |
+| `P0-S3` | Docs + CI wiring | `docs/EM_SCRIPTS_GUIDE.md`, `README.md`, `.github/workflows/plan-marker-validate.yml` | guide sections, README row, two CI steps, docs-grep gate | `testDocsGrepGate` + `gh pr checks` | no script edits |
+
+### 10.1 Dependency graph
+
+```text
+S1 ── S3
+S2 ── S3   (S1 ∥ S2 independent; S3 last)
+```
+
+## §11 Cut Order
+
+1. `testDocsGrepGate` as a standalone test (fold the grep into §15 manual ledger row instead) — only under severe context pressure; the guide edits themselves are NOT cuttable (normative RFC deliverable).
+2. REQ-10 chain closure (downgrade to direct refs + tracked issue) — only if §19 review rejects the design extension.
+
+Do **not** cut:
+
+- REQ-2 isolated-HOME fixture (the RFC acceptance gate for P0).
+- REQ-7/8 protection + lapse (the R6 acceptance rows).
+- REQ-5 flag-off byte-identity (blast radius).
+- Same-PR docs (RFC normative clause).
+
+## §12 Contracts
+
+### `resolveHermeticConfig(argv) → {hermetic, scope} | error` (inline logic, not a named export)
+
+**Input contract:** process argv after `--help` short-circuit.
+**Output contract:** effective scope + hermetic bit, or error JSON + exit 1 (fail closed on conflict).
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. no flag | `!argv.includes('--hermetic')` | hermetic=false, scope as today (`--scope` or `'all'`) | none |
+| B. flag, no explicit scope | flag set, `!argv.includes('--scope')` | hermetic=true, scope=`'local'` | none |
+| C. flag + `--scope local` | both | hermetic=true, scope=`'local'` | none |
+| D. flag + `--scope global`\|`all` | both | error JSON (REQ-3 message), exit 1 | none |
+| E. flag + `--scope <invalid>` | both | existing invalid-scope error wins (checked first, unchanged order) | none |
+
+### `loadPatternsIndex() → patterns[] | null` (modified)
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. hermetic, local registry | `<LOCAL_DIR>/patterns/_index.json` parses with `patterns[]` | that array | none |
+| B. hermetic, project registry | A absent/invalid, `<PROJECT_ROOT>/patterns/_index.json` valid | that array | none |
+| C. hermetic, neither | both absent/invalid | `null` → existing error message path (message text extended to name searched paths) | exit 1 |
+| D. non-hermetic | flag off | today's `[CWD, $HOME]` candidates, byte-identical | none |
+
+### `computeProtectedIds(referenceRows, todayStr) → Map<id, {reason, via}>`
+
+**Input contract:** the UNION of index rows from BOTH stores (each tagged `_store: 'local'|'global'`; NO id-dedupe — planner F3); `todayStr` = `YYYY-MM-DD` UTC.
+**Output contract:** Map; never throws on malformed rows; reasons per REQ-13 precedence; `via` = protecting referencer id.
+
+**Referencer validity predicate `isValidReferencer(row, todayStr)` (one predicate, every class — planner F2/F12):** `row.status !== 'superseded'` AND (`row.review_by` absent, non-string, not `^\d{4}-\d{2}-\d{2}$`, or `>= todayStr`). A row with NO status field is valid (the #447 tolerated-writer class).
+
+**State table (exhaustive):**
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. evidence forward-link | row `category==='lesson'` + valid referencer, `Array.isArray(evidence)` | each string item → `evidence-linked-violation`, via=row.id | none |
+| B. violation back-link | row `category==='violation'` with `Array.isArray(lessons)`, any listed id resolving (in ANY store's rows) to a `category==='lesson'` valid-referencer row | row's own id → `evidence-linked-violation`, via=the matching lesson id | none |
+| C. trigger-bearing | row `category==='lesson'` + valid referencer + `Array.isArray(triggers) && triggers.filter(t => typeof t === 'string').length > 0` | own id → `trigger-bearing-lesson`, via=own id | none |
+| D. expired/superseded referencer | any A/B/C/E shape whose referencer fails the validity predicate | contributes nothing (lapse — may still protect via another valid referencer) | none |
+| E. consolidates member | any valid-referencer row with `Array.isArray(consolidates)` | each string item → `consolidates-member`, via=row.id | none |
+| F. latest run record | rows with `record_type==='clerk-run'` AND a string `id`, grouped by `_store`: lexicographically greatest id per group (ids are unique by construction; rows without `id` skipped) | that id → `latest-run-record`, via=own id | none |
+| G. older run record | non-max clerk-run rows | not protected | none |
+| H. chain closure | ids reachable from any A/B/C/E-protected id via: (1) the row's own `supersedes` string, (2) DERIVED forward edges from inverting the `supersedes` map over the union rows, (3) `superseded_by` strings when present (never relied on — planner F1); transitive, visited-set cycle guard | each new id → `chain-member`, via=the anchor protected id | none |
+| I. malformed fields | `evidence`/`lessons`/`triggers`/`consolidates` present but non-array; array items non-string | field ignored (items skipped) | none |
+| J. duplicate id across stores | same id in both stores with conflicting rows | BOTH rows scanned (union semantics); protected if EITHER justifies it | none |
+
+**Error codes:** none — the function is total; unreadable other-store index upstream degrades to `[]` (REQ-11 fail direction: a broken reference source must not make prune fatal, and under-protection is surfaced by the `protected` count dropping, caught by fixtures).
+
+### `pruneDir(dataDir, label, protectedIds)` (modified)
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. score ≥ threshold | any entry | toKeep (unchanged) | none |
+| B. score < threshold, unprotected | id not in map | toPrune (unchanged) | archive on real prune |
+| C. score < threshold, protected | id in map | toKeep + protected list entry `{id, score, reason}` | none — never archived, any mode |
+| D. check mode | after selection | `{scope, prunable, remaining, protected}` | none |
+| E. dry-run | after selection | D + `episodes` preview + `protected_episodes` | none |
+| F. real prune | after selection | existing result + `protected` | archives only set B |
+
+## §13 Edge Cases
+
+| # | Scenario | Expected behavior | Test |
+|---|---|---|---|
+| EC1 | empty/missing index.jsonl in either store | reference scan sees `[]`; prune result unchanged from today | `testCrossStoreProtection` (missing-global leg) |
+| EC2 | non-git fixture cwd (resolveLocalDir cwd-fallback) | PROJECT_ROOT = cwd; hermetic paths resolve inside fixture | all hermetic tests run in non-git fixtures |
+| EC3 | concurrent store append during prune | existing documented race, unchanged by this diff | n/a (documented limitation, em-prune.mjs:156-158) |
+| EC4 | supersession cycle (A supersedes B, B superseded_by A) | closure walk terminates via visited set | `testChainMembersProtected` (cycle fixture) |
+| EC5 | duplicate id across stores | UNION semantics — both rows scanned, no id-dedupe; protection holds if EITHER row justifies it (§12-J) | `testCrossStoreProtection` |
+| EC6 | validate-then-write ordering | protection decided before any archive/rename side effect (I3) | `testProtectedCountInOutput` |
+| EC7 | evidence names a nonexistent id | id enters the map; harmless (nothing to retain); no crash | `testMalformedFieldsTolerated` |
+| EC8 | `--hermetic` + `--pattern <unknown>` | existing unknown-pattern error path unchanged | covered by `testNonHermeticUnchanged` shape assertions |
+| EC9 | hand-written row with no `category` | skipped by class predicates, scored normally; a no-STATUS row is a VALID referencer (REQ-7) | `testMissingStatusReferencerProtects` |
+| EC10 | hermetic run from a repo SUBDIRECTORY | PROJECT_ROOT-based candidates hold (intended improvement over the CWD-based legacy candidate — pinned, not accidental; planner #20) | `testHermeticPatternsProjectOnly` (subdir leg) |
+| EC11 | malformed-`date` row (NaN score) | survives prune in all modes (`NaN < threshold` false) — pinned as contract | `testMalformedFieldsTolerated` (NaN-date row) |
+| EC12 | stale superseded copy of a referencer in one store, active row in the other | union semantics: protection holds (no shadowing) | `testCrossStoreProtection` (shadowing leg) |
+
+## §14 Test Case Catalog
+
+```text
+Group R5 — tests/test-pattern-health-hermetic.mjs (8 tests)
+  testHermeticHomeIsolation — populated vs empty HOME byte-identical under --hermetic; DIVERGES without the flag (negative control)
+  testHermeticScopeConflict — --hermetic --scope all → exit 1 + REQ-3 message; --scope global likewise
+  testHermeticDefaultsLocal — no --scope: global fixture violation absent from counts
+  testHermeticPatternsProjectOnly — divergent $HOME patterns registry not read; LOCAL_DIR beats PROJECT_ROOT registry; subdir-cwd leg pins PROJECT_ROOT-based resolution (EC10)
+  testHermeticEnforcementProjectOnly — fake-HOME hook not detected; project .claude/hooks hook detected
+  testHermeticCheckExit — 3-violation no-enforcement fixture: --hermetic --check exit 1; healthy fixture exit 0
+  testHermeticHasEnforcementOverride — override flips has_enforcement true under --hermetic
+  testNonHermeticUnchanged — without flag: fake-HOME hook detected + scope-all counts global store (pins legacy)
+
+Group R6 — tests/test-prune-protection.mjs (13 tests)
+  testEvidenceLinkedViolationSurvives — aged violation + valid lesson evidence link survives dry-run AND real prune
+  testViolationLessonsBacklinkSurvives — violation.lessons → valid lesson id protects the violation
+  testTriggerBearingLessonSurvives — aged valid lesson with triggers survives
+  testConsolidatesMemberSurvives — aged member named in valid row's consolidates survives; lapse leg: superseded consolidating referencer → member prunable (class-c lapse, codex r2)
+  testMissingStatusReferencerProtects — referencer row WITHOUT a status field still protects (planner F2; #447 class)
+  testProtectionLapseOnSupersede — same fixtures, referencing lesson status superseded → archived (guard goes RED)
+  testExpiredTriggerLessonPrunable — review_by past → class-b lapses
+  testExpiredReferencerLapsesEvidence — expired referencing lesson lapses class-a protection of its evidence (planner F12)
+  testLatestRunRecordSurvives — newest clerk-run row (max id per store) survives, older one archived; idless clerk-run row skipped
+  testChainMembersProtected — intermediate revision with NO superseded_by field survives via INVERTED supersedes edges (planner F1); cycle fixture terminates
+  testCrossStoreProtection — global lesson evidence protects local violation under --scope local; missing global index degrades clean; stale local superseded copy does NOT shadow the active global referencer (planner F3)
+  testMalformedFieldsTolerated — string evidence / numeric triggers / no-category row / NaN-date row: no crash, malformed fields don't protect, NaN-date row survives (pinned)
+  testProtectedCountInOutput — protected count + partition invariant (remaining = kept + protected) in all three modes; protected_episodes {id, score, reason, via}; --check exit excludes protected; existing fields unchanged
+
+Group docs (1 test, S3)
+  testDocsGrepGate — EM_SCRIPTS_GUIDE.md contains `--hermetic` and `protected_episodes`
+```
+
+Total: 22 tests. Runners: `node tests/test-pattern-health-hermetic.mjs`, `node tests/test-prune-protection.mjs` (each prints `N/N pass`, exit non-zero on failure; docs grep folded into the prune test file as its final case to avoid a third CI step — named separately here for traceability).
+
+All fixtures are isolated non-git scratch dirs + controlled `HOME` env, driving the REAL scripts via `spawnSync` with explicit `cwd` (behavior-simulation convention; no mental-trace, no stubs).
+
+## §15 Verification Ledger (verify by artifact)
+
+| Claim | Command (the strong-layer one) | Observed artifact |
+|---|---|---|
+| R5 group passes | `node tests/test-pattern-health-hermetic.mjs` | _fill at impl_ |
+| R6 group passes | `node tests/test-prune-protection.mjs` | _fill at impl_ |
+| Legacy suite green | `node tests/test-rfc002-phase2.mjs` (existing pattern-health coverage) | _fill at impl_ |
+| Hermetic acceptance (RFC gate) | re-run §3 probes A-D with `--hermetic`: A≡B, C rejected | _fill at impl_ |
+| Prune protection live | re-run §3 probe E post-impl: 3 protected, 0 prunable, reasons listed | _fill at impl_ |
+| No `$HOME` token behind the flag | reading pass over the two hermetic path-set constructs + broad-token `grep -n "HOME" scripts/em-pattern-health.mjs` disposition list | _fill at impl_ |
+| em-prune consumers unaffected | `grep -rn "em-prune" scripts plugins .claude/hooks docs` → per-site disposition | _fill at impl_ |
+| CI green | `gh pr checks <PR>` (never a local proxy) | _fill at impl_ |
+| Docs gate | grep `EM_SCRIPTS_GUIDE.md` for `--hermetic`, `protected_episodes` | _fill at impl_ |
+| Merged | `gh pr view <n> --json state,mergeCommit` | _fill at merge_ |
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Flag-off regression in pattern-health | High | Low | I2 token-identical construction; `testNonHermeticUnchanged`; existing rfc002 tests |
+| Protection misses a class spelling and knowledge is lost later | High | Med | Fixtures per class + lapse negatives; §19 hands codex the full equivalence class (invariant + matrix), not one spelling |
+| Prune starvation via crafted rows | Med | Low | visibility (`protected` count + reasons); lapse-on-supersede reversibility |
+| Chain-closure REQ-10 rejected in review | Low | Med | isolated slice-step; fallback direct-refs + issue (§17) |
+| plan-marker-validate.yml battery grows unrelated to its name | Low | High | accepted repo precedent (general battery already lives there); noted for a future workflow-split issue |
+
+## §17 Open Decisions
+
+- **Pre-existing unwired tests** (`test-em-help-flags.mjs`, `test-em-sort-missing-datetime.mjs`, `test-install-scripts-guide.mjs` absent from every workflow — grep 2026-07-06) → deferred to a GitHub issue filed at PR time, not this diff. 5-field DEFER: (1) repro = the workflow grep above, they never run in CI; (2) spec: no RFC row requires them wired (Rule 13 is the driver — advisory); (3) history: check-actual-CI memory 2026-07-01, same class; (4) same-class: THIS plan's tests are wired (REQ-15), closing the class going forward; (5) residual: regressions in those three surfaces reach main silently until wired — graceful (test files still runnable locally). Issue to cite all three files.
+- **REQ-10 chain closure** — decided IN (rationale in REQ-10); planner axis-6 probe PR1 confirmed the break class live; revisit only on §19 HOLD; fallback documented in §11.
+- **DEFER (planner DEFER-1): scan-to-archive race** — a lesson stored between the protection scan and the archive rename protects one run late. (1) repro: feasible two-child spawn, same class as the documented append race at `em-prune.mjs:156-158`; (2) spec: R6 silent on concurrency, script self-documents "maintenance operation, not a hot path"; (3) history: `reference_codex_concurrency_review_methodology` (PR #313) — no prune-specific prior; (4) same-class: archived-index append race + tags.json rewrite race, both documented-known; resolution extends that comment to name the protection scan (step 2.4); (5) residual: one-run protection miss, recoverable via `em-restore`/archived-index (file moved, not deleted). No issue needed — documented limitation class.
+- **DEFER (planner DEFER-2, F6): `em-recall`'s duplicated prune score (`em-recall.mjs:479-489`) ignores protection** — its `prune_suggestion` overcounts. (1) repro: planner probe observed `"11 episodes below threshold"` where post-P0 prune archives fewer; (2) spec: R6 changes prune, not em-recall; the suggestion routes operators to `--dry-run`, which post-P0 shows the truth; (3) history: none; (4) same-class: the only other score copy (grep `computePruneScore`); (5) residual: advisory overcount only, zero data loss. → GitHub issue filed at PR time (step 9).
+- **`<LOCAL_DIR>/patterns/_index.json` (hermetic candidate 1) has no writer or schema validator** (planner #22). Kept per the RFC's explicit "local patterns registry" wording; read guard is the existing `Array.isArray(data.patterns)` check; drift ownership recorded as a #448-family cell in the issue above's body.
+
+## §18 Done Criteria
+
+- [ ] All 22 §14 tests pass (artifact in §15).
+- [ ] §15 ledger fully populated with observed output.
+- [ ] RFC-009 P0 checklist rows marked done in the RFC's Implementation table in the same PR (Rule 10: never batch).
+- [ ] Workplan episode revised to v163 (P0 shipped) after merge.
+- [ ] Every deferred finding has an issue/comment/violation artifact (Rule 18 step 9; §17 issue filed).
+
+## §19 Review Consensus (Rule 18)
+
+Second-opinion review: codex, interactive cmux (standing directive 2026-06-28; cmux driver `~/.claude/cmux-drive.sh`), fallback `codex-drive.sh` tmux then the one-shot harness. Dispatch body hands off the complete bug-class: the I1-I4 invariants, the §12 state tables, the §13 matrix, FP controls (fixtures that must STAY green), and the refactor boundary (scoring formula and non-hermetic path untouchable); requires findings grounded in R5a/R6/R2 and P-numbers; requires runtime probes for behavior claims.
+
+| Pass | Reviewer | Provider/Model | Blocker count | Verdict (ACCEPT/HOLD/REJECT) | Reply episode |
+|---|---|---|---|---|---|
+| 0 | negative-scenario-planner (pre-§7) | claude subagent | 3 (F1/F2/F3) | HOLD → all merged | n/a (inline dispatch; findings merged 2026-07-06, table below) |
+| 1 | codex (cmux interactive) | gpt-5.5 high | 0 BLOCKER, 2 MAJOR + 1 MINOR | HOLD (ran against the mid-rewrite plan; findings subsumed by r2) | n/a (cmux transcript) |
+| 2 | codex (cmux interactive) | gpt-5.5 high | 0 BLOCKER, 2 MAJOR + 2 MINOR | HOLD → all 4 fixed (r2-F1 §8.3/EC5 union wording; r2-F2 class-c lapse leg; r2-F3 I1 reword; r2-F4 §18 count). Positive evidence: codex instantiated the fenced artifacts in a temp copy — S1 tests 8/8, S2 tests 13/13; all anchors unique | n/a (cmux transcript) |
+| 3 | codex (cmux interactive) | gpt-5.5 high | 0 | ACCEPT — all r2 fixes verified at file:line + runtime probe re-run (temp-copy S1 8/8, S2 13/13 incl. the class-c lapse leg) | n/a (cmux transcript, 2026-07-06) |
+
+### 19.1 Resolved blockers
+
+| # | Blocker (cite R-number) | Verdict (ACCEPT/MODIFY/REJECT/DEFER) | Resolution + evidence |
+|---|---|---|---|
+| F1 | `superseded_by` is writer-phantom; one-direction walk breaks R2 chain rationale (R6/R2) | ACCEPT | REQ-10/§12-H: invert `supersedes` over union rows; honor `superseded_by` only as bonus; inverted-edge-only fixture |
+| F2 | `status === 'active'` un-protects missing-status rows (R6, #447 class) | ACCEPT | REQ-7 validity predicate `status !== 'superseded'`; `testMissingStatusReferencerProtects` |
+| F3 | local-precedence dedupe shadows active global referencers (R6) | ACCEPT | REQ-11 union semantics; shadowing leg in `testCrossStoreProtection` |
+| F4 | single-site HOME fixture passes vacuously (R5a acceptance) | ACCEPT | REQ-2 three-site populated HOME + no-flag divergence control |
+| F5 | `remaining` membership of protected rows undefined across 4 surfaces (R6) | ACCEPT | REQ-13 partition invariant, asserted per mode |
+| F10 | starvation invisible without referencer id (R6/P4) | ACCEPT WITH MODIFICATION | `via` field added; reason enum unchanged |
+| F11 | cycle hang + clerk-run ordering undefined (R6/P6) | ACCEPT | visited set + cycle fixture (already designed); max-id-per-store rule + idless-row skip pinned in §12-F |
+| F12 | class-a protected evidence of EXPIRED lessons, diverging from RFC lapse clause (R6) | ACCEPT | folded into the uniform REQ-7 validity predicate; `testExpiredReferencerLapsesEvidence` |
+| F7/F9 | contract wording: $HOME-containing PROJECT_ROOT; git subprocess reads | ACCEPT (prescription) / NEEDS EVIDENCE (git diagnosis, not probed — wording sidesteps it) | REQ-2 note: contract = the script's OWN fs ops; fixture project outside fixture HOME |
+| F13 | scope-branch enumeration | ACCEPT | `testHermeticScopeConflict` legs: explicit global/all/local, absent, invalid-scope ordering |
+| F14 | enforcement-boundary check | PASS (no change) | watch item already §5 non-goal (R5b is P3) |
+
+Cap at 2 codex rounds (stopping rule); a 3rd same-class HOLD = boundary redesign, not respelling.
+
+## §20 Lessons Encoded (traceability — do not re-learn)
+
+| Lesson (episode / memory) | One-line rule | Enforced in |
+|---|---|---|
+| behavior-simulation (2026-07-05) | runtime probes before design claims; static reading is hypothesis | §3 probes, §14 real-script fixtures, §19 dispatch body |
+| `…9ac4` governing-artifact consult | PRINCIPLES + CAPABILITIES + em-* disposition before design | §5/§7 boundary rows; disposition table lives in RFC-009 itself (checked current) |
+| verify-the-strong-claim `…7918` | E2E = real scripts on real fixtures; CI = `gh pr checks` | §15 |
+| `…540d` unfiltered audit | broad-token grep + reading pass, not phrase greps | §15 `$HOME` row |
+| canonical-agent dispatch | planner BEFORE self-walk on §7 | §7 header |
+| handoff-complete-bug-class | invariant + matrix + FP controls + boundary to codex | §19 |
+| bp1 step-9 5-field DEFER | every defer carries 5 fields + issue | §17 |
+| check-actual-CI (2026-07-01) | wire tests into the curated workflow; verify with `gh pr checks` | REQ-15, §15 |
+| #447 hand-written row crash | malformed index rows tolerated everywhere | REQ-12, EC9 |
+| mock/fixture not mental-trace | isolated fixture stores + controlled HOME | §14 |
+
+---
+
+# Appendix A: Mechanical Execution Spec (for a low-capability executor)
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value for this plan |
+|---|---|
+| Language / runtime | Node.js 20+, `.mjs` ESM, zero deps |
+| Runtime check (§A.4 row) | `node --version` → `v20` or higher |
+| Test-runner shape | `node tests/test-pattern-health-hermetic.mjs` / `node tests/test-prune-protection.mjs` |
+| New-function phrasing (§A.6) | top-level `function name(args)` (scripts are single-file CLIs; nothing exported) |
+| Portable break-input override (§A.6b, §A.9) | negative controls are FIXTURE-DRIVEN: each red-run row invokes the same test file against a fixture variant the test itself builds (e.g. the lapse fixtures); no env-prefix needed |
+| Search tool for verifies | `grep -n` / `grep -c` from the repo root |
+| Repo-specific done-commands (§A.8) | n/a — no hooks/patterns deployed by this PR (scripts deploy via `install.mjs` at operator's post-merge step per deploy-after-merge memory) |
+
+## A.1 Forbidden-phrase lint
+
+Run before marking ready; template-quoted phrases in §0.2/§A.1 excluded per the acceptance rule. Disposition recorded beside the run in §15 at finalization.
+
+## A.2 Executor contract
+
+1. Do the steps **in numeric order**. Do not skip, reorder, or batch.
+2. Each step names exactly which file, the exact change, and how to verify it.
+3. **Make no design decisions.** If a step is ambiguous, or the anchor text is not found
+   **verbatim**, **STOP and ask** (§A.3) — do not guess, invent, or pick "the closest match".
+4. Run the verify command after each step. If it fails, fix **only that step**; do not proceed
+   until it is green.
+5. **Edit exactly ONE file per step** — the single file named in that step's `File` column. If a
+   change spans two files, it is split into two consecutive numbered steps, one file each.
+   Read-only references (look, never edit): `scripts/lib/local-dir.mjs`, `docs/rfcs/RFC-009-lesson-activation.md`,
+   `docs/PLAN_TEMPLATE.md`, and in S2 additionally `scripts/em-pattern-health.mjs` (dedupe/loadIndex precedent).
+6. Run no command outside the per-step verify commands and the slice test command. **Each
+   verify command is a single command** — no `;`, `&&`, `||`, pipes, or subshells (this
+   repo's `compound-bash-gate` hard-blocks them; limit output with Read/Grep, not `cmd | head`).
+7. One slice = one commit, message `P0-S<n>: <slice title>`, ending with the required
+   `Co-Authored-By` trailer for the active tool.
+8. Do not commit, push, or open a PR unless the plan's §18 Done Criteria for the slice are
+   green **and** the human has approved.
+9. **No aspirational output.** Every human-readable string a step emits that *describes a check*
+   (an `echo`/`log` line, a comment, a heredoc banner) MUST be backed by an assertion that actually
+   performs that check. A descriptive line with no backing assertion is a bug — it makes a stub read
+   as coverage. If you cannot assert it, do not announce it.
+
+## A.3 STOP-and-ask protocol
+
+When a step is ambiguous or an anchor is missing, emit exactly this and halt:
+
+```text
+STOP — step <n.m> blocked.
+Reason: <anchor not found | ambiguous instruction | verify failed after fix>.
+File: <path>
+Expected anchor (verbatim): <text>
+What I found instead: <actual surrounding text, ±3 lines>
+Question: <the single decision the plan owner must make>
+```
+
+Do not continue to step `<n.(m+1)>` until answered.
+
+## A.4 Pre-flight (step 0 of every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| Branch | `git branch --show-current` | `feat/rfc-009-p0` |
+| Clean tree | `git status --porcelain` | empty (untracked session files aside — STOP if tracked files dirty) |
+| Baseline green | `node tests/test-rfc002-phase2.mjs` | all pass |
+| Runtime | `node --version` | `v20+` |
+
+## A.5 Shared constants
+
+None new beyond literals spelled in the steps (REQ-3 error message, reason strings, `record_type` literal `'clerk-run'`).
+
+## A.6 Anchor format (how to read the "Exact action" column)
+
+- **ANCHOR:** a verbatim, unique substring already present in the file. If it is not unique or
+  not present, STOP (§A.3). Never anchor on a line number alone — line numbers drift (the §9
+  line numbers are orientation, not anchors).
+- **Literal change** — exact error strings, field names, numeric bounds, and regex are spelled
+  out in the step or §12; `"--hermetic is project-local only; omit --scope or pass --scope local"`,
+  not "an error message".
+- **Delete/replace** — the step quotes the exact `old` span and exact `new` content.
+
+**Three action kinds — every §A.7 step is labeled:**
+- **CREATE** — whole-file `Write` of a brand-new file (its own step). The **only** place a whole-file
+  write is allowed.
+- **EDIT** — anchored `ANCHOR → REPLACE` on existing content: change only that span. Never rewrite a
+  whole function, never reflow/reformat untouched lines, never `Write`-overwrite an existing file.
+- **APPEND** — add a new function/block (surgical: adds, changes nothing existing), including
+  additions to a file `CREATE`-d earlier in the same slice.
+
+## A.6b Falsifiable Verify
+
+Every step's Verify MUST **fail if the step's intent is absent or stubbed** — visible in the
+command itself, not asserted in prose.
+
+**Verify deny-list — any of these is a planning bug:**
+- tolerant exit-code comparison (`test $? -ne 1`, `|| true`, `&& echo ok`) — a no-op passes it;
+- grep for a literal the step itself writes into a comment/echo/heredoc (self-fulfilling);
+- happy path only, no negative control proving the guard can fail (§A.9 red-then-green);
+- for a MUST/§7 mitigation: a manual or `command -v`-skippable smoke with no `UNGUARDED-IN-CI` tag.
+
+**Positive obligation:** every Verify names (a) the observed value it inspects (captured stdout /
+exit code / file contents) and (b) the expected concrete value. "Exits 0" alone fails the gate.
+
+**Compound-bash caveat (this repo):** a Verify is ONE command — no `;`/`&&`/`||`/pipes/subshells
+(`compound-bash-gate` hard-blocks them). Negative controls run as their own rows (here: the
+fixture-variant legs inside the test files, listed in each red-run step).
+
+## A.7 Per-slice step tables
+
+> Every EDIT quotes a verbatim `ANCHOR` block and a complete `REPLACE` block (fenced artifacts
+> below each table, the `docs/plans/rfc-008-p7-pi-agent.md` convention); every CREATE writes a
+> fenced block as the file's ENTIRE contents, byte for byte. No lookup, no field to invent.
+
+### `P0-S1` — `--hermetic` on em-pattern-health (REQ-1..6)
+
+**Files this slice may touch:** `scripts/em-pattern-health.mjs`, `tests/test-pattern-health-hermetic.mjs`. **Read-only:** `scripts/lib/local-dir.mjs`.
+
+| Step | File | Kind | Exact action | Verify (observed → expected) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4. | every row passes |
+| 1.1 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A1-ANCHOR`** with **`S1-A1-REPLACE`**. | `grep -c "const PROJECT_ROOT = path.dirname(LOCAL_DIR)" scripts/em-pattern-health.mjs` → `1` |
+| 1.2 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A2-ANCHOR`** with **`S1-A2-REPLACE`**. | `grep -c "const hermeticMode = argv.includes('--hermetic')" scripts/em-pattern-health.mjs` → `1` |
+| 1.3 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A3-ANCHOR`** with **`S1-A3-REPLACE`** (adds the conflict error + `effectiveScope`). | `node scripts/em-pattern-health.mjs --hermetic --scope all` → exit 1, stdout contains `--hermetic is project-local only; omit --scope or pass --scope local` |
+| 1.4 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A4-ANCHOR`** with **`S1-A4-REPLACE`** (SCOPE_DIRS reads `effectiveScope`). | `grep -c "effectiveScope === 'local'" scripts/em-pattern-health.mjs` → `1` |
+| 1.5 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A5-ANCHOR`** with **`S1-A5-REPLACE`** (patterns candidates + hermetic not-found message). | `grep -c "(--hermetic never reads \\$HOME)" scripts/em-pattern-health.mjs` → `1` |
+| 1.6 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A6-ANCHOR`** with **`S1-A6-REPLACE`** (ENFORCEMENT_PATHS hermetic trio). | `grep -c "hermeticMode$" scripts/em-pattern-health.mjs` → ≥1 and `node --check scripts/em-pattern-health.mjs` → exit 0 |
+| 1.7 | `scripts/em-pattern-health.mjs` | EDIT | Replace verbatim anchor **`S1-A7-ANCHOR`** with **`S1-A7-REPLACE`** (usage string). | `node scripts/em-pattern-health.mjs --help` → stdout contains `[--hermetic]` |
+| 1.8 | `tests/test-pattern-health-hermetic.mjs` | CREATE | Write the fenced block **`S1-TEST`** as the file's ENTIRE contents. | `node tests/test-pattern-health-hermetic.mjs` → last line `8/8 pass`, exit 0 |
+| 1.9 | — | — | Negative-control confirmation: the runner output MUST list `testHermeticHomeIsolation` including its `divergence-without-flag` leg (the §A.9 red control lives inside the test; a hermetic leak makes 1.8 exit non-zero). | runner detail line `ok testHermeticHomeIsolation` present in captured output |
+| 1.10 | — | — | Commit exactly: `git add scripts/em-pattern-health.mjs tests/test-pattern-health-hermetic.mjs` then `git commit -m "P0-S1: em-pattern-health --hermetic (RFC-009 R5a)"` with the `Co-Authored-By` trailer. | `git log -1 --oneline` shows `P0-S1`; `git show --stat HEAD` lists both files |
+
+**S1 literal artifacts** (replace/insert verbatim — do not consult any other file):
+
+`S1-A1-ANCHOR`:
+
+```js
+const LOCAL_DIR = resolveLocalDir(CWD)
+```
+
+`S1-A1-REPLACE`:
+
+```js
+const LOCAL_DIR = resolveLocalDir(CWD)
+const PROJECT_ROOT = path.dirname(LOCAL_DIR)
+```
+
+`S1-A2-ANCHOR`:
+
+```js
+const jsonMode = argv.includes('--json')
+```
+
+`S1-A2-REPLACE`:
+
+```js
+const jsonMode = argv.includes('--json')
+const hermeticMode = argv.includes('--hermetic')
+const scopeExplicit = argv.includes('--scope')
+```
+
+`S1-A3-ANCHOR`:
+
+```js
+if (!VALID_SCOPES.includes(scope)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(1)
+}
+```
+
+`S1-A3-REPLACE`:
+
+```js
+if (!VALID_SCOPES.includes(scope)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(1)
+}
+if (hermeticMode && scopeExplicit && scope !== 'local') {
+  console.log(JSON.stringify({ status: 'error', message: '--hermetic is project-local only; omit --scope or pass --scope local' }))
+  process.exit(1)
+}
+// R5a: hermetic mode is project-local by definition; all path sets below key off
+// effectiveScope / hermeticMode so the flag-off path stays byte-identical.
+const effectiveScope = hermeticMode ? 'local' : scope
+```
+
+`S1-A4-ANCHOR`:
+
+```js
+if (scope === 'local' || scope === 'all') SCOPE_DIRS.push({ dir: LOCAL_DIR, source: 'local' })
+if (scope === 'global' || scope === 'all') SCOPE_DIRS.push({ dir: GLOBAL_DIR, source: 'global' })
+```
+
+`S1-A4-REPLACE`:
+
+```js
+if (effectiveScope === 'local' || effectiveScope === 'all') SCOPE_DIRS.push({ dir: LOCAL_DIR, source: 'local' })
+if (effectiveScope === 'global' || effectiveScope === 'all') SCOPE_DIRS.push({ dir: GLOBAL_DIR, source: 'global' })
+```
+
+`S1-A5-ANCHOR`:
+
+```js
+function loadPatternsIndex() {
+  const candidates = [
+    path.join(CWD, 'patterns', '_index.json'),
+    path.join(HOME, '.episodic-memory', 'patterns', '_index.json'),
+  ]
+  for (const p of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+      if (data.patterns && Array.isArray(data.patterns)) return data.patterns
+    } catch {}
+  }
+  return null
+}
+
+const patterns = loadPatternsIndex()
+if (!patterns) {
+  console.log(JSON.stringify({ status: 'error', message: 'patterns/_index.json not found in project or ~/.episodic-memory/patterns/' }))
+  process.exit(1)
+}
+```
+
+`S1-A5-REPLACE`:
+
+```js
+function loadPatternsIndex() {
+  // R5a: under --hermetic the registry candidates are the project-local store's
+  // registry then the repo's own patterns/_index.json — never $HOME.
+  const candidates = hermeticMode
+    ? [
+        path.join(LOCAL_DIR, 'patterns', '_index.json'),
+        path.join(PROJECT_ROOT, 'patterns', '_index.json'),
+      ]
+    : [
+        path.join(CWD, 'patterns', '_index.json'),
+        path.join(HOME, '.episodic-memory', 'patterns', '_index.json'),
+      ]
+  for (const p of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8'))
+      if (data.patterns && Array.isArray(data.patterns)) return data.patterns
+    } catch {}
+  }
+  return null
+}
+
+const patterns = loadPatternsIndex()
+if (!patterns) {
+  const msg = hermeticMode
+    ? `patterns/_index.json not found in ${path.join(LOCAL_DIR, 'patterns')} or ${path.join(PROJECT_ROOT, 'patterns')} (--hermetic never reads $HOME)`
+    : 'patterns/_index.json not found in project or ~/.episodic-memory/patterns/'
+  console.log(JSON.stringify({ status: 'error', message: msg }))
+  process.exit(1)
+}
+```
+
+`S1-A6-ANCHOR`:
+
+```js
+const ENFORCEMENT_PATHS = [
+  { dir: path.join(HOME, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+  { dir: path.join(CWD, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+  { dir: path.join(CWD, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
+  { dir: path.join(CWD, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
+]
+```
+
+`S1-A6-REPLACE`:
+
+```js
+const ENFORCEMENT_PATHS = hermeticMode
+  ? [
+      { dir: path.join(PROJECT_ROOT, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(PROJECT_ROOT, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
+      { dir: path.join(PROJECT_ROOT, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
+    ]
+  : [
+      { dir: path.join(HOME, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(CWD, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(CWD, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
+      { dir: path.join(CWD, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
+    ]
+```
+
+`S1-A7-ANCHOR`:
+
+```js
+  console.log(JSON.stringify({ status: 'help', script: 'em-pattern-health.mjs', usage: 'node em-pattern-health.mjs [--pattern <id>] [--scope local|global|all] [--window-days <N>] [--min-violations <N>] [--has-enforcement <id>] [--check] [--json] [--summary]' }))
+```
+
+`S1-A7-REPLACE`:
+
+```js
+  console.log(JSON.stringify({ status: 'help', script: 'em-pattern-health.mjs', usage: 'node em-pattern-health.mjs [--pattern <id>] [--scope local|global|all] [--window-days <N>] [--min-violations <N>] [--has-enforcement <id>] [--hermetic] [--check] [--json] [--summary]' }))
+```
+
+`S1-TEST` — the entire contents of `tests/test-pattern-health-hermetic.mjs`:
+
+```js
+#!/usr/bin/env node
+// test-pattern-health-hermetic.mjs — RFC-009 P0 R5a acceptance (plan §14 group R5).
+// Drives the REAL script against isolated fixture stores with controlled HOME.
+// Fixture layout: PROJ (a git repo, NOT under either home), homeA (populated:
+// ALL THREE $HOME read sites planted), homeB (empty). Recent violation dates keep
+// rows inside the default 30-day window.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const SCRIPT = path.join(REPO, 'scripts', 'em-pattern-health.mjs')
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'em-p0-hermetic-'))
+const PROJ = path.join(ROOT, 'proj')
+const HOME_POP = path.join(ROOT, 'homeA')
+const HOME_EMPTY = path.join(ROOT, 'homeB')
+const RECENT = new Date().toISOString().slice(0, 10)
+
+function writeJson(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2))
+}
+function writeLines(p, rows) {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+}
+function vio(id, pattern, date) {
+  return { id, date, time: '00:00', project: 'fx', category: 'violation', status: 'active', supersedes: null, tags: [`violated:${pattern}`], summary: `fixture ${id}`, access_count: 0, last_accessed: null }
+}
+
+// --- fixture build ---
+fs.mkdirSync(HOME_EMPTY, { recursive: true })
+fs.mkdirSync(PROJ, { recursive: true })
+spawnSync('git', ['init', '-q'], { cwd: PROJ })
+fs.mkdirSync(path.join(PROJ, 'sub'), { recursive: true })
+writeJson(path.join(PROJ, 'patterns', '_index.json'), { patterns: [{ pattern_id: 'tst-001' }, { pattern_id: 'tst-002' }] })
+writeLines(path.join(PROJ, '.episodic-memory', 'index.jsonl'), [
+  vio('20260701-000001-local-a', 'tst-001', RECENT),
+  vio('20260701-000002-local-b', 'tst-002', RECENT),
+  vio('20260701-000003-local-c', 'tst-002', RECENT),
+  vio('20260701-000004-local-d', 'tst-002', RECENT),
+])
+// populated HOME: all three $HOME read sites (planner F4 — single-site is vacuous)
+fs.mkdirSync(path.join(HOME_POP, '.claude', 'hooks'), { recursive: true })
+fs.writeFileSync(path.join(HOME_POP, '.claude', 'hooks', 'enforce.sh'), '#!/bin/bash\nnode check tst-001 --gate\n')
+writeLines(path.join(HOME_POP, '.episodic-memory', 'index.jsonl'), [
+  vio('20260701-000005-glob-a', 'tst-001', RECENT),
+  vio('20260701-000006-glob-b', 'tst-001', RECENT),
+])
+writeJson(path.join(HOME_POP, '.episodic-memory', 'patterns', '_index.json'), { patterns: [{ pattern_id: 'zzz-999' }] })
+
+function run(args, home, cwd = PROJ) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+}
+function row(res, id) {
+  return JSON.parse(res.stdout).patterns.find(p => p.pattern_id === id)
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+
+t('testHermeticHomeIsolation', () => {
+  const a = run(['--hermetic'], HOME_POP)
+  const b = run(['--hermetic'], HOME_EMPTY)
+  assert(a.stdout === b.stdout, `hermetic stdout diverged:\nA=${a.stdout}\nB=${b.stdout}`)
+  assert(a.status === b.status, `hermetic exit diverged: ${a.status} vs ${b.status}`)
+  // divergence-without-flag leg: proves this fixture would catch a leak
+  const c = run([], HOME_POP)
+  const d = run([], HOME_EMPTY)
+  assert(c.stdout !== d.stdout, 'no-flag runs did NOT diverge — fixture cannot discriminate, vacuous')
+})
+
+t('testHermeticScopeConflict', () => {
+  for (const s of ['all', 'global']) {
+    const r = run(['--hermetic', '--scope', s], HOME_EMPTY)
+    assert(r.status === 1, `--scope ${s}: exit ${r.status}, want 1`)
+    assert(r.stdout.includes('--hermetic is project-local only; omit --scope or pass --scope local'), `--scope ${s}: message missing: ${r.stdout}`)
+  }
+  const ok = run(['--hermetic', '--scope', 'local'], HOME_EMPTY)
+  assert(ok.status === 0, `--scope local under hermetic: exit ${ok.status}, want 0`)
+  const bad = run(['--hermetic', '--scope', 'bogus'], HOME_EMPTY)
+  assert(bad.status === 1 && bad.stdout.includes('Invalid --scope'), `invalid-scope ordering: ${bad.stdout}`)
+})
+
+t('testHermeticDefaultsLocal', () => {
+  const r = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(r.violations === 1, `hermetic tst-001 violations ${r.violations}, want 1 (local only; global has 2 more)`)
+})
+
+t('testHermeticPatternsProjectOnly', () => {
+  const out = JSON.parse(run(['--hermetic'], HOME_POP).stdout)
+  assert(!out.patterns.some(p => p.pattern_id === 'zzz-999'), '$HOME-only pattern zzz-999 leaked into hermetic output')
+  // subdir leg (EC10): PROJ is a git repo, so PROJECT_ROOT resolves from sub/ too
+  const sub = run(['--hermetic'], HOME_EMPTY, path.join(PROJ, 'sub'))
+  const root = run(['--hermetic'], HOME_EMPTY)
+  assert(sub.stdout === root.stdout, `subdir cwd diverged from root cwd:\nSUB=${sub.stdout}\nROOT=${root.stdout}`)
+  // LOCAL_DIR registry beats PROJECT_ROOT registry (candidate order)
+  writeJson(path.join(PROJ, '.episodic-memory', 'patterns', '_index.json'), { patterns: [{ pattern_id: 'loc-111' }] })
+  const loc = JSON.parse(run(['--hermetic'], HOME_EMPTY).stdout)
+  fs.rmSync(path.join(PROJ, '.episodic-memory', 'patterns'), { recursive: true, force: true })
+  assert(loc.patterns.length === 1 && loc.patterns[0].pattern_id === 'loc-111', `LOCAL_DIR registry did not win: ${JSON.stringify(loc.patterns)}`)
+})
+
+t('testHermeticEnforcementProjectOnly', () => {
+  const before = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(before.has_enforcement === false, 'populated-HOME hook detected under --hermetic ($HOME leak)')
+  // MUTATES fixture: adds a project hook naming tst-001; later tests use tst-002 or non-hermetic runs
+  fs.mkdirSync(path.join(PROJ, '.claude', 'hooks'), { recursive: true })
+  fs.writeFileSync(path.join(PROJ, '.claude', 'hooks', 'proj.sh'), '#!/bin/bash\nnode check tst-001 --gate\n')
+  const after = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(after.has_enforcement === true, 'project .claude/hooks hook NOT detected under --hermetic')
+})
+
+t('testHermeticCheckExit', () => {
+  const bad = run(['--hermetic', '--check', '--pattern', 'tst-002'], HOME_EMPTY)
+  assert(bad.status === 1, `3 violations, no enforcement: --check exit ${bad.status}, want 1`)
+  const healthy = run(['--hermetic', '--check', '--pattern', 'tst-002', '--min-violations', '5'], HOME_EMPTY)
+  assert(healthy.status === 0, `healthy fixture: --check exit ${healthy.status}, want 0`)
+})
+
+t('testHermeticHasEnforcementOverride', () => {
+  const r = row(run(['--hermetic', '--has-enforcement', 'tst-002'], HOME_EMPTY), 'tst-002')
+  assert(r.has_enforcement === true, 'argv --has-enforcement override ignored under --hermetic')
+  assert(r.recommendation === 'needs-attention', `override recommendation ${r.recommendation}, want needs-attention`)
+})
+
+t('testNonHermeticUnchanged', () => {
+  const r = row(run([], HOME_POP), 'tst-001')
+  assert(r.has_enforcement === true, 'legacy path lost the $HOME/.claude/hooks scan')
+  assert(r.violations === 3, `legacy scope-all tst-001 violations ${r.violations}, want 3 (1 local + 2 global)`)
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)
+```
+
+### `P0-S2` — R6 protection set in em-prune (REQ-7..13)
+
+**Files this slice may touch:** `scripts/em-prune.mjs`, `tests/test-prune-protection.mjs`. **Read-only:** none needed (all code is in the fenced artifacts).
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 2.0 | — | — | Pre-flight §A.4 (tree clean post-S1 commit). | every row passes |
+| 2.1 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A1-ANCHOR`** with **`S2-A1-REPLACE`** (inserts `TODAY`, `loadIndexRows`, `stringItems`, `isValidReferencer`, `computeProtectedIds` before `loadTagsIndex`). | `node --check scripts/em-prune.mjs` → exit 0; `grep -c "function computeProtectedIds" scripts/em-prune.mjs` → `1` |
+| 2.2 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A2-ANCHOR`** with **`S2-A2-REPLACE`** (pruneDir signature + protected selection loop + empty-index early return field). | `grep -c "function pruneDir(dataDir, label, protectedIds)" scripts/em-prune.mjs` → `1` |
+| 2.3 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A3-ANCHOR`** with **`S2-A3-REPLACE`** (check + dry-run returns gain `protected` / `protected_episodes`). | `grep -c "protected_episodes: protectedEntries" scripts/em-prune.mjs` → `1` |
+| 2.4 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A4-ANCHOR`** with **`S2-A4-REPLACE`** (real-prune returns gain `protected`). | `grep -c "protected: protectedEntries.length" scripts/em-prune.mjs` → `4` |
+| 2.5 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A5-ANCHOR`** with **`S2-A5-REPLACE`** (reference scan + threading into both pruneDir calls + race-comment extension). | `node scripts/em-prune.mjs --help` → exit 0; `grep -c "computeProtectedIds(referenceRows, TODAY)" scripts/em-prune.mjs` → `1` |
+| 2.6 | `scripts/em-prune.mjs` | EDIT | Replace verbatim anchor **`S2-A6-ANCHOR`** with **`S2-A6-REPLACE`** (usage string documents protection). | `node scripts/em-prune.mjs --help` → stdout contains `protected_episodes` |
+| 2.7 | `tests/test-prune-protection.mjs` | CREATE | Write the fenced block **`S2-TEST`** as the file's ENTIRE contents. | `node tests/test-prune-protection.mjs` → last line `13/13 pass`, exit 0 |
+| 2.8 | — | — | Red-control confirmation: runner output lists `ok testProtectionLapseOnSupersede`, `ok testExpiredTriggerLessonPrunable`, `ok testExpiredReferencerLapsesEvidence` (each asserts the fixture IS archived when protection genuinely lapses — the guard observed RED). | those three `ok` lines present in captured output |
+| 2.9 | — | — | Commit exactly: `git add scripts/em-prune.mjs tests/test-prune-protection.mjs` then `git commit -m "P0-S2: em-prune R6 protection set (RFC-009 R6)"` with the `Co-Authored-By` trailer. | `git log -1 --oneline` shows `P0-S2`; `git show --stat HEAD` lists both files |
+
+**S2 literal artifacts:**
+
+`S2-A1-ANCHOR`:
+
+```js
+function loadTagsIndex(dataDir) {
+```
+
+`S2-A1-REPLACE`:
+
+```js
+const TODAY = new Date().toISOString().slice(0, 10)
+
+function loadIndexRows(dataDir, storeLabel) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  const out = []
+  for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const e = JSON.parse(line)
+      e._store = storeLabel
+      out.push(e)
+    } catch {}
+  }
+  return out
+}
+
+function stringItems(v) {
+  return Array.isArray(v) ? v.filter(x => typeof x === 'string') : []
+}
+
+// RFC-009 R6 referencer validity: protection lapses when the referencing episode
+// is superseded or expired. A row with NO status field is a valid referencer (the
+// tolerated hand-written-writer class, #447); a malformed review_by never expires.
+function isValidReferencer(row, todayStr) {
+  if (!row || row.status === 'superseded') return false
+  const rb = row.review_by
+  if (typeof rb === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(rb) && rb < todayStr) return false
+  return true
+}
+
+// RFC-009 R6 protection set. rows = UNION of both stores' index rows (deliberately
+// NO id-dedupe: a stale superseded copy in one store must not shadow an active
+// referencer in the other). Returns Map<id, {reason, via}>; first-set reason wins in
+// the order: evidence-linked-violation, trigger-bearing-lesson, consolidates-member,
+// latest-run-record, chain-member.
+function computeProtectedIds(rows, todayStr) {
+  const map = new Map()
+  const set = (id, reason, via) => { if (typeof id === 'string' && !map.has(id)) map.set(id, { reason, via }) }
+  const lessonRowsById = new Map()
+  for (const r of rows) {
+    if (r.category === 'lesson' && typeof r.id === 'string') {
+      if (!lessonRowsById.has(r.id)) lessonRowsById.set(r.id, [])
+      lessonRowsById.get(r.id).push(r)
+    }
+  }
+  // class a, forward: valid lesson's evidence names violations
+  for (const r of rows) {
+    if (r.category !== 'lesson' || !isValidReferencer(r, todayStr)) continue
+    for (const vid of stringItems(r.evidence)) set(vid, 'evidence-linked-violation', r.id)
+  }
+  // class a, back-link: violation.lessons names a valid lesson (in ANY store)
+  for (const r of rows) {
+    if (r.category !== 'violation' || typeof r.id !== 'string') continue
+    for (const lid of stringItems(r.lessons)) {
+      const cands = lessonRowsById.get(lid) || []
+      if (cands.some(l => isValidReferencer(l, todayStr))) {
+        set(r.id, 'evidence-linked-violation', lid)
+        break
+      }
+    }
+  }
+  // class b: valid trigger-bearing lessons protect themselves
+  for (const r of rows) {
+    if (r.category !== 'lesson' || typeof r.id !== 'string') continue
+    if (!isValidReferencer(r, todayStr)) continue
+    if (stringItems(r.triggers).length > 0) set(r.id, 'trigger-bearing-lesson', r.id)
+  }
+  // class c: consolidates members of valid referencers
+  for (const r of rows) {
+    if (typeof r.id !== 'string' || !isValidReferencer(r, todayStr)) continue
+    for (const mid of stringItems(r.consolidates)) set(mid, 'consolidates-member', r.id)
+  }
+  // class d: latest clerk run record per store (max id; ids sort chronologically)
+  const latestByStore = new Map()
+  for (const r of rows) {
+    if (r.record_type !== 'clerk-run' || typeof r.id !== 'string') continue
+    const cur = latestByStore.get(r._store)
+    if (!cur || r.id > cur) latestByStore.set(r._store, r.id)
+  }
+  for (const id of latestByStore.values()) set(id, 'latest-run-record', id)
+  // chain closure over class a/b/c anchors (NOT class d): backward via each row's
+  // `supersedes`, forward via INVERTED supersedes edges (superseded_by has no
+  // substrate writer today) plus `superseded_by` strings when present. An archived
+  // intermediate would silently break R2's chain-resolved band counting.
+  const rowsById = new Map()
+  const successorsOf = new Map() // supersededId -> [successor ids]
+  for (const r of rows) {
+    if (typeof r.id !== 'string') continue
+    if (!rowsById.has(r.id)) rowsById.set(r.id, [])
+    rowsById.get(r.id).push(r)
+    if (typeof r.supersedes === 'string') {
+      if (!successorsOf.has(r.supersedes)) successorsOf.set(r.supersedes, [])
+      successorsOf.get(r.supersedes).push(r.id)
+    }
+  }
+  const anchorOf = new Map()
+  const queue = []
+  for (const [id, v] of map.entries()) {
+    if (v.reason === 'latest-run-record') continue
+    anchorOf.set(id, id)
+    queue.push(id)
+  }
+  const visited = new Set(queue)
+  while (queue.length) {
+    const id = queue.shift()
+    const neighbors = []
+    for (const r of rowsById.get(id) || []) {
+      if (typeof r.supersedes === 'string') neighbors.push(r.supersedes)
+      if (typeof r.superseded_by === 'string') neighbors.push(r.superseded_by)
+    }
+    for (const succ of successorsOf.get(id) || []) neighbors.push(succ)
+    for (const n of neighbors) {
+      if (visited.has(n)) continue
+      visited.add(n)
+      anchorOf.set(n, anchorOf.get(id))
+      set(n, 'chain-member', anchorOf.get(id))
+      queue.push(n)
+    }
+  }
+  return map
+}
+
+function loadTagsIndex(dataDir) {
+```
+
+`S2-A2-ANCHOR`:
+
+```js
+function pruneDir(dataDir, label) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const episodesDir = path.join(dataDir, 'episodes')
+  const archivedDir = path.join(dataDir, 'archived')
+  const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+
+  if (!fs.existsSync(indexFile)) {
+    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, episodes: [] }
+  }
+
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  const entries = lines.map(line => {
+    try { return JSON.parse(line) } catch { return null }
+  }).filter(Boolean)
+
+  const toPrune = []
+  const toKeep = []
+
+  for (const entry of entries) {
+    const score = computePruneScore(entry)
+    if (score < threshold) {
+      toPrune.push({ ...entry, _pruneScore: score })
+    } else {
+      toKeep.push(entry)
+    }
+  }
+```
+
+`S2-A2-REPLACE`:
+
+```js
+function pruneDir(dataDir, label, protectedIds) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const episodesDir = path.join(dataDir, 'episodes')
+  const archivedDir = path.join(dataDir, 'archived')
+  const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+
+  if (!fs.existsSync(indexFile)) {
+    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, protected: 0, episodes: [] }
+  }
+
+  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  const entries = lines.map(line => {
+    try { return JSON.parse(line) } catch { return null }
+  }).filter(Boolean)
+
+  const toPrune = []
+  const toKeep = []
+  const protectedEntries = []
+
+  // R6: protection is decided HERE, in the one selection loop every mode shares
+  // (check / dry-run / real prune) — the mode branches below only format the
+  // already-decided sets. Partition: entries = toKeep (incl. protected) + toPrune.
+  for (const entry of entries) {
+    const score = computePruneScore(entry)
+    if (score < threshold) {
+      const p = protectedIds.get(entry.id)
+      if (p) {
+        toKeep.push(entry)
+        protectedEntries.push({ id: entry.id, score: Math.round(score * 1000) / 1000, reason: p.reason, via: p.via })
+      } else {
+        toPrune.push({ ...entry, _pruneScore: score })
+      }
+    } else {
+      toKeep.push(entry)
+    }
+  }
+```
+
+`S2-A3-ANCHOR`:
+
+```js
+  if (checkOnly) {
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length }
+  }
+
+  if (dryRun) {
+    let totalSize = 0
+    const preview = toPrune.map(e => {
+      const filePath = path.join(episodesDir, `${e.id}.md`)
+      let size = 0
+      try { size = fs.statSync(filePath).size } catch {}
+      totalSize += size
+      return { id: e.id, score: Math.round(e._pruneScore * 1000) / 1000, size }
+    })
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, episodes: preview }
+  }
+```
+
+`S2-A3-REPLACE`:
+
+```js
+  if (checkOnly) {
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, protected: protectedEntries.length }
+  }
+
+  if (dryRun) {
+    let totalSize = 0
+    const preview = toPrune.map(e => {
+      const filePath = path.join(episodesDir, `${e.id}.md`)
+      let size = 0
+      try { size = fs.statSync(filePath).size } catch {}
+      totalSize += size
+      return { id: e.id, score: Math.round(e._pruneScore * 1000) / 1000, size }
+    })
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, protected: protectedEntries.length, protected_episodes: protectedEntries, episodes: preview }
+  }
+```
+
+`S2-A4-ANCHOR`:
+
+```js
+  // Actual prune
+  if (toPrune.length === 0) {
+    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0 }
+  }
+```
+
+`S2-A4-REPLACE`:
+
+```js
+  // Actual prune
+  if (toPrune.length === 0) {
+    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0, protected: protectedEntries.length }
+  }
+```
+
+…and the final return of `pruneDir` (same step, same fenced pair — this anchor is unique):
+
+```js
+  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes }
+```
+
+replaced by:
+
+```js
+  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes, protected: protectedEntries.length }
+```
+
+`S2-A5-ANCHOR`:
+
+```js
+const results = []
+if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local'))
+if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global'))
+```
+
+`S2-A5-REPLACE`:
+
+```js
+// R6 reference scan: UNION of both stores regardless of prune scope — a global
+// lesson's evidence can name a local violation. Deliberately NO id-dedupe (the
+// search-side local-precedence convention would let a stale superseded copy
+// shadow an active referencer). Like the archived-index append race below, the
+// scan-to-archive window is a documented limitation: an episode stored mid-prune
+// protects one run late (recovery: em-restore / archived-index).
+const referenceRows = [...loadIndexRows(LOCAL_DIR, 'local'), ...loadIndexRows(GLOBAL_DIR, 'global')]
+const protectedIds = computeProtectedIds(referenceRows, TODAY)
+
+const results = []
+if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local', protectedIds))
+if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global', protectedIds))
+```
+
+`S2-A6-ANCHOR`:
+
+```js
+  console.log(JSON.stringify({ status: 'help', script: 'em-prune.mjs', usage: 'node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check]' }))
+```
+
+`S2-A6-REPLACE`:
+
+```js
+  console.log(JSON.stringify({ status: 'help', script: 'em-prune.mjs', usage: 'node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check] — RFC-009 R6 protection: evidence-linked violations, trigger-bearing lessons, consolidates members, and the latest clerk run record are never archived (see protected / protected_episodes output fields)' }))
+```
+
+`S2-TEST` — the entire contents of `tests/test-prune-protection.mjs`:
+
+```js
+#!/usr/bin/env node
+// test-prune-protection.mjs — RFC-009 P0 R6 prune-protection acceptance (plan §14 group R6).
+// Each test builds a FRESH isolated store (real prune mutates), spawns the REAL
+// script with explicit cwd + controlled HOME, and asserts on captured JSON + disk.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const SCRIPT = path.join(REPO, 'scripts', 'em-prune.mjs')
+const AGED = '2025-05-01'          // score 0.1 < default threshold 0.15
+const RECENT = new Date().toISOString().slice(0, 10)
+const PAST = '2025-01-01'          // expired review_by
+const FUTURE = '2099-01-01'
+
+function row(id, extra = {}) {
+  return { id, date: AGED, time: '00:00', project: 'fx', category: 'violation', status: 'active', supersedes: null, tags: [], summary: `fixture ${id}`, access_count: 0, last_accessed: null, ...extra }
+}
+function mkWorld(localRows, globalRows = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em-p0-prune-'))
+  const proj = path.join(root, 'proj')
+  const home = path.join(root, 'home')
+  const write = (dir, rows) => {
+    fs.mkdirSync(path.join(dir, 'episodes'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'index.jsonl'), rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+    for (const r of rows) fs.writeFileSync(path.join(dir, 'episodes', `${r.id}.md`), `# ${r.id}\n`)
+  }
+  write(path.join(proj, '.episodic-memory'), localRows)
+  fs.mkdirSync(home, { recursive: true })
+  if (globalRows.length) write(path.join(home, '.episodic-memory'), globalRows)
+  return { proj, home }
+}
+function prune(world, args) {
+  const r = spawnSync(process.execPath, [SCRIPT, '--scope', 'local', ...args], { cwd: world.proj, env: { ...process.env, HOME: world.home, USERPROFILE: world.home }, encoding: 'utf8' })
+  return { status: r.status, out: JSON.parse(r.stdout).results[0], raw: r.stdout }
+}
+function survives(world, id) {
+  return fs.existsSync(path.join(world.proj, '.episodic-memory', 'episodes', `${id}.md`)) &&
+    fs.readFileSync(path.join(world.proj, '.episodic-memory', 'index.jsonl'), 'utf8').includes(`"${id}"`)
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+
+t('testEvidenceLinkedViolationSurvives', () => {
+  const w = mkWorld([row('v1'), row('l1', { category: 'lesson', date: RECENT, evidence: ['v1'] })])
+  const dry = prune(w, ['--dry-run']).out
+  assert(dry.protected === 1 && dry.protected_episodes[0].id === 'v1' && dry.protected_episodes[0].reason === 'evidence-linked-violation' && dry.protected_episodes[0].via === 'l1', `dry-run: ${JSON.stringify(dry)}`)
+  prune(w, [])
+  assert(survives(w, 'v1'), 'v1 archived despite active evidence link')
+})
+
+t('testViolationLessonsBacklinkSurvives', () => {
+  const w = mkWorld([row('v2', { lessons: ['l2'] }), row('l2', { category: 'lesson', date: RECENT })])
+  prune(w, [])
+  assert(survives(w, 'v2'), 'v2 archived despite lessons back-link to active lesson')
+})
+
+t('testTriggerBearingLessonSurvives', () => {
+  const w = mkWorld([row('l3', { category: 'lesson', triggers: ['second opinion'] })])
+  const dry = prune(w, ['--dry-run']).out
+  assert(dry.protected_episodes[0].reason === 'trigger-bearing-lesson' && dry.protected_episodes[0].via === 'l3', JSON.stringify(dry))
+  prune(w, [])
+  assert(survives(w, 'l3'), 'aged active trigger-bearing lesson archived')
+})
+
+t('testConsolidatesMemberSurvives', () => {
+  const w = mkWorld([row('m4', { category: 'lesson', status: 'superseded' }), row('c4', { category: 'lesson', date: RECENT, consolidates: ['m4'] })])
+  prune(w, [])
+  assert(survives(w, 'm4'), 'consolidates member archived while consolidated lesson active')
+  // class-c lapse leg (codex r2 F2): a superseded consolidating referencer stops protecting
+  const w2 = mkWorld([row('m4b', { category: 'lesson', status: 'superseded' }), row('c4b', { category: 'lesson', date: RECENT, status: 'superseded', consolidates: ['m4b'] })])
+  prune(w2, [])
+  assert(!survives(w2, 'm4b'), 'member survived though its consolidating referencer is superseded — class-c lapse broken')
+})
+
+t('testMissingStatusReferencerProtects', () => {
+  const noStatus = row('l5', { category: 'lesson', date: RECENT, evidence: ['v5'] })
+  delete noStatus.status
+  const w = mkWorld([row('v5'), noStatus])
+  prune(w, [])
+  assert(survives(w, 'v5'), 'missing-status referencer failed to protect (planner F2 class)')
+})
+
+t('testProtectionLapseOnSupersede', () => {
+  const w = mkWorld([row('v6'), row('l6', { category: 'lesson', date: RECENT, evidence: ['v6'], status: 'superseded' })])
+  prune(w, [])
+  assert(!survives(w, 'v6'), 'v6 survived though its only referencer is superseded — protection cannot lapse (guard never RED)')
+})
+
+t('testExpiredTriggerLessonPrunable', () => {
+  const w = mkWorld([row('l7', { category: 'lesson', triggers: ['x'], review_by: PAST })])
+  prune(w, [])
+  assert(!survives(w, 'l7'), 'expired trigger-bearing lesson survived — review_by lapse broken')
+})
+
+t('testExpiredReferencerLapsesEvidence', () => {
+  const w = mkWorld([row('v8'), row('l8', { category: 'lesson', date: RECENT, evidence: ['v8'], review_by: PAST })])
+  prune(w, [])
+  assert(!survives(w, 'v8'), 'evidence of an EXPIRED lesson survived — planner F12 lapse not applied to class a')
+})
+
+t('testLatestRunRecordSurvives', () => {
+  const w = mkWorld([
+    row('20250501-000001-run-old', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+    row('20250502-000001-run-new', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+  ])
+  prune(w, [])
+  assert(survives(w, '20250502-000001-run-new'), 'latest clerk-run archived')
+  assert(!survives(w, '20250501-000001-run-old'), 'older clerk-run survived — aging out broken')
+})
+
+t('testChainMembersProtected', () => {
+  // v10a: chain root (superseded, NO superseded_by field anywhere — forward edge
+  // must come from INVERTING v10b.supersedes; planner F1). Both aged.
+  const w = mkWorld([
+    row('v10a', { status: 'superseded' }),
+    row('v10b', { supersedes: 'v10a' }),
+    row('l10', { category: 'lesson', date: RECENT, evidence: ['v10a'] }),
+    // cycle fixture: mutually superseding aged rows anchored by l11 (EC4)
+    row('c1', { supersedes: 'c2' }),
+    row('c2', { supersedes: 'c1' }),
+    row('l11', { category: 'lesson', date: RECENT, evidence: ['c1'] }),
+  ])
+  const dry = prune(w, ['--dry-run']).out
+  const v10b = dry.protected_episodes.find(p => p.id === 'v10b')
+  assert(v10b && v10b.reason === 'chain-member' && v10b.via === 'v10a', `v10b: ${JSON.stringify(dry.protected_episodes)}`)
+  prune(w, [])
+  for (const id of ['v10a', 'v10b', 'c1', 'c2']) assert(survives(w, id), `${id} archived — chain closure broken`)
+})
+
+t('testCrossStoreProtection', () => {
+  // global active lesson protects a local violation; a STALE local superseded copy
+  // of the same lesson id must not shadow it (union semantics, planner F3)
+  const w = mkWorld(
+    [row('vl'), row('lg', { category: 'lesson', status: 'superseded' })],
+    [row('lg', { category: 'lesson', date: RECENT, evidence: ['vl'] })]
+  )
+  prune(w, [])
+  assert(survives(w, 'vl'), 'cross-store protection failed (or stale local copy shadowed the active global referencer)')
+  // missing-global leg: no home store at all → clean run
+  const w2 = mkWorld([row('u1')])
+  const r = prune(w2, [])
+  assert(r.status === 0 && !survives(w2, 'u1'), 'missing global index broke prune')
+})
+
+t('testMalformedFieldsTolerated', () => {
+  const nan = row('nan1', { date: 'not-a-date' })
+  const w = mkWorld([
+    row('vm'),
+    row('lm1', { category: 'lesson', date: RECENT, evidence: 'vm' }),      // non-array: must NOT protect
+    row('lm2', { category: 'lesson', date: RECENT, triggers: 42 }),        // non-array: no crash
+    nan,                                                                    // NaN score: survives (EC11, pinned)
+  ])
+  const r = prune(w, [])
+  assert(r.status === 0, `malformed fields crashed prune: ${r.raw}`)
+  assert(!survives(w, 'vm'), 'string evidence field protected vm — malformed must not protect')
+  assert(survives(w, 'nan1'), 'NaN-date row was archived — EC11 contract broken')
+})
+
+t('testProtectedCountInOutput', () => {
+  const mk = () => mkWorld([row('vp'), row('lp', { category: 'lesson', date: RECENT, evidence: ['vp'] }), row('u2'), row('k1', { date: RECENT })])
+  // 4 rows: vp protected-aged, u2 unprotected-aged, lp + k1 recent
+  const chk = prune(mk(), ['--check'])
+  assert(chk.out.prunable === 1 && chk.out.remaining === 3 && chk.out.protected === 1, `check: ${JSON.stringify(chk.out)}`)
+  assert(chk.status === 1, `check exit ${chk.status}, want 1 (u2 prunable)`)
+  const dry = prune(mk(), ['--dry-run']).out
+  assert(dry.prunable === 1 && dry.remaining === 3 && dry.protected === 1, `dry: ${JSON.stringify(dry)}`)
+  assert(dry.episodes.length === 1 && dry.episodes[0].id === 'u2', `dry preview: ${JSON.stringify(dry.episodes)}`)
+  assert(dry.protected_episodes.length === 1 && dry.protected_episodes[0].via === 'lp', `dry protected: ${JSON.stringify(dry.protected_episodes)}`)
+  const real = prune(mk(), []).out
+  assert(real.pruned === 1 && real.remaining === 3 && real.protected === 1, `real: ${JSON.stringify(real)}`)
+  // partition invariant, all three modes: 4 = remaining + prunable/pruned
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)
+```
+
+### `P0-S3` — docs + CI wiring (REQ-14, REQ-15)
+
+**Files this slice may touch:** `docs/EM_SCRIPTS_GUIDE.md`, `README.md`, `.github/workflows/plan-marker-validate.yml`, `tests/test-prune-protection.mjs` (append docs-grep test), `docs/rfcs/RFC-009-lesson-activation.md` (Implementation table row).
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 3.1 | `docs/EM_SCRIPTS_GUIDE.md` | EDIT | Replace verbatim anchor **`S3-A1-ANCHOR`** with **`S3-A1-REPLACE`** (em-prune protection paragraph). | `grep -c "protected_episodes" docs/EM_SCRIPTS_GUIDE.md` → ≥1 |
+| 3.2 | `docs/EM_SCRIPTS_GUIDE.md` | EDIT | Replace verbatim anchor **`S3-A2-ANCHOR`** with **`S3-A2-REPLACE`** (em-pattern-health `--hermetic` paragraph). | `grep -c "\-\-hermetic" docs/EM_SCRIPTS_GUIDE.md` → ≥2 |
+| 3.3 | `README.md` | EDIT | Replace verbatim anchor **`S3-A3-ANCHOR`** with **`S3-A3-REPLACE`** (prune example gains protection note). | `grep -c "protected_episodes" README.md` → `1` |
+| 3.4 | `README.md` | EDIT | Replace verbatim anchor **`S3-A4-ANCHOR`** with **`S3-A4-REPLACE`** (pattern-health example gains `--hermetic`). | `grep -c "\-\-hermetic" README.md` → `1` |
+| 3.5 | `tests/test-prune-protection.mjs` | EDIT | Replace verbatim anchor **`S3-A5-ANCHOR`** with **`S3-A5-REPLACE`** (appends `testDocsGrepGate` before the runner). | `node tests/test-prune-protection.mjs` → last line `14/14 pass`, exit 0 |
+| 3.6 | `.github/workflows/plan-marker-validate.yml` | EDIT | Replace verbatim anchor **`S3-A6-ANCHOR`** with **`S3-A6-REPLACE`** (two CI steps appended). | `grep -c "RFC-009 P0" .github/workflows/plan-marker-validate.yml` → `2` |
+| 3.7 | `docs/rfcs/RFC-009-lesson-activation.md` | EDIT | Replace verbatim anchor **`S3-A7-ANCHOR`** with **`S3-A7-REPLACE`** (Implementation table P0 row — Rule 10: mark immediately; fill `<PR#>` after `gh pr create`). | `grep -c "P0-S1..S3" docs/rfcs/RFC-009-lesson-activation.md` → `1` |
+| 3.8 | — | — | Commit exactly: `git add docs/EM_SCRIPTS_GUIDE.md README.md tests/test-prune-protection.mjs .github/workflows/plan-marker-validate.yml docs/rfcs/RFC-009-lesson-activation.md` then `git commit -m "P0-S3: docs + CI wiring for RFC-009 P0"` with the `Co-Authored-By` trailer; push; open PR. | `gh pr checks <PR>` all green incl. the two new steps |
+
+**S3 literal artifacts:**
+
+`S3-A1-ANCHOR`:
+
+```markdown
+`--check` exits 1 when prunable episodes exist (CI gate). `--dry-run` previews with
+no writes.
+```
+
+`S3-A1-REPLACE`:
+
+```markdown
+`--check` exits 1 when prunable episodes exist (CI gate). `--dry-run` previews with
+no writes.
+
+**Protection set (RFC-009 R6).** Prune never archives, in any mode: violations
+evidence-linked to a valid lesson (either direction: the lesson's `evidence` array
+or the violation's `lessons` array); valid lessons carrying `triggers`; episodes
+named in a valid episode's `consolidates` array; supersession-chain members of any
+of those; and the latest `record_type: clerk-run` episode per store. "Valid" means
+not superseded and `review_by` absent or unexpired — protection lapses when the
+referencing episode is superseded or expires. Retained entries are counted in the
+`protected` output field; `--dry-run` lists them in `protected_episodes` as
+`{id, score, reason, via}` where `via` names the protecting episode. `remaining`
+includes protected entries; the `--check` exit code ignores them.
+```
+
+`S3-A2-ANCHOR`:
+
+```markdown
+`needs-enforcement` means violated repeatedly with no hook found. `needs-attention`
+means a hook exists but violations continue (escalate to a human).
+```
+
+`S3-A2-REPLACE`:
+
+```markdown
+`needs-enforcement` means violated repeatedly with no hook found. `needs-attention`
+means a hook exists but violations continue (escalate to a human).
+
+**`--hermetic` (RFC-009 R5a).** Reads ONLY project surfaces: violations from the
+project-local store, the patterns registry from `<project>/.episodic-memory/patterns/`
+falling back to `<project>/patterns/_index.json`, and enforcement detection over
+`<project>/.claude/hooks`, `<project>/.git/hooks`, `<project>/.github/workflows` —
+zero `$HOME` reads, so output is identical under any HOME. Scope is forced to
+`local`; combining with an explicit `--scope global|all` errors. Output shape and
+the `--check` exit contract are unchanged.
+
+```
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --hermetic --check   # project-only CI gate (R5b wires this in Phase 3)
+```
+```
+
+`S3-A3-ANCHOR`:
+
+```markdown
+node ~/.episodic-memory/scripts/em-prune.mjs --check  # exit 1 if prunable episodes exist
+```
+
+`S3-A3-REPLACE`:
+
+```markdown
+node ~/.episodic-memory/scripts/em-prune.mjs --check  # exit 1 if prunable episodes exist
+# RFC-009 R6: evidence-linked violations, trigger-bearing lessons, consolidates
+# members, and the latest clerk run record are never archived — see the
+# protected / protected_episodes output fields in --dry-run.
+```
+
+`S3-A4-ANCHOR`:
+
+```markdown
+# Manual override when enforcement detection misses a hook
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --has-enforcement bp-006-push-after-verify
+```
+
+`S3-A4-REPLACE`:
+
+```markdown
+# Manual override when enforcement detection misses a hook
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --has-enforcement bp-006-push-after-verify
+
+# Hermetic mode (RFC-009 R5a) — project-only reads, zero $HOME dependence
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --hermetic --check
+```
+
+`S3-A5-ANCHOR`:
+
+```js
+let pass = 0
+```
+
+`S3-A5-REPLACE`:
+
+```js
+t('testDocsGrepGate', () => {
+  const guide = fs.readFileSync(path.join(REPO, 'docs', 'EM_SCRIPTS_GUIDE.md'), 'utf8')
+  assert(guide.includes('--hermetic'), 'EM_SCRIPTS_GUIDE.md missing --hermetic (RFC-009 P0 docs gate)')
+  assert(guide.includes('protected_episodes'), 'EM_SCRIPTS_GUIDE.md missing protected_episodes (RFC-009 P0 docs gate)')
+})
+
+let pass = 0
+```
+
+`S3-A6-ANCHOR`:
+
+```yaml
+        run: bash tests/test-preflight-prompt-helper.sh
+```
+
+`S3-A6-REPLACE`:
+
+```yaml
+        run: bash tests/test-preflight-prompt-helper.sh
+
+      - name: Run RFC-009 P0 hermetic pattern-health tests
+        run: node tests/test-pattern-health-hermetic.mjs
+
+      - name: Run RFC-009 P0 prune-protection tests
+        run: node tests/test-prune-protection.mjs
+```
+
+`S3-A7-ANCHOR`:
+
+```markdown
+| _pending_ | _pending_ | _pending_ | _pending_ |
+```
+
+`S3-A7-REPLACE`:
+
+```markdown
+| P0 (P0-S1..S3, PR #<PR#>) | `scripts/em-pattern-health.mjs` (`--hermetic`, R5a), `scripts/em-prune.mjs` (R6 protection set), docs guide + README + CI wiring | `tests/test-pattern-health-hermetic.mjs` (8), `tests/test-prune-protection.mjs` (14) | R6 blend half lands with R2 in P1; R5b CI gate is P3 |
+| _pending_ | _pending_ | _pending_ | _pending_ |
+```
+
+## A.8 Definition of done (whole plan, mechanical)
+
+```bash
+node tests/test-pattern-health-hermetic.mjs   # → 8/8 pass
+node tests/test-prune-protection.mjs          # → 14/14 pass
+node tests/test-rfc002-phase2.mjs             # → existing suite green
+node /private/tmp/.../probe-run.mjs           # → hermetic reruns: A≡B; prune rerun: protected 3, prunable 0
+```
+
+Each line's observed output pasted into §15. No step done by inspection.
+
+## A.9 Blast-radius notes applied
+
+- Legacy pins first: `testNonHermeticUnchanged` and the existing rfc002 suite are the fixture-change ledger — this diff edits NO existing assertion.
+- Discriminating fixtures: the hermetic isolation fixture DIVERGES without the flag; lapse fixtures archive when protection genuinely lapses (guards observed RED).
+- High-blast flag: step 2.3 (shared selection loop) marked **focused review before build** — it touches the one path all three prune modes share.

--- a/docs/rfcs/RFC-009-lesson-activation.md
+++ b/docs/rfcs/RFC-009-lesson-activation.md
@@ -487,7 +487,7 @@ Each phase's merge is gated by the R-groups below plus its phase-specific gates;
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
-| P0 (P0-S1..S3, PR #454) | `scripts/em-pattern-health.mjs` (`--hermetic`, R5a), `scripts/em-prune.mjs` (R6 protection set), docs guide + README + CI wiring | `tests/test-pattern-health-hermetic.mjs` (8), `tests/test-prune-protection.mjs` (14) | R6 blend half lands with R2 in P1; R5b CI gate is P3 |
+| P0 (P0-S1..S3, PR #454) | `scripts/em-pattern-health.mjs` (`--hermetic`, R5a), `scripts/em-prune.mjs` (R6 protection set), docs guide + README + CI wiring | `tests/test-pattern-health-hermetic.mjs` (8), `tests/test-prune-protection.mjs` (17) | R6 blend half lands with R2 in P1; R5b CI gate is P3 |
 | _pending_ | _pending_ | _pending_ | _pending_ |
 
 ---

--- a/docs/rfcs/RFC-009-lesson-activation.md
+++ b/docs/rfcs/RFC-009-lesson-activation.md
@@ -487,6 +487,7 @@ Each phase's merge is gated by the R-groups below plus its phase-specific gates;
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
+| P0 (P0-S1..S3, PR #454) | `scripts/em-pattern-health.mjs` (`--hermetic`, R5a), `scripts/em-prune.mjs` (R6 protection set), docs guide + README + CI wiring | `tests/test-pattern-health-hermetic.mjs` (8), `tests/test-prune-protection.mjs` (14) | R6 blend half lands with R2 in P1; R5b CI gate is P3 |
 | _pending_ | _pending_ | _pending_ | _pending_ |
 
 ---

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -25,6 +25,7 @@ const HOME = os.homedir()
 const CWD = process.cwd()
 const GLOBAL_DIR = path.join(HOME, '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir(CWD)
+const PROJECT_ROOT = path.dirname(LOCAL_DIR)
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -32,7 +33,7 @@ const LOCAL_DIR = resolveLocalDir(CWD)
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-pattern-health.mjs', usage: 'node em-pattern-health.mjs [--pattern <id>] [--scope local|global|all] [--window-days <N>] [--min-violations <N>] [--has-enforcement <id>] [--check] [--json] [--summary]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-pattern-health.mjs', usage: 'node em-pattern-health.mjs [--pattern <id>] [--scope local|global|all] [--window-days <N>] [--min-violations <N>] [--has-enforcement <id>] [--hermetic] [--check] [--json] [--summary]' }))
   process.exit(0)
 }
 
@@ -69,12 +70,21 @@ const hasEnforcementOverrides = new Set(multiFlag('--has-enforcement'))
 const checkMode = argv.includes('--check')
 const summaryMode = argv.includes('--summary')
 const jsonMode = argv.includes('--json')
+const hermeticMode = argv.includes('--hermetic')
+const scopeExplicit = argv.includes('--scope')
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
   console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
   process.exit(1)
 }
+if (hermeticMode && scopeExplicit && scope !== 'local') {
+  console.log(JSON.stringify({ status: 'error', message: '--hermetic is project-local only; omit --scope or pass --scope local' }))
+  process.exit(1)
+}
+// R5a: hermetic mode is project-local by definition; all path sets below key off
+// effectiveScope / hermeticMode so the flag-off path stays byte-identical.
+const effectiveScope = hermeticMode ? 'local' : scope
 if (summaryMode && jsonMode) {
   console.log(JSON.stringify({ status: 'error', message: '--summary and --json are mutually exclusive' }))
   process.exit(1)
@@ -92,10 +102,17 @@ if (Number.isNaN(minViolations) || minViolations <= 0) {
 // Load patterns registry (project-local first, then global install)
 // ---------------------------------------------------------------------------
 function loadPatternsIndex() {
-  const candidates = [
-    path.join(CWD, 'patterns', '_index.json'),
-    path.join(HOME, '.episodic-memory', 'patterns', '_index.json'),
-  ]
+  // R5a: under --hermetic the registry candidates are the project-local store's
+  // registry then the repo's own patterns/_index.json — never $HOME.
+  const candidates = hermeticMode
+    ? [
+        path.join(LOCAL_DIR, 'patterns', '_index.json'),
+        path.join(PROJECT_ROOT, 'patterns', '_index.json'),
+      ]
+    : [
+        path.join(CWD, 'patterns', '_index.json'),
+        path.join(HOME, '.episodic-memory', 'patterns', '_index.json'),
+      ]
   for (const p of candidates) {
     try {
       const data = JSON.parse(fs.readFileSync(p, 'utf8'))
@@ -107,7 +124,10 @@ function loadPatternsIndex() {
 
 const patterns = loadPatternsIndex()
 if (!patterns) {
-  console.log(JSON.stringify({ status: 'error', message: 'patterns/_index.json not found in project or ~/.episodic-memory/patterns/' }))
+  const msg = hermeticMode
+    ? `patterns/_index.json not found in ${path.join(LOCAL_DIR, 'patterns')} or ${path.join(PROJECT_ROOT, 'patterns')} (--hermetic never reads $HOME)`
+    : 'patterns/_index.json not found in project or ~/.episodic-memory/patterns/'
+  console.log(JSON.stringify({ status: 'error', message: msg }))
   process.exit(1)
 }
 
@@ -120,8 +140,8 @@ if (!patterns) {
 //     em-store appends will simply not appear until the next invocation.
 // ---------------------------------------------------------------------------
 const SCOPE_DIRS = []
-if (scope === 'local' || scope === 'all') SCOPE_DIRS.push({ dir: LOCAL_DIR, source: 'local' })
-if (scope === 'global' || scope === 'all') SCOPE_DIRS.push({ dir: GLOBAL_DIR, source: 'global' })
+if (effectiveScope === 'local' || effectiveScope === 'all') SCOPE_DIRS.push({ dir: LOCAL_DIR, source: 'local' })
+if (effectiveScope === 'global' || effectiveScope === 'all') SCOPE_DIRS.push({ dir: GLOBAL_DIR, source: 'global' })
 
 // Concurrent em-store appends are NOT atomic: a partial last line can appear
 // if em-pattern-health reads while em-store is mid-write. Malformed lines are
@@ -260,12 +280,18 @@ function countViolationsForPattern(patternId) {
 //   false-positives (bp-001 inside bp-001-v2). Limitations are accepted per
 //   RFC-002 §Phase 2; --has-enforcement is the documented escape hatch.
 // ---------------------------------------------------------------------------
-const ENFORCEMENT_PATHS = [
-  { dir: path.join(HOME, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
-  { dir: path.join(CWD, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
-  { dir: path.join(CWD, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
-  { dir: path.join(CWD, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
-]
+const ENFORCEMENT_PATHS = hermeticMode
+  ? [
+      { dir: path.join(PROJECT_ROOT, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(PROJECT_ROOT, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
+      { dir: path.join(PROJECT_ROOT, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
+    ]
+  : [
+      { dir: path.join(HOME, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(CWD, '.claude', 'hooks'), include: f => /\.sh$/.test(f) },
+      { dir: path.join(CWD, '.git', 'hooks'), include: f => !/\.sample$/.test(f) },
+      { dir: path.join(CWD, '.github', 'workflows'), include: f => /\.ya?ml$/.test(f) },
+    ]
 
 function listEnforcementFiles() {
   const files = []

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -99,7 +99,9 @@ function isValidReferencer(row, todayStr) {
 // latest-run-record, chain-member.
 function computeProtectedIds(rows, todayStr) {
   const map = new Map()
-  const set = (id, reason, via) => { if (typeof id === 'string' && !map.has(id)) map.set(id, { reason, via }) }
+  // via normalizes to null when the protecting referencer row has no string id
+  // (the tolerated hand-written class) so the output contract field never vanishes.
+  const set = (id, reason, via) => { if (typeof id === 'string' && !map.has(id)) map.set(id, { reason, via: typeof via === 'string' ? via : null }) }
   const lessonRowsById = new Map()
   for (const r of rows) {
     if (r.category === 'lesson' && typeof r.id === 'string') {
@@ -129,19 +131,26 @@ function computeProtectedIds(rows, todayStr) {
     if (!isValidReferencer(r, todayStr)) continue
     if (stringItems(r.triggers).length > 0) set(r.id, 'trigger-bearing-lesson', r.id)
   }
-  // class c: consolidates members of valid referencers
+  // class c: consolidates members of valid referencers (no id requirement on the
+  // referencer — symmetric with class a; an idless valid row still protects)
   for (const r of rows) {
-    if (typeof r.id !== 'string' || !isValidReferencer(r, todayStr)) continue
+    if (!isValidReferencer(r, todayStr)) continue
     for (const mid of stringItems(r.consolidates)) set(mid, 'consolidates-member', r.id)
   }
-  // class d: latest clerk run record per store (max id; ids sort chronologically)
+  // class d: latest clerk run record per store. Canonical ids (YYYYMMDD-HHMMSS-…)
+  // sort chronologically and are preferred; a hand-written non-canonical id must
+  // not shadow the real latest (it competes only against other non-canonical ids).
   const latestByStore = new Map()
+  const CANONICAL_ID = /^\d{8}-\d{6}-/
   for (const r of rows) {
     if (r.record_type !== 'clerk-run' || typeof r.id !== 'string') continue
+    const canonical = CANONICAL_ID.test(r.id)
     const cur = latestByStore.get(r._store)
-    if (!cur || r.id > cur) latestByStore.set(r._store, r.id)
+    if (!cur || (canonical === cur.canonical ? r.id > cur.id : canonical)) {
+      latestByStore.set(r._store, { id: r.id, canonical })
+    }
   }
-  for (const id of latestByStore.values()) set(id, 'latest-run-record', id)
+  for (const v of latestByStore.values()) set(v.id, 'latest-run-record', v.id)
   // chain closure over class a/b/c anchors (NOT class d): backward via each row's
   // `supersedes`, forward via INVERTED supersedes edges (superseded_by has no
   // substrate writer today) plus `superseded_by` strings when present. An archived
@@ -218,7 +227,7 @@ function pruneDir(dataDir, label, protectedIds) {
   for (const entry of entries) {
     const score = computePruneScore(entry)
     if (score < threshold) {
-      const p = protectedIds.get(entry.id)
+      const p = protectedIds.get(String(entry.id))
       if (p) {
         toKeep.push(entry)
         protectedEntries.push({ id: entry.id, score: Math.round(score * 1000) / 1000, reason: p.reason, via: p.via })

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -32,7 +32,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-prune.mjs', usage: 'node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-prune.mjs', usage: 'node em-prune.mjs [--scope local|global|all] [--threshold <n>] [--dry-run] [--check] — RFC-009 R6 protection: evidence-linked violations, trigger-bearing lessons, consolidates members, and the latest clerk run record are never archived (see protected / protected_episodes output fields)' }))
   process.exit(0)
 }
 
@@ -61,6 +61,129 @@ function computePruneScore(entry) {
   return timeFactor * accessFactor
 }
 
+const TODAY = new Date().toISOString().slice(0, 10)
+
+function loadIndexRows(dataDir, storeLabel) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  const out = []
+  for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const e = JSON.parse(line)
+      e._store = storeLabel
+      out.push(e)
+    } catch {}
+  }
+  return out
+}
+
+function stringItems(v) {
+  return Array.isArray(v) ? v.filter(x => typeof x === 'string') : []
+}
+
+// RFC-009 R6 referencer validity: protection lapses when the referencing episode
+// is superseded or expired. A row with NO status field is a valid referencer (the
+// tolerated hand-written-writer class, #447); a malformed review_by never expires.
+function isValidReferencer(row, todayStr) {
+  if (!row || row.status === 'superseded') return false
+  const rb = row.review_by
+  if (typeof rb === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(rb) && rb < todayStr) return false
+  return true
+}
+
+// RFC-009 R6 protection set. rows = UNION of both stores' index rows (deliberately
+// NO id-dedupe: a stale superseded copy in one store must not shadow an active
+// referencer in the other). Returns Map<id, {reason, via}>; first-set reason wins in
+// the order: evidence-linked-violation, trigger-bearing-lesson, consolidates-member,
+// latest-run-record, chain-member.
+function computeProtectedIds(rows, todayStr) {
+  const map = new Map()
+  const set = (id, reason, via) => { if (typeof id === 'string' && !map.has(id)) map.set(id, { reason, via }) }
+  const lessonRowsById = new Map()
+  for (const r of rows) {
+    if (r.category === 'lesson' && typeof r.id === 'string') {
+      if (!lessonRowsById.has(r.id)) lessonRowsById.set(r.id, [])
+      lessonRowsById.get(r.id).push(r)
+    }
+  }
+  // class a, forward: valid lesson's evidence names violations
+  for (const r of rows) {
+    if (r.category !== 'lesson' || !isValidReferencer(r, todayStr)) continue
+    for (const vid of stringItems(r.evidence)) set(vid, 'evidence-linked-violation', r.id)
+  }
+  // class a, back-link: violation.lessons names a valid lesson (in ANY store)
+  for (const r of rows) {
+    if (r.category !== 'violation' || typeof r.id !== 'string') continue
+    for (const lid of stringItems(r.lessons)) {
+      const cands = lessonRowsById.get(lid) || []
+      if (cands.some(l => isValidReferencer(l, todayStr))) {
+        set(r.id, 'evidence-linked-violation', lid)
+        break
+      }
+    }
+  }
+  // class b: valid trigger-bearing lessons protect themselves
+  for (const r of rows) {
+    if (r.category !== 'lesson' || typeof r.id !== 'string') continue
+    if (!isValidReferencer(r, todayStr)) continue
+    if (stringItems(r.triggers).length > 0) set(r.id, 'trigger-bearing-lesson', r.id)
+  }
+  // class c: consolidates members of valid referencers
+  for (const r of rows) {
+    if (typeof r.id !== 'string' || !isValidReferencer(r, todayStr)) continue
+    for (const mid of stringItems(r.consolidates)) set(mid, 'consolidates-member', r.id)
+  }
+  // class d: latest clerk run record per store (max id; ids sort chronologically)
+  const latestByStore = new Map()
+  for (const r of rows) {
+    if (r.record_type !== 'clerk-run' || typeof r.id !== 'string') continue
+    const cur = latestByStore.get(r._store)
+    if (!cur || r.id > cur) latestByStore.set(r._store, r.id)
+  }
+  for (const id of latestByStore.values()) set(id, 'latest-run-record', id)
+  // chain closure over class a/b/c anchors (NOT class d): backward via each row's
+  // `supersedes`, forward via INVERTED supersedes edges (superseded_by has no
+  // substrate writer today) plus `superseded_by` strings when present. An archived
+  // intermediate would silently break R2's chain-resolved band counting.
+  const rowsById = new Map()
+  const successorsOf = new Map() // supersededId -> [successor ids]
+  for (const r of rows) {
+    if (typeof r.id !== 'string') continue
+    if (!rowsById.has(r.id)) rowsById.set(r.id, [])
+    rowsById.get(r.id).push(r)
+    if (typeof r.supersedes === 'string') {
+      if (!successorsOf.has(r.supersedes)) successorsOf.set(r.supersedes, [])
+      successorsOf.get(r.supersedes).push(r.id)
+    }
+  }
+  const anchorOf = new Map()
+  const queue = []
+  for (const [id, v] of map.entries()) {
+    if (v.reason === 'latest-run-record') continue
+    anchorOf.set(id, id)
+    queue.push(id)
+  }
+  const visited = new Set(queue)
+  while (queue.length) {
+    const id = queue.shift()
+    const neighbors = []
+    for (const r of rowsById.get(id) || []) {
+      if (typeof r.supersedes === 'string') neighbors.push(r.supersedes)
+      if (typeof r.superseded_by === 'string') neighbors.push(r.superseded_by)
+    }
+    for (const succ of successorsOf.get(id) || []) neighbors.push(succ)
+    for (const n of neighbors) {
+      if (visited.has(n)) continue
+      visited.add(n)
+      anchorOf.set(n, anchorOf.get(id))
+      set(n, 'chain-member', anchorOf.get(id))
+      queue.push(n)
+    }
+  }
+  return map
+}
+
 function loadTagsIndex(dataDir) {
   const tagsFile = path.join(dataDir, 'tags.json')
   try {
@@ -70,14 +193,14 @@ function loadTagsIndex(dataDir) {
   }
 }
 
-function pruneDir(dataDir, label) {
+function pruneDir(dataDir, label, protectedIds) {
   const indexFile = path.join(dataDir, 'index.jsonl')
   const episodesDir = path.join(dataDir, 'episodes')
   const archivedDir = path.join(dataDir, 'archived')
   const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
 
   if (!fs.existsSync(indexFile)) {
-    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, episodes: [] }
+    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, protected: 0, episodes: [] }
   }
 
   const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
@@ -87,18 +210,28 @@ function pruneDir(dataDir, label) {
 
   const toPrune = []
   const toKeep = []
+  const protectedEntries = []
 
+  // R6: protection is decided HERE, in the one selection loop every mode shares
+  // (check / dry-run / real prune) — the mode branches below only format the
+  // already-decided sets. Partition: entries = toKeep (incl. protected) + toPrune.
   for (const entry of entries) {
     const score = computePruneScore(entry)
     if (score < threshold) {
-      toPrune.push({ ...entry, _pruneScore: score })
+      const p = protectedIds.get(entry.id)
+      if (p) {
+        toKeep.push(entry)
+        protectedEntries.push({ id: entry.id, score: Math.round(score * 1000) / 1000, reason: p.reason, via: p.via })
+      } else {
+        toPrune.push({ ...entry, _pruneScore: score })
+      }
     } else {
       toKeep.push(entry)
     }
   }
 
   if (checkOnly) {
-    return { scope: label, prunable: toPrune.length, remaining: toKeep.length }
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, protected: protectedEntries.length }
   }
 
   if (dryRun) {
@@ -110,12 +243,12 @@ function pruneDir(dataDir, label) {
       totalSize += size
       return { id: e.id, score: Math.round(e._pruneScore * 1000) / 1000, size }
     })
-    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, episodes: preview }
+    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, protected: protectedEntries.length, protected_episodes: protectedEntries, episodes: preview }
   }
 
   // Actual prune
   if (toPrune.length === 0) {
-    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0 }
+    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0, protected: protectedEntries.length }
   }
 
   fs.mkdirSync(archivedDir, { recursive: true })
@@ -161,12 +294,21 @@ function pruneDir(dataDir, label) {
   fs.writeFileSync(archivedTmp, existingArchived + archivedEntries.join('\n') + '\n', 'utf8')
   fs.renameSync(archivedTmp, archivedIndexFile)
 
-  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes }
+  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes, protected: protectedEntries.length }
 }
 
+// R6 reference scan: UNION of both stores regardless of prune scope — a global
+// lesson's evidence can name a local violation. Deliberately NO id-dedupe (the
+// search-side local-precedence convention would let a stale superseded copy
+// shadow an active referencer). Like the archived-index append race below, the
+// scan-to-archive window is a documented limitation: an episode stored mid-prune
+// protects one run late (recovery: em-restore / archived-index).
+const referenceRows = [...loadIndexRows(LOCAL_DIR, 'local'), ...loadIndexRows(GLOBAL_DIR, 'global')]
+const protectedIds = computeProtectedIds(referenceRows, TODAY)
+
 const results = []
-if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global'))
+if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local', protectedIds))
+if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global', protectedIds))
 
 const totalPruned = results.reduce((sum, r) => sum + (r.pruned || r.prunable || 0), 0)
 

--- a/tests/test-pattern-health-hermetic.mjs
+++ b/tests/test-pattern-health-hermetic.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// test-pattern-health-hermetic.mjs — RFC-009 P0 R5a acceptance (plan §14 group R5).
+// Drives the REAL script against isolated fixture stores with controlled HOME.
+// Fixture layout: PROJ (a git repo, NOT under either home), homeA (populated:
+// ALL THREE $HOME read sites planted), homeB (empty). Recent violation dates keep
+// rows inside the default 30-day window.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const SCRIPT = path.join(REPO, 'scripts', 'em-pattern-health.mjs')
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'em-p0-hermetic-'))
+const PROJ = path.join(ROOT, 'proj')
+const HOME_POP = path.join(ROOT, 'homeA')
+const HOME_EMPTY = path.join(ROOT, 'homeB')
+const RECENT = new Date().toISOString().slice(0, 10)
+
+function writeJson(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2))
+}
+function writeLines(p, rows) {
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+}
+function vio(id, pattern, date) {
+  return { id, date, time: '00:00', project: 'fx', category: 'violation', status: 'active', supersedes: null, tags: [`violated:${pattern}`], summary: `fixture ${id}`, access_count: 0, last_accessed: null }
+}
+
+// --- fixture build ---
+fs.mkdirSync(HOME_EMPTY, { recursive: true })
+fs.mkdirSync(PROJ, { recursive: true })
+spawnSync('git', ['init', '-q'], { cwd: PROJ })
+fs.mkdirSync(path.join(PROJ, 'sub'), { recursive: true })
+writeJson(path.join(PROJ, 'patterns', '_index.json'), { patterns: [{ pattern_id: 'tst-001' }, { pattern_id: 'tst-002' }] })
+writeLines(path.join(PROJ, '.episodic-memory', 'index.jsonl'), [
+  vio('20260701-000001-local-a', 'tst-001', RECENT),
+  vio('20260701-000002-local-b', 'tst-002', RECENT),
+  vio('20260701-000003-local-c', 'tst-002', RECENT),
+  vio('20260701-000004-local-d', 'tst-002', RECENT),
+])
+// populated HOME: all three $HOME read sites (planner F4 — single-site is vacuous)
+fs.mkdirSync(path.join(HOME_POP, '.claude', 'hooks'), { recursive: true })
+fs.writeFileSync(path.join(HOME_POP, '.claude', 'hooks', 'enforce.sh'), '#!/bin/bash\nnode check tst-001 --gate\n')
+writeLines(path.join(HOME_POP, '.episodic-memory', 'index.jsonl'), [
+  vio('20260701-000005-glob-a', 'tst-001', RECENT),
+  vio('20260701-000006-glob-b', 'tst-001', RECENT),
+])
+writeJson(path.join(HOME_POP, '.episodic-memory', 'patterns', '_index.json'), { patterns: [{ pattern_id: 'zzz-999' }] })
+
+function run(args, home, cwd = PROJ) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+}
+function row(res, id) {
+  return JSON.parse(res.stdout).patterns.find(p => p.pattern_id === id)
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+
+t('testHermeticHomeIsolation', () => {
+  const a = run(['--hermetic'], HOME_POP)
+  const b = run(['--hermetic'], HOME_EMPTY)
+  assert(a.stdout === b.stdout, `hermetic stdout diverged:\nA=${a.stdout}\nB=${b.stdout}`)
+  assert(a.status === b.status, `hermetic exit diverged: ${a.status} vs ${b.status}`)
+  // divergence-without-flag leg: proves this fixture would catch a leak
+  const c = run([], HOME_POP)
+  const d = run([], HOME_EMPTY)
+  assert(c.stdout !== d.stdout, 'no-flag runs did NOT diverge — fixture cannot discriminate, vacuous')
+})
+
+t('testHermeticScopeConflict', () => {
+  for (const s of ['all', 'global']) {
+    const r = run(['--hermetic', '--scope', s], HOME_EMPTY)
+    assert(r.status === 1, `--scope ${s}: exit ${r.status}, want 1`)
+    assert(r.stdout.includes('--hermetic is project-local only; omit --scope or pass --scope local'), `--scope ${s}: message missing: ${r.stdout}`)
+  }
+  const ok = run(['--hermetic', '--scope', 'local'], HOME_EMPTY)
+  assert(ok.status === 0, `--scope local under hermetic: exit ${ok.status}, want 0`)
+  const bad = run(['--hermetic', '--scope', 'bogus'], HOME_EMPTY)
+  assert(bad.status === 1 && bad.stdout.includes('Invalid --scope'), `invalid-scope ordering: ${bad.stdout}`)
+})
+
+t('testHermeticDefaultsLocal', () => {
+  const r = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(r.violations === 1, `hermetic tst-001 violations ${r.violations}, want 1 (local only; global has 2 more)`)
+})
+
+t('testHermeticPatternsProjectOnly', () => {
+  const out = JSON.parse(run(['--hermetic'], HOME_POP).stdout)
+  assert(!out.patterns.some(p => p.pattern_id === 'zzz-999'), '$HOME-only pattern zzz-999 leaked into hermetic output')
+  // subdir leg (EC10): PROJ is a git repo, so PROJECT_ROOT resolves from sub/ too
+  const sub = run(['--hermetic'], HOME_EMPTY, path.join(PROJ, 'sub'))
+  const root = run(['--hermetic'], HOME_EMPTY)
+  assert(sub.stdout === root.stdout, `subdir cwd diverged from root cwd:\nSUB=${sub.stdout}\nROOT=${root.stdout}`)
+  // LOCAL_DIR registry beats PROJECT_ROOT registry (candidate order)
+  writeJson(path.join(PROJ, '.episodic-memory', 'patterns', '_index.json'), { patterns: [{ pattern_id: 'loc-111' }] })
+  const loc = JSON.parse(run(['--hermetic'], HOME_EMPTY).stdout)
+  fs.rmSync(path.join(PROJ, '.episodic-memory', 'patterns'), { recursive: true, force: true })
+  assert(loc.patterns.length === 1 && loc.patterns[0].pattern_id === 'loc-111', `LOCAL_DIR registry did not win: ${JSON.stringify(loc.patterns)}`)
+})
+
+t('testHermeticEnforcementProjectOnly', () => {
+  const before = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(before.has_enforcement === false, 'populated-HOME hook detected under --hermetic ($HOME leak)')
+  // MUTATES fixture: adds a project hook naming tst-001; later tests use tst-002 or non-hermetic runs
+  fs.mkdirSync(path.join(PROJ, '.claude', 'hooks'), { recursive: true })
+  fs.writeFileSync(path.join(PROJ, '.claude', 'hooks', 'proj.sh'), '#!/bin/bash\nnode check tst-001 --gate\n')
+  const after = row(run(['--hermetic'], HOME_POP), 'tst-001')
+  assert(after.has_enforcement === true, 'project .claude/hooks hook NOT detected under --hermetic')
+})
+
+t('testHermeticCheckExit', () => {
+  const bad = run(['--hermetic', '--check', '--pattern', 'tst-002'], HOME_EMPTY)
+  assert(bad.status === 1, `3 violations, no enforcement: --check exit ${bad.status}, want 1`)
+  const healthy = run(['--hermetic', '--check', '--pattern', 'tst-002', '--min-violations', '5'], HOME_EMPTY)
+  assert(healthy.status === 0, `healthy fixture: --check exit ${healthy.status}, want 0`)
+})
+
+t('testHermeticHasEnforcementOverride', () => {
+  const r = row(run(['--hermetic', '--has-enforcement', 'tst-002'], HOME_EMPTY), 'tst-002')
+  assert(r.has_enforcement === true, 'argv --has-enforcement override ignored under --hermetic')
+  assert(r.recommendation === 'needs-attention', `override recommendation ${r.recommendation}, want needs-attention`)
+})
+
+t('testNonHermeticUnchanged', () => {
+  const r = row(run([], HOME_POP), 'tst-001')
+  assert(r.has_enforcement === true, 'legacy path lost the $HOME/.claude/hooks scan')
+  assert(r.violations === 3, `legacy scope-all tst-001 violations ${r.violations}, want 3 (1 local + 2 global)`)
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)

--- a/tests/test-prune-protection.mjs
+++ b/tests/test-prune-protection.mjs
@@ -175,6 +175,12 @@ t('testProtectedCountInOutput', () => {
   // partition invariant, all three modes: 4 = remaining + prunable/pruned
 })
 
+t('testDocsGrepGate', () => {
+  const guide = fs.readFileSync(path.join(REPO, 'docs', 'EM_SCRIPTS_GUIDE.md'), 'utf8')
+  assert(guide.includes('--hermetic'), 'EM_SCRIPTS_GUIDE.md missing --hermetic (RFC-009 P0 docs gate)')
+  assert(guide.includes('protected_episodes'), 'EM_SCRIPTS_GUIDE.md missing protected_episodes (RFC-009 P0 docs gate)')
+})
+
 let pass = 0
 for (const [name, fn] of tests) {
   try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }

--- a/tests/test-prune-protection.mjs
+++ b/tests/test-prune-protection.mjs
@@ -175,6 +175,45 @@ t('testProtectedCountInOutput', () => {
   // partition invariant, all three modes: 4 = remaining + prunable/pruned
 })
 
+t('testIdlessReferencerProtectsBothClasses', () => {
+  // reviewer F1/F2: an idless valid referencer protects via evidence AND consolidates
+  // symmetrically; via renders as null, never dropped from the JSON
+  const noIdA = row('x', { category: 'lesson', date: RECENT, evidence: ['va'] })
+  delete noIdA.id
+  const noIdC = row('y', { category: 'lesson', date: RECENT, consolidates: ['ma'] })
+  delete noIdC.id
+  const w = mkWorld([row('va'), row('ma', { category: 'lesson', status: 'superseded' }), noIdA, noIdC])
+  const dry = prune(w, ['--dry-run']).out
+  const va = dry.protected_episodes.find(p => p.id === 'va')
+  const ma = dry.protected_episodes.find(p => p.id === 'ma')
+  assert(va && va.reason === 'evidence-linked-violation' && va.via === null, `va: ${JSON.stringify(dry.protected_episodes)}`)
+  assert(ma && ma.reason === 'consolidates-member' && ma.via === null, `ma: ${JSON.stringify(dry.protected_episodes)}`)
+  prune(w, [])
+  assert(survives(w, 'va') && survives(w, 'ma'), 'idless-referencer protection asymmetric across classes')
+})
+
+t('testNumericIdRowProtected', () => {
+  // reviewer F3: a numeric-id row named by a valid lesson's evidence is protected
+  // (string-keyed map, String() lookup)
+  const w = mkWorld([row(20250101), row('ln', { category: 'lesson', date: RECENT, evidence: ['20250101'] })])
+  const r = prune(w, [])
+  assert(r.out.protected === 1, `numeric-id row not protected: ${JSON.stringify(r.out)}`)
+  const idx = fs.readFileSync(path.join(w.proj, '.episodic-memory', 'index.jsonl'), 'utf8')
+  assert(idx.includes('20250101'), 'numeric-id row archived — String() lookup missing')
+})
+
+t('testJunkRunRecordIdDoesNotShadow', () => {
+  // reviewer F4: a hand-written non-canonical clerk-run id must not shadow the
+  // canonical latest run record
+  const w = mkWorld([
+    row('zzz-handwritten', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+    row('20250502-000001-run-new', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+  ])
+  prune(w, [])
+  assert(survives(w, '20250502-000001-run-new'), 'canonical latest run record archived — junk id shadowed it')
+  assert(!survives(w, 'zzz-handwritten'), 'junk clerk-run row survived — should age out under normal score')
+})
+
 t('testDocsGrepGate', () => {
   const guide = fs.readFileSync(path.join(REPO, 'docs', 'EM_SCRIPTS_GUIDE.md'), 'utf8')
   assert(guide.includes('--hermetic'), 'EM_SCRIPTS_GUIDE.md missing --hermetic (RFC-009 P0 docs gate)')

--- a/tests/test-prune-protection.mjs
+++ b/tests/test-prune-protection.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// test-prune-protection.mjs — RFC-009 P0 R6 prune-protection acceptance (plan §14 group R6).
+// Each test builds a FRESH isolated store (real prune mutates), spawns the REAL
+// script with explicit cwd + controlled HOME, and asserts on captured JSON + disk.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const SCRIPT = path.join(REPO, 'scripts', 'em-prune.mjs')
+const AGED = '2025-05-01'          // score 0.1 < default threshold 0.15
+const RECENT = new Date().toISOString().slice(0, 10)
+const PAST = '2025-01-01'          // expired review_by
+
+function row(id, extra = {}) {
+  return { id, date: AGED, time: '00:00', project: 'fx', category: 'violation', status: 'active', supersedes: null, tags: [], summary: `fixture ${id}`, access_count: 0, last_accessed: null, ...extra }
+}
+function mkWorld(localRows, globalRows = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em-p0-prune-'))
+  const proj = path.join(root, 'proj')
+  const home = path.join(root, 'home')
+  const write = (dir, rows) => {
+    fs.mkdirSync(path.join(dir, 'episodes'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'index.jsonl'), rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+    for (const r of rows) fs.writeFileSync(path.join(dir, 'episodes', `${r.id}.md`), `# ${r.id}\n`)
+  }
+  write(path.join(proj, '.episodic-memory'), localRows)
+  fs.mkdirSync(home, { recursive: true })
+  if (globalRows.length) write(path.join(home, '.episodic-memory'), globalRows)
+  return { proj, home }
+}
+function prune(world, args) {
+  const r = spawnSync(process.execPath, [SCRIPT, '--scope', 'local', ...args], { cwd: world.proj, env: { ...process.env, HOME: world.home, USERPROFILE: world.home }, encoding: 'utf8' })
+  return { status: r.status, out: JSON.parse(r.stdout).results[0], raw: r.stdout }
+}
+function survives(world, id) {
+  return fs.existsSync(path.join(world.proj, '.episodic-memory', 'episodes', `${id}.md`)) &&
+    fs.readFileSync(path.join(world.proj, '.episodic-memory', 'index.jsonl'), 'utf8').includes(`"${id}"`)
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+
+t('testEvidenceLinkedViolationSurvives', () => {
+  const w = mkWorld([row('v1'), row('l1', { category: 'lesson', date: RECENT, evidence: ['v1'] })])
+  const dry = prune(w, ['--dry-run']).out
+  assert(dry.protected === 1 && dry.protected_episodes[0].id === 'v1' && dry.protected_episodes[0].reason === 'evidence-linked-violation' && dry.protected_episodes[0].via === 'l1', `dry-run: ${JSON.stringify(dry)}`)
+  prune(w, [])
+  assert(survives(w, 'v1'), 'v1 archived despite active evidence link')
+})
+
+t('testViolationLessonsBacklinkSurvives', () => {
+  const w = mkWorld([row('v2', { lessons: ['l2'] }), row('l2', { category: 'lesson', date: RECENT })])
+  prune(w, [])
+  assert(survives(w, 'v2'), 'v2 archived despite lessons back-link to active lesson')
+})
+
+t('testTriggerBearingLessonSurvives', () => {
+  const w = mkWorld([row('l3', { category: 'lesson', triggers: ['second opinion'] })])
+  const dry = prune(w, ['--dry-run']).out
+  assert(dry.protected_episodes[0].reason === 'trigger-bearing-lesson' && dry.protected_episodes[0].via === 'l3', JSON.stringify(dry))
+  prune(w, [])
+  assert(survives(w, 'l3'), 'aged active trigger-bearing lesson archived')
+})
+
+t('testConsolidatesMemberSurvives', () => {
+  const w = mkWorld([row('m4', { category: 'lesson', status: 'superseded' }), row('c4', { category: 'lesson', date: RECENT, consolidates: ['m4'] })])
+  prune(w, [])
+  assert(survives(w, 'm4'), 'consolidates member archived while consolidated lesson active')
+  // class-c lapse leg (codex r2 F2): a superseded consolidating referencer stops protecting
+  const w2 = mkWorld([row('m4b', { category: 'lesson', status: 'superseded' }), row('c4b', { category: 'lesson', date: RECENT, status: 'superseded', consolidates: ['m4b'] })])
+  prune(w2, [])
+  assert(!survives(w2, 'm4b'), 'member survived though its consolidating referencer is superseded — class-c lapse broken')
+})
+
+t('testMissingStatusReferencerProtects', () => {
+  const noStatus = row('l5', { category: 'lesson', date: RECENT, evidence: ['v5'] })
+  delete noStatus.status
+  const w = mkWorld([row('v5'), noStatus])
+  prune(w, [])
+  assert(survives(w, 'v5'), 'missing-status referencer failed to protect (planner F2 class)')
+})
+
+t('testProtectionLapseOnSupersede', () => {
+  const w = mkWorld([row('v6'), row('l6', { category: 'lesson', date: RECENT, evidence: ['v6'], status: 'superseded' })])
+  prune(w, [])
+  assert(!survives(w, 'v6'), 'v6 survived though its only referencer is superseded — protection cannot lapse (guard never RED)')
+})
+
+t('testExpiredTriggerLessonPrunable', () => {
+  const w = mkWorld([row('l7', { category: 'lesson', triggers: ['x'], review_by: PAST })])
+  prune(w, [])
+  assert(!survives(w, 'l7'), 'expired trigger-bearing lesson survived — review_by lapse broken')
+})
+
+t('testExpiredReferencerLapsesEvidence', () => {
+  const w = mkWorld([row('v8'), row('l8', { category: 'lesson', date: RECENT, evidence: ['v8'], review_by: PAST })])
+  prune(w, [])
+  assert(!survives(w, 'v8'), 'evidence of an EXPIRED lesson survived — planner F12 lapse not applied to class a')
+})
+
+t('testLatestRunRecordSurvives', () => {
+  const w = mkWorld([
+    row('20250501-000001-run-old', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+    row('20250502-000001-run-new', { category: 'workflow.lifecycle', record_type: 'clerk-run' }),
+  ])
+  prune(w, [])
+  assert(survives(w, '20250502-000001-run-new'), 'latest clerk-run archived')
+  assert(!survives(w, '20250501-000001-run-old'), 'older clerk-run survived — aging out broken')
+})
+
+t('testChainMembersProtected', () => {
+  // v10a: chain root (superseded, NO superseded_by field anywhere — forward edge
+  // must come from INVERTING v10b.supersedes; planner F1). Both aged.
+  const w = mkWorld([
+    row('v10a', { status: 'superseded' }),
+    row('v10b', { supersedes: 'v10a' }),
+    row('l10', { category: 'lesson', date: RECENT, evidence: ['v10a'] }),
+    // cycle fixture: mutually superseding aged rows anchored by l11 (EC4)
+    row('c1', { supersedes: 'c2' }),
+    row('c2', { supersedes: 'c1' }),
+    row('l11', { category: 'lesson', date: RECENT, evidence: ['c1'] }),
+  ])
+  const dry = prune(w, ['--dry-run']).out
+  const v10b = dry.protected_episodes.find(p => p.id === 'v10b')
+  assert(v10b && v10b.reason === 'chain-member' && v10b.via === 'v10a', `v10b: ${JSON.stringify(dry.protected_episodes)}`)
+  prune(w, [])
+  for (const id of ['v10a', 'v10b', 'c1', 'c2']) assert(survives(w, id), `${id} archived — chain closure broken`)
+})
+
+t('testCrossStoreProtection', () => {
+  // global active lesson protects a local violation; a STALE local superseded copy
+  // of the same lesson id must not shadow it (union semantics, planner F3)
+  const w = mkWorld(
+    [row('vl'), row('lg', { category: 'lesson', status: 'superseded' })],
+    [row('lg', { category: 'lesson', date: RECENT, evidence: ['vl'] })]
+  )
+  prune(w, [])
+  assert(survives(w, 'vl'), 'cross-store protection failed (or stale local copy shadowed the active global referencer)')
+  // missing-global leg: no home store at all → clean run
+  const w2 = mkWorld([row('u1')])
+  const r = prune(w2, [])
+  assert(r.status === 0 && !survives(w2, 'u1'), 'missing global index broke prune')
+})
+
+t('testMalformedFieldsTolerated', () => {
+  const nan = row('nan1', { date: 'not-a-date' })
+  const w = mkWorld([
+    row('vm'),
+    row('lm1', { category: 'lesson', date: RECENT, evidence: 'vm' }),      // non-array: must NOT protect
+    row('lm2', { category: 'lesson', date: RECENT, triggers: 42 }),        // non-array: no crash
+    nan,                                                                    // NaN score: survives (EC11, pinned)
+  ])
+  const r = prune(w, [])
+  assert(r.status === 0, `malformed fields crashed prune: ${r.raw}`)
+  assert(!survives(w, 'vm'), 'string evidence field protected vm — malformed must not protect')
+  assert(survives(w, 'nan1'), 'NaN-date row was archived — EC11 contract broken')
+})
+
+t('testProtectedCountInOutput', () => {
+  const mk = () => mkWorld([row('vp'), row('lp', { category: 'lesson', date: RECENT, evidence: ['vp'] }), row('u2'), row('k1', { date: RECENT })])
+  // 4 rows: vp protected-aged, u2 unprotected-aged, lp + k1 recent
+  const chk = prune(mk(), ['--check'])
+  assert(chk.out.prunable === 1 && chk.out.remaining === 3 && chk.out.protected === 1, `check: ${JSON.stringify(chk.out)}`)
+  assert(chk.status === 1, `check exit ${chk.status}, want 1 (u2 prunable)`)
+  const dry = prune(mk(), ['--dry-run']).out
+  assert(dry.prunable === 1 && dry.remaining === 3 && dry.protected === 1, `dry: ${JSON.stringify(dry)}`)
+  assert(dry.episodes.length === 1 && dry.episodes[0].id === 'u2', `dry preview: ${JSON.stringify(dry.episodes)}`)
+  assert(dry.protected_episodes.length === 1 && dry.protected_episodes[0].via === 'lp', `dry protected: ${JSON.stringify(dry.protected_episodes)}`)
+  const real = prune(mk(), []).out
+  assert(real.pruned === 1 && real.remaining === 3 && real.protected === 1, `real: ${JSON.stringify(real)}`)
+  // partition invariant, all three modes: 4 = remaining + prunable/pruned
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)


### PR DESCRIPTION
## Summary

Phase 0 of RFC-009 Lesson Activation, built from the approved plan `docs/plans/rfc-009-p0.md` (negative-scenario-planner pass merged; codex cmux r3 ACCEPT with the reviewer executing the plan's fenced artifacts; post-impl negative-scenario-reviewer HOLD → F1-F4 fixed with regression tests).

- **R5a** — `em-pattern-health --hermetic`: reads ONLY project surfaces (local store violations, `<project>/.episodic-memory/patterns/` → `<project>/patterns/_index.json` registry, project-only enforcement scan); zero HOME-derived fs reads — output byte-identical under any HOME (fixture plants all three read sites); scope forced local, explicit `--scope global|all` errors; `--check` exit contract unchanged; flag-off path byte-identical to main.
- **R6 protection set** — `em-prune` never archives (any mode): evidence-linked violations (both link directions), valid trigger-bearing lessons, `consolidates` members, supersession-chain members (forward edges DERIVED by inverting `supersedes` — `superseded_by` has no writer until P4), and the latest canonical `clerk-run` record per store. Uniform validity predicate (`status !== 'superseded'`, unexpired `review_by`) — protection lapses on supersession/expiry. Cross-store UNION scan (no id-dedupe: a stale local copy must not shadow an active global referencer). Additive output: `protected` count + `--dry-run` `protected_episodes [{id, score, reason, via}]`; `remaining` includes protected; `--check` exit excludes them.
- **Docs + CI**: EM_SCRIPTS_GUIDE + README sections, docs-grep gate test, two workflow steps in `plan-marker-validate.yml`, RFC Implementation row marked.

## Evidence

- Runtime probes (isolated fixture store): pre-impl HOME divergence (`has_enforcement` true/false, violations 2/1) → post-impl `IDENTITY A===B: true`; pre-impl `prunable: 3` → post-impl `prunable: 0, protected: 3` with reasons + via.
- Suites: `test-pattern-health-hermetic.mjs` 8/8, `test-prune-protection.mjs` 17/17, `test-rfc002-phase2.mjs` 31/31, `test-phase2.mjs` 24/24, `em-rfc-validate` green.
- Review trail in plan §19: planner F1-F14 merged; codex r1/r2 HOLD → r3 ACCEPT; post-impl reviewer F1-F4 fixed (class-c id-guard symmetry, `via: null` normalization, `String()` id lookup, canonical-id run-record ordering), F5 pre-existing crash → follow-up issue.

## Deferred (issues at merge)

- F5: pre-existing string-typed `tags` crash in the linear-scan fallback (main + branch, exposure raised by the future R5b CI gate).
- DEFER-2: `em-recall`'s duplicated prune score ignores protection (advisory overcount only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaVRe2gVZSLwgbE6jARqmv