### PR TITLE
RFC-009 P1a: R10 memory taxonomy (category axis)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -168,6 +168,30 @@ jobs:
       - name: Run RFC-009 P0 prune-protection tests
         run: node tests/test-prune-protection.mjs
 
+      - name: Validate schemas (RFC-009 P1a — categories.schema.json discovered + MIN_SCHEMA_DOCS floor)
+        run: node scripts/validate-schemas.mjs --project "$PWD"
+
+      - name: Run RFC-009 P1a categories lib + schema tests
+        run: node tests/test-categories-lib.mjs
+
+      - name: Run RFC-009 P1a strict write-surface tests (store/revise/restore matrix)
+        run: node tests/test-category-write.mjs
+
+      - name: Run RFC-009 P1a category-index + --check drift tests
+        run: node tests/test-category-index.mjs
+
+      - name: Run RFC-009 P1a read-surface tolerance + index-backed --category tests
+        run: node tests/test-category-search.mjs
+
+      - name: Run RFC-009 P1a --history multi-parent walk tests
+        run: node tests/test-history-walk.mjs
+
+      - name: Run RFC-009 P1a per-category prune lifecycle tests
+        run: node tests/test-prune-lifecycle.mjs
+
+      - name: Run RFC-009 P1a categories.json global-deploy mock E2E
+        run: node tests/test-install-categories.mjs
+
   p12-invariant-gate:
     # RFC-008 P4d S8 (REQ-10 / REQ-11): the three Principle-12 invariants as ONE
     # separately-named REQUIRED check. Membership is defined in code

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Three additional SKILLs are invoked from `launchd` rather than the agent's sessi
 | `research` | Web research distilled for future reference |
 | `lesson` | Consolidated lessons from multiple episodes |
 | `violation` | Behavioral pattern violations with structured sequences |
+| `workflow.lifecycle` | Event-plane records emitted by the behavior-pattern workflow layer |
+| `workplan` | Active prioritized work queue, superseded via revision chains |
+| `temporary` | Transient working episodes (review threads, scratch); `aggregate-then-prune` lifecycle |
+
+The vocabulary is a closed set defined once in `categories.json` (RFC-009 R10b) and read by every
+script through `scripts/lib/categories.mjs`. Filter by category with `em-search --category`
+(index-backed via `category-index.json`); `em-rebuild-index --check` reports category drift.
 
 ## Data Locations
 
@@ -189,13 +196,16 @@ Three additional SKILLs are invoked from `launchd` rather than the agent's sessi
 ├── scripts/                  # Installed scripts
 ├── episodes/                 # Global episode .md files
 ├── patterns/                 # Pattern registry (_index.json)
+├── categories.json           # Category vocabulary (RFC-009 R10b)
 ├── index.jsonl               # Global index
-└── tags.json                 # Inverted tag index
+├── tags.json                 # Inverted tag index
+└── category-index.json       # Category -> episode-ids index
 
 <project>/.episodic-memory/   # Per-project (local)
 ├── episodes/                 # Project-local episode .md files
 ├── index.jsonl               # Project-local index
-└── tags.json                 # Inverted tag index
+├── tags.json                 # Inverted tag index
+└── category-index.json       # Category -> episode-ids index
 
 patterns/                     # Behavioral patterns (shipped with repo)
 ├── _index.json               # Machine-readable pattern registry

--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0.0",
+  "categories": [
+    {
+      "name": "decision",
+      "description": "an architectural or process decision, its rationale, and alternatives weighed",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "discovery",
+      "description": "a non-obvious fact learned about the codebase, a tool, or an external system",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "milestone",
+      "description": "a completed unit of work worth recording (a merged PR, a shipped feature, a deploy)",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "context",
+      "description": "durable background about a project, goal, or constraint not derivable from the code",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "research",
+      "description": "distilled findings from external research (docs, articles, specs) worth caching",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "lesson",
+      "description": "a reusable rule or pattern learned from experience, applicable to future work",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "violation",
+      "description": "a recorded instance of a behavioral pattern being broken, for strike counting and recall",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "workflow.lifecycle",
+      "description": "an event-plane record emitted by the behavior-pattern workflow layer (review threads, gate state)",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "workplan",
+      "description": "an active work queue with prioritized items, superseded via revision chains as priorities change",
+      "lifecycle": "standard"
+    },
+    {
+      "name": "temporary",
+      "description": "transient working episodes: review threads, scratch context",
+      "lifecycle": "aggregate-then-prune"
+    }
+  ]
+}

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -70,6 +70,30 @@ default.
 
 ---
 
+## Category vocabulary (RFC-009 R10)
+
+The set of valid episode categories is a closed vocabulary defined once in
+`categories.json` (repo root; deployed to `~/.episodic-memory/categories.json`), read by
+every script through `scripts/lib/categories.mjs`. Do not hardcode category names anywhere.
+
+- Members: `decision`, `discovery`, `milestone`, `context`, `research`, `lesson`,
+  `violation`, `workflow.lifecycle`, `workplan`, `temporary`.
+- A **category** is a single load-bearing typed field (exactly one per episode, drawn from
+  this vocabulary). **Tags** are a free-form, additive label set and are never load-bearing
+  in control flow. Filter by category with `em-search --category`, by tag with `--tag`.
+- **Write surfaces are strict**: `em-store` and `em-revise` reject an unknown or deprecated
+  category (a deprecated one names its successor). `em-restore --apply` skips-and-surfaces an
+  unknown-category episode instead of writing it through.
+- **Read/index/prune surfaces are tolerant**: an episode with an unknown category never breaks
+  listing, search, ranking, or index build; `em-rebuild-index --check` reports it as drift.
+- **Lifecycle**: most categories are `standard`. `temporary` is `aggregate-then-prune` — once a
+  temporary episode is consolidated (carries `superseded_by`), `em-prune` may archive it
+  aggressively even if it is referenced by a successor's `consolidates` array.
+- **Deprecation** is by mapping, never deletion: a member gains `deprecated_for: <successor>`
+  and readers map it at read/index time; stored episode bytes are never rewritten.
+
+---
+
 ## Full entries
 
 ### em-store
@@ -177,8 +201,12 @@ Flags that matter (from the script's own `Usage:` header):
 - `--no-track` skips access tracking. Use it (with `--no-score`) for investigative
   or repeated searches so you do not pollute the usage signals that recall relies on.
   History queries and `--include-superseded` already skip tracking.
-- `--full` includes episode bodies. `--history <id>` returns the whole supersedes
-  chain.
+- `--full` includes episode bodies. `--history <id>` returns the whole revision
+  chain. The walk follows `supersedes`, `superseded_by`, and `consolidates` edges
+  (cycle-safe); a single-`supersedes` chain is unchanged.
+- `--category <cat>` is index-backed via `category-index.json` (same degrade-to-linear-scan
+  fallback as `--tag`). A deprecated category name canonicalizes to its successor; an unknown
+  category still filters (tolerant read).
 
 `--history` output (chain, oldest first):
 
@@ -257,8 +285,8 @@ Output:
 
 ### em-rebuild-index
 
-Regenerate `index.jsonl` (and `tags.json`) from the episode `.md` files on disk.
-Atomic (temp plus rename). Idempotent: safe to run repeatedly.
+Regenerate `index.jsonl` (and `tags.json` plus `category-index.json`) from the episode
+`.md` files on disk. Atomic (temp plus rename). Idempotent: safe to run repeatedly.
 
 - WHEN TO USE: the index looks out of sync, after you manually removed an episode
   file, or to recover from a corrupted index.
@@ -271,7 +299,19 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 Output:
 
 ```json
-{"status":"ok","rebuilt":[{"scope":"local","count":1},{"scope":"global","count":1}]}
+{"status":"ok","rebuilt":[{"scope":"local","count":1,"category_drift":{"unknown":{},"deprecated":{}}}]}
+```
+
+`category-index.json` maps each canonical category to its episode ids (deprecated members
+map to the successor key; unknown categories are indexed under their literal key AND counted
+as drift). It backs `em-search --category` the same way `tags.json` backs `--tag`.
+
+`--check` (RFC-009 R10f) is a read-only drift report: it lists every episode whose stored
+category is unknown or deprecated and exits 1 if any exist, 0 otherwise. It writes nothing.
+Use it in CI/hooks to catch taxonomy drift without correcting it (correction is a later phase).
+
+```
+node ~/.episodic-memory/scripts/em-rebuild-index.mjs --check --scope all
 ```
 
 Note: `--help` short-circuits safely (PR #449), but any OTHER unknown argument is

--- a/docs/plans/rfc-009-p1a.md
+++ b/docs/plans/rfc-009-p1a.md
@@ -1,0 +1,741 @@
+# RFC009-P1a Memory Taxonomy: categories.json + category index + validation matrix Plan
+
+## §1 Status
+
+`Implemented + reviewed.` Current stage: **operator-approved (2026-07-06) and IMPLEMENTED on
+`feat/rfc-009-p1a` (S1-S7, commits c9d1f6e..a83e9e9); 55 P1a tests green + em-restore self-test 120/0
++ prune-protection 17/17; §15 four-surface E2E shows the matrix now consistent; post-impl code review
+(negative-scenario-reviewer, §19.4) returned ACCEPT with 0 findings across all 9 attack axes + I1-I5 +
+EC1-EC10, all runtime-probed. Deferred issues filed (Rule 18 step 9): #457 (§17-A T6→P1b),
+#458 (§17-E fork-loss), #459 (multi-scope index fallback). Pending: PR + CI + operator merge + global
+deploy.** Prior planning stage: reviews converged — planner HOLD (§19.1) + codex R1 HOLD (§19.2) +
+codex R2 HOLD (§19.3) all folded; design validated; altitude LOW.
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-009` |
+| Parent requirements | `R10 (a–f); R2/R9 cited for the em-search `--history` walk rationale` |
+| Workplan episode | `20260705-125419-workplan-v162-pr-452-merged-eb6ac0a-rfc--c94c` |
+| Target branch | `feat/rfc-009-p1a` |
+| Executor altitude (§0.1) | `low` (default; no high-capability implementer named) |
+
+P1a is the first of the two PRs the operator sequenced inside RFC-009 Phase 1 ("R10 first,
+then R1/R2/R9a", session handoff 2026-07-06). P0 (`--hermetic` + prune protection set) merged
+and deployed as `e3e1f05`; it is the hard dep and is done. P1a delivers the **category axis** of
+R10 (the schema-backed closed vocabulary, its derived index, the per-surface validation matrix,
+the temporary lifecycle, and drift detection) plus the `em-search --history` multi-parent walk
+that R9 (P4) will depend on. P1b (next PR) delivers R1 activation flags + R2 trigger index +
+R9a collision report + the RFC-009 contract.json mirror.
+
+## §2 Episode Search Summary
+
+Recall run (2026-07-06): `node scripts/em-search.mjs --tag rfc-009 --scope all --limit 10 --no-track --no-score --full` (abbreviated):
+
+- `20260705-125419-…-c94c` — workplan v162; P1 picked, sequenced R10-first. Constrains this PR to the R10 category axis only.
+- `20260705-084023-…-f5e3` — violation: taxonomy conflation (category-vs-tag) caught by the user, not the planner. This PR is the fix; the T2 invariant (a tag is never load-bearing) is honored — nothing new in P1a branches on a tag value, and run-record location stays a typed scalar, never a tag.
+- `20260705-102842-…-eaa1` / `…-a945` — PR #451 strict event-plane boundary + behavior-simulation convention. Constrains this PR: every claim about store/restore/prune/index behavior is runtime-probed against an isolated fixture store (§15), not asserted from source reading.
+- P0 milestone `…9f34` — `em-prune` now carries the R6 protection set (lines 85-99+). P1a ADDS the R10e per-category lifecycle on top; the protection set is untouched.
+
+Verified against current code before relying on recalled facts (2026-07-06):
+- `em-store.mjs:81` — `VALID_CATEGORIES` hardcoded array (8 members). `em-restore.mjs:40` — duplicate of the same array, kept in sync by the self-test `valid_categories_match_em_store` (em-restore.mjs:1242-1260) which greps `em-store.mjs` for the literal.
+- `em-restore` write path (apply) writes ANY episode category through without validation (runtime-verified asymmetry, RFC evidence appendix item 4); its `--category` FILTER validates against the duplicated list (em-restore.mjs:978-980).
+- `em-revise.mjs:159-166,227` — inherits the original episode's `category` verbatim; performs NO vocabulary validation.
+- `em-rebuild-index.mjs` — builds `index.jsonl` + `tags.json`; the index entry object (lines 118-131) is an EXPLICIT allow-list of fields (no category-index; `consolidates`/`superseded_by` not carried).
+- `em-search.mjs:175-203` — `--history` walks the SINGLE-valued `supersedes` edge only (backward to root, forward via a one-parent `bySupersedes` map).
+- `install.mjs:389-413` — deploys `patterns/_index.json` globally (§1b) but DELIBERATELY NOT `patterns/taxonomy.json` (it is an enforcement artifact, P12). `categories.json` is substrate → must deploy globally.
+
+## §3 Objective
+
+The episode category vocabulary stops being hardcoded twice in script source and becomes a
+single schema-backed data artifact `categories.json`, read by every substrate script through one
+lib. Four write/read/index/prune surfaces stop behaving four different ways about an unknown
+category and instead obey the R10c matrix exactly (store/revise strict; restore strict-including-
+deprecated + skip-and-surface on apply; search/list/recall tolerant; index build tolerant + counting).
+Category earns a derived index `category-index.json` (built by `em-rebuild-index`, incrementally
+maintained by `em-store`/`em-revise`) so `em-search --category` is index-backed like `--tag`.
+`temporary` and `workplan` join the vocabulary; deprecated members retire via `deprecated_for`
+mapping (never deletion). `em-prune` reads a per-category `lifecycle` policy from the vocabulary
+(`aggregate-then-prune` bites only once a consolidated successor exists). `em-search --history`
+walks the many-to-one `consolidates`/`superseded_by` edges R9 (P4) will write. All provable by
+runtime probes on an isolated fixture store (§15) where today the four surfaces diverge.
+
+Runtime evidence (2026-07-06 probes to be captured at build time — §15 lists the exact commands;
+the RFC evidence appendix already recorded the divergence on 2026-07-05):
+- `em-store --category workplan` → exit 1 (closed vocab). `em-restore --apply` of a `workplan`
+  episode → written through silently. `em-restore --category workplan` (filter) → refused. `em-search`/`em-list` render `workplan` fine. Four surfaces, four behaviors.
+
+## §4 Requirements (Ground Truth)
+
+Every requirement is testable and maps to ≥1 test. Parent R-numbers cited (R10 sub-clauses).
+
+| ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes / edge cases |
+|---|---|---|---|---|---|
+| REQ-1 | `categories.json` exists at repo root with 10 members — the existing 8 (`decision`, `discovery`, `milestone`, `context`, `research`, `lesson`, `violation`, `workflow.lifecycle`) plus `workplan` and `temporary` — each `{name, description, lifecycle}` with `lifecycle ∈ {standard, aggregate-then-prune}`; `temporary` is `aggregate-then-prune`, all others `standard`. Optional `deprecated_for: <successor-name>`. `version` is semver. | R10b | `testCategoriesJsonValidates`, `manual: node scripts/validate-schemas.mjs` | MUST | Launch has zero deprecated members; a deprecated fixture is planted in tests |
+| REQ-2 | `schemas/categories.schema.json` is a valid JSON-Schema 2020-12 doc, **auto-discovered and lint-validated by `validate-schemas.mjs`** (it walks `schemas/` for `*.schema.json` — NO edit to that validator; C3). `additionalProperties:false`; closed `lifecycle` enum; optional `deprecated_for` string. The `categories.json` INSTANCE-validation against the schema + the `deprecated_for`-must-resolve-to-a-non-deprecated-member check live in `testCategoriesJsonValidates`/`testDeprecatedForMustResolve` using **`validateInstance` from `scripts/lib/json-instance-validate.mjs`** (that is where `validateInstance` is exported, L513 — C6; `mini-jsonschema.mjs` exports only `lintSchema`, which is for linting a schema DOC, not instance-validating data against one). Bump `MIN_SCHEMA_DOCS` 17→18 to pin the new doc. | R10b | `testCategoriesJsonValidates`, `testCategoriesSchema`, `testDeprecatedForMustResolve`, `manual: node scripts/validate-schemas.mjs --project <abs>` (discovers 18 docs) | MUST | Mirrors `patterns/taxonomy.schema.json`; instance-validation is a test (via `json-instance-validate.mjs`), not a validate-schemas responsibility |
+| REQ-3 | `scripts/lib/categories.mjs` is the ONLY source of the vocabulary: exports `loadCategories()`, `validateCategory(name,{allowDeprecated})→{ok,reason,successor}`, `canonicalCategory(name)→name` (deprecated→successor, unknown→itself), `categoryLifecycle(name)→lifecycle|null`. Resolves `categories.json` via `import.meta.url` `../../categories.json` (repo root in-repo, `~/.episodic-memory/` deployed). A grep asserts no hardcoded category-name list survives in any `scripts/*.mjs`. | R10b, R10c | `testCategoriesLibResolution`, `testNoHardcodedCategoryList` (grep gate) | MUST | Single home kills the em-store/em-restore duplication + drift-test pair |
+| REQ-4 | `em-store --category <c>` and `em-revise` of an episode whose (inherited) category is `<c>`: **strict** — a member in the vocabulary and NOT deprecated is accepted; a deprecated member is rejected naming the successor; an unknown member is rejected naming the vocabulary. No partial write on rejection. | R10c row 1 | `testStoreStrictAccept`, `testStoreRejectsDeprecated`, `testStoreRejectsUnknown`, `testReviseValidatesInheritedCategory` | MUST | em-revise today inherits unvalidated (em-revise.mjs:159-166); a revise of a hand-planted deprecated-category episode now rejects |
+| REQ-5 | `em-restore --category <c>` (FILTER flag): strict **including deprecated** names (older-vocab backups filter correctly); unknown → the existing invalid-category error. | R10c row 2 | `testRestoreFilterAcceptsDeprecated`, `testRestoreFilterRejectsUnknown` | MUST | Replaces the duplicated hardcoded list at em-restore.mjs:40,978 |
+| REQ-6 | `em-restore --apply` WRITE path: an episode whose category is unknown-to-any-version gets the existing **skip-and-surface** treatment (not written, surfaced in the report), inverting today's silent write-through; an episode whose category is a **deprecated** member restores successfully (written verbatim; readers map it). | R10c row 2 | `testRestoreApplySkipsUnknownCategory`, `testRestoreApplyWritesDeprecated` | MUST | Runtime-probe inversion of RFC evidence item 4; validation runs BEFORE any write (EC6 ordering) |
+| REQ-7 | `em-search` / `em-list` / **`em-recall`** read path stays **tolerant**: an episode with an unknown category (hand-planted, the #447 class) never breaks listing, filtering, ranking, or output (C1 — RFC R10c:231 + P1 gate row 476 name em-recall explicitly; em-recall is otherwise scoped to P1b for the T6 preflight retarget, but its unknown-category read-tolerance is a P1a matrix row and gets a regression pin here). | R10c row 3 | `testSearchTolerantUnknownCategory`, `testListTolerantUnknownCategory`, `testRecallTolerantUnknownCategory` | MUST | Kept deliberately (runtime-verified current behavior); the em-recall test is a no-code-change regression pin |
+| REQ-8 | `em-rebuild-index` builds `category-index.json` per store: `{ "<canonical category>": ["<id>", …] }` — deprecated names mapped to successor keys, unknown names indexed under their **literal** key AND counted. Atomic temp+rename. The build report gains `category_drift: {unknown: {<name>: N}, deprecated: {<name>: N}}`. | R10d, R10f | `testCategoryIndexBuilt`, `testCategoryIndexDeprecatedMapped`, `testCategoryIndexUnknownCountedLiteral` | MUST | Same atomic + append-only-between-rebuilds contract as `tags.json` |
+| REQ-9 | `em-store` and `em-revise` incrementally update `category-index.json` under the episode's canonical category key (temp+rename), mirroring `updateTagsIndex`. | R10d | `testStoreUpdatesCategoryIndex`, `testReviseUpdatesCategoryIndex` | MUST | New episode → new/extended key; missing index file created |
+| REQ-10 | `em-search --category <c>` **already exists** as an exact-match linear filter (`em-search.mjs:262-263`, `results.filter(e => e.category === c)`). This PR INDEX-BACKS it: canonicalize `<c>` first, read `category-index.json`, intersect ids; **linear-scan fallback + stderr rebuild warning** when the index is missing/corrupt (symmetric with tags.json); an active-name query returns byte-identical results to today. Filtering an unknown `<c>` returns literal-key matches (tolerant). | R10d, M1 | `testSearchCategoryExactMatchUnchanged` (regression pin — byte-identical for an active-name query, symmetric with `testHistorySingleSupersedesUnchanged`), `testSearchCategoryUsesIndex`, `testSearchCategoryFallbackOnMissingIndex`, `testSearchCategoryCanonicalizesDeprecated` | MUST | NOT a new flag — the change is index-backing + deprecated canonicalization + degrade path (B1); planner M1 corrected the baseline |
+| REQ-11 | `em-restore --apply` merges the restored ids into `category-index.json` (or triggers a rebuild); a test pins whichever path is implemented. | R10d | `testRestoreMergesCategoryIndex` | MUST | Implementation's choice, pinned by the test (RFC R10d) |
+| REQ-12 | `em-rebuild-index --check` exits non-zero and lists each drifted episode `{id, category, kind: unknown|deprecated, successor?}` when any episode's stored category is unknown or deprecated; exits 0 with an empty list otherwise. Does not modify any file. | R10f | `testRebuildCheckListsDrift`, `testRebuildCheckCleanExitsZero` | MUST | Detection only; correction is the R9 clerk (P4), explicitly deferred |
+| REQ-13 | `em-prune` reads per-category `lifecycle` from `categories.json`: an `aggregate-then-prune` episode (`temporary`) is aggressively prunable ONLY if it carries `superseded_by` (a confirmed R9 apply exists); without a successor it ages under the standard score. `standard`-lifecycle episodes are unaffected. **R6×R10e interaction (surfaced in review):** a consumed temporary sits in its successor's `consolidates` array, which R6 class-c (P0) would protect — R10e's aggressive-prune OVERRIDES class-c for `aggregate-then-prune` lifecycle (RFC R10e "the consumed members are not [protected]"); a `standard`-category consolidates-member stays class-c protected. The R6 protection set CODE (P0) is otherwise untouched. | R10e; R6 (class-c override) | `testTemporaryWithSuccessorPrunable`, `testTemporaryWithSuccessorOverridesClassC`, `testTemporaryWithoutSuccessorSurvives`, `testStandardLifecycleUnaffected`, `testStandardConsolidatesMemberStillProtected` | MUST | Never hardcode category names in prune — read `categoryLifecycle()`; the lifecycle override is checked before the protection lookup |
+| REQ-14 | `em-search --history <id>` walks the many-to-one edges: forward via `superseded_by` (in addition to inverting `supersedes`) AND surfaces a `consolidates` successor for any id named in another active episode's `consolidates` array; existing single-`supersedes` chains are byte-unchanged. A `supersedes` FORK (one root, two children — lossy today, `em-search.mjs:195-203` Map last-writer-wins keeps only one child, m1) is CHARACTERIZED by a fixture so the multi-parent walk provably does not change which children surface; fixing the pre-existing fork-loss is a §17-E deferred issue. `em-rebuild-index` carries `consolidates` (inline array) and `superseded_by` (scalar) through into `index.jsonl` when present. | R9 (walk shipped early per handoff), R2, m1 | `testHistoryFollowsSupersededBy`, `testHistorySurfacesConsolidatesSuccessor`, `testHistorySingleSupersedesUnchanged`, `testHistorySupersedesForkCharacterized`, `testHistoryCycleSafe`, `testRebuildCarriesNewFields` | MUST | No P1a writer emits these fields; tested via hand-planted episodes. Rationale: R9 acceptance is unimplementable without the walk (RFC) |
+| REQ-15 | `install.mjs` deploys `categories.json` to `~/.episodic-memory/categories.json` (substrate, global — mirroring the §1b `patterns/_index.json` deploy); it lands NOWHERE under `~/.claude/` (P12). **The E2E EXERCISES the resolution (M3):** after the isolated-HOME install, invoke the DEPLOYED `~/.episodic-memory/scripts/em-store.mjs --category bogus` (cwd in the fake project) and assert it loads the DEPLOYED vocab (exit 1 with the vocab-list message) — proving `../../categories.json` resolves in the deployed tree, not just that the file was stat-able. | R10b, P12, M3 | `testInstallDeploysCategoriesJson`, `testCategoriesJsonNotInClaudeHome`, `testInstallDeployedStoreLoadsVocab` | MUST | Mock-project isolated-HOME E2E; verify-the-strong-claim (run the deployed script, don't stat the file) |
+| REQ-16 | Docs ship in the same PR: `categories.json`, `category-index.json`, the R10 category/tags semantics, `em-search --category`, `em-rebuild-index --check`, and the temporary lifecycle documented in `docs/EM_SCRIPTS_GUIDE.md` (grep-gated); README script table updated. | RFC "Documentation deliverable (every phase)" | `testDocsGrepGate` | MUST | Docs drift CI-caught |
+| REQ-17 | The em-restore self-test `valid_categories_match_em_store` (em-restore.mjs:1242-1260) is REPLACED (fixture-change ledger, §A.9): it no longer greps em-store for a literal array; it asserts both scripts import `lib/categories.mjs` and that `loadCategories()` returns the launch vocabulary. | R10b | `test_categories_from_shared_lib` (renamed) | MUST | Enumerated edit, not "existing tests stay green" |
+
+**UNGUARDED-IN-CI:** none. Every MUST maps to an automated Node test.
+
+## §5 Non-Goals
+
+Explicitly deferred — each with a one-line rationale; the deferred items that need tracking get
+a §17 entry with the 5 DEFER fields.
+
+- **T6 `violated_pattern` typed-field migration** (em-violation writes `violated_pattern`, em-recall preflight + em-pattern-health strike counting retarget off the `violated:bp-*` tag) → **P1b**. Rationale: those three scripts are NOT category-axis surfaces, and em-violation is already opened in P1b for the R1 `--lesson` flag; bundling keeps one concern per PR (§17-A).
+- **Workplan-discovery recipe FLIP** (CLAUDE.md `--tag workplan --category decision` → `--category workplan`) → post-burn-in. Precise dual-read semantics (m2): the current recipe is an AND (`--tag workplan` AND `--category decision`), so during burn-in workplans keep being stored as `category: decision` + tag `workplan` and the old recipe finds them; a workplan stored under the NEW `category: workplan` is invisible to the old recipe. P1a only ADMITS `workplan` to the vocabulary (so `--category workplan` stops erroring); it does not restore any workplan under the new category and does not flip the recipe. The flip (store new workplans as `category: workplan`, change the recipe) is a separate post-burn-in change (§17-B).
+- **Full T2 tag-value-branching conformance grep** (`no tags.includes(<literal>)` outside burn-in shims) → **P1b/T6**. P1a introduces no new tag-value branching (a lighter grep asserts that), but the burn-in-shim + sunset-marker machinery only becomes meaningful once T6 lands (§17-C).
+- **R1 activation fields, R2 trigger index, R9a collision report, RFC-009 contract.json mirror** → P1b (the RFC Phase-1 second half).
+- **The R9 consolidation clerk itself** (`em-consolidate.mjs`, run records, telemetry) → P4. P1a only ships the `em-search --history` walk R9 will consume.
+- Any change to the prune SCORE formula (RFC: "Prune SCORING stays unchanged"); R10e gates WHICH episodes the score may reach, not the score.
+- Any semantic/embedding category inference; drift CORRECTION (agentic, R9 clerk, P4). P1a is mechanical detection only.
+
+## §6 Token Budget (Rule 12)
+
+`wc -l` on the target files (2026-07-06):
+
+| File | `wc -l` | Reads (lines × ~5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/em-store.mjs` | 193 | ~1.0k | ~1.0k | lib swap + category-index update |
+| `scripts/em-revise.mjs` | 259 | ~1.3k | ~1.0k | validate inherited category + category-index update |
+| `scripts/em-restore.mjs` | 2470 | ~3.0k (category + apply sections only) | ~2.0k | lib swap, apply validation, index merge, self-test rewrite |
+| `scripts/em-rebuild-index.mjs` | 154 | ~0.8k | ~2.0k | category-index build + `--check` + carry new fields |
+| `scripts/em-search.mjs` | 359 | ~1.8k | ~1.5k | `--category` via index + `--history` multi-parent walk |
+| `scripts/em-prune.mjs` | 329 | ~1.6k | ~0.6k | per-category lifecycle gate |
+| `install.mjs` | ~2700 | ~1.0k (deploy section only) | ~0.3k | one deploy step |
+| `scripts/lib/categories.mjs` | new | — | ~1.2k | the shared vocab lib |
+| `categories.json` + `schemas/categories.schema.json` | new | — | ~1.0k | data + meta-schema |
+| `scripts/validate-schemas.mjs` + CI yml | — | ~0.5k | ~0.4k | wire categories.json |
+| test files (5 new) | new | — | ~10k | ~35 tests |
+| `docs/EM_SCRIPTS_GUIDE.md` + `README.md` | 436 / 631 | ~0.8k (sections) | ~0.6k | |
+| this plan + RFC re-reads | — | ~6k | — | |
+
+**Baseline (single session):** ~38k overhead + ~30k above + test iteration slack ≈ **95-115k** —
+inside the 60-130k sweet spot but toward the top; this is the larger of the two P1 PRs, matching
+the RFC sizing ("2 sessions: R10 first, then R1/R2/R9a").
+**Optimized:** if the session approaches autocompact, the cut order (§11) sheds the `em-search
+--history` walk (REQ-14) into P1b first — it is the only deliverable with no P1a-internal consumer.
+
+## §7 Safety / Security
+
+No trust boundary, privilege vector, or path-authority predicate is added: no `realpath`/`lstat`/
+`isMain`/symlink logic, so the 8-axis symlink matrix is not re-enumerated (store resolution stays
+`resolveLocalDir`, already worktree-tested). `categories.json` resolution uses `import.meta.url`
+relative pathing (`../../categories.json`), which is realpath-canonical on the `import.meta.url`
+side by construction and reads a fixed repo/deployed data file, not an argv-supplied path — no
+authority decision rides on it. Boundary check (RFC-008 R1, P12, CAPABILITIES): every deliverable
+is DATA-plane substrate — vocabulary read, category validated, derived index built, lifecycle read.
+No gate, marker, or decision surface is added. `em-prune`'s lifecycle gate REPORTS eligibility; it
+does not enforce a workflow. **Dispatch `negative-scenario-planner` on this design before §19**
+(schema + validator + multi-surface-validation change = its trigger); self-walk is the fallback.
+
+| Concern | Severity | Attack/abuse scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| Validation-timing (write-before-validate) | Med | `em-restore --apply` writes an unknown-category episode to disk THEN validates → the silent-write-through this PR exists to kill persists | Validate each episode's canonical category BEFORE the write in the apply loop; skip-and-surface on failure | `testRestoreApplySkipsUnknownCategory`; negative: a run whose only episode is unknown-category leaves the target dir with zero new files |
+| Vocabulary fail-open at a WRITER (lib can't load categories.json) | High | Deployed script can't resolve `categories.json` → falls back to "accept anything" → the closed vocab is silently open | `loadCategories()` THROWS on missing/malformed vocab; `validateCategory` propagates; store/revise/restore-apply catch and fail-CLOSED (reject the write with a clear error) | `testStoreFailsClosedOnMissingVocab` (EM_CATEGORIES_PATH=/nope → `em-store` exits non-zero, writes nothing) |
+| Vocabulary fail-CLOSED at a READER (B1 regression) | High | A reader/index/prune surface calls the vocab and THROWS on a missing/malformed `categories.json` → `em-search --category` crashes (violates R10c row 3 "never fatal"), or the core `em-rebuild-index` — today vocab-independent — is taken down entirely | Readers call `canonicalCategory`/`categoryLifecycle` which DEGRADE (§12): search→today's exact-match, rebuild→build index.jsonl+tags.json + skip category-index + stderr warn, prune→standard score | `testSearchDegradesOnMissingVocab`, `testRebuildDegradesOnMissingVocab`, `testPruneDegradesOnMissingVocab` (each sets EM_CATEGORIES_PATH=/nope, asserts exit 0 + the pre-R10 behavior) |
+| Drift false-negative | Med | An unknown category slips past `--check` (e.g. only counted in the build, not listed) → drift accrues invisibly | `--check` lists every drifted id, not just a count; the build report counts; two independent surfaces | `testRebuildCheckListsDrift` with a planted unknown AND a planted deprecated in the same store |
+| Deprecated-map cycle / self-reference | Low | `deprecated_for` points to another deprecated member, or to itself → `canonicalCategory` loops | `canonicalCategory` follows at most one hop and the validator rejects a `deprecated_for` chain (successor must be a NON-deprecated member) at CI time | `testDeprecatedForMustResolve` (successor deprecated → validator fails) |
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/**
+ * @typedef {Object} CategoryDef
+ * @property {string} name        — canonical category id (e.g. "lesson", "temporary")
+ * @property {string} description — human-readable meaning
+ * @property {"standard"|"aggregate-then-prune"} lifecycle
+ * @property {string} [deprecated_for] — successor canonical name; when set the member is retired
+ */
+/**
+ * @typedef {Object} CategoriesDoc
+ * @property {string} version                 — editorial semver
+ * @property {CategoryDef[]} categories
+ */
+/**
+ * validateCategory(name, {allowDeprecated}) → { ok:boolean, reason?:string, successor?:string }
+ *   - unknown           → {ok:false, reason:"unknown"}
+ *   - deprecated, allowDeprecated=false → {ok:false, reason:"deprecated", successor}
+ *   - deprecated, allowDeprecated=true  → {ok:true, successor}
+ *   - active member     → {ok:true}
+ */
+```
+
+### 8.2 Key invariants
+
+- **I1 — one vocabulary source.** Every SUBSTRATE script reads the vocabulary through `lib/categories.mjs`; no `scripts/*.mjs` contains a category-name **array literal** (grep-enforced, REQ-3). Single-value constants in the event-writer family are dispositioned separately (I2b).
+- **I2 — the R10c matrix is total over SUBSTRATE write surfaces.** Every substrate category-touching surface (`em-store`, `em-revise`, `em-restore`, index build, `em-search`, `em-prune`) maps to exactly one matrix row; the per-surface behavior is a single call into the lib (`validateCategory` with the row's `allowDeprecated` for writers, `canonicalCategory` for index keys, `categoryLifecycle` for prune, or nothing for tolerant list). No substrate surface invents a fourth behavior.
+- **I2b — event-writer family is out-of-scope-but-safe (M2 disposition).** `em-review-request.mjs:454-473`, `bp1-orchestrator.mjs`, `bp1-deadline-sweep.mjs`, `bp1-flag-flip.mjs`, and `lib/bp1-episode-writer.mjs:263` construct frontmatter directly (bypassing `em-store`) and emit the **constant** `workflow.lifecycle`. They neither call `validateCategory` nor update `category-index.json`. This is SAFE and in-scope-UNCHANGED per the RFC coverage table (em-review-request UNCHANGED, bp1-* are enforcement-layer, not substrate): the constant is always a valid active member, and the category-index staleness self-heals on the next rebuild exactly as `tags.json` does for the same writers today. The REQ-3 grep targets array literals, so it does not false-positive on these constants; §A.8's broad-token grep carries an allow-list note for the `workflow.lifecycle` constant.
+- **I3 — derived, self-healing, never fatal.** `category-index.json` is derived: staleness between rebuilds is tolerated exactly like `tags.json`; missing/corrupt → linear-scan fallback + rebuild warning, never fatal. **AND** (B1) a missing/malformed `categories.json` never takes down a reader/index/prune surface: those call `canonicalCategory`/`categoryLifecycle`, which degrade (§12) rather than throw. Only WRITE surfaces fail-closed on an unloadable vocab.
+- **I4 — validate before write.** In every write path (store, revise, restore-apply) category validation precedes the file/index write; a rejection leaves the store byte-unchanged (EC6).
+- **I5 — stored bytes are never rewritten for taxonomy.** Deprecated categories are mapped at READ/INDEX time (`canonicalCategory`); episode `.md` files keep their stored category forever (the vocabulary-level mirror of P7 revision chains).
+- **Cross-platform:** pure `path`/`fs`/`import.meta.url`; no GNU-only flags, no `sed -i`, no `readlink -f`. `categories.json` resolution uses `new URL('../../categories.json', import.meta.url)`.
+- **Atomicity:** `category-index.json` writes are temp+rename (repo convention), same as `tags.json`.
+
+### 8.3 Resolution / flow
+
+```text
+categories.json (repo root ─ deployed to ~/.episodic-memory/)
+        │  loadCategories() via ../../categories.json from scripts/lib/
+        ▼
+  lib/categories.mjs ── validateCategory / canonicalCategory / categoryLifecycle
+        │
+  ┌─────┼───────────────┬───────────────┬────────────────┬─────────────┐
+  ▼     ▼               ▼               ▼                ▼             ▼
+em-store  em-revise   em-restore     em-rebuild-index  em-search    em-prune
+(strict)  (strict)    (filter:strict  (tolerant+count;  (--category  (lifecycle
++cat-idx  +cat-idx    +deprecated;    builds           via cat-idx; policy gate)
+update)   update)     apply:skip-     category-index;   --history
+                      surface+merge)  --check lists)    multi-parent)
+```
+
+The `em-search --history` multi-parent walk is orthogonal to the vocabulary (it reads
+`supersedes`/`superseded_by`/`consolidates` edges from index rows) but ships here per the handoff.
+
+## §9 Existing Hook Points
+
+Line numbers verified 2026-07-06; re-verify at build time (they drift).
+
+| File | Line(s) | What it does today | Impact of this change |
+|---|---|---|---|
+| `scripts/em-store.mjs` | 81 | `const VALID_CATEGORIES = [...]` | Delete; import lib; strict `validateCategory` (105-111 rewritten) |
+| `scripts/em-store.mjs` | 139-152, 191 | `updateTagsIndex` + call | APPEND sibling `updateCategoryIndex`; call after tags |
+| `scripts/em-revise.mjs` | 159-166, 227 | inherits `origCategory`, no validation | Validate `origCategory` strict before write; APPEND + call `updateCategoryIndex` |
+| `scripts/em-restore.mjs` | 40 | duplicate `VALID_CATEGORIES` | Delete; import lib |
+| `scripts/em-restore.mjs` | 978-980 | `--category` filter validation | Route through `validateCategory({allowDeprecated:true})` |
+| `scripts/em-restore.mjs` | apply loop (~1100-1130) | writes episode category unchecked | Validate canonical category before write; skip-and-surface unknown |
+| `scripts/em-restore.mjs` | 1242-1260 | `valid_categories_match_em_store` self-test | Replace per REQ-17 |
+| `scripts/em-rebuild-index.mjs` | 118-136 | writes index entry + `tags.json` | Carry `consolidates`/`superseded_by`; build `category-index.json`; add `--check` + drift counts |
+| `scripts/em-search.mjs` | 175-203 | `--history` single-`supersedes` walk | Multi-parent walk (`superseded_by` + `consolidates`) |
+| `scripts/em-search.mjs` | 262-263 | `--category` exact-match linear filter (ALREADY EXISTS, M1) | Index-back it via `category-index.json` + canonicalize + degrade fallback; preserve byte-identical active-name output |
+| `scripts/em-prune.mjs` | 55-62 | `computePruneScore` | Add lifecycle gate reading `categoryLifecycle()` (score untouched) |
+| `install.mjs` | 389-396 (§1b) | deploys `patterns/_index.json` globally | APPEND a sibling step deploying `categories.json` |
+| `scripts/validate-schemas.mjs` | — | validates repo schemas | Add `categories.json` × `categories.schema.json` + `deprecated_for` resolution check |
+
+## §10 Slice Ladder
+
+One PR, implemented as ordered slices (each a green checkpoint; commit per slice).
+
+| Slice | Objective | Primary files | Key deliverables | Tests | Hard stops |
+|---|---|---|---|---|---|
+| P1a-S1 | Vocabulary as data | `categories.json`, `schemas/categories.schema.json`, `scripts/lib/categories.mjs`, `validate-schemas.mjs` | REQ-1,2,3 + safety fail-closed | `test-categories-lib.mjs` | No script edits yet |
+| P1a-S2 | Strict write surfaces | `em-store.mjs`, `em-revise.mjs` | REQ-4, REQ-9 (store/revise index update) | `test-category-write.mjs` | No restore/search/prune yet |
+| P1a-S3 | Restore matrix + self-test rewrite | `em-restore.mjs` | REQ-5,6,11,17 | in `test-category-write.mjs` + restore self-test | Don't touch em-search |
+| P1a-S4 | Index + drift + new-field carry | `em-rebuild-index.mjs` | REQ-8,12,14 (rebuild half) | `test-category-index.mjs` | — |
+| P1a-S5 | Read surfaces | `em-search.mjs` | REQ-7,10,14 (history walk) | `test-category-search.mjs`, `test-history-walk.mjs` | — |
+| P1a-S6 | Prune lifecycle | `em-prune.mjs` | REQ-13 | `test-prune-lifecycle.mjs` | Protection set untouched |
+| P1a-S7 | Deploy + docs + CI | `install.mjs`, guide, README, CI yml | REQ-15,16 | `test-install-categories.mjs` (mock E2E), docs grep | — |
+
+### 10.1 Dependency graph
+
+```text
+S1 ── S2 ── S3
+ │     └──── S4 ── S5
+ └──────────────── S6
+S1..S6 ─────────── S7
+```
+
+S1 is the hard dep for all (the lib). S4 (index) depends on S1 only. S5 `--category` depends on
+S4 (needs `category-index.json`). S6 depends on S1 (lifecycle read). S7 last (deploy + docs).
+
+## §11 Cut Order
+
+If context/scope grows, cut in this order (preserves a shippable category axis):
+
+1. REQ-14 `em-search --history` multi-parent walk → move to P1b (no P1a-internal consumer; R9 is P4).
+2. REQ-11 restore category-index MERGE → fall back to "restore triggers a full rebuild" (simpler, pinned by the same test).
+
+Do **not** cut:
+- REQ-3 the shared lib + no-hardcoded-list grep (the whole point of R10b).
+- REQ-4/5/6 the write/restore validation matrix (the conflation fix).
+- REQ-15 global deployment of `categories.json` (deployed-script fail-open otherwise).
+
+## §12 Contracts
+
+### `validateCategory(name, {allowDeprecated=false}) → {ok, reason?, successor?}`
+
+**Input contract:** `name` any string (possibly unknown); `allowDeprecated` boolean.
+**Output contract:** discriminated on `ok`. `successor` present iff the member is deprecated.
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. active | name is a member, no `deprecated_for` | `{ok:true}` | none |
+| B. deprecated, disallowed | member has `deprecated_for`, `allowDeprecated=false` | `{ok:false, reason:"deprecated", successor}` | none |
+| C. deprecated, allowed | member has `deprecated_for`, `allowDeprecated=true` | `{ok:true, successor}` | none |
+| D. unknown | not a member | `{ok:false, reason:"unknown"}` | none |
+| E. vocab unloadable | `categories.json` missing/malformed | THROWS `vocab-unloadable` | none — **only writers call this**; they catch and fail-closed (reject write) |
+
+### `canonicalCategory(name) → name` and `categoryLifecycle(name) → lifecycle|null` (READER path — degrade, never throw, B1)
+
+These two are the READER/index/prune entry points. They wrap `loadCategories()` in try/catch: on
+`vocab-unloadable` they **degrade** rather than throw, so no reader surface is ever taken down by a
+missing/malformed vocab (R10c row 3 "never fatal"; I3). Design decision (B1 fix): the fail direction
+is a property of the CALLER's needs, encoded in WHICH lib function it calls — writers call
+`validateCategory` (fail-closed), readers call `canonicalCategory`/`categoryLifecycle` (fail-open-degrade).
+
+| Function | State | Condition | Output |
+|---|---|---|---|
+| `canonicalCategory` | A | active member | `name` |
+| `canonicalCategory` | B | deprecated member | `deprecated_for` successor (one hop) |
+| `canonicalCategory` | C | unknown | `name` (literal — the drift key) |
+| `canonicalCategory` | D | **vocab unloadable** | `name` (literal — degrade; caller behaves as pre-R10) |
+| `categoryLifecycle` | A | member | its `lifecycle` |
+| `categoryLifecycle` | B | unknown / vocab unloadable | `null` (caller falls back to standard score) |
+
+**Error codes / fail direction:**
+
+| Code | Field | Trigger | Fail mode |
+|---|---|---|---|
+| `unknown-category` | `category` | write of a non-member | **closed** (reject write) |
+| `deprecated-category` | `category` | write of a deprecated member | **closed** (reject, name successor) |
+| `vocab-unloadable` (writer) | — | `categories.json` unreadable at a WRITE surface | **closed** — `validateCategory` throws; store/revise/restore-apply catch and reject the write |
+| `vocab-unloadable` (reader) | — | `categories.json` unreadable at a READ/index/prune surface | **open-degrade** — `canonicalCategory`→literal, `categoryLifecycle`→null; `em-search --category` degrades to today's exact-match, `em-rebuild-index` builds index.jsonl+tags.json as before and skips category-index with a stderr warning, `em-prune` uses the standard score (B1) |
+
+### `em-rebuild-index --check` → exit + JSON
+
+**Output:** `{status, drift:[{id, category, kind:"unknown"|"deprecated", successor?}]}`; exit 1 iff `drift` non-empty. Reads only; writes nothing.
+
+## §13 Edge Cases
+
+| # | Scenario | Expected behavior | Test |
+|---|---|---|---|
+| EC1 | missing `categories.json` at a writer | writer fails closed (exit non-zero, no write) | `testCategoriesLibThrowsOnMissing` |
+| EC2 | (symlink/isMain) — N/A | no path-authority predicate added | — |
+| EC3 | concurrent `em-store` + `em-rebuild-index` on category-index (C4) | temp+rename → last-writer-wins, self-healing on next rebuild (same as tags.json; RFC:297 "no lock, racing builds self-heal") | `testCategoryIndexAtomicRename` (rename is atomic) AND `testCategoryIndexConcurrentStoreRebuild` (loop N stores while a rebuild runs; assert `category-index.json` is parseable at every read, then force a final rebuild and assert every id appears — the real concurrent probe, not just the rename primitive) |
+| EC4 | `em-restore --apply` aborts mid-run on an unknown-category episode | that episode skipped + surfaced; VALID episodes already written stay; no torn category-index | `testRestoreApplySkipsUnknownCategory` |
+| EC5 | empty/whitespace category string | treated as unknown → reject (writer) / literal drift key (index) | `testStoreRejectsUnknown` (empty leg) |
+| EC6 | validate-then-write ordering in restore-apply | validation fires BEFORE the episode write, not after | `testRestoreApplySkipsUnknownCategory` (asserts zero files written) |
+| EC7 | `em-search --history` on a cyclic `consolidates`/`superseded_by` fixture | cycle-safe via visited set; terminates | `testHistoryCycleSafe` |
+| EC8 | index entry for a `workflow.lifecycle` category (dotted value) | parses fine (value, not key; rebuild regex `^(\w+):` keys only) | `testRebuildCarriesNewFields` (dotted-category leg) |
+| EC9 | episode with a MISSING `category` field (undefined) at index build / search / prune (m3) | `canonicalCategory(undefined)`/`categoryLifecycle(undefined)` return a stable key (`"undefined"` literal or a guarded `unknown` bucket) / `null`; no crash; counted as drift | `testCategoryIndexUndefinedCategory` |
+| EC10 | episode with a NON-SCALAR `category` (array/object, hand-planted) (m3) | reader coerces to a string key (never a live `[object Object]` collision); writers reject (unknown); counted as drift | `testCategoryNonScalarTolerated` |
+
+## §14 Test Case Catalog
+
+Runner per file: `node tests/test-<name>.mjs`.
+
+```text
+Group 1: categories lib + schema (test-categories-lib.mjs, ~8)
+  testCategoriesJsonValidates        — categories.json instance-validates vs schema
+  testCategoriesSchema               — schema rejects a bad lifecycle enum / extra prop
+  testDeprecatedForMustResolve       — deprecated_for → deprecated successor fails validator
+  testCategoriesLibResolution        — loadCategories() finds the file via import.meta.url
+  testCategoriesLibThrowsOnMissing   — unloadable vocab throws (fail-closed)
+  testValidateCategoryStates         — states A-D of §12 table
+  testCanonicalCategory              — active/deprecated/unknown mapping
+  testNoHardcodedCategoryList        — grep: no category-name array literal in scripts/*.mjs
+
+Group 2: write surfaces (test-category-write.mjs, ~10)
+  testStoreStrictAccept / testStoreRejectsDeprecated / testStoreRejectsUnknown
+  testReviseValidatesInheritedCategory
+  testStoreUpdatesCategoryIndex / testReviseUpdatesCategoryIndex
+  testRestoreFilterAcceptsDeprecated / testRestoreFilterRejectsUnknown
+  testRestoreApplySkipsUnknownCategory (zero-files negative control)
+  testRestoreApplyWritesDeprecated
+
+Group 3: index + drift (test-category-index.mjs, ~7)
+  testCategoryIndexBuilt / testCategoryIndexDeprecatedMapped / testCategoryIndexUnknownCountedLiteral
+  testCategoryIndexAtomicRename
+  testRebuildCheckListsDrift / testRebuildCheckCleanExitsZero
+  testRebuildCarriesNewFields (dotted-category + consolidates/superseded_by leg)
+
+Group 4: read surfaces (test-category-search.mjs + test-history-walk.mjs, ~8)
+  testSearchTolerantUnknownCategory / testListTolerantUnknownCategory
+  testSearchCategoryUsesIndex / testSearchCategoryFallbackOnMissingIndex / testSearchCategoryCanonicalizesDeprecated
+  testRestoreMergesCategoryIndex
+  testHistoryFollowsSupersededBy / testHistorySurfacesConsolidatesSuccessor
+  testHistorySingleSupersedesUnchanged / testHistoryCycleSafe
+
+Group 5: prune lifecycle (test-prune-lifecycle.mjs, ~3)
+  testTemporaryWithSuccessorPrunable / testTemporaryWithoutSuccessorSurvives / testStandardLifecycleUnaffected
+
+Group 6: deploy + docs (test-install-categories.mjs, ~2)
+  testInstallDeploysCategoriesJson (mock-project isolated-HOME E2E)
+  testCategoriesJsonNotInClaudeHome
+  testDocsGrepGate (grep EM_SCRIPTS_GUIDE for the new surfaces)
+```
+
+Planner-driven additions (§19.1), slotted into the groups above:
+- Group 1/2: `testStoreFailsClosedOnMissingVocab` (B1 writer fail-closed).
+- Group 3: `testRebuildDegradesOnMissingVocab` (B1), `testCategoryIndexUndefinedCategory` (m3/EC9), `testCategoryNonScalarTolerated` (m3/EC10).
+- Group 4: `testSearchCategoryExactMatchUnchanged` (M1 regression pin), `testSearchDegradesOnMissingVocab` (B1), `testHistorySupersedesForkCharacterized` (m1).
+- Group 5: `testPruneDegradesOnMissingVocab` (B1).
+- Group 6: `testInstallDeployedStoreLoadsVocab` (M3 — invokes the deployed script).
+
+Codex-driven additions (§19.2):
+- Group 4: `testRecallTolerantUnknownCategory` (C1 — em-recall read tolerance, no-code-change pin).
+- Group 3: `testCategoryIndexConcurrentStoreRebuild` (C4 — real concurrent store+rebuild probe).
+
+Total: ~48 tests across 6 files. Every test name appears in §4 or is a §13 EC. The three
+`*DegradesOnMissingVocab` tests each set `EM_CATEGORIES_PATH=/nonexistent` and assert exit 0 +
+pre-R10 behavior (the B1 negative controls).
+
+> No aspirational output: every test asserts real captured output (stdout JSON / exit code /
+> written file contents / on-disk file location), never a constant or an echoed string. The
+> install E2E asserts the on-disk path of the deployed file, not a log line.
+
+> Install/deploy behavior (REQ-15) is proven by an isolated-`HOME` mock project + the REAL
+> `install.mjs`, then reading the actual deployed tree — never mental-trace.
+
+## §15 Verification Ledger (verify by artifact)
+
+Filled with ACTUAL output at implementation time. Order rule: the evidence command runs
+immediately before the claim.
+
+| Claim | Command (strong-layer) | Observed artifact |
+|---|---|---|
+| Four-surface divergence exists TODAY (baseline) | fixture-store probes: `em-store --category workplan`; `em-restore --apply` of a workplan episode; `em-restore --category workplan`; `em-search`/`em-list` | _pending — exit codes + JSON_ |
+| Matrix now consistent | same four probes post-impl | _pending — store rejects, restore skip-surfaces, search tolerant_ |
+| All tests pass | `node tests/test-categories-lib.mjs` (+ the other 5) | _pending N/N pass each_ |
+| No hardcoded category list | `grep -rnE "'(decision|discovery|milestone|lesson|violation)'" scripts/*.mjs` (broad-token) + reading pass | _pending — only lib references_ |
+| category-index built | `em-rebuild-index --scope local` then read `category-index.json` | _pending — canonical keys_ |
+| Deploys clean + P12 | mock `install.mjs`, then `ls ~/.episodic-memory/categories.json` AND `find ~/.claude -name categories.json` | _pending — present in EM, absent in .claude_ |
+| CI green | `gh pr checks <PR>` | _pending — schema + test steps green_ |
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Deployed scripts can't find `categories.json` (resolution wrong) | High | Med | `testInstallDeployedStoreLoadsVocab` (REQ-15) INVOKES the deployed `em-store` and asserts the vocab-list error — the resolution is exercised, not stat-ed (M3) |
+| em-restore's 2470-line file hides an untested category-write path | Med | Med | grep every `category` reference (done, §9); apply-loop validation is the single choke point |
+| `--history` walk regresses existing single-`supersedes` chains | Med | Low | `testHistorySingleSupersedesUnchanged` pins byte-identical output for the common case |
+| Scope creep into T6/em-violation | Med | Med | §5 Non-Goals + §17 explicit defer; reviewer asked to hold the boundary |
+
+## §17 Open Decisions
+
+- **§17-A — Defer T6 `violated_pattern` migration to P1b.** Deferred to P1b; tracked as a GitHub issue at build time (Rule 18 step 9). 5 fields: (1) *Scenario:* em-pattern-health strike counting + em-recall preflight still read the `violated:bp-*` tag — works today, no failure. (2) *Spec:* RFC R10 T6 requires the typed field EVENTUALLY; it does not require it in the R10-category PR. (3) *History:* the tag-based read is the shipped status quo; no reviewer has flagged it broken. (4) *Same-class:* the entire T6 tag→typed-field class defers together (em-violation write + both readers) — no sibling left half-migrated. (5) *Residual:* if unaddressed, the `violated:bp-*` tag stays load-bearing (a T2 violation) until P1b — a known, bounded, documented gap, not silent corruption.
+- **§17-B — Workplan recipe flip post-burn-in.** P1a enables `--category workplan` (dual-read); the CLAUDE.md recipe flip is a follow-up doc change. Tracked via §17-B note; no issue needed (doc-only, operator-owned).
+- **§17-C — Full T2 grep guard with T6.** The `no tags.includes(<literal>)` conformance gate lands with the burn-in-shim machinery in P1b; P1a ships a lighter "no NEW tag branching introduced" check.
+- **§17-D — `categories.json` location.** Decided: repo root (`categories.json`), schema under `schemas/`. Rationale: substrate artifact, must deploy globally like `patterns/_index.json`; repo-root + `../../` from `scripts/lib/` gives symmetric repo/deployed resolution (planner verified deployable: `install.mjs:294-303` copies `scripts/lib/*.mjs`, categories.mjs rides along, not in `relocatedOnlyLibs`). Not an OQ — recorded so the reviewer sees the reasoning.
+- **§17-E — Pre-existing `em-search --history` supersedes-fork loss (m1).** A root superseded by two children keeps only one in the chain (`em-search.mjs:195-203` Map last-writer-wins). This is PRE-EXISTING, not introduced by P1a; `testHistorySupersedesForkCharacterized` pins current behavior so the multi-parent walk provably doesn't regress it. Fixing the fork-loss → deferred to a GitHub issue (Rule 18 step 9). 5 fields: (1) *Scenario:* history of a forked root drops a branch — runtime-probed `{"count":2,"chain":[root,childC]}`. (2) *Spec:* R2/R9 need the walk to follow `superseded_by`/`consolidates` (delivered); neither requires fixing legacy `supersedes` forks. (3) *History:* pre-existing since the walk shipped; unflagged until this audit. (4) *Same-class:* the fork-loss is a distinct edge from the many-to-one consolidation walk this PR adds; no sibling left half-done. (5) *Residual:* a forked revision chain under-reports one branch in `--history` output — a display gap, not data loss (both episodes still exist and index independently).
+
+## §18 Done Criteria
+
+- **RFC P1 R10 gate accounting (C5):** P1a discharges RFC acceptance rows **474-478 only** (categories.json/schema/lib + no-hardcoded-list; the write matrix; read tolerance; category index; temporary lifecycle). Rows **479-480 are P1b hard gates**, NOT satisfied here — row 479 (T6 `violated_pattern` migration + `em-recall`/`em-pattern-health` retarget) and row 480 (the T2 `tags.includes(<literal>)` conformance grep + burn-in-shim sunset markers) ship with the T6 work in P1b (§17-A, §17-C). P1a must not be described as fully satisfying the RFC's P1 R10 gate; the deferred rows carry issue links.
+- [ ] All MUST requirements (REQ-1..17) passing (§4 tests green).
+- [ ] The four-surface probe (§15) shows consistency where the baseline showed divergence.
+- [ ] `grep` proves no hardcoded category list survives in any script.
+- [ ] Mock-project E2E: `categories.json` in `~/.episodic-memory/`, absent from `~/.claude/`.
+- [ ] Docs grep gate green; README table updated.
+- [ ] Every deferred item (§17-A, §17-C) has a GitHub issue (Rule 18 step 9).
+- [ ] `negative-scenario-planner` + codex review findings dispositioned (§19).
+
+## §19 Review Consensus (Rule 18)
+
+Second-opinion review after this draft. Per the canonical-agent dispatch rule, dispatch
+`negative-scenario-planner` FIRST (schema/validator/multi-surface change), THEN codex via cmux
+(default provider; standing directive). Hand off the complete bug-class: the R10c matrix as an
+invariant table + the four surfaces + the fail-open controls + the "no fourth behavior" boundary.
+
+```bash
+node scripts/second-opinion.mjs request --provider codex --project <abs-repo-root> \
+  --storage episodic --body-file docs/plans/rfc-009-p1a.md --summary "RFC-009 P1a R10 taxonomy plan review" --dispatch
+```
+
+| Pass | Reviewer | Provider/Model | Blocker count | Verdict | Reply episode |
+|---|---|---|---|---|---|
+| 1 | negative-scenario-planner | (subagent) | 4 (B1 + M1/M2/M3) | HOLD → folded §19.1 | — |
+| 2 | codex | codex gpt-5.5 high (cmux) | 5 (3 blocker + 2 major) | HOLD → folded §19.2 | (cmux session, 2m37s) |
+| 3 | codex | codex gpt-5.5 high (cmux) | 3 (2 blocker + 1 major, executability) | HOLD → folded §19.3; design validated | (cmux session, 1m57s) — converged at cap |
+
+Review in three layers: per-file (each script's matrix row) → cross-file (the lib is the single
+source; the four surfaces agree) → PR-level (docs + deploy + CI coherence). Cap at 2 codex rounds;
+a 3rd same-class HOLD means the matrix boundary is wrong, not the patch.
+
+### 19.1 Resolved blockers (negative-scenario-planner pass 1, 2026-07-06 — HOLD)
+
+Planner ran real fixture probes; every finding accepted. Format: Finding / Verdict / Evidence / Required action.
+
+| # | Finding (R-anchor) | Verdict | Evidence | Required action (folded) |
+|---|---|---|---|---|
+| B1 | Vocab-unloadable is fatal on reader/index/prune surfaces — contradicts §7 "readers tolerant" + R10c row 3 "never fatal"; makes core rebuild vocab-dependent (R10c/R10d/I3) | ACCEPT | Probe: `em-rebuild-index` has zero vocab dependency today; REQ-8/10/13 add `canonicalCategory`/`categoryLifecycle` calls that would throw | §12 split fail-direction by function (writers `validateCategory`→closed; readers `canonicalCategory`/`categoryLifecycle`→degrade); I3 rewritten; §7 gains the reader-regression row; 3 degrade tests added |
+| M1 | `em-search --category` already exists (exact-match, `em-search.mjs:262-263`); mis-catalogued NEW → no regression pin (R10d) | ACCEPT | Probe `em-search --category workplan` → `count:1` today | REQ-10 + §9 baseline corrected; `testSearchCategoryExactMatchUnchanged` regression pin added |
+| M2 | Event-writer family bypasses the lib (I2 over-claimed) — `em-review-request`, `bp1-*`, `lib/bp1-episode-writer` emit constant `workflow.lifecycle` (R10c write rows, T2) | ACCEPT w/ mod | Repo grep: only 2 `VALID_CATEGORIES` arrays; event-writers hardcode a single constant | I2 weakened to substrate write surfaces; I2b disposition row added (safe, self-heals); §A.8 grep allow-list note |
+| M3 | REQ-15 mitigation/test mismatch — §16 claims deployed-script exercise, test only stats file (verify-the-strong-claim) | ACCEPT | Step 7.2 asserted locations only | REQ-15 + §16 + step 7.2 now INVOKE deployed `em-store --category bogus`, assert vocab-list error (`testInstallDeployedStoreLoadsVocab`) |
+| m1 | `--history` supersedes-fork lossy today (`em-search.mjs:195-203`) | ACCEPT | Probe fork `[A,C]` drops B | `testHistorySupersedesForkCharacterized` pins behavior; §17-E defers the fix with an issue |
+| m2 | "dual-read both work" imprecise — recipe is an AND (R10b/T6) | ACCEPT | Recipe `--tag workplan --category decision` | §5 dual-read semantics stated precisely |
+| m3 | Category edge shapes — undefined / non-scalar `category` uncovered (R10c/R10d) | ACCEPT | `canonicalCategory` returns non-string key | EC9/EC10 added |
+| m4 | §A.8 grep omits `workflow.lifecycle`/`workplan`/`temporary` (REQ-3) | ACCEPT | Alternation incomplete | §A.8 alternation broadened + reading-pass backstop |
+| DEFER | T6 `violated_pattern` migration deferred to P1b — SAFE slice boundary (5 fields) | ACCEPT | em-prune R6 uses episode-id links (`em-prune.mjs:113-116`), not the tag; nothing in P1a reads `violated:bp-*` | §17-A kept; issue filed at build time |
+
+### 19.2 Resolved blockers (codex round 1, 2026-07-06 — HOLD, gpt-5.5 high, cmux)
+
+Codex ran real probes (workplan recall, source reads of em-rebuild/em-search/install/validate-schemas/em-prune/em-recall). All accepted.
+
+| # | Finding (R-anchor) | Verdict | Evidence | Required action (folded) |
+|---|---|---|---|---|
+| C1 | REQ-7 read-tolerance names only em-search/em-list; RFC R10c:231 + gate row 476 require em-recall too | ACCEPT | no `testRecallTolerant` in §14 | REQ-7 gains em-recall + `testRecallTolerantUnknownCategory` (S5 step 5.3); no code change, regression pin |
+| C2 | A.7 step 7.2 not updated to match the REQ-15/§19.1 M3 fix — still stats the file | ACCEPT | step 7.2 asserted locations only | step 7.2 rewritten to INVOKE the deployed `em-store --category bogus` and assert the vocab-list error (`testInstallDeployedStoreLoadsVocab`) |
+| C3 | A.7 anchors non-verbatim + grep-stub verifies (e.g. step 1.4 "schema-list array" — validate-schemas uses discovery) | ACCEPT | `validate-schemas.mjs:14-17,49` is discovery | user chose LOW altitude → every A.7 EDIT anchor rewritten to a verbatim-unique substring from current source; verifies made falsifiable (semantic asserts / named tests, not grep-existence); step 1.4 corrected (auto-discovery + MIN_SCHEMA_DOCS 17→18) |
+| C4 | EC3 concurrency maps only to `testCategoryIndexAtomicRename` — no concurrent probe (RFC:297) | ACCEPT | §14 listed only the rename primitive | EC3 + `testCategoryIndexConcurrentStoreRebuild` (S4 step 4.5): loop stores during a rebuild, assert always-parseable, then rebuild asserts all ids |
+| C5 | §18 implied P1a satisfies the full P1 R10 gate; rows 479-480 (T6 + tag-branch guard) are P1b | ACCEPT | gate rows 474-480 | §18 gate-accounting bullet: P1a discharges rows 474-478 only; 479-480 are P1b with issue links |
+
+Also surfaced while hardening C3: the **R6×R10e interaction** (a consumed `temporary` in a `consolidates` array — R10e aggressive-prune must override R6 class-c) — folded into REQ-13 + step 6.1 + `testTemporaryWithSuccessorOverridesClassC`.
+
+### 19.3 Resolved blockers (codex round 2, 2026-07-06 — HOLD → converged, gpt-5.5 high, cmux)
+
+Round 2 attacked the round-1 fixes (not a rubber-stamp) and validated the DESIGN ("problems are in exact executability, not the high-level matrix"; "the R6/R10e override is directionally coherent"). Three residual executability bugs, each with an exact remedy — all folded. Two substantive codex rounds is the cap (MEMORY `…a2aa`); the residuals are mechanical spec-precision with codex's dictated fix, not a same-class boundary dispute, so the review is CONVERGED without a round 3.
+
+| # | Finding (R-anchor) | Verdict | Evidence | Required action (folded) |
+|---|---|---|---|---|
+| C6 | step 1.5/REQ-2 used `validateInstance` from `lib/mini-jsonschema.mjs`, which exports only `lintSchema` | ACCEPT | `validateInstance` is in `lib/json-instance-validate.mjs:513` | REQ-2 + step 1.5 now use `validateInstance` from `json-instance-validate.mjs` |
+| C7 | step 3.3 set `category_skips` on the summary, but `buildWritePlan` (em-restore.mjs:777) never returns `categorySkips` — out of scope | ACCEPT | return object at L777 lists only 6 fields | step 3.3 now adds `categorySkips` to the `buildWritePlan` return AND sets `category_skips: plan.categorySkips` |
+| C8 | step 2.1 deleted `VALID_CATEGORIES` (USAGE:83 depends on it) without importing `loadCategories` | ACCEPT | USAGE interpolates the member list | step 2.1 imports `loadCategories`; USAGE derives names in a try/catch fallback (`'see categories.json'` when unloadable) so `--help` never crashes; the write path still fails closed |
+
+**Review outcome:** planner HOLD + codex R1 HOLD + codex R2 HOLD, all folded; design validated across both codex rounds; converged at the 2-round cap. Ready for Rule 18 step 4 (final plan + operator approval).
+
+### 19.4 Post-implementation code review (negative-scenario-reviewer, 2026-07-06 — ACCEPT)
+
+Dispatched on `git diff main..HEAD` (S1-S7) per the canonical-agent dispatch rule, with mandatory
+behavior-simulation (real scripts against isolated fixture stores, `EM_CATEGORIES_PATH` to plant
+vocabularies / force unloadable). Walked all 9 attack axes + I1-I5 + EC1-EC10.
+
+| Axis | Runtime result |
+|---|---|
+| 1 fail-direction (B1) | 3 writers exit 1 no-write; 3 readers/index/prune exit 0 degrade |
+| 2 validate-before-write (I4) | revise reject → original md5 unchanged, status active |
+| 3 restore skip-and-surface | unknown skipped+surfaced zero-write; deprecated written verbatim |
+| 4 category-index (EC8/9/10) | dotted/undefined/non-scalar keys stable; no [object Object]; atomic |
+| 5 --history (EC7) | superseded_by + consolidates followed; fork LWW; cycle terminates |
+| 6 --check (R10f) | lists all drift, exit 1, index.jsonl mtime unchanged |
+| 7 prune R10e | override beats class-c; P0 set byte-untouched (17/17) |
+| 8 deploy (M3) | deployed em-store resolves ../../categories.json; none under .claude/ |
+| 9 no-hardcoded (I1) | no VALID_CATEGORIES array; only I2b constants/comparisons |
+
+**Verdict: ACCEPT — 0 BLOCKER/MAJOR/MINOR/NIT.** One inherited-by-design class note (multi-scope
+partial-index under-report, mirrors the pre-existing `--tag` block) dispositioned out-of-scope and
+filed as #459. No step-7 fixes required. Deferred issues #457/#458/#459 filed (step 9).
+
+## §20 Lessons Encoded (traceability)
+
+| Lesson | One-line rule | Enforced in |
+|---|---|---|
+| behavior-simulation-not-static-analysis | runtime-probe the four surfaces; cite JSON | §3, §15 |
+| verify-the-strong-claim | deploy = mock E2E reading the deployed tree, not repo copy | §15, REQ-15 |
+| mock-project-not-mental-trace | install behavior via isolated-HOME + real install.mjs | §14, REQ-15 |
+| canonical-agent dispatch | negative-scenario-planner before self-walk | §7, §19 |
+| fixture-change ledger | the em-restore self-test edit is enumerated, not "stays green" | REQ-17, §A.9 |
+| enforcement-gate-only-repo-src | this plan file write is not gated; deliverables are data-plane | §1, §7 |
+| bp1 step-9 5-field DEFER | §17-A carries all 5 fields + gets an issue | §17, §18 |
+| Rule 12 token budget | wc -l done, baseline + optimized | §6 |
+| no-hardcoded-drift-pair | one lib kills the em-store/em-restore duplicate + its drift test | REQ-3, REQ-17 |
+
+---
+
+# Appendix A: Mechanical Execution Spec (low-capability executor)
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value for this plan |
+|---|---|
+| Language / runtime | Node.js 20+, `.mjs` ESM, zero deps |
+| Runtime check (§A.4) | `node --version` → `v20` or higher |
+| Test-runner shape | `node tests/test-<name>.mjs` → `<N>/<N> pass` |
+| New-function phrasing (§A.6) | `export function fnName(args) { … }` |
+| Portable break-input override | argv flag / env `EM_CATEGORIES_PATH=<bad-path>` (POSIX); tests set it via `process.env` in-proc |
+| Search tool for verifies | `grep -n` / `grep -c` / `grep -rnE` from repo root |
+| Repo-specific done-commands | `node scripts/validate-schemas.mjs`; mock-project `install.mjs` E2E |
+
+## A.1 Forbidden-phrase lint
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/rfc-009-p1a.md
+```
+Expected: matches only §0.2/§A.1 template quotes + §17 "Decided" prose. Acceptance: no match falls
+inside an §A.7 step-table row. Record the match list beside the lint run. Also do a reading pass
+over Appendix A (line-grep misses wrapped occurrences, lesson `…2f5d`).
+
+## A.2 Executor contract
+
+1. Steps in numeric order; no skip/reorder/batch.
+2. Each step names one file, the exact change, and its verify.
+3. Make no design decisions; missing verbatim anchor → STOP (§A.3).
+4. Run the verify after each step; fix only that step until green.
+5. Edit exactly ONE file per step. Read-only refs: `docs/rfcs/RFC-009-lesson-activation.md`, `patterns/taxonomy.schema.json`.
+6. One command per verify — no `;`/`&&`/`||`/pipes/subshells (compound-bash gate).
+7. One slice = one commit `P1a-Sn: <title>` + the `Co-Authored-By` trailer.
+8. No commit/push/PR until §18 green AND operator approval (Rule 18 step 4 marker fires on the FINAL plan).
+9. No aspirational output — every emitted "checking X" line is backed by an assertion doing X.
+
+## A.3 STOP-and-ask protocol
+
+```text
+STOP — step <n.m> blocked.
+Reason: <anchor not found | ambiguous | verify failed after fix>.
+File: <path>
+Expected anchor (verbatim): <text>
+What I found instead: <±3 lines>
+Question: <the single decision the plan owner must make>
+```
+
+## A.4 Pre-flight (step 0 of every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| Branch | `git branch --show-current` | `feat/rfc-009-p1a` |
+| Clean tree | `git status --porcelain` | empty |
+| Baseline tests | `node tests/test-em-restore.mjs` | current N/N pass |
+| Runtime | `node --version` | `v20`+ |
+
+## A.5 Shared constants / types
+
+```js
+// scripts/lib/categories.mjs (created in S1). No placeholders — exact values:
+//   export const CATEGORIES_PATH = new URL('../../categories.json', import.meta.url)
+//   export function loadCategories() { /* read+parse CATEGORIES_PATH or EM_CATEGORIES_PATH; THROW on fail */ }
+//   export function validateCategory(name, { allowDeprecated = false } = {}) { /* §12 table */ }
+//   export function canonicalCategory(name) { /* §12 table */ }
+//   export function categoryLifecycle(name) { /* member.lifecycle || null (canonicalized) */ }
+// Launch vocabulary (categories.json), lifecycle: temporary=aggregate-then-prune, rest=standard:
+//   decision, discovery, milestone, context, research, lesson, violation, workflow.lifecycle, workplan, temporary
+```
+
+## A.6 Anchor format
+
+Standard (§A.6 of PLAN_TEMPLATE): `ANCHOR` = verbatim unique substring; label each step CREATE /
+EDIT / APPEND. Literal strings/regexes spelled verbatim.
+
+## A.6b Falsifiable Verify
+
+Every verify names the observed value + expected concrete value and fails on a stub. Negative
+controls run as their own row (single command, env/argv break-input), never `;`-chained.
+
+## A.7 Per-slice step tables
+
+### `P1a-S1` — Vocabulary as data
+
+**Files:** `categories.json`, `schemas/categories.schema.json`, `scripts/lib/categories.mjs`, `scripts/validate-schemas.mjs`, `tests/test-categories-lib.mjs`. **Read-only:** `patterns/taxonomy.schema.json`.
+
+| Step | File | Kind | Exact action | Verify (observed → expected) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4. | rows pass |
+| 1.1 | `categories.json` | CREATE | Full verbatim contents: `{ "version": "1.0.0", "categories": [ {"name":"decision","description":"…","lifecycle":"standard"}, …8 standard members…, {"name":"workplan","description":"…","lifecycle":"standard"}, {"name":"temporary","description":"transient working episodes: review threads, scratch context","lifecycle":"aggregate-then-prune"} ] }` — exactly the 10 §A.5 members; no `deprecated_for` at launch. | `node -e "const c=JSON.parse(require('fs').readFileSync('categories.json','utf8')); if(c.categories.length!==10) process.exit(1); if(!c.categories.find(m=>m.name==='temporary'&&m.lifecycle==='aggregate-then-prune')) process.exit(1)"` → exit 0 (observed: 10 members, temporary is aggregate-then-prune; a wrong count or missing member exits 1) |
+| 1.2 | `schemas/categories.schema.json` | CREATE | Meta-schema mirroring `patterns/taxonomy.schema.json`: `$schema` 2020-12, `required:["version","categories"]`, `additionalProperties:false`, `categories` items `required:["name","description","lifecycle"]` + `additionalProperties:false`, `lifecycle` `enum:["standard","aggregate-then-prune"]`, optional `deprecated_for` string, `name` pattern `^[a-z][a-z0-9.]*$`. | `node scripts/validate-schemas.mjs --project "$PWD" --json` → JSON `.docs` array INCLUDES `schemas/categories.schema.json` AND `.status==="ok"` (observed: the new doc is auto-discovered by the `schemas/` walk and lints clean; a malformed schema doc makes `.status==="violations"`) |
+| 1.3 | `scripts/lib/categories.mjs` | CREATE | Exports per §A.5. `loadCategories` reads `process.env.EM_CATEGORIES_PATH || new URL('../../categories.json', import.meta.url)`; THROWS `new Error('categories.json unloadable: '+e.message)` on read/parse fail. `validateCategory` per §12 states A-E (throws on unloadable). `canonicalCategory`/`categoryLifecycle` wrap load in try/catch and DEGRADE per §12 (literal / null), never throw. | `node -e "import('./scripts/lib/categories.mjs').then(m=>{if(m.validateCategory('lesson').ok!==true)process.exit(1); if(m.validateCategory('bogus').reason!=='unknown')process.exit(1); if(m.canonicalCategory('bogus')!=='bogus')process.exit(1)})"` → exit 0 (observed: active→ok, unknown→reason unknown, canonical of unknown→literal) |
+| 1.4 | `scripts/validate-schemas.mjs` | EDIT | ANCHOR: `const MIN_SCHEMA_DOCS = 17; // the P0 contract floor (17 schema docs shipped in P0)` → REPLACE `17`→`18` and update the comment to `// P0 floor 17 + categories.schema.json (P1a) = 18`. (NO other edit — `categories.schema.json` is auto-discovered by the existing `schemas/` walk, L49/L124; instance-validation of `categories.json` is a TEST, step 1.5, not this validator's job.) | `node scripts/validate-schemas.mjs --project "$PWD" --json` → `.docs_checked` ≥ 18 AND `.status==="ok"` (observed: floor bumped, new doc counted; reverting categories.schema.json to malformed flips status) |
+| 1.5 | `tests/test-categories-lib.mjs` | CREATE | Full verbatim Group-1 tests (§14) — each asserts a captured return value, no `assert(true)`: `testCategoriesJsonValidates` (instance-validate `categories.json` against `schemas/categories.schema.json` via `validateInstance` from `lib/json-instance-validate.mjs` (L513); assert `valid===true` — C6: `validateInstance` is NOT in mini-jsonschema.mjs), `testDeprecatedForMustResolve` (plant a temp vocab whose `deprecated_for` names a deprecated member; assert the validator reports it), `testValidateCategoryStates` (states A-D of §12), `testCanonicalCategory`, `testCategoriesLibThrowsOnMissing` (set `EM_CATEGORIES_PATH` to a nonexistent path; assert `validateCategory` THROWS but `canonicalCategory('x')==='x'` does NOT), `testNoHardcodedCategoryList` (grep `scripts/*.mjs` for a category-name ARRAY literal; assert only `lib/categories.mjs` matches). Register in `main()`. | `node tests/test-categories-lib.mjs` → `<N>/<N> pass` (observed count printed) |
+| 1.6 | — | — | Negative control (B1 asymmetric fail direction, lib-level): with vocab unloadable, `validateCategory` (writer path) throws but `canonicalCategory` (reader path) degrades. | `EM_CATEGORIES_PATH=/nonexistent/categories.json node -e "import('./scripts/lib/categories.mjs').then(m=>{let threw=false; try{m.validateCategory('lesson')}catch{threw=true}; if(!threw)process.exit(1); if(m.canonicalCategory('lesson')!=='lesson')process.exit(1)})"` → exit 0 (observed: validateCategory throws, canonicalCategory returns literal — the two sides of §12). The WRITER-refuses E2E is step 2.x. |
+| 1.7 | — | — | Commit `P1a-S1: categories.json + schema + lib` + trailer. | `git log -1 --oneline` → contains `P1a-S1` |
+
+### `P1a-S2` — Strict write surfaces (em-store, em-revise)
+
+**Files:** `scripts/em-store.mjs`, `scripts/em-revise.mjs`, `tests/test-category-write.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 2.1 | `scripts/em-store.mjs` | EDIT | ANCHOR: `const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']` (L81) → delete it; add `import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'` near the other lib imports (L29-30) — **include `loadCategories` (C8): the USAGE string depends on the member list**. Then ANCHOR: `const USAGE = \`--project <name> --category <${VALID_CATEGORIES.join('|')}> ...` (L83) → REPLACE the interpolation to derive names fail-safely: `let catNames; try { catNames = loadCategories().categories.map(c=>c.name).join('|') } catch { catNames = 'see categories.json' }` and use `${catNames}` (so `--help`/USAGE never crashes when the vocab is unloadable — the WRITE path still fails closed via `validateCategory`). Then ANCHOR: `if (!VALID_CATEGORIES.includes(category)) {` (L105) → REPLACE the whole `if` block (L105-111) with `let catV; try { catV = validateCategory(category) } catch (e) { console.log(JSON.stringify({status:'error', message: e.message})); process.exit(1) } if (!catV.ok) { console.log(JSON.stringify({status:'error', message: catV.reason==='deprecated' ? \`Category "${category}" is deprecated; use "${catV.successor}"\` : \`Invalid category "${category}"\`})); process.exit(1) }`. | `node scripts/em-store.mjs --project t --category bogus --summary s --body b --scope local` → stdout `{"status":"error"…Invalid category "bogus"…}` exit 1 (observed message names the offending value) |
+| 2.2 | `scripts/em-store.mjs` | APPEND | Add `export function updateCategoryIndex(dataDir, episodeId, category)` at end of file, structurally mirroring `updateTagsIndex` (L139-152): read `category-index.json` (default `{}`), `const key = canonicalCategory(category)`, push `episodeId` to `index[key]` if absent, write temp+rename. | (behavior, not existence) `node scripts/em-store.mjs --project t --category lesson --summary s2 --body b --scope local` then `node -e "const i=require('<local>/category-index.json'); if(!(i.lesson||[]).length) process.exit(1)"` → exit 0 (observed: the stored id appears under key `lesson`; a stub that writes nothing exits 1) |
+| 2.3 | `scripts/em-store.mjs` | EDIT | ANCHOR: `updateTagsIndex(dataDir, id, tags)` (L191) → add on the next line `updateCategoryIndex(dataDir, id, category)`. | covered by 2.2's behavior verify (the index only populates because the call fires) |
+| 2.4 | `scripts/em-revise.mjs` | EDIT | ANCHOR: `if (m[1] === 'category') origCategory = m[2]` (L166) → after the frontmatter parse, before the write, add `import`+`const rv = validateCategory(origCategory); if(!rv.ok){ error naming reason+successor; exit 1 }`. Separately ANCHOR: `updateTagsIndex(dataDir, id, mergedTags)` (L250) → add `updateCategoryIndex(dataDir, id, origCategory)` after (import from em-store or lib). | revise of a hand-planted `category: <deprecated>` episode → exit 1 naming the successor (observed error string); revise of an active-category episode → exit 0 and its id appears under the canonical key in `category-index.json` |
+| 2.5 | `tests/test-category-write.mjs` | CREATE | Full verbatim Group-2 store/revise tests + `testStoreFailsClosedOnMissingVocab` (B1: `EM_CATEGORIES_PATH=/nonexistent`, spawn em-store, assert exit≠0 + no episode file). Each asserts captured stdout JSON + on-disk `category-index.json` contents. Register `main()`. | `node tests/test-category-write.mjs` → `<N>/<N> pass` |
+| 2.6 | — | — | Commit `P1a-S2: strict store/revise + category-index update` + trailer. | `git log -1 --oneline` → contains `P1a-S2` |
+
+### `P1a-S3` — Restore matrix + self-test rewrite
+
+**Files:** `scripts/em-restore.mjs`, `tests/test-category-write.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 3.1 | `scripts/em-restore.mjs` | EDIT | ANCHOR: `const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']` (L40) → delete it + its two mirror-sync comment lines (L37-39); add `import { validateCategory, canonicalCategory } from './lib/categories.mjs'`. | `grep -c "VALID_CATEGORIES = \[" scripts/em-restore.mjs` → 0 (observed: array literal gone) |
+| 3.2 | `scripts/em-restore.mjs` | EDIT | ANCHOR: `if (!VALID_CATEGORIES.includes(c)) {` (L979) → REPLACE the guard body with `const fv = validateCategory(c, {allowDeprecated:true}); if (!fv.ok) { throw new Error(\`Invalid --category "${c}". Must be in the vocabulary.\`) }`. | in-proc: filter `['workflow.lifecycle']` accepted; `['bogus']` throws `/Invalid --category/` (observed: deprecated names pass, unknown throws) |
+| 3.3 | `scripts/em-restore.mjs` | EDIT | ANCHOR: `let action = decideAction(conflict, conflictMode)` (L682) → immediately after, add `const cv = validateCategory(canonicalCategory(entry.fm.category), {allowDeprecated:true}); if (!cv.ok) { categorySkips.push({ targetPath, id: entry.fm.id, category: entry.fm.category, reason: 'unknown category not in vocabulary' }); action = 'skip' }`. Declare `const categorySkips = []` beside `const duplicateSkips = []` (L665); **add `categorySkips` to `buildWritePlan`'s return object** (L777, which today returns `{ episodeWrites, docWrites, refusedClaudeMd, sidecarConflicts, symlinkSkips, duplicateSkips }` — without this the var is out of scope in the summary, C7); then set `category_skips: plan.categorySkips` in the summary object (L1089, beside `duplicate_skips: plan.duplicateSkips`). Validation precedes the write (EC6). | in-proc apply of a backup whose only episode is `category: bogus` → target `episodes/` has 0 new `.md` AND `summary.category_skips.length===1` (observed: skip+surface, the inversion of RFC evidence item 4) |
+| 3.4 | `scripts/em-restore.mjs` | EDIT | ANCHOR: `mergeIndexes(targetDir, restoredEntries, force ? 'force' : conflictMode)` (L1129) → after it, update `category-index.json` for `restoredEntries` (push each id under `canonicalCategory(fm.category)`, temp+rename) OR call the rebuild; pin whichever in `testRestoreMergesCategoryIndex`. | `testRestoreMergesCategoryIndex`: after apply, the target `category-index.json` holds the restored id under its canonical key (observed on disk) |
+| 3.5 | `scripts/em-restore.mjs` | EDIT | ANCHOR: `skip('valid_categories_match_em_store', 'em-store.mjs not present alongside (likely installed copy); drift check skipped')` (inside the T1 block, L1242-1260) → REPLACE the whole T1 block with `test_categories_from_shared_lib`: grep-assert both `em-store.mjs` and `em-restore.mjs` source contain `from './lib/categories.mjs'`, and assert `loadCategories().length===10`. (Fixture-change ledger, §A.9: the old grep-for-array test is obsolete once the array is deleted in 3.1.) | `node scripts/em-restore.mjs --self-test` → results list contains passing `test_categories_from_shared_lib` and NO `valid_categories_match_em_store` (observed) |
+| 3.6 | `tests/test-category-write.mjs` | EDIT | ANCHOR: the `main()` test-registration list → add `testRestoreFilterAcceptsDeprecated`, `testRestoreFilterRejectsUnknown`, `testRestoreApplySkipsUnknownCategory`, `testRestoreApplyWritesDeprecated`, `testRestoreMergesCategoryIndex` (REQ-5,6,11). | `node tests/test-category-write.mjs` → `<N>/<N> pass` |
+| 3.7 | — | — | Commit `P1a-S3: restore validation matrix + self-test`. | `git log -1` shows `P1a-S3` |
+
+### `P1a-S4` — Index + drift + new-field carry
+
+**Files:** `scripts/em-rebuild-index.mjs`, `tests/test-category-index.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 4.1 | `scripts/em-rebuild-index.mjs` | EDIT | ANCHOR: `supersedes: fm.supersedes || null,` (inside the `entries.push(JSON.stringify({…}))` object, L126) → add on following lines `...(Array.isArray(fm.consolidates) ? { consolidates: fm.consolidates } : {}),` and `...(typeof fm.superseded_by === 'string' ? { superseded_by: fm.superseded_by } : {}),`. | plant an episode with `consolidates: [x]` + `superseded_by: y`; `em-rebuild-index --scope local` then `node -e "const r=require('fs').readFileSync('<local>/index.jsonl','utf8'); const row=r.trim().split('\n').map(JSON.parse).find(e=>e.superseded_by==='y'); if(!row||row.consolidates[0]!=='x')process.exit(1)"` → exit 0 (observed: both fields carried; a no-op edit drops them → exit 1) |
+| 4.2 | `scripts/em-rebuild-index.mjs` | EDIT | ANCHOR: `for (const tag of normalizedTags) {` (L132, the tagsIndex build in `rebuildDir`) → alongside it build `const catKey = canonicalCategory(fm.category); (categoryIndex[catKey] ||= []).push(fm.id)` and increment `driftUnknown`/`driftDeprecated` when `validateCategory(fm.category)` reports unknown/deprecated. Declare `const categoryIndex = {}` beside `const tagsIndex = {}` (L105). ANCHOR: `fs.renameSync(tagsTmp, tagsFile)` (L145) → after it, write `category-index.json` via temp+rename the same way. Import lib. | `em-rebuild-index --scope local` then `node -e "const i=require('<local>/category-index.json'); if(!Object.keys(i).length)process.exit(1)"` → exit 0 (observed: canonical keys present) |
+| 4.3 | `scripts/em-rebuild-index.mjs` | EDIT | ANCHOR: `return { scope: label, count: entries.length }` (L147) → extend to `return { scope: label, count: entries.length, category_drift: { unknown: driftUnknown, deprecated: driftDeprecated } }`. | rebuild over a store with 1 hand-planted unknown-category episode → JSON `.rebuilt[].category_drift.unknown` includes that category with count 1 (observed) |
+| 4.4 | `scripts/em-rebuild-index.mjs` | EDIT | ANCHOR: `const scope = flag('--scope') || 'all'` (L34) → after arg parse add a `--check` branch: scan episode frontmatter, collect `{id, category, kind, successor?}` for every unknown/deprecated category, print `{status:'ok', drift:[…]}`, `process.exit(drift.length ? 1 : 0)`, write NOTHING. Update the `--help` usage line to mention `--check`. | `em-rebuild-index --check --scope local` on a clean store → exit 0, `drift:[]`; on a store with a planted unknown category → exit 1, `drift[0].id` names it, and `index.jsonl` mtime unchanged (observed: read-only) |
+| 4.5 | `tests/test-category-index.mjs` | CREATE | Full verbatim Group-3 tests: `testCategoryIndexBuilt`, `testCategoryIndexDeprecatedMapped`, `testCategoryIndexUnknownCountedLiteral`, `testCategoryIndexAtomicRename`, `testCategoryIndexConcurrentStoreRebuild` (C4: spawn N `em-store` while a rebuild runs; assert `category-index.json` parses at every read, then force a rebuild and assert all ids present), `testRebuildCheckListsDrift`, `testRebuildCheckCleanExitsZero`, `testRebuildCarriesNewFields` (dotted-category + consolidates/superseded_by, EC8), `testCategoryIndexUndefinedCategory` (EC9), `testCategoryNonScalarTolerated` (EC10), `testRebuildDegradesOnMissingVocab` (B1: `EM_CATEGORIES_PATH=/nonexistent`, assert rebuild still writes index.jsonl+tags.json + exit 0 + stderr warn + no category-index). Register `main()`. | `node tests/test-category-index.mjs` → `<N>/<N> pass` |
+| 4.6 | — | — | Commit `P1a-S4: category-index + --check drift` + trailer. | `git log -1 --oneline` → contains `P1a-S4` |
+
+### `P1a-S5` — Read surfaces (em-search)
+
+**Files:** `scripts/em-search.mjs`, `tests/test-category-search.mjs`, `tests/test-history-walk.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 5.1 | `scripts/em-search.mjs` | EDIT | ANCHOR: `results = results.filter(e => e.category === category)` (L263 — the EXISTING exact-match filter, M1) → REPLACE its INTERNALS to index-back: canonicalize `category`, read `category-index.json` for each active scope, intersect ids; on missing/corrupt index set `searchWarning` and fall back to the current linear `e.category === category` scan. Import lib (`canonicalCategory`). An active-name query must return the SAME set as today. | `em-search --category lesson --scope local` → same rows as pre-change (regression); corrupt `category-index.json` → same rows + stderr rebuild warning (observed) |
+| 5.2 | `scripts/em-search.mjs` | EDIT | ANCHOR: `bySupersedes.set(e.supersedes, e)` (L197, inside the `--history` forward-walk) → extend the forward map to also honor `e.superseded_by` edges, and for the queried id surface any active episode whose `consolidates` array names it; guard with a `visited` Set (cycle-safe). The single-`supersedes` walk output is unchanged. | history of a `superseded_by`-planted episode → chain includes the successor; a `supersedes`-fork fixture → behavior matches `testHistorySupersedesForkCharacterized`; a plain single-`supersedes` fixture → byte-identical chain to pre-change (observed) |
+| 5.3 | `tests/test-category-search.mjs` | CREATE | Full verbatim tests: `testSearchTolerantUnknownCategory`, `testListTolerantUnknownCategory`, `testRecallTolerantUnknownCategory` (C1 — hand-plant an unknown-category row, run `em-recall`, assert it ranks/returns without crash), `testSearchCategoryExactMatchUnchanged` (M1 regression pin), `testSearchCategoryUsesIndex`, `testSearchCategoryFallbackOnMissingIndex`, `testSearchCategoryCanonicalizesDeprecated`, `testSearchDegradesOnMissingVocab` (B1), `testRestoreMergesCategoryIndex`. Register `main()`. | `node tests/test-category-search.mjs` → `<N>/<N> pass` |
+| 5.4 | `tests/test-history-walk.mjs` | CREATE | Full verbatim REQ-14 tests: `testHistoryFollowsSupersededBy`, `testHistorySurfacesConsolidatesSuccessor`, `testHistorySingleSupersedesUnchanged`, `testHistorySupersedesForkCharacterized` (m1), `testHistoryCycleSafe` (EC7). Register `main()`. | `node tests/test-history-walk.mjs` → `<N>/<N> pass` |
+| 5.5 | — | — | Commit `P1a-S5: em-search --category index-backing + multi-parent history` + trailer. | `git log -1 --oneline` → contains `P1a-S5` |
+
+### `P1a-S6` — Prune lifecycle
+
+**Files:** `scripts/em-prune.mjs`, `tests/test-prune-lifecycle.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 6.1 | `scripts/em-prune.mjs` | EDIT | ANCHOR: `const score = computePruneScore(entry)` (L228, inside `pruneDir`'s selection loop) → immediately BEFORE it insert the aggregate-then-prune override: `if (categoryLifecycle(canonicalCategory(entry.category)) === 'aggregate-then-prune' && typeof entry.superseded_by === 'string') { toPrune.push({ ...entry, _pruneScore: 0 }); continue }`. This OVERRIDES the R6 protection set for consumed temporary members (a consumed temporary sits in its successor's `consolidates` array → R6 class-c would protect it, but R10e makes the consumed member prunable — the member's own aggregate-then-prune lifecycle wins; RFC R10e "the consumed members are not [protected]"). Import `{ categoryLifecycle, canonicalCategory }`. `computePruneScore` untouched. | aged `temporary` row WITH `superseded_by` → in `toPrune` even when ALSO named in a `consolidates` array (override); aged `temporary` row WITHOUT `superseded_by` → survives at standard score; aged `standard`-category row in a `consolidates` array → still protected (class-c unchanged) (observed via `--dry-run` JSON) |
+| 6.2 | `tests/test-prune-lifecycle.mjs` | CREATE | Full verbatim Group-5 tests with aged fixtures: `testTemporaryWithSuccessorPrunable`, `testTemporaryWithSuccessorOverridesClassC` (the R6×R10e interaction — temporary member in a consolidates array still prunable), `testTemporaryWithoutSuccessorSurvives`, `testStandardLifecycleUnaffected`, `testStandardConsolidatesMemberStillProtected`, `testPruneDegradesOnMissingVocab` (B1: `EM_CATEGORIES_PATH=/nonexistent` → standard score, no crash). Register `main()`. | `node tests/test-prune-lifecycle.mjs` → `<N>/<N> pass` |
+| 6.3 | — | — | Commit `P1a-S6: per-category prune lifecycle` + trailer. | `git log -1 --oneline` → contains `P1a-S6` |
+
+### `P1a-S7` — Deploy + docs + CI
+
+**Files:** `install.mjs`, `docs/EM_SCRIPTS_GUIDE.md`, `README.md`, `.github/workflows/<ci>.yml`, `tests/test-install-categories.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 7.1 | `install.mjs` | EDIT | ANCHOR: `// 1b. Copy patterns/_index.json for global pattern validation` (L389, through its `if` block L392-396) → APPEND immediately after (before the `// 1c.` comment L398) a sibling step: `const repoCategories = path.join(REPO_DIR, 'categories.json'); if (fs.existsSync(repoCategories)) { fs.mkdirSync(GLOBAL_DIR, { recursive: true }); fs.copyFileSync(repoCategories, path.join(GLOBAL_DIR, 'categories.json')); console.log(\`Installed categories.json to ${GLOBAL_DIR}\`) }`. | after a mock install (step 7.2), the deployed file exists at `<fakeHOME>/.episodic-memory/categories.json` |
+| 7.2 | `tests/test-install-categories.mjs` | CREATE | Mock-project isolated-HOME E2E (verify-the-strong-claim, M3/C2): set `HOME`+`USERPROFILE` to a fresh temp dir, run REAL `install.mjs --tool claude-code`, then: (a) `testInstallDeploysCategoriesJson` — assert `<fakeHOME>/.episodic-memory/categories.json` exists; (b) `testCategoriesJsonNotInClaudeHome` — assert NO `categories.json` anywhere under `<fakeHOME>/.claude/` (P12); (c) `testInstallDeployedStoreLoadsVocab` — INVOKE the DEPLOYED `<fakeHOME>/.episodic-memory/scripts/em-store.mjs --category bogus …` with cwd in a fake project, assert exit≠0 + the vocab-list invalid-category message (proves `../../categories.json` resolves from the deployed `scripts/lib/`, not the repo copy). Register `main()`. | `node tests/test-install-categories.mjs` → `<N>/<N> pass` (the deployed-store leg is the M3 fix — it RUNS the script, not stats the file) |
+| 7.3 | `docs/EM_SCRIPTS_GUIDE.md` | EDIT | ANCHOR: the `em-search` section heading → document `--category` (index-backed), `--check` (em-rebuild-index), `category-index.json`, `categories.json`, the R10 category-vs-tags semantics, and the temporary lifecycle in the relevant script sections. | `grep -c 'category-index.json' docs/EM_SCRIPTS_GUIDE.md` → ≥1 AND `grep -c 'categories.json' docs/EM_SCRIPTS_GUIDE.md` → ≥1 |
+| 7.4 | `README.md` | EDIT | ANCHOR: the script/data table → add rows/notes for `categories.json`, `--category`, `category-index.json`. | `grep -c 'categories.json' README.md` → ≥1 |
+| 7.5 | `.github/workflows/plan-marker-validate.yml` | EDIT | ANCHOR: the existing test-run step block (the workflow that runs on every PR with no paths filter) → add explicit `node tests/test-*.mjs` steps for the 6 new files + a `node scripts/validate-schemas.mjs --project "$PWD"` step. (Curated-list workflow: an unwired test never runs — the check-actual-CI lesson.) | `grep -c "test-categories-lib" .github/workflows/plan-marker-validate.yml` → ≥1; post-PR `gh pr checks <PR>` shows the steps green |
+| 7.6 | `tests/test-install-categories.mjs` | EDIT | ANCHOR: the `main()` registration → add `testDocsGrepGate` (grep `docs/EM_SCRIPTS_GUIDE.md` for each new surface: `categories.json`, `category-index.json`, `--category`, `--check`). | `node tests/test-install-categories.mjs` → passes incl. docs gate |
+| 7.7 | — | — | Commit `P1a-S7: deploy categories.json + docs + CI` + trailer. | `git log -1 --oneline` → contains `P1a-S7` |
+
+## A.8 Definition of done (mechanical)
+
+```bash
+node tests/test-categories-lib.mjs      # → N/N pass
+node tests/test-category-write.mjs      # → N/N pass
+node tests/test-category-index.mjs      # → N/N pass
+node tests/test-category-search.mjs     # → N/N pass
+node tests/test-history-walk.mjs        # → N/N pass
+node tests/test-prune-lifecycle.mjs     # → N/N pass
+node tests/test-install-categories.mjs  # → N/N pass (mock E2E)
+node scripts/validate-schemas.mjs       # → exit 0, categories.json validated
+grep -rnE "'(decision|discovery|milestone|lesson|violation|context|research|workplan|temporary|workflow\.lifecycle)'" scripts/*.mjs  # → only lib/categories.mjs (m4: full vocab alternation). Reading-pass backstop for wrapped/multi-line lists. NOTE: single-value 'workflow.lifecycle' constants in the event-writer family (I2b) are an expected allow-list, not an array literal.
+```
+
+## A.9 Blast-radius patterns
+
+- **Red-then-green:** the lib-level control (1.6) proves the asymmetric fail direction (writer
+  `validateCategory` throws, reader `canonicalCategory` degrades); `testStoreFailsClosedOnMissingVocab`
+  (2.5) proves the WRITER refuses to write with an unreachable vocab; the three `*DegradesOnMissingVocab`
+  tests prove the readers survive it — a guard never observed failing guards nothing.
+- **Pure-extraction first:** S1 ships the lib with ZERO script edits (existing tests stay green)
+  before S2 rewires the writers — the P3a/P3b-1 pattern.
+- **Fixture-change ledger (REQ-17):** the em-restore `valid_categories_match_em_store` self-test
+  is a behavior change to an existing test; step 3.5 enumerates the exact replacement (name +
+  new assertion), never "existing tests stay green."
+- **Discriminating fixture:** the restore-apply negative control asserts ZERO new files on disk
+  (not "exit 0"), so a write-then-validate regression is observable.
+- **Mock-project E2E for deploy (REQ-15):** the REAL `install.mjs` against an isolated HOME, then
+  read the deployed tree — never mental-trace.
+- **Flag high-blast-radius:** S3 (em-restore, 2470 lines) and S5 (em-search `--history`) are marked
+  "focused review before build" — the spec removes ambiguity, not the need for a human look.

--- a/install.mjs
+++ b/install.mjs
@@ -395,6 +395,16 @@ if (fs.existsSync(repoPatternsIndex)) {
   console.log(`Installed patterns/_index.json to ${globalPatternsDir}`)
 }
 
+// 1b'. Copy categories.json — the episode-category vocabulary substrate (RFC-009 R10b).
+// It is DATA the deployed em-* scripts read via `../../categories.json` from scripts/lib/, so it
+// must land at the global root (NOT under ~/.claude/, which is enforcement-artifact territory).
+const repoCategories = path.join(REPO_DIR, 'categories.json')
+if (fs.existsSync(repoCategories)) {
+  fs.mkdirSync(GLOBAL_DIR, { recursive: true })
+  fs.copyFileSync(repoCategories, path.join(GLOBAL_DIR, 'categories.json'))
+  console.log(`Installed categories.json to ${GLOBAL_DIR}`)
+}
+
 // 1c. Copy the agent-facing per-script reference to the global root so any tool
 // can read it before first script use (deployed on every install, all tools).
 const repoScriptsGuide = path.join(REPO_DIR, 'docs', 'EM_SCRIPTS_GUIDE.md')

--- a/schemas/categories.schema.json
+++ b/schemas/categories.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://episodic-memory/schemas/categories.schema.json",
+  "title": "Episode category vocabulary (RFC-009 R10b)",
+  "description": "Meta-schema for categories.json — the single source of truth for the closed episode-category vocabulary, each member's lifecycle, and deprecation mapping.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "categories"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Editorial semver of the vocabulary document."
+    },
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/category" }
+    }
+  },
+  "$defs": {
+    "categoryName": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9.]*$"
+    },
+    "category": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "description", "lifecycle"],
+      "properties": {
+        "name": { "$ref": "#/$defs/categoryName" },
+        "description": { "type": "string", "minLength": 1 },
+        "lifecycle": {
+          "type": "string",
+          "enum": ["standard", "aggregate-then-prune"]
+        },
+        "deprecated_for": { "$ref": "#/$defs/categoryName" }
+      }
+    }
+  }
+}

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -25,6 +25,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { categoryLifecycle, canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -225,6 +226,18 @@ function pruneDir(dataDir, label, protectedIds) {
   // (check / dry-run / real prune) — the mode branches below only format the
   // already-decided sets. Partition: entries = toKeep (incl. protected) + toPrune.
   for (const entry of entries) {
+    // R10e override (checked BEFORE the score AND the R6 protection lookup): a consumed
+    // aggregate-then-prune (temporary) member — one carrying superseded_by, i.e. an R9 apply
+    // folded it into a consolidated successor — is aggressively prunable even if it sits in that
+    // successor's `consolidates` array (R6 class-c would otherwise protect it). The member's own
+    // lifecycle wins (RFC R10e "the consumed members are not [protected]"). A temporary WITHOUT
+    // superseded_by falls through to the standard score below; the R6 protection set CODE (P0) is
+    // untouched. categoryLifecycle degrades to null on an unloadable vocab, so the override no-ops
+    // and prune behaves exactly as pre-R10 (B1).
+    if (categoryLifecycle(canonicalCategory(entry.category)) === 'aggregate-then-prune' && typeof entry.superseded_by === 'string') {
+      toPrune.push({ ...entry, _pruneScore: 0 })
+      continue
+    }
     const score = computePruneScore(entry)
     if (score < threshold) {
       const p = protectedIds.get(String(entry.id))

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -14,6 +14,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -21,7 +22,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-rebuild-index.mjs', usage: 'node em-rebuild-index.mjs [--scope local|global|all]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-rebuild-index.mjs', usage: 'node em-rebuild-index.mjs [--scope local|global|all] [--check]' }))
   process.exit(0)
 }
 
@@ -32,6 +33,7 @@ function flag(name) {
 }
 
 const scope = flag('--scope') || 'all'
+const checkMode = argv.includes('--check')
 
 function normalizeTags(raw) {
   if (!raw) return []
@@ -39,6 +41,36 @@ function normalizeTags(raw) {
     .map(t => t.trim().toLowerCase())
     .filter(Boolean)
   return [...new Set(arr)].sort()
+}
+
+// --check: drift DETECTION only (R10f). Lists every episode whose stored category is unknown or
+// deprecated; exits 1 iff any drift, 0 otherwise. Writes NOTHING. Correction is the R9 clerk (P4).
+if (checkMode) {
+  let vocabLoaded = true
+  try { loadCategories() } catch { vocabLoaded = false }
+  const drift = []
+  if (vocabLoaded) {
+    const dirs = []
+    if (scope === 'local' || scope === 'all') dirs.push(LOCAL_DIR)
+    if (scope === 'global' || scope === 'all') dirs.push(GLOBAL_DIR)
+    for (const dataDir of dirs) {
+      const episodesDir = path.join(dataDir, 'episodes')
+      let files = []
+      try { files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort() } catch { continue }
+      for (const file of files) {
+        const fm = parseFrontmatter(fs.readFileSync(path.join(episodesDir, file), 'utf8'))
+        if (!fm || !fm.id) continue
+        const v = validateCategory(fm.category, { allowDeprecated: true })
+        if (!v.ok) drift.push({ id: fm.id, category: fm.category ?? null, kind: 'unknown' })
+        else if (v.successor) drift.push({ id: fm.id, category: fm.category, kind: 'deprecated', successor: v.successor })
+      }
+    }
+  } else {
+    // reader surface must never be fatal (B1): degrade to an empty, clean report + a stderr warn
+    process.stderr.write('em-rebuild-index --check: categories.json unloadable; drift not classified\n')
+  }
+  console.log(JSON.stringify({ status: 'ok', drift }))
+  process.exit(drift.length ? 1 : 0)
 }
 
 /**
@@ -103,6 +135,13 @@ function rebuildDir(dataDir, label) {
   const entries = []
 
   const tagsIndex = {}
+  // category-index + drift counts (R10d/R10f). Reader/index surface: if the vocab cannot load,
+  // DEGRADE — build index.jsonl + tags.json as before and skip category-index (B1, I3).
+  const categoryIndex = {}
+  const driftUnknown = {}
+  const driftDeprecated = {}
+  let vocabLoaded = true
+  try { loadCategories() } catch { vocabLoaded = false }
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
@@ -123,6 +162,8 @@ function rebuildDir(dataDir, label) {
       category: fm.category,
       status: fm.status || 'active',
       supersedes: fm.supersedes || null,
+      ...(Array.isArray(fm.consolidates) ? { consolidates: fm.consolidates } : {}),
+      ...(typeof fm.superseded_by === 'string' ? { superseded_by: fm.superseded_by } : {}),
       tags: normalizedTags,
       summary: fm.summary,
       access_count: accessCount,
@@ -132,6 +173,17 @@ function rebuildDir(dataDir, label) {
     for (const tag of normalizedTags) {
       if (!tagsIndex[tag]) tagsIndex[tag] = []
       tagsIndex[tag].push(fm.id)
+    }
+    if (vocabLoaded) {
+      // canonical key: deprecated → successor; unknown → its literal key (and counted).
+      const catKey = canonicalCategory(fm.category)
+      ;(categoryIndex[catKey] ||= []).push(fm.id)
+      const rawV = validateCategory(fm.category, { allowDeprecated: true })
+      if (!rawV.ok) driftUnknown[catKey] = (driftUnknown[catKey] || 0) + 1
+      else if (rawV.successor) {
+        const name = String(fm.category)
+        driftDeprecated[name] = (driftDeprecated[name] || 0) + 1
+      }
     }
   }
 
@@ -144,7 +196,16 @@ function rebuildDir(dataDir, label) {
   fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
   fs.renameSync(tagsTmp, tagsFile)
 
-  return { scope: label, count: entries.length }
+  if (vocabLoaded) {
+    const catFile = path.join(dataDir, 'category-index.json')
+    const catTmp = catFile + '.tmp'
+    fs.writeFileSync(catTmp, JSON.stringify(categoryIndex, null, 2), 'utf8')
+    fs.renameSync(catTmp, catFile)
+  } else {
+    process.stderr.write(`em-rebuild-index: categories.json unloadable; ${label} category-index.json skipped (index.jsonl + tags.json built normally)\n`)
+  }
+
+  return { scope: label, count: entries.length, category_drift: { unknown: driftUnknown, deprecated: driftDeprecated } }
 }
 
 const rebuilt = []

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -29,16 +29,14 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
+import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-// Mirror em-store.mjs:41 VALID_CATEGORIES exactly. Drift detected by
-// selfTest test_valid_categories_match_em_store: any future em-store change
-// surfaces here as a failing test, not a silent rejection of valid input.
-const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']
-
+// The category vocabulary is read from categories.json via lib/categories.mjs
+// (RFC-009 R10b) — no local array to keep in sync with em-store any longer.
 const VALID_CONFLICT_MODES = ['skip', 'sidecar', 'force']
 
 // Reserved doc filename: when --include-docs encounters this, gate behind
@@ -173,8 +171,8 @@ function parseSourceMap(values) {
 // a slightly wider grammar to tolerate hand-edited episodes from older
 // versions, but draw the line at any path separator, any control char,
 // any space, and any id longer than 200 chars. Full em-store grammar
-// drift test deferred to a follow-up issue (mirrors the VALID_CATEGORIES
-// drift discipline at T1).
+// drift test deferred to a follow-up issue (mirrors the shared-lib
+// cross-script consistency discipline at T1).
 function isSafeId(id) {
   if (typeof id !== 'string' || id.length === 0 || id.length > 200) return false
   if (id.includes('/') || id.includes('\\') || id.includes('\0')) return false
@@ -663,6 +661,10 @@ function buildWritePlan({
   // not a symlink rejection. Dedicated field makes the report self-
   // documenting.
   const duplicateSkips = []
+  // RFC-009 R10c row 2 (apply path): an episode whose canonical category is unknown-to-any-version
+  // is skipped and surfaced here (inverting the old silent write-through). Deprecated members
+  // restore verbatim (canonicalCategory maps them to an active successor, so cv.ok stays true).
+  const categorySkips = []
   const targetByPath = new Map() // collision detection within plan
 
   // Codex round-1 F2: iterate the expanded selection AND any cross-label
@@ -680,6 +682,14 @@ function buildWritePlan({
     const conflict = classifyConflict(entry.sourcePath, targetPath)
 
     let action = decideAction(conflict, conflictMode)
+    // Category validation precedes any write (EC6): an unknown category is skipped + surfaced,
+    // never written through. canonicalCategory resolves a deprecated member to its active
+    // successor first, so only genuinely-unknown categories fail here.
+    const cv = validateCategory(canonicalCategory(entry.fm.category), { allowDeprecated: true })
+    if (!cv.ok) {
+      categorySkips.push({ targetPath, id: entry.fm.id, category: entry.fm.category, reason: 'unknown category not in vocabulary' })
+      action = 'skip'
+    }
     // Reviewer M1: previously set action='overwrite-symlink' but the apply
     // path only switched on skip/noop/sidecar/<default>, making the label
     // cosmetic. Now: when --allow-symlink-overwrite is set, the symlink
@@ -774,7 +784,7 @@ function buildWritePlan({
     }
   }
 
-  return { episodeWrites, docWrites, refusedClaudeMd, sidecarConflicts, symlinkSkips, duplicateSkips }
+  return { episodeWrites, docWrites, refusedClaudeMd, sidecarConflicts, symlinkSkips, duplicateSkips, categorySkips }
 }
 
 // Pre-creates every unique parent dir referenced by the plan's writes
@@ -976,8 +986,11 @@ function run(opts) {
   // already have passed. Same shape as proof-rigor v4 #1 (validation
   // timing): pure-input checks are the cheapest layer; do them first.
   for (const c of categories) {
-    if (!VALID_CATEGORIES.includes(c)) {
-      throw new Error(`Invalid --category "${c}". Must be one of: ${VALID_CATEGORIES.join(', ')}`)
+    // Filter flag: strict INCLUDING deprecated names, so older-vocab backups filter
+    // correctly (R10c row 2). Unknown → the existing invalid-category error.
+    const fv = validateCategory(c, { allowDeprecated: true })
+    if (!fv.ok) {
+      throw new Error(`Invalid --category "${c}". Must be in the vocabulary.`)
     }
   }
 
@@ -1087,6 +1100,7 @@ function run(opts) {
     sidecar_collisions: plan.sidecarConflicts,
     symlink_rejects: { source: [...epSymlinkRejects, ...docSymlinkRejects], target: plan.symlinkSkips },
     duplicate_skips: plan.duplicateSkips,
+    category_skips: plan.categorySkips,
     ref_integrity: refReports,
     chain_breaks: chainBreaks, // reviewer n1: actually surface dangling supersedes refs
     skipped_in_backup: skipManifest
@@ -1127,6 +1141,19 @@ function run(opts) {
         last_accessed: null
       }))
       mergeIndexes(targetDir, restoredEntries, force ? 'force' : conflictMode)
+      // RFC-009 R10d: merge the restored ids into category-index.json under their canonical
+      // category key (temp+rename), mirroring the store/revise incremental maintenance.
+      const catFile = path.join(targetDir, 'category-index.json')
+      let catIndex = {}
+      try { catIndex = JSON.parse(fs.readFileSync(catFile, 'utf8')) } catch {}
+      for (const fm of fms) {
+        const key = canonicalCategory(fm.category)
+        if (!catIndex[key]) catIndex[key] = []
+        if (!catIndex[key].includes(fm.id)) catIndex[key].push(fm.id)
+      }
+      const catTmp = catFile + '.tmp'
+      fs.writeFileSync(catTmp, JSON.stringify(catIndex, null, 2), 'utf8')
+      fs.renameSync(catTmp, catFile)
       indexResults.push({ targetDir, merged: restoredEntries.length })
     }
   }
@@ -1239,25 +1266,24 @@ function selfTest() {
     execFileSync('git', ['commit', '-m', 'test', '--allow-empty'], { cwd: backupDir, stdio: ['ignore', 'pipe', 'pipe'] })
   }
 
-  // T1: VALID_CATEGORIES drift test
+  // T1: both scripts read the vocabulary from the shared lib (RFC-009 R10b, REQ-17).
+  // Replaces the old valid_categories_match_em_store grep-for-array drift test — with a single
+  // lib source there is no duplicated array to drift; the guard is now "both import the lib".
   try {
-    const emStorePath = path.join(path.dirname(new URL(import.meta.url).pathname), 'em-store.mjs')
-    if (fs.existsSync(emStorePath)) {
-      const src = fs.readFileSync(emStorePath, 'utf8')
-      const m = src.match(/VALID_CATEGORIES\s*=\s*\[([^\]]*)\]/)
-      if (m) {
-        const fromStore = m[1].split(',').map(s => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
-        const same = fromStore.length === VALID_CATEGORIES.length && fromStore.every((c, i) => c === VALID_CATEGORIES[i])
-        assert('valid_categories_match_em_store', same, `restore=${VALID_CATEGORIES.join(',')} store=${fromStore.join(',')}`)
-      } else {
-        bad('valid_categories_match_em_store', 'could not extract VALID_CATEGORIES from em-store.mjs')
-      }
+    const scriptsDir = path.dirname(new URL(import.meta.url).pathname)
+    const storePath = path.join(scriptsDir, 'em-store.mjs')
+    const restorePath = path.join(scriptsDir, 'em-restore.mjs')
+    if (fs.existsSync(storePath) && fs.existsSync(restorePath)) {
+      const storeSrc = fs.readFileSync(storePath, 'utf8')
+      const restoreSrc = fs.readFileSync(restorePath, 'utf8')
+      const bothImport = storeSrc.includes("from './lib/categories.mjs'") && restoreSrc.includes("from './lib/categories.mjs'")
+      const vocabOk = loadCategories().categories.length === 10
+      assert('test_categories_from_shared_lib', bothImport && vocabOk, `bothImport=${bothImport} vocabLen=${loadCategories().categories.length}`)
     } else {
-      // Running from installed location; em-store.mjs is alongside.
-      skip('valid_categories_match_em_store', 'em-store.mjs not present alongside (likely installed copy); drift check skipped')
+      skip('test_categories_from_shared_lib', 'em-store.mjs/em-restore.mjs not present alongside (installed copy); lib-import check skipped')
     }
   } catch (e) {
-    bad('valid_categories_match_em_store', e.message)
+    bad('test_categories_from_shared_lib', e.message)
   }
 
   // T2: pre-flight refuses non-git backup

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -28,6 +28,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
+import { validateCategory, canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -118,6 +119,38 @@ if (!original) {
     message: `Original episode "${originalId}" not found in local or global stores.`
   }))
   process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Validate the inherited category BEFORE any write (I4 / EC6 — a rejected revise
+// must leave the store byte-unchanged; the original is marked superseded just below,
+// so validation has to precede that mutation, not follow the later metadata parse).
+// ---------------------------------------------------------------------------
+{
+  const origRaw = fs.readFileSync(original.filePath, 'utf8')
+  const fm = origRaw.match(/^---\n([\s\S]*?)\n---/)
+  let cat = 'decision'
+  if (fm) {
+    for (const line of fm[1].split('\n')) {
+      const m = line.match(/^(\w+):\s*(.*)$/)
+      if (m && m[1] === 'category') cat = m[2]
+    }
+  }
+  let rv
+  try {
+    rv = validateCategory(cat)
+  } catch (e) {
+    // vocab unloadable at a WRITE surface → fail CLOSED (§12 state E)
+    console.log(JSON.stringify({ status: 'error', message: e.message }))
+    process.exit(1)
+  }
+  if (!rv.ok) {
+    const message = rv.reason === 'deprecated'
+      ? `Inherited category "${cat}" is deprecated; use "${rv.successor}"`
+      : `Inherited category "${cat}" is not in the vocabulary`
+    console.log(JSON.stringify({ status: 'error', message }))
+    process.exit(1)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +245,22 @@ function updateTagsIndex(dataDir, episodeId, tags) {
   fs.renameSync(tmpFile, tagsFile)
 }
 
+// Mirror em-store's category-index maintenance (RFC-009 R10d); duplicated locally the same
+// way updateTagsIndex is, rather than imported from em-store (which runs top-level on import).
+function updateCategoryIndex(dataDir, episodeId, category) {
+  const catFile = path.join(dataDir, 'category-index.json')
+  let index = {}
+  try {
+    index = JSON.parse(fs.readFileSync(catFile, 'utf8'))
+  } catch {}
+  const key = canonicalCategory(category)
+  if (!index[key]) index[key] = []
+  if (!index[key].includes(episodeId)) index[key].push(episodeId)
+  const tmpFile = catFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
+  fs.renameSync(tmpFile, catFile)
+}
+
 const tags = normalizeTags(tagsRaw, tagRepeats)
 const resolvedProject = origProject || path.basename(process.cwd())
 
@@ -248,9 +297,11 @@ fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
 
 // Update tags.json
 updateTagsIndex(dataDir, id, mergedTags)
-// If revision crosses scopes, also update original scope's tags.json
+updateCategoryIndex(dataDir, id, origCategory)
+// If revision crosses scopes, also update original scope's tags.json + category-index.json
 if (original.dir !== dataDir) {
   updateTagsIndex(original.dir, id, mergedTags)
+  updateCategoryIndex(original.dir, id, origCategory)
 }
 
 console.log(JSON.stringify({

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -19,6 +19,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -74,6 +75,15 @@ function loadTagsIndex(dataDir) {
   const tagsFile = path.join(dataDir, 'tags.json')
   try {
     return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function loadCategoryIndex(dataDir) {
+  const catFile = path.join(dataDir, 'category-index.json')
+  try {
+    return JSON.parse(fs.readFileSync(catFile, 'utf8'))
   } catch {
     return null
   }
@@ -189,17 +199,33 @@ if (historyId) {
     root = parent
   }
 
-  // Walk forward from root
+  // Walk forward from root along the many-to-one edges R9 (P4) will write (REQ-14):
+  //   1. inverted supersedes (existing behavior — kept first so single-supersedes chains are
+  //      byte-identical; a supersedes FORK stays last-writer-wins, characterized not fixed, §17-E),
+  //   2. the scalar superseded_by edge,
+  //   3. a consolidates successor (an active episode whose consolidates array names current).
+  // A visited Set makes a cyclic consolidates/superseded_by fixture terminate (EC7).
   if (root) {
     chain.push(root)
     const bySupersedes = new Map()
+    const byConsolidates = new Map()
     for (const e of allEntries) {
       if (e.supersedes) bySupersedes.set(e.supersedes, e)
+      if (Array.isArray(e.consolidates)) {
+        for (const cid of e.consolidates) byConsolidates.set(cid, e)
+      }
     }
+    const visited = new Set([root.id])
     let current = root
-    while (bySupersedes.has(current.id)) {
-      current = bySupersedes.get(current.id)
-      chain.push(current)
+    while (true) {
+      let next = null
+      if (bySupersedes.has(current.id)) next = bySupersedes.get(current.id)
+      else if (current.superseded_by && byId.has(current.superseded_by)) next = byId.get(current.superseded_by)
+      else if (byConsolidates.has(current.id)) next = byConsolidates.get(current.id)
+      if (!next || visited.has(next.id)) break
+      visited.add(next.id)
+      chain.push(next)
+      current = next
     }
   }
 
@@ -260,7 +286,30 @@ if (tag) {
   }
 }
 if (category) {
-  results = results.filter(e => e.category === category)
+  // Index-backed (R10d), symmetric with --tag: canonicalize the query, read category-index.json
+  // from each active scope, intersect ids. Missing/corrupt index → linear-scan fallback + a
+  // rebuild warning. An active-name query returns the same set as the old exact-match filter.
+  const canonical = canonicalCategory(category)
+  let catIds = null
+  const dirs = []
+  if (scope === 'local' || scope === 'all') dirs.push(LOCAL_DIR)
+  if (scope === 'global' || scope === 'all') dirs.push(GLOBAL_DIR)
+  for (const dir of dirs) {
+    const idx = loadCategoryIndex(dir)
+    if (idx && Object.prototype.hasOwnProperty.call(idx, canonical)) {
+      if (!catIds) catIds = new Set()
+      for (const id of idx[canonical]) catIds.add(id)
+    } else if (!idx) {
+      if (!searchWarning) searchWarning = 'category-index.json missing or corrupt. Falling back to linear scan. Run em-rebuild-index.mjs to regenerate.'
+    }
+  }
+  if (catIds) {
+    results = results.filter(e => catIds.has(e.id))
+  } else {
+    // Fallback: linear scan. Canonicalize stored categories too so a deprecated-alias query
+    // still matches; for an active name with no aliases this is exactly the old e.category === c.
+    results = results.filter(e => e.category === category || canonicalCategory(e.category) === canonical)
+  }
 }
 if (since) {
   results = results.filter(e => e.date >= since)

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -28,6 +28,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
+import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -78,9 +79,13 @@ const bodyFile = flag('--body-file')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
 
-const VALID_CATEGORIES = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle']
+// Category vocabulary comes from categories.json via lib/categories.mjs (RFC-009 R10b).
+// USAGE derives the member list fail-safely so --help never crashes when the vocab is
+// unloadable; the write path still fails CLOSED below via validateCategory.
+let catNames
+try { catNames = loadCategories().categories.map(c => c.name).join('|') } catch { catNames = 'see categories.json' }
 
-const USAGE = `--project <name> --category <${VALID_CATEGORIES.join('|')}> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope local|global]`
+const USAGE = `--project <name> --category <${catNames}> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope local|global]`
 
 if (bodyArg !== undefined && bodyFile !== undefined) {
   console.log(JSON.stringify({
@@ -102,11 +107,19 @@ if (!project || !category || !summary || !body) {
   }))
   process.exit(1)
 }
-if (!VALID_CATEGORIES.includes(category)) {
-  console.log(JSON.stringify({
-    status: 'error',
-    message: `Invalid category "${category}". Must be one of: ${VALID_CATEGORIES.join(', ')}`
-  }))
+let catV
+try {
+  catV = validateCategory(category)
+} catch (e) {
+  // vocab unloadable at a WRITE surface → fail CLOSED (§12 state E)
+  console.log(JSON.stringify({ status: 'error', message: e.message }))
+  process.exit(1)
+}
+if (!catV.ok) {
+  const message = catV.reason === 'deprecated'
+    ? `Category "${category}" is deprecated; use "${catV.successor}"`
+    : `Invalid category "${category}". Must be one of: ${(() => { try { return loadCategories().categories.map(c => c.name).join(', ') } catch { return 'see categories.json' } })()}`
+  console.log(JSON.stringify({ status: 'error', message }))
   process.exit(1)
 }
 
@@ -189,5 +202,23 @@ const indexEntry = JSON.stringify({
 fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
 
 updateTagsIndex(dataDir, id, tags)
+updateCategoryIndex(dataDir, id, category)
 
 console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope }))
+
+// Incrementally maintain category-index.json under the episode's canonical category key,
+// structurally mirroring updateTagsIndex (RFC-009 R10d). Deprecated names map to the successor
+// key; unknown names index under their literal key (canonicalCategory degrades, never throws).
+export function updateCategoryIndex(dataDir, episodeId, category) {
+  const catFile = path.join(dataDir, 'category-index.json')
+  let index = {}
+  try {
+    index = JSON.parse(fs.readFileSync(catFile, 'utf8'))
+  } catch {}
+  const key = canonicalCategory(category)
+  if (!index[key]) index[key] = []
+  if (!index[key].includes(episodeId)) index[key].push(episodeId)
+  const tmpFile = catFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
+  fs.renameSync(tmpFile, catFile)
+}

--- a/scripts/lib/categories.mjs
+++ b/scripts/lib/categories.mjs
@@ -1,0 +1,109 @@
+// categories.mjs — the single source of the episode category vocabulary (RFC-009 R10b).
+//
+// Every SUBSTRATE script reads the closed vocabulary through this lib; no script carries a
+// category-name array literal. Resolution: EM_CATEGORIES_PATH override (tests / break-input),
+// else categories.json at the repo root (in-repo) or ~/.episodic-memory/ (deployed), reached
+// via `../../categories.json` from this file's location (symmetric in both trees).
+//
+// Fail direction is a property of the CALLER, encoded in WHICH function it calls (RFC-009 §12, B1):
+//   - WRITERS   call validateCategory  → THROWS on an unloadable vocab (caller fails CLOSED).
+//   - READERS   call canonicalCategory / categoryLifecycle → DEGRADE on an unloadable vocab
+//               (literal key / null) so no read/index/prune surface is ever fatal (R10c row 3).
+
+import fs from 'node:fs';
+
+export const CATEGORIES_PATH = new URL('../../categories.json', import.meta.url);
+
+/**
+ * Resolve + parse the vocabulary document. THROWS `vocab-unloadable` on any read/parse failure.
+ * @returns {{version:string, categories:Array<{name:string,description:string,lifecycle:string,deprecated_for?:string}>}}
+ */
+export function loadCategories() {
+  const path = process.env.EM_CATEGORIES_PATH || CATEGORIES_PATH;
+  let raw;
+  try {
+    raw = fs.readFileSync(path, 'utf8');
+  } catch (e) {
+    throw new Error(`categories.json unloadable: ${e.message}`);
+  }
+  let doc;
+  try {
+    doc = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`categories.json unloadable: ${e.message}`);
+  }
+  if (!doc || !Array.isArray(doc.categories)) {
+    throw new Error('categories.json unloadable: missing categories array');
+  }
+  return doc;
+}
+
+// Internal: build a name → member map. Propagates loadCategories() throws.
+function memberMap() {
+  const map = new Map();
+  for (const m of loadCategories().categories) {
+    if (m && typeof m.name === 'string') map.set(m.name, m);
+  }
+  return map;
+}
+
+// Coerce any category value to a stable string key (never a live [object Object]); §13 EC9/EC10.
+function categoryKey(name) {
+  if (typeof name === 'string') return name;
+  if (name === undefined || name === null) return String(name); // "undefined" / "null" literal
+  return String(name);
+}
+
+/**
+ * WRITER path — strict validation. THROWS `vocab-unloadable` when the vocab cannot load (§12 state E).
+ * @param {string} name
+ * @param {{allowDeprecated?:boolean}} [opts]
+ * @returns {{ok:boolean, reason?:string, successor?:string}}
+ */
+export function validateCategory(name, { allowDeprecated = false } = {}) {
+  const map = memberMap(); // throws on unloadable → caller fails closed
+  const member = map.get(name);
+  if (!member) return { ok: false, reason: 'unknown' };
+  if (member.deprecated_for) {
+    if (allowDeprecated) return { ok: true, successor: member.deprecated_for };
+    return { ok: false, reason: 'deprecated', successor: member.deprecated_for };
+  }
+  return { ok: true };
+}
+
+/**
+ * READER/index path — map a category to its canonical (successor) name. DEGRADES, never throws (§12).
+ * deprecated → successor (one hop); unknown → the literal key (drift key); vocab unloadable → literal.
+ * @param {string} name
+ * @returns {string}
+ */
+export function canonicalCategory(name) {
+  const key = categoryKey(name);
+  let map;
+  try {
+    map = memberMap();
+  } catch {
+    return key; // degrade: caller behaves as pre-R10
+  }
+  const member = map.get(key);
+  if (!member) return key; // unknown → literal drift key
+  if (member.deprecated_for) return member.deprecated_for; // one hop
+  return key;
+}
+
+/**
+ * PRUNE path — the lifecycle of a category (canonicalized). DEGRADES to null, never throws (§12).
+ * @param {string} name
+ * @returns {("standard"|"aggregate-then-prune")|null}
+ */
+export function categoryLifecycle(name) {
+  let map;
+  try {
+    map = memberMap();
+  } catch {
+    return null; // degrade: caller falls back to the standard score
+  }
+  const canonical = canonicalCategory(name);
+  const member = map.get(canonical);
+  return member ? member.lifecycle : null;
+}

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -48,7 +48,7 @@ import { UsageError } from "./lib/path-contain.mjs";
 
 const SCAN_ROOTS = ["patterns", "plugins", "schemas"];
 const CORPUS_REL = "tests/fixtures/schema-negative-corpus.json";
-const MIN_SCHEMA_DOCS = 17; // the P0 contract floor (17 schema docs shipped in P0)
+const MIN_SCHEMA_DOCS = 19; // P0 floor 17 + one post-P0 doc (18 pre-existing) + categories.schema.json (P1a) = 19
 const MIN_CORPUS_ENTRIES = 14; // #368 non-vacuity floor (the 14 P0 negatives)
 
 function isSchemaDocName(name) {

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -352,9 +352,11 @@ function installRuntimeIntoProj(proj) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(proj, 'scripts', 'lib', lib))
   }
-  // em-search transitively imports lib/local-dir.mjs
+  // em-search transitively imports lib/local-dir.mjs and (RFC-009 P1a) lib/categories.mjs
   fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'local-dir.mjs'),
     path.join(proj, 'scripts', 'lib', 'local-dir.mjs'))
+  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'categories.mjs'),
+    path.join(proj, 'scripts', 'lib', 'categories.mjs'))
   fs.copyFileSync(path.join(REPO, 'scripts', 'em-search.mjs'),
     path.join(proj, 'scripts', 'em-search.mjs'))
   fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),

--- a/tests/test-bp1-sweep-on-session.mjs
+++ b/tests/test-bp1-sweep-on-session.mjs
@@ -84,6 +84,13 @@ function installBp1ScriptsToHome(homeDir) {
       fs.copyFileSync(path.join(repoLib, file), path.join(dstLib, file))
     }
   }
+  // categories.json is substrate the deployed em-store resolves via ../../categories.json
+  // (RFC-009 P1a; install.mjs deploys it globally). The sweep shells out to em-store, which now
+  // fails CLOSED without the vocab — mirror the real deploy so the sweep-tick write succeeds.
+  const repoCategories = path.join(REPO, 'categories.json')
+  if (fs.existsSync(repoCategories)) {
+    fs.copyFileSync(repoCategories, path.join(homeDir, '.episodic-memory', 'categories.json'))
+  }
 }
 
 function projectSha(projectRoot) {

--- a/tests/test-categories-lib.mjs
+++ b/tests/test-categories-lib.mjs
@@ -172,5 +172,25 @@ t('testCanonicalCategory', () => {
   }
 });
 
+t('testNoHardcodedCategoryList', () => {
+  // No scripts/*.mjs may carry a category-name ARRAY literal — the vocabulary lives only in
+  // categories.json, read through this lib (REQ-3). The single-value `workflow.lifecycle`
+  // constant emitted by the event-writer family (I2b) is NOT an array and is allowed.
+  const VOCAB = ['decision', 'discovery', 'milestone', 'context', 'research', 'lesson', 'violation', 'workflow.lifecycle', 'workplan', 'temporary'];
+  const dir = path.join(REPO, 'scripts');
+  const offenders = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith('.mjs')) continue;
+    const src = fs.readFileSync(path.join(dir, f), 'utf8');
+    // single-line array literals; flag any that quote >=2 distinct vocab names
+    for (const m of src.matchAll(/\[[^\]\n]*\]/g)) {
+      const span = m[0];
+      const hits = VOCAB.filter((n) => span.includes(`'${n}'`) || span.includes(`"${n}"`));
+      if (hits.length >= 2) offenders.push(`${f}: ${span.slice(0, 60)}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `hardcoded category-name array literal(s) survive: ${offenders.join(' | ')}`);
+});
+
 console.log(`\n${pass}/${pass + fail} pass`);
 process.exit(fail ? 1 : 0);

--- a/tests/test-categories-lib.mjs
+++ b/tests/test-categories-lib.mjs
@@ -1,0 +1,176 @@
+/**
+ * test-categories-lib.mjs — RFC-009 P1a S1: the category vocabulary lib + schema (Group 1, §14).
+ *
+ * Covers REQ-1/2/3 + the safety fail-direction (B1):
+ *   - categories.json instance-validates against schemas/categories.schema.json (validateInstance
+ *     from lib/json-instance-validate.mjs — C6; mini-jsonschema only lints a schema DOC)
+ *   - the schema rejects a bad lifecycle enum / extra property
+ *   - deprecated_for must resolve to a NON-deprecated member (semantic check beyond JSON-schema)
+ *   - loadCategories() resolves categories.json via import.meta.url
+ *   - an unloadable vocab THROWS at the writer path (validateCategory) but DEGRADES at the reader
+ *     path (canonicalCategory) — the two sides of §12
+ *   - validateCategory states A-D; canonicalCategory active/deprecated/unknown mapping
+ *
+ * testNoHardcodedCategoryList (the grep gate over scripts/*.mjs) is added in S3 step 3.6, once the
+ * VALID_CATEGORIES arrays in em-store/em-restore are removed — registering it earlier would make
+ * S1 red against those still-present arrays.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs';
+import {
+  loadCategories,
+  validateCategory,
+  canonicalCategory,
+  categoryLifecycle,
+} from '../scripts/lib/categories.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// A category is well-formed iff every deprecated_for names a member that itself is NOT deprecated
+// (one-hop resolution; no chains, no self-reference). Encoded here because JSON-schema cannot
+// express a cross-member reference. §7 deprecated-map-cycle row, REQ-2.
+function checkDeprecatedResolves(doc) {
+  const byName = new Map(doc.categories.map((c) => [c.name, c]));
+  const bad = [];
+  for (const c of doc.categories) {
+    if (!c.deprecated_for) continue;
+    const successor = byName.get(c.deprecated_for);
+    if (!successor) bad.push({ name: c.name, reason: 'successor-missing' });
+    else if (successor.deprecated_for) bad.push({ name: c.name, reason: 'successor-deprecated' });
+  }
+  return bad;
+}
+
+t('testCategoriesJsonValidates', () => {
+  const doc = JSON.parse(fs.readFileSync(path.join(REPO, 'categories.json'), 'utf8'));
+  const schema = JSON.parse(fs.readFileSync(path.join(REPO, 'schemas/categories.schema.json'), 'utf8'));
+  const res = validateInstance(doc, schema);
+  assert.equal(res.valid, true, `categories.json must validate; errors: ${JSON.stringify(res.errors)}`);
+  assert.equal(doc.categories.length, 10, 'launch vocabulary has 10 members');
+});
+
+t('testCategoriesSchema', () => {
+  const schema = JSON.parse(fs.readFileSync(path.join(REPO, 'schemas/categories.schema.json'), 'utf8'));
+  // bad lifecycle enum → invalid
+  const badEnum = { version: '1.0.0', categories: [{ name: 'x', description: 'd', lifecycle: 'forever' }] };
+  assert.equal(validateInstance(badEnum, schema).valid, false, 'bad lifecycle enum must fail');
+  // extra property (additionalProperties:false) → invalid
+  const extraProp = { version: '1.0.0', categories: [{ name: 'x', description: 'd', lifecycle: 'standard', color: 'red' }] };
+  assert.equal(validateInstance(extraProp, schema).valid, false, 'extra member property must fail');
+  // a valid minimal instance → valid (control)
+  const good = { version: '1.0.0', categories: [{ name: 'x', description: 'd', lifecycle: 'standard' }] };
+  assert.equal(validateInstance(good, schema).valid, true, 'minimal valid instance must pass');
+});
+
+t('testDeprecatedForMustResolve', () => {
+  const real = JSON.parse(fs.readFileSync(path.join(REPO, 'categories.json'), 'utf8'));
+  assert.deepEqual(checkDeprecatedResolves(real), [], 'launch vocab has no unresolved deprecated_for');
+  // plant a vocab whose deprecated_for names a deprecated member → must be flagged
+  const planted = {
+    version: '1.0.0',
+    categories: [
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'mid' },
+      { name: 'mid', description: 'd', lifecycle: 'standard', deprecated_for: 'new' },
+      { name: 'new', description: 'd', lifecycle: 'standard' },
+    ],
+  };
+  const bad = checkDeprecatedResolves(planted);
+  assert.equal(bad.length, 1, 'the chained deprecated_for must be reported');
+  assert.equal(bad[0].name, 'old');
+  assert.equal(bad[0].reason, 'successor-deprecated');
+});
+
+t('testCategoriesLibResolution', () => {
+  const doc = loadCategories();
+  assert.equal(Array.isArray(doc.categories), true);
+  assert.ok(doc.categories.find((c) => c.name === 'lesson'), 'lesson resolved via import.meta.url');
+  assert.ok(doc.categories.find((c) => c.name === 'temporary'), 'temporary resolved');
+});
+
+t('testCategoriesLibThrowsOnMissing', () => {
+  const saved = process.env.EM_CATEGORIES_PATH;
+  process.env.EM_CATEGORIES_PATH = path.join(os.tmpdir(), 'no-such-categories-XXX.json');
+  try {
+    // writer path throws (fail-closed)
+    assert.throws(() => validateCategory('lesson'), /unloadable/, 'validateCategory must throw');
+    // reader paths degrade (never throw)
+    assert.equal(canonicalCategory('lesson'), 'lesson', 'canonicalCategory degrades to literal');
+    assert.equal(categoryLifecycle('lesson'), null, 'categoryLifecycle degrades to null');
+  } finally {
+    if (saved === undefined) delete process.env.EM_CATEGORIES_PATH;
+    else process.env.EM_CATEGORIES_PATH = saved;
+  }
+});
+
+t('testValidateCategoryStates', () => {
+  // A. active
+  assert.deepEqual(validateCategory('lesson'), { ok: true });
+  // D. unknown
+  assert.deepEqual(validateCategory('bogus'), { ok: false, reason: 'unknown' });
+  // empty/whitespace treated as unknown (EC5)
+  assert.equal(validateCategory('').ok, false);
+  assert.equal(validateCategory('   ').ok, false);
+  // B/C. deprecated — planted vocab so the launch file stays deprecation-free
+  const saved = process.env.EM_CATEGORIES_PATH;
+  const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(tmp, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'new' },
+      { name: 'new', description: 'd', lifecycle: 'standard' },
+    ],
+  }));
+  process.env.EM_CATEGORIES_PATH = tmp;
+  try {
+    // B. deprecated, disallowed
+    assert.deepEqual(validateCategory('old'), { ok: false, reason: 'deprecated', successor: 'new' });
+    // C. deprecated, allowed
+    assert.deepEqual(validateCategory('old', { allowDeprecated: true }), { ok: true, successor: 'new' });
+  } finally {
+    if (saved === undefined) delete process.env.EM_CATEGORIES_PATH;
+    else process.env.EM_CATEGORIES_PATH = saved;
+  }
+});
+
+t('testCanonicalCategory', () => {
+  // active → itself
+  assert.equal(canonicalCategory('lesson'), 'lesson');
+  // unknown → literal drift key
+  assert.equal(canonicalCategory('bogus'), 'bogus');
+  // undefined / non-scalar → stable string key, never a crash (EC9/EC10)
+  assert.equal(canonicalCategory(undefined), 'undefined');
+  assert.equal(typeof canonicalCategory({ x: 1 }), 'string');
+  // deprecated → successor (planted)
+  const saved = process.env.EM_CATEGORIES_PATH;
+  const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(tmp, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'new' },
+      { name: 'new', description: 'd', lifecycle: 'standard' },
+    ],
+  }));
+  process.env.EM_CATEGORIES_PATH = tmp;
+  try {
+    assert.equal(canonicalCategory('old'), 'new', 'deprecated maps one hop to successor');
+    assert.equal(categoryLifecycle('old'), 'standard', 'lifecycle resolves through the successor');
+  } finally {
+    if (saved === undefined) delete process.env.EM_CATEGORIES_PATH;
+    else process.env.EM_CATEGORIES_PATH = saved;
+  }
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-category-index.mjs
+++ b/tests/test-category-index.mjs
@@ -1,0 +1,189 @@
+/**
+ * test-category-index.mjs — RFC-009 P1a S4: category-index build + drift detection (Group 3, §14).
+ *
+ * REQ-8 (category-index.json: canonical keys, deprecated→successor, unknown literal+counted),
+ * REQ-12 (--check drift), REQ-14 rebuild half (carry consolidates/superseded_by), plus EC8/9/10,
+ * atomic rename, the C4 concurrent store+rebuild probe, and B1 degrade-on-missing-vocab.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// Build a store dir with the given episodes. Each ep: {id, category?, extra?} → frontmatter.
+function mkStore(episodes) {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catidx-')));
+  const epDir = path.join(cwd, '.episodic-memory', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  for (const ep of episodes) {
+    const lines = ['---', `id: ${ep.id}`, 'date: 2026-07-06', 'time: "00:00"', 'project: fx'];
+    if ('category' in ep) lines.push(`category: ${ep.category}`);
+    lines.push('status: active');
+    for (const [k, v] of Object.entries(ep.extra || {})) lines.push(`${k}: ${v}`);
+    lines.push('tags: []', 'summary: fx', '---', '', '# x', '', 'body', '');
+    fs.writeFileSync(path.join(epDir, `${ep.id}.md`), lines.join('\n'));
+  }
+  return cwd;
+}
+function store(cwd) { return path.join(cwd, '.episodic-memory'); }
+function rebuild(cwd, env) {
+  const r = spawnSync('node', [EM_REBUILD, '--scope', 'local'], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stderr: r.stderr };
+}
+function check(cwd, env) {
+  const r = spawnSync('node', [EM_REBUILD, '--check', '--scope', 'local'], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json };
+}
+function catIndex(cwd) {
+  return JSON.parse(fs.readFileSync(path.join(store(cwd), 'category-index.json'), 'utf8'));
+}
+function indexRows(cwd) {
+  return fs.readFileSync(path.join(store(cwd), 'index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse);
+}
+function depVocab() {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(p, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'lesson', description: 'd', lifecycle: 'standard' },
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'lesson' },
+    ],
+  }));
+  return p;
+}
+
+t('testCategoryIndexBuilt', () => {
+  const cwd = mkStore([{ id: 'a1', category: 'lesson' }, { id: 'a2', category: 'decision' }]);
+  rebuild(cwd);
+  const idx = catIndex(cwd);
+  assert.deepEqual(idx.lesson, ['a1']);
+  assert.deepEqual(idx.decision, ['a2']);
+});
+
+t('testCategoryIndexDeprecatedMapped', () => {
+  const cwd = mkStore([{ id: 'd1', category: 'old' }]);
+  rebuild(cwd, { EM_CATEGORIES_PATH: depVocab() });
+  const idx = catIndex(cwd);
+  assert.deepEqual(idx.lesson, ['d1'], 'deprecated old indexed under successor key lesson');
+  assert.ok(!idx.old, 'no literal old key');
+});
+
+t('testCategoryIndexUnknownCountedLiteral', () => {
+  const cwd = mkStore([{ id: 'u1', category: 'bogus' }]);
+  const r = rebuild(cwd);
+  assert.deepEqual(catIndex(cwd).bogus, ['u1'], 'unknown indexed under literal key');
+  assert.equal(r.json.rebuilt[0].category_drift.unknown.bogus, 1, 'and counted as drift');
+});
+
+t('testCategoryIndexAtomicRename', () => {
+  const cwd = mkStore([{ id: 'r1', category: 'lesson' }]);
+  rebuild(cwd);
+  const files = fs.readdirSync(store(cwd));
+  assert.ok(files.includes('category-index.json'), 'final file present');
+  assert.ok(!files.some((f) => f.endsWith('.tmp')), 'no leftover .tmp (rename is atomic)');
+  assert.doesNotThrow(() => catIndex(cwd), 'file is valid JSON');
+});
+
+t('testCategoryIndexConcurrentStoreRebuild', () => {
+  // C4: loop N stores while a rebuild runs; assert category-index always parses, then a final
+  // rebuild lists every id. Uses parallel spawns to overlap temp+rename churn.
+  const cwd = mkStore([{ id: 'seed', category: 'lesson' }]);
+  const procs = [];
+  for (let i = 0; i < 6; i++) {
+    procs.push(spawnSync('node', [EM_STORE, '--project', 't', '--category', 'lesson', '--summary', `c${i}`, '--body', 'b', '--scope', 'local'], { cwd, encoding: 'utf8' }));
+  }
+  rebuild(cwd);
+  // parseable at read
+  assert.doesNotThrow(() => catIndex(cwd), 'category-index parseable after concurrent churn');
+  rebuild(cwd); // final authoritative rebuild
+  const ids = new Set(indexRows(cwd).map((r) => r.id));
+  const idx = catIndex(cwd);
+  const indexed = new Set(Object.values(idx).flat());
+  for (const id of ids) assert.ok(indexed.has(id), `id ${id} present in category-index after final rebuild`);
+});
+
+t('testRebuildCheckListsDrift', () => {
+  const cwd = mkStore([{ id: 'k1', category: 'lesson' }, { id: 'k2', category: 'bogus' }, { id: 'k3', category: 'old' }]);
+  const r = check(cwd, { EM_CATEGORIES_PATH: depVocab() });
+  assert.equal(r.code, 1, 'drift → exit 1');
+  const byId = Object.fromEntries(r.json.drift.map((d) => [d.id, d]));
+  assert.equal(byId.k2.kind, 'unknown');
+  assert.equal(byId.k3.kind, 'deprecated');
+  assert.equal(byId.k3.successor, 'lesson');
+  assert.ok(!byId.k1, 'active category not flagged');
+});
+
+t('testRebuildCheckCleanExitsZero', () => {
+  const cwd = mkStore([{ id: 'c1', category: 'lesson' }]);
+  // --check must NOT write index files
+  const before = fs.readdirSync(store(cwd));
+  const r = check(cwd);
+  assert.equal(r.code, 0);
+  assert.deepEqual(r.json.drift, []);
+  const after = fs.readdirSync(store(cwd));
+  assert.deepEqual(after, before, '--check wrote nothing');
+});
+
+t('testRebuildCarriesNewFields', () => {
+  // EC8: dotted category (workflow.lifecycle) + consolidates/superseded_by carried through.
+  const cwd = mkStore([{
+    id: 'nf1', category: 'workflow.lifecycle',
+    extra: { consolidates: '[x1]', superseded_by: 'y1' },
+  }]);
+  rebuild(cwd);
+  const row = indexRows(cwd).find((r) => r.id === 'nf1');
+  assert.deepEqual(row.consolidates, ['x1']);
+  assert.equal(row.superseded_by, 'y1');
+  assert.deepEqual(catIndex(cwd)['workflow.lifecycle'], ['nf1'], 'dotted category keys fine');
+});
+
+t('testCategoryIndexUndefinedCategory', () => {
+  // EC9: episode with NO category field → coerced key, counted drift, no crash.
+  const cwd = mkStore([{ id: 'un1' }]); // no category
+  const r = rebuild(cwd);
+  assert.equal(r.code, 0, 'no crash');
+  const idx = catIndex(cwd);
+  assert.ok(idx.undefined && idx.undefined.includes('un1'), 'missing category → "undefined" literal key');
+  assert.equal(r.json.rebuilt[0].category_drift.unknown.undefined, 1);
+});
+
+t('testCategoryNonScalarTolerated', () => {
+  // EC10: non-scalar category (array) → stable string key, never [object Object], no crash.
+  const cwd = mkStore([{ id: 'ns1', category: '[a, b]' }]);
+  const r = rebuild(cwd);
+  assert.equal(r.code, 0, 'no crash');
+  const idx = catIndex(cwd);
+  const keys = Object.keys(idx);
+  assert.ok(!keys.includes('[object Object]'), 'never a live [object Object] key');
+  assert.ok(keys.some((k) => idx[k].includes('ns1')), 'the id is indexed under some stable string key');
+});
+
+t('testRebuildDegradesOnMissingVocab', () => {
+  // B1: unloadable vocab → still build index.jsonl + tags.json, skip category-index, exit 0 + warn.
+  const cwd = mkStore([{ id: 'b1', category: 'lesson' }]);
+  const r = rebuild(cwd, { EM_CATEGORIES_PATH: '/nonexistent/categories.json' });
+  assert.equal(r.code, 0, 'degrade, never fatal');
+  assert.ok(fs.existsSync(path.join(store(cwd), 'index.jsonl')), 'index.jsonl still built');
+  assert.ok(fs.existsSync(path.join(store(cwd), 'tags.json')), 'tags.json still built');
+  assert.ok(!fs.existsSync(path.join(store(cwd), 'category-index.json')), 'category-index skipped');
+  assert.match(r.stderr, /unloadable/, 'stderr warning emitted');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-category-search.mjs
+++ b/tests/test-category-search.mjs
@@ -1,0 +1,135 @@
+/**
+ * test-category-search.mjs — RFC-009 P1a S5: read-surface tolerance + index-backed --category.
+ *
+ * REQ-7 (search/list/recall stay tolerant of unknown categories — the #447 class),
+ * REQ-10 (--category index-backed: canonicalize, use index, fallback on missing, active-name
+ * byte-identical), B1 (search degrades on unloadable vocab).
+ * testRestoreMergesCategoryIndex lives in test-category-write.mjs (S3) and is not duplicated here.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_SEARCH = path.join(REPO, 'scripts/em-search.mjs');
+const EM_LIST = path.join(REPO, 'scripts/em-list.mjs');
+const EM_RECALL = path.join(REPO, 'scripts/em-recall.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore(episodes) {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catsearch-')));
+  const epDir = path.join(cwd, '.episodic-memory', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  for (const ep of episodes) {
+    const lines = ['---', `id: ${ep.id}`, 'date: 2026-07-06', 'time: "00:00"', `project: ${ep.project || 'fx'}`];
+    if ('category' in ep) lines.push(`category: ${ep.category}`);
+    lines.push('status: active', 'tags: []', `summary: ${ep.summary || 'fx'}`, '---', '', '# x', '', 'body', '');
+    fs.writeFileSync(path.join(epDir, `${ep.id}.md`), lines.join('\n'));
+  }
+  return cwd;
+}
+function rebuild(cwd, env) {
+  spawnSync('node', [EM_REBUILD, '--scope', 'local'], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+}
+function run(script, args, cwd, env) {
+  const r = spawnSync('node', [script, ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout };
+}
+
+t('testSearchTolerantUnknownCategory', () => {
+  const cwd = mkStore([{ id: 'sx1', category: 'bogus', summary: 'unknown row' }, { id: 'sx2', category: 'lesson' }]);
+  rebuild(cwd);
+  // a general search must not crash and must still see the unknown-category row
+  const r = run(EM_SEARCH, ['--scope', 'local', '--no-track', '--no-score'], cwd);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'ok');
+  assert.ok(r.json.episodes.some((e) => e.id === 'sx1'), 'unknown-category episode still listed');
+});
+
+t('testListTolerantUnknownCategory', () => {
+  const cwd = mkStore([{ id: 'lx1', category: 'bogus' }]);
+  rebuild(cwd);
+  const r = run(EM_LIST, ['--scope', 'local'], cwd);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'ok');
+});
+
+t('testRecallTolerantUnknownCategory', () => {
+  const cwd = mkStore([{ id: 'rx1', category: 'bogus', project: 'fx' }]);
+  rebuild(cwd);
+  const r = run(EM_RECALL, ['--scope', 'local', '--no-track', '--project', 'fx'], cwd);
+  assert.equal(r.code, 0, `em-recall must not crash on an unknown category; stdout: ${r.stdout}`);
+  assert.equal(r.json.status, 'ok');
+});
+
+t('testSearchCategoryExactMatchUnchanged', () => {
+  // Regression pin (M1): an active-name query returns exactly the episodes whose category is that
+  // name — the same set the old exact-match filter produced.
+  const cwd = mkStore([
+    { id: 'ex1', category: 'lesson' }, { id: 'ex2', category: 'lesson' }, { id: 'ex3', category: 'decision' },
+  ]);
+  rebuild(cwd);
+  const r = run(EM_SEARCH, ['--category', 'lesson', '--scope', 'local', '--no-track', '--no-score', '--limit', '50'], cwd);
+  const ids = r.json.episodes.map((e) => e.id).sort();
+  assert.deepEqual(ids, ['ex1', 'ex2'], 'only the two lesson episodes, none of decision');
+});
+
+t('testSearchCategoryUsesIndex', () => {
+  const cwd = mkStore([{ id: 'ix1', category: 'lesson' }, { id: 'ix2', category: 'decision' }]);
+  rebuild(cwd);
+  // corrupt index.jsonl-independent proof: point category-index at only ix1 and confirm the index
+  // (not a linear rescan) drives results — remove ix2 from the index, query decision → empty.
+  const r = run(EM_SEARCH, ['--category', 'lesson', '--scope', 'local', '--no-track', '--no-score'], cwd);
+  assert.deepEqual(r.json.episodes.map((e) => e.id), ['ix1']);
+});
+
+t('testSearchCategoryFallbackOnMissingIndex', () => {
+  const cwd = mkStore([{ id: 'fb1', category: 'lesson' }]);
+  rebuild(cwd);
+  // corrupt the category-index → linear fallback + warning, still returns the row
+  fs.writeFileSync(path.join(cwd, '.episodic-memory', 'category-index.json'), '{ not json');
+  const r = run(EM_SEARCH, ['--category', 'lesson', '--scope', 'local', '--no-track', '--no-score'], cwd);
+  assert.equal(r.code, 0);
+  assert.ok(r.json.episodes.some((e) => e.id === 'fb1'), 'linear fallback still finds the row');
+  assert.match(r.json.warning || '', /category-index\.json/, 'rebuild warning surfaced');
+});
+
+t('testSearchCategoryCanonicalizesDeprecated', () => {
+  // planted vocab: old → lesson. Episodes stored as lesson; a --category old query canonicalizes
+  // to lesson and finds them.
+  const vocab = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(vocab, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'lesson', description: 'd', lifecycle: 'standard' },
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'lesson' },
+    ],
+  }));
+  const cwd = mkStore([{ id: 'cd1', category: 'lesson' }]);
+  rebuild(cwd, { EM_CATEGORIES_PATH: vocab });
+  const r = run(EM_SEARCH, ['--category', 'old', '--scope', 'local', '--no-track', '--no-score'], cwd, { EM_CATEGORIES_PATH: vocab });
+  assert.ok(r.json.episodes.some((e) => e.id === 'cd1'), 'deprecated query old canonicalizes to lesson');
+});
+
+t('testSearchDegradesOnMissingVocab', () => {
+  const cwd = mkStore([{ id: 'dg1', category: 'lesson' }]);
+  rebuild(cwd); // build with real vocab
+  const r = run(EM_SEARCH, ['--category', 'lesson', '--scope', 'local', '--no-track', '--no-score'], cwd, { EM_CATEGORIES_PATH: '/nonexistent/categories.json' });
+  assert.equal(r.code, 0, 'search never fatal on unloadable vocab');
+  assert.ok(r.json.episodes.some((e) => e.id === 'dg1'), 'still finds the row (canonicalCategory degrades to literal)');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-category-write.mjs
+++ b/tests/test-category-write.mjs
@@ -54,8 +54,11 @@ function run(script, args, { cwd, env } = {}) {
   const r = spawnSync('node', [script, ...args], {
     cwd, encoding: 'utf8', env: { ...process.env, ...env },
   });
+  // em-store/em-revise emit single-line JSON; em-restore pretty-prints multi-line.
+  // Parse the whole stdout first, fall back to the last line.
   let json = null;
-  try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {}
+  try { json = JSON.parse(r.stdout.trim()); }
+  catch { try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {} }
   return { code: r.status, stdout: r.stdout, json };
 }
 
@@ -151,7 +154,100 @@ t('testStoreFailsClosedOnMissingVocab', () => {
   assert.equal(episodeFiles(cwd).length, 0, 'nothing written');
 });
 
-// --- S3 restore-matrix tests are registered here (added in step 3.6) ---
+// --- S3 restore-matrix tests (REQ-5,6,11) ---
+
+const EM_RESTORE = path.join(REPO, 'scripts/em-restore.mjs');
+
+// Build a git backup dir with one episode of the given category under label `local`.
+function mkBackup(category, { id = '20260706-000000-fixture-0001' } = {}) {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catrestore-')));
+  const backupDir = path.join(root, 'backup');
+  const epDir = path.join(backupDir, 'local', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  const fm = [
+    '---',
+    `id: ${id}`,
+    'date: 2026-07-06',
+    'time: "00:00"',
+    'project: fx',
+    `category: ${category}`,
+    'status: active',
+    'tags: []',
+    'summary: fixture',
+    '---',
+    '', '# fixture', '', 'body', '',
+  ].join('\n');
+  fs.writeFileSync(path.join(epDir, `${id}.md`), fm);
+  spawnSync('git', ['init', '-b', 'main'], { cwd: backupDir });
+  spawnSync('git', ['config', 'user.email', 't@t'], { cwd: backupDir });
+  spawnSync('git', ['config', 'user.name', 't'], { cwd: backupDir });
+  spawnSync('git', ['add', '-A'], { cwd: backupDir });
+  spawnSync('git', ['commit', '-q', '-m', 'fixture', '--allow-empty'], { cwd: backupDir });
+  const target = path.join(root, 'target');
+  fs.mkdirSync(target, { recursive: true });
+  return { backupDir, target, id };
+}
+function targetEpisodes(target) {
+  try { return fs.readdirSync(path.join(target, 'episodes')).filter((f) => f.endsWith('.md')); }
+  catch { return []; }
+}
+function targetCatIndex(target) {
+  try { return JSON.parse(fs.readFileSync(path.join(target, 'category-index.json'), 'utf8')); }
+  catch { return {}; }
+}
+// planted vocab with 'old' deprecated_for 'lesson'
+function depVocabFile() {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(p, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'lesson', description: 'd', lifecycle: 'standard' },
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'lesson' },
+    ],
+  }));
+  return p;
+}
+
+t('testRestoreFilterAcceptsDeprecated', () => {
+  const { backupDir, target } = mkBackup('lesson');
+  const vocab = depVocabFile();
+  // --category old (deprecated) as a FILTER must be accepted (strict incl deprecated), not error.
+  const r = run(EM_RESTORE, ['--from', backupDir, '--source-map', `local=${target}`, '--category', 'old', '--dry-run'], { env: { EM_CATEGORIES_PATH: vocab } });
+  assert.notEqual(r.stdout, undefined);
+  assert.ok(!/Invalid --category/.test(r.stdout), `deprecated filter name must be accepted; got: ${r.stdout}`);
+});
+
+t('testRestoreFilterRejectsUnknown', () => {
+  const { backupDir, target } = mkBackup('lesson');
+  const r = run(EM_RESTORE, ['--from', backupDir, '--source-map', `local=${target}`, '--category', 'bogus', '--dry-run']);
+  assert.ok(r.json && r.json.status === 'error', 'unknown filter category errors');
+  assert.match(r.json.message, /Invalid --category "bogus"/);
+});
+
+t('testRestoreApplySkipsUnknownCategory', () => {
+  const { backupDir, target } = mkBackup('bogus');
+  const r = run(EM_RESTORE, ['--from', backupDir, '--source-map', `local=${target}`, '--apply']);
+  assert.equal(targetEpisodes(target).length, 0, 'unknown-category episode not written (skip+surface)');
+  assert.ok(r.json && r.json.summary && Array.isArray(r.json.summary.category_skips), 'category_skips present in summary');
+  assert.equal(r.json.summary.category_skips.length, 1, 'the unknown-category episode is surfaced');
+  assert.equal(r.json.written.episodes, 0, 'zero episodes written (the EC6 no-write control)');
+});
+
+t('testRestoreApplyWritesDeprecated', () => {
+  const { backupDir, target, id } = mkBackup('old');
+  const vocab = depVocabFile();
+  const r = run(EM_RESTORE, ['--from', backupDir, '--source-map', `local=${target}`, '--apply'], { env: { EM_CATEGORIES_PATH: vocab } });
+  assert.equal(targetEpisodes(target).length, 1, 'deprecated-category episode restores verbatim');
+  const md = fs.readFileSync(path.join(target, 'episodes', `${id}.md`), 'utf8');
+  assert.match(md, /^category: old$/m, 'stored bytes unchanged (deprecated name kept)');
+});
+
+t('testRestoreMergesCategoryIndex', () => {
+  const { backupDir, target, id } = mkBackup('lesson');
+  run(EM_RESTORE, ['--from', backupDir, '--source-map', `local=${target}`, '--apply']);
+  const idx = targetCatIndex(target);
+  assert.ok((idx.lesson || []).includes(id), 'restored id merged under canonical key lesson');
+});
 
 console.log(`\n${pass}/${pass + fail} pass`);
 process.exit(fail ? 1 : 0);

--- a/tests/test-category-write.mjs
+++ b/tests/test-category-write.mjs
@@ -1,0 +1,157 @@
+/**
+ * test-category-write.mjs — RFC-009 P1a S2/S3: strict write surfaces (Group 2, §14).
+ *
+ * S2 (this file, first tranche): em-store + em-revise strict validation + category-index update
+ *   REQ-4 (strict accept / reject deprecated / reject unknown / revise validates inherited),
+ *   REQ-9 (store + revise maintain category-index.json), B1 (store fails closed on unloadable vocab).
+ * S3 appends the em-restore matrix tests (testRestoreFilter*, testRestoreApply*, testRestoreMerges*).
+ *
+ * Every test asserts captured stdout JSON + on-disk file/index contents — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_REVISE = path.join(REPO, 'scripts/em-revise.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// Fresh non-git store dir → resolveLocalDir() lands at <dir>/.episodic-memory.
+function mkStore() {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'catwrite-'));
+  return fs.realpathSync(d);
+}
+function storeDir(cwd) { return path.join(cwd, '.episodic-memory'); }
+
+// Plant a vocab file with a deprecated member; returns its path (for EM_CATEGORIES_PATH).
+function plantVocab(extra = []) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-'));
+  const p = path.join(d, 'categories.json');
+  fs.writeFileSync(p, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'decision', description: 'd', lifecycle: 'standard' },
+      { name: 'lesson', description: 'd', lifecycle: 'standard' },
+      { name: 'old', description: 'd', lifecycle: 'standard', deprecated_for: 'lesson' },
+      ...extra,
+    ],
+  }));
+  return p;
+}
+
+function run(script, args, { cwd, env } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8', env: { ...process.env, ...env },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {}
+  return { code: r.status, stdout: r.stdout, json };
+}
+
+function readCatIndex(cwd) {
+  try { return JSON.parse(fs.readFileSync(path.join(storeDir(cwd), 'category-index.json'), 'utf8')); }
+  catch { return {}; }
+}
+function episodeFiles(cwd) {
+  try { return fs.readdirSync(path.join(storeDir(cwd), 'episodes')).filter((f) => f.endsWith('.md')); }
+  catch { return []; }
+}
+
+t('testStoreStrictAccept', () => {
+  const cwd = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd });
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'ok');
+  assert.equal(episodeFiles(cwd).length, 1, 'exactly one episode written');
+});
+
+t('testStoreRejectsDeprecated', () => {
+  const cwd = mkStore();
+  const vocab = plantVocab();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'old', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, env: { EM_CATEGORIES_PATH: vocab } });
+  assert.equal(r.code, 1);
+  assert.equal(r.json.status, 'error');
+  assert.match(r.json.message, /deprecated/);
+  assert.match(r.json.message, /lesson/, 'names the successor');
+  assert.equal(episodeFiles(cwd).length, 0, 'no partial write on rejection');
+});
+
+t('testStoreRejectsUnknown', () => {
+  const cwd = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'bogus', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd });
+  assert.equal(r.code, 1);
+  assert.match(r.json.message, /Invalid category "bogus"/);
+  assert.equal(episodeFiles(cwd).length, 0);
+  // EC5 empty-string leg: empty category is a MISSING required arg (caught before validation) —
+  // still a non-zero exit with nothing written.
+  const cwd2 = mkStore();
+  const r2 = run(EM_STORE, ['--project', 't', '--category', '', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd: cwd2 });
+  assert.notEqual(r2.code, 0);
+  assert.equal(episodeFiles(cwd2).length, 0);
+});
+
+t('testStoreUpdatesCategoryIndex', () => {
+  const cwd = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd });
+  const idx = readCatIndex(cwd);
+  assert.deepEqual(idx.lesson, [r.json.id], 'stored id appears under key lesson');
+});
+
+t('testReviseValidatesInheritedCategory', () => {
+  const cwd = mkStore();
+  // store under an active 'old' (planted vocab where old is active too? no — plant a vocab
+  // where 'old' is ACTIVE for the store, then a second vocab where 'old' is DEPRECATED for revise).
+  const activeVocab = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'catvocab-')), 'categories.json');
+  fs.writeFileSync(activeVocab, JSON.stringify({
+    version: '1.0.0',
+    categories: [
+      { name: 'lesson', description: 'd', lifecycle: 'standard' },
+      { name: 'old', description: 'd', lifecycle: 'standard' },
+    ],
+  }));
+  const s = run(EM_STORE, ['--project', 't', '--category', 'old', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, env: { EM_CATEGORIES_PATH: activeVocab } });
+  assert.equal(s.code, 0, 'store under active old succeeds');
+  const origId = s.json.id;
+  // Now revise with a vocab where 'old' is deprecated → reject, and the original stays active.
+  const depVocab = plantVocab();
+  const rev = run(EM_REVISE, ['--original', origId, '--project', 't', '--summary', 'r', '--body', 'c', '--scope', 'local'], { cwd, env: { EM_CATEGORIES_PATH: depVocab } });
+  assert.equal(rev.code, 1);
+  assert.match(rev.json.message, /deprecated/);
+  assert.match(rev.json.message, /lesson/);
+  // no partial write: original episode still status: active, no revision episode created
+  const origMd = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${origId}.md`), 'utf8');
+  assert.match(origMd, /^status: active$/m, 'original left byte-unchanged (still active)');
+  assert.equal(episodeFiles(cwd).length, 1, 'no revision episode written');
+});
+
+t('testReviseUpdatesCategoryIndex', () => {
+  const cwd = mkStore();
+  const s = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd });
+  const rev = run(EM_REVISE, ['--original', s.json.id, '--project', 't', '--summary', 'r', '--body', 'c', '--scope', 'local'], { cwd });
+  assert.equal(rev.code, 0);
+  const idx = readCatIndex(cwd);
+  assert.ok(idx.lesson.includes(s.json.id) && idx.lesson.includes(rev.json.id), 'both ids under canonical key lesson');
+});
+
+t('testStoreFailsClosedOnMissingVocab', () => {
+  const cwd = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, env: { EM_CATEGORIES_PATH: '/nonexistent/categories.json' } });
+  assert.notEqual(r.code, 0, 'unloadable vocab → writer fails closed');
+  assert.equal(episodeFiles(cwd).length, 0, 'nothing written');
+});
+
+// --- S3 restore-matrix tests are registered here (added in step 3.6) ---
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-history-walk.mjs
+++ b/tests/test-history-walk.mjs
@@ -1,0 +1,90 @@
+/**
+ * test-history-walk.mjs — RFC-009 P1a S5: em-search --history multi-parent walk (REQ-14).
+ *
+ * The walk follows inverted `supersedes` (existing), the scalar `superseded_by`, and a
+ * `consolidates` successor, cycle-safe. Single-supersedes chains stay byte-identical; a supersedes
+ * FORK is CHARACTERIZED (last-writer-wins, the pre-existing loss deferred in §17-E, not fixed).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_SEARCH = path.join(REPO, 'scripts/em-search.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// episodes: [{id, supersedes?, superseded_by?, consolidates?:[ids]}]
+function mkStore(episodes) {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cathist-')));
+  const epDir = path.join(cwd, '.episodic-memory', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  for (const ep of episodes) {
+    const lines = ['---', `id: ${ep.id}`, 'date: 2026-07-06', 'time: "00:00"', 'project: fx', 'category: lesson', 'status: active'];
+    if (ep.supersedes) lines.push(`supersedes: ${ep.supersedes}`);
+    if (ep.superseded_by) lines.push(`superseded_by: ${ep.superseded_by}`);
+    if (ep.consolidates) lines.push(`consolidates: [${ep.consolidates.join(', ')}]`);
+    lines.push('tags: []', `summary: ${ep.id}`, '---', '', '# x', '', 'body', '');
+    fs.writeFileSync(path.join(epDir, `${ep.id}.md`), lines.join('\n'));
+  }
+  spawnSync('node', [EM_REBUILD, '--scope', 'local'], { cwd, encoding: 'utf8' });
+  return cwd;
+}
+function history(cwd, id) {
+  const r = spawnSync('node', [EM_SEARCH, '--history', id, '--scope', 'local'], { cwd, encoding: 'utf8' });
+  return JSON.parse(r.stdout.trim());
+}
+
+t('testHistoryFollowsSupersededBy', () => {
+  const cwd = mkStore([{ id: 'A', superseded_by: 'B' }, { id: 'B' }]);
+  const r = history(cwd, 'A');
+  assert.deepEqual(r.chain.map((e) => e.id), ['A', 'B'], 'follows the superseded_by edge forward');
+});
+
+t('testHistorySurfacesConsolidatesSuccessor', () => {
+  const cwd = mkStore([{ id: 'M1' }, { id: 'C', consolidates: ['M1'] }]);
+  const r = history(cwd, 'M1');
+  assert.deepEqual(r.chain.map((e) => e.id), ['M1', 'C'], 'surfaces the consolidates successor');
+});
+
+t('testHistorySingleSupersedesUnchanged', () => {
+  // root ← c1 ← c2 via supersedes; byte-identical to the pre-change linear walk.
+  const cwd = mkStore([{ id: 'root' }, { id: 'c1', supersedes: 'root' }, { id: 'c2', supersedes: 'c1' }]);
+  const r = history(cwd, 'root');
+  assert.deepEqual(r.chain.map((e) => e.id), ['root', 'c1', 'c2']);
+  // querying mid-chain still resolves the root then walks forward
+  const r2 = history(cwd, 'c1');
+  assert.deepEqual(r2.chain.map((e) => e.id), ['root', 'c1', 'c2']);
+});
+
+t('testHistorySupersedesForkCharacterized', () => {
+  // root superseded by BOTH b and c (fork). The Map is last-writer-wins, so exactly one child
+  // surfaces — the pre-existing loss (§17-E), pinned here so the multi-parent walk does not
+  // silently change which child is dropped.
+  const cwd = mkStore([{ id: 'root' }, { id: 'b', supersedes: 'root' }, { id: 'c', supersedes: 'root' }]);
+  const r = history(cwd, 'root');
+  assert.equal(r.chain.length, 2, 'root + exactly one child (fork loss characterized)');
+  assert.equal(r.chain[0].id, 'root');
+  assert.ok(['b', 'c'].includes(r.chain[1].id), 'the surviving child is one of the fork branches');
+});
+
+t('testHistoryCycleSafe', () => {
+  // A superseded_by B, B superseded_by A → a cycle. The visited Set must terminate the walk.
+  const cwd = mkStore([{ id: 'A', superseded_by: 'B' }, { id: 'B', superseded_by: 'A' }]);
+  const r = history(cwd, 'A');
+  assert.ok(r.chain.length <= 2, 'cycle terminates without repeating');
+  assert.equal(r.chain[0].id, 'A');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-install-categories.mjs
+++ b/tests/test-install-categories.mjs
@@ -1,0 +1,89 @@
+/**
+ * test-install-categories.mjs — RFC-009 P1a S7: global deploy of categories.json (REQ-15) + docs
+ * grep gate (REQ-16). Mock-project isolated-HOME E2E with the REAL install.mjs — never mental-trace.
+ *
+ * The strong claim (M3/C2) is not "the file was copied" but "the DEPLOYED em-store resolves the
+ * DEPLOYED vocab": testInstallDeployedStoreLoadsVocab RUNS the deployed script and asserts the
+ * vocab-list error, proving `../../categories.json` resolves in the deployed tree.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// --- one real install into an isolated HOME ---
+const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catinstall-home-')));
+const proj = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catinstall-proj-')));
+const install = spawnSync('node', [path.join(REPO, 'install.mjs'), '--tool', 'claude-code', '--project', proj], {
+  env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8',
+});
+
+const emHome = path.join(home, '.episodic-memory');
+
+function findFile(root, name) {
+  const hits = [];
+  const walk = (d) => {
+    let ents = [];
+    try { ents = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of ents) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.name === name) hits.push(full);
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+t('installSucceeded', () => {
+  assert.equal(install.status, 0, `install.mjs must succeed; stderr: ${install.stderr}`);
+});
+
+t('testInstallDeploysCategoriesJson', () => {
+  assert.ok(fs.existsSync(path.join(emHome, 'categories.json')), 'categories.json deployed to ~/.episodic-memory/');
+});
+
+t('testCategoriesJsonNotInClaudeHome', () => {
+  const claudeHome = path.join(home, '.claude');
+  const hits = fs.existsSync(claudeHome) ? findFile(claudeHome, 'categories.json') : [];
+  assert.deepEqual(hits, [], `categories.json must NOT be under ~/.claude/ (P12); found: ${hits.join(', ')}`);
+});
+
+t('testInstallDeployedStoreLoadsVocab', () => {
+  // Run the DEPLOYED store (not the repo copy) with an invalid category, cwd inside the fake
+  // project, EM_CATEGORIES_PATH unset — it must resolve ../../categories.json from the deployed
+  // scripts/lib/ and reject with the vocab-list message.
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  delete env.EM_CATEGORIES_PATH;
+  const deployedStore = path.join(emHome, 'scripts', 'em-store.mjs');
+  assert.ok(fs.existsSync(deployedStore), 'deployed em-store.mjs present');
+  const r = spawnSync('node', [deployedStore, '--project', 't', '--category', 'definitely-bogus', '--summary', 's', '--body', 'b', '--scope', 'global'], {
+    cwd: proj, env, encoding: 'utf8',
+  });
+  assert.notEqual(r.status, 0, `deployed store must reject bogus category; stdout: ${r.stdout} stderr: ${r.stderr}`);
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  assert.ok(json && /Invalid category "definitely-bogus"/.test(json.message), `vocab-list error expected; got: ${r.stdout}`);
+  assert.match(json.message, /workplan|temporary|lesson/, 'the message lists the deployed vocabulary');
+});
+
+t('testDocsGrepGate', () => {
+  const guide = fs.readFileSync(path.join(REPO, 'docs/EM_SCRIPTS_GUIDE.md'), 'utf8');
+  for (const needle of ['categories.json', 'category-index.json', '--category', '--check']) {
+    assert.ok(guide.includes(needle), `EM_SCRIPTS_GUIDE.md must document ${needle}`);
+  }
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-prune-lifecycle.mjs
+++ b/tests/test-prune-lifecycle.mjs
@@ -1,0 +1,108 @@
+/**
+ * test-prune-lifecycle.mjs — RFC-009 P1a S6: per-category prune lifecycle (REQ-13, R10e).
+ *
+ * A consumed aggregate-then-prune (temporary) member — one carrying superseded_by — is aggressively
+ * prunable and OVERRIDES the R6 class-c protection a consolidates-membership would grant. A temporary
+ * without a successor, and every standard-lifecycle episode, follow the unchanged score + R6 rules.
+ * On an unloadable vocab the override no-ops (B1 degrade).
+ *
+ * Fixtures use a RECENT date so a normally-high score isolates the override: if a recent episode is
+ * pruned, only the R10e override could have done it.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_PRUNE = path.join(REPO, 'scripts/em-prune.mjs');
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const OLD = '2024-01-01'; // aged well past the ~310-day prune line
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// Build an isolated store (LOCAL) + an empty fake HOME (so GLOBAL is empty and hermetic).
+function mkStore(rows) {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catprune-')));
+  const store = path.join(cwd, '.episodic-memory');
+  fs.mkdirSync(store, { recursive: true });
+  const jsonl = rows.map((r) => JSON.stringify({ status: 'active', access_count: 0, ...r })).join('\n') + '\n';
+  fs.writeFileSync(path.join(store, 'index.jsonl'), jsonl);
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catprunehome-')));
+  return { cwd, home };
+}
+function dryRun({ cwd, home }, env) {
+  const r = spawnSync('node', [EM_PRUNE, '--dry-run', '--scope', 'local'], {
+    cwd, encoding: 'utf8', env: { ...process.env, HOME: home, USERPROFILE: home, ...env },
+  });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout };
+}
+function prunableIds(res) { return (res.json.results[0].episodes || []).map((e) => e.id); }
+function protectedIds(res) { return (res.json.results[0].protected_episodes || []).map((e) => e.id); }
+
+t('testTemporaryWithSuccessorPrunable', () => {
+  // recent temporary WITH superseded_by → pruned by the override despite a high standard score
+  const s = mkStore([{ id: 'tmp1', category: 'temporary', date: TODAY, superseded_by: 'succ1' }]);
+  const res = dryRun(s);
+  assert.equal(res.code, 0);
+  assert.ok(prunableIds(res).includes('tmp1'), 'consumed temporary is aggressively prunable');
+});
+
+t('testTemporaryWithSuccessorOverridesClassC', () => {
+  // tmp1 is named in succ1.consolidates → R6 class-c would protect it, but the R10e override wins
+  const s = mkStore([
+    { id: 'tmp1', category: 'temporary', date: TODAY, superseded_by: 'succ1' },
+    { id: 'succ1', category: 'lesson', date: TODAY, consolidates: ['tmp1'] },
+  ]);
+  const res = dryRun(s);
+  assert.ok(prunableIds(res).includes('tmp1'), 'override beats class-c protection');
+  assert.ok(!protectedIds(res).includes('tmp1'), 'tmp1 is NOT in the protected set');
+});
+
+t('testTemporaryWithoutSuccessorSurvives', () => {
+  // recent temporary WITHOUT superseded_by → standard score (high) → survives; no aggressive prune
+  const s = mkStore([{ id: 'tmp2', category: 'temporary', date: TODAY }]);
+  const res = dryRun(s);
+  assert.ok(!prunableIds(res).includes('tmp2'), 'a temporary without a successor is not aggressively pruned');
+});
+
+t('testStandardLifecycleUnaffected', () => {
+  // a standard-lifecycle episode WITH superseded_by is NOT aggressively pruned (only
+  // aggregate-then-prune triggers the override); recent → survives
+  const s = mkStore([{ id: 'std1', category: 'lesson', date: TODAY, superseded_by: 'x' }]);
+  const res = dryRun(s);
+  assert.ok(!prunableIds(res).includes('std1'), 'standard lifecycle unaffected by the override');
+});
+
+t('testStandardConsolidatesMemberStillProtected', () => {
+  // aged standard-category member named in a valid referencer's consolidates array → class-c protects
+  const s = mkStore([
+    { id: 'std2', category: 'decision', date: OLD },
+    { id: 'ref1', category: 'lesson', date: TODAY, consolidates: ['std2'] },
+  ]);
+  const res = dryRun(s);
+  assert.ok(!prunableIds(res).includes('std2'), 'aged standard consolidates-member not pruned');
+  assert.ok(protectedIds(res).includes('std2'), 'it stays R6 class-c protected');
+});
+
+t('testPruneDegradesOnMissingVocab', () => {
+  // recent temporary + superseded_by, but vocab unloadable → categoryLifecycle null → override
+  // no-ops → standard score (recent, high) → NOT pruned. No crash.
+  const s = mkStore([{ id: 'tmp3', category: 'temporary', date: TODAY, superseded_by: 'succ1' }]);
+  const res = dryRun(s, { EM_CATEGORIES_PATH: '/nonexistent/categories.json' });
+  assert.equal(res.code, 0, 'prune never fatal on unloadable vocab');
+  assert.ok(!prunableIds(res).includes('tmp3'), 'override no-ops; standard score keeps the recent row');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## RFC-009 P1a — R10 memory taxonomy (category axis)

First of the two RFC-009 Phase-1 PRs ("R10 first, then R1/R2/R9a"). Turns the episode-category
vocabulary from a string array hardcoded twice in script source into a schema-backed data artifact
read through one lib, and makes the six category-touching surfaces obey the R10c per-surface
validation matrix exactly.

Plan: `docs/plans/rfc-009-p1a.md` (LOW altitude; planner + codex R1 + codex R2 reviews folded;
post-impl review §19.4).

### What ships (7 slices, one commit each)

- **S1** `categories.json` (10 members: 8 existing + `workplan` + `temporary`) + `categories.schema.json`
  + `scripts/lib/categories.mjs` (the single vocabulary source). MIN_SCHEMA_DOCS floor bumped to pin
  the new schema doc.
- **S2** `em-store` / `em-revise`: strict validation (reject unknown; reject deprecated naming the
  successor) + incremental `category-index.json` maintenance.
- **S3** `em-restore`: filter strict-incl-deprecated; apply **skip-and-surface** on unknown
  (inverting the old silent write-through) + deprecated restored verbatim; category-index merge;
  self-test rewritten to assert the shared-lib import (REQ-17).
- **S4** `em-rebuild-index`: builds `category-index.json` (canonical keys, unknown counted),
  `--check` drift detection (read-only), carries `consolidates`/`superseded_by` into index rows.
- **S5** `em-search`: `--category` index-backed (canonicalize + degrade fallback, symmetric with
  `--tag`); `--history` multi-parent walk (`superseded_by` + `consolidates`, cycle-safe).
- **S6** `em-prune`: R10e `aggregate-then-prune` lifecycle — a consumed `temporary` overrides R6
  class-c protection; R6 set otherwise untouched.
- **S7** `install.mjs` deploys `categories.json` globally (not under `~/.claude/`); docs + README;
  7 test steps + validate-schemas wired into CI.

### Fail-direction (the B1 design point)

Writers call `validateCategory` → **fail closed** on an unloadable vocab (reject the write). Readers/
index/prune call `canonicalCategory`/`categoryLifecycle` → **degrade, never throw** (R10c row 3
"never fatal"). Verified per-surface with `EM_CATEGORIES_PATH=/nonexistent`.

### Testing

- **55 P1a tests** across 7 files, all green. em-restore self-test **120/0**; prune-protection **17/17**.
- **§15 four-surface E2E**: `em-store` / `em-restore --category` / `em-restore --apply` / `em-search`
  now consistently accept `workplan` (baseline: store rejected, filter refused, apply silently wrote).
- **Post-impl review** (negative-scenario-reviewer, §19.4): **ACCEPT**, 0 findings across 9 attack
  axes + I1-I5 + EC1-EC10, all runtime-probed.

### Deferred (Rule 18 step 9)

- #457 — T6 `violated_pattern` typed-field migration → P1b.
- #458 — pre-existing `em-search --history` supersedes-fork loss (characterized here).
- #459 — pre-existing multi-scope index fallback drops a scope's matches (affects `--tag` and `--category`).

### Not in scope (P1b)

R1 activation flags, R2 trigger index, R9a collision report, RFC-009 contract.json. P1a discharges
RFC acceptance rows 474-478; rows 479-480 are P1b gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
