### PR TITLE
Substrate usability overhaul: multi-term relevance search, em-doctor, unified `em` CLI, wizard installer with migrate flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,30 @@ sequenceDiagram
 git clone <repo-url> episodic-memory
 cd episodic-memory
 
-# Install for a specific tool in a target project
+# Recommended: interactive guided setup (prereq checks, tool + project
+# selection, optional hooks/backup, PATH shim, health verification)
+node install.mjs --wizard
+
+# Or non-interactive: install for a specific tool in a target project
 node install.mjs --tool cursor --project /path/to/my-project
 
 # Install for all bundled targets except OpenCode
 node install.mjs --tool all --project /path/to/my-project
+```
+
+The wizard also handles **migrating to a new machine** (restore stores from an
+em-backup repository via a dry-run-first `em-restore`) and **health-checking an
+existing install** (`em doctor`, with optional automatic repair).
+
+After install, the unified CLI is available (add `~/.episodic-memory/bin` to
+your `PATH` — the wizard offers to do this for you):
+
+```bash
+em recall              # what does memory know about this project?
+em search --query "atomic rename index"   # multi-term relevance search
+em store --project myapp --category decision --summary "..." --body "..."
+em doctor              # store + install health check; `em doctor --fix` repairs
+em help                # full command table
 ```
 
 The installer:
@@ -291,6 +310,22 @@ Episodic-memory and user-preferences are fully independent — install either or
 
 All scripts are zero-dependency `.mjs` files using Node.js stdlib only. They output JSON to stdout.
 
+### Unified CLI
+Every script below is also reachable through the `em` dispatcher (installed at `~/.episodic-memory/bin/em`): `em <command>` ≡ `node ~/.episodic-memory/scripts/em-<command>.mjs`. `em help` lists all commands; unknown commands get did-you-mean suggestions.
+```bash
+em store --project my-project --category decision --summary "..." --body "..."
+em search --query "auth token refresh"
+em doctor --fix
+```
+
+### Doctor
+Health check + repair for stores and installation: index parse/drift, tags + category inverted-index consistency, dangling supersedes pointers, stale `.tmp`/`.lock` litter, installed-script drift against the repo checkout, backup config presence.
+```bash
+node ~/.episodic-memory/scripts/em-doctor.mjs            # report (exit 1 on errors)
+node ~/.episodic-memory/scripts/em-doctor.mjs --fix      # rebuild indexes, clear litter
+node ~/.episodic-memory/scripts/em-doctor.mjs --strict   # CI mode: warns also fail
+```
+
 ### Store
 ```bash
 node ~/.episodic-memory/scripts/em-store.mjs \
@@ -326,6 +361,13 @@ node ~/.episodic-memory/scripts/em-search.mjs --tag auth --category decision --s
 node ~/.episodic-memory/scripts/em-search.mjs --history <id> --full
 node ~/.episodic-memory/scripts/em-search.mjs --include-superseded
 ```
+
+`--query` uses tiered relevance matching: an exact summary match scores 1.0, a
+contiguous summary substring 0.7, and a **multi-term query** matches when every
+token lands somewhere in the summary, tags, or body (scored by field weight —
+summary > tags > body — always below a contiguous match). `--query "index
+atomic writes"` finds *"Use atomic rename for index writes"* even though the
+words are scattered.
 
 ### List
 ```bash

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -8,6 +8,11 @@ runtime. After `install.mjs` runs, every script below lives at
 node ~/.episodic-memory/scripts/<script>.mjs [flags]
 ```
 
+There is also a unified dispatcher: `em <command>` ≡ `node
+~/.episodic-memory/scripts/em-<command>.mjs` (shim at
+`~/.episodic-memory/bin/em`; `em help --json` lists every command). Both forms
+are equivalent — use whichever the harness makes easier.
+
 Every script prints a single JSON object to stdout. Parse that JSON. Do not scrape
 prose, and do not read the episode `.md` files or the `index.jsonl` directly to get
 data that a script will return for you.
@@ -32,6 +37,7 @@ Match your intent to the command. The third column is the wrong habit it replace
 | Correct a wrong past decision | `em-revise --original <id> --summary ... --body ...` | Editing the original episode file in place |
 | Investigative / exploratory search | `em-search --query ... --no-track --no-score` | A plain `em-search` that reorders results and bumps access counts |
 | Index looks wrong / out of sync | `em-rebuild-index --scope all` | Hand-editing `index.jsonl` |
+| Anything feels broken / slow / inconsistent | `em-doctor` (then `em-doctor --fix`) | Guessing at which index to rebuild, or ignoring warnings |
 | Find a topic across all projects | `em-search --query <topic> --scope all` | Grepping episode files |
 | Show the full history of one episode | `em-search --history <id> --full` | Guessing which revision is current |
 
@@ -194,6 +200,11 @@ Output:
 ```
 
 Flags that matter (from the script's own `Usage:` header):
+- `--query` is tiered: exact summary match (1.0) > contiguous summary substring
+  (0.7) > all-tokens-match across summary/tags/body (field-weighted, < 0.7) >
+  contiguous body substring (0.4). Multi-word queries no longer need to be an
+  exact substring — every token just has to land somewhere. Token order does
+  not matter; a token missing everywhere means no match.
 - By default `em-search` scores results by relevance and tracks access (each hit
   bumps the episode's `access_count` and reorders future relevance).
 - `--no-score` skips relevance scoring so results come back in a stable
@@ -316,6 +327,38 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --check --scope all
 
 Note: `--help` short-circuits safely (PR #449), but any OTHER unknown argument is
 ignored and a rebuild runs. `--scope all` rebuilds both local and global.
+
+### em-doctor
+
+Health check + repair for the stores and the installation. One command answers
+"is memory healthy, and if not, what exactly is wrong and how do I fix it".
+
+- WHEN TO USE: something feels off (searches slow, warnings about missing
+  indexes, results missing), after a crash/interrupted write, after moving
+  machines, or as a periodic maintenance check.
+- WHEN NOT TO USE: as a data query (use search/list/recall).
+
+```
+node ~/.episodic-memory/scripts/em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]
+```
+
+Checks: Node version, index.jsonl parse, index↔episode-file drift (both
+directions), tags.json + category-index.json consistency, dangling
+`supersedes` pointers, stale `.tmp` files from interrupted atomic writes,
+dead-pid `.lock` files, installed-script presence/drift, backup config.
+
+Output (trimmed):
+
+```json
+{"status":"issues","summary":{"ok":6,"warn":2,"error":1},"checks":[{"id":"index-parse","scope":"local","level":"error","message":"1 malformed line(s) in index.jsonl","fix":"em-rebuild-index"}]}
+```
+
+- Exit 0 when no `error`-level findings; 1 otherwise. `--strict` makes `warn`
+  findings also exit 1 (CI mode).
+- `--fix` rebuilds indexes (delegating to `em-rebuild-index`) and removes stale
+  `.tmp`/`.lock` litter, then re-runs the store checks and reports the post-fix
+  state. Everything else stays report-only.
+- Every non-ok finding carries a `fix` hint when a safe automated repair exists.
 
 ### em-prune
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -95,10 +95,10 @@ project path; abbreviated as `<HOME>` here.)
 8. Known error:
    `TypeError: (b.date + b.time).localeCompare is not a function`
    from `em-list` (or `em-search` without `--no-score`) means a hand-appended index
-   row is missing `date` / `time`. Fixed read-side in PR #447; writer-side validation
-   is tracked in issue #448. Repair: add `date:` and `time:` to the offending episode
-   frontmatter and its matching index row, or delete the bad episode file and run
-   `em-rebuild-index --scope all`.
+   row is missing `date` / `time`. Fixed read-side in PR #447; repair side closed in
+   issue #448: `em-doctor` reports the row (`row-shape`), and
+   `em-rebuild-index` (or `em-doctor --fix`) backfills `date`/`time` from the
+   episode id prefix.
 
 ## After install
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -47,10 +47,18 @@ git clone <repo-url> <ABSOLUTE_PATH_TO_CLONE>
 node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool <harness> --project <ABSOLUTE_PATH_TO_TARGET_PROJECT>
 ```
 
+Interactive alternative — `node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --wizard`
+walks prerequisite checks, tool + project selection, optional Claude Code
+hooks, optional backup config, the `em` PATH shim, and verifies the result
+with `em-doctor`. The wizard also has a **migrate** flow (restore stores from
+an em-backup repository, dry-run first) and a **doctor** flow. Answers are
+plain stdin lines, so agents can script it:
+`printf '1\n2\n/abs/project\nn\nn\n' | node install.mjs --wizard`.
+
 Every install (all tools) prints, among other lines:
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory
 ...
@@ -94,11 +102,15 @@ project path; abbreviated as `<HOME>` here.)
 
 ## After install
 
-Verify the shared substrate and read the command reference:
+Verify the shared substrate with one command and read the command reference:
 
 ```
-ls <HOME>/.episodic-memory/scripts        # 21 scripts (20 em-*.mjs + second-opinion.mjs) + lib/
+node <HOME>/.episodic-memory/scripts/em-doctor.mjs   # {"status":"ok",...} + exit 0 = healthy
+ls <HOME>/.episodic-memory/scripts        # 23 scripts (21 em-*.mjs + em.mjs + second-opinion.mjs) + lib/
 cat <HOME>/.episodic-memory/EM_SCRIPTS_GUIDE.md
 ```
+
+The `em` unified CLI is at `<HOME>/.episodic-memory/bin/em` (`em help` lists
+every command; `em doctor --fix` repairs index drift and stale lock/tmp litter).
 
 Then follow your harness file for the tool-specific verify commands.

--- a/docs/install/claude-code.md
+++ b/docs/install/claude-code.md
@@ -145,7 +145,7 @@ returns `{"status":"ok","count":N,"episodes":[...]}`.
 - `--project` defaults to `process.cwd()`. Always pass an absolute `--project`.
 - Never hand-write episode files or index rows. Known crash:
   `TypeError: (b.date + b.time).localeCompare is not a function` from `em-list` means
-  a hand-appended index row lacks `date`/`time` (PR #447 read-side fix; issue #448
-  writer-side). Repair: fix the frontmatter + index row, or delete the bad episode
-  and run `em-rebuild-index --scope all`.
+  a hand-appended index row lacks `date`/`time` (PR #447 read-side fix; #448 repair
+  side closed). Repair: `em-doctor --fix` (or `em-rebuild-index --scope all`) —
+  the rebuild backfills `date`/`time` from the episode id prefix.
 - Full per-script reference: `~/.episodic-memory/EM_SCRIPTS_GUIDE.md`.

--- a/docs/install/claude-code.md
+++ b/docs/install/claude-code.md
@@ -33,7 +33,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool claude-code --project <ABSOLUTE
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -33,7 +33,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool codex --project <ABSOLUTE_PATH_
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/docs/install/cursor.md
+++ b/docs/install/cursor.md
@@ -33,7 +33,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool cursor --project <ABSOLUTE_PATH
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/docs/install/opencode.md
+++ b/docs/install/opencode.md
@@ -35,7 +35,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool opencode --project <ABSOLUTE_PA
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/docs/install/pi-agent.md
+++ b/docs/install/pi-agent.md
@@ -33,7 +33,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool pi-agent --project <ABSOLUTE_PA
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/docs/install/windsurf.md
+++ b/docs/install/windsurf.md
@@ -33,7 +33,7 @@ node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool windsurf --project <ABSOLUTE_PA
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
 ```
-Installed 21 scripts to <HOME>/.episodic-memory/scripts
+Installed 23 scripts to <HOME>/.episodic-memory/scripts
 Seeded default LLM classifier config at <HOME>/.episodic-memory/classifier-config.json
 Installed patterns/_index.json to <HOME>/.episodic-memory/patterns
 Installed EM_SCRIPTS_GUIDE.md to <HOME>/.episodic-memory

--- a/install.mjs
+++ b/install.mjs
@@ -126,8 +126,19 @@ if (bootstrapLastPrompt) {
   if (!tool) process.exit(0)
 }
 
+// --wizard: interactive guided setup (prereq checks → tool/project selection →
+// optional hooks/backup → verify with em-doctor; also drives migrate-from-backup
+// and health-check flows). Delegates to scripts/install-wizard.mjs, which
+// re-invokes this installer non-interactively with the composed flags.
+if (argv.includes('--wizard')) {
+  const { spawnSync } = await import('child_process')
+  const r = spawnSync(process.execPath, [path.join(REPO_DIR, 'scripts', 'install-wizard.mjs')], { stdio: 'inherit' })
+  process.exit(r.status === null ? 1 : r.status)
+}
+
 if (!tool) {
-  console.log(`Usage: node install.mjs --tool <claude-code|cursor|codex|opencode|pi-agent|windsurf|all> [--project <path>] [--install-hooks] [--install-enforcement] [--uninstall-enforcement [--purge-config]] [--install-hooks-force] [--install-second-opinion] [--bootstrap-last-prompt]
+  console.log(`Usage: node install.mjs --wizard   (interactive guided setup — recommended)
+       node install.mjs --tool <claude-code|cursor|codex|opencode|pi-agent|windsurf|all> [--project <path>] [--install-hooks] [--install-enforcement] [--uninstall-enforcement [--purge-config]] [--install-hooks-force] [--install-second-opinion] [--bootstrap-last-prompt]
 
 Tools:
   claude-code  Install SKILL.md + plugin structure
@@ -335,6 +346,21 @@ function copyDirRecursive(src, dst) {
 }
 
 console.log(`Installed ${scriptFiles.length} scripts to ${SCRIPTS_DIR}`)
+
+// ---------------------------------------------------------------------------
+// Unified CLI shim: ~/.episodic-memory/bin/em → scripts/em.mjs, so a single
+// PATH entry gives `em store|search|recall|doctor|...` everywhere. Clobbered
+// on every install like the substrate scripts (drift-proof by overwrite).
+// ---------------------------------------------------------------------------
+const BIN_DIR = path.join(GLOBAL_DIR, 'bin')
+fs.mkdirSync(BIN_DIR, { recursive: true })
+const emShim = path.join(BIN_DIR, 'em')
+fs.writeFileSync(emShim, `#!/bin/sh\nexec node "${path.join(SCRIPTS_DIR, 'em.mjs')}" "$@"\n`, 'utf8')
+fs.chmodSync(emShim, 0o755)
+console.log(`Installed unified CLI shim at ${emShim}`)
+if (!(process.env.PATH || '').split(path.delimiter).includes(BIN_DIR)) {
+  console.log(`  → add it to your PATH:  export PATH="$HOME/.episodic-memory/bin:$PATH"`)
+}
 
 // ---------------------------------------------------------------------------
 // F45 (RFC-008 P3d): em-recall purity sentinel. em-recall.mjs is the memory

--- a/scripts/em-doctor.mjs
+++ b/scripts/em-doctor.mjs
@@ -136,8 +136,27 @@ function checkStore(dataDir, scopeName) {
     report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
   }
 
+  // --- row-shape: schema-deviant rows (#448 class) -------------------------
+  // Hand-appended rows missing string date/time/summary (or with non-array
+  // tags) no longer crash readers (#447) but sort last and degrade filters.
+  // em-rebuild-index backfills date/time from the id prefix, so the fix hint
+  // is a real repair, not just a report.
+  const entriesForShape = loadIndex(dataDir, scopeName)
+  const deviant = entriesForShape.filter(e =>
+    typeof e.id !== 'string' || typeof e.date !== 'string' ||
+    typeof e.time !== 'string' || typeof e.summary !== 'string' ||
+    !Array.isArray(e.tags)
+  )
+  if (deviant.length) {
+    report('row-shape', scopeName, 'warn',
+      `${deviant.length} index row(s) missing typed id/date/time/summary/tags (hand-appended?). Rebuild backfills date/time from the episode id.`,
+      { fix: 'em-rebuild-index', ...(verbose ? { rows: deviant.map(e => e.id).filter(Boolean) } : {}) })
+  } else if (entriesForShape.length) {
+    report('row-shape', scopeName, 'ok', 'all index rows carry typed id/date/time/summary/tags')
+  }
+
   // --- index-drift: index rows ↔ episode files ----------------------------
-  const entries = loadIndex(dataDir, scopeName)
+  const entries = entriesForShape
   const indexedIds = new Set(entries.map(e => e.id))
   const missingFiles = [...indexedIds].filter(id => !episodeIds.has(id))
   const unindexed = [...episodeIds].filter(id => !indexedIds.has(id))

--- a/scripts/em-doctor.mjs
+++ b/scripts/em-doctor.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+/**
+ * em-doctor.mjs — One-command health check + repair for the episodic-memory
+ * substrate. The maintenance entry point: run it any time something feels off
+ * (or on a schedule) and it tells you exactly what is wrong and how to fix it
+ * — or fixes it for you with --fix.
+ *
+ * Usage:
+ *   node em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]
+ *
+ * Checks, per store scope:
+ *   node-version      Node.js >= 18
+ *   store             store dir + episodes/ layout
+ *   index-parse       index.jsonl rows all parse as JSON
+ *   index-drift       index rows ↔ episodes/*.md agree (both directions)
+ *   tags-index        tags.json present; every referenced id exists
+ *   category-index    category-index.json present; every referenced id exists
+ *   supersedes-links  supersedes pointers resolve (dangling → warn)
+ *   tmp-litter        leftover *.tmp files from interrupted atomic writes
+ *   stale-locks       *.lock files whose owning pid is gone
+ *   installed-scripts global ~/.episodic-memory/scripts has the core tools;
+ *                     when run from a repo checkout, byte-compares installed
+ *                     copies against repo sources (drift → warn)
+ *   backup            backup config presence (info only)
+ *
+ * --fix repairs what is safely repairable: rebuilds indexes (via
+ * em-rebuild-index.mjs) when index/tags/category checks fail, and removes
+ * stale *.tmp files (older than 1h) and dead-pid *.lock files. Everything
+ * else stays report-only.
+ *
+ * Exit codes: 0 = no error-level findings (warns allowed), 1 = errors found
+ * (or, with --strict, warns found), 2 = usage error.
+ *
+ * Outputs JSON: { status, summary: {ok,warn,error}, checks: [...], fixes: [...] }
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { resolveLocalDir } from './lib/local-dir.mjs'
+import { loadIndex } from './lib/relevance.mjs'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+const LOCAL_DIR = resolveLocalDir()
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-doctor.mjs', usage: 'node em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]' }))
+  process.exit(0)
+}
+
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const scope = flag('--scope') || 'all'
+const fix = argv.includes('--fix')
+const strict = argv.includes('--strict')
+const verbose = argv.includes('--verbose')
+
+const VALID_SCOPES = ['local', 'global', 'all']
+if (!VALID_SCOPES.includes(scope)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID_SCOPES.join(', ')}` }))
+  process.exit(2)
+}
+
+const checks = []
+const fixes = []
+
+function report(id, scopeName, level, message, extra) {
+  checks.push({ id, scope: scopeName, level, message, ...(extra || {}) })
+}
+
+// Age threshold for treating a .tmp sidecar as litter rather than an
+// in-flight atomic write.
+const TMP_LITTER_MS = 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Environment checks
+// ---------------------------------------------------------------------------
+function checkNodeVersion() {
+  const major = parseInt(process.versions.node.split('.')[0], 10)
+  if (major >= 18) {
+    report('node-version', '-', 'ok', `Node.js ${process.versions.node}`)
+  } else {
+    report('node-version', '-', 'error', `Node.js ${process.versions.node} is below the supported floor (18). Upgrade Node.js.`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-store checks
+// ---------------------------------------------------------------------------
+function checkStore(dataDir, scopeName) {
+  if (!fs.existsSync(dataDir)) {
+    // A missing store is not an error — scripts create it on first write.
+    report('store', scopeName, 'ok', `No store at ${dataDir} (created on first use)`)
+    return
+  }
+
+  const episodesDir = path.join(dataDir, 'episodes')
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const hasEpisodes = fs.existsSync(episodesDir)
+  const hasIndex = fs.existsSync(indexFile)
+
+  // Episode files on disk (source of truth for drift checks).
+  const episodeIds = new Set(
+    hasEpisodes
+      ? fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).map(f => f.slice(0, -3))
+      : []
+  )
+
+  if (!hasIndex && episodeIds.size === 0) {
+    report('store', scopeName, 'ok', `Empty store at ${dataDir}`)
+    return
+  }
+  report('store', scopeName, 'ok', `Store at ${dataDir}: ${episodeIds.size} episode file(s)`)
+
+  // --- index-parse: count rows that fail to parse -------------------------
+  let rawLines = []
+  let badLines = 0
+  if (hasIndex) {
+    rawLines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    for (const line of rawLines) {
+      try { JSON.parse(line) } catch { badLines++ }
+    }
+  }
+  if (badLines > 0) {
+    report('index-parse', scopeName, 'error', `${badLines} malformed line(s) in index.jsonl`, { fix: 'em-rebuild-index' })
+  } else {
+    report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
+  }
+
+  // --- index-drift: index rows ↔ episode files ----------------------------
+  const entries = loadIndex(dataDir, scopeName)
+  const indexedIds = new Set(entries.map(e => e.id))
+  const missingFiles = [...indexedIds].filter(id => !episodeIds.has(id))
+  const unindexed = [...episodeIds].filter(id => !indexedIds.has(id))
+  if (missingFiles.length || unindexed.length) {
+    report('index-drift', scopeName, 'error',
+      `${missingFiles.length} indexed id(s) with no episode file; ${unindexed.length} episode file(s) not in index`,
+      { fix: 'em-rebuild-index', ...(verbose ? { missing_files: missingFiles, unindexed_files: unindexed } : {}) })
+  } else {
+    report('index-drift', scopeName, 'ok', 'index.jsonl and episodes/ agree')
+  }
+
+  // --- tags-index / category-index ----------------------------------------
+  for (const [checkId, fileName] of [['tags-index', 'tags.json'], ['category-index', 'category-index.json']]) {
+    const p = path.join(dataDir, fileName)
+    if (!fs.existsSync(p)) {
+      if (indexedIds.size > 0) {
+        report(checkId, scopeName, 'warn', `${fileName} missing — searches fall back to slow linear scan`, { fix: 'em-rebuild-index' })
+      } else {
+        report(checkId, scopeName, 'ok', `${fileName} absent (empty store)`)
+      }
+      continue
+    }
+    let idx
+    try {
+      idx = JSON.parse(fs.readFileSync(p, 'utf8'))
+    } catch {
+      report(checkId, scopeName, 'error', `${fileName} is corrupt (invalid JSON)`, { fix: 'em-rebuild-index' })
+      continue
+    }
+    const danglers = []
+    for (const ids of Object.values(idx)) {
+      if (!Array.isArray(ids)) continue
+      for (const id of ids) if (!indexedIds.has(id)) danglers.push(id)
+    }
+    if (danglers.length) {
+      report(checkId, scopeName, 'warn', `${fileName} references ${danglers.length} id(s) not in index.jsonl`, { fix: 'em-rebuild-index', ...(verbose ? { dangling: [...new Set(danglers)] } : {}) })
+    } else {
+      report(checkId, scopeName, 'ok', `${fileName} consistent`)
+    }
+  }
+
+  // --- supersedes-links ----------------------------------------------------
+  const dangling = entries.filter(e => e.supersedes && !indexedIds.has(e.supersedes)).map(e => e.id)
+  if (dangling.length) {
+    // Dangling supersedes can be legitimate (chain crosses scopes, or the
+    // original was pruned) — surface, don't fail.
+    report('supersedes-links', scopeName, 'warn', `${dangling.length} episode(s) supersede id(s) not present in this scope`, verbose ? { episodes: dangling } : undefined)
+  } else {
+    report('supersedes-links', scopeName, 'ok', 'all supersedes pointers resolve')
+  }
+
+  // --- tmp-litter -----------------------------------------------------------
+  const now = Date.now()
+  const tmpFiles = fs.readdirSync(dataDir)
+    .filter(f => f.endsWith('.tmp'))
+    .map(f => path.join(dataDir, f))
+    .filter(p2 => {
+      try { return now - fs.statSync(p2).mtimeMs > TMP_LITTER_MS } catch { return false }
+    })
+  if (tmpFiles.length) {
+    if (fix) {
+      for (const f of tmpFiles) {
+        try { fs.unlinkSync(f); fixes.push({ action: 'removed-tmp', file: f }) } catch {}
+      }
+      report('tmp-litter', scopeName, 'ok', `removed ${tmpFiles.length} stale .tmp file(s)`)
+    } else {
+      report('tmp-litter', scopeName, 'warn', `${tmpFiles.length} stale .tmp file(s) from interrupted writes (--fix removes)`, verbose ? { files: tmpFiles } : undefined)
+    }
+  } else {
+    report('tmp-litter', scopeName, 'ok', 'no stale .tmp files')
+  }
+
+  // --- stale-locks ----------------------------------------------------------
+  const lockFiles = fs.readdirSync(dataDir).filter(f => f.endsWith('.lock')).map(f => path.join(dataDir, f))
+  const stale = []
+  for (const lf of lockFiles) {
+    let pid = null
+    try {
+      const m = fs.readFileSync(lf, 'utf8').match(/\d+/)
+      if (m) pid = parseInt(m[0], 10)
+    } catch { continue }
+    let alive = false
+    if (pid) {
+      try { process.kill(pid, 0); alive = true } catch { alive = false }
+    }
+    if (!alive) stale.push(lf)
+  }
+  if (stale.length) {
+    if (fix) {
+      for (const f of stale) {
+        try { fs.unlinkSync(f); fixes.push({ action: 'removed-stale-lock', file: f }) } catch {}
+      }
+      report('stale-locks', scopeName, 'ok', `removed ${stale.length} stale lock file(s)`)
+    } else {
+      report('stale-locks', scopeName, 'warn', `${stale.length} lock file(s) held by dead process(es) (--fix removes)`, verbose ? { files: stale } : undefined)
+    }
+  } else {
+    report('stale-locks', scopeName, 'ok', lockFiles.length ? `${lockFiles.length} lock(s), all live` : 'no lock files')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Installed-scripts check. Two situations:
+//   - running the installed copy: SCRIPT_DIR == the global scripts dir →
+//     presence check only.
+//   - running from a repo checkout: also byte-compare installed substrate
+//     copies against the repo sources (install.mjs clobbers on every run, so
+//     any diff means "re-run install").
+// ---------------------------------------------------------------------------
+const CORE_SCRIPTS = ['em-store.mjs', 'em-search.mjs', 'em-list.mjs', 'em-recall.mjs', 'em-revise.mjs', 'em-rebuild-index.mjs', 'em-doctor.mjs']
+
+function checkInstalledScripts() {
+  const installedDir = path.join(GLOBAL_DIR, 'scripts')
+  if (!fs.existsSync(installedDir)) {
+    report('installed-scripts', 'global', 'warn', `No installed scripts at ${installedDir}. Run: node <clone>/install.mjs --tool <your-tool> --project <your-project>`)
+    return
+  }
+  const missing = CORE_SCRIPTS.filter(f => !fs.existsSync(path.join(installedDir, f)))
+  if (missing.length) {
+    report('installed-scripts', 'global', 'warn', `Installed scripts dir is missing: ${missing.join(', ')}. Re-run install.mjs to refresh.`)
+    return
+  }
+
+  // Repo checkout detection: this script lives in <repo>/scripts iff the
+  // parent holds install.mjs. The installed copy's parent is GLOBAL_DIR,
+  // which has no install.mjs, so the drift comparison self-disables there.
+  const repoRoot = path.dirname(SCRIPT_DIR)
+  if (!fs.existsSync(path.join(repoRoot, 'install.mjs')) || path.resolve(SCRIPT_DIR) === path.resolve(installedDir)) {
+    report('installed-scripts', 'global', 'ok', `All core scripts present at ${installedDir}`)
+    return
+  }
+  const drifted = []
+  for (const f of fs.readdirSync(SCRIPT_DIR).filter(f => f.startsWith('em-') && f.endsWith('.mjs'))) {
+    const installed = path.join(installedDir, f)
+    if (!fs.existsSync(installed)) continue
+    try {
+      if (!fs.readFileSync(path.join(SCRIPT_DIR, f)).equals(fs.readFileSync(installed))) drifted.push(f)
+    } catch {}
+  }
+  if (drifted.length) {
+    report('installed-scripts', 'global', 'warn', `${drifted.length} installed script(s) differ from this repo checkout: ${drifted.join(', ')}. Re-run install.mjs to refresh.`, verbose ? { drifted } : undefined)
+  } else {
+    report('installed-scripts', 'global', 'ok', `Installed scripts match this repo checkout`)
+  }
+}
+
+function checkBackupConfig() {
+  const candidates = [process.env.EM_BACKUP_CONFIG, path.join(os.homedir(), '.config/em-backup/config.json')].filter(Boolean)
+  const found = candidates.find(c => fs.existsSync(c))
+  if (found) {
+    report('backup', '-', 'ok', `Backup config present at ${found}`)
+  } else {
+    report('backup', '-', 'ok', 'No backup config (optional). See scripts/em-backup.mjs --help to set one up.')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run checks
+// ---------------------------------------------------------------------------
+checkNodeVersion()
+if (scope === 'local' || scope === 'all') checkStore(LOCAL_DIR, 'local')
+if (scope === 'global' || scope === 'all') checkStore(GLOBAL_DIR, 'global')
+checkInstalledScripts()
+checkBackupConfig()
+
+// ---------------------------------------------------------------------------
+// --fix: rebuild indexes for scopes with rebuildable findings, then re-verify
+// by re-running the store checks and replacing their rows.
+// ---------------------------------------------------------------------------
+if (fix) {
+  const rebuildScopes = new Set(
+    checks.filter(c => c.fix === 'em-rebuild-index' && c.level !== 'ok').map(c => c.scope)
+  )
+  for (const s of rebuildScopes) {
+    const rebuildScript = path.join(SCRIPT_DIR, 'em-rebuild-index.mjs')
+    const r = spawnSync(process.execPath, [rebuildScript, '--scope', s], {
+      encoding: 'utf8',
+      // local rebuild must resolve the SAME local store this doctor saw
+      cwd: s === 'local' ? path.dirname(LOCAL_DIR) : process.cwd()
+    })
+    fixes.push({ action: 'rebuild-index', scope: s, exit: r.status, output: (r.stdout || '').trim().slice(0, 500) })
+  }
+  if (rebuildScopes.size > 0) {
+    // Re-verify: drop the pre-fix store rows and re-run those checks.
+    const rerun = [...rebuildScopes]
+    for (let i = checks.length - 1; i >= 0; i--) {
+      if (rerun.includes(checks[i].scope)) checks.splice(i, 1)
+    }
+    for (const s of rerun) checkStore(s === 'local' ? LOCAL_DIR : GLOBAL_DIR, s)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+const summary = { ok: 0, warn: 0, error: 0 }
+for (const c of checks) summary[c.level] = (summary[c.level] || 0) + 1
+
+const healthy = summary.error === 0 && (!strict || summary.warn === 0)
+const result = {
+  status: healthy ? 'ok' : 'issues',
+  summary,
+  checks,
+  ...(fixes.length ? { fixes } : {})
+}
+console.log(JSON.stringify(result))
+process.exit(healthy ? 0 : 1)

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -154,10 +154,26 @@ function rebuildDir(dataDir, label) {
     const accessCount = old ? (old.access_count || 0) : 0
     const lastAccessed = old ? (old.last_accessed || null) : null
 
+    // #448 write/repair side: a hand-authored episode (foreign harness,
+    // `created:` instead of `date:`/`time:`) used to round-trip its malformed
+    // row through every rebuild — fm.date/fm.time copied verbatim. Backfill
+    // from the id prefix (`YYYYMMDD-HHMMSS-…`, always present and
+    // total-ordered) whenever the frontmatter value is not a string, so a
+    // rebuild now REPAIRS the row instead of reproducing it. Well-formed
+    // episodes are byte-identical: string values pass through untouched.
+    let { date, time } = fm
+    if (typeof date !== 'string' || typeof time !== 'string') {
+      const m = fm.id.match(/^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})\d{2}-/)
+      if (m) {
+        if (typeof date !== 'string') date = `${m[1]}-${m[2]}-${m[3]}`
+        if (typeof time !== 'string') time = `${m[4]}:${m[5]}`
+      }
+    }
+
     entries.push(JSON.stringify({
       id: fm.id,
-      date: fm.date,
-      time: fm.time,
+      date,
+      time,
       project: fm.project,
       category: fm.category,
       status: fm.status || 'active',
@@ -168,7 +184,7 @@ function rebuildDir(dataDir, label) {
       summary: fm.summary,
       access_count: accessCount,
       last_accessed: lastAccessed,
-      ...(fm.url ? { url: fm.url, fetched: fm.fetched || fm.date } : {})
+      ...(fm.url ? { url: fm.url, fetched: fm.fetched || date } : {})
     }))
     for (const tag of normalizedTags) {
       if (!tagsIndex[tag]) tagsIndex[tag] = []

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -20,6 +20,10 @@ import path from 'path'
 import os from 'os'
 import { execSync } from 'child_process'
 import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
+import {
+  normalizeTags, loadTagsIndex, loadIndex,
+  computeScore, writeBackAccessTracking
+} from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -85,80 +89,9 @@ const STOPWORDS = new Set([
   'enforce', 'pattern'
 ])
 
-// ---------------------------------------------------------------------------
-// SYNC: em-search.mjs:normalizeTags — update both on change
-// ---------------------------------------------------------------------------
-function normalizeTags(raw) {
-  if (!raw) return []
-  const arr = (Array.isArray(raw) ? raw : raw.split(','))
-    .map(t => t.trim().toLowerCase())
-    .filter(Boolean)
-  return [...new Set(arr)].sort()
-}
-
-// ---------------------------------------------------------------------------
-// SYNC: em-search.mjs:loadTagsIndex — update both on change
-// ---------------------------------------------------------------------------
-function loadTagsIndex(dataDir) {
-  const tagsFile = path.join(dataDir, 'tags.json')
-  try {
-    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
-  } catch {
-    return null
-  }
-}
-
-// ---------------------------------------------------------------------------
-// SYNC: em-search.mjs:computeScore — update both on change
-// ---------------------------------------------------------------------------
-function computeScore(entry, textMatchScore) {
-  const accessCount = entry.access_count || 0
-  // Use new Date(entry.date) for decay — sub-day precision unnecessary
-  const created = new Date(entry.date)
-  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
-  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
-  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
-  return textMatchScore * timeFactor * accessFactor
-}
-
-// ---------------------------------------------------------------------------
-// SYNC: em-search.mjs:writeBackAccessTracking — update both on change
-// ---------------------------------------------------------------------------
-function writeBackAccessTracking(results) {
-  // Group results by source data directory
-  const byDir = new Map()
-  for (const e of results) {
-    if (!e._dataDir) continue
-    if (!byDir.has(e._dataDir)) byDir.set(e._dataDir, new Set())
-    byDir.get(e._dataDir).add(e.id)
-  }
-
-  const now = new Date().toISOString().slice(0, 19) + 'Z'
-
-  for (const [dataDir, ids] of byDir) {
-    const indexFile = path.join(dataDir, 'index.jsonl')
-    try {
-      // Re-read just before writing to narrow race window with concurrent em-store appends.
-      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
-      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-      const updated = lines.map(line => {
-        try {
-          const entry = JSON.parse(line)
-          if (ids.has(entry.id)) {
-            entry.access_count = (entry.access_count || 0) + 1
-            entry.last_accessed = now
-          }
-          return JSON.stringify(entry)
-        } catch { return line }
-      })
-      const tmpFile = indexFile + '.tmp'
-      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
-      fs.renameSync(tmpFile, indexFile)
-    } catch {
-      // Access tracking is best-effort — skip silently on failure
-    }
-  }
-}
+// Retrieval primitives (normalizeTags, loadTagsIndex, loadIndex, computeScore,
+// writeBackAccessTracking) are shared with em-search.mjs via lib/relevance.mjs
+// — the former SYNC: blocks, now a single source.
 
 // ---------------------------------------------------------------------------
 // Task-type → relevant pattern_ids (RFC-002 Phase 3)
@@ -272,22 +205,6 @@ function resolveProjectName(projectRoot) {
   } catch {}
 
   return path.basename(projectRoot)
-}
-
-// ---------------------------------------------------------------------------
-// SYNC: em-search.mjs:loadIndex — update both on change
-// ---------------------------------------------------------------------------
-function loadIndex(dataDir, source) {
-  const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
-    try {
-      const entry = JSON.parse(line)
-      entry._source = source
-      entry._dataDir = dataDir
-      return entry
-    } catch { return null }
-  }).filter(Boolean)
 }
 
 // ---------------------------------------------------------------------------
@@ -429,6 +346,19 @@ if (context.effective_tokens.length > 0) {
   for (const e of activeEntries) {
     if (matchingIds.has(e.id)) {
       const score = computeScore(e, 0.7)
+      pass2.set(e.id, { entry: e, score })
+    }
+  }
+
+  // Pass 2b: summary token match. Branch/keyword tokens rarely coincide with
+  // stored tags verbatim, so episodes whose SUMMARY mentions the topic were
+  // invisible to pass 2. Weighted 0.6 — below an exact tag hit (0.7), above
+  // recency-only (0.5). Merge keeps the higher score when both passes hit.
+  for (const e of activeEntries) {
+    if (pass2.has(e.id)) continue
+    const summaryLower = (e.summary || '').toLowerCase()
+    if (summaryLower && normalizedTokens.some(t => summaryLower.includes(t))) {
+      const score = computeScore(e, 0.6)
       pass2.set(e.id, { entry: e, score })
     }
   }

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -20,6 +20,10 @@ import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
+import {
+  normalizeTags, loadTagsIndex, loadCategoryIndex, loadIndex,
+  computeScore, writeBackAccessTracking, scoreTextMatch
+} from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -63,99 +67,9 @@ if (!VALID_SCOPES_SEARCH.includes(scope)) {
 
 const searchStart = Date.now()
 
-function normalizeTags(raw) {
-  if (!raw) return []
-  const arr = (Array.isArray(raw) ? raw : raw.split(','))
-    .map(t => t.trim().toLowerCase())
-    .filter(Boolean)
-  return [...new Set(arr)].sort()
-}
-
-function loadTagsIndex(dataDir) {
-  const tagsFile = path.join(dataDir, 'tags.json')
-  try {
-    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
-  } catch {
-    return null
-  }
-}
-
-function loadCategoryIndex(dataDir) {
-  const catFile = path.join(dataDir, 'category-index.json')
-  try {
-    return JSON.parse(fs.readFileSync(catFile, 'utf8'))
-  } catch {
-    return null
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Relevance scoring
-// ---------------------------------------------------------------------------
-function computeScore(entry, textMatchScore) {
-  const accessCount = entry.access_count || 0
-  // Use new Date(entry.date) for decay — sub-day precision unnecessary
-  const created = new Date(entry.date)
-  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
-  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
-  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
-  return textMatchScore * timeFactor * accessFactor
-}
-
-// ---------------------------------------------------------------------------
-// Access tracking write-back
-// ---------------------------------------------------------------------------
-function writeBackAccessTracking(results) {
-  // Group results by source data directory
-  const byDir = new Map()
-  for (const e of results) {
-    if (!e._dataDir) continue
-    if (!byDir.has(e._dataDir)) byDir.set(e._dataDir, new Set())
-    byDir.get(e._dataDir).add(e.id)
-  }
-
-  const now = new Date().toISOString().slice(0, 19) + 'Z'
-
-  for (const [dataDir, ids] of byDir) {
-    const indexFile = path.join(dataDir, 'index.jsonl')
-    try {
-      // Re-read just before writing to narrow race window with concurrent em-store appends.
-      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
-      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-      const updated = lines.map(line => {
-        try {
-          const entry = JSON.parse(line)
-          if (ids.has(entry.id)) {
-            entry.access_count = (entry.access_count || 0) + 1
-            entry.last_accessed = now
-          }
-          return JSON.stringify(entry)
-        } catch { return line }
-      })
-      const tmpFile = indexFile + '.tmp'
-      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
-      fs.renameSync(tmpFile, indexFile)
-    } catch {
-      // Access tracking is best-effort — skip silently on failure
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Load index entries from a data directory
-// ---------------------------------------------------------------------------
-function loadIndex(dataDir, source) {
-  const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
-    try {
-      const entry = JSON.parse(line)
-      entry._source = source
-      entry._dataDir = dataDir
-      return entry
-    } catch { return null }
-  }).filter(Boolean)
-}
+// Retrieval primitives (normalizeTags, loadTagsIndex, loadCategoryIndex,
+// loadIndex, computeScore, writeBackAccessTracking, scoreTextMatch) are
+// shared with em-recall.mjs via lib/relevance.mjs — the former SYNC: blocks.
 
 // ---------------------------------------------------------------------------
 // Collect entries based on scope
@@ -315,25 +229,22 @@ if (since) {
   results = results.filter(e => e.date >= since)
 }
 
-// Full-text search in episode bodies + compute text_match scores
-const queryLower = query ? query.toLowerCase() : null
+// Full-text search: tiered matcher from lib/relevance.mjs. Contiguous
+// summary/body substring matches keep their pre-lib scores (1.0/0.7/0.4);
+// multi-term queries additionally match when every token lands somewhere in
+// summary/tags/body, scored by discounted field weights. Bodies load lazily,
+// at most once per episode.
 if (query) {
   results = results.filter(e => {
-    const summaryLower = (e.summary || '').toLowerCase()
-    if (summaryLower.includes(queryLower)) {
-      e._textMatch = summaryLower === queryLower ? 1.0 : 0.7
-      return true
+    const readBody = () => {
+      const filePath = path.join(e._dataDir, 'episodes', `${e.id}.md`)
+      try { return fs.readFileSync(filePath, 'utf8') } catch { return null }
     }
-    const filePath = path.join(e._dataDir, 'episodes', `${e.id}.md`)
-    if (fs.existsSync(filePath)) {
-      const content = fs.readFileSync(filePath, 'utf8')
-      if (content.toLowerCase().includes(queryLower)) {
-        e._textMatch = 0.4
-        if (full) e._body = content
-        return true
-      }
-    }
-    return false
+    const { matched, textMatch, body } = scoreTextMatch(e, query, readBody)
+    if (!matched) return false
+    e._textMatch = textMatch
+    if (full && body) e._body = body
+    return true
   })
 }
 

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -116,6 +116,29 @@ function flushTagsIndex() {
   fs.renameSync(tmpFile, tagsFile)
 }
 
+// Mirror of the tags flush for category-index.json (R10d). Without this a
+// fresh install seeds patterns with NO category index, so every search on the
+// new store degrades to the linear-scan fallback until a manual rebuild.
+const pendingCategoryUpdates = []
+
+function queueCategoryUpdate(episodeId, category) {
+  pendingCategoryUpdates.push({ episodeId, category })
+}
+
+function flushCategoryIndex() {
+  if (pendingCategoryUpdates.length === 0) return
+  const catFile = path.join(GLOBAL_DIR, 'category-index.json')
+  let idx = {}
+  try { idx = JSON.parse(fs.readFileSync(catFile, 'utf8')) } catch {}
+  for (const { episodeId, category } of pendingCategoryUpdates) {
+    if (!idx[category]) idx[category] = []
+    if (!idx[category].includes(episodeId)) idx[category].push(episodeId)
+  }
+  const tmpFile = catFile + '.tmp'
+  fs.writeFileSync(tmpFile, JSON.stringify(idx, null, 2), 'utf8')
+  fs.renameSync(tmpFile, catFile)
+}
+
 // ---------------------------------------------------------------------------
 // Seed patterns
 // ---------------------------------------------------------------------------
@@ -198,14 +221,16 @@ for (const entry of index.patterns || []) {
   })
   fs.appendFileSync(globalIndexFile, indexEntry + '\n', 'utf8')
 
-  // Queue tags.json update
+  // Queue tags.json + category-index.json updates
   queueTagsUpdate(id, tags)
+  queueCategoryUpdate(id, category)
 
   seeded++
 }
 
-// Flush all tag updates in one atomic write
+// Flush all tag + category updates, one atomic write each
 flushTagsIndex()
+flushCategoryIndex()
 
 const total = (index.patterns || []).length
 console.log(JSON.stringify({

--- a/scripts/em.mjs
+++ b/scripts/em.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * em.mjs — unified entry point for the episodic-memory substrate.
+ *
+ * One command instead of 20 script paths:
+ *
+ *   em <command> [args...]        ≡  node <scripts-dir>/em-<command>.mjs [args...]
+ *
+ * Examples:
+ *   em store --project demo --category decision --summary "..." --body "..."
+ *   em search --query "atomic rename" --scope all
+ *   em recall
+ *   em doctor --fix
+ *
+ * `em help` prints a human-readable command table (the only non-JSON output
+ * surface in the substrate — every delegated command still emits JSON).
+ * `em help --json` emits the same table as JSON for tooling.
+ *
+ * Command resolution is directory-driven: any em-<name>.mjs sitting next to
+ * this file is a valid subcommand, so newly added substrate scripts are
+ * dispatchable with zero changes here. Exit code and stdio pass through from
+ * the delegated script.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+// One-line descriptions for the help table. Commands discovered on disk but
+// absent here still dispatch — they just render without a description.
+const DESCRIPTIONS = {
+  store: 'Save a new episode (decision, lesson, discovery, ...)',
+  search: 'Search episodes by query/tag/category/project',
+  list: 'List episodes, newest first',
+  recall: 'Proactive session-start recall for the current project',
+  revise: 'Correct a past episode via a revision chain',
+  doctor: 'Health-check the stores and installation (--fix repairs)',
+  prune: 'Archive stale low-relevance episodes',
+  'rebuild-index': 'Regenerate index.jsonl, tags.json, category-index.json',
+  backup: 'Sync stores to a backup git repository',
+  restore: 'Restore stores from a backup repository',
+  violation: 'Record a behavioral-pattern violation',
+  'check-stale': 'Flag episodes past their review-by date',
+  'pattern-health': 'Report behavioral-pattern health metrics',
+  'seed-patterns': 'Seed the behavioral patterns into global memory',
+  'mine-transcripts': 'Mine session transcripts for storable episodes',
+  'audit-compliance': 'Audit episode-storage compliance for a session',
+  'review-request': 'File a cross-tool review-request episode',
+  'watch-codex': 'Watch for Codex review-reply episodes',
+  'rfc-validate': 'Validate RFC registry/frontmatter/README consistency',
+  'workflow-validate': 'Validate a workflow definition',
+  lock: 'Run a command under an atomic file lock',
+  'session-end-prompt': 'SessionEnd hook helper (enforcement layer)',
+}
+
+function availableCommands() {
+  return fs.readdirSync(SCRIPT_DIR)
+    .filter(f => /^em-.+\.mjs$/.test(f))
+    .map(f => f.slice(3, -4))
+    .sort()
+}
+
+function printHelp(asJson) {
+  const cmds = availableCommands()
+  if (asJson) {
+    console.log(JSON.stringify({
+      status: 'help',
+      script: 'em.mjs',
+      usage: 'em <command> [args...] — every command supports --help',
+      commands: cmds.map(c => ({ command: c, description: DESCRIPTIONS[c] || '' }))
+    }))
+    return
+  }
+  const pad = Math.max(...cmds.map(c => c.length)) + 2
+  console.log('em — episodic memory for AI coding agents')
+  console.log('')
+  console.log('Usage: em <command> [args...]   (every command supports --help)')
+  console.log('')
+  console.log('Commands:')
+  for (const c of cmds) {
+    console.log(`  ${c.padEnd(pad)}${DESCRIPTIONS[c] || ''}`)
+  }
+  console.log('')
+  console.log('Common flags: --scope local|global|all, --project <name>, --limit <n>')
+  console.log('Start here:   em recall            (what does memory know right now?)')
+  console.log('              em doctor            (is everything healthy?)')
+  console.log('Docs:         https://github.com/lantisprime/episodic-memory')
+}
+
+const argv = process.argv.slice(2)
+const command = argv[0]
+
+if (!command || command === 'help' || command === '--help' || command === '-h') {
+  printHelp(argv.includes('--json'))
+  process.exit(command ? 0 : 1)
+}
+
+function editDistance(a, b) {
+  const dp = Array.from({ length: a.length + 1 }, (_, i) => [i, ...Array(b.length).fill(0)])
+  for (let j = 0; j <= b.length; j++) dp[0][j] = j
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      )
+    }
+  }
+  return dp[a.length][b.length]
+}
+
+const target = path.join(SCRIPT_DIR, `em-${command}.mjs`)
+if (!/^[a-z][a-z0-9-]*$/.test(command) || !fs.existsSync(target)) {
+  const cmds = availableCommands()
+  const close = cmds.filter(c => editDistance(c, command) <= 2 || c.startsWith(command))
+  console.log(JSON.stringify({
+    status: 'error',
+    message: `Unknown command "${command}". Run "em help" for the command list.`,
+    ...(close.length ? { did_you_mean: close } : {})
+  }))
+  process.exit(2)
+}
+
+const r = spawnSync(process.execPath, [target, ...argv.slice(1)], { stdio: 'inherit' })
+process.exit(r.status === null ? 1 : r.status)

--- a/scripts/install-wizard.mjs
+++ b/scripts/install-wizard.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * install-wizard.mjs — interactive guided setup for episodic-memory.
+ * Invoked via `node install.mjs --wizard` (or directly). Repo-dev script:
+ * runs from the clone, ships nowhere (Principle 12 — it drives install.mjs,
+ * which is only meaningful clone-side).
+ *
+ * Three flows:
+ *   install  — prerequisite checks → tool + project selection → optional
+ *              Claude Code hooks / second-opinion → optional backup config →
+ *              runs install.mjs non-interactively per tool → PATH shim offer
+ *              → verifies the result with em-doctor.
+ *   migrate  — clone (or reuse) an em-backup repository and restore it into
+ *              the stores via em-restore (dry-run preview, then confirmed
+ *              --apply), then verify with em-doctor.
+ *   doctor   — health-check the stores; offer --fix when issues are found.
+ *
+ * Answers are read from stdin, so the wizard is scriptable:
+ *   printf '1\n1\n/path/to/proj\nn\nn\nn\n' | node install.mjs --wizard
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import readline from 'readline/promises'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const REPO_DIR = path.dirname(SCRIPT_DIR)
+const INSTALL = path.join(REPO_DIR, 'install.mjs')
+const HOME = os.homedir()
+const GLOBAL_DIR = path.join(HOME, '.episodic-memory')
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'install-wizard.mjs', usage: 'node install.mjs --wizard — interactive guided setup (install | migrate-from-backup | doctor)' }))
+  process.exit(0)
+}
+
+// Buffered line reader. Plain rl.question() drops piped lines that arrive
+// while no question is pending (and leaves an unsettled await at EOF), which
+// breaks the scriptable `printf '...' | node install.mjs --wizard` shape.
+// Queue every line as it arrives; EOF resolves pending/future asks to null
+// (callers then take the default), so the wizard can never hang.
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: process.stdin.isTTY === true })
+const lineQueue = []
+let stdinClosed = false
+let lineWaiter = null
+rl.on('line', line => {
+  if (lineWaiter) { const w = lineWaiter; lineWaiter = null; w(line) }
+  else lineQueue.push(line)
+})
+rl.on('close', () => {
+  stdinClosed = true
+  if (lineWaiter) { const w = lineWaiter; lineWaiter = null; w(null) }
+})
+
+function nextLine() {
+  if (lineQueue.length) return Promise.resolve(lineQueue.shift())
+  if (stdinClosed) return Promise.resolve(null)
+  return new Promise(resolve => { lineWaiter = resolve })
+}
+
+async function ask(question, def) {
+  const suffix = def !== undefined && def !== '' ? ` [${def}]` : ''
+  process.stdout.write(`${question}${suffix}: `)
+  const raw = await nextLine()
+  if (raw === null) { process.stdout.write('(eof — using default)\n'); return def ?? '' }
+  const answer = raw.trim()
+  return answer === '' ? (def ?? '') : answer
+}
+
+async function askYesNo(question, defYes = false) {
+  process.stdout.write(`${question} [${defYes ? 'Y/n' : 'y/N'}]: `)
+  const raw = await nextLine()
+  if (raw === null) { process.stdout.write('(eof — using default)\n'); return defYes }
+  const answer = raw.trim().toLowerCase()
+  if (answer === '') return defYes
+  return answer === 'y' || answer === 'yes'
+}
+
+function expandHome(p) {
+  if (!p) return p
+  if (p === '~') return HOME
+  if (p.startsWith('~/')) return path.join(HOME, p.slice(2))
+  return p
+}
+
+function runVisible(cmd, args, opts) {
+  console.log(`\n$ ${cmd === process.execPath ? 'node' : cmd} ${args.join(' ')}`)
+  return spawnSync(cmd, args, { stdio: 'inherit', ...opts })
+}
+
+function runJson(args, opts) {
+  const r = spawnSync(process.execPath, args, { encoding: 'utf8', ...opts })
+  let json = null
+  try { json = JSON.parse((r.stdout || '').trim().split('\n').pop()) } catch {}
+  return { code: r.status, json, stdout: r.stdout || '', stderr: r.stderr || '' }
+}
+
+const OK = '  ✓'
+const BAD = '  ✗'
+
+// ---------------------------------------------------------------------------
+// Step 1: prerequisites. Zero npm dependencies by design — the "dependencies"
+// are the two runtime tools everything else assumes.
+// ---------------------------------------------------------------------------
+function checkPrerequisites() {
+  console.log('\n[1/2] Checking prerequisites (zero npm dependencies — Node.js stdlib only)')
+  const nodeMajor = parseInt(process.versions.node.split('.')[0], 10)
+  if (nodeMajor >= 18) {
+    console.log(`${OK} Node.js ${process.versions.node}`)
+  } else {
+    console.log(`${BAD} Node.js ${process.versions.node} — version 18+ required. Install a current LTS from https://nodejs.org and re-run.`)
+    return false
+  }
+  const git = spawnSync('git', ['--version'], { encoding: 'utf8' })
+  if (git.status === 0) {
+    console.log(`${OK} ${git.stdout.trim()}`)
+  } else {
+    console.log(`${BAD} git not found — required for backup/restore and updating the clone. Install git, or continue without backup features.`)
+  }
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Install flow
+// ---------------------------------------------------------------------------
+const TOOL_MENU = [
+  ['claude-code', 'Claude Code (skill + optional session hooks)'],
+  ['cursor', 'Cursor (.cursor/rules)'],
+  ['codex', 'Codex / OpenAI (.agents/skills)'],
+  ['windsurf', 'Windsurf / Continue (.windsurfrules)'],
+  ['opencode', 'OpenCode (.opencode/skills)'],
+  ['pi-agent', 'Pi Agent (.agents/skills, shared with Codex)'],
+]
+
+async function flowInstall() {
+  // --- tools ---------------------------------------------------------------
+  console.log('\nWhich tools should share the memory? (all selected tools read/write the SAME store)')
+  TOOL_MENU.forEach(([id, desc], i) => console.log(`  ${i + 1}. ${id.padEnd(12)} ${desc}`))
+  const rawTools = await ask('Select by number, comma-separated, or "all"', '1')
+  let tools
+  if (rawTools.toLowerCase() === 'all') {
+    tools = TOOL_MENU.map(([id]) => id)
+  } else {
+    tools = [...new Set(rawTools.split(',').map(s => parseInt(s.trim(), 10)))]
+      .filter(n => n >= 1 && n <= TOOL_MENU.length)
+      .map(n => TOOL_MENU[n - 1][0])
+  }
+  if (tools.length === 0) {
+    console.log('No valid tool selection — aborting.')
+    return 1
+  }
+
+  // --- project -------------------------------------------------------------
+  let projectDir
+  for (let attempts = 0; ; attempts++) {
+    if (attempts >= 3) {
+      console.log('No usable project path after 3 attempts — aborting.')
+      return 1
+    }
+    projectDir = path.resolve(expandHome(await ask('Project to install into (absolute path)', process.cwd())))
+    if (path.resolve(projectDir) === path.resolve(REPO_DIR)) {
+      const sure = await askYesNo('That is the episodic-memory clone itself — installing here is usually a mistake. Continue anyway?', false)
+      if (!sure) continue
+    }
+    if (!fs.existsSync(projectDir)) {
+      if (await askYesNo(`${projectDir} does not exist. Create it?`, false)) {
+        fs.mkdirSync(projectDir, { recursive: true })
+      } else {
+        continue
+      }
+    }
+    break
+  }
+
+  // --- claude-code extras ----------------------------------------------------
+  const extras = []
+  if (tools.includes('claude-code')) {
+    if (await askYesNo('Install Claude Code session hooks (proactive recall on session start)?', true)) {
+      extras.push('--install-hooks')
+    }
+    if (await askYesNo('Install the second-opinion review harness registry?', false)) {
+      extras.push('--install-second-opinion')
+    }
+  }
+
+  // --- backup config ---------------------------------------------------------
+  await maybeConfigureBackup()
+
+  // --- run the installs -------------------------------------------------------
+  console.log(`\nInstalling for: ${tools.join(', ')}  →  ${projectDir}`)
+  for (const t of tools) {
+    const args = [INSTALL, '--tool', t, '--project', projectDir, ...(t === 'claude-code' ? extras : [])]
+    const r = runVisible(process.execPath, args)
+    if (r.status !== 0) {
+      console.log(`\n${BAD} install failed for ${t} (exit ${r.status}) — stopping here so you can inspect the output above.`)
+      return 1
+    }
+  }
+
+  await maybeAddPathShim()
+  return verifyWithDoctor(projectDir)
+}
+
+async function maybeConfigureBackup() {
+  const configPath = path.join(HOME, '.config/em-backup/config.json')
+  if (fs.existsSync(configPath)) {
+    console.log(`${OK} Backup already configured (${configPath})`)
+    return
+  }
+  if (!(await askYesNo('Configure automatic backup to a private git repository?', false))) return
+  const owner = await ask('GitHub owner (user/org) for the backup repo')
+  const repo = await ask('Backup repository name', 'episodic-memory-backup')
+  const backupDir = expandHome(await ask('Local backup working dir', '~/.local/share/episodic-memory-backup'))
+  if (!owner || !repo) {
+    console.log('  Skipping backup config (owner/repo required).')
+    return
+  }
+  const config = {
+    repo_owner: owner,
+    repo_name: repo,
+    backup_dir: backupDir,
+    sources: [{ src: '~/.episodic-memory', dest: 'global', label: 'global' }],
+  }
+  fs.mkdirSync(path.dirname(configPath), { recursive: true })
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8')
+  console.log(`${OK} Wrote ${configPath}`)
+  console.log('    Initialize + first sync when ready:  em backup --init && em backup --sync')
+}
+
+async function maybeAddPathShim() {
+  const binDir = path.join(GLOBAL_DIR, 'bin')
+  if ((process.env.PATH || '').split(path.delimiter).includes(binDir)) {
+    console.log(`${OK} ${binDir} already on PATH — the "em" command is ready`)
+    return
+  }
+  const exportLine = 'export PATH="$HOME/.episodic-memory/bin:$PATH"'
+  const shell = process.env.SHELL || ''
+  const rc = shell.endsWith('zsh') ? path.join(HOME, '.zshrc')
+    : shell.endsWith('bash') ? path.join(HOME, '.bashrc')
+    : path.join(HOME, '.profile')
+  if (await askYesNo(`Add the "em" command to your PATH via ${rc}?`, true)) {
+    const existing = fs.existsSync(rc) ? fs.readFileSync(rc, 'utf8') : ''
+    if (existing.includes('.episodic-memory/bin')) {
+      console.log(`${OK} ${rc} already references .episodic-memory/bin`)
+    } else {
+      fs.appendFileSync(rc, `\n# episodic-memory unified CLI\n${exportLine}\n`, 'utf8')
+      console.log(`${OK} Appended to ${rc} — restart your shell (or: source ${rc})`)
+    }
+  } else {
+    console.log(`    You can add it later:  ${exportLine}`)
+  }
+}
+
+function verifyWithDoctor(projectDir) {
+  console.log('\n[verify] Running em-doctor against the fresh install...')
+  const doctor = path.join(GLOBAL_DIR, 'scripts', 'em-doctor.mjs')
+  const r = runJson([fs.existsSync(doctor) ? doctor : path.join(SCRIPT_DIR, 'em-doctor.mjs'), '--scope', 'all'], { cwd: projectDir })
+  if (r.json) {
+    const { ok, warn, error } = r.json.summary
+    console.log(`  doctor: ${r.json.status} (${ok} ok, ${warn} warn, ${error} error)`)
+    for (const c of r.json.checks.filter(c => c.level !== 'ok')) {
+      console.log(`  ${c.level.toUpperCase().padEnd(5)} [${c.id}] ${c.message}`)
+    }
+  }
+  console.log('\nDone. Try it out:')
+  console.log('  em recall            # what does memory know about this project?')
+  console.log('  em store --help      # save your first episode')
+  console.log('  em doctor            # re-check health any time')
+  return r.code === 0 ? 0 : 1
+}
+
+// ---------------------------------------------------------------------------
+// Migrate flow — restore stores from an em-backup repository (new machine, or
+// disaster recovery).
+// ---------------------------------------------------------------------------
+async function flowMigrate() {
+  console.log('\nMigrate: restore episodic stores from an em-backup repository.')
+  console.log('Note: backups are content-redacted at backup time; restore cannot undo redaction.')
+
+  const source = await ask('Backup source — git URL (git@.../https://...) or existing local backup dir')
+  if (!source) {
+    console.log('A source is required — aborting.')
+    return 1
+  }
+
+  let backupDir = expandHome(source)
+  if (!fs.existsSync(backupDir)) {
+    // Treat as a git URL and clone it.
+    backupDir = expandHome(await ask('Clone backup into', '~/.local/share/episodic-memory-backup'))
+    if (fs.existsSync(backupDir) && fs.readdirSync(backupDir).length > 0) {
+      console.log(`${BAD} ${backupDir} exists and is not empty — pass it directly as a local dir, or choose another location.`)
+      return 1
+    }
+    const clone = runVisible('git', ['clone', source, backupDir])
+    if (clone.status !== 0) {
+      console.log(`${BAD} git clone failed — check the URL and your access, then re-run.`)
+      return 1
+    }
+  }
+
+  const target = expandHome(await ask('Restore the "global" store into', '~/.episodic-memory'))
+  const restore = path.join(SCRIPT_DIR, 'em-restore.mjs')
+  const baseArgs = [restore, '--from', backupDir, '--source-map', `global=${target}`]
+
+  console.log('\n[preview] Dry run (no disk writes):')
+  const dry = runVisible(process.execPath, [...baseArgs, '--dry-run'])
+  if (dry.status !== 0) {
+    console.log(`${BAD} dry-run failed — inspect the output above (is this a valid em-backup repo?).`)
+    return 1
+  }
+
+  if (!(await askYesNo('Apply this restore?', false))) {
+    console.log('Left everything untouched (dry-run only).')
+    return 0
+  }
+  const apply = runVisible(process.execPath, [...baseArgs, '--apply', '--rebuild-index'])
+  if (apply.status !== 0) {
+    console.log(`${BAD} restore failed — the output above has the reason.`)
+    return 1
+  }
+  return verifyWithDoctor(process.cwd())
+}
+
+// ---------------------------------------------------------------------------
+// Doctor flow
+// ---------------------------------------------------------------------------
+async function flowDoctor() {
+  const doctorInstalled = path.join(GLOBAL_DIR, 'scripts', 'em-doctor.mjs')
+  const doctor = fs.existsSync(doctorInstalled) ? doctorInstalled : path.join(SCRIPT_DIR, 'em-doctor.mjs')
+  const r = runJson([doctor, '--scope', 'all'], { cwd: process.cwd() })
+  if (!r.json) {
+    console.log(`${BAD} doctor did not produce a report (exit ${r.code})`)
+    return 1
+  }
+  const { ok, warn, error } = r.json.summary
+  console.log(`\ndoctor: ${r.json.status} (${ok} ok, ${warn} warn, ${error} error)`)
+  for (const c of r.json.checks) {
+    console.log(`  ${c.level === 'ok' ? OK.trim() : c.level.toUpperCase().padEnd(5)} [${c.id}${c.scope !== '-' ? `:${c.scope}` : ''}] ${c.message}`)
+  }
+  if (r.json.status !== 'ok' && (await askYesNo('Attempt automatic repair (em-doctor --fix)?', true))) {
+    const f = runJson([doctor, '--scope', 'all', '--fix'], { cwd: process.cwd() })
+    if (f.json) {
+      console.log(`after --fix: ${f.json.status} (${f.json.summary.ok} ok, ${f.json.summary.warn} warn, ${f.json.summary.error} error)`)
+      return f.code === 0 ? 0 : 1
+    }
+    return 1
+  }
+  return r.json.status === 'ok' ? 0 : 1
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+console.log('episodic-memory setup wizard')
+console.log('════════════════════════════')
+
+if (!checkPrerequisites()) {
+  rl.close()
+  process.exit(1)
+}
+
+console.log('\n[2/2] What would you like to do?')
+console.log('  1. install   Set up episodic memory for your AI coding tools')
+console.log('  2. migrate   Restore memory stores from an em-backup repository')
+console.log('  3. doctor    Health-check an existing installation')
+const action = await ask('Choose', '1')
+
+let exit = 1
+try {
+  if (action === '1' || action === 'install') exit = await flowInstall()
+  else if (action === '2' || action === 'migrate') exit = await flowMigrate()
+  else if (action === '3' || action === 'doctor') exit = await flowDoctor()
+  else console.log(`Unknown choice "${action}" — expected 1, 2, or 3.`)
+} finally {
+  rl.close()
+}
+process.exit(exit)

--- a/scripts/lib/install-manifest.mjs
+++ b/scripts/lib/install-manifest.mjs
@@ -195,7 +195,9 @@ export function isEnforcementEntryScript(basename) {
 //   enforcement → per-project  (isEnforcementEntryScript + ENFORCEMENT_HOOK_SCRIPTS)
 //   repo-dev    → nowhere       (isRepoDevScript — the remainder)
 // ───────────────────────────────────────────────────────────────────────────
-const SUBSTRATE_CAPABILITY_SCRIPTS = new Set(['second-opinion.mjs'])
+// em.mjs is the unified CLI dispatcher over the em-* substrate scripts — it
+// doesn't match the em-* pattern (no dash) so it's allowlisted by name.
+const SUBSTRATE_CAPABILITY_SCRIPTS = new Set(['second-opinion.mjs', 'em.mjs'])
 export function isSubstrateScript(basename) {
   if (ENFORCEMENT_HOOK_SCRIPTS.includes(basename)) return false
   return /^em-.+\.mjs$/.test(basename) || SUBSTRATE_CAPABILITY_SCRIPTS.has(basename)

--- a/scripts/lib/relevance.mjs
+++ b/scripts/lib/relevance.mjs
@@ -1,0 +1,209 @@
+// relevance.mjs — shared retrieval primitives for the memory substrate.
+//
+// Single source of truth for the functions em-search.mjs and em-recall.mjs
+// previously duplicated under SYNC: comments (computeScore, loadIndex,
+// normalizeTags, loadTagsIndex, writeBackAccessTracking), plus the tokenized
+// multi-term text matcher that upgrades --query from exact-substring-only to
+// field-weighted token matching.
+//
+// Scoring contract (pinned by tests/test-phase2.mjs — do not reorder tiers):
+//   exact summary match            → text_match 1.0
+//   whole-query substring, summary → text_match 0.7
+//   all query tokens found across
+//     summary/tags/body            → text_match 0.95 × avg(per-token best
+//                                    field weight)  (max 0.665 — always below
+//                                    a contiguous summary substring match)
+//   whole-query substring, body    → text_match 0.4
+// The final signal is the MAX of the applicable tiers, so every query that
+// matched before this lib existed still matches with an identical score;
+// token matching only ADDS results (and never outranks a contiguous match
+// in the same field).
+//
+// Zero external dependencies — Node.js stdlib only.
+
+import fs from 'fs'
+import path from 'path'
+
+// Per-token field weights for the multi-term tier. Summary tokens count just
+// under a contiguous summary substring (0.7); tags sit between summary and
+// body; body tokens mirror the body-substring tier (0.4).
+export const FIELD_WEIGHTS = { summary: 0.7, tags: 0.6, body: 0.4 }
+
+// Discount applied to the averaged token weights so a scattered token match
+// can never tie a contiguous substring match in the same field.
+const TOKEN_MATCH_DISCOUNT = 0.95
+
+// ---------------------------------------------------------------------------
+// normalizeTags(raw) — comma string or array → lowercased, trimmed, deduped,
+// sorted tag list.
+// ---------------------------------------------------------------------------
+export function normalizeTags(raw) {
+  if (!raw) return []
+  const arr = (Array.isArray(raw) ? raw : raw.split(','))
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+  return [...new Set(arr)].sort()
+}
+
+// ---------------------------------------------------------------------------
+// loadTagsIndex(dataDir) / loadCategoryIndex(dataDir) — inverted indexes.
+// Return null when missing/corrupt (callers degrade to linear scan).
+// ---------------------------------------------------------------------------
+export function loadTagsIndex(dataDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dataDir, 'tags.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+export function loadCategoryIndex(dataDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dataDir, 'category-index.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// loadIndex(dataDir, source) — read index.jsonl rows, tagging each with the
+// scope it came from. Malformed lines are skipped, not fatal.
+// ---------------------------------------------------------------------------
+export function loadIndex(dataDir, source) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  if (!fs.existsSync(indexFile)) return []
+  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+    try {
+      const entry = JSON.parse(line)
+      entry._source = source
+      entry._dataDir = dataDir
+      return entry
+    } catch { return null }
+  }).filter(Boolean)
+}
+
+// ---------------------------------------------------------------------------
+// computeScore(entry, textMatchScore) — relevance = text match × linear time
+// decay (floored at 0.1 after ~1 year) × mild access-count boost.
+// ---------------------------------------------------------------------------
+export function computeScore(entry, textMatchScore) {
+  const accessCount = entry.access_count || 0
+  // Use new Date(entry.date) for decay — sub-day precision unnecessary
+  const created = new Date(entry.date)
+  const daysSince = Math.max(0, (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24))
+  const timeFactor = Math.max(0.1, 1 - (daysSince / 365))
+  const accessFactor = 1 + Math.log1p(accessCount) * 0.1
+  return textMatchScore * timeFactor * accessFactor
+}
+
+// ---------------------------------------------------------------------------
+// writeBackAccessTracking(results) — best-effort access_count/last_accessed
+// bump, grouped per source store. Last-writer-wins for concurrent searches.
+// ---------------------------------------------------------------------------
+export function writeBackAccessTracking(results) {
+  const byDir = new Map()
+  for (const e of results) {
+    if (!e._dataDir) continue
+    if (!byDir.has(e._dataDir)) byDir.set(e._dataDir, new Set())
+    byDir.get(e._dataDir).add(e.id)
+  }
+
+  const now = new Date().toISOString().slice(0, 19) + 'Z'
+
+  for (const [dataDir, ids] of byDir) {
+    const indexFile = path.join(dataDir, 'index.jsonl')
+    try {
+      // Re-read just before writing to narrow race window with concurrent em-store appends.
+      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
+      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      const updated = lines.map(line => {
+        try {
+          const entry = JSON.parse(line)
+          if (ids.has(entry.id)) {
+            entry.access_count = (entry.access_count || 0) + 1
+            entry.last_accessed = now
+          }
+          return JSON.stringify(entry)
+        } catch { return line }
+      })
+      const tmpFile = indexFile + '.tmp'
+      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
+      fs.renameSync(tmpFile, indexFile)
+    } catch {
+      // Access tracking is best-effort — skip silently on failure
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tokenizeQuery(text) — lowercase alphanumeric tokens (length ≥ 2), deduped,
+// input order preserved. The unit the multi-term tier matches on.
+// ---------------------------------------------------------------------------
+export function tokenizeQuery(text) {
+  if (!text) return []
+  return [...new Set(
+    text.toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length >= 2)
+  )]
+}
+
+// ---------------------------------------------------------------------------
+// scoreTextMatch(entry, query, readBody) — the tiered matcher.
+//
+//   entry:    index row ({ summary, tags, ... })
+//   query:    raw query string (case-insensitive)
+//   readBody: () => string|null — lazy body loader; called at most once, only
+//             when summary/tags alone cannot settle the match. Pass null to
+//             restrict matching to index fields.
+//
+// Returns { matched, textMatch, body } — body is the loaded content when
+// readBody was invoked (so callers can reuse it for --full output without a
+// second read), else undefined.
+// ---------------------------------------------------------------------------
+export function scoreTextMatch(entry, query, readBody) {
+  const queryLower = query.toLowerCase()
+  const summaryLower = (entry.summary || '').toLowerCase()
+
+  // Tier 1/2: contiguous match in summary — body never needs loading.
+  if (summaryLower.includes(queryLower)) {
+    return { matched: true, textMatch: summaryLower === queryLower ? 1.0 : 0.7 }
+  }
+
+  const tokens = tokenizeQuery(queryLower)
+  const tagsLower = normalizeTags(entry.tags).join(' ')
+
+  // Multi-term tier, index-field pass: which tokens already resolve from
+  // summary/tags? Only unresolved tokens force a body read.
+  const weights = new Map()
+  for (const tok of tokens) {
+    if (summaryLower.includes(tok)) weights.set(tok, FIELD_WEIGHTS.summary)
+    else if (tagsLower.includes(tok)) weights.set(tok, FIELD_WEIGHTS.tags)
+  }
+
+  const needsBody = tokens.length === 0 || weights.size < tokens.length
+  const body = needsBody && readBody ? readBody() : null
+  const bodyLower = body ? body.toLowerCase() : null
+
+  if (bodyLower) {
+    for (const tok of tokens) {
+      if (!weights.has(tok) && bodyLower.includes(tok)) weights.set(tok, FIELD_WEIGHTS.body)
+    }
+  }
+
+  let tokenScore = 0
+  if (tokens.length > 0 && weights.size === tokens.length) {
+    // AND semantics: every token must land somewhere. Score = discounted
+    // average of each token's best field weight.
+    let sum = 0
+    for (const w of weights.values()) sum += w
+    tokenScore = TOKEN_MATCH_DISCOUNT * (sum / tokens.length)
+  }
+
+  // Tier 4: whole-query substring in body (the pre-lib body tier).
+  const bodySubstring = bodyLower && bodyLower.includes(queryLower) ? FIELD_WEIGHTS.body : 0
+
+  const textMatch = Math.max(tokenScore, bodySubstring)
+  if (textMatch > 0) {
+    return { matched: true, textMatch, body: body || undefined }
+  }
+  return { matched: false, textMatch: 0 }
+}

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -26,6 +26,7 @@ import assert from 'node:assert/strict'
 // testing the guard via buildCanonicalPrompts is preempted by Node's
 // path.join() TypeError before the helper-layer guard executes.
 import { resolveLatestEpisodeId } from '../scripts/lib/bp1-manifest.mjs'
+import { computeLibClosure } from '../scripts/lib/install-manifest.mjs'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 const SCRIPT = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
@@ -352,11 +353,14 @@ function installRuntimeIntoProj(proj) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(proj, 'scripts', 'lib', lib))
   }
-  // em-search transitively imports lib/local-dir.mjs and (RFC-009 P1a) lib/categories.mjs
-  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'local-dir.mjs'),
-    path.join(proj, 'scripts', 'lib', 'local-dir.mjs'))
-  fs.copyFileSync(path.join(REPO, 'scripts', 'lib', 'categories.mjs'),
-    path.join(proj, 'scripts', 'lib', 'categories.mjs'))
+  // em-search's transitive lib closure, DERIVED (Rule 14) via computeLibClosure
+  // instead of a hand-maintained list — a new lib import inside em-search
+  // (e.g. relevance.mjs) can no longer drift past this fixture and crash the
+  // copied tree with ERR_MODULE_NOT_FOUND.
+  for (const lib of computeLibClosure(REPO, ['em-search.mjs'])) {
+    fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
+      path.join(proj, 'scripts', 'lib', lib))
+  }
   fs.copyFileSync(path.join(REPO, 'scripts', 'em-search.mjs'),
     path.join(proj, 'scripts', 'em-search.mjs'))
   fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),

--- a/tests/test-em-cli.mjs
+++ b/tests/test-em-cli.mjs
@@ -1,0 +1,108 @@
+/**
+ * test-em-cli.mjs — em.mjs unified dispatcher runtime probes.
+ *
+ * Covers: help output (human + --json), directory-driven command discovery,
+ * delegation with argument + exit-code passthrough, unknown-command
+ * suggestions, and rejection of path-shaped commands.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM = path.join(REPO, 'scripts/em.mjs');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function run(args, cwd, env) {
+  const r = spawnSync('node', [EM, ...args], { cwd: cwd || REPO, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout };
+}
+
+t('em help exits 0 and lists core commands', () => {
+  const r = run(['help']);
+  assert.equal(r.code, 0);
+  for (const c of ['store', 'search', 'recall', 'doctor', 'revise', 'prune']) {
+    assert.ok(r.stdout.includes(`  ${c}`), `help must list "${c}"`);
+  }
+});
+
+t('em with no args prints help but exits 1', () => {
+  const r = run([]);
+  assert.equal(r.code, 1);
+  assert.ok(r.stdout.includes('Usage: em <command>'));
+});
+
+t('em help --json emits machine-readable command table', () => {
+  const r = run(['help', '--json']);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'help');
+  const cmds = r.json.commands.map(c => c.command);
+  assert.ok(cmds.includes('search') && cmds.includes('doctor'));
+  assert.ok(r.json.commands.find(c => c.command === 'doctor').description.length > 0);
+});
+
+t('command discovery is directory-driven (every em-*.mjs is dispatchable)', () => {
+  const r = run(['help', '--json']);
+  const onDisk = fs.readdirSync(path.join(REPO, 'scripts'))
+    .filter(f => /^em-.+\.mjs$/.test(f)).map(f => f.slice(3, -4)).sort();
+  assert.deepEqual(r.json.commands.map(c => c.command), onDisk);
+});
+
+t('delegation: em store → em search round-trip in isolated store', () => {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emcli-')));
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emcli-home-')));
+  const env = { HOME: home };
+  const s = run(['store', '--project', 'fx', '--category', 'decision', '--summary', 'via dispatcher',
+    '--body', 'stored through em.mjs', '--tags', 'cli', '--scope', 'local'], cwd, env);
+  assert.equal(s.code, 0);
+  assert.equal(s.json.status, 'ok');
+  const q = run(['search', '--query', 'via dispatcher', '--scope', 'local', '--no-track'], cwd, env);
+  assert.equal(q.json.count, 1);
+  fs.rmSync(cwd, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+t('delegated exit codes pass through (invalid scope → 1)', () => {
+  const r = run(['search', '--scope', 'bogus']);
+  assert.equal(r.code, 1);
+  assert.equal(r.json.status, 'error');
+});
+
+t('unknown command → exit 2 with did_you_mean suggestion', () => {
+  const r = run(['sarch']);
+  assert.equal(r.code, 2);
+  assert.equal(r.json.status, 'error');
+  assert.ok(r.json.did_you_mean.includes('search'));
+});
+
+t('path-shaped command is rejected, not resolved', () => {
+  const r = run(['../evil']);
+  assert.equal(r.code, 2);
+  assert.equal(r.json.status, 'error');
+});
+
+t('help table stays in sync: every described command exists on disk', () => {
+  // guards against DESCRIPTIONS drifting ahead of real scripts
+  const src = fs.readFileSync(EM, 'utf8');
+  const described = [...src.matchAll(/^\s{2}'?([a-z][a-z0-9-]*)'?:\s'/gm)].map(m => m[1]);
+  const onDisk = new Set(fs.readdirSync(path.join(REPO, 'scripts'))
+    .filter(f => /^em-.+\.mjs$/.test(f)).map(f => f.slice(3, -4)));
+  for (const d of described) {
+    assert.ok(onDisk.has(d), `DESCRIPTIONS entry "${d}" has no em-${d}.mjs on disk`);
+  }
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-em-doctor.mjs
+++ b/tests/test-em-doctor.mjs
@@ -126,6 +126,31 @@ t('live lock is NOT flagged stale; --strict escalates warns to exit 1', () => {
   assert.equal(r.code, 0, 'warns alone must not fail without --strict');
 });
 
+// ---------------------------------------------------------------------------
+const deviant = mkFixture();
+
+t('#448: hand-appended row without date/time → row-shape warn; --fix backfills from id prefix', () => {
+  // The real incident shape: foreign-harness episode with `created:` instead
+  // of date:/time:, plus a hand-appended index row missing both fields.
+  const id = '20260702-141607-p5b-1-s2-b1bc';
+  fs.writeFileSync(path.join(deviant.store, 'episodes', `${id}.md`), [
+    '---', `id: ${id}`, 'created: 2026-07-02', 'project: pi-extensions',
+    'category: decision', 'tags: [p5b]', 'summary: hand-authored', '---', '', 'body', '',
+  ].join('\n'));
+  fs.appendFileSync(path.join(deviant.store, 'index.jsonl'),
+    JSON.stringify({ id, project: 'pi-extensions', category: 'decision', tags: ['p5b'], summary: 'hand-authored' }) + '\n');
+
+  let r = run(['--scope', 'local'], deviant.cwd, deviant.env);
+  assert.equal(check(r.json, 'row-shape').level, 'warn');
+
+  r = run(['--scope', 'local', '--fix'], deviant.cwd, deviant.env);
+  assert.equal(check(r.json, 'row-shape').level, 'ok', `row-shape must repair:\n${r.stdout}`);
+  const row = fs.readFileSync(path.join(deviant.store, 'index.jsonl'), 'utf8')
+    .split('\n').filter(Boolean).map(l => JSON.parse(l)).find(e => e.id === id);
+  assert.equal(row.date, '2026-07-02', 'date backfilled from id prefix');
+  assert.equal(row.time, '14:16', 'time backfilled from id prefix');
+});
+
 t('missing store is ok (created on first use), not an error', () => {
   const emptyCwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-empty-')));
   const r = run(['--scope', 'local'], emptyCwd, warned.env);
@@ -133,7 +158,7 @@ t('missing store is ok (created on first use), not an error', () => {
   fs.rmSync(emptyCwd, { recursive: true, force: true });
 });
 
-for (const f of [healthy, sick, warned]) {
+for (const f of [healthy, sick, warned, deviant]) {
   fs.rmSync(f.cwd, { recursive: true, force: true });
   fs.rmSync(f.home, { recursive: true, force: true });
 }

--- a/tests/test-em-doctor.mjs
+++ b/tests/test-em-doctor.mjs
@@ -1,0 +1,141 @@
+/**
+ * test-em-doctor.mjs — em-doctor.mjs runtime probes against isolated fixture
+ * stores (real script, real corruption, isolated HOME).
+ *
+ * Covers: healthy store → ok/exit 0; each corruption class detected at the
+ * right level; --fix repairs rebuildable + removable findings and re-verifies;
+ * --strict escalates warns to exit 1; invalid scope → exit 2.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_DOCTOR = path.join(REPO, 'scripts/em-doctor.mjs');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function run(args, cwd, env) {
+  const r = spawnSync('node', [EM_DOCTOR, ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout };
+}
+
+function check(json, id) {
+  return json.checks.find(c => c.id === id);
+}
+
+function mkFixture() {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-')));
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-home-')));
+  const env = { HOME: home };
+  for (let i = 0; i < 3; i++) {
+    spawnSync('node', [EM_STORE, '--project', 'fx', '--category', 'decision',
+      '--summary', `episode ${i}`, '--body', `body ${i}`, '--tags', 'fx', '--scope', 'local'],
+      { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  }
+  return { cwd, home, env, store: path.join(cwd, '.episodic-memory') };
+}
+
+// ---------------------------------------------------------------------------
+const healthy = mkFixture();
+
+t('healthy store → status ok, exit 0, no warn/error', () => {
+  const r = run(['--scope', 'local'], healthy.cwd, healthy.env);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'ok');
+  assert.equal(r.json.summary.error, 0);
+  for (const id of ['index-parse', 'index-drift', 'tags-index', 'category-index', 'supersedes-links', 'tmp-litter', 'stale-locks']) {
+    assert.equal(check(r.json, id).level, 'ok', `${id} should be ok`);
+  }
+});
+
+t('invalid --scope → exit 2', () => {
+  const r = run(['--scope', 'bogus'], healthy.cwd, healthy.env);
+  assert.equal(r.code, 2);
+  assert.equal(r.json.status, 'error');
+});
+
+t('--help short-circuits', () => {
+  const r = run(['--help'], healthy.cwd, healthy.env);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.status, 'help');
+});
+
+// ---------------------------------------------------------------------------
+const sick = mkFixture();
+
+t('corruptions detected: bad index line, missing tags.json, deleted episode file, stale tmp+lock', () => {
+  fs.appendFileSync(path.join(sick.store, 'index.jsonl'), 'NOT-JSON\n');
+  fs.rmSync(path.join(sick.store, 'tags.json'));
+  const anyEp = fs.readdirSync(path.join(sick.store, 'episodes'))[0];
+  fs.rmSync(path.join(sick.store, 'episodes', anyEp));
+  const oldTmp = path.join(sick.store, 'leftover.tmp');
+  fs.writeFileSync(oldTmp, 'x');
+  fs.utimesSync(oldTmp, new Date(Date.now() - 2 * 3600e3), new Date(Date.now() - 2 * 3600e3));
+  fs.writeFileSync(path.join(sick.store, 'dead.lock'), '999999');
+
+  const r = run(['--scope', 'local'], sick.cwd, sick.env);
+  assert.equal(r.code, 1);
+  assert.equal(r.json.status, 'issues');
+  assert.equal(check(r.json, 'index-parse').level, 'error');
+  assert.equal(check(r.json, 'index-drift').level, 'error');
+  assert.equal(check(r.json, 'tags-index').level, 'warn');
+  assert.equal(check(r.json, 'tmp-litter').level, 'warn');
+  assert.equal(check(r.json, 'stale-locks').level, 'warn');
+});
+
+t('--fix repairs and re-verifies: store returns to full health', () => {
+  const r = run(['--scope', 'local', '--fix'], sick.cwd, sick.env);
+  assert.equal(r.code, 0, `expected clean exit, got ${r.stdout}`);
+  assert.equal(r.json.status, 'ok');
+  assert.ok(r.json.fixes.some(f => f.action === 'rebuild-index' && f.exit === 0), 'rebuild-index fix must run');
+  assert.ok(r.json.fixes.some(f => f.action === 'removed-tmp'), 'stale tmp must be removed');
+  assert.ok(r.json.fixes.some(f => f.action === 'removed-stale-lock'), 'stale lock must be removed');
+  for (const id of ['index-parse', 'index-drift', 'tags-index', 'tmp-litter', 'stale-locks']) {
+    assert.equal(check(r.json, id).level, 'ok', `${id} should be ok after --fix`);
+  }
+  assert.ok(!fs.existsSync(path.join(sick.store, 'dead.lock')));
+  assert.ok(!fs.existsSync(path.join(sick.store, 'leftover.tmp')));
+});
+
+// ---------------------------------------------------------------------------
+const warned = mkFixture();
+
+t('live lock is NOT flagged stale; --strict escalates warns to exit 1', () => {
+  // live lock: our own pid
+  fs.writeFileSync(path.join(warned.store, 'live.lock'), String(process.pid));
+  let r = run(['--scope', 'local'], warned.cwd, warned.env);
+  assert.equal(check(r.json, 'stale-locks').level, 'ok');
+  assert.equal(r.code, 0);
+  // add a warn-level finding, then --strict must exit 1
+  fs.rmSync(path.join(warned.store, 'tags.json'));
+  r = run(['--scope', 'local', '--strict'], warned.cwd, warned.env);
+  assert.equal(r.code, 1);
+  r = run(['--scope', 'local'], warned.cwd, warned.env);
+  assert.equal(r.code, 0, 'warns alone must not fail without --strict');
+});
+
+t('missing store is ok (created on first use), not an error', () => {
+  const emptyCwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-empty-')));
+  const r = run(['--scope', 'local'], emptyCwd, warned.env);
+  assert.equal(check(r.json, 'store').level, 'ok');
+  fs.rmSync(emptyCwd, { recursive: true, force: true });
+});
+
+for (const f of [healthy, sick, warned]) {
+  fs.rmSync(f.cwd, { recursive: true, force: true });
+  fs.rmSync(f.home, { recursive: true, force: true });
+}
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-install-wizard.mjs
+++ b/tests/test-install-wizard.mjs
@@ -1,0 +1,127 @@
+/**
+ * test-install-wizard.mjs — wizard E2E probes: real install.mjs --wizard runs
+ * with piped answers against isolated HOMEs (the scriptable stdin contract).
+ *
+ * Covers: install flow (tool install + PATH rc append + doctor verify),
+ * migrate flow (git-backed backup fixture → dry-run → apply → episodes land),
+ * doctor flow, EOF safety (starved stdin must terminate, not hang), and the
+ * clone-itself guard.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const INSTALL = path.join(REPO, 'install.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function wizard(answers, env, opts) {
+  return spawnSync('node', [INSTALL, '--wizard'], {
+    input: answers.join('\n') + '\n',
+    encoding: 'utf8',
+    cwd: REPO,
+    timeout: 120000,
+    env: { ...process.env, SHELL: '/bin/bash', ...env },
+    ...opts,
+  });
+}
+
+function mkHome(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+// ---------------------------------------------------------------------------
+t('install flow: cursor install + PATH append + doctor verify, exit 0', () => {
+  const home = mkHome('wiz-install-');
+  const proj = path.join(home, 'proj');
+  fs.mkdirSync(proj);
+  // action=install, tools=2 (cursor), project, backup=n, PATH=y
+  const r = wizard(['1', '2', proj, 'n', 'y'], { HOME: home });
+  assert.equal(r.status, 0, `exit ${r.status}\n${r.stdout}\n${r.stderr}`);
+  assert.ok(fs.existsSync(path.join(proj, '.cursor/rules/episodic-memory.mdc')), 'cursor rules must install');
+  assert.ok(fs.existsSync(path.join(home, '.episodic-memory/bin/em')), 'em shim must install');
+  assert.ok(fs.readFileSync(path.join(home, '.bashrc'), 'utf8').includes('.episodic-memory/bin'), 'PATH export must append to rc');
+  assert.ok(r.stdout.includes('doctor: ok'), `doctor must verify clean:\n${r.stdout}`);
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+t('clone-itself guard: default cwd (the repo) requires explicit confirmation', () => {
+  const home = mkHome('wiz-guard-');
+  // action=install, tools=1, project=<enter → cwd=REPO>, decline, then EOF
+  const r = wizard(['1', '1', '', 'n'], { HOME: home });
+  assert.ok(r.stdout.includes('episodic-memory clone itself'), 'must warn about installing into the clone');
+  assert.notEqual(r.status, 0, 'declining the guard with no fallback path must not succeed silently');
+  assert.ok(!fs.existsSync(path.join(home, '.episodic-memory/scripts')), 'no install may happen after declined guard');
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+t('EOF starvation terminates cleanly (no hang, defaults applied)', () => {
+  const home = mkHome('wiz-eof-');
+  const r = wizard([], { HOME: home }); // zero answers: every ask hits EOF
+  assert.notEqual(r.signal, 'SIGTERM', 'wizard must not hit the spawn timeout');
+  assert.ok(r.stdout.includes('setup wizard'), 'banner must print');
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+t('migrate flow: git backup fixture → apply → episodes restored + index rebuilt', () => {
+  const home = mkHome('wiz-migrate-');
+  const backup = mkHome('wiz-backup-');
+  // Build a minimal em-backup-shaped fixture: <backup>/global/episodes/*.md in a git repo.
+  const epDir = path.join(backup, 'global', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  const id = '20260101-000000-fixture-episode-abcd';
+  fs.writeFileSync(path.join(epDir, `${id}.md`), [
+    '---', `id: ${id}`, 'date: 2026-01-01', 'time: "00:00"', 'project: fx',
+    'category: decision', 'status: active', 'tags: [fixture]', 'summary: wizard migrate fixture', '---', '', 'body', '',
+  ].join('\n'));
+  const g = (args) => spawnSync('git', args, { cwd: backup, encoding: 'utf8' });
+  g(['init', '-q']);
+  g(['add', '-A']);
+  g(['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'snap']);
+
+  // action=migrate, source=backup dir, target=<enter → ~/.episodic-memory>, apply=y
+  const r = wizard(['2', backup, '', 'y'], { HOME: home });
+  assert.equal(r.status, 0, `exit ${r.status}\n${r.stdout}\n${r.stderr}`);
+  assert.ok(fs.existsSync(path.join(home, '.episodic-memory', 'episodes', `${id}.md`)), 'episode must be restored');
+  assert.ok(fs.existsSync(path.join(home, '.episodic-memory', 'index.jsonl')), 'index must be rebuilt');
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(backup, { recursive: true, force: true });
+});
+
+t('migrate flow: declining apply leaves the store untouched', () => {
+  const home = mkHome('wiz-dryrun-');
+  const backup = mkHome('wiz-drybk-');
+  const epDir = path.join(backup, 'global', 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  fs.writeFileSync(path.join(epDir, '20260101-000000-x-aaaa.md'),
+    '---\nid: 20260101-000000-x-aaaa\ndate: 2026-01-01\ntime: "00:00"\nproject: fx\ncategory: decision\nstatus: active\ntags: []\nsummary: x\n---\n\nbody\n');
+  const g = (args) => spawnSync('git', args, { cwd: backup, encoding: 'utf8' });
+  g(['init', '-q']); g(['add', '-A']); g(['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'snap']);
+
+  const r = wizard(['2', backup, '', 'n'], { HOME: home });
+  assert.equal(r.status, 0, `exit ${r.status}\n${r.stdout}`);
+  assert.ok(!fs.existsSync(path.join(home, '.episodic-memory', 'episodes')), 'declined apply must write nothing');
+  fs.rmSync(home, { recursive: true, force: true });
+  fs.rmSync(backup, { recursive: true, force: true });
+});
+
+t('doctor flow runs against the current stores', () => {
+  const home = mkHome('wiz-doctor-');
+  const r = wizard(['3', 'n'], { HOME: home });
+  assert.ok(r.stdout.includes('doctor:'), 'doctor summary must print');
+  assert.notEqual(r.signal, 'SIGTERM');
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-phase3.mjs
+++ b/tests/test-phase3.mjs
@@ -303,27 +303,27 @@ test('19. package.json keywords fed into effective tokens', () => {
 console.log('\n--- Drift Detection ---')
 // ===========================================================================
 
-test('20. Inlined functions match em-search.mjs source', () => {
+test('20. Retrieval primitives come from the shared lib, not inlined copies', () => {
+  // The formerly SYNC-duplicated functions live in lib/relevance.mjs. Drift is
+  // structurally impossible as long as BOTH scripts import them from the lib
+  // and NEITHER redeclares a local copy.
   const recallSrc = fs.readFileSync(path.join(SCRIPTS, 'em-recall.mjs'), 'utf8')
   const searchSrc = fs.readFileSync(path.join(SCRIPTS, 'em-search.mjs'), 'utf8')
+  const libSrc = fs.readFileSync(path.join(SCRIPTS, 'lib', 'relevance.mjs'), 'utf8')
 
-  // Extract function bodies by SYNC marker
-  const syncFunctions = ['normalizeTags', 'loadTagsIndex', 'computeScore', 'writeBackAccessTracking', 'loadIndex']
+  const sharedFunctions = ['normalizeTags', 'loadTagsIndex', 'computeScore', 'writeBackAccessTracking', 'loadIndex']
 
-  for (const fnName of syncFunctions) {
-    // Extract function body: from "function name(...) {" to the closing "}" at column 0
-    const fnRegex = new RegExp(`function ${fnName}\\([^)]*\\) \\{([\\s\\S]*?)\\n\\}`)
+  assert.ok(recallSrc.includes("from './lib/relevance.mjs'"), 'em-recall.mjs must import from lib/relevance.mjs')
+  assert.ok(searchSrc.includes("from './lib/relevance.mjs'"), 'em-search.mjs must import from lib/relevance.mjs')
 
-    const recallMatch = recallSrc.match(fnRegex)
-    const searchMatch = searchSrc.match(fnRegex)
-
-    assert.ok(recallMatch, `${fnName} not found in em-recall.mjs`)
-    assert.ok(searchMatch, `${fnName} not found in em-search.mjs`)
-
-    // Verify SYNC marker exists in recall
-    assert.ok(recallSrc.includes(`// SYNC: em-search.mjs:${fnName}`), `${fnName} missing SYNC marker in em-recall.mjs`)
-
-    assert.strictEqual(recallMatch[1].trim(), searchMatch[1].trim(), `${fnName} body differs between em-recall.mjs and em-search.mjs`)
+  for (const fnName of sharedFunctions) {
+    const declRegex = new RegExp(`function ${fnName}\\(`)
+    assert.ok(!declRegex.test(recallSrc), `${fnName} redeclared locally in em-recall.mjs — must come from lib/relevance.mjs`)
+    assert.ok(!declRegex.test(searchSrc), `${fnName} redeclared locally in em-search.mjs — must come from lib/relevance.mjs`)
+    assert.ok(new RegExp(`export function ${fnName}\\(`).test(libSrc), `${fnName} not exported by lib/relevance.mjs`)
+    // Both scripts must actually reference the shared name (import list / call site).
+    assert.ok(recallSrc.includes(fnName), `${fnName} unreferenced in em-recall.mjs`)
+    assert.ok(searchSrc.includes(fnName), `${fnName} unreferenced in em-search.mjs`)
   }
 })
 

--- a/tests/test-relevance.mjs
+++ b/tests/test-relevance.mjs
@@ -1,0 +1,177 @@
+/**
+ * test-relevance.mjs — lib/relevance.mjs unit tests + em-search/em-recall
+ * runtime probes for the tokenized multi-term matcher.
+ *
+ * Back-compat invariants (must match pre-lib behavior byte-for-byte):
+ *   exact summary → 1.0, summary substring → 0.7, body substring → 0.4.
+ * New capability: multi-term queries match when EVERY token lands in
+ * summary/tags/body, scored 0.95 × avg(field weights) — always below a
+ * contiguous summary substring match.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { tokenizeQuery, scoreTextMatch, normalizeTags, computeScore } from '../scripts/lib/relevance.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_SEARCH = path.join(REPO, 'scripts/em-search.mjs');
+const EM_RECALL = path.join(REPO, 'scripts/em-recall.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// ---------------------------------------------------------------------------
+// Unit: tokenizeQuery
+// ---------------------------------------------------------------------------
+t('tokenize splits on non-alphanumerics, lowercases, dedupes, keeps len>=2', () => {
+  assert.deepEqual(tokenizeQuery('Auth token-refresh AUTH x'), ['auth', 'token', 'refresh']);
+  assert.deepEqual(tokenizeQuery(''), []);
+  assert.deepEqual(tokenizeQuery('a b c'), []);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: scoreTextMatch tiers
+// ---------------------------------------------------------------------------
+const entry = { summary: 'Use atomic rename for index writes', tags: ['storage', 'index'] };
+const body = () => 'All index rebuilds go through a temp file plus rename step.';
+
+t('exact summary match → 1.0', () => {
+  const r = scoreTextMatch(entry, 'Use atomic rename for index writes', body);
+  assert.equal(r.matched, true);
+  assert.equal(r.textMatch, 1.0);
+});
+
+t('summary substring → 0.7', () => {
+  const r = scoreTextMatch(entry, 'atomic rename', body);
+  assert.equal(r.textMatch, 0.7);
+});
+
+t('body substring → 0.4', () => {
+  // tokens chosen so none appear in summary/tags — body tier decides alone
+  const r = scoreTextMatch(entry, 'temp file plus', body);
+  assert.equal(r.textMatch, 0.4);
+});
+
+t('mixed-field tokens beat plain body substring (max-of-tiers)', () => {
+  // "rename" resolves from summary (0.7), temp/file from body (0.4):
+  // 0.95 × avg(0.7,0.4,0.4) > 0.4 body tier
+  const r = scoreTextMatch(entry, 'temp file rename', body);
+  assert.ok(r.textMatch > 0.4, `got ${r.textMatch}`);
+});
+
+t('scattered tokens all in summary → 0.95 × 0.7 = 0.665', () => {
+  const r = scoreTextMatch(entry, 'index atomic writes', body);
+  assert.equal(r.matched, true);
+  assert.ok(Math.abs(r.textMatch - 0.665) < 1e-9, `got ${r.textMatch}`);
+});
+
+t('token match never outranks contiguous summary substring', () => {
+  const contiguous = scoreTextMatch(entry, 'atomic rename', body).textMatch;
+  const scattered = scoreTextMatch(entry, 'rename atomic index writes', body).textMatch;
+  assert.ok(scattered < contiguous, `${scattered} !< ${contiguous}`);
+});
+
+t('AND semantics: one unmatched token → no match', () => {
+  const r = scoreTextMatch(entry, 'atomic kubernetes', body);
+  assert.equal(r.matched, false);
+});
+
+t('tokens can resolve from tags (weight 0.6)', () => {
+  const e2 = { summary: 'Middleware ordering', tags: ['storage'] };
+  const r = scoreTextMatch(e2, 'storage middleware', () => null);
+  assert.equal(r.matched, true);
+  // avg(0.6 tags, 0.7 summary) × 0.95
+  assert.ok(Math.abs(r.textMatch - 0.95 * 0.65) < 1e-9, `got ${r.textMatch}`);
+});
+
+t('body loads lazily: summary-substring path never reads the body', () => {
+  let reads = 0;
+  const spyBody = () => { reads++; return 'body'; };
+  scoreTextMatch(entry, 'atomic rename', spyBody);
+  assert.equal(reads, 0);
+  scoreTextMatch(entry, 'temp file', spyBody);
+  assert.equal(reads, 1);
+});
+
+t('null readBody restricts matching to index fields without crashing', () => {
+  const r = scoreTextMatch(entry, 'temp file plus rename', null);
+  assert.equal(r.matched, false);
+});
+
+t('normalizeTags dedupes/sorts; computeScore floors time decay at 0.1', () => {
+  assert.deepEqual(normalizeTags('B, a ,b'), ['a', 'b']);
+  const old = { date: '2020-01-01', access_count: 0 };
+  const s = computeScore(old, 1.0);
+  assert.ok(Math.abs(s - 0.1) < 1e-9, `got ${s}`);
+});
+
+// ---------------------------------------------------------------------------
+// Runtime probes: real scripts against an isolated fixture store
+// ---------------------------------------------------------------------------
+function run(script, args, cwd, env) {
+  const r = spawnSync('node', [script, ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout };
+}
+
+const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'relevance-')));
+const fakeHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'relevance-home-')));
+const env = { HOME: fakeHome };
+
+run(EM_STORE, ['--project', 'fx', '--category', 'decision', '--summary', 'Use atomic rename for index writes',
+  '--body', 'All index rebuilds go through temp file plus rename.', '--tags', 'storage,index', '--scope', 'local'], cwd, env);
+run(EM_STORE, ['--project', 'fx', '--category', 'lesson', '--summary', 'Middleware ordering matters',
+  '--body', 'The atomic write rename pattern also applies here.', '--tags', 'auth', '--scope', 'local'], cwd, env);
+run(EM_STORE, ['--project', 'other', '--category', 'discovery', '--summary', 'Widget relevance heuristics',
+  '--body', 'unrelated', '--tags', 'misc', '--scope', 'local'], cwd, env);
+
+t('em-search: substring query behaves as before (score 0.7)', () => {
+  const r = run(EM_SEARCH, ['--query', 'atomic rename', '--scope', 'local', '--no-track'], cwd, env);
+  const hit = r.json.episodes.find(e => e.summary.startsWith('Use atomic'));
+  assert.ok(hit, 'summary-substring episode must match');
+  assert.equal(hit.score, 0.7);
+});
+
+t('em-search: scattered multi-term query now matches (new capability)', () => {
+  const r = run(EM_SEARCH, ['--query', 'index atomic writes', '--scope', 'local', '--no-track'], cwd, env);
+  assert.equal(r.json.count, 1);
+  assert.equal(r.json.episodes[0].score, 0.665);
+});
+
+t('em-search: body substring still matches at 0.4', () => {
+  const r = run(EM_SEARCH, ['--query', 'write rename pattern', '--scope', 'local', '--no-track'], cwd, env);
+  const hit = r.json.episodes.find(e => e.summary.startsWith('Middleware'));
+  assert.ok(hit);
+  assert.equal(hit.score, 0.4);
+});
+
+t('em-search: unmatched query returns empty', () => {
+  const r = run(EM_SEARCH, ['--query', 'kubernetes', '--scope', 'local', '--no-track'], cwd, env);
+  assert.equal(r.json.count, 0);
+});
+
+t('em-recall: pass 2b surfaces cross-project episodes via summary tokens', () => {
+  // package.json keyword "widget" (≥4 chars, not a stopword) becomes an
+  // effective token; the "other"-project episode has no matching tag but
+  // mentions widget in its SUMMARY → reachable only through pass 2b.
+  fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify({ name: 'fx', keywords: ['widget'] }));
+  const r = run(EM_RECALL, ['--scope', 'local', '--no-track', '--days', '0', '--limit', '10'], cwd, env);
+  const other = r.json.episodes.find(e => e.project === 'other');
+  assert.ok(other, `cross-project summary-token episode missing: ${JSON.stringify(r.json.episodes.map(e => e.summary))}`);
+  assert.equal(other.score, 0.6);
+});
+
+fs.rmSync(cwd, { recursive: true, force: true });
+fs.rmSync(fakeHome, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
End-to-end usability pass over the memory substrate — install → daily use → maintenance — in four commits.

## 1. Shared relevance lib + tokenized multi-term search (`scripts/lib/relevance.mjs`)
- The retrieval primitives previously duplicated between `em-search`/`em-recall` under `SYNC:` comments (`computeScore`, `loadIndex`, `normalizeTags`, `loadTagsIndex`, `writeBackAccessTracking`) now live in one lib; the phase3 drift guard (#20) was updated from byte-compare to an import-guard, so drift is structurally impossible.
- `--query` upgrades from exact-substring-only to tiered matching: exact summary `1.0` > summary substring `0.7` > **all query tokens found across summary/tags/body** (field-weighted, discounted so it never outranks a contiguous match) > body substring `0.4`. Every query that matched before keeps its identical score; multi-term queries like `"index atomic writes"` now find scattered-word episodes.
- `em-recall` pass 2b: context tokens matched against episode **summaries** (weight 0.6, between tag hit 0.7 and recency 0.5) — branch/keyword tokens rarely coincide with stored tags verbatim, so topical episodes were invisible to the tag-only pass.

## 2. `em-doctor` — one-command health check + repair
Checks per scope: index.jsonl parse, index↔episode-file drift (both directions), tags/category inverted-index consistency, dangling `supersedes`, stale `.tmp` litter, dead-pid `.lock` files, installed-script presence + byte-drift vs repo checkout, backup config. `--fix` rebuilds indexes and clears litter, then re-verifies; `--strict` for CI. Exit 0/1/2.

**Real bug caught by doctor on its first run:** `em-seed-patterns` never wrote `category-index.json`, so every *fresh install* degraded `--category` searches to the linear-scan fallback until a manual rebuild. Fixed in the seeder (mirrors the tags flush); a fresh install now doctors fully green.

## 3. Unified `em` CLI (`scripts/em.mjs` + `~/.episodic-memory/bin/em` shim)
`em store|search|recall|doctor|...` ≡ `node ~/.episodic-memory/scripts/em-<cmd>.mjs`. Directory-driven command discovery (new substrate scripts dispatch with zero changes here), human help table + `em help --json`, did-you-mean suggestions, exit-code passthrough, path-shaped commands rejected. Added to the P12 substrate allowlist; installer writes the bin shim and prints the PATH hint.

## 4. Wizard installer + migrate flow (`node install.mjs --wizard`)
Three flows, all driven by plain stdin lines (scriptable: `printf '…' | node install.mjs --wizard`):
- **install** — prereq checks (Node ≥18, git), tool multi-select, project path with a clone-itself guard, optional Claude Code hooks/second-opinion, optional em-backup config seeding, PATH rc append, final `em-doctor` verification.
- **migrate** — clone or reuse an em-backup repository, `em-restore` dry-run preview, confirmed `--apply --rebuild-index`, doctor verify. (New-machine restore path.)
- **doctor** — report + offered `--fix`.
Buffered stdin line queue so piped answers and EOF starvation terminate cleanly instead of hanging on an unsettled `rl.question`.

## Tests
39 new assertions across 4 new test files (all runtime probes on isolated fixture stores/HOMEs, per the repo's behavior-simulation rule): `test-relevance.mjs` (17), `test-em-doctor.mjs` (7), `test-em-cli.mjs` (9), `test-install-wizard.mjs` (6, real `install.mjs --wizard` E2E including a git-backed backup fixture).

Regression sweep green: phase2/phase3, category-search, em-recall-purity (36), seed-patterns, em-help-flags (29), p12-global-clean + p12-invariant-suite, install-dedup/categories/scripts-guide/second-opinion-e2e, migration-cutover, plugin-registry, validate-schemas, prune-lifecycle/protection, lib-closure, repo-source-parity, field-bindings, effective-tier, sort-missing-datetime.

Docs: README (wizard as recommended path, CLI quickstart, doctor + query-tier sections), EM_SCRIPTS_GUIDE (ships with installs), docs/install/* (wizard shape, doctor verify, script count 21→23).

Note: authored with explicit maintainer authorization to work outside the RFC/workplan process for this change set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RkVbV4ek4GrajQAWQG1Ut

---
_Generated by [Claude Code](https://claude.ai/code/session_013RkVbV4ek4GrajQAWQG1Ut)_