### PR TITLE
All-projects central consolidation layer: registry-driven stats/doctor/fold + experimental em-promote

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -258,6 +258,18 @@ jobs:
       - name: Run em-consolidate fold-superseded suite (S4)
         run: node tests/test-fold-superseded.mjs
 
+      - name: Run registered-stores lib suite (APC-S1)
+        run: node tests/test-registered-stores.mjs
+
+      - name: Run all-projects stats+doctor observability suite (APC-S2/S3)
+        run: node tests/test-all-projects-observability.mjs
+
+      - name: Run fold --all-projects suite (APC-S4)
+        run: node tests/test-fold-all-projects.mjs
+
+      - name: Run em-promote experimental suite (APC-S5)
+        run: node tests/test-em-promote.mjs
+
       - name: Run install version-manifest + registry + update-sweep suite (Layer 1)
         run: node tests/test-install-manifest.mjs
 

--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -36,7 +36,7 @@ All four are ways of **using episodes**. None of them enforce workflows.
 |---|---|---|---|---|---|
 | **Memory-store strategy** | Persists episodes and builds derived indexes from them (e.g. knowledge graph) | episodes (write) + derived indexes | `em-store` | `store-strategy` | append-only log + lexical index |
 | **Recall strategy** | Retrieves + ranks episodes for use | episodes (read) | `em-recall` | `recall-strategy` | lexical tag-based (zero-dep) |
-| **Learning strategy** | Derives new knowledge from episodes + derived indexes, writes it back as global episodes | indexes (read) → episodes (write) | `em-store` (write-back) | `learning` | none (opt-in) |
+| **Learning strategy** | Derives new knowledge from episodes + derived indexes, writes it back as global episodes | indexes (read) → episodes (write) | `em-store` (write-back) | `learning` | `em-promote` (EXPERIMENTAL, decision 2026-10-08); otherwise none (opt-in) |
 | **Curation strategy** | Maintains, reorganizes, and audits the corpus without deriving new knowledge (archive, fold, relocate, verify) | episodes + derived indexes (read/move/archive) | `em-prune`, `em-consolidate`, `em-doctor` | `curation` | manual opt-in commands |
 
 ### 1. Memory-store strategy
@@ -55,6 +55,10 @@ RFC-007 Graph Projection); this charter owns only the capability contract.
 How the system turns accumulated episodes (and the derived indexes a store strategy builds)
 into **new** knowledge, written back as new global episodes for future recall. Reads indexes,
 persists derived knowledge via `em-store`. Opt-in, substrate-side, enforcement-free.
+First shipped member: `em-promote` (EXPERIMENTAL tier, promote-or-remove decision
+2026-10-08) — detects lessons recurring across ≥2 registered project stores and, on
+explicit `--apply`, writes one derived global lesson episode per recurrence (sources
+untouched; provenance carried in-body pending RFC-009 P1b typed linkage).
 
 ### 4. Curation strategy
 How the corpus stays healthy over time: pruning, backup and restore, relocation between
@@ -73,7 +77,10 @@ Every capability is **a way to use memory episodes** — storing them, recalling
 learning from them, or curating them. A capability may operate over a single store or
 across many registered stores (discovery via the consumer registry at
 `~/.episodic-memory/installs.json`); cross-store scope changes reach, not these rules.
-This is the test for "does X belong here":
+Shipped cross-store members: `em-stats --all-projects` and `em-doctor --all-projects`
+(curation: per-registered-store analytics and health), `em-consolidate --fold-superseded
+--all-projects` (curation: reversible chain folding, `--confirm`-gated), and `em-promote`
+(learning, experimental). This is the test for "does X belong here":
 
 - X is an operation over episodes that **does not** enforce workflow → it is a substrate
   capability (this document).

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -50,6 +50,8 @@ Match your intent to the command. The third column is the wrong habit it replace
 | "What is connected to this episode?" (lineage, clusters, hubs) | `em-graph --from <id>` / `--orphans` / `--hubs` | Manual joins across multiple searches |
 | Significant session ended, nothing stored yet | `em-capture extract` then `review` (or `em-capture list` when recall reports `pending_drafts`) | Reconstructing the session from memory, or silently storing without review |
 | Session start printed an install version-drift notice | `em-sync-install` (this project, from the dist cache) or `node <repo>/install.mjs --update-consumers` (all registered projects) | Hand-copying hook/skill files, or re-running full installs in every consuming project |
+| One view of EVERY registered project's store (analytics/health/fold) | `em-stats --all-projects`, `em-doctor --all-projects`, `em-consolidate --fold-superseded --all-projects --dry-run` | Cd-ing into each project and running per-store commands |
+| The same lesson keeps recurring across projects | `em-promote` (dry-run), then `em-promote --apply` (EXPERIMENTAL) | Re-learning it per project, or hand-copying lesson episodes to global |
 
 Default write scope is GLOBAL. Pass `--scope local` to keep an episode inside the
 current repo's `.episodic-memory/`. Searches read local and global together by
@@ -417,6 +419,8 @@ node ~/.episodic-memory/scripts/em-consolidate.mjs [--scope local|global] \
   [--include-pinned] [--apply] [--confirm]
 node ~/.episodic-memory/scripts/em-consolidate.mjs --fold-superseded \
   [--min-chain <n>] [--dry-run] [--scope local|global]
+node ~/.episodic-memory/scripts/em-consolidate.mjs --fold-superseded \
+  --all-projects [--min-chain <n>] [--dry-run] [--confirm]
 ```
 
 Clustering is body-token Jaccard within (project, category) groups; the
@@ -439,13 +443,28 @@ still-active members are kept and reported; forked/non-linear chains are
 skipped whole. `--dry-run` lists exactly what a real run would move. Output:
 `{"status":"ok","mode":"fold-superseded","dry_run":false,"chains":[{"terminal":"...","chain_length":12,"folded":[...],"kept":[...]}],"folded_total":11}`.
 
+`--all-projects` (fold mode only, mutually exclusive with `--scope`) folds
+every consumer-registry store in one pass; output gains a per-store `stores`
+array. A REAL multi-store run requires `--confirm` and fails closed before
+any move. R6 protection is unioned across cwd-local + global + ALL registered
+stores, so a referencer in any store protects a chain member in any other.
+Registrations whose substrate-resolved store is not `<project>/.episodic-memory`
+(git-nested paths, linked worktrees, symlinked store dirs) are reported
+`skipped_store: "non-root-store"` and never written.
+
 ### em-stats
 
 Read-only store analytics — never writes, never bumps access counters.
 
 ```
-node ~/.episodic-memory/scripts/em-stats.mjs [--scope local|global|all] [--top <n>]
+node ~/.episodic-memory/scripts/em-stats.mjs [--scope local|global|all] [--top <n>] [--all-projects]
 ```
+
+`--all-projects` appends one scope block per consumer-registry store (label
+`project:<basename>`; the `dir` field is the identity — labels can collide,
+dirs cannot). Stores already covered by the `--scope` blocks are skipped by
+realpath, so a symlink-aliased local store never double-counts. Totals include
+the appended blocks.
 
 Per scope: episode totals (active/superseded/pinned), archived count,
 category + project + tag distributions, age buckets, access/feedback
@@ -683,8 +702,18 @@ Health check + repair for the stores and the installation. One command answers
 - WHEN NOT TO USE: as a data query (use search/list/recall).
 
 ```
-node ~/.episodic-memory/scripts/em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]
+node ~/.episodic-memory/scripts/em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose] [--all-projects]
 ```
+
+`--all-projects` additionally runs the store-class checks once per
+consumer-registry store (scope label `project:<basename>`; every store-class
+row carries `data_dir` — the identity, since labels can collide). `--fix`
+routes rebuilds by `data_dir` (spawning `em-rebuild-index --scope local` with
+`cwd` at that project's root) and reports `skipped: non-root-store` for
+registrations whose substrate-resolved store is not
+`<project>/.episodic-memory` (git-nested paths, linked worktrees) — a rebuild
+there would repair a different store than the one diagnosed. Non-store checks
+(gate friction, installs-drift, backup, drafts) still run exactly once.
 
 Checks: Node version, index.jsonl parse, index↔episode-file drift (both
 directions), tags.json + category-index.json consistency, tokens.json bloat
@@ -796,6 +825,38 @@ referencing episode is superseded or expires. Retained entries are counted in th
 `protected` output field; `--dry-run` lists them in `protected_episodes` as
 `{id, score, reason, via}` where `via` names the protecting episode. `remaining`
 includes protected entries; the `--check` exit code ignores them.
+
+### em-promote
+
+EXPERIMENTAL (promote-or-remove decision 2026-10-08) — cross-project
+recurring-lesson promotion, the first learning-strategy capability
+(CAPABILITIES.md experimental tier). Dry-run by DEFAULT — `--apply` writes.
+
+- WHEN TO USE: the same lesson keeps getting re-learned in different
+  registered projects; you want it surfaced globally with provenance.
+- WHEN NOT TO USE: near-duplicates inside ONE store (`em-consolidate`),
+  moving a single episode between scopes (`em-move`), or fewer than 2
+  registered projects (nothing to correlate).
+
+```
+node ~/.episodic-memory/scripts/em-promote.mjs [--min-sim <0..1>] [--apply]
+```
+
+Scans every consumer-registry store for active `lesson` episodes and clusters
+them by body-token Jaccard (default 0.35, same vocabulary as
+`em-consolidate`). A candidate must span >=2 distinct stores with >=2 distinct
+member identities: replicas (same id AND summary — clone/fork stores)
+collapse to one member and never count as recurrence, while a coincident id
+with different content stays two members. `--apply` writes ONE global lesson
+episode per candidate via `em-store` (never hand-written files): project
+`cross-project`, tags = member-tag union + `promoted-lesson` +
+`promoted:<sha8>` (the identity hash over sorted `<id>#<sha8(summary)>`
+member keys), body = per-member excerpts + a `## Sources` list. Source
+stores are NEVER written. Re-runs are idempotent by hash; a grown cluster
+promotes under its new hash with a `Supersedes-promotion:` back-reference.
+Malformed existing promoted episodes (bad hash tag, missing `## Sources`)
+are reported in `warnings`, never fatal. Exit 1 only when an `--apply` write
+failed; usage errors exit 2.
 
 ### em-pattern-health
 

--- a/docs/plans/all-projects-consolidation.md
+++ b/docs/plans/all-projects-consolidation.md
@@ -1,0 +1,689 @@
+# APC — All-Projects Central Consolidation Layer Plan
+
+## §1 Status
+
+Current stage: **approved** — planner round 1 (HOLD, folded) + codex round 1 (HOLD, folded);
+operator pre-approved implementation and waived further plan rounds (2026-07-08, in-session).
+Implementation deviation under the same grant: ONE branch/PR (`feat/all-projects-layer`)
+instead of the 3-PR split.
+
+| Field | Value |
+|---|---|
+| RFC | `n/a` (capability charter work — CAPABILITIES.md cross-store clause + experimental tier) |
+| Parent requirements | CAPABILITIES.md "unifying invariant" cross-store clause; PRINCIPLES P1/P3/P6/P7/P9/P10/P12 |
+| Workplan episode | `20260706-143551-workplan-v165-rfc-009-p1b-plan-authored--8edf` (queue re-ordered by handoff `20260708-073204-…-3ce6`: all-projects layer is NEXT) |
+| Target branch | `feat/all-projects-layer` (PR-A); `feat/all-projects-fold` (PR-B); `feat/em-promote` (PR-C) |
+| Executor altitude (§0.1) | **low** (default; Appendix A is the build path) |
+
+## §2 Episode Search Summary
+
+Commands run (2026-07-08, this session):
+
+```bash
+node scripts/em-search.mjs --tag workplan --category decision --limit 1 --scope all --full --no-score --no-track
+node scripts/em-search.mjs --query "consolidate curation cross-project registry all projects" --scope all --limit 8 --no-track
+```
+
+Key active memories (verified against current main `5cdc45c` this session):
+
+- `20260708-073204-…-3ce6` (handoff): all-projects layer = "em-stats/em-doctor/em-consolidate over
+  the consumer registry; cross-project recurring-lesson promotion to global"; plan-worthy; read the
+  just-amended PRINCIPLES/CAPABILITIES first. This plan's scope statement.
+- `20260706-143551-…-8edf` (workplan v165): P1b awaits approval on a separate track; `--evidence`
+  linkage (typed provenance) is NOT yet implemented → em-promote v1 cannot use it (→ §17-A DEFER).
+- `20260705-090618-…-97a5` (violation, fourth-catch): a new data artifact needs its COMPLETE
+  contract — shape, drift handling, derived-index behavior — at design time. Applied to the
+  promoted-lesson episode artifact in §8.4.
+- `20260509-061106-…-3260` (lesson, fixture-transitive-import drift): hermetic fixtures that stage
+  real .mjs files must mirror transitive imports. Applied in §14: tests spawn the REAL repo scripts
+  with explicit `cwd` + isolated `HOME`, never staged copies.
+- `20260705-064947-…-9ac4` (lesson, three-legs design discipline): PRINCIPLES + CAPABILITIES read
+  this session (see §3 P-citations); disposition sweep of ALL em-* scripts in §9b.
+- `20260708-035412-…-8ff2` (lesson, wave-6): real-store probing found what fixtures could not →
+  §15 includes a real-store dry-run smoke on top of hermetic tests.
+
+## §3 Objective
+
+Give the substrate a central, registry-driven view and maintenance path over EVERY registered
+project store, not just cwd-local + global. Concretely: `em-stats --all-projects` and
+`em-doctor --all-projects` report per-registered-store analytics/health from any cwd;
+`em-consolidate --fold-superseded --all-projects` archives long superseded chains across all
+registered stores with per-store R6 protection; a new EXPERIMENTAL `em-promote` detects lessons
+recurring across ≥2 project stores and (on `--apply`) writes ONE derived global lesson episode per
+recurrence, sources untouched. Provable by the §14 hermetic multi-store suites + §15 ledger.
+
+**Charter grounding (three legs, run this session):**
+
+- **CAPABILITIES.md** sanctions the scope: "A capability may operate over a single store or across
+  many registered stores (discovery via the consumer registry at `~/.episodic-memory/installs.json`)"
+  (unifying-invariant section). Stats/doctor/consolidate = **curation** family; em-promote =
+  **learning** family ("derives new knowledge from episodes … writes it back as global episodes",
+  default "none (opt-in)") shipped under the **experimental tier** (explicit opt-in, declared side
+  effects, EXPERIMENTAL label, smoke test, decision date).
+- **PRINCIPLES.md**: P1 (episodes stay the only data layer — the registry is an existing
+  distribution-layer artifact, read-only here; no new store), P3/P10 (cross-project WRITES are
+  consent-gated + reversible: fold is an archival move, `--confirm` required for multi-store real
+  runs), P6 (manual opt-in commands, no background work, small JSON), P7 (promotion writes NEW
+  episodes referencing sources; nothing mutated in place), P9 (core imports core lib only; no
+  adapter knowledge), P12 (zero hooks, zero registrations; substrate stays hook-free — guarded by
+  the existing `test-p12-global-clean.mjs`).
+
+**Runtime evidence of the gap (fixture probe, this session, isolated HOME + 2 registered mock
+projects):** from projA, `em-stats --scope all` returned only projA-local (2 episodes) + global
+(0); projB's 2 episodes were invisible. `em-doctor --scope all` ran store checks only on
+projA-local + global while its `installs-drift` check simultaneously saw "2 consumer project(s)"
+— the registry is readable but store health/analytics do not follow it. From a neutral cwd,
+totals were 0. Fixture driver: scratchpad `allproj-fixture.mjs`, output captured in-session.
+
+## §4 Requirements (Ground Truth)
+
+| ID | Requirement (concrete, testable) | Parent | Test(s) | Priority | Notes / edge cases |
+|---|---|---|---|---|---|
+| REQ-1 | `resolveRegisteredStores({globalDir})` returns `[{project_path, data_dir, label, store_matches_project}]` for registry entries whose `project_path` exists; `data_dir` = `resolveLocalDir(project_path)` (the SAME resolution the substrate's spawned scripts use — planner B1), realpath'd when it exists; `store_matches_project` = (resolveLocalDir result equals the plain `join(project_path,'.episodic-memory')` AND realpath(data_dir) is contained under realpath(project_path)); deduped by realpath of `data_dir` (realpath BOTH sides — planner B5); entries whose `data_dir` realpath equals the global store dir are dropped; malformed/absent registry → `[]`; never throws | P1, CAPABILITIES cross-store clause; planner B1/B5 | `testResolveRegisteredStoresBasic`, `testResolveDedupesByRealpath`, `testResolveExcludesGlobalStore`, `testResolveMalformedRegistryEmpty`, `testResolveVanishedPathDropped`, `testResolveNonRootStoreFlagged` (git-nested + linked-worktree entries → `store_matches_project:false`), `testResolveSymlinkAliasDedupe` | MUST | realpath via `fs.realpathSync` with `path.resolve` fallback (mirrors `normalizeProjectPath`); resolution logic lives ONLY in this lib — consumers never re-derive (planner B1 refactor boundary) |
+| REQ-2 | `em-stats --all-projects` appends one scope block per registered store (label `project:<basename>`, existing `dir` field disambiguates same-basename projects) after the `--scope`-selected blocks, skipping stores whose realpath equals the realpath of an already-included block's dir (realpath BOTH operands — planner B5: the `dir` field is observed to carry the UNRESOLVED path); totals include appended blocks; writes nothing anywhere | P6, curation family; planner B5 | `testStatsAllProjectsSeesForeignStore`, `testStatsAllProjectsSkipsDuplicateOfLocal` (same-spelling AND symlink-alias spelling: cwd store symlinked to a registered store), `testStatsAllProjectsReadOnly` (byte parity of foreign store before/after) | MUST | absent foreign store dir → block renders with zero counts (statsFor handles missing dir) |
+| REQ-3 | `em-doctor --all-projects` runs the store-class checks (`checkStore`) once per registered store with scope `project:<basename>` AND a `data_dir` field on every such check row (codex CX1: the label is display-only and non-unique; `data_dir` is the identity downstream consumers key on); exit-code semantics unchanged (errors → 1); non-store checks (gate-friction, installs-drift, installed-scripts, backup, drafts) run exactly once | curation family; codex CX1 | `testDoctorAllProjectsChecksForeignStore`, `testDoctorAllProjectsForeignCorruptIndexExits1`, `testDoctorAllProjectsSingletonChecks` | MUST | foreign store with malformed index.jsonl must surface as `error` + exit 1 |
+| REQ-4 | `em-doctor --all-projects --fix` repairs a foreign store by spawning `em-rebuild-index.mjs --scope local` with `cwd = <that project_path>` ONLY for entries with `store_matches_project:true`; fix routing is keyed by the check row's `data_dir` (realpath identity), NEVER by the `project:<basename>` scope label (codex CX1: the current fix loop at `em-doctor.mjs:561-581` keys `rebuildScopes` by scope name — two same-basename projects with rebuildable findings would collide/merge under a label key); mismatched entries (git-nested, linked-worktree — planner B1 runtime evidence) are reported `skipped: non-root-store` and never spawned; re-verify re-runs `checkStore` on the resolved dir and the test asserts ON DISK which store's index changed | curation family; planner B1; codex CX1 | `testDoctorAllProjectsFixRebuildsForeignIndex` (disk-location assertion), `testDoctorFixSkipsNonRootStore`, `testDoctorFixSameBasenameProjects` (two registered projects named `app`, both with rebuildable corruption → BOTH stores rebuilt, disk-asserted) | MUST | non-git fixture project resolves its own local store (local-dir cwd fallback — probe-confirmed) |
+| REQ-5 | `em-consolidate --fold-superseded --all-projects` iterates registered stores with `store_matches_project:true` (others `skipped: non-root-store`); the R6 protection scan loads rows ONCE as the UNION of cwd-local + global + ALL registered stores (planner B3: a valid referencer in a third store must protect — probe confirmed cross-store protection is live behavior), passing realpath(data_dir) as each `storeLabel` (planner B4: `computeProtectedIds` class-d keys `latestByStore` by `_store`; basename labels merge colliding stores and silently unprotect); a protected chain member in any iterated store is never archived | P10, RFC-009 R6 protection invariant; planner B3/B4 | `testFoldAllProjectsArchivesForeignChain`, `negative: testFoldAllProjectsHonorsForeignProtection` (referencer in a THIRD store; asserts FULL chain-closure keep — member count + both `r6-protected:*` and `chain-member` reasons, planner M1: one anchor kept while 10 closure members archived must FAIL the test), `testFoldProtectionLabelIsRealpath` (basename-colliding fixture) | MUST | this is the §7-C1 trust-boundary row; single-store fold behavior unchanged (existing `test-fold-superseded.mjs` stays green) |
+| REQ-6 | `--all-projects` without `--fold-superseded` on em-consolidate, or combined with `--scope`, exits 2 with a JSON usage error; a real (non-`--dry-run`) `--all-projects` fold requires `--confirm` (absent → exit 2, nothing written) | P3, P10 | `testFoldAllProjectsRequiresFoldMode`, `testFoldAllProjectsScopeConflict`, `negative: testFoldAllProjectsRealRunNeedsConfirm` | MUST | fail-closed: the guard fires BEFORE any archive move |
+| REQ-7 | `em-promote` (dry-run default) lists candidate clusters: active canonical-`lesson` episodes with token-set Jaccard ≥ `--min-sim` (default 0.35) spanning ≥2 DISTINCT registered project stores; replica collapse BEFORE clustering requires id AND summary equality (codex CX2: episode ids are not proven globally unique across independent stores — a coincident id with DIFFERENT content stays two distinct members, never silently collapsed); single-store clusters never listed | learning family; planner M4; codex CX2 | `testPromoteFindsCrossStoreRecurrence`, `testPromoteIgnoresSingleStoreCluster`, `testPromoteSkipsReplicaMembers` (id+summary match collapses), `testPromoteSameIdDifferentContentStaysDistinct` | MUST | tokens via `episodeTokens` (summary+tags+body), same vocabulary as em-consolidate |
+| REQ-8 | `em-promote --apply` writes ONE global episode per candidate by spawning the sibling `em-store.mjs` with `--scope global --category lesson --tags <union>,promoted-lesson,promoted:<sha8> --body-file <tmp>` where `<sha8>` = first 8 hex of sha256 over the newline-joined SORTED list of member keys `<id>#<sha8(summary)>` (codex CX2: content-qualified so a coincident-id forgery cannot alias another cluster's identity; stable across store relocation because the summary travels with the immutable episode — episode files are never edited, revisions mint NEW ids); body carries a `## Sources` section listing each member `id`, `project`, and store dir; source stores byte-identical before/after | P7, learning family; codex CX2 | `testPromoteApplyWritesGlobalEpisode`, `testPromoteApplyBodyCarriesSources` (sentinel id asserted in written episode file), `negative: testPromoteNeverWritesSourceStores` (foreign index.jsonl byte-parity) | MUST | spawn `process.execPath` + sibling script path; `--body-file` per body-file lesson |
+| REQ-9 | `em-promote` idempotency keys on SOURCE IDENTITY, never similarity (planner B2: runtime probe measured Jaccard(member, minimal 2-member digest) = 0.255 — the digest is a token superset and similarity DILUTES with cluster size, so a similarity threshold re-promotes unboundedly): a candidate whose `promoted:<sha8>` tag matches any ACTIVE global episode's tag is skipped, reported `skipped: already-promoted`; re-running `--apply` twice writes zero new episodes on the second run; a candidate whose member set strictly contains an already-promoted set has a DEFINED disposition: promote (new hash) with the prior digest id named in `## Sources` under `Supersedes-promotion:` | P6, §8.4 drift contract; planner B2 | `testPromoteApplyIdempotent` (hash-keyed; runs twice, asserts 0 new episodes AND 0 new files in global episodes/), `testPromoteSupersetClusterPromotesWithBackref` | MUST | no `--dedupe-sim` flag ships (similarity dedupe removed from the contract entirely) |
+| REQ-10 | `em-promote --help` and its file header carry `EXPERIMENTAL` + promote-or-remove decision date `2026-10-08`; dry-run is the default; `--apply` is the only write path | P5, CAPABILITIES experimental tier | `testPromoteHelpCarriesExperimental`, `manual: node scripts/em-promote.mjs --help` | MUST | tier honesty is a charter criterion, hence MUST |
+| REQ-11 | New script + flags deploy with ZERO installer/dispatcher edits: `em-promote.mjs` appears in `globalEntryScripts()` output and `em promote --help` dispatches | P9, distribution layer | `testPromoteIsSubstrateScript` (imports `isSubstrateScript`, asserts true), `manual: node scripts/em.mjs promote --help` | SHOULD | auto-enumeration verified at `install-manifest.mjs:202-205` this session |
+| REQ-12 | All multi-store behavior is proven under isolated `HOME` (fixtures never touch the operator's real stores); every new suite registers in `.github/workflows/plan-marker-validate.yml` | repo test conventions | suite files themselves + `grep -c "test-registered-stores\|test-all-projects-observability\|test-fold-all-projects\|test-em-promote" .github/workflows/plan-marker-validate.yml` → 4 (codex CX3: the proof grep must name ALL FOUR suites — the earlier spelling omitted the fold suite, the riskiest write path) | MUST | registration is the check-actual-CI lesson (`gh pr checks` verifies at PR time) |
+| REQ-13 | Governing MD files reflect the shipped capability: CAPABILITIES.md learning-strategy row names `em-promote (experimental)`; curation-family text names the `--all-projects` cross-store operation; EM_SCRIPTS_GUIDE.md documents the new flags + script | user instruction 2026-07-08; Rule 10/11 | `grep -n "em-promote" CAPABILITIES.md docs/EM_SCRIPTS_GUIDE.md` → ≥1 match each; docs index files checked per Rule 10 at build time | MUST | user instruction this session: "ensure new capabilities reflect in the MD files" |
+| REQ-14 | Cross-platform: no shell string interpolation for paths; spawns use `process.execPath` + argv arrays; all path math via `path`; fixtures via `os.tmpdir()`-safe scratch or test-owned dirs | cross-platform rule | code review + `grep -n "execSync(" <new files>` → 0 matches | MUST | registry paths may contain spaces |
+
+## §5 Non-Goals
+
+- Cluster-mode (similarity digest) consolidation across foreign stores — fold-superseded only.
+  Digest writing into another project's store changes that store's semantics beyond a reversible
+  archival move; revisit after fold burn-in.
+- Typed provenance field (`promoted_from` / `--evidence`) on promoted episodes — deferred to
+  RFC-009 P1b's linkage flags (§17-A).
+- Scheduling (`em-routines` integration for a periodic all-projects doctor) — §17-B.
+- Any enforcement/hook surface. This layer is substrate + one adjacent-layer read (registry).
+- Registry schema changes. `installs.json` is read as-is.
+- `em-prune`/`em-search`/`em-recall` cross-store variants — out of scope; fold + stats + doctor +
+  promote are the charter-named set for this layer.
+
+## §6 Token Budget (Rule 12)
+
+`wc -l` run this session (main @ `5cdc45c`):
+
+| File | `wc -l` | Reads (×~5) | Writes (est) | Notes |
+|---|---|---|---|---|
+| `scripts/em-stats.mjs` | 180 | 900 | ~30 lines | flag + loop |
+| `scripts/em-doctor.mjs` | 598 | 3,000 | ~50 lines | flag + loop + fix map |
+| `scripts/em-consolidate.mjs` | 521 | 2,600 | ~80 lines | fold-mode iteration + guards |
+| `scripts/lib/install-version.mjs` | 614 | partial ~1,200 | 0 | import surface only |
+| `scripts/lib/relevance.mjs` | 418 | partial ~1,000 | 0 | episodeTokens/loadIndex |
+| `scripts/lib/protection.mjs` | 149 | 750 | 0 | read-only |
+| `scripts/lib/local-dir.mjs` | 72 | 360 | 0 | read-only |
+| `scripts/em-capture.mjs` | 481 | partial ~800 | 0 | spawn-em-store precedent |
+| NEW `scripts/lib/registered-stores.mjs` | — | — | ~70 lines | |
+| NEW `scripts/em-promote.mjs` | — | — | ~240 lines | |
+| NEW tests (4 suites) | — | — | ~750 lines | hermetic HOME fixtures |
+| `.github/workflows/plan-marker-validate.yml` | ~290 | 400 | ~12 lines | 4 run steps |
+| `CAPABILITIES.md` | 163 | 815 | ~10 lines | |
+| `docs/EM_SCRIPTS_GUIDE.md` | 945 | partial ~600 | ~60 lines | |
+
+**Baseline (single session, all three PRs):** ~38k overhead + ~13k reads + ~35k writes/iteration +
+review cycles ≈ **~110–130k** — autocompact-risk band.
+**Optimized (3 sessions, one PR each):** PR-A ~60k, PR-B ~50k, PR-C ~60k. **DEFAULT = 3 sessions**;
+a single session is acceptable only if context stays under 110k at PR-A completion.
+
+## §7 Safety / Security
+
+Canonical planner note: `negative-scenario-planner` dispatch happens as Rule 18 step 2 leg 1
+(§19); the matrix below is the plan-author pass it will audit.
+
+| Concern | Severity | Attack/abuse scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| C1: fold archives protected episodes in a foreign store | High | fold runs from repo X against project Y; protection scan reads X-local + global (current code `em-consolidate.mjs:148-152`), missing Y's — or a THIRD registered store's (planner B3) — evidence-linked rows → protected episode archived | protection rows loaded ONCE as the union of cwd-local + global + ALL registered stores, `storeLabel` = realpath(data_dir) (planner B4) | `negative: testFoldAllProjectsHonorsForeignProtection` — third-store referencer; full chain-closure keep asserted (planner M1) |
+| C2: poisoned registry path drives writes outside a store | Med | hand-edited `installs.json` entry `project_path: "/"`, a path whose `.episodic-memory` is a symlink into unrelated data, or a git-nested/worktree path whose substrate-resolved store is a DIFFERENT directory than the plain join (planner B1: spawned scripts resolve via git, observed writing the git root's store) | write ops run only for `store_matches_project:true` entries (resolveLocalDir result == plain join AND realpath(data_dir) contained under realpath(project_path)); mismatches → `skipped: non-root-store`; a `data_dir` without `index.jsonl` is skipped for WRITE operations (read ops render empty blocks) | `negative: testFoldSkipsSymlinkEscapeStore` — symlinked store dir pointing at a victim dir: victim byte-identical after real fold run; `testDoctorFixSkipsNonRootStore`, `testResolveNonRootStoreFlagged` |
+| C3: multi-store real fold fires unconfirmed | Med | operator habit-runs the single-store fold spelling with `--all-projects`; N stores archived at once | `--all-projects` fold real run requires `--confirm` (exit 2 before any move otherwise); dry-run needs no confirm | `negative: testFoldAllProjectsRealRunNeedsConfirm` — asserts exit 2 AND all stores byte-identical |
+| C4: promote writes into source project stores | Med | a bug routes the em-store spawn at local scope of an iterated project | spawn args pin `--scope global`; spawn `cwd` = a neutral dir (the global dir), so even a scope regression cannot resolve a project-local store | `negative: testPromoteNeverWritesSourceStores` — byte-parity on every fixture project store after `--apply` |
+| C5: concurrent invocations tear a foreign index | Low | two fold runs hit the same store | same exposure as the existing single-store fold (temp+rename per file; no cross-file transaction). Not worsened by this plan; residual documented in §16 | existing atomic-write pattern; `testFoldAllProjectsArchivesForeignChain` asserts index parses post-run |
+| C6: registry read makes substrate depend on distribution layer | Low | import cycle / adapter knowledge leaking into core (P9) | `registered-stores.mjs` imports only `install-version.mjs` (scripts/lib, core) + node stdlib; behavior with NO registry present = today's behavior (flags simply find zero stores) | `testResolveMalformedRegistryEmpty`; `grep -n "adapters/" scripts/lib/registered-stores.mjs scripts/em-promote.mjs` → 0 |
+
+Path-authority note (8-axis pre-enumeration for C2): the only new path predicate is "is
+`data_dir` inside `project_path`". Axes: (1) `project_path` symlink → realpath'd by
+`normalizeProjectPath`; (2) `data_dir` symlink → realpath'd before containment; (3) macOS
+`/var`→`/private/var` → both sides realpath'd, comparison on canonical forms; (4) case-insensitive
+FS → containment via `path.relative` not string prefix; (5) trailing separators → `path.resolve`;
+(6) `project_path` vanished → dropped by REQ-1; (7) `data_dir` is a file not a dir → skipped;
+(8) UNC/Windows drive split → `path.relative` returns non-`..` only for same-root. No
+`import.meta.url`/isMain authority decisions are added (new lib has no main mode; em-promote's
+CLI entry is unconditional like every sibling em-* script).
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/**
+ * @typedef {Object} RegisteredStore
+ * @property {string} project_path — realpath of the registry entry's project
+ * @property {string} data_dir — resolveLocalDir(project_path), realpath'd when it exists —
+ *   the store the substrate's OWN scripts resolve for that project (planner B1), not a naive join
+ * @property {string} label — "project:<basename(project_path)>" (DISPLAY only; identity is
+ *   realpath(data_dir) everywhere a key/bucket/comparison is needed — planner B4/B5)
+ * @property {boolean} store_matches_project — resolveLocalDir == plain join AND realpath(data_dir)
+ *   contained under realpath(project_path); false for git-nested and linked-worktree entries;
+ *   WRITE consumers (fold, doctor --fix) require true, READ consumers include either way
+ */
+
+/**
+ * @typedef {Object} PromoteCandidate
+ * @property {Array<{id: string, project: string, store: string, summary: string}>} members
+ * @property {string[]} store_dirs — distinct data_dirs spanned (length >= 2 by construction)
+ * @property {number} linked_pair_similarity_avg
+ * @property {"candidate"|"already-promoted"} disposition
+ */
+```
+
+### 8.2 Key invariants
+
+- **Read/write asymmetry:** stats/doctor(no fix)/promote read foreign stores; ONLY fold and
+  doctor `--fix` write them, and both are reversible-class (archive move / index rebuild).
+- **Identity is `data_dir` realpath**, never label or registry order; dedupe happens once in the lib.
+- **Global store is never an iterated "project" store** (REQ-1 exclusion) — prevents double
+  counting and prevents fold treating global as a foreign project.
+- **Promote writes global-only, via the em-store subprocess contract** (em-capture precedent:
+  never hand-written episode files) — derived indexes (tags.json, category-index, tokens.json)
+  stay consistent because em-store owns them.
+- **Cross-platform:** `path` module everywhere; spawns are `spawnSync(process.execPath, [script,
+  ...args], {cwd, env})`; no shell.
+- **Atomicity:** unchanged mechanisms — fold reuses the existing per-store temp+rename writes;
+  promote's only write is em-store's own atomic append.
+
+### 8.3 Resolution / flow
+
+```text
+registry (installs.json)
+  → readRegistry (existing, degrade-not-throw)
+  → resolveRegisteredStores: filter existing → realpath → dedupe → exclude global dir
+  → per consumer:
+      em-stats:        statsFor(data_dir, "project:<base>")          [read]
+      em-doctor:       checkStore(data_dir, "project:<base>")        [read; --fix spawns rebuild cwd=project]
+      em-consolidate:  fold(data_dir) with protection(store+global)  [write, --confirm-gated]
+      em-promote:      loadIndex(data_dir) → cross-store clusters → em-store --scope global [read; --apply writes global]
+```
+
+### 8.4 Promoted-lesson data-artifact contract (fourth-catch lesson `…97a5`; #22 rows per planner M2)
+
+- **Shape:** a normal global `lesson` episode. Tags = union of member tags + `promoted-lesson` +
+  `promoted:<sha8>` (identity hash over sorted member ids, REQ-8). Project field = `cross-project`.
+  Summary = `Recurring lesson: <terminal member's summary>`. Body = generated header line, one
+  `## <summary>` section per member (id, project, store dir, body excerpt ≤ 40 lines), closing
+  `## Sources` list (per-member `id`, `project`, store dir; optional `Supersedes-promotion:` line).
+- **Schema + validator (#22 row 1):** frontmatter validated by em-store (the only sanctioned
+  writer); the body convention is validated by em-promote itself at read time (see drift row).
+- **Versioning/deprecation (#22 row 2):** the `promoted-lesson`/`promoted:<sha8>` tag convention
+  and the `cross-project` sentinel are EXPERIMENTAL-tier surface with the same decision date
+  (2026-10-08): P1b typed provenance retires them (migration = one re-tag sweep, tracked in the
+  §17-A issue). Waived beyond that under the experimental clause — explicitly, not silently.
+- **All writers + validation symmetry (#22 row 3):** em-promote-via-em-store is the sanctioned
+  writer. Hand-written episodes carrying `promoted-lesson` are tolerated inputs (recall surfaces
+  them like any lesson) but CANNOT collide with idempotency: dedupe keys on `promoted:<sha8>`,
+  which hand-written rows lack unless deliberately forged — a forged hash tag is an operator
+  self-inflicted skip, reported in dry-run output (`skipped: already-promoted` names the episode).
+- **Drift detection (#22 row 4):** `em-promote` (dry-run and `--apply`) scans existing active
+  `promoted-lesson` global episodes and reports a `warnings` array for any with absent/malformed
+  `## Sources` or a `promoted:` tag that fails the sha8 shape — mechanical detection; correction
+  flows through em-revise (P7). Sources later archived/superseded do NOT invalidate the episode
+  (derived knowledge); identity-hash dedupe (REQ-9) makes source drift unable to duplicate
+  promotions.
+- **Derived lookup (#22 row 5):** tags.json serves both tags (probe-observed em-search hit); no
+  new index.
+- **Size/retention (#22 row 6):** member excerpts ≤ 40 lines; digest count bounded by REQ-9
+  identity dedupe; promoted episodes are prunable/consolidatable like any global episode
+  (curation family owns retention).
+- **Conformance (#22 row 7):** §14 Group 4 (now 11 tests) covers every row above.
+
+## §9 Existing Hook Points
+
+Verified this session at main `5cdc45c`:
+
+| File | Line(s) | What it does today | Impact of this change |
+|---|---|---|---|
+| `scripts/lib/install-version.mjs` | 58, 67-69, 326-342 | `REGISTRY_BASENAME`, `registryPath()`, `readRegistry()` degrade-not-throw | imported by new lib; untouched |
+| `scripts/em-stats.mjs` | 76, 168-170 | `statsFor(dataDir, label)`; scope loop | append registered-store blocks after existing loop |
+| `scripts/em-doctor.mjs` | 111, 549-555 | `checkStore(dataDir, scopeName)`; run sequence | add registered-store loop beside existing calls |
+| `scripts/em-doctor.mjs` | 561-581 | `--fix` maps scope→dir for `local`/`global` only | extend map: `project:*` scopes → spawn rebuild with `cwd = project_path` |
+| `scripts/em-consolidate.mjs` | 107, 128-285 | fold mode fixed to one `DATA_DIR`; protection rows read LOCAL_DIR + GLOBAL_DIR (148-152) | extract fold body into a per-store function; per-store protection rows |
+| `scripts/em-consolidate.mjs` | 98-101 | scope validation | add `--all-projects` mutual-exclusion + `--confirm` guard |
+| `scripts/lib/install-manifest.mjs` | 202-205 | `isSubstrateScript` auto-classifies `em-*.mjs` | zero change; REQ-11 asserts it |
+| `scripts/em.mjs` | 19-21, 71-72, 127 | directory-driven dispatch | zero change |
+| `.github/workflows/plan-marker-validate.yml` | 226, 238, 259 area | substrate suite block | add 4 run steps |
+| `CAPABILITIES.md` | 39 (learning row), 70-83 (invariant) | learning default "none (opt-in)" | name `em-promote (experimental)`; note shipped cross-store ops |
+| `docs/EM_SCRIPTS_GUIDE.md` | (per-script sections) | documents each em-* script | add flags + em-promote section |
+
+## §9b Disposition sweep — ALL em-* scripts (current main `5cdc45c`)
+
+**CHANGED:** `em-stats.mjs` (flag), `em-doctor.mjs` (flag + fix map), `em-consolidate.mjs`
+(fold iteration + guards), NEW `em-promote.mjs`, NEW `scripts/lib/registered-stores.mjs`.
+
+**INTERACTS (verified, no edits):**
+
+| Script | Interaction | Disposition |
+|---|---|---|
+| `em-store.mjs` | promote's write path (subprocess, `--scope global`, `--body-file`) | UNCHANGED — existing flags suffice (verified: no provenance flag exists; §17-A) |
+| `em-rebuild-index.mjs` | doctor `--fix` spawns it per foreign store with explicit cwd | UNCHANGED |
+| `em-prune.mjs` | shares `protection.mjs` + archive mechanism with fold | UNCHANGED — protection lib reused read-only |
+| `em-restore.mjs` | reversibility path for fold archives (per store) | UNCHANGED — operates per store dir already |
+| `em-search.mjs` / `em-list.mjs` / `em-recall.mjs` | surface promoted global lessons via normal recall; `--history` unaffected (fold semantics unchanged) | UNCHANGED |
+| `em-capture.mjs` | precedent: draft-then-em-store spawn pattern; promote copies the spawn contract, not the draft store | UNCHANGED |
+| `em-move.mjs` | scope-relocation sibling; NOT used by promote (promotion derives, never moves) | UNCHANGED |
+| `em-sync-install.mjs` | registry co-reader (same `readRegistry`) | UNCHANGED |
+| `em-routines.mjs` | future scheduling host for all-projects doctor (§17-B) | UNCHANGED |
+| `em-revise.mjs` | correction path for promoted episodes (P7) | UNCHANGED |
+| `em.mjs` | auto-dispatches `em promote` | UNCHANGED (REQ-11 asserts) |
+
+**UNCHANGED (no interaction beyond shared libs):** `em-audit-compliance`, `em-backup`,
+`em-check-stale`, `em-embed`, `em-feedback`, `em-graph`, `em-lock`, `em-mine-transcripts`,
+`em-pattern-health`, `em-pin`, `em-review-request`, `em-rfc-validate`, `em-seed-patterns`,
+`em-semantic`, `em-session-end-prompt`, `em-violation`, `em-watch-codex`,
+`em-workflow-validate`.
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Key deliverables | Tests | Hard stops (do NOT do in this slice) |
+|---|---|---|---|---|---|
+| APC-S1 | registered-stores lib | `scripts/lib/registered-stores.mjs`, `tests/test-registered-stores.mjs` | REQ-1 lib + 7 tests | 7 | no consumer edits |
+| APC-S2 | stats flag | `scripts/em-stats.mjs`, `tests/test-all-projects-observability.mjs` | REQ-2 | 3 | no doctor edits |
+| APC-S3 | doctor flag + fix | `scripts/em-doctor.mjs`, `tests/test-all-projects-observability.mjs` | REQ-3, REQ-4 | 7 | no consolidate edits |
+| APC-S4 | fold cross-store | `scripts/em-consolidate.mjs`, `tests/test-fold-all-projects.mjs` | REQ-5, REQ-6 + C1-C3 negatives | 8 | no cluster-mode changes |
+| APC-S5 | em-promote (experimental) | `scripts/em-promote.mjs`, `tests/test-em-promote.mjs` | REQ-7–REQ-11 + C4 negative | 12 | no schema/frontmatter additions |
+| APC-S6 | MD reflection + CI registration | `CAPABILITIES.md`, `docs/EM_SCRIPTS_GUIDE.md`, `.github/workflows/plan-marker-validate.yml` | REQ-12, REQ-13 | grep checks | no principle-text rewrites (clarification tier only if needed) |
+
+### 10.1 Dependency graph
+
+```text
+S1 ── S2 ── S3          (PR-A: read-only observability; S6 doc rows for these ride PR-A)
+ └─── S4                (PR-B: fold; hard dep on S1)
+ └─── S5 ── S6          (PR-C: promote + charter reflection; S5 hard-deps S1)
+```
+
+Hard deps: S1 before everything; S6's CAPABILITIES row lands with S5 (a charter naming an
+unshipped script would be dishonest, P5). Each PR registers its own CI steps in the same PR.
+
+## §11 Cut Order
+
+1. S5/S6 promote (PR-C) — observability + fold still ship whole.
+2. S4 fold (PR-B) — observability alone still closes the "no central view" gap.
+3. Doctor `--fix` for foreign stores (REQ-4) — report-only doctor still lands.
+
+Do **not** cut:
+
+- REQ-5 per-store protection scan (shipping fold without it archives protected episodes).
+- REQ-6 confirm gate.
+- REQ-13 MD reflection for whatever DID ship (user instruction).
+
+## §12 Contracts
+
+### `resolveRegisteredStores({ globalDir }) → RegisteredStore[]`
+
+**Input contract:** `globalDir` = absolute path of the global data dir (default
+`path.join(os.homedir(), '.episodic-memory')`).
+**Output contract:** array (possibly empty), never null, never throws; order = registry sort
+(project_path asc); every `data_dir` exists→realpath'd or is the plain join when the dir does not
+exist yet (read consumers render empty stores; write consumers skip via their own guards).
+
+**State table (exhaustive):**
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. no registry file | `installs.json` absent | `[]` | none |
+| B. malformed registry | unparseable / non-object / no `entries[]` | `[]` (readRegistry's stderr note fires) | stderr note only |
+| C. entry path vanished | `!fs.existsSync(project_path)` | entry dropped | none |
+| D. duplicate project, two tools | same realpath twice | one RegisteredStore | none |
+| E. entry resolves to global store | realpath(data_dir) === realpath(globalDir) | entry dropped | none |
+| F. store dir absent under live project | project exists, resolved store dir absent | included, `data_dir` = resolveLocalDir result (unrealpath'd), `store_matches_project` per definition | none |
+| G. happy path (git root or plain dir) | live project + store, resolution == plain join, contained | included, realpath'd, `store_matches_project:true` | none |
+| H. git-nested / linked-worktree entry | resolveLocalDir(project_path) ≠ plain join | included, `store_matches_project:false` (write consumers skip + report `non-root-store`) | none |
+| I. symlinked `.episodic-memory` escaping project | realpath(data_dir) not under realpath(project_path) | included, `store_matches_project:false` | none |
+
+**Error codes:** none — the lib never exits; consumers own exit codes.
+
+### `em-consolidate --fold-superseded --all-projects` (CLI contract additions)
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. `--all-projects` without `--fold-superseded` | cluster mode | `{status:"error"}` exit 2 | none |
+| B. `--all-projects` + `--scope` | both flags | `{status:"error"}` exit 2 | none |
+| C. `--all-projects --dry-run` | any registry state | `{status:"ok", mode:"fold-superseded", all_projects:true, stores:[{project_path, chains, folded_total, …}]}` exit 0 | none |
+| D. `--all-projects` real run, no `--confirm` | would-fold ≥ 0 | `{status:"error"}` naming `--confirm` exit 2 | **none — guard precedes any move** |
+| E. `--all-projects --confirm` real run | per-store fold over `store_matches_project:true` entries | per-store report blocks; skips (`non-root-store`, no index.jsonl) reported per store | archive moves per store |
+| F. zero registered stores | empty lib result | `{status:"ok", stores:[], folded_total:0}` exit 0 | none |
+
+Fail direction: every guard (A, B, D, C2 symlink escape) fails **closed** — error/skip before write.
+
+### `em-promote [--min-sim <f>] [--apply]`
+
+(codex CX5: no `--limit` flag ships — it was advertised without ordering/apply semantics; removed
+rather than specified. Candidate output order is deterministic: sorted by promoted-hash asc.)
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. <2 registered stores | lib returns 0–1 stores | `{status:"ok", candidates:[], note:"needs >=2 registered stores"}` exit 0 | none |
+| B. dry-run (default) | candidates found | `{status:"ok", dry_run:true, candidates:[…], warnings:[…]}` exit 0 | none |
+| C. `--apply`, fresh candidates | ≥1 candidate with unseen `promoted:<sha8>` | per-candidate em-store spawn; `{status:"ok", promoted:[{digest_id, members}]}` exit 0 | global episodes written |
+| D. `--apply`, all deduped | every candidate's hash tag already on an active global episode | `{status:"ok", promoted:[], skipped:[{reason:"already-promoted", existing:<id>}]}` exit 0 | none |
+| E. em-store spawn fails | non-zero child exit | candidate reported `{error}`; remaining candidates continue; final exit 1 | partial (each write atomic via em-store) |
+| F. invalid `--min-sim` | outside (0,1] | `{status:"error"}` exit 2 | none |
+| G. replica members (planner M4 + codex CX2) | same episode id AND same summary present in ≥2 stores | replicas collapse to one member pre-clustering; a cluster left spanning <2 stores drops; same id with DIFFERENT summary stays two members | none |
+| H. superset cluster (planner B2 boundary) | member set strictly contains an already-promoted set | promoted (new hash), `Supersedes-promotion:` back-ref in Sources | global episode written |
+| I. malformed existing promoted episode | absent/malformed `## Sources` or bad hash-tag shape | listed in `warnings`; never blocks | none |
+
+## §13 Edge Cases
+
+| # | Scenario | Expected behavior | Test |
+|---|---|---|---|
+| EC1 | empty/absent registry | all flags degrade to today's behavior; promote exits 0 with note | `testResolveMalformedRegistryEmpty`, promote state A |
+| EC2 | symlinked `data_dir` escaping `project_path`; macOS `/var`→`/private/var` | realpath both sides; escape → write ops skip + report, read ops still realpath-dedupe | `testFoldSkipsSymlinkEscapeStore` |
+| EC3 | two registry entries, same store, different tools | one iteration (realpath dedupe) | `testResolveDedupesByRealpath` |
+| EC4 | registered store == cwd-local store | stats/doctor skip the duplicate block | `testStatsAllProjectsSkipsDuplicateOfLocal` |
+| EC5 | registered project_path == `$HOME` (data_dir == global store) | dropped by REQ-1 exclusion | `testResolveExcludesGlobalStore` |
+| EC6 | foreign store corrupt (malformed index.jsonl) | doctor errors + exit 1; stats renders what parses (loadIndex behavior); fold skips store with report | `testDoctorAllProjectsForeignCorruptIndexExits1` |
+| EC7 | promote candidate where all members share ONE store | not a candidate (cross-store means ≥2 distinct data_dirs) | `testPromoteIgnoresSingleStoreCluster` |
+| EC8 | `--apply` re-run after success | zero new episodes (identity-hash dedupe, planner B2) | `testPromoteApplyIdempotent` |
+| EC11 | registered project_path is git-nested or a linked worktree | `store_matches_project:false`; reads render the RESOLVED store; writes skip + report | `testResolveNonRootStoreFlagged`, `testDoctorFixSkipsNonRootStore` |
+| EC12 | two registered projects share a basename | protection buckets keyed by realpath, not label (planner B4) | `testFoldProtectionLabelIsRealpath` |
+| EC13 | cwd-local store is a symlink alias of a registered store | one block, not two (realpath both sides, planner B5) | `testStatsAllProjectsSkipsDuplicateOfLocal` (alias spelling) |
+| EC14 | clone/fork stores carrying identical episode ids | replicas are one member; not a recurrence by themselves (planner M4) | `testPromoteSkipsReplicaMembers` |
+| EC9 | validate-then-write ordering (confirm gate, symlink guard) | guard exits BEFORE first archive rename | `negative: testFoldAllProjectsRealRunNeedsConfirm` |
+| EC10 | foreign store locked/mid-write `.tmp` present | fold unaffected (reads index.jsonl as-is); doctor's tmp-litter check reports it per store | covered by `testDoctorAllProjectsChecksForeignStore` fixture |
+
+(EC5-template row from PLAN_TEMPLATE — empty/whitespace identity diff — instantiates here as the
+byte-parity negatives: parity is computed over non-empty captured file bytes, and each parity test
+asserts the fixture file is non-empty before comparing.)
+
+## §14 Test Case Catalog
+
+```text
+Group 1: registered-stores lib (7) — tests/test-registered-stores.mjs
+  testResolveRegisteredStoresBasic — 2 live entries → 2 stores, realpath'd, labeled
+  testResolveDedupesByRealpath — same project via symlink + plain path → 1 store
+  testResolveExcludesGlobalStore — entry at $HOME → dropped
+  testResolveMalformedRegistryEmpty — garbage installs.json → []
+  testResolveVanishedPathDropped — nonexistent project_path → dropped
+  testResolveNonRootStoreFlagged — git-nested + linked-worktree entries → store_matches_project:false, resolved data_dir = git root's store (planner B1)
+  testResolveSymlinkAliasDedupe — /tmp vs /private/tmp spellings + symlinked project_path → 1 store
+
+Group 2: observability (10) — tests/test-all-projects-observability.mjs
+  testStatsAllProjectsSeesForeignStore — projB block present, totals include it
+  testStatsAllProjectsSkipsDuplicateOfLocal — (a) cwd=projA: one projA block; (b) cwd store SYMLINKED to projA's: still one block (planner B5)
+  testStatsAllProjectsReadOnly — foreign index.jsonl bytes identical pre/post
+  testDoctorAllProjectsChecksForeignStore — project:projB rows present
+  testDoctorAllProjectsForeignCorruptIndexExits1 — malformed projB index → error row + exit 1
+  testDoctorAllProjectsSingletonChecks — exactly one installs-drift row with the flag
+  testDoctorAllProjectsFixRebuildsForeignIndex — --fix repairs projB; ON-DISK assertion: projB's index.jsonl changed, sibling git-root store byte-identical (planner B1)
+  testDoctorFixSkipsNonRootStore — git-nested entry: no rebuild spawned, skipped: non-root-store reported
+  testDoctorFixSameBasenameProjects — two projects named "app", both corrupt → BOTH rebuilt (fix keyed by data_dir, codex CX1)
+  testDoctorAllProjectsForeignStoreAbsentOk — registered project without a store → ok row
+
+Group 3: fold cross-store (8) — tests/test-fold-all-projects.mjs
+  testFoldSingleStoreUnchanged — existing test-fold-superseded.mjs green (no regression)
+  testFoldAllProjectsArchivesForeignChain — 12-chain in projB archived; terminal intact; index parses
+  testFoldAllProjectsHonorsForeignProtection — referencer in a THIRD store; FULL chain-closure keep: kept count + reasons r6-protected:* AND chain-member all present (planner B3+M1)
+  testFoldProtectionLabelIsRealpath — two registered projects with colliding basenames: both stores' class-d latest records stay protected (planner B4)
+  testFoldAllProjectsRequiresFoldMode — cluster+--all-projects → exit 2
+  testFoldAllProjectsScopeConflict — --all-projects + --scope → exit 2
+  testFoldAllProjectsRealRunNeedsConfirm — no --confirm → exit 2, all stores byte-identical
+  testFoldSkipsSymlinkEscapeStore — symlinked store dir → skipped + victim untouched
+
+Group 4: promote (12) — tests/test-em-promote.mjs
+  testPromoteFindsCrossStoreRecurrence — same lesson in projA+projB → 1 candidate
+  testPromoteIgnoresSingleStoreCluster — near-dupes inside projA only → 0 candidates
+  testPromoteSkipsReplicaMembers — identical episode id+summary in projA+projB → replica collapsed, 0 candidates (planner M4)
+  testPromoteSameIdDifferentContentStaysDistinct — same id, different summary across stores → two members, no silent collapse (codex CX2)
+  testPromoteApplyWritesGlobalEpisode — global index gains 1 row, tags promoted-lesson + promoted:<sha8>
+  testPromoteApplyBodyCarriesSources — member id sentinel appears in written episode body
+  testPromoteNeverWritesSourceStores — projA/projB store bytes identical after --apply
+  testPromoteApplyIdempotent — second --apply run: 0 new episodes AND 0 new files in global episodes/ (hash-keyed, planner B2)
+  testPromoteSupersetClusterPromotesWithBackref — grown cluster promotes; Sources carries Supersedes-promotion: <prior digest id>
+  testPromoteWarnsOnMalformedPromotedEpisode — hand-broken Sources section → warnings entry, exit 0
+  testPromoteHelpCarriesExperimental — --help JSON contains "EXPERIMENTAL"
+  testPromoteIsSubstrateScript — isSubstrateScript('em-promote.mjs') === true
+
+Total: 37 tests (+ existing suites stay green).
+Runners: node tests/test-registered-stores.mjs · node tests/test-all-projects-observability.mjs ·
+node tests/test-fold-all-projects.mjs · node tests/test-em-promote.mjs
+```
+
+All four suites: isolated `HOME` (mkdtemp under the test's own scratch), REAL repo scripts spawned
+with explicit `cwd` and `env.HOME` — never staged copies (lesson `…3260`), never mental-trace.
+Byte-parity assertions capture real file bytes (sha256) pre/post and assert the pre-hash is
+non-empty-input-derived (EC-empty-identity guard).
+
+## §15 Verification Ledger (verify by artifact)
+
+Filled with observed output at implementation time:
+
+| Claim | Command (strong layer) | Observed artifact |
+|---|---|---|
+| All new tests pass | `node tests/test-<each>.mjs` (4 commands) | `<N>/<N> pass` each |
+| Existing fold suite unregressed | `node tests/test-fold-superseded.mjs` | `<N>/<N> pass` |
+| P12 untouched | `node tests/test-p12-invariant-suite.mjs` | pass |
+| Real-store smoke (read-only) | `node scripts/em-stats.mjs --all-projects` on operator machine | JSON with ≥1 project block |
+| Real-store fold dry-run only | `node scripts/em-consolidate.mjs --fold-superseded --all-projects --dry-run` | JSON report, zero writes |
+| CI green per workflow | `gh pr checks <PR>` then `gh run list` per workflow (lesson `…8ff2`) | all SUCCESS |
+| Deployed after merge | `install.mjs` + shasum repo vs `~/.episodic-memory/scripts/<file>` | hash equality |
+| MD reflection | `grep -n "em-promote" CAPABILITIES.md docs/EM_SCRIPTS_GUIDE.md` | ≥1 match each |
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Foreign-store write races (no cross-process lock) | Med | Low | same exposure class as existing single-store ops; per-file temp+rename; documented residual — locking is `em-lock` integration, out of scope |
+| Concurrent `em-promote --apply` double-writes a digest (planner M5, axis-7 DEFER) | Low | Low | duplication only, never corruption (em-store appends are per-write atomic); identity-hash dedupe shrinks the window; correctable via em-revise/em-prune; 5-field DEFER in §17-D |
+| Registry grows stale (vanished projects) | Low | Med | REQ-1 drops vanished paths; doctor's installs-drift already reports; update sweep prunes |
+| Promote false positives (unrelated lessons cluster) | Med | Med | dry-run default + explicit `--apply`; calibrated 0.35 body-token threshold (same as em-consolidate); experimental tier makes removal cheap |
+| Basename label collisions confuse readers | Low | Med | `dir` field in every block is the identity; label is display-only (stated in help text) |
+| Single-session context blowout | Med | Med | 3-PR split is the default (§6) |
+
+## §17 Open Decisions
+
+- **§17-A Typed provenance on promoted episodes** → deferred to RFC-009 P1b `--evidence`/`--lesson`
+  linkage; tracked in an issue filed at PR-C time (Rule 18 step 9). 5 fields: (1) scenario: body-only
+  sources cannot be machine-joined — reproduced by grepping a promoted fixture episode for a typed
+  field (absent); (2) spec: no accepted RFC requires typed provenance today (RFC-009 P1b ships it;
+  P1b is approved-pending, not merged); (3) history: codex R1/R2 on P1b validated the linkage design
+  (workplan v165 §19.2-3); (4) same-class: em-capture drafts share the body-carried-context shape and
+  are similarly untyped in v1 — class-consistent; (5) residual: promoted episodes can't be
+  automatically re-verified against sources until P1b lands; failure mode is graceful (stale derived
+  lesson, correctable via em-revise).
+- **§17-B em-routines scheduling of all-projects doctor** → deferred; issue at PR-A time. 5 fields:
+  (1) scenario: nothing breaks — absence just means manual invocation; (2) spec: P6 requires opt-in
+  triggers for recurring work — deferral is the conservative side; (3) history: em-routines launchd
+  work (v116-era) shipped separately from the capabilities it schedules; (4) same-class: em-doctor
+  single-store is likewise unscheduled by default; (5) residual: operators run it by hand; no
+  corruption path.
+- **§17-C Cluster-mode consolidate across projects** → non-goal (§5), revisit after fold burn-in;
+  issue at PR-B time with the same 5-field discipline.
+- **§17-D Concurrent `--apply` TOCTOU (planner M5)** → deferred; folded into the §17-A issue.
+  5 fields: (1) scenario: two concurrent applies both pass the hash-dedupe read then both write →
+  duplicate digest content, no corruption (em-store appends atomic per write; not reproduced — same
+  exposure class as existing fold C5); (2) spec: P6/P10 mandate no locking; em-lock integration out
+  of scope per §16; (3) history: planner reply `20260708-080241-…-afc8` axis-7 row documents the
+  class; (4) same-class: fold C5 shares the shape and is likewise documented-residual; (5) residual:
+  duplicate promoted episode, graceful, correctable via em-revise/em-prune.
+- **§17-E Axis-conflation carried by v1 promote surface (planner M3)** → the `cross-project`
+  sentinel inside the open `project` field and the `promoted-lesson`/`promoted:<sha8>` routing
+  tags are the same class the R10 taxonomy work retired for categories; both are named
+  EXPERIMENTAL surface (§8.4 row 2) and are retired by RFC-009 P1b typed provenance — added to the
+  §17-A issue so P1b's implementer sees them.
+
+## §18 Done Criteria
+
+- [ ] All 37 §14 tests pass + all pre-existing suites green (per workflow, `gh run list`).
+- [ ] §15 ledger fully populated with observed output.
+- [ ] Real-store read-only smoke run (stats + fold dry-run) pasted into PR body.
+- [ ] CAPABILITIES.md + EM_SCRIPTS_GUIDE.md reflect shipped capabilities (REQ-13).
+- [ ] Deferred items §17-A/B/C each have a GitHub issue (Rule 18 step 9, 5-field).
+- [ ] Post-merge deploy: install.mjs run, deployed hashes equal repo, real `--all-projects` smoke.
+
+## §19 Review Consensus (Rule 18)
+
+Leg 1: `negative-scenario-planner` dispatch on this plan (§7 audit). Leg 2+: codex via
+interactive cmux (standing directive 2026-06-28), 2-round cap, iterate HOLDs without asking.
+
+| Pass | Reviewer | Provider/Model | Blocker count | Verdict | Reply episode |
+|---|---|---|---|---|---|
+| 1 | negative-scenario-planner (v6.7) | claude subagent | 5 (+3 MAJOR, 2 MINOR) | HOLD | `20260708-080241-hold-apc-plan-round-1-afc8` |
+| 2 | codex R1 | codex gpt-5.5 high (cmux, interactive) | 5 | HOLD — all folded (CX1-CX5 below); operator waived further rounds and pre-approved implementation (2026-07-08) | cmux transcript, session `apc-review` |
+
+### 19.1 Resolved blockers — planner round 1 (all folded, this revision)
+
+| # | Blocker | Verdict | Resolution + evidence |
+|---|---|---|---|
+| B1 | store-identity resolution divergence (join ≠ substrate resolution; runtime-observed on git-nested fixture) | ACCEPT | REQ-1 re-specified: `data_dir` = `resolveLocalDir(project_path)` + `store_matches_project` flag; write ops skip mismatches (`non-root-store`); REQ-4 on-disk assertions; §12 states H/I; tests `testResolveNonRootStoreFlagged`, `testDoctorFixSkipsNonRootStore` |
+| B2 | similarity dedupe falsified (J=0.255 on minimal digest; dilutes with cluster size) | ACCEPT | REQ-9 re-keyed on `promoted:<sha8-of-sorted-member-ids>` identity tag; `--dedupe-sim` removed from contract; superset disposition defined (state H, back-ref); `testPromoteApplyIdempotent` hash-keyed |
+| B3 | protection referencer in a THIRD store unprotected under {store, global} scan | ACCEPT | REQ-5: protection rows = union of cwd-local + global + ALL registered stores, loaded once; negative test moved to third-store shape |
+| B4 | label-as-identity leak into protection class-d `latestByStore` bucket | ACCEPT | REQ-5/§8.1: `storeLabel` = realpath(data_dir), label is display-only; `testFoldProtectionLabelIsRealpath` with colliding basenames |
+| B5 | realpath asymmetry in duplicate-skip (observed unresolved `dir` field) | ACCEPT | REQ-2: realpath both operands; symlink-alias + `/tmp`↔`/private/tmp` fixtures added (EC13) |
+| M1 | protection negative must assert full chain-closure keep | ACCEPT | folded into `testFoldAllProjectsHonorsForeignProtection` (count + both reasons) |
+| M2 | missing #22 rows on promoted-lesson artifact | ACCEPT | §8.4 now carries all 7 rows (versioning waiver under experimental tier, writer asymmetry, malformed-Sources `warnings` detection) |
+| M3 | `cross-project` sentinel + routing tags = axis conflation | ACCEPT WITH MODIFICATION | kept for v1 as named EXPERIMENTAL surface; §17-E added so P1b retires them — removal now would leave promote without any provenance surface |
+| M4 | clone-store replica false recurrence | ACCEPT | REQ-7 id-dedup pre-clustering; `testPromoteSkipsReplicaMembers` |
+| M5 | concurrent `--apply` TOCTOU | DEFER | §17-D 5-field block + §16 row |
+
+Codex round 1 (gpt-5.5 high, static review; planner round carried the runtime probes):
+
+| # | Blocker | Verdict | Resolution + evidence |
+|---|---|---|---|
+| CX1 | doctor `--fix` routing keyed by `check.scope` label; same-basename projects collide (`em-doctor.mjs:561`) | ACCEPT | REQ-3 adds `data_dir` to every per-store check row; REQ-4 keys fix routing by `data_dir`; `testDoctorFixSameBasenameProjects` |
+| CX2 | episode ids not proven globally unique across stores — replica collapse + id-only hash can mis-collapse/mis-dedupe | ACCEPT | REQ-7 replica collapse requires id+summary equality; REQ-8 member key = `<id>#<sha8(summary)>` (stable: episodes immutable); `testPromoteSameIdDifferentContentStaysDistinct` |
+| CX3 | REQ-12 CI grep proof omitted the fold suite | ACCEPT | grep names all four suites, expects 4 |
+| CX4 | LOW altitude with deferred A.7 tables; stale 5/5 count symptom | ACCEPT WITH MODIFICATION | §A.7 staged mechanical-spec gate (per-slice table + lint BEFORE first edit, recorded in PR); 5/5→7/7 fixed |
+| CX5 | `--limit` advertised but unspecified | ACCEPT | flag removed; deterministic hash-asc candidate ordering stated |
+
+## §20 Lessons Encoded
+
+| Lesson | One-line rule | Enforced in |
+|---|---|---|
+| `…97a5` fourth-catch data-artifact contract | new artifact ships shape + drift + index contract | §8.4 |
+| `…3260` fixture transitive imports | spawn real scripts, never staged copies | §14 |
+| `…8ff2` gh pr checks collapses jobs | verify per workflow via `gh run list` | §15, §18 |
+| `…9ac4` three legs | P/C citations + full script disposition sweep | §3, §9b |
+| C1 discovery (this session) | protection scan must follow the store being folded | §7-C1, REQ-5 |
+| behavior-simulation rule | design claims cite fixture probe output | §3 runtime evidence |
+| planner B1 (`…afc8`) | store identity = the substrate's OWN resolution, never a naive join | REQ-1, §8.1, §12 H/I |
+| planner B2 (`…afc8`) | similarity cannot prove identity on derived supersets — key idempotency on source-id sets | REQ-9, §8.4 |
+| planner B4 (`…afc8`) | display labels never feed identity keys/buckets | §8.1, REQ-5 |
+
+---
+
+# Appendix A: Mechanical Execution Spec
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value for this plan |
+|---|---|
+| Language / runtime | Node.js 18+ (repo floor), `.mjs` ESM, zero deps |
+| Runtime check (§A.4 row) | `node --version` → `v18` or higher |
+| Test-runner shape | `node tests/test-<suite>.mjs` |
+| New-function phrasing | `export function fnName(args)` |
+| Portable break-input override | argv flag on the test file, e.g. `node tests/test-fold-all-projects.mjs --break-protection` (POSIX + Windows safe) |
+| Search tool for verifies | `grep -c` / `grep -n` from repo root |
+| Repo-specific done-commands | `node tests/test-p12-invariant-suite.mjs`; per-suite runners |
+
+## A.1 Forbidden-phrase lint
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/all-projects-consolidation.md
+```
+
+Disposition rule per template §A.1: matches inside template-quoting prose and §19 TBD cells
+(review results not yet produced) are acceptable; matches inside §A.5/§A.7 step rows are bugs.
+Run + record at finalization.
+
+## A.2–A.3 Executor contract & STOP protocol
+
+Per PLAN_TEMPLATE §A.2/§A.3 verbatim (copy into handoff). Read-only references for all slices:
+`scripts/lib/install-version.mjs`, `scripts/lib/relevance.mjs`, `scripts/lib/protection.mjs`,
+`scripts/lib/local-dir.mjs`, `scripts/em-capture.mjs`.
+
+## A.4 Pre-flight (every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| Branch | `git branch --show-current` | slice's PR branch (§1) |
+| Clean tree | `git status --porcelain` | empty |
+| Baseline suites green | `node tests/test-fold-superseded.mjs` (and slice-relevant existing suites) | all pass |
+| Runtime | `node --version` | ≥ v18 |
+
+## A.5 Shared constants
+
+```js
+// scripts/lib/registered-stores.mjs (APC-S1) exports these; later slices import them.
+export const STORE_DIR_BASENAME = '.episodic-memory'
+export const PROJECT_SCOPE_PREFIX = 'project:'
+// em-promote.mjs (APC-S5) constants:
+export const PROMOTED_TAG = 'promoted-lesson'
+export const PROMOTED_HASH_TAG_PREFIX = 'promoted:' // + first 8 hex of sha256 over newline-joined sorted member keys `<id>#<sha8(summary)>` (codex CX2)
+export const PROMOTE_MIN_SIM_DEFAULT = 0.35
+export const PROMOTE_DECISION_DATE = '2026-10-08'
+```
+
+## A.6–A.6b Anchor + falsifiable-verify rules
+
+Per PLAN_TEMPLATE verbatim. Every Verify below names observed → expected and fails on a stub;
+negative controls are their own rows via argv break flags.
+
+## A.7 Per-slice step tables
+
+**Staged mechanical-spec gate (codex CX4, ACCEPT WITH MODIFICATION).** The altitude stays LOW,
+and the full verbatim step tables (exact anchors, exact code payloads, exact assertions) are
+authored per-slice at slice start against the THEN-current file state — because anchors authored
+now WILL drift before build (workplan v165 key lesson: line numbers and constants drift; every
+§A.7 anchor gets re-verified against the actual file). To keep that deferral honest instead of a
+hole in the Rule 18 gate, it is itself gated: **before a slice's first edit, its `A.7-S<n>` table
+MUST be appended to this plan, pass the §A.1 forbidden-phrase lint and the §A.7 executor-ready
+gate (one file per step, verbatim anchors, falsifiable verifies), and the passing lint output is
+recorded in that slice's PR body.** Operator approval of this plan covers §1–§20 plus this staging
+contract; an A.7 table that fails its gate blocks that slice exactly as a failed plan review
+would. The slice-level file/kind/verify skeleton is fixed NOW:
+
+### APC-S1 skeleton
+| Step | File | Kind | Action | Verify |
+|---|---|---|---|---|
+| 1.1 | `scripts/lib/registered-stores.mjs` | CREATE | lib per §12 contract, §A.5 constants, `resolveRegisteredStores` state table A–G | `grep -c "export function resolveRegisteredStores" scripts/lib/registered-stores.mjs` → 1 |
+| 1.2 | `tests/test-registered-stores.mjs` | CREATE | 7 Group-1 tests, isolated HOME, real lib import; sentinel project paths | `node tests/test-registered-stores.mjs` → `7/7 pass` |
+| 1.3 | — | — | negative control: `--break-registry` flag corrupts fixture registry mid-test → expects `[]` path exercised | `node tests/test-registered-stores.mjs --break-registry` → non-zero exit |
+| 1.4 | — | — | commit `APC-1: registered-stores lib` + trailer | `git log -1 --oneline` shows `APC-1` |
+
+### APC-S2/S3/S4/S5 skeletons
+Same shape: one CREATE/EDIT step per file listed in §10, one test-suite CREATE with the §14
+group's named tests, one argv-flag negative-control row per §7 mitigation touching that slice,
+one CI-registration EDIT (`.github/workflows/plan-marker-validate.yml`, APPEND run step after the
+`test-fold-superseded.mjs` step at current line 259), one commit row.
+
+### APC-S6 skeleton
+| Step | File | Kind | Action | Verify |
+|---|---|---|---|---|
+| 6.1 | `CAPABILITIES.md` | EDIT | learning-row default cell: `none (opt-in)` → `em-promote (EXPERIMENTAL, decision 2026-10-08); otherwise none (opt-in)`; curation family paragraph gains one sentence naming shipped `--all-projects` ops | `grep -c "em-promote" CAPABILITIES.md` → ≥1 |
+| 6.2 | `docs/EM_SCRIPTS_GUIDE.md` | EDIT | new em-promote section + `--all-projects` rows for stats/doctor/consolidate | `grep -c "all-projects" docs/EM_SCRIPTS_GUIDE.md` → ≥3 |
+| 6.3 | — | — | Rule 10/11 index check: `docs/README.md` + `docs/_index.json` updated iff EM_SCRIPTS_GUIDE has registered triggers there (verify at build) | grep of `_index.json` for the guide's entry |
+| 6.4 | — | — | commit `APC-6: charter + guide reflection` + trailer | `git log -1 --oneline` |
+
+## A.8 Definition of done (mechanical)
+
+```bash
+node tests/test-registered-stores.mjs         # 7/7
+node tests/test-all-projects-observability.mjs # 10/10
+node tests/test-fold-all-projects.mjs          # 8/8
+node tests/test-em-promote.mjs                 # 12/12
+node tests/test-fold-superseded.mjs            # unregressed
+node tests/test-p12-invariant-suite.mjs        # pass
+node scripts/em-stats.mjs --all-projects       # real-store JSON, >=1 project block
+```
+
+## A.9 Blast-radius notes
+
+- S4 extracts the fold body into a per-store function — **pure extraction first** (fold body
+  behavior-identical for the single-store path, existing suite green) THEN the iteration caller.
+- Protection-scan change is the **high-blast-radius** edit → "focused review before build" mark.
+- Red-then-green: every §7 negative control runs as its own argv-flag row before the green run.

--- a/docs/plans/all-projects-consolidation.md
+++ b/docs/plans/all-projects-consolidation.md
@@ -448,7 +448,7 @@ Group 4: promote (12) — tests/test-em-promote.mjs
   testPromoteHelpCarriesExperimental — --help JSON contains "EXPERIMENTAL"
   testPromoteIsSubstrateScript — isSubstrateScript('em-promote.mjs') === true
 
-Total: 37 tests (+ existing suites stay green).
+Total: 40 tests (Group 4 grew to 15 with the reviewer F1-F3 regressions; + existing suites stay green).
 Runners: node tests/test-registered-stores.mjs · node tests/test-all-projects-observability.mjs ·
 node tests/test-fold-all-projects.mjs · node tests/test-em-promote.mjs
 ```
@@ -462,16 +462,21 @@ non-empty-input-derived (EC-empty-identity guard).
 
 Filled with observed output at implementation time:
 
-| Claim | Command (strong layer) | Observed artifact |
+| Claim | Command (strong layer) | Observed artifact (2026-07-08 build session) |
 |---|---|---|
-| All new tests pass | `node tests/test-<each>.mjs` (4 commands) | `<N>/<N> pass` each |
-| Existing fold suite unregressed | `node tests/test-fold-superseded.mjs` | `<N>/<N> pass` |
-| P12 untouched | `node tests/test-p12-invariant-suite.mjs` | pass |
-| Real-store smoke (read-only) | `node scripts/em-stats.mjs --all-projects` on operator machine | JSON with ≥1 project block |
-| Real-store fold dry-run only | `node scripts/em-consolidate.mjs --fold-superseded --all-projects --dry-run` | JSON report, zero writes |
-| CI green per workflow | `gh pr checks <PR>` then `gh run list` per workflow (lesson `…8ff2`) | all SUCCESS |
-| Deployed after merge | `install.mjs` + shasum repo vs `~/.episodic-memory/scripts/<file>` | hash equality |
-| MD reflection | `grep -n "em-promote" CAPABILITIES.md docs/EM_SCRIPTS_GUIDE.md` | ≥1 match each |
+| All new tests pass | `node tests/test-<each>.mjs` (4 commands) | 7/7, 10/10, 8/8, 15/15 pass |
+| Existing fold suite unregressed | `node tests/test-fold-superseded.mjs` | 11/11 pass (also test-em-consolidate 8/8, test-em-doctor 13/13, test-em-stats-semantic 13/13) |
+| P12 untouched | `node tests/test-p12-invariant-suite.mjs` | `P12 INVARIANT GATE: PASS` (7 members) |
+| Repo-wide guards | control-bytes, install-manifest, lib-closure, em-cli, readonly-manifest suites | 552 files clean; 57/57; 6/6; 9/9; 16/16 |
+| Real-store smoke (read-only) | `node scripts/em-stats.mjs --all-projects --scope global` | `project:episodic-memory` block present, 1816 episodes, totals 2299 |
+| Real-store fold dry-run only | `node scripts/em-consolidate.mjs --fold-superseded --all-projects --dry-run` | real 49-member workplan chain found (folded_total 48 preview, terminal kept, forked chain skipped non-linear), zero writes |
+| em dispatch + experimental label | `node scripts/em.mjs promote --help` | `tier:"EXPERIMENTAL", decision_date:"2026-10-08"` |
+| Promote degrade (1 store) | `node scripts/em-promote.mjs` | `note:"needs >=2 registered stores (consumer registry lists 1)"` |
+| REQ-12 CI registration | 4-suite grep of plan-marker-validate.yml | `4` |
+| Step-9 issues | `gh issue create` ×3 | #478 (§17-A/D/E), #479 (§17-B), #480 (§17-C) |
+| CI green per workflow | `gh pr checks <PR>` then `gh run list` per workflow (lesson `…8ff2`) | (at PR time) |
+| Deployed after merge | `install.mjs` + shasum repo vs `~/.episodic-memory/scripts/<file>` | (post-merge) |
+| MD reflection | `grep -c "em-promote" CAPABILITIES.md docs/EM_SCRIPTS_GUIDE.md` | 3 + 3 matches |
 
 ## §16 Risk Analysis
 
@@ -487,7 +492,7 @@ Filled with observed output at implementation time:
 ## §17 Open Decisions
 
 - **§17-A Typed provenance on promoted episodes** → deferred to RFC-009 P1b `--evidence`/`--lesson`
-  linkage; tracked in an issue filed at PR-C time (Rule 18 step 9). 5 fields: (1) scenario: body-only
+  linkage; tracked in **#478** (also carries §17-D and §17-E). 5 fields: (1) scenario: body-only
   sources cannot be machine-joined — reproduced by grepping a promoted fixture episode for a typed
   field (absent); (2) spec: no accepted RFC requires typed provenance today (RFC-009 P1b ships it;
   P1b is approved-pending, not merged); (3) history: codex R1/R2 on P1b validated the linkage design
@@ -495,14 +500,14 @@ Filled with observed output at implementation time:
   are similarly untyped in v1 — class-consistent; (5) residual: promoted episodes can't be
   automatically re-verified against sources until P1b lands; failure mode is graceful (stale derived
   lesson, correctable via em-revise).
-- **§17-B em-routines scheduling of all-projects doctor** → deferred; issue at PR-A time. 5 fields:
+- **§17-B em-routines scheduling of all-projects doctor** → deferred; tracked in **#479**. 5 fields:
   (1) scenario: nothing breaks — absence just means manual invocation; (2) spec: P6 requires opt-in
   triggers for recurring work — deferral is the conservative side; (3) history: em-routines launchd
   work (v116-era) shipped separately from the capabilities it schedules; (4) same-class: em-doctor
   single-store is likewise unscheduled by default; (5) residual: operators run it by hand; no
   corruption path.
 - **§17-C Cluster-mode consolidate across projects** → non-goal (§5), revisit after fold burn-in;
-  issue at PR-B time with the same 5-field discipline.
+  tracked in **#480** with the 5-field discipline.
 - **§17-D Concurrent `--apply` TOCTOU (planner M5)** → deferred; folded into the §17-A issue.
   5 fields: (1) scenario: two concurrent applies both pass the hash-dedupe read then both write →
   duplicate digest content, no corruption (em-store appends atomic per write; not reproduced — same
@@ -518,7 +523,7 @@ Filled with observed output at implementation time:
 
 ## §18 Done Criteria
 
-- [ ] All 37 §14 tests pass + all pre-existing suites green (per workflow, `gh run list`).
+- [ ] All 40 §14 tests pass + all pre-existing suites green (per workflow, `gh run list`).
 - [ ] §15 ledger fully populated with observed output.
 - [ ] Real-store read-only smoke run (stats + fold dry-run) pasted into PR body.
 - [ ] CAPABILITIES.md + EM_SCRIPTS_GUIDE.md reflect shipped capabilities (REQ-13).
@@ -534,6 +539,7 @@ interactive cmux (standing directive 2026-06-28), 2-round cap, iterate HOLDs wit
 |---|---|---|---|---|---|
 | 1 | negative-scenario-planner (v6.7) | claude subagent | 5 (+3 MAJOR, 2 MINOR) | HOLD | `20260708-080241-hold-apc-plan-round-1-afc8` |
 | 2 | codex R1 | codex gpt-5.5 high (cmux, interactive) | 5 | HOLD — all folded (CX1-CX5 below); operator waived further rounds and pre-approved implementation (2026-07-08) | cmux transcript, session `apc-review` |
+| 3 | negative-scenario-reviewer (v4.8, impl diff) | claude subagent | 2 MAJOR + 1 MINOR (all em-promote.mjs) | HOLD — all fixed same cycle (F1-F3 below) | `20260708-084913-hold-apc-impl-round-1-2-major-em-promote-09f3` |
 
 ### 19.1 Resolved blockers — planner round 1 (all folded, this revision)
 
@@ -559,6 +565,15 @@ Codex round 1 (gpt-5.5 high, static review; planner round carried the runtime pr
 | CX3 | REQ-12 CI grep proof omitted the fold suite | ACCEPT | grep names all four suites, expects 4 |
 | CX4 | LOW altitude with deferred A.7 tables; stale 5/5 count symptom | ACCEPT WITH MODIFICATION | §A.7 staged mechanical-spec gate (per-slice table + lint BEFORE first edit, recorded in PR); 5/5→7/7 fixed |
 | CX5 | `--limit` advertised but unspecified | ACCEPT | flag removed; deterministic hash-asc candidate ordering stated |
+
+Implementation review round (negative-scenario-reviewer v4.8 on `git diff main...HEAD`; fold/gate/protection/doctor/cwd-binding all held under its runtime probes):
+
+| # | Finding | Verdict | Resolution + evidence |
+|---|---|---|---|
+| F1 | recurrence predicate satisfiable by store replication alone (full clone → observed `candidates=1`) | ACCEPT | predicate re-specified: a candidate requires a pair of DISTINCT members with DISJOINT store-sets (fail-safe: partial-clone shapes excluded); `testPromoteCloneStoreCannotFabricateRecurrence` (full + partial clone + independent control) |
+| F2 | `## Sources` first-match parse hijackable by untrusted member excerpts (observed doubled header + `supersedes_promotion:null`) | ACCEPT | write side quotes heading lines in excerpts + `## Member:` prefix; read side parses the LAST section + warns on multiple headers; `testPromoteSourcesHeaderInjectionContained` |
+| F3 | member tag union leaks stray `promoted:*` tags into the dedupe identity set | ACCEPT | identity-prefixed tags stripped from the union (exactly one hash tag per digest); `testPromoteStripsForeignIdentityTags` |
+| N1/N2 | scope-label dual role; identity on the tag axis | DEFER | documented P1b retirements, #478 |
 
 ## §20 Lessons Encoded
 
@@ -675,7 +690,7 @@ one CI-registration EDIT (`.github/workflows/plan-marker-validate.yml`, APPEND r
 node tests/test-registered-stores.mjs         # 7/7
 node tests/test-all-projects-observability.mjs # 10/10
 node tests/test-fold-all-projects.mjs          # 8/8
-node tests/test-em-promote.mjs                 # 12/12
+node tests/test-em-promote.mjs                 # 15/15
 node tests/test-fold-superseded.mjs            # unregressed
 node tests/test-p12-invariant-suite.mjs        # pass
 node scripts/em-stats.mjs --all-projects       # real-store JSON, >=1 project block

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -62,6 +62,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
 import { loadCategories, canonicalCategory, machineConsumedCategories } from './lib/categories.mjs'
 import { loadProtectionRows, computeProtectedIds } from './lib/protection.mjs'
+import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -69,7 +70,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-consolidate.mjs', usage: 'node em-consolidate.mjs [--scope local|global] [--min-sim <0..1>] [--min-cluster <n>] [--category <cat>] [--project <name>] [--include-pinned] [--apply] [--confirm] — fold near-duplicate episodes into digest episodes (dry-run by default) | --fold-superseded [--min-chain <n>] [--dry-run] — archive non-terminal members of long supersedes-chains (reversible; terminal untouched; history walk still resolves the chain)' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-consolidate.mjs', usage: 'node em-consolidate.mjs [--scope local|global] [--min-sim <0..1>] [--min-cluster <n>] [--category <cat>] [--project <name>] [--include-pinned] [--apply] [--confirm] — fold near-duplicate episodes into digest episodes (dry-run by default) | --fold-superseded [--min-chain <n>] [--dry-run] [--all-projects] — archive non-terminal members of long supersedes-chains (reversible; terminal untouched; history walk still resolves the chain). --all-projects (fold mode only, mutually exclusive with --scope) folds every consumer-registry store; a real multi-store run requires --confirm; per-store R6 protection unions cwd-local + global + all registered stores' }))
   process.exit(0)
 }
 
@@ -94,6 +95,20 @@ const dryRun = argv.includes('--dry-run')
 // store's worst chain measured ~145 members).
 const DEFAULT_MIN_CHAIN = 10
 const minChain = parseInt(flag('--min-chain') || String(DEFAULT_MIN_CHAIN), 10)
+
+const allProjects = argv.includes('--all-projects')
+// --all-projects guards fail CLOSED before any other work: fold mode only,
+// never combined with --scope (the registry, not the scope flag, names the
+// stores), and a real multi-store run demands --confirm (checked in the fold
+// block before the first archive move).
+if (allProjects && !foldSuperseded) {
+  console.log(JSON.stringify({ status: 'error', message: '--all-projects is valid only with --fold-superseded (cluster-mode digests never write into other projects\' stores; plan §5).' }))
+  process.exit(2)
+}
+if (allProjects && argv.includes('--scope')) {
+  console.log(JSON.stringify({ status: 'error', message: '--all-projects and --scope are mutually exclusive: the consumer registry names the stores.' }))
+  process.exit(2)
+}
 
 if (scope !== 'local' && scope !== 'global') {
   console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be local or global (single-scope by design; em-move first for cross-scope folding).` }))
@@ -131,144 +146,210 @@ if (foldSuperseded) {
     process.exit(2)
   }
 
-  const rows = loadIndex(DATA_DIR, scope)
-  const byId = new Map()
-  for (const r of rows) {
-    if (typeof r.id === 'string' && !byId.has(r.id)) byId.set(r.id, r)
+  // Multi-store consent gate (plan REQ-6): a REAL --all-projects fold requires
+  // --confirm, checked before ANY store is touched (fail closed).
+  if (allProjects && !dryRun && !confirm) {
+    console.log(JSON.stringify({ status: 'error', message: 'A real --all-projects fold archives across every registered store. Re-run with --confirm (or --dry-run to preview).' }))
+    process.exit(2)
   }
 
-  // RFC-009 R6 archival protection — the SAME set em-prune honors, so a folded
-  // chain member that is evidence-linked, a trigger-bearing lesson, a
-  // consolidates-member, a latest run record, or in the chain-closure of any of
-  // those is NEVER archived by fold (review finding: fold bypassed this,
-  // archiving episodes em-prune guarantees are protected). The protection scan
-  // is cross-store (a global lesson's evidence can name a local violation), so
-  // it reads BOTH stores' index rows regardless of the fold's own scope.
+  // Fold one store. Pure extraction of the single-store fold body — the
+  // caller supplies the store dir, a display label, and the (possibly
+  // cross-store) protected-id set; behavior for the single-store path is
+  // unchanged.
+  function foldStore(dataDir, loadLabel, protectedIds) {
+    const episodesDir = path.join(dataDir, 'episodes')
+    const rows = loadIndex(dataDir, loadLabel)
+    const byId = new Map()
+    for (const r of rows) {
+      if (typeof r.id === 'string' && !byId.has(r.id)) byId.set(r.id, r)
+    }
+
+    // Supersession edges only (supersedes back-pointers + explicit
+    // superseded_by) — consolidates edges belong to digest clusters, not
+    // revision chains, and are deliberately not followed here.
+    const successorsOf = new Map() // id -> Set<successor id>
+    const predecessorsOf = new Map() // id -> Set<predecessor id>
+    const addEdge = (from, to) => {
+      if (!successorsOf.has(from)) successorsOf.set(from, new Set())
+      successorsOf.get(from).add(to)
+      if (!predecessorsOf.has(to)) predecessorsOf.set(to, new Set())
+      predecessorsOf.get(to).add(from)
+    }
+    for (const r of byId.values()) {
+      if (typeof r.supersedes === 'string' && byId.has(r.supersedes) && r.supersedes !== r.id) addEdge(r.supersedes, r.id)
+      if (typeof r.superseded_by === 'string' && byId.has(r.superseded_by) && r.superseded_by !== r.id) addEdge(r.id, r.superseded_by)
+    }
+
+    // Connected components over the supersession edges (union-find).
+    const parentUF = new Map()
+    const findUF = (x) => {
+      while (parentUF.get(x) !== x) { parentUF.set(x, parentUF.get(parentUF.get(x))); x = parentUF.get(x) }
+      return x
+    }
+    const unionUF = (a, b) => { const ra = findUF(a), rb = findUF(b); if (ra !== rb) parentUF.set(ra, rb) }
+    for (const id of byId.keys()) parentUF.set(id, id)
+    for (const [from, succs] of successorsOf) for (const to of succs) unionUF(from, to)
+
+    const components = new Map()
+    for (const id of byId.keys()) {
+      const root = findUF(id)
+      if (!components.has(root)) components.set(root, [])
+      components.get(root).push(id)
+    }
+
+    const chains = []
+    const skipped = []
+    for (const memberIds of components.values()) {
+      if (memberIds.length < minChain) continue // chain shorter than N: untouched
+      // Linearity: a fold-eligible chain is a simple path — every member has at
+      // most one successor and one predecessor, and exactly one terminal (no
+      // successor). Forks/merges (e.g. two revisions superseding the same
+      // episode, or a consolidation cluster's shared superseded_by target) are
+      // skipped whole: archiving any member of an ambiguous chain could hide
+      // the branch the walk would have surfaced.
+      const terminals = memberIds.filter(id => !(successorsOf.get(id)?.size))
+      const nonLinear = memberIds.some(id => (successorsOf.get(id)?.size || 0) > 1 || (predecessorsOf.get(id)?.size || 0) > 1)
+      if (terminals.length !== 1 || nonLinear) {
+        skipped.push({ members: [...memberIds].sort(), reason: 'non-linear', terminals: terminals.sort() })
+        continue
+      }
+      const terminal = terminals[0]
+      const folded = []
+      const kept = []
+      for (const id of memberIds) {
+        if (id === terminal) continue
+        const r = byId.get(id)
+        if (r.pinned === true) kept.push({ id, reason: 'pinned' })
+        else if (r.status !== 'superseded') kept.push({ id, reason: 'not-superseded' })
+        else if (protectedIds.has(id)) kept.push({ id, reason: `r6-protected:${protectedIds.get(id).reason}` })
+        else folded.push(id)
+      }
+      folded.sort()
+      kept.sort((a, b) => a.id.localeCompare(b.id))
+      chains.push({ terminal, chain_length: memberIds.length, folded, kept })
+    }
+    chains.sort((a, b) => a.terminal.localeCompare(b.terminal))
+
+    const allFoldIds = new Set(chains.flatMap(c => c.folded))
+
+    if (!dryRun && allFoldIds.size > 0) {
+      // SAME archive mechanism as em-prune.pruneDir: move the file to
+      // archived/, drop the index row, clean tags.json, append the row to
+      // archived-index.jsonl. Reversible (nothing is ever deleted); the
+      // history walk keeps resolving the chain from archived metadata.
+      const archivedDir = path.join(dataDir, 'archived')
+      const indexFile = path.join(dataDir, 'index.jsonl')
+      const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+      fs.mkdirSync(archivedDir, { recursive: true })
+
+      for (const id of allFoldIds) {
+        try {
+          fs.renameSync(path.join(episodesDir, `${id}.md`), path.join(archivedDir, `${id}.md`))
+        } catch {}
+      }
+
+      // index.jsonl: keep only non-folded rows (atomic rewrite); folded rows
+      // move to archived-index.jsonl with reader-internal fields stripped.
+      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      const keptLines = []
+      const archivedLines = []
+      for (const line of lines) {
+        let entry = null
+        try { entry = JSON.parse(line) } catch {}
+        if (entry && allFoldIds.has(entry.id)) archivedLines.push(JSON.stringify(entry))
+        else keptLines.push(line)
+      }
+      const tmpIndex = indexFile + '.tmp'
+      fs.writeFileSync(tmpIndex, keptLines.join('\n') + (keptLines.length ? '\n' : ''), 'utf8')
+      fs.renameSync(tmpIndex, indexFile)
+
+      const tagsFile = path.join(dataDir, 'tags.json')
+      // Null-proto map (#469/#470): a tag literally named "constructor"/"__proto__"
+      // must not resolve to an inherited Object.prototype member. loadTagsIndex
+      // is the sanctioned reader; raw JSON.parse reintroduces the collision.
+      const tagsIndex = loadTagsIndex(dataDir) || Object.create(null)
+      for (const tag of Object.keys(tagsIndex)) {
+        if (!Array.isArray(tagsIndex[tag])) continue
+        tagsIndex[tag] = tagsIndex[tag].filter(id => !allFoldIds.has(id))
+        if (tagsIndex[tag].length === 0) delete tagsIndex[tag]
+      }
+      const tagsTmp = tagsFile + '.tmp'
+      fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
+      fs.renameSync(tagsTmp, tagsFile)
+
+      const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
+      const archivedTmp = archivedIndexFile + '.tmp'
+      fs.writeFileSync(archivedTmp, existingArchived + archivedLines.join('\n') + '\n', 'utf8')
+      fs.renameSync(archivedTmp, archivedIndexFile)
+    }
+
+    return { chains, skipped, folded_total: allFoldIds.size }
+  }
+
   const today = new Date().toISOString().slice(0, 10)
+
+  if (allProjects) {
+    // Registry-driven fold. Protection rows are loaded ONCE as the UNION of
+    // cwd-local + global + every registered store (planner B3: a referencer
+    // in a THIRD store validly protects a member folded elsewhere), with
+    // storeLabel = realpath(data_dir) — the display label must never feed the
+    // class-d latestByStore bucket key (planner B4: basename collisions merge
+    // buckets and silently unprotect one store's latest run record).
+    const registered = resolveRegisteredStores()
+    const protectionDirs = new Map() // realpath -> dir
+    for (const d of [LOCAL_DIR, GLOBAL_DIR, ...registered.map(s => s.data_dir)]) {
+      const key = realpathSafe(d)
+      if (!protectionDirs.has(key)) protectionDirs.set(key, d)
+    }
+    const protectionRows = []
+    for (const [key, d] of protectionDirs) {
+      protectionRows.push(...loadProtectionRows(fs, path, d, key))
+    }
+    const protectedIds = computeProtectedIds(protectionRows, today)
+
+    const stores = []
+    let foldedTotal = 0
+    for (const st of registered) {
+      if (!st.store_matches_project) {
+        stores.push({ project_path: st.project_path, data_dir: st.data_dir, label: st.label, skipped_store: 'non-root-store' })
+        continue
+      }
+      if (!fs.existsSync(path.join(st.data_dir, 'index.jsonl'))) {
+        stores.push({ project_path: st.project_path, data_dir: st.data_dir, label: st.label, skipped_store: 'no-index' })
+        continue
+      }
+      const res = foldStore(st.data_dir, st.label, protectedIds)
+      foldedTotal += res.folded_total
+      stores.push({ project_path: st.project_path, data_dir: st.data_dir, label: st.label, ...res })
+    }
+
+    console.log(JSON.stringify({
+      status: 'ok',
+      mode: 'fold-superseded',
+      all_projects: true,
+      dry_run: dryRun,
+      min_chain: minChain,
+      stores,
+      folded_total: foldedTotal,
+      ...(dryRun && foldedTotal ? { hint: 'Re-run without --dry-run (plus --confirm) to archive.' } : {}),
+    }))
+    process.exit(0)
+  }
+
+  // Single-store fold (unchanged behavior). RFC-009 R6 archival protection —
+  // the SAME set em-prune honors, so a folded chain member that is
+  // evidence-linked, a trigger-bearing lesson, a consolidates-member, a latest
+  // run record, or in the chain-closure of any of those is NEVER archived by
+  // fold. The protection scan is cross-store (a global lesson's evidence can
+  // name a local violation), so it reads BOTH stores' index rows regardless of
+  // the fold's own scope.
   const protectionRows = [
     ...loadProtectionRows(fs, path, LOCAL_DIR, 'local'),
     ...loadProtectionRows(fs, path, GLOBAL_DIR, 'global')
   ]
   const protectedIds = computeProtectedIds(protectionRows, today)
-
-  // Supersession edges only (supersedes back-pointers + explicit
-  // superseded_by) — consolidates edges belong to digest clusters, not
-  // revision chains, and are deliberately not followed here.
-  const successorsOf = new Map() // id -> Set<successor id>
-  const predecessorsOf = new Map() // id -> Set<predecessor id>
-  const addEdge = (from, to) => {
-    if (!successorsOf.has(from)) successorsOf.set(from, new Set())
-    successorsOf.get(from).add(to)
-    if (!predecessorsOf.has(to)) predecessorsOf.set(to, new Set())
-    predecessorsOf.get(to).add(from)
-  }
-  for (const r of byId.values()) {
-    if (typeof r.supersedes === 'string' && byId.has(r.supersedes) && r.supersedes !== r.id) addEdge(r.supersedes, r.id)
-    if (typeof r.superseded_by === 'string' && byId.has(r.superseded_by) && r.superseded_by !== r.id) addEdge(r.id, r.superseded_by)
-  }
-
-  // Connected components over the supersession edges (union-find).
-  const parentUF = new Map()
-  const findUF = (x) => {
-    while (parentUF.get(x) !== x) { parentUF.set(x, parentUF.get(parentUF.get(x))); x = parentUF.get(x) }
-    return x
-  }
-  const unionUF = (a, b) => { const ra = findUF(a), rb = findUF(b); if (ra !== rb) parentUF.set(ra, rb) }
-  for (const id of byId.keys()) parentUF.set(id, id)
-  for (const [from, succs] of successorsOf) for (const to of succs) unionUF(from, to)
-
-  const components = new Map()
-  for (const id of byId.keys()) {
-    const root = findUF(id)
-    if (!components.has(root)) components.set(root, [])
-    components.get(root).push(id)
-  }
-
-  const chains = []
-  const skipped = []
-  for (const memberIds of components.values()) {
-    if (memberIds.length < minChain) continue // chain shorter than N: untouched
-    // Linearity: a fold-eligible chain is a simple path — every member has at
-    // most one successor and one predecessor, and exactly one terminal (no
-    // successor). Forks/merges (e.g. two revisions superseding the same
-    // episode, or a consolidation cluster's shared superseded_by target) are
-    // skipped whole: archiving any member of an ambiguous chain could hide
-    // the branch the walk would have surfaced.
-    const terminals = memberIds.filter(id => !(successorsOf.get(id)?.size))
-    const nonLinear = memberIds.some(id => (successorsOf.get(id)?.size || 0) > 1 || (predecessorsOf.get(id)?.size || 0) > 1)
-    if (terminals.length !== 1 || nonLinear) {
-      skipped.push({ members: [...memberIds].sort(), reason: 'non-linear', terminals: terminals.sort() })
-      continue
-    }
-    const terminal = terminals[0]
-    const folded = []
-    const kept = []
-    for (const id of memberIds) {
-      if (id === terminal) continue
-      const r = byId.get(id)
-      if (r.pinned === true) kept.push({ id, reason: 'pinned' })
-      else if (r.status !== 'superseded') kept.push({ id, reason: 'not-superseded' })
-      else if (protectedIds.has(id)) kept.push({ id, reason: `r6-protected:${protectedIds.get(id).reason}` })
-      else folded.push(id)
-    }
-    folded.sort()
-    kept.sort((a, b) => a.id.localeCompare(b.id))
-    chains.push({ terminal, chain_length: memberIds.length, folded, kept })
-  }
-  chains.sort((a, b) => a.terminal.localeCompare(b.terminal))
-
-  const allFoldIds = new Set(chains.flatMap(c => c.folded))
-
-  if (!dryRun && allFoldIds.size > 0) {
-    // SAME archive mechanism as em-prune.pruneDir: move the file to
-    // archived/, drop the index row, clean tags.json, append the row to
-    // archived-index.jsonl. Reversible (nothing is ever deleted); the
-    // history walk keeps resolving the chain from archived metadata.
-    const archivedDir = path.join(DATA_DIR, 'archived')
-    const indexFile = path.join(DATA_DIR, 'index.jsonl')
-    const archivedIndexFile = path.join(DATA_DIR, 'archived-index.jsonl')
-    fs.mkdirSync(archivedDir, { recursive: true })
-
-    for (const id of allFoldIds) {
-      try {
-        fs.renameSync(path.join(EPISODES_DIR, `${id}.md`), path.join(archivedDir, `${id}.md`))
-      } catch {}
-    }
-
-    // index.jsonl: keep only non-folded rows (atomic rewrite); folded rows
-    // move to archived-index.jsonl with reader-internal fields stripped.
-    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-    const keptLines = []
-    const archivedLines = []
-    for (const line of lines) {
-      let entry = null
-      try { entry = JSON.parse(line) } catch {}
-      if (entry && allFoldIds.has(entry.id)) archivedLines.push(JSON.stringify(entry))
-      else keptLines.push(line)
-    }
-    const tmpIndex = indexFile + '.tmp'
-    fs.writeFileSync(tmpIndex, keptLines.join('\n') + (keptLines.length ? '\n' : ''), 'utf8')
-    fs.renameSync(tmpIndex, indexFile)
-
-    const tagsFile = path.join(DATA_DIR, 'tags.json')
-    // Null-proto map (#469/#470): a tag literally named "constructor"/"__proto__"
-    // must not resolve to an inherited Object.prototype member. loadTagsIndex
-    // is the sanctioned reader; raw JSON.parse reintroduces the collision.
-    const tagsIndex = loadTagsIndex(DATA_DIR) || Object.create(null)
-    for (const tag of Object.keys(tagsIndex)) {
-      if (!Array.isArray(tagsIndex[tag])) continue
-      tagsIndex[tag] = tagsIndex[tag].filter(id => !allFoldIds.has(id))
-      if (tagsIndex[tag].length === 0) delete tagsIndex[tag]
-    }
-    const tagsTmp = tagsFile + '.tmp'
-    fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
-    fs.renameSync(tagsTmp, tagsFile)
-
-    const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
-    const archivedTmp = archivedIndexFile + '.tmp'
-    fs.writeFileSync(archivedTmp, existingArchived + archivedLines.join('\n') + '\n', 'utf8')
-    fs.renameSync(archivedTmp, archivedIndexFile)
-  }
+  const res = foldStore(DATA_DIR, scope, protectedIds)
 
   console.log(JSON.stringify({
     status: 'ok',
@@ -276,10 +357,10 @@ if (foldSuperseded) {
     dry_run: dryRun,
     scope,
     min_chain: minChain,
-    chains,
-    ...(skipped.length ? { skipped } : {}),
-    folded_total: allFoldIds.size,
-    ...(dryRun && allFoldIds.size ? { hint: 'Re-run without --dry-run to archive.' } : {}),
+    chains: res.chains,
+    ...(res.skipped.length ? { skipped: res.skipped } : {}),
+    folded_total: res.folded_total,
+    ...(dryRun && res.folded_total ? { hint: 'Re-run without --dry-run to archive.' } : {}),
   }))
   process.exit(0)
 }

--- a/scripts/em-doctor.mjs
+++ b/scripts/em-doctor.mjs
@@ -7,6 +7,16 @@
  *
  * Usage:
  *   node em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]
+ *                      [--all-projects]
+ *
+ * --all-projects additionally runs the store-class checks once per consumer-
+ * registry store (scope label `project:<basename>`; every store-class row
+ * carries a `data_dir` field — the label is display-only and non-unique, the
+ * dir is the identity). --fix routes rebuilds by data_dir, never by label,
+ * and only for stores the substrate itself would resolve at that project root
+ * (store_matches_project — a git-nested/worktree registration is reported
+ * `skipped: non-root-store` because a spawned rebuild would repair a DIFFERENT
+ * store than the one diagnosed).
  *
  * Checks, per store scope:
  *   node-version      Node.js >= 18
@@ -48,6 +58,7 @@ import { spawnSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
+import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -56,7 +67,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-doctor.mjs', usage: 'node em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-doctor.mjs', usage: 'node em-doctor.mjs [--scope local|global|all] [--fix] [--strict] [--verbose] [--all-projects] — --all-projects adds per-consumer-registry-store health checks (rows carry data_dir; --fix routes by data_dir and skips non-root-store registrations)' }))
   process.exit(0)
 }
 
@@ -70,6 +81,7 @@ const scope = flag('--scope') || 'all'
 const fix = argv.includes('--fix')
 const strict = argv.includes('--strict')
 const verbose = argv.includes('--verbose')
+const allProjects = argv.includes('--all-projects')
 
 const VALID_SCOPES = ['local', 'global', 'all']
 if (!VALID_SCOPES.includes(scope)) {
@@ -546,8 +558,30 @@ function checkInstallsDrift() {
   }
 }
 
-if (scope === 'local' || scope === 'all') checkStore(LOCAL_DIR, 'local')
-if (scope === 'global' || scope === 'all') checkStore(GLOBAL_DIR, 'global')
+// Every store-class row carries data_dir (the identity; scope labels are
+// display-only and can collide across same-basename registered projects).
+function checkStoreWithDir(dataDir, scopeName) {
+  const before = checks.length
+  checkStore(dataDir, scopeName)
+  for (let i = before; i < checks.length; i++) checks[i].data_dir = dataDir
+}
+
+const ranStoreDirs = new Set()
+if (scope === 'local' || scope === 'all') { checkStoreWithDir(LOCAL_DIR, 'local'); ranStoreDirs.add(realpathSafe(LOCAL_DIR)) }
+if (scope === 'global' || scope === 'all') { checkStoreWithDir(GLOBAL_DIR, 'global'); ranStoreDirs.add(realpathSafe(GLOBAL_DIR)) }
+
+// --all-projects: store-class checks per consumer-registry store not already
+// covered (realpath both sides — a cwd-local store symlinked to a registered
+// store must not produce two blocks). Non-store checks below still run once.
+const registeredStores = allProjects ? resolveRegisteredStores() : []
+const registeredByDir = new Map(registeredStores.map(st => [st.data_dir, st]))
+for (const st of registeredStores) {
+  const key = realpathSafe(st.data_dir)
+  if (ranStoreDirs.has(key)) continue
+  ranStoreDirs.add(key)
+  checkStoreWithDir(st.data_dir, st.label)
+}
+
 if (scope === 'local' || scope === 'all') checkGateFriction()
 if (scope === 'global' || scope === 'all') checkInstallsDrift()
 checkInstalledScripts()
@@ -559,25 +593,49 @@ checkDrafts()
 // by re-running the store checks and replacing their rows.
 // ---------------------------------------------------------------------------
 if (fix) {
-  const rebuildScopes = new Set(
-    checks.filter(c => c.fix === 'em-rebuild-index' && c.level !== 'ok').map(c => c.scope)
-  )
-  for (const s of rebuildScopes) {
-    const rebuildScript = path.join(SCRIPT_DIR, 'em-rebuild-index.mjs')
-    const r = spawnSync(process.execPath, [rebuildScript, '--scope', s], {
-      encoding: 'utf8',
-      // local rebuild must resolve the SAME local store this doctor saw
-      cwd: s === 'local' ? path.dirname(LOCAL_DIR) : process.cwd()
-    })
-    fixes.push({ action: 'rebuild-index', scope: s, exit: r.status, output: (r.stdout || '').trim().slice(0, 500) })
-  }
-  if (rebuildScopes.size > 0) {
-    // Re-verify: drop the pre-fix store rows and re-run those checks.
-    const rerun = [...rebuildScopes]
-    for (let i = checks.length - 1; i >= 0; i--) {
-      if (rerun.includes(checks[i].scope)) checks.splice(i, 1)
+  // Rebuild routing is keyed by data_dir (identity), never by the scope label
+  // (display-only; two registered projects named "app" share a label). Foreign
+  // stores rebuild via a spawn with cwd = that project's root, and ONLY when
+  // the substrate's own resolution matches that root (store_matches_project) —
+  // otherwise the spawned rebuild would repair a different store than the one
+  // diagnosed, so the entry is reported and skipped.
+  const rebuildTargets = new Map() // data_dir -> {scopeLabel, scopeArg, cwd}
+  const skippedNonRoot = new Set()
+  for (const c of checks) {
+    if (c.fix !== 'em-rebuild-index' || c.level === 'ok') continue
+    if (c.scope === 'local') {
+      rebuildTargets.set(LOCAL_DIR, { scopeLabel: 'local', scopeArg: 'local', cwd: path.dirname(LOCAL_DIR) })
+    } else if (c.scope === 'global') {
+      rebuildTargets.set(GLOBAL_DIR, { scopeLabel: 'global', scopeArg: 'global', cwd: process.cwd() })
+    } else if (typeof c.data_dir === 'string') {
+      const st = registeredByDir.get(c.data_dir)
+      if (!st) continue
+      if (!st.store_matches_project) {
+        if (!skippedNonRoot.has(c.data_dir)) {
+          skippedNonRoot.add(c.data_dir)
+          fixes.push({ action: 'skipped', reason: 'non-root-store', scope: c.scope, dir: c.data_dir, project: st.project_path })
+        }
+        continue
+      }
+      rebuildTargets.set(c.data_dir, { scopeLabel: c.scope, scopeArg: 'local', cwd: st.project_path })
     }
-    for (const s of rerun) checkStore(s === 'local' ? LOCAL_DIR : GLOBAL_DIR, s)
+  }
+  for (const [dataDir, t] of rebuildTargets) {
+    const rebuildScript = path.join(SCRIPT_DIR, 'em-rebuild-index.mjs')
+    const r = spawnSync(process.execPath, [rebuildScript, '--scope', t.scopeArg], {
+      encoding: 'utf8',
+      // the rebuild must resolve the SAME store this doctor saw
+      cwd: t.cwd,
+    })
+    fixes.push({ action: 'rebuild-index', scope: t.scopeLabel, dir: dataDir, exit: r.status, output: (r.stdout || '').trim().slice(0, 500) })
+  }
+  if (rebuildTargets.size > 0) {
+    // Re-verify: drop the pre-fix store rows for rebuilt dirs and re-run.
+    const rerunDirs = new Set(rebuildTargets.keys())
+    for (let i = checks.length - 1; i >= 0; i--) {
+      if (typeof checks[i].data_dir === 'string' && rerunDirs.has(checks[i].data_dir)) checks.splice(i, 1)
+    }
+    for (const [dataDir, t] of rebuildTargets) checkStoreWithDir(dataDir, t.scopeLabel)
   }
 }
 

--- a/scripts/em-promote.mjs
+++ b/scripts/em-promote.mjs
@@ -166,15 +166,29 @@ for (const m of members) {
   byRoot.get(root).push(m)
 }
 
-// Candidate: >=2 distinct member identities spanning >=2 distinct stores.
-// A lone replica (one identity present in two stores) is clone-store noise,
-// not recurrence; two near-identical lessons inside ONE store are
+// Candidate: recurrence must be INDEPENDENT presence, never explainable by
+// replication (reviewer F1: a full store clone makes every member span both
+// stores, so "spans >=2 stores" is satisfiable by copying alone). The
+// predicate is a pair of DISTINCT member identities whose store-sets are
+// DISJOINT — the two lessons never co-reside, so no replication of one store
+// can account for both. Fail-safe direction: mixed replication shapes
+// (lesson1 in {A,B}, lesson2 in {B}) are excluded even when a genuine
+// recurrence might hide inside — a missed promotion is recoverable, a
+// fabricated one pollutes global. Near-duplicates inside ONE store are
 // em-consolidate's business, not promotion's.
 const candidates = []
 for (const cluster of byRoot.values()) {
   if (cluster.length < 2) continue
+  let independent = false
+  outer: for (let i = 0; i < cluster.length; i++) {
+    for (let j = i + 1; j < cluster.length; j++) {
+      let sharesStore = false
+      for (const s of cluster[i].stores) if (cluster[j].stores.has(s)) { sharesStore = true; break }
+      if (!sharesStore) { independent = true; break outer }
+    }
+  }
+  if (!independent) continue
   const storeUnion = new Set(cluster.flatMap(m => [...m.stores]))
-  if (storeUnion.size < 2) continue
   cluster.sort((a, b) => a.id.localeCompare(b.id) || a.key.localeCompare(b.key))
   const keys = cluster.map(m => m.key).sort()
   candidates.push({
@@ -209,11 +223,21 @@ for (const r of globalRows) {
     warnings.push({ episode: r.id, problem: 'episode file missing' })
     continue
   }
-  const srcSection = content.split(/^## Sources$/m)[1]
-  if (typeof srcSection !== 'string') {
+  // Reviewer F2: member excerpts are UNTRUSTED text composed above the real
+  // Sources section — a body containing a literal "## Sources" line would
+  // hijack a first-match parse and poison the superset back-ref with fake
+  // ids. The REAL section is always composed LAST, so parse the final
+  // segment; multiple headers are surfaced (write-side quoting below makes
+  // them rare, but hand-written episodes stay possible).
+  const segments = content.split(/^## Sources$/m)
+  if (segments.length < 2) {
     warnings.push({ episode: r.id, problem: 'missing ## Sources section' })
     continue
   }
+  if (segments.length > 2) {
+    warnings.push({ episode: r.id, problem: `multiple ## Sources headers (${segments.length - 1}) — parsing the last` })
+  }
+  const srcSection = segments[segments.length - 1]
   const ids = new Set()
   for (const m of srcSection.matchAll(/^- (\S+) \(/gm)) ids.add(m[1])
   if (ids.size === 0) warnings.push({ episode: r.id, problem: 'empty/malformed ## Sources list' })
@@ -268,14 +292,21 @@ const today = new Date().toISOString().slice(0, 10)
 for (const c of fresh) {
   const newest = c.members[c.members.length - 1]
   const summary = `Recurring lesson: ${newest.summary}`
+  // Reviewer F3: member tags are untrusted for the IDENTITY axis — a stray
+  // promoted:* member tag unioned onto the digest would enter the dedupe set
+  // and silently skip a future legitimate candidate. Only OUR hash tag rides.
   const tags = normalizeTags([
-    ...c.members.flatMap(m => m.tags),
+    ...c.members.flatMap(m => m.tags).filter(t => !String(t).startsWith(PROMOTED_HASH_TAG_PREFIX) && String(t) !== PROMOTED_TAG),
     PROMOTED_TAG,
     `${PROMOTED_HASH_TAG_PREFIX}${c.hash}`,
   ])
+  // Reviewer F2 (write side): excerpts and summaries are untrusted markdown —
+  // quote any heading line so member text can never mint a section marker
+  // (the read side additionally parses only the LAST ## Sources section).
+  const quoteHeadings = (s) => s.replace(/^(#{1,6} ?)/gm, '> $1')
   const sections = c.members.map(m => {
-    const excerpt = m.body.split('\n').slice(0, EXCERPT_MAX_LINES).join('\n').trim()
-    return `## ${m.summary}\n\n(id: \`${m.id}\`, project: ${m.project}, stores: ${[...m.stores].sort().join(', ')})\n\n${excerpt}`
+    const excerpt = quoteHeadings(m.body.split('\n').slice(0, EXCERPT_MAX_LINES).join('\n').trim())
+    return `## Member: ${quoteHeadings(m.summary)}\n\n(id: \`${m.id}\`, project: ${m.project}, stores: ${[...m.stores].sort().join(', ')})\n\n${excerpt}`
   })
   const sourceLines = c.members.map(m => `- ${m.id} (${m.project}, ${[...m.stores].sort().join(', ')})`)
   if (c.supersedes_promotion) sourceLines.push(`- Supersedes-promotion: ${c.supersedes_promotion}`)

--- a/scripts/em-promote.mjs
+++ b/scripts/em-promote.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/**
+ * em-promote.mjs — EXPERIMENTAL cross-project recurring-lesson promotion.
+ *
+ * Learning strategy (CAPABILITIES.md: derives new knowledge from episodes and
+ * writes it back as global episodes) shipped under the EXPERIMENTAL tier:
+ * explicit opt-in command, dry-run by default, declared side effects (writes
+ * GLOBAL episodes only, via the em-store subprocess; never touches a project
+ * store), promote-or-remove decision date 2026-10-08.
+ *
+ * Usage:
+ *   node em-promote.mjs [--min-sim <0..1>] [--apply]
+ *
+ * Scans every consumer-registry store (~/.episodic-memory/installs.json,
+ * resolved via scripts/lib/registered-stores.mjs) for active `lesson`
+ * episodes; clusters them by token-set Jaccard (episodeTokens over
+ * summary+tags+body — the same vocabulary em-consolidate uses); a cluster is
+ * a promotion candidate only when it spans >=2 DISTINCT project stores with
+ * >=2 distinct member identities. Replicas (same id AND same summary in
+ * multiple stores — clone/fork stores) collapse to one member and are NOT
+ * recurrence by themselves; a coincident id with DIFFERENT content stays two
+ * distinct members (episode ids are not proven globally unique across
+ * independent stores).
+ *
+ * Idempotency keys on SOURCE IDENTITY, never similarity (a digest is a token
+ * superset of its members, so similarity dilutes as clusters grow): each
+ * member's key is `<id>#<sha8(summary)>` (stable — episode files are
+ * immutable; revisions mint new ids), and the candidate hash is
+ * sha8 over the newline-joined sorted key list, carried as a `promoted:<sha8>`
+ * tag on the written episode. A candidate whose hash tag already exists on an
+ * ACTIVE global episode is skipped (`already-promoted`). A grown cluster
+ * (strict superset of an already-promoted member set) promotes under its new
+ * hash with a `Supersedes-promotion:` back-reference in its Sources.
+ *
+ * Drift detection: existing active `promoted-lesson` episodes with a
+ * malformed hash tag or an absent/malformed `## Sources` section are reported
+ * in `warnings` (correction flows through em-revise; never blocks).
+ *
+ * Candidate ordering is deterministic: sorted by promoted-hash ascending.
+ *
+ * Outputs JSON: { status, dry_run, min_sim, candidates|promoted, skipped,
+ * warnings, note? }. Exit 0; exit 1 when an --apply spawn failed; exit 2 on
+ * usage errors.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { loadIndex, episodeTokens, normalizeTags } from './lib/relevance.mjs'
+import { canonicalCategory } from './lib/categories.mjs'
+import { resolveRegisteredStores } from './lib/registered-stores.mjs'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+export const PROMOTED_TAG = 'promoted-lesson'
+export const PROMOTED_HASH_TAG_PREFIX = 'promoted:'
+export const PROMOTE_MIN_SIM_DEFAULT = 0.35
+export const PROMOTE_DECISION_DATE = '2026-10-08'
+const EXCERPT_MAX_LINES = 40
+
+const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({
+    status: 'help',
+    script: 'em-promote.mjs',
+    tier: 'EXPERIMENTAL',
+    decision_date: PROMOTE_DECISION_DATE,
+    usage: `node em-promote.mjs [--min-sim <0..1>] [--apply] — EXPERIMENTAL (promote-or-remove decision ${PROMOTE_DECISION_DATE}): detect lessons recurring across >=2 consumer-registry project stores; dry-run by default; --apply writes ONE global lesson episode per recurrence (tags ${PROMOTED_TAG} + ${PROMOTED_HASH_TAG_PREFIX}<sha8>, body carries a ## Sources section); source stores are never written`,
+  }))
+  process.exit(0)
+}
+
+function flagValue(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+const minSim = parseFloat(flagValue('--min-sim') || String(PROMOTE_MIN_SIM_DEFAULT))
+const apply = argv.includes('--apply')
+
+if (!(minSim > 0 && minSim <= 1)) {
+  console.log(JSON.stringify({ status: 'error', message: `Invalid --min-sim "${flagValue('--min-sim')}". Must be in (0, 1].` }))
+  process.exit(2)
+}
+
+function sha8(s) {
+  return crypto.createHash('sha256').update(s).digest('hex').slice(0, 8)
+}
+
+function bodyOf(content) {
+  const parts = content.split('---')
+  return parts.length >= 3 ? parts.slice(2).join('---').trim() : content.trim()
+}
+
+function jaccard(a, b) {
+  let inter = 0
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a]
+  for (const tok of small) if (large.has(tok)) inter++
+  const union = a.size + b.size - inter
+  return union === 0 ? 0 : inter / union
+}
+
+// ---------------------------------------------------------------------------
+// Gather candidate members from every registered store (read-only).
+// ---------------------------------------------------------------------------
+const stores = resolveRegisteredStores()
+if (stores.length < 2) {
+  console.log(JSON.stringify({ status: 'ok', dry_run: !apply, min_sim: minSim, candidates: [], skipped: [], warnings: [], note: 'needs >=2 registered stores (consumer registry lists ' + stores.length + ')' }))
+  process.exit(0)
+}
+
+// memberKey `<id>#<sha8(summary)>` collapses replicas (same id + same summary)
+// while keeping coincident-id-different-content rows distinct.
+const byKey = new Map() // key -> {id, summary, project, tags, tokens, stores: Set, storeShown: string}
+for (const st of stores) {
+  const rows = loadIndex(st.data_dir, st.label)
+  for (const r of rows) {
+    if (r.status === 'superseded') continue
+    if (typeof r.id !== 'string' || typeof r.summary !== 'string') continue
+    if (canonicalCategory(r.category) !== 'lesson') continue
+    const key = `${r.id}#${sha8(r.summary)}`
+    if (byKey.has(key)) {
+      byKey.get(key).stores.add(st.data_dir)
+      continue
+    }
+    let body = ''
+    try { body = bodyOf(fs.readFileSync(path.join(st.data_dir, 'episodes', `${r.id}.md`), 'utf8')) } catch {}
+    byKey.set(key, {
+      key,
+      id: r.id,
+      summary: r.summary,
+      project: typeof r.project === 'string' ? r.project : path.basename(st.project_path),
+      tags: Array.isArray(r.tags) ? r.tags : [],
+      body,
+      tokens: episodeTokens({ summary: r.summary, tags: r.tags, body }),
+      stores: new Set([st.data_dir]),
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cluster (union-find over Jaccard >= --min-sim).
+// ---------------------------------------------------------------------------
+const members = [...byKey.values()]
+const parent = new Map(members.map(m => [m.key, m.key]))
+const find = (x) => {
+  while (parent.get(x) !== x) { parent.set(x, parent.get(parent.get(x))); x = parent.get(x) }
+  return x
+}
+const union = (a, b) => { const ra = find(a), rb = find(b); if (ra !== rb) parent.set(ra, rb) }
+for (let i = 0; i < members.length; i++) {
+  for (let j = i + 1; j < members.length; j++) {
+    if (jaccard(members[i].tokens, members[j].tokens) >= minSim) union(members[i].key, members[j].key)
+  }
+}
+const byRoot = new Map()
+for (const m of members) {
+  const root = find(m.key)
+  if (!byRoot.has(root)) byRoot.set(root, [])
+  byRoot.get(root).push(m)
+}
+
+// Candidate: >=2 distinct member identities spanning >=2 distinct stores.
+// A lone replica (one identity present in two stores) is clone-store noise,
+// not recurrence; two near-identical lessons inside ONE store are
+// em-consolidate's business, not promotion's.
+const candidates = []
+for (const cluster of byRoot.values()) {
+  if (cluster.length < 2) continue
+  const storeUnion = new Set(cluster.flatMap(m => [...m.stores]))
+  if (storeUnion.size < 2) continue
+  cluster.sort((a, b) => a.id.localeCompare(b.id) || a.key.localeCompare(b.key))
+  const keys = cluster.map(m => m.key).sort()
+  candidates.push({
+    hash: sha8(keys.join('\n')),
+    members: cluster,
+    store_dirs: [...storeUnion].sort(),
+  })
+}
+candidates.sort((a, b) => a.hash.localeCompare(b.hash))
+
+// ---------------------------------------------------------------------------
+// Existing promoted episodes: dedupe set + drift warnings + superset back-refs.
+// ---------------------------------------------------------------------------
+const HASH_TAG_RE = /^promoted:[0-9a-f]{8}$/
+const globalRows = loadIndex(GLOBAL_DIR, 'global')
+const existingByHashTag = new Map() // 'promoted:<sha8>' -> episode id
+const existingSourceSets = []       // {id, ids: Set<member episode id>}
+const warnings = []
+for (const r of globalRows) {
+  if (r.status === 'superseded') continue
+  const tags = Array.isArray(r.tags) ? r.tags.map(String) : []
+  if (!tags.includes(PROMOTED_TAG)) continue
+  const hashTags = tags.filter(t => t.startsWith(PROMOTED_HASH_TAG_PREFIX))
+  for (const ht of hashTags) {
+    if (HASH_TAG_RE.test(ht)) existingByHashTag.set(ht, r.id)
+    else warnings.push({ episode: r.id, problem: `malformed hash tag "${ht}"` })
+  }
+  if (hashTags.length === 0) warnings.push({ episode: r.id, problem: 'promoted-lesson episode without a promoted:<sha8> tag' })
+  let content = null
+  try { content = fs.readFileSync(path.join(GLOBAL_DIR, 'episodes', `${r.id}.md`), 'utf8') } catch {}
+  if (content === null) {
+    warnings.push({ episode: r.id, problem: 'episode file missing' })
+    continue
+  }
+  const srcSection = content.split(/^## Sources$/m)[1]
+  if (typeof srcSection !== 'string') {
+    warnings.push({ episode: r.id, problem: 'missing ## Sources section' })
+    continue
+  }
+  const ids = new Set()
+  for (const m of srcSection.matchAll(/^- (\S+) \(/gm)) ids.add(m[1])
+  if (ids.size === 0) warnings.push({ episode: r.id, problem: 'empty/malformed ## Sources list' })
+  else existingSourceSets.push({ id: r.id, ids })
+}
+
+const fresh = []
+const skipped = []
+for (const c of candidates) {
+  const tag = `${PROMOTED_HASH_TAG_PREFIX}${c.hash}`
+  const existing = existingByHashTag.get(tag)
+  if (existing) {
+    skipped.push({ hash: c.hash, reason: 'already-promoted', existing })
+    continue
+  }
+  // Strict-superset of an already-promoted member set → defined disposition:
+  // promote under the new hash, back-referencing the prior digest.
+  const memberIds = new Set(c.members.map(m => m.id))
+  const prior = existingSourceSets.find(s =>
+    s.ids.size < memberIds.size && [...s.ids].every(id => memberIds.has(id)))
+  if (prior) c.supersedes_promotion = prior.id
+  fresh.push(c)
+}
+
+function candidateReport(c) {
+  return {
+    hash: c.hash,
+    stores: c.store_dirs,
+    ...(c.supersedes_promotion ? { supersedes_promotion: c.supersedes_promotion } : {}),
+    members: c.members.map(m => ({ id: m.id, project: m.project, summary: m.summary, stores: [...m.stores].sort() })),
+  }
+}
+
+if (!apply) {
+  console.log(JSON.stringify({ status: 'ok', dry_run: true, min_sim: minSim, candidates: fresh.map(candidateReport), skipped, warnings }))
+  process.exit(0)
+}
+
+// ---------------------------------------------------------------------------
+// --apply: one global episode per fresh candidate, written via the sanctioned
+// writer (em-store subprocess — never hand-written episode files). Spawn cwd
+// is the GLOBAL dir (a neutral, non-project directory) and the scope is
+// pinned global, so no project-local store can be resolved even under a
+// regression (plan §7-C4).
+// ---------------------------------------------------------------------------
+const EM_STORE = path.join(SCRIPT_DIR, 'em-store.mjs')
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'em-promote-'))
+const promoted = []
+let anyFailure = false
+const today = new Date().toISOString().slice(0, 10)
+
+for (const c of fresh) {
+  const newest = c.members[c.members.length - 1]
+  const summary = `Recurring lesson: ${newest.summary}`
+  const tags = normalizeTags([
+    ...c.members.flatMap(m => m.tags),
+    PROMOTED_TAG,
+    `${PROMOTED_HASH_TAG_PREFIX}${c.hash}`,
+  ])
+  const sections = c.members.map(m => {
+    const excerpt = m.body.split('\n').slice(0, EXCERPT_MAX_LINES).join('\n').trim()
+    return `## ${m.summary}\n\n(id: \`${m.id}\`, project: ${m.project}, stores: ${[...m.stores].sort().join(', ')})\n\n${excerpt}`
+  })
+  const sourceLines = c.members.map(m => `- ${m.id} (${m.project}, ${[...m.stores].sort().join(', ')})`)
+  if (c.supersedes_promotion) sourceLines.push(`- Supersedes-promotion: ${c.supersedes_promotion}`)
+  const body = [
+    `Recurring lesson promoted from ${c.store_dirs.length} project stores (em-promote, ${today}).`,
+    ...sections,
+    '## Sources\n' + sourceLines.join('\n'),
+  ].join('\n\n')
+  const bodyFile = path.join(tmpDir, `${c.hash}.md`)
+  fs.writeFileSync(bodyFile, body, 'utf8')
+  const r = spawnSync(process.execPath, [
+    EM_STORE,
+    '--scope', 'global',
+    '--project', 'cross-project',
+    '--category', 'lesson',
+    '--tags', tags.join(','),
+    '--summary', summary,
+    '--body-file', bodyFile,
+  ], { cwd: GLOBAL_DIR, encoding: 'utf8' })
+  let child = null
+  try { child = JSON.parse(r.stdout) } catch {}
+  if (r.status !== 0 || !child || child.status !== 'ok') {
+    anyFailure = true
+    promoted.push({ hash: c.hash, error: (child && child.message) || (r.stderr || r.stdout || '').trim().slice(0, 300) })
+    continue
+  }
+  promoted.push({ digest_id: child.id, hash: c.hash, ...(c.supersedes_promotion ? { supersedes_promotion: c.supersedes_promotion } : {}), members: c.members.map(m => ({ id: m.id, project: m.project })) })
+}
+try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+
+console.log(JSON.stringify({ status: 'ok', dry_run: false, min_sim: minSim, promoted, skipped, warnings }))
+process.exit(anyFailure ? 1 : 0)

--- a/scripts/em-stats.mjs
+++ b/scripts/em-stats.mjs
@@ -3,7 +3,7 @@
  * em-stats.mjs — store analytics: what does memory actually hold?
  *
  * Usage:
- *   node em-stats.mjs [--scope local|global|all] [--top <n>]
+ *   node em-stats.mjs [--scope local|global|all] [--top <n>] [--all-projects]
  *
  * Per scope: episode totals (active/superseded/pinned), archived count,
  * category and project distributions, age buckets, top tags, access +
@@ -21,6 +21,7 @@ import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, computeScore } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
+import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -28,7 +29,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-stats.mjs', usage: 'node em-stats.mjs [--scope local|global|all] [--top <n>] — read-only store analytics (totals, categories, projects, age buckets, tags, access/feedback, prunable estimate)' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-stats.mjs', usage: 'node em-stats.mjs [--scope local|global|all] [--top <n>] [--all-projects] — read-only store analytics (totals, categories, projects, age buckets, tags, access/feedback, prunable estimate); --all-projects appends one scope block per consumer-registry store (label project:<basename>; the dir field is the identity)' }))
   process.exit(0)
 }
 
@@ -168,6 +169,20 @@ function statsFor(dataDir, label) {
 const scopes = []
 if (scope === 'local' || scope === 'all') scopes.push(statsFor(LOCAL_DIR, 'local'))
 if (scope === 'global' || scope === 'all') scopes.push(statsFor(GLOBAL_DIR, 'global'))
+
+// --all-projects: one block per consumer-registry store not already covered.
+// Identity is realpath on BOTH comparison operands (the dir field a block
+// carries is the unresolved spelling; a cwd-local store symlinked to a
+// registered store must not double-count).
+if (argv.includes('--all-projects')) {
+  const included = new Set(scopes.map(s => realpathSafe(s.dir)))
+  for (const st of resolveRegisteredStores()) {
+    const key = realpathSafe(st.data_dir)
+    if (included.has(key)) continue
+    included.add(key)
+    scopes.push(statsFor(st.data_dir, st.label))
+  }
+}
 
 const totals = {
   episodes: scopes.reduce((n, s) => n + s.episodes.total, 0),

--- a/scripts/lib/registered-stores.mjs
+++ b/scripts/lib/registered-stores.mjs
@@ -1,0 +1,85 @@
+/**
+ * registered-stores.mjs — resolve every registered consumer project's episode
+ * store from the consumer registry (~/.episodic-memory/installs.json), for the
+ * --all-projects layer (em-stats / em-doctor / em-consolidate / em-promote).
+ *
+ * CAPABILITIES.md sanctions the scope: "A capability may operate over a single
+ * store or across many registered stores (discovery via the consumer registry)".
+ * The registry is a distribution-layer artifact read here read-only (P1: no new
+ * data layer); this lib imports only core scripts/lib + node stdlib (P9).
+ *
+ * Identity rules (plan §8.1/§8.2, planner blockers B1/B4/B5):
+ *   - data_dir is what the SUBSTRATE resolves for that project —
+ *     resolveLocalDir(project_path) — never a naive join. A git-nested or
+ *     linked-worktree project_path resolves to a DIFFERENT directory than
+ *     <project_path>/.episodic-memory; spawned scripts (em-store,
+ *     em-rebuild-index) operate on the resolved store, so consumers must too.
+ *   - store identity is realpath(data_dir). label is DISPLAY ONLY.
+ *   - store_matches_project gates WRITE consumers (fold, doctor --fix): true
+ *     only when the resolution equals the plain join AND realpath(data_dir)
+ *     stays under realpath(project_path) (a symlinked store escaping the
+ *     project is a poisoned-registry shape, plan §7-C2).
+ *
+ * Degrade-not-throw: absent/malformed registry, vanished project paths, and
+ * unresolvable dirs never throw — entries are dropped or flagged. Read
+ * consumers may include store_matches_project:false entries (the resolved
+ * store is still real); write consumers skip them with a report.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { resolveLocalDir } from './local-dir.mjs'
+import { readRegistry, registryPath } from './install-version.mjs'
+
+export const STORE_DIR_BASENAME = '.episodic-memory'
+export const PROJECT_SCOPE_PREFIX = 'project:'
+
+export function realpathSafe(p) {
+  try { return fs.realpathSync(p) } catch { return path.resolve(p) }
+}
+
+// True when child (realpath'd) is strictly inside parent (realpath'd).
+function containedIn(child, parent) {
+  const rel = path.relative(parent, child)
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+/**
+ * @returns {Array<{project_path: string, data_dir: string, label: string,
+ *   store_matches_project: boolean}>}
+ */
+export function resolveRegisteredStores({ globalDir } = {}) {
+  const gDir = globalDir || path.join(os.homedir(), STORE_DIR_BASENAME)
+  const { entries } = readRegistry(registryPath(gDir))
+  const globalReal = realpathSafe(gDir)
+  const seen = new Set()
+  const out = []
+  const sorted = [...entries].sort((a, b) => a.project_path.localeCompare(b.project_path))
+  for (const e of sorted) {
+    let projectReal
+    try {
+      if (!fs.existsSync(e.project_path)) continue
+      projectReal = fs.realpathSync(e.project_path)
+    } catch { continue }
+    // The substrate's own resolution for this project (git-common-dir walk,
+    // cwd fallback for non-git dirs) — what a spawned em-* script would use.
+    let resolved
+    try { resolved = resolveLocalDir(projectReal) } catch { resolved = path.join(projectReal, STORE_DIR_BASENAME) }
+    const plainJoin = path.join(projectReal, STORE_DIR_BASENAME)
+    const dataDirReal = realpathSafe(resolved)
+    if (dataDirReal === globalReal) continue // never treat the global store as a project store
+    if (seen.has(dataDirReal)) continue
+    seen.add(dataDirReal)
+    const storeMatches =
+      path.resolve(resolved) === path.resolve(plainJoin) &&
+      containedIn(dataDirReal, projectReal)
+    out.push({
+      project_path: projectReal,
+      data_dir: fs.existsSync(resolved) ? dataDirReal : resolved,
+      label: `${PROJECT_SCOPE_PREFIX}${path.basename(projectReal)}`,
+      store_matches_project: storeMatches,
+    })
+  }
+  return out
+}

--- a/tests/test-all-projects-observability.mjs
+++ b/tests/test-all-projects-observability.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// test-all-projects-observability.mjs — APC-S2/S3 (plan §14 Group 2).
+// Drives the REAL em-stats / em-doctor against an isolated HOME with a
+// consumer registry of mock projects. Covers: foreign-store visibility,
+// realpath duplicate-skip (incl. symlink alias, planner B5), read-only parity,
+// corrupt-foreign exit semantics, singleton non-store checks, --fix routed by
+// data_dir (incl. same-basename collision, codex CX1) with ON-DISK assertions
+// (planner B1), and non-root-store skip.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const STATS = path.join(REPO, 'scripts', 'em-stats.mjs')
+const DOCTOR = path.join(REPO, 'scripts', 'em-doctor.mjs')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+
+function sha(p) { return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex') }
+// The lib realpaths store identities (/var → /private/var on macOS); expected
+// paths must be realpath'd the same way before comparing.
+function storeDirOf(project) { return fs.realpathSync(path.join(project, '.episodic-memory')) }
+
+function mkWorld(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `em-apc-${name}-`))
+  const home = path.join(root, 'home')
+  fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  const world = {
+    root, home,
+    entries: [],
+    register(projectPath) {
+      world.entries.push({ project_path: projectPath, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z' })
+      fs.writeFileSync(path.join(home, '.episodic-memory', 'installs.json'),
+        JSON.stringify({ schema_version: 1, entries: world.entries }, null, 2))
+    },
+    project(name, { seed = 0 } = {}) {
+      const p = path.join(root, name)
+      fs.mkdirSync(p, { recursive: true })
+      for (let i = 0; i < seed; i++) {
+        const r = spawnSync(process.execPath, [STORE, '--project', name, '--category', 'lesson',
+          '--summary', `${name} lesson ${i}`, '--body', `${name} body ${i}`, '--scope', 'local'],
+          { cwd: p, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+        if (r.status !== 0) throw new Error(`seed em-store failed: ${r.stdout}${r.stderr}`)
+      }
+      return p
+    },
+    run(script, args, cwd) {
+      return spawnSync(process.execPath, [script, ...args],
+        { cwd, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+    },
+  }
+  return world
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+function parse(r) {
+  try { return JSON.parse(r.stdout) } catch { throw new Error(`non-JSON stdout: ${r.stdout}\n${r.stderr}`) }
+}
+
+t('testStatsAllProjectsSeesForeignStore', () => {
+  const w = mkWorld('stats-sees')
+  const a = w.project('projA', { seed: 2 })
+  const b = w.project('projB', { seed: 3 })
+  w.register(a); w.register(b)
+  const out = parse(w.run(STATS, ['--scope', 'all', '--all-projects'], a))
+  const bBlock = out.scopes.find(s => s.scope === 'project:projB')
+  assert(bBlock, `projB block missing: ${JSON.stringify(out.scopes.map(s => s.scope))}`)
+  assert(bBlock.episodes.total === 3, `projB total ${bBlock.episodes.total}, want 3`)
+  assert(out.totals.episodes === 5, `grand total ${out.totals.episodes}, want 5 (2 local + 3 foreign; empty global)`)
+  const noFlag = parse(w.run(STATS, ['--scope', 'all'], a))
+  assert(!noFlag.scopes.some(s => s.scope === 'project:projB'), 'without the flag projB must stay invisible (discriminating control)')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testStatsAllProjectsSkipsDuplicateOfLocal', () => {
+  const w = mkWorld('stats-dup')
+  const a = w.project('projA', { seed: 2 })
+  w.register(a)
+  // (a) same-spelling: cwd IS the registered project
+  let out = parse(w.run(STATS, ['--scope', 'all', '--all-projects'], a))
+  const aBlocks = out.scopes.filter(s => s.dir.includes('projA') || s.scope === 'project:projA')
+  assert(aBlocks.length === 1, `same-spelling: want exactly 1 projA block, got ${aBlocks.length}: ${JSON.stringify(out.scopes.map(s => [s.scope, s.dir]))}`)
+  // (b) alias spelling: cwd whose .episodic-memory SYMLINKS projA's store (planner B5)
+  const aliasProj = path.join(w.root, 'aliasProj')
+  fs.mkdirSync(aliasProj, { recursive: true })
+  fs.symlinkSync(path.join(a, '.episodic-memory'), path.join(aliasProj, '.episodic-memory'))
+  out = parse(w.run(STATS, ['--scope', 'all', '--all-projects'], aliasProj))
+  const totals = out.scopes.filter(s => s.episodes.total === 2)
+  assert(totals.length === 1, `alias spelling: projA's 2 episodes counted ${totals.length} times, want 1: ${JSON.stringify(out.scopes.map(s => [s.scope, s.dir, s.episodes.total]))}`)
+  assert(out.totals.episodes === 2, `alias grand total ${out.totals.episodes}, want 2 (no double count)`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testStatsAllProjectsReadOnly', () => {
+  const w = mkWorld('stats-ro')
+  const a = w.project('projA', { seed: 1 })
+  const b = w.project('projB', { seed: 2 })
+  w.register(a); w.register(b)
+  const idx = path.join(b, '.episodic-memory', 'index.jsonl')
+  assert(fs.readFileSync(idx, 'utf8').length > 0, 'fixture index must be non-empty before parity check')
+  const before = sha(idx)
+  const r = w.run(STATS, ['--scope', 'all', '--all-projects'], a)
+  assert(r.status === 0, `stats exit ${r.status}`)
+  assert(sha(idx) === before, 'foreign index.jsonl bytes changed — stats must be read-only')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorAllProjectsChecksForeignStore', () => {
+  const w = mkWorld('doc-sees')
+  const a = w.project('projA', { seed: 1 })
+  const b = w.project('projB', { seed: 1 })
+  w.register(a); w.register(b)
+  const out = parse(w.run(DOCTOR, ['--all-projects'], a))
+  const bRows = out.checks.filter(c => c.scope === 'project:projB')
+  assert(bRows.length > 0, `no project:projB rows: ${JSON.stringify(out.checks.map(c => c.scope))}`)
+  assert(bRows.every(c => c.data_dir === storeDirOf(b)), `projB rows must carry data_dir: ${JSON.stringify(bRows[0])}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorAllProjectsForeignCorruptIndexExits1', () => {
+  const w = mkWorld('doc-corrupt')
+  const a = w.project('projA', { seed: 1 })
+  const b = w.project('projB', { seed: 1 })
+  w.register(a); w.register(b)
+  fs.appendFileSync(path.join(b, '.episodic-memory', 'index.jsonl'), 'NOT JSON\n')
+  const r = w.run(DOCTOR, ['--all-projects'], a)
+  const out = parse(r)
+  assert(r.status === 1, `corrupt foreign store: exit ${r.status}, want 1`)
+  assert(out.checks.some(c => c.scope === 'project:projB' && c.id === 'index-parse' && c.level === 'error'),
+    `missing projB index-parse error row: ${JSON.stringify(out.checks.filter(c => c.scope === 'project:projB'))}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorAllProjectsSingletonChecks', () => {
+  const w = mkWorld('doc-singleton')
+  const a = w.project('projA', { seed: 1 })
+  const b = w.project('projB', { seed: 1 })
+  w.register(a); w.register(b)
+  const out = parse(w.run(DOCTOR, ['--all-projects'], a))
+  for (const id of ['installs-drift', 'node-version', 'backup', 'drafts']) {
+    const n = out.checks.filter(c => c.id === id).length
+    assert(n === 1, `check ${id} ran ${n} times, want exactly 1`)
+  }
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorAllProjectsFixRebuildsForeignIndex', () => {
+  const w = mkWorld('doc-fix')
+  const a = w.project('projA', { seed: 1 })
+  const b = w.project('projB', { seed: 2 })
+  w.register(a); w.register(b)
+  // Corrupt projB: delete tags.json so the doctor flags a rebuildable finding.
+  fs.rmSync(path.join(b, '.episodic-memory', 'tags.json'))
+  const aIdxBefore = sha(path.join(a, '.episodic-memory', 'index.jsonl'))
+  const out = parse(w.run(DOCTOR, ['--all-projects', '--fix'], a))
+  const fixRow = (out.fixes || []).find(f => f.action === 'rebuild-index' && f.dir === storeDirOf(b))
+  assert(fixRow && fixRow.exit === 0, `projB rebuild fix row missing/failed: ${JSON.stringify(out.fixes)}`)
+  // ON-DISK: projB's tags.json regenerated; projA's index untouched (planner B1 assertion shape).
+  assert(fs.existsSync(path.join(b, '.episodic-memory', 'tags.json')), 'projB tags.json not regenerated on disk')
+  assert(sha(path.join(a, '.episodic-memory', 'index.jsonl')) === aIdxBefore, 'projA index changed — fix repaired the wrong store')
+  const bRows = out.checks.filter(c => c.scope === 'project:projB' && c.id === 'tags-index')
+  assert(bRows.length === 1 && bRows[0].level === 'ok', `re-verify row not ok: ${JSON.stringify(bRows)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorFixSkipsNonRootStore', () => {
+  const w = mkWorld('doc-nonroot')
+  // A git repo whose NESTED subdir is registered: substrate resolution walks to
+  // the git root, so a --fix at the nested registration must be skipped.
+  const gitRoot = path.join(w.root, 'gitroot')
+  fs.mkdirSync(gitRoot, { recursive: true })
+  spawnSync('git', ['init', '-q'], { cwd: gitRoot })
+  const nested = path.join(gitRoot, 'nested')
+  fs.mkdirSync(nested, { recursive: true })
+  // Seed the ROOT store via em-store from the nested cwd (proves the resolution class).
+  const r0 = w.run(STORE, ['--project', 'gp', '--category', 'lesson', '--summary', 'root lesson', '--body', 'b', '--scope', 'local'], nested)
+  assert(r0.status === 0, `seed failed: ${r0.stdout}${r0.stderr}`)
+  assert(fs.existsSync(path.join(gitRoot, '.episodic-memory', 'index.jsonl')), 'seed must land at the git ROOT store')
+  w.register(nested)
+  fs.rmSync(path.join(gitRoot, '.episodic-memory', 'tags.json'))
+  const out = parse(w.run(DOCTOR, ['--all-projects', '--fix'], w.home))
+  const skip = (out.fixes || []).find(f => f.action === 'skipped' && f.reason === 'non-root-store')
+  assert(skip, `non-root-store skip row missing: ${JSON.stringify(out.fixes)}`)
+  assert(!(out.fixes || []).some(f => f.action === 'rebuild-index' && f.dir === path.join(gitRoot, '.episodic-memory')),
+    'non-root registration must never spawn a rebuild')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorFixSameBasenameProjects', () => {
+  const w = mkWorld('doc-basename')
+  // codex CX1: two registered projects both named "app"; both corrupt; BOTH rebuilt.
+  const app1 = w.project(path.join('teamA', 'app'), { seed: 1 })
+  const app2 = w.project(path.join('teamB', 'app'), { seed: 1 })
+  w.register(app1); w.register(app2)
+  fs.rmSync(path.join(app1, '.episodic-memory', 'tags.json'))
+  fs.rmSync(path.join(app2, '.episodic-memory', 'tags.json'))
+  const out = parse(w.run(DOCTOR, ['--all-projects', '--fix'], w.home))
+  for (const app of [app1, app2]) {
+    const dir = storeDirOf(app)
+    assert((out.fixes || []).some(f => f.action === 'rebuild-index' && f.dir === dir && f.exit === 0),
+      `rebuild missing for ${dir}: ${JSON.stringify(out.fixes)}`)
+    assert(fs.existsSync(path.join(dir, 'tags.json')), `${dir}/tags.json not regenerated`)
+  }
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testDoctorAllProjectsForeignStoreAbsentOk', () => {
+  const w = mkWorld('doc-absent')
+  const a = w.project('projA', { seed: 1 })
+  const bare = path.join(w.root, 'bareProj')
+  fs.mkdirSync(bare, { recursive: true })
+  w.register(a); w.register(bare)
+  const r = w.run(DOCTOR, ['--all-projects'], a)
+  const out = parse(r)
+  assert(r.status === 0, `absent foreign store must not fail doctor: exit ${r.status}`)
+  const row = out.checks.find(c => c.scope === 'project:bareProj' && c.id === 'store')
+  assert(row && row.level === 'ok', `bareProj store row: ${JSON.stringify(row)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)

--- a/tests/test-em-promote.mjs
+++ b/tests/test-em-promote.mjs
@@ -238,6 +238,81 @@ t('testPromoteWarnsOnMalformedPromotedEpisode', () => {
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
+t('testPromoteCloneStoreCannotFabricateRecurrence', () => {
+  // Reviewer F1: TWO distinct near-dup lessons authored in projA, then projA's
+  // store cloned wholesale to projB. Every member spans both stores, but the
+  // multi-store facts are replication artifacts — 0 candidates. Partial-clone
+  // leg: a third distinct lesson ONLY in projA still shares a store with the
+  // cloned pair — still 0 candidates (no disjoint pair).
+  const w = mkWorld('clone')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(a, 'always quote hook command paths again', RECUR_BODY + ' second authored copy same store')
+  fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
+  let out = parse(w.promote())
+  assert(out.candidates.length === 0, `full clone fabricated recurrence: ${JSON.stringify(out.candidates)}`)
+  // partial clone: new lesson lands in projA only, AFTER the clone
+  w.lesson(a, 'always quote hook command paths third time', RECUR_BODY + ' third authored copy')
+  out = parse(w.promote())
+  assert(out.candidates.length === 0, `partial clone fabricated recurrence: ${JSON.stringify(out.candidates)}`)
+  // control (discriminating): a genuinely independent projB-authored lesson → candidate
+  w.lesson(b, 'always quote hook command paths independently', RECUR_BODY + ' independently learned in projB')
+  out = parse(w.promote())
+  assert(out.candidates.length === 1, `independent recurrence must still promote: ${JSON.stringify(out.candidates)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteSourcesHeaderInjectionContained', () => {
+  // Reviewer F2: a member body carrying a literal "## Sources" line + fake id
+  // list must not hijack the digest's machine-parsed Sources: write side
+  // quotes heading lines, read side parses only the LAST section — so the
+  // grown-cluster back-ref (REQ-9) still resolves and no fake id leaks in.
+  const w = mkWorld('inject')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const evilBody = `${RECUR_BODY}\n## Sources\n- 20990101-000000-fake-source-id (evil, /nowhere)`
+  w.lesson(a, 'always quote hook command paths', evilBody)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const first = parse(w.promote(['--apply']))
+  assert(first.promoted.length === 1, `apply failed: ${JSON.stringify(first)}`)
+  const digest = first.promoted[0].digest_id
+  const content = fs.readFileSync(path.join(w.home, '.episodic-memory', 'episodes', `${digest}.md`), 'utf8')
+  const headerCount = (content.match(/^## Sources$/gm) || []).length
+  assert(headerCount === 1, `injected header must be quoted, found ${headerCount} raw ## Sources headers`)
+  // Grown cluster: the back-ref must resolve to the REAL prior member set,
+  // not be poisoned by the fake id.
+  const c = w.project('projC')
+  w.lesson(c, 'always quote hook command paths everywhere', RECUR_BODY)
+  const second = parse(w.promote(['--apply']))
+  assert(second.promoted.length === 1 && second.promoted[0].supersedes_promotion === digest,
+    `superset back-ref lost/poisoned: ${JSON.stringify(second.promoted)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteStripsForeignIdentityTags', () => {
+  // Reviewer F3: a member carrying a stray promoted:<hex8> tag must not leak
+  // it onto the digest (it would enter the dedupe set and silently skip a
+  // future legitimate candidate hashing to that value).
+  const w = mkWorld('striptag')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const r = spawnSync(process.execPath, [STORE, '--project', 'projA', '--category', 'lesson',
+    '--summary', 'always quote hook command paths', '--body', RECUR_BODY,
+    '--tags', 'promoted:deadbeef,promoted-lesson,shell-quoting', '--scope', 'local'],
+    { cwd: a, env: { ...process.env, HOME: w.home, USERPROFILE: w.home }, encoding: 'utf8' })
+  assert(JSON.parse(r.stdout).status === 'ok', `seed failed: ${r.stdout}${r.stderr}`)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const out = parse(w.promote(['--apply']))
+  assert(out.promoted.length === 1, `apply failed: ${JSON.stringify(out)}`)
+  const row = w.globalIndexRows()[0]
+  const tags = row.tags.map(String)
+  assert(!tags.includes('promoted:deadbeef'), `stray identity tag leaked onto digest: ${JSON.stringify(tags)}`)
+  assert(tags.includes('shell-quoting'), `legitimate member tag must survive the filter: ${JSON.stringify(tags)}`)
+  assert(tags.filter(t2 => /^promoted:/.test(t2)).length === 1, `digest must carry exactly ONE identity tag: ${JSON.stringify(tags)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
 t('testPromoteHelpCarriesExperimental', () => {
   const r = spawnSync(process.execPath, [PROMOTE, '--help'], { encoding: 'utf8' })
   const out = JSON.parse(r.stdout)

--- a/tests/test-em-promote.mjs
+++ b/tests/test-em-promote.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+// test-em-promote.mjs — APC-S5 (plan §14 Group 4). Drives the REAL em-promote
+// (and em-store for seeding/writing) under isolated HOME. Covers: cross-store
+// recurrence detection, single-store/replica exclusions (planner M4), the
+// coincident-id-different-content class (codex CX2), global-only writes with
+// source byte-parity, identity-hash idempotency (planner B2), superset
+// back-refs, drift warnings, experimental labeling, and substrate-class
+// auto-distribution.
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { isSubstrateScript } from '../scripts/lib/install-manifest.mjs'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const PROMOTE = path.join(REPO, 'scripts', 'em-promote.mjs')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+
+const SENTINEL = 'SENTINEL_ap37c1'
+
+function sha(p) { return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex') }
+
+function mkWorld(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `em-promote-${name}-`))
+  const home = path.join(root, 'home')
+  fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  const world = {
+    root, home, entries: [],
+    register(projectPath) {
+      world.entries.push({ project_path: projectPath, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z' })
+      fs.writeFileSync(path.join(home, '.episodic-memory', 'installs.json'),
+        JSON.stringify({ schema_version: 1, entries: world.entries }, null, 2))
+    },
+    project(name) {
+      const p = path.join(root, name)
+      fs.mkdirSync(p, { recursive: true })
+      world.register(p)
+      return p
+    },
+    lesson(project, summary, body) {
+      const r = spawnSync(process.execPath, [STORE, '--project', path.basename(project), '--category', 'lesson',
+        '--summary', summary, '--body', body, '--scope', 'local'],
+        { cwd: project, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+      const out = JSON.parse(r.stdout)
+      if (out.status !== 'ok') throw new Error(`seed lesson failed: ${r.stdout}${r.stderr}`)
+      return out.id
+    },
+    promote(args = []) {
+      return spawnSync(process.execPath, [PROMOTE, ...args],
+        { cwd: root, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+    },
+    globalIndexRows() {
+      const p = path.join(home, '.episodic-memory', 'index.jsonl')
+      if (!fs.existsSync(p)) return []
+      return fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l))
+    },
+  }
+  return world
+}
+
+const RECUR_BODY = `always quote hook command paths in settings json ${SENTINEL} because unquoted node paths split on spaces and the gate never fires`
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+function parse(r) {
+  try { return JSON.parse(r.stdout) } catch { throw new Error(`non-JSON stdout: ${r.stdout}\n${r.stderr}`) }
+}
+
+t('testPromoteFindsCrossStoreRecurrence', () => {
+  const w = mkWorld('finds')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  w.lesson(a, 'unrelated widget observation', 'widgets rotate freely on the flange axis nothing shared here')
+  const out = parse(w.promote())
+  assert(out.dry_run === true, 'dry-run must be the default')
+  assert(out.candidates.length === 1, `want 1 candidate, got ${out.candidates.length}: ${JSON.stringify(out.candidates)}`)
+  assert(out.candidates[0].stores.length === 2, `candidate must span 2 stores: ${JSON.stringify(out.candidates[0].stores)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteIgnoresSingleStoreCluster', () => {
+  const w = mkWorld('single')
+  const a = w.project('projA')
+  w.project('projB') // registered but empty — >=2 stores so the scan runs
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(a, 'always quote hook command paths again', RECUR_BODY + ' repeated in the same project store')
+  const out = parse(w.promote())
+  assert(out.candidates.length === 0, `single-store cluster must not promote: ${JSON.stringify(out.candidates)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteSkipsReplicaMembers', () => {
+  // Clone-store class (planner M4): the SAME episode (id + summary) copied
+  // into two stores is a replica, not a recurrence.
+  const w = mkWorld('replica')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const id = w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
+  const out = parse(w.promote())
+  assert(out.candidates.length === 0, `replica must not count as recurrence: ${JSON.stringify(out.candidates)}`)
+  assert(id, 'seed id must exist')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteSameIdDifferentContentStaysDistinct', () => {
+  // codex CX2: a coincident id with DIFFERENT content across independent
+  // stores is two members, never silently collapsed — and (being similar
+  // bodies in two stores) it IS a legitimate recurrence candidate.
+  const w = mkWorld('sameid')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const id = w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
+  // Hand-edit projB's copy to a DIFFERENT summary (same id) — index row + file.
+  const idxPath = path.join(b, '.episodic-memory', 'index.jsonl')
+  const rows = fs.readFileSync(idxPath, 'utf8').trim().split('\n').map(l => JSON.parse(l))
+  rows[0].summary = 'always quote hook command paths differently worded'
+  fs.writeFileSync(idxPath, rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+  const out = parse(w.promote())
+  assert(out.candidates.length === 1, `distinct-content same-id must form a candidate: ${JSON.stringify(out)}`)
+  const memberIds = out.candidates[0].members.map(m => m.id)
+  assert(memberIds.length === 2 && memberIds[0] === id && memberIds[1] === id,
+    `both same-id members must be listed distinctly: ${JSON.stringify(out.candidates[0].members)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteApplyWritesGlobalEpisode', () => {
+  const w = mkWorld('apply')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const r = w.promote(['--apply'])
+  const out = parse(r)
+  assert(r.status === 0 && out.promoted.length === 1 && out.promoted[0].digest_id, `apply failed: ${r.stdout}${r.stderr}`)
+  const globals = w.globalIndexRows()
+  assert(globals.length === 1, `global index rows ${globals.length}, want 1`)
+  const tags = globals[0].tags.map(String)
+  assert(tags.includes('promoted-lesson'), `promoted-lesson tag missing: ${JSON.stringify(tags)}`)
+  assert(tags.some(t2 => /^promoted:[0-9a-f]{8}$/.test(t2)), `promoted:<sha8> tag missing: ${JSON.stringify(tags)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteApplyBodyCarriesSources', () => {
+  const w = mkWorld('sources')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const idA = w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  const idB = w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const out = parse(w.promote(['--apply']))
+  const digest = out.promoted[0].digest_id
+  const content = fs.readFileSync(path.join(w.home, '.episodic-memory', 'episodes', `${digest}.md`), 'utf8')
+  assert(content.includes('## Sources'), 'Sources section missing from written episode')
+  for (const id of [idA, idB]) {
+    assert(content.includes(id), `member id ${id} missing from digest body`)
+  }
+  assert(content.includes(SENTINEL), 'member body sentinel missing from digest excerpt')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteNeverWritesSourceStores', () => {
+  const w = mkWorld('parity')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const idxA = path.join(a, '.episodic-memory', 'index.jsonl')
+  const idxB = path.join(b, '.episodic-memory', 'index.jsonl')
+  assert(fs.readFileSync(idxA, 'utf8').length > 0, 'fixture index must be non-empty before parity check')
+  const beforeA = sha(idxA)
+  const beforeB = sha(idxB)
+  const r = w.promote(['--apply'])
+  assert(r.status === 0, `apply failed: ${r.stdout}${r.stderr}`)
+  assert(sha(idxA) === beforeA && sha(idxB) === beforeB, 'a source store index changed — promote must write global only')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteApplyIdempotent', () => {
+  const w = mkWorld('idem')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const first = parse(w.promote(['--apply']))
+  assert(first.promoted.length === 1, `first apply: ${JSON.stringify(first)}`)
+  const epsDir = path.join(w.home, '.episodic-memory', 'episodes')
+  const filesAfterFirst = fs.readdirSync(epsDir).length
+  const second = parse(w.promote(['--apply']))
+  assert(second.promoted.length === 0, `second apply must promote nothing: ${JSON.stringify(second.promoted)}`)
+  assert(second.skipped.some(s => s.reason === 'already-promoted' && s.existing === first.promoted[0].digest_id),
+    `skip must name the existing digest: ${JSON.stringify(second.skipped)}`)
+  assert(fs.readdirSync(epsDir).length === filesAfterFirst, 'second apply added episode files')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteSupersetClusterPromotesWithBackref', () => {
+  const w = mkWorld('superset')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const c = w.project('projC')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const first = parse(w.promote(['--apply']))
+  const priorId = first.promoted[0].digest_id
+  // Cluster grows: a third store gains the same recurring lesson.
+  w.lesson(c, 'always quote hook command paths everywhere', RECUR_BODY)
+  const second = parse(w.promote(['--apply']))
+  assert(second.promoted.length === 1, `grown cluster must promote under its new hash: ${JSON.stringify(second)}`)
+  assert(second.promoted[0].supersedes_promotion === priorId,
+    `back-ref missing: ${JSON.stringify(second.promoted[0])}, want ${priorId}`)
+  const content = fs.readFileSync(path.join(w.home, '.episodic-memory', 'episodes', `${second.promoted[0].digest_id}.md`), 'utf8')
+  assert(content.includes(`Supersedes-promotion: ${priorId}`), 'Supersedes-promotion line missing from Sources')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteWarnsOnMalformedPromotedEpisode', () => {
+  const w = mkWorld('warn')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.lesson(a, 'always quote hook command paths', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const first = parse(w.promote(['--apply']))
+  const digest = first.promoted[0].digest_id
+  // Hand-break the written episode: strip the Sources section.
+  const p = path.join(w.home, '.episodic-memory', 'episodes', `${digest}.md`)
+  fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(/^## Sources$[\s\S]*$/m, ''))
+  const r = w.promote()
+  const out = parse(r)
+  assert(r.status === 0, `warnings must never block: exit ${r.status}`)
+  assert(out.warnings.some(x => x.episode === digest && /Sources/.test(x.problem)),
+    `missing-Sources warning absent: ${JSON.stringify(out.warnings)}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteHelpCarriesExperimental', () => {
+  const r = spawnSync(process.execPath, [PROMOTE, '--help'], { encoding: 'utf8' })
+  const out = JSON.parse(r.stdout)
+  assert(out.tier === 'EXPERIMENTAL', `help tier: ${out.tier}`)
+  assert(out.decision_date === '2026-10-08', `decision_date: ${out.decision_date}`)
+  assert(/EXPERIMENTAL/.test(out.usage), 'usage text must carry EXPERIMENTAL')
+})
+
+t('testPromoteIsSubstrateScript', () => {
+  assert(isSubstrateScript('em-promote.mjs') === true, 'em-promote.mjs must auto-classify as substrate (global deploy, em dispatch)')
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)

--- a/tests/test-fold-all-projects.mjs
+++ b/tests/test-fold-all-projects.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+// test-fold-all-projects.mjs — APC-S4 (plan §14 Group 3). Drives the REAL
+// em-consolidate --fold-superseded --all-projects against isolated-HOME
+// fixture registries. Covers: no single-store regression, foreign-chain
+// archive, THIRD-store protection referencer with FULL chain-closure keep
+// (planner B3+M1), realpath store labels for class-d protection (planner B4),
+// mode/scope/confirm guards (fail-closed, byte-parity), and symlink-escape
+// store skip (plan §7-C2).
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const CONSOLIDATE = path.join(REPO, 'scripts', 'em-consolidate.mjs')
+
+function sha(p) { return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex') }
+
+function mkWorld(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `em-fold-ap-${name}-`))
+  const home = path.join(root, 'home')
+  fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  const world = {
+    root, home, entries: [],
+    register(projectPath) {
+      world.entries.push({ project_path: projectPath, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z' })
+      fs.writeFileSync(path.join(home, '.episodic-memory', 'installs.json'),
+        JSON.stringify({ schema_version: 1, entries: world.entries }, null, 2))
+    },
+    project(name) {
+      const p = path.join(root, name)
+      fs.mkdirSync(path.join(p, '.episodic-memory', 'episodes'), { recursive: true })
+      return p
+    },
+    run(args, cwd) {
+      return spawnSync(process.execPath, [CONSOLIDATE, ...args],
+        { cwd, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+    },
+  }
+  return world
+}
+
+// Writes a LINEAR supersedes chain of n members into a project store. Member
+// ids sort chronologically; only the terminal is active. Returns the id list.
+function seedChain(project, tag, n, { rowPatch = {} } = {}) {
+  const dir = path.join(project, '.episodic-memory')
+  const ids = []
+  const rows = []
+  for (let i = 1; i <= n; i++) {
+    const id = `20260601-${String(100000 + i).slice(1)}-${tag}-${String(i).padStart(2, '0')}`
+    ids.push(id)
+    const row = {
+      id, date: '2026-06-01', time: '00:00', project: path.basename(project),
+      category: 'decision', status: i === n ? 'active' : 'superseded',
+      supersedes: i === 1 ? null : ids[i - 2], tags: [tag], summary: `${tag} rev ${i}`,
+      ...(rowPatch[i] || {}),
+    }
+    rows.push(row)
+    fs.writeFileSync(path.join(dir, 'episodes', `${id}.md`),
+      `---\nid: ${id}\nstatus: ${row.status}\n---\n\n# ${row.summary}\n`)
+  }
+  fs.appendFileSync(path.join(dir, 'index.jsonl'), rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+  return ids
+}
+
+function appendRow(project, row) {
+  fs.appendFileSync(path.join(project, '.episodic-memory', 'index.jsonl'), JSON.stringify(row) + '\n')
+}
+
+function storeSnapshot(project) {
+  const dir = path.join(project, '.episodic-memory')
+  const files = []
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name)
+      if (e.isDirectory()) walk(p)
+      else files.push(`${path.relative(dir, p)}:${sha(p)}`)
+    }
+  }
+  walk(dir)
+  return files.sort().join('\n')
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+function parse(r) {
+  try { return JSON.parse(r.stdout) } catch { throw new Error(`non-JSON stdout: ${r.stdout}\n${r.stderr}`) }
+}
+
+t('testFoldSingleStoreUnchanged', () => {
+  const r = spawnSync(process.execPath, [path.join(REPO, 'tests', 'test-fold-superseded.mjs')], { encoding: 'utf8' })
+  assert(r.status === 0, `existing single-store fold suite regressed:\n${r.stdout}\n${r.stderr}`)
+})
+
+t('testFoldAllProjectsArchivesForeignChain', () => {
+  const w = mkWorld('archive')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.register(a); w.register(b)
+  const ids = seedChain(b, 'bchain', 12)
+  const r = w.run(['--fold-superseded', '--all-projects', '--confirm'], a)
+  const out = parse(r)
+  assert(r.status === 0 && out.all_projects === true, `run failed: ${r.stdout}`)
+  const bStore = out.stores.find(s => s.project_path.endsWith('projB'))
+  assert(bStore && bStore.folded_total === 11, `projB folded_total ${bStore && bStore.folded_total}, want 11`)
+  const archived = fs.readdirSync(path.join(b, '.episodic-memory', 'archived'))
+  assert(archived.length === 11, `archived/ has ${archived.length} files, want 11`)
+  const terminal = ids[11]
+  assert(fs.existsSync(path.join(b, '.episodic-memory', 'episodes', `${terminal}.md`)), 'terminal episode file must stay')
+  const idxLines = fs.readFileSync(path.join(b, '.episodic-memory', 'index.jsonl'), 'utf8').trim().split('\n')
+  for (const line of idxLines) JSON.parse(line) // parses post-run
+  assert(idxLines.length === 1 && JSON.parse(idxLines[0]).id === terminal, `index must keep only the terminal: ${idxLines.length} rows`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldAllProjectsHonorsForeignProtection', () => {
+  // planner B3 + M1: the referencer lives in a THIRD registered store, and one
+  // evidence link must keep the ENTIRE chain via closure (an implementation
+  // keeping only the anchor while archiving 10 closure members must FAIL).
+  const w = mkWorld('protect')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const c = w.project('projC')
+  w.register(a); w.register(b); w.register(c)
+  const ids = seedChain(b, 'protchain', 12)
+  appendRow(c, {
+    id: '20260701-000001-c-lesson', date: '2026-07-01', time: '00:00', project: 'projC',
+    category: 'lesson', status: 'active', supersedes: null, tags: ['x'],
+    summary: 'lesson naming a projB chain member', evidence: [ids[5]],
+  })
+  const before = storeSnapshot(b)
+  const r = w.run(['--fold-superseded', '--all-projects', '--confirm'], a)
+  const out = parse(r)
+  const bStore = out.stores.find(s => s.project_path.endsWith('projB'))
+  assert(bStore.folded_total === 0, `protected chain folded ${bStore.folded_total} members, want 0: ${JSON.stringify(bStore.chains)}`)
+  const kept = bStore.chains[0].kept
+  const reasons = kept.map(k => k.reason)
+  assert(kept.length === 11, `kept ${kept.length} non-terminal members, want all 11 (M1 full-closure)`)
+  assert(reasons.includes('r6-protected:evidence-linked-violation'), `anchor reason missing: ${JSON.stringify(reasons)}`)
+  assert(reasons.includes('r6-protected:chain-member'), `closure reason missing: ${JSON.stringify(reasons)}`)
+  assert(storeSnapshot(b) === before, 'projB store bytes changed despite full protection')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldProtectionLabelIsRealpath', () => {
+  // planner B4: two registered projects share the basename "app". Class-d
+  // protection keys latestByStore by the storeLabel; if the DISPLAY label
+  // (project:app) were used, both stores merge into one bucket and the store
+  // whose clerk-run id sorts LOWER loses its latest-run protection.
+  const w = mkWorld('basename')
+  const a = w.project('projA')
+  const app1 = w.project(path.join('teamA', 'app'))
+  const app2 = w.project(path.join('teamB', 'app'))
+  w.register(a); w.register(app1); w.register(app2)
+  // Each store holds exactly one clerk-run member; under a merged bucket only
+  // the id-max one survives (a1chain-06 < a2chain-06, so app1's would be
+  // shadowed and archived), while per-realpath buckets protect BOTH.
+  seedChain(app1, 'a1chain', 12, { rowPatch: { 6: { record_type: 'clerk-run' } } })
+  seedChain(app2, 'a2chain', 12, { rowPatch: { 6: { record_type: 'clerk-run' } } })
+  const r = w.run(['--fold-superseded', '--all-projects', '--confirm'], a)
+  const out = parse(r)
+  for (const base of ['teamA/app', 'teamB/app']) {
+    const st = out.stores.find(s => s.project_path.endsWith(base))
+    const kept = (st.chains[0] && st.chains[0].kept) || []
+    assert(kept.some(k => k.reason === 'r6-protected:latest-run-record'),
+      `${base}: latest clerk-run member not protected (label leaked into class-d bucket): ${JSON.stringify(st.chains)}`)
+  }
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldAllProjectsRequiresFoldMode', () => {
+  const w = mkWorld('mode')
+  const a = w.project('projA')
+  w.register(a)
+  const r = w.run(['--all-projects'], a)
+  assert(r.status === 2, `cluster+--all-projects exit ${r.status}, want 2`)
+  assert(parse(r).status === 'error', `want JSON error: ${r.stdout}`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldAllProjectsScopeConflict', () => {
+  const w = mkWorld('scope')
+  const a = w.project('projA')
+  w.register(a)
+  const r = w.run(['--fold-superseded', '--all-projects', '--scope', 'local'], a)
+  assert(r.status === 2, `--all-projects+--scope exit ${r.status}, want 2`)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldAllProjectsRealRunNeedsConfirm', () => {
+  const w = mkWorld('confirm')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  w.register(a); w.register(b)
+  seedChain(b, 'cchain', 12)
+  const before = storeSnapshot(b)
+  assert(before.length > 0, 'fixture snapshot must be non-empty before the negative run')
+  const r = w.run(['--fold-superseded', '--all-projects'], a)
+  assert(r.status === 2, `unconfirmed real run exit ${r.status}, want 2`)
+  assert(parse(r).message.includes('--confirm'), `error must name --confirm: ${r.stdout}`)
+  assert(storeSnapshot(b) === before, 'unconfirmed run touched a store — guard must fire before any move')
+  // dry-run needs no confirm and still writes nothing
+  const dry = w.run(['--fold-superseded', '--all-projects', '--dry-run'], a)
+  assert(dry.status === 0 && parse(dry).folded_total === 11, `dry-run: ${dry.stdout}`)
+  assert(storeSnapshot(b) === before, 'dry-run wrote to a store')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testFoldSkipsSymlinkEscapeStore', () => {
+  const w = mkWorld('symlink')
+  const a = w.project('projA')
+  const victim = w.project('victimProj') // NOT registered; holds a foldable chain
+  seedChain(victim, 'vchain', 12)
+  const evil = path.join(w.root, 'evilProj')
+  fs.mkdirSync(evil, { recursive: true })
+  fs.symlinkSync(path.join(victim, '.episodic-memory'), path.join(evil, '.episodic-memory'))
+  w.register(a); w.register(evil)
+  const before = storeSnapshot(victim)
+  const r = w.run(['--fold-superseded', '--all-projects', '--confirm'], a)
+  const out = parse(r)
+  const evilStore = out.stores.find(s => s.project_path.endsWith('evilProj'))
+  assert(evilStore && evilStore.skipped_store === 'non-root-store', `evil store must be skipped: ${JSON.stringify(out.stores)}`)
+  assert(storeSnapshot(victim) === before, 'victim store bytes changed through the symlinked registration')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)

--- a/tests/test-registered-stores.mjs
+++ b/tests/test-registered-stores.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// test-registered-stores.mjs — APC-S1 (plan §14 Group 1). Exercises the REAL
+// lib against an isolated fixture registry: dedupe by realpath, global-store
+// exclusion, malformed-registry degrade, vanished-path drop, and the planner-B1
+// store-identity class (git-nested + linked-worktree entries resolve to the
+// git root's store and are flagged store_matches_project:false).
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { resolveRegisteredStores, STORE_DIR_BASENAME } from '../scripts/lib/registered-stores.mjs'
+
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'em-regstores-'))
+const GLOBAL_DIR = path.join(ROOT, 'home', STORE_DIR_BASENAME)
+
+function writeRegistry(entries) {
+  fs.mkdirSync(GLOBAL_DIR, { recursive: true })
+  fs.writeFileSync(path.join(GLOBAL_DIR, 'installs.json'),
+    JSON.stringify({ schema_version: 1, entries }, null, 2))
+}
+function entry(project_path) {
+  return { project_path, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z' }
+}
+function mkProject(name, { git = false, store = true } = {}) {
+  const p = path.join(ROOT, name)
+  fs.mkdirSync(p, { recursive: true })
+  if (git) spawnSync('git', ['init', '-q'], { cwd: p })
+  if (store) fs.mkdirSync(path.join(p, STORE_DIR_BASENAME), { recursive: true })
+  return p
+}
+
+const tests = []
+const t = (name, fn) => tests.push([name, fn])
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+
+t('testResolveRegisteredStoresBasic', () => {
+  const a = mkProject('basicA')
+  const b = mkProject('basicB', { git: true })
+  writeRegistry([entry(a), entry(b)])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(stores.length === 2, `want 2 stores, got ${stores.length}: ${JSON.stringify(stores)}`)
+  const byBase = Object.fromEntries(stores.map(s => [path.basename(s.project_path), s]))
+  assert(byBase.basicA.data_dir === fs.realpathSync(path.join(a, STORE_DIR_BASENAME)), `basicA data_dir: ${byBase.basicA.data_dir}`)
+  assert(byBase.basicA.label === 'project:basicA', `label: ${byBase.basicA.label}`)
+  assert(byBase.basicA.store_matches_project === true, 'plain dir must match')
+  assert(byBase.basicB.store_matches_project === true, 'git root must match')
+})
+
+t('testResolveDedupesByRealpath', () => {
+  const real = mkProject('dedupeReal')
+  const alias = path.join(ROOT, 'dedupeAlias')
+  fs.symlinkSync(real, alias)
+  writeRegistry([entry(real), entry(alias)])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(stores.length === 1, `symlink alias must dedupe to 1, got ${stores.length}: ${JSON.stringify(stores.map(s => s.data_dir))}`)
+})
+
+t('testResolveExcludesGlobalStore', () => {
+  // A registry entry whose resolved store IS the global store must be dropped.
+  const home = path.dirname(GLOBAL_DIR)
+  writeRegistry([entry(home)])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(stores.length === 0, `entry at $HOME must be dropped, got ${JSON.stringify(stores)}`)
+})
+
+t('testResolveMalformedRegistryEmpty', () => {
+  fs.mkdirSync(GLOBAL_DIR, { recursive: true })
+  fs.writeFileSync(path.join(GLOBAL_DIR, 'installs.json'), 'not json {{{')
+  assert(resolveRegisteredStores({ globalDir: GLOBAL_DIR }).length === 0, 'malformed registry must yield []')
+  fs.rmSync(path.join(GLOBAL_DIR, 'installs.json'))
+  assert(resolveRegisteredStores({ globalDir: GLOBAL_DIR }).length === 0, 'absent registry must yield []')
+})
+
+t('testResolveVanishedPathDropped', () => {
+  const live = mkProject('vanishLive')
+  writeRegistry([entry(live), entry(path.join(ROOT, 'no-such-dir'))])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(stores.length === 1 && stores[0].project_path === fs.realpathSync(live),
+    `vanished path must drop: ${JSON.stringify(stores)}`)
+})
+
+t('testResolveNonRootStoreFlagged', () => {
+  // planner B1: git-nested and linked-worktree project paths resolve to the
+  // git ROOT's store (what spawned em-* scripts actually operate on) and are
+  // write-ineligible.
+  const gitRoot = mkProject('b1root', { git: true })
+  const nested = path.join(gitRoot, 'nested')
+  fs.mkdirSync(nested, { recursive: true })
+  spawnSync('git', ['-C', gitRoot, 'commit', '--allow-empty', '-q', '-m', 'init'], {
+    env: { ...process.env, GIT_AUTHOR_NAME: 'fx', GIT_AUTHOR_EMAIL: 'fx@fx', GIT_COMMITTER_NAME: 'fx', GIT_COMMITTER_EMAIL: 'fx@fx' },
+  })
+  const worktree = path.join(ROOT, 'b1worktree')
+  spawnSync('git', ['-C', gitRoot, 'worktree', 'add', '-q', worktree], { encoding: 'utf8' })
+  writeRegistry([entry(nested), entry(worktree)])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  const rootStore = fs.realpathSync(path.join(gitRoot, STORE_DIR_BASENAME))
+  // Both entries resolve to the SAME git-root store → dedupe to one, flagged false.
+  assert(stores.length === 1, `nested+worktree must dedupe onto the root store, got ${stores.length}: ${JSON.stringify(stores.map(s => s.data_dir))}`)
+  assert(stores[0].data_dir === rootStore, `resolved data_dir ${stores[0].data_dir}, want ${rootStore}`)
+  assert(stores[0].store_matches_project === false, 'nested/worktree entry must be store_matches_project:false')
+})
+
+t('testResolveSymlinkAliasDedupe', () => {
+  // /tmp vs /private/tmp class: two spellings realpathing to one store → one
+  // entry. On non-macOS the symlink fixture below provides the same class.
+  const real = mkProject('aliasReal')
+  const link = path.join(ROOT, 'aliasLink')
+  fs.symlinkSync(real, link)
+  const spelledViaLink = path.join(link) // registry carries the alias spelling
+  writeRegistry([entry(spelledViaLink), entry(real)])
+  const stores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(stores.length === 1, `alias spellings must resolve to 1 store, got ${stores.length}`)
+  // The store dir itself symlinked OUTSIDE the project → flagged unwritable.
+  const victim = path.join(ROOT, 'victim-store')
+  fs.mkdirSync(victim, { recursive: true })
+  const evil = mkProject('evilProj', { store: false })
+  fs.symlinkSync(victim, path.join(evil, STORE_DIR_BASENAME))
+  writeRegistry([entry(evil)])
+  const evilStores = resolveRegisteredStores({ globalDir: GLOBAL_DIR })
+  assert(evilStores.length === 1, 'symlinked store still listed for reads')
+  assert(evilStores[0].store_matches_project === false, 'store symlinked outside the project must be write-ineligible')
+})
+
+let pass = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); pass++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+fs.rmSync(ROOT, { recursive: true, force: true })
+console.log(`${pass}/${tests.length} pass`)
+process.exit(pass === tests.length ? 0 : 1)


### PR DESCRIPTION
Implements docs/plans/all-projects-consolidation.md (APC). Closes the gap where the substrate could only see cwd-local + global while the consumer registry already knew every project store.

## What ships

- **`scripts/lib/registered-stores.mjs`** — registry store discovery. `data_dir` uses the substrate's OWN resolution (`resolveLocalDir(project_path)`), realpath identity, and a `store_matches_project` write gate (git-nested/worktree/symlink-escape registrations are read-visible but write-ineligible).
- **`em-stats --all-projects`** — one scope block per registered store, realpath duplicate-skip, read-only.
- **`em-doctor --all-projects`** — store-class health checks per registered store; every row carries `data_dir`; `--fix` routes rebuilds by `data_dir` (never the collidable `project:<basename>` label) with `cwd` at that project's root, and reports `skipped: non-root-store` where a rebuild would repair a different store than diagnosed.
- **`em-consolidate --fold-superseded --all-projects`** — folds every registered store; pure-extraction `foldStore()` keeps the single-store path behavior-identical (existing suite 11/11); R6 protection unions cwd-local + global + ALL registered stores with realpath store labels; a REAL multi-store run requires `--confirm` and fails closed before any move.
- **`em-promote` (NEW, EXPERIMENTAL, decision 2026-10-08)** — first learning-strategy capability: detects lessons recurring across ≥2 registered stores (recurrence requires a disjoint-store-set member pair, so clone/fork stores cannot fabricate it) and on `--apply` writes ONE global lesson episode per recurrence via the em-store subprocess, with `## Sources` provenance and `promoted:<sha8>` identity-hash idempotency. Source stores are never written.
- **Charter/docs reflection** — CAPABILITIES.md (learning-strategy default + shipped cross-store members), EM_SCRIPTS_GUIDE.md (flag docs, em-promote entry, intent-routing rows).

## Review trail (plan §19)

- negative-scenario-planner v6.7: HOLD, 5 blockers (store-identity resolution, similarity-dedupe falsified at J=0.255, third-store protection, label-as-identity, realpath symmetry) — all folded; reply `20260708-080241-…-afc8`.
- codex gpt-5.5 (cmux, interactive): HOLD, 5 blockers (doctor fix-routing collision, id-uniqueness qualification, CI grep proof, staged A.7 gate, unspecified --limit) — all folded.
- negative-scenario-reviewer v4.8 on the impl diff: HOLD, F1 clone-fabricated recurrence / F2 Sources header injection / F3 identity-tag leak — all fixed with regressions (`test-em-promote.mjs` 15/15).

## Verification

40 new tests across 4 suites (7/7, 10/10, 8/8, 15/15), all registered in `plan-marker-validate.yml`. Existing suites unregressed (fold 11/11, consolidate 8/8, doctor 13/13, stats/semantic 13/13, install-manifest 57/57, readonly-manifest 16/16, em-cli 9/9, P12 invariant gate PASS, control-bytes clean). Real-store smokes: stats central view shows this repo's 1,816-episode store; fold dry-run found the live 49-member workplan chain (48 fold preview, terminal kept, forked chain skipped, zero writes); promote degrades cleanly on a 1-store registry.

Deferred (5-field, Rule 18 step 9): #478 typed provenance via RFC-009 P1b (+ TOCTOU + tag-axis retirement), #479 em-routines scheduling, #480 cross-store cluster mode.

Operator pre-approved implementation in-session (2026-07-08); single PR instead of the planned 3-PR split under the same grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)