### PR TITLE
Fix #455: tolerate string-typed tags in em-pattern-health linear-scan

### DIFF
--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -210,7 +210,12 @@ function violationIdsLinearScan(patternId) {
   const key = `violated:${patternId}`.toLowerCase()
   const ids = new Set()
   for (const e of dedupedEntries) {
-    if (!e.tags) continue
+    // Tolerate-and-skip a non-array `tags` (a hand-written row with
+    // `"tags": "..."`, the #447 tolerated-writer class): a raw `.map` here
+    // crashes the linear-scan fallback with a stack trace instead of the JSON
+    // contract — and the fallback is the COMMON path in hermetic projects that
+    // have no tags.json (issue #455). Mirrors em-prune's stringItems guard.
+    if (!Array.isArray(e.tags)) continue
     if (e.tags.map(t => String(t).toLowerCase().trim()).includes(key)) ids.add(e.id)
   }
   return ids

--- a/tests/test-pattern-health-hermetic.mjs
+++ b/tests/test-pattern-health-hermetic.mjs
@@ -133,6 +133,34 @@ t('testNonHermeticUnchanged', () => {
   assert(r.violations === 3, `legacy scope-all tst-001 violations ${r.violations}, want 3 (1 local + 2 global)`)
 })
 
+// Issue #455: a hand-written index row with a STRING `tags` field (the #447
+// tolerated-writer class) must not crash violationIdsLinearScan — the fallback
+// is the common hermetic path (no tags.json). Regression: pre-fix this threw
+// `e.tags.map is not a function` (stack trace, exit 1) instead of JSON.
+t('testStringTagsDoesNotCrashLinearScan', () => {
+  const badRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'em-455-'))
+  const badProj = path.join(badRoot, 'proj')
+  const badHome = path.join(badRoot, 'home')
+  fs.mkdirSync(badHome, { recursive: true })
+  fs.mkdirSync(badProj, { recursive: true })
+  spawnSync('git', ['init', '-q'], { cwd: badProj })
+  writeJson(path.join(badProj, 'patterns', '_index.json'), { patterns: [{ pattern_id: 'tst-001' }] })
+  // NO tags.json → linear-scan fallback. One well-formed row + one string-tags row.
+  writeLines(path.join(badProj, '.episodic-memory', 'index.jsonl'), [
+    vio('20260701-000001-ok', 'tst-001', RECENT),
+    { id: '20260701-000002-bad', date: RECENT, time: '00:00', project: 'fx', category: 'violation', status: 'active', supersedes: null, tags: 'violated:tst-001', summary: 'string-tags row', access_count: 0, last_accessed: null },
+  ])
+  const r = spawnSync(process.execPath, [SCRIPT, '--hermetic'], { cwd: badProj, env: { ...process.env, HOME: badHome, USERPROFILE: badHome }, encoding: 'utf8' })
+  assert(!/is not a function|TypeError/.test(r.stderr || ''), `crashed on string tags: ${r.stderr}`)
+  let out
+  try { out = JSON.parse(r.stdout) } catch { throw new Error(`non-JSON output: ${r.stdout}\n${r.stderr}`) }
+  assert(Array.isArray(out.patterns), `JSON contract broken: ${r.stdout}`)
+  // The string-tags row is skipped (tolerated), the well-formed one counts.
+  const row001 = out.patterns.find(p => p.pattern_id === 'tst-001')
+  assert(row001 && row001.violations === 1, `well-formed row must still count, string row skipped: ${JSON.stringify(row001)}`)
+  fs.rmSync(badRoot, { recursive: true, force: true })
+})
+
 let pass = 0
 for (const [name, fn] of tests) {
   try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }


### PR DESCRIPTION
Closes #455.

## Problem
`violationIdsLinearScan` called `e.tags.map(...)` on every index row. A hand-written row with `"tags": "not-an-array"` (the #447 tolerated-writer class) crashed the linear scan with `e.tags.map is not a function` — a stack trace and exit 1 instead of the JSON contract. The linear-scan fallback is the COMMON path in hermetic projects with no `tags.json`, and RFC-009 P3's `--hermetic --check` CI gate consumes that output, so the crash blocks P3/R5b.

## Fix
Guard with `Array.isArray(e.tags)` (tolerate-and-skip, mirroring em-prune's `stringItems` and the #447 hand-written-row tolerance). The string-tags row is skipped; well-formed rows still count.

## Test
`testStringTagsDoesNotCrashLinearScan` in `tests/test-pattern-health-hermetic.mjs` (already CI-registered): plants a string-tags row alongside a well-formed one under `--hermetic` (no tags.json → linear scan), asserts valid JSON output, no TypeError, and that the well-formed row still counts (violations=1). Verified to FAIL pre-fix (crash) and PASS post-fix. Suite 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)