### PR TITLE
Fix #469: null-proto index maps so "constructor" keys can't hit Object.prototype

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -192,6 +192,12 @@ jobs:
       - name: Run RFC-009 P1a categories.json global-deploy mock E2E
         run: node tests/test-install-categories.mjs
 
+      - name: Run issue #469 prototype-key-collision regression tests
+        run: node tests/test-prototype-key-collision.mjs
+
+      - name: Run recall-v2 token-index suite (tokens.json write/read parity)
+        run: node tests/test-recall-v2.mjs
+
   p12-invariant-gate:
     # RFC-008 P4d S8 (REQ-10 / REQ-11): the three Principle-12 invariants as ONE
     # separately-named REQUIRED check. Membership is defined in code

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -43,7 +43,7 @@ import crypto from 'crypto'
 import { execFileSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { resolveLocalDir } from './lib/local-dir.mjs'
-import { normalizeTags, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
+import { normalizeTags, episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -131,8 +131,10 @@ function removeFromInverted(dataDir, fileName, id, warnings, pretty) {
 function addToInverted(dataDir, fileName, id, keys, pretty) {
   if (keys.length === 0) return
   const p = path.join(dataDir, fileName)
-  let idx = {}
-  try { idx = JSON.parse(fs.readFileSync(p, 'utf8')) } catch {}
+  // Null-proto: a tag/category key named "constructor" must not resolve to
+  // Object.prototype (issue #469)
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(p, 'utf8'))) } catch {}
   for (const key of keys) {
     if (!idx[key]) idx[key] = []
     if (!idx[key].includes(id)) idx[key].push(id)

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -135,13 +135,16 @@ function rebuildDir(dataDir, label) {
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []
 
-  const tagsIndex = {}
-  const tokensIndex = {}
+  // Null-proto maps: keys come from episode content (tags, tokens, category
+  // names), and "constructor" on a plain {} resolves to Object.prototype's
+  // inherited function instead of undefined (issue #469).
+  const tagsIndex = Object.create(null)
+  const tokensIndex = Object.create(null)
   // category-index + drift counts (R10d/R10f). Reader/index surface: if the vocab cannot load,
   // DEGRADE — build index.jsonl + tags.json as before and skip category-index (B1, I3).
-  const categoryIndex = {}
-  const driftUnknown = {}
-  const driftDeprecated = {}
+  const categoryIndex = Object.create(null)
+  const driftUnknown = Object.create(null)
+  const driftDeprecated = Object.create(null)
   let vocabLoaded = true
   try { loadCategories() } catch { vocabLoaded = false }
 

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -30,6 +30,7 @@ import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
+import { nullProtoIndex } from './lib/relevance.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -444,7 +445,8 @@ function mergeIndexes(targetDir, restoredEntries, conflictMode) {
   // single-output-boundary lesson (`20260503-134615-...-8457`) to file
   // ownership: tags.json is rebuilt EXCLUSIVELY from the merged index map,
   // never read from disk. em-rebuild-index uses the same discipline.
-  const tagsIndex = {}
+  // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+  const tagsIndex = Object.create(null)
   for (const id of sortedIds) {
     const e = merged.get(id)
     for (const tag of (e.tags || [])) {
@@ -1144,8 +1146,9 @@ function run(opts) {
       // RFC-009 R10d: merge the restored ids into category-index.json under their canonical
       // category key (temp+rename), mirroring the store/revise incremental maintenance.
       const catFile = path.join(targetDir, 'category-index.json')
-      let catIndex = {}
-      try { catIndex = JSON.parse(fs.readFileSync(catFile, 'utf8')) } catch {}
+      // Null-proto: unknown categories index under their literal key (issue #469)
+      let catIndex = Object.create(null)
+      try { catIndex = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8'))) } catch {}
       for (const fm of fms) {
         const key = canonicalCategory(fm.category)
         if (!catIndex[key]) catIndex[key] = []
@@ -1180,7 +1183,8 @@ function redactPlanItem(w) {
 }
 
 function countBy(iter, key) {
-  const m = {}
+  // Null-proto: tally keys can be episode-derived strings (issue #469)
+  const m = Object.create(null)
   for (const x of (iter instanceof Map ? iter.values() : iter)) {
     const k = key(x)
     m[k] = (m[k] || 0) + 1

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -47,6 +47,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -476,8 +477,9 @@ fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
 
 function updateTagsIndex(dir, episodeId, tagList) {
   const tagsFile = path.join(dir, 'tags.json')
-  let idx = {}
-  try { idx = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+  // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8'))) } catch {}
   for (const t of tagList) {
     if (!idx[t]) idx[t] = []
     if (!idx[t].includes(episodeId)) idx[t].push(episodeId)

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
+import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -235,9 +235,10 @@ function normalizeTags(raw, repeats = []) {
 
 function updateTagsIndex(dataDir, episodeId, tags) {
   const tagsFile = path.join(dataDir, 'tags.json')
-  let index = {}
+  // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+  let index = Object.create(null)
   try {
-    index = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+    index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
   } catch {}
   for (const tag of tags) {
     if (!index[tag]) index[tag] = []
@@ -252,9 +253,11 @@ function updateTagsIndex(dataDir, episodeId, tags) {
 // way updateTagsIndex is, rather than imported from em-store (which runs top-level on import).
 function updateCategoryIndex(dataDir, episodeId, category) {
   const catFile = path.join(dataDir, 'category-index.json')
-  let index = {}
+  // Null-proto: unknown categories index under their literal key, which could
+  // collide with Object.prototype names (issue #469)
+  let index = Object.create(null)
   try {
-    index = JSON.parse(fs.readFileSync(catFile, 'utf8'))
+    index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
   } catch {}
   const key = canonicalCategory(category)
   if (!index[key]) index[key] = []

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -16,6 +16,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 
@@ -56,9 +57,11 @@ try {
 // Load existing tags.json to check for already-seeded patterns
 // ---------------------------------------------------------------------------
 const tagsFile = path.join(GLOBAL_DIR, 'tags.json')
-let tagsIndex = {}
+// Null-proto: a pattern_id/tag named "constructor" must not resolve to
+// Object.prototype — the inherited function reads as "already seeded" (issue #469)
+let tagsIndex = Object.create(null)
 try {
-  tagsIndex = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+  tagsIndex = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
 } catch {}
 
 // ---------------------------------------------------------------------------
@@ -103,8 +106,8 @@ function queueTagsUpdate(episodeId, tags) {
 function flushTagsIndex() {
   if (pendingTagUpdates.length === 0) return
   const tagsFile = path.join(GLOBAL_DIR, 'tags.json')
-  let idx = {}
-  try { idx = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8'))) } catch {}
   for (const { episodeId, tags } of pendingTagUpdates) {
     for (const tag of tags) {
       if (!idx[tag]) idx[tag] = []
@@ -128,8 +131,8 @@ function queueCategoryUpdate(episodeId, category) {
 function flushCategoryIndex() {
   if (pendingCategoryUpdates.length === 0) return
   const catFile = path.join(GLOBAL_DIR, 'category-index.json')
-  let idx = {}
-  try { idx = JSON.parse(fs.readFileSync(catFile, 'utf8')) } catch {}
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8'))) } catch {}
   for (const { episodeId, category } of pendingCategoryUpdates) {
     if (!idx[category]) idx[category] = []
     if (!idx[category].includes(episodeId)) idx[category].push(episodeId)

--- a/scripts/em-stats.mjs
+++ b/scripts/em-stats.mjs
@@ -77,9 +77,11 @@ function statsFor(dataDir, label) {
   const rows = loadIndex(dataDir, label)
   const active = rows.filter(r => r.status !== 'superseded')
 
-  const byCategory = {}
-  const byProject = {}
-  const byTag = {}
+  // Null-proto: keys are episode-derived (a tag named "constructor" would
+  // otherwise tally onto Object.prototype's inherited function, issue #469)
+  const byCategory = Object.create(null)
+  const byProject = Object.create(null)
+  const byTag = Object.create(null)
   const age = { last_7d: 0, last_30d: 0, last_90d: 0, last_year: 0, older: 0, undated: 0 }
   let pinned = 0
   let accessTotal = 0

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
+import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -155,9 +155,10 @@ function normalizeTags(raw, repeats = []) {
 
 function updateTagsIndex(dataDir, episodeId, tags) {
   const tagsFile = path.join(dataDir, 'tags.json')
-  let index = {}
+  // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+  let index = Object.create(null)
   try {
-    index = JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+    index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
   } catch {}
   for (const tag of tags) {
     if (!index[tag]) index[tag] = []
@@ -220,9 +221,11 @@ console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope }))
 // key; unknown names index under their literal key (canonicalCategory degrades, never throws).
 export function updateCategoryIndex(dataDir, episodeId, category) {
   const catFile = path.join(dataDir, 'category-index.json')
-  let index = {}
+  // Null-proto: unknown categories index under their literal key, which could
+  // collide with Object.prototype names (issue #469)
+  let index = Object.create(null)
   try {
-    index = JSON.parse(fs.readFileSync(catFile, 'utf8'))
+    index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
   } catch {}
   const key = canonicalCategory(category)
   if (!index[key]) index[key] = []

--- a/scripts/lib/relevance.mjs
+++ b/scripts/lib/relevance.mjs
@@ -48,10 +48,20 @@ export function normalizeTags(raw) {
 // ---------------------------------------------------------------------------
 // loadTagsIndex(dataDir) / loadCategoryIndex(dataDir) — inverted indexes.
 // Return null when missing/corrupt (callers degrade to linear scan).
+//
+// Index maps are keyed by episode-derived strings (tags, tokens, categories),
+// so lookups must not see Object.prototype: a token/tag named "constructor"
+// on a plain {} returns the inherited Object function instead of undefined
+// (issue #469). Every map is rehydrated onto a null prototype after
+// JSON.parse; fresh maps are built with Object.create(null).
 // ---------------------------------------------------------------------------
+export function nullProtoIndex(parsed) {
+  return Object.assign(Object.create(null), parsed)
+}
+
 export function loadTagsIndex(dataDir) {
   try {
-    return JSON.parse(fs.readFileSync(path.join(dataDir, 'tags.json'), 'utf8'))
+    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'tags.json'), 'utf8')))
   } catch {
     return null
   }
@@ -59,7 +69,7 @@ export function loadTagsIndex(dataDir) {
 
 export function loadCategoryIndex(dataDir) {
   try {
-    return JSON.parse(fs.readFileSync(path.join(dataDir, 'category-index.json'), 'utf8'))
+    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'category-index.json'), 'utf8')))
   } catch {
     return null
   }
@@ -248,7 +258,7 @@ export function episodeTokens({ summary, tags, body }) {
 
 export function loadTokensIndex(dataDir) {
   try {
-    return JSON.parse(fs.readFileSync(path.join(dataDir, 'tokens.json'), 'utf8'))
+    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'tokens.json'), 'utf8')))
   } catch {
     return null
   }
@@ -258,9 +268,9 @@ export function loadTokensIndex(dataDir) {
 // Shared here (not in em-store) because em-store executes top-level on import.
 export function updateTokensIndex(dataDir, episodeId, tokens) {
   const tokensFile = path.join(dataDir, 'tokens.json')
-  let index = {}
+  let index = Object.create(null)
   try {
-    index = JSON.parse(fs.readFileSync(tokensFile, 'utf8'))
+    index = nullProtoIndex(JSON.parse(fs.readFileSync(tokensFile, 'utf8')))
   } catch {}
   for (const tok of tokens) {
     if (!index[tok]) index[tok] = []

--- a/tests/test-prototype-key-collision.mjs
+++ b/tests/test-prototype-key-collision.mjs
@@ -149,6 +149,42 @@ t('loadTagsIndex returns a null-proto map (read path cannot see Object.prototype
   assert.equal(Object.getPrototypeOf(idx), null);
 });
 
+t('em-move local->global survives a "constructor" tag (left a partial move before)', () => {
+  const s = run('em-store.mjs', ['--project', 'fx', '--category', 'decision',
+    '--summary', 'movable episode', '--body', 'constructor token here too',
+    '--tags', 'constructor', '--scope', 'local'], cwd, env);
+  assert.equal(s.json?.status, 'ok', s.stdout);
+  const r = run('em-move.mjs', ['--id', s.json.id, '--to', 'global', '--confirm', '--no-audit'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}\nstdout: ${r.stdout}`);
+  assert.equal(r.json?.status, 'ok', r.stdout);
+  const globalTags = JSON.parse(fs.readFileSync(path.join(home, '.episodic-memory', 'tags.json'), 'utf8'));
+  assert.ok(Object.hasOwn(globalTags, 'constructor'), 'destination tags.json must own-key "constructor"');
+  assert.ok(globalTags['constructor'].includes(s.json.id));
+});
+
+t('em-seed-patterns seeds a pattern_id/tag "constructor" (falsely skipped, then crashed before)', () => {
+  // Fresh HOME: the em-move probe above legitimately put a "constructor" tag
+  // into the shared global store, which would make a skip here correct.
+  const seedHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'protokey-seed-home-')));
+  const seedEnv = { HOME: seedHome };
+  const pdir = path.join(cwd, 'patterns-fixture');
+  fs.mkdirSync(pdir, { recursive: true });
+  fs.writeFileSync(path.join(pdir, '_index.json'), JSON.stringify({
+    patterns: [{ pattern_id: 'constructor', file: 'c.md', name: 'colliding pattern' }]
+  }), 'utf8');
+  fs.writeFileSync(path.join(pdir, 'c.md'), [
+    '---', 'name: colliding pattern', 'category: decision',
+    'tags: [constructor]', '---', '', 'pattern body', ''
+  ].join('\n'), 'utf8');
+  const r = run('em-seed-patterns.mjs', ['--dir', pdir], cwd, seedEnv);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.equal(r.json?.seeded, 1, `inherited Object.prototype.constructor must not read as already-seeded: ${r.stdout}`);
+  assert.equal(r.json?.skipped, 0, r.stdout);
+  const globalTags = JSON.parse(fs.readFileSync(path.join(seedHome, '.episodic-memory', 'tags.json'), 'utf8'));
+  assert.ok(Object.hasOwn(globalTags, 'constructor'), 'seeded tag must land in global tags.json');
+  fs.rmSync(seedHome, { recursive: true, force: true });
+});
+
 fs.rmSync(cwd, { recursive: true, force: true });
 fs.rmSync(home, { recursive: true, force: true });
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/test-prototype-key-collision.mjs
+++ b/tests/test-prototype-key-collision.mjs
@@ -1,0 +1,155 @@
+/**
+ * test-prototype-key-collision.mjs — regression suite for issue #469.
+ *
+ * Bug: index maps (tokens.json, tags.json, category-index.json, stats/drift
+ * tallies) were plain {} objects, so an episode-derived key that collides
+ * with an Object.prototype property name — "constructor" is the only one
+ * that survives the [^a-z0-9]+ tokenizer — resolved to the inherited
+ * Object function instead of undefined. Symptoms: em-rebuild-index and
+ * em-store/em-revise crashed with "push is not a function" on any store
+ * containing the token "constructor"; em-search --tag constructor threw
+ * "not iterable"; em-stats tallied garbage strings.
+ *
+ * Fix: fresh maps are Object.create(null); JSON.parse-loaded maps are
+ * rehydrated via nullProtoIndex() (lib/relevance.mjs).
+ *
+ * Runtime probes against an isolated fixture store (no mental tracing).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { nullProtoIndex, updateTokensIndex, loadTagsIndex } from '../scripts/lib/relevance.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const SCRIPTS = path.join(REPO, 'scripts');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function run(script, args, cwd, env) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, json, stdout: r.stdout, stderr: r.stderr };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: the isolated mechanism
+// ---------------------------------------------------------------------------
+t('nullProtoIndex: "constructor" lookup is undefined, own keys survive', () => {
+  const idx = nullProtoIndex({ storage: ['a'] });
+  assert.equal(idx['constructor'], undefined);
+  assert.deepEqual(idx['storage'], ['a']);
+});
+
+t('updateTokensIndex: token "constructor" lands as an own key', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'protokey-unit-'));
+  updateTokensIndex(dir, 'ep1', new Set(['constructor', 'atomic']));
+  updateTokensIndex(dir, 'ep2', new Set(['constructor']));
+  const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'tokens.json'), 'utf8'));
+  assert.deepEqual(onDisk['constructor'], ['ep1', 'ep2']);
+  assert.deepEqual(onDisk['atomic'], ['ep1']);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime probes — isolated fixture store
+// ---------------------------------------------------------------------------
+const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'protokey-')));
+const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'protokey-home-')));
+const env = { HOME: home };
+const store = path.join(cwd, '.episodic-memory');
+
+let storedId = null;
+t('em-store survives body + tag "constructor" (crashed before #469 fix)', () => {
+  const r = run('em-store.mjs', ['--project', 'fx', '--category', 'decision',
+    '--summary', 'Null-proto maps for index keys',
+    '--body', 'The constructor token used to hit Object.prototype and crash the write path.',
+    '--tags', 'constructor,storage', '--scope', 'local'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.equal(r.json?.status, 'ok');
+  storedId = r.json.id;
+  const tokens = JSON.parse(fs.readFileSync(path.join(store, 'tokens.json'), 'utf8'));
+  assert.ok(Object.hasOwn(tokens, 'constructor'), 'tokens.json must own-key "constructor"');
+  assert.ok(tokens['constructor'].includes(storedId));
+  const tags = JSON.parse(fs.readFileSync(path.join(store, 'tags.json'), 'utf8'));
+  assert.deepEqual(tags['constructor'], [storedId]);
+});
+
+t('em-search --tag constructor finds the episode (threw "not iterable" before)', () => {
+  const r = run('em-search.mjs', ['--tag', 'constructor', '--scope', 'local', '--no-track'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.ok(r.json.episodes.some(e => e.id === storedId), JSON.stringify(r.json));
+});
+
+t('em-search --query constructor finds the episode via the token index', () => {
+  const r = run('em-search.mjs', ['--query', 'constructor token', '--scope', 'local', '--no-track'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.ok(r.json.episodes.some(e => e.id === storedId), JSON.stringify(r.json));
+});
+
+t('em-revise survives a chain whose text/tags contain "constructor"', () => {
+  const r = run('em-revise.mjs', ['--original', storedId,
+    '--summary', 'Null-proto maps for index keys (revised)',
+    '--body', 'Still mentions constructor after revision.'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.equal(r.json?.status, 'ok');
+});
+
+t('em-rebuild-index --scope local succeeds and indexes the token (crashed before)', () => {
+  const r = run('em-rebuild-index.mjs', ['--scope', 'local'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.equal(r.json?.status, 'ok');
+  const tokens = JSON.parse(fs.readFileSync(path.join(store, 'tokens.json'), 'utf8'));
+  assert.ok(Object.hasOwn(tokens, 'constructor'));
+  assert.ok(tokens['constructor'].length >= 1);
+  const tags = JSON.parse(fs.readFileSync(path.join(store, 'tags.json'), 'utf8'));
+  assert.ok(Array.isArray(tags['constructor']));
+});
+
+t('rebuild survives a hand-authored episode with category "constructor" (unknown-vocab path)', () => {
+  // Readers DEGRADE on unknown categories (RFC-009 R10c), so a foreign-harness
+  // episode with a colliding literal category key must not crash the rebuild.
+  const id = '20260101-120000-aaaa';
+  fs.writeFileSync(path.join(store, 'episodes', `${id}.md`), [
+    '---', `id: ${id}`, 'date: 2026-01-01', 'time: "12:00"', 'project: fx',
+    'category: constructor', 'status: active', 'tags: []',
+    'summary: hand-authored colliding category', '---', '',
+    '# hand-authored colliding category', '', 'body text', ''
+  ].join('\n'), 'utf8');
+  const r = run('em-rebuild-index.mjs', ['--scope', 'local'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  assert.equal(r.json?.status, 'ok');
+  const catIdx = JSON.parse(fs.readFileSync(path.join(store, 'category-index.json'), 'utf8'));
+  assert.deepEqual(catIdx['constructor'], [id]);
+});
+
+t('em-stats tallies a "constructor" tag/category as numbers, not garbage strings', () => {
+  const r = run('em-stats.mjs', ['--scope', 'local'], cwd, env);
+  assert.equal(r.code, 0, `stderr: ${r.stderr}`);
+  const s = JSON.stringify(r.json);
+  const local = r.json.scopes.find(sc => sc.scope === 'local');
+  assert.ok(local, s);
+  assert.equal(typeof local.by_category['constructor'], 'number', s);
+  for (const v of Object.values(local.by_category)) assert.equal(typeof v, 'number', s);
+  assert.ok(!s.includes('native code'), `stats output must not serialize Object.prototype functions: ${s}`);
+});
+
+t('loadTagsIndex returns a null-proto map (read path cannot see Object.prototype)', () => {
+  const idx = loadTagsIndex(store);
+  assert.ok(idx, 'tags.json must load');
+  assert.equal(Object.getPrototypeOf(idx), null);
+});
+
+fs.rmSync(cwd, { recursive: true, force: true });
+fs.rmSync(home, { recursive: true, force: true });
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #469.

## Bug

Index maps keyed by episode-derived strings (tokens, tags, category names, stats tallies) were plain `{}` objects. A key colliding with an `Object.prototype` property name — `constructor` is the only one that survives the `[^a-z0-9]+` tokenizer — resolved to the inherited `Object` function instead of `undefined`.

Confirmed failures (all reproduced at runtime, not traced):
- `em-store` / `em-revise`: crash on storing/revising any episode whose text contains the word `constructor` (the issue's live global-store edge)
- `em-rebuild-index`: crash on any store containing the token, plus the literal unknown-category key path
- `em-search --tag constructor`: "not iterable" crash
- `em-move`: **partial move** — episode+index moved, destination `tags.json` update crashed (codex round-1 repro)
- `em-restore`: crash mid-apply restoring a backup containing the tag (codex round-1 repro)
- `em-seed-patterns`: silent misroute — inherited `Object.prototype.constructor` read as "already seeded" (`seeded:0, skipped:1`), and crash flushing the tag (codex round-1 repro)
- `em-stats` / drift tallies: garbage string counters (corruption, not crash)

## Fix

One idiom everywhere: fresh maps are `Object.create(null)`; `JSON.parse`-loaded maps are rehydrated via the new `nullProtoIndex()` helper in `scripts/lib/relevance.mjs` (loaders + all incremental updaters). `em-prune`'s local loader and the `parseFrontmatter`/redact-clone maps are untouched — they are `Object.keys`-walked or assignment-only, which never sees inherited properties (verified by codex sweep, round 2).

## Tests (Rule 15)

`tests/test-prototype-key-collision.mjs` — 12 runtime probes on isolated fixture stores: store/search(tag+query)/revise/rebuild/stats/move/seed with `constructor` as token, tag, `pattern_id`, and hand-authored category, plus the isolated-mechanism units. Negative control: the suite's scenario run against the pre-fix scripts reproduces `TypeError: index[tok].includes is not a function` at `relevance.mjs:267`.

Wired into CI (`plan-marker-validate.yml`), along with `test-recall-v2.mjs` which was previously not run by any workflow — that gap is why no CI fixture ever contained the colliding token.

## Second opinion

Codex (harness, provider codex): round 1 HOLD — F1 found the `em-move`/`em-restore`/`em-seed-patterns` writers my sweep missed, each with a runtime repro. ACCEPTED and fixed in the round-2 commit. Round 2 ACCEPT — codex reran its own round-1 repros clean and confirmed no remaining unsafe inverted-index/tally writers on episode-derived keys. Replies: `.review-store/replies/20260708-021416-a8f576a0dbef.body.md`, `.review-store/replies/20260708-022553-4d9de2c2bd4e.body.md`.

## Post-merge deploy note

Global scripts at `~/.episodic-memory/scripts/` currently carry the bug (deployed from pre-fix main). After merge: redeploy via `install.mjs`, then `em-rebuild-index --scope all` should succeed on the global store that crashes today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)