### PR TITLE
em-console web UI + em-manage wizard: presentation layer over the CLI contract

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -270,6 +270,12 @@ jobs:
       - name: Run em-promote experimental suite (APC-S5)
         run: node tests/test-em-promote.mjs
 
+      - name: Run em-console web console suite
+        run: node tests/test-em-console.mjs
+
+      - name: Run em-manage wizard suite
+        run: node tests/test-em-manage.mjs
+
       - name: Run install version-manifest + registry + update-sweep suite (Layer 1)
         run: node tests/test-install-manifest.mjs
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,24 @@ node ~/.episodic-memory/scripts/em-promote.mjs            # preview candidates
 node ~/.episodic-memory/scripts/em-promote.mjs --apply    # write global lessons
 ```
 
+### Web console (`em console`) and manager (`em manage`)
+```bash
+# Point-and-click view of the store: dashboard (stats + doctor), browse/search
+# with history chains, recall preview, pending capture drafts, hygiene panel.
+# Loopback-only with a per-launch token; read-only unless --allow-write; idles
+# out after 30 minutes by default. Open the URL it prints.
+node ~/.episodic-memory/scripts/em-console.mjs                  # read-only
+node ~/.episodic-memory/scripts/em-console.mjs --allow-write    # + store/revise/pin/fix
+
+# Guided day-2 maintenance without memorizing flags: status, hygiene
+# (rebuild-index / fold / prune / doctor --fix, dry-run first), backup,
+# capture drafts, routines, console launcher.
+node ~/.episodic-memory/scripts/em-manage.mjs
+```
+Both are presentation layers over the same CLI contract: every button and menu
+action spawns the corresponding `em-*` script and shows its JSON. Nothing is
+decided in the UI, and no data leaves your machine.
+
 ### Graph traversal (`em graph`)
 ```bash
 # What is connected to this episode? Lineage across supersedes/consolidates/

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -52,6 +52,8 @@ Match your intent to the command. The third column is the wrong habit it replace
 | Session start printed an install version-drift notice | `em-sync-install` (this project, from the dist cache) or `node <repo>/install.mjs --update-consumers` (all registered projects) | Hand-copying hook/skill files, or re-running full installs in every consuming project |
 | One view of EVERY registered project's store (analytics/health/fold) | `em-stats --all-projects`, `em-doctor --all-projects`, `em-consolidate --fold-superseded --all-projects --dry-run` | Cd-ing into each project and running per-store commands |
 | The same lesson keeps recurring across projects | `em-promote` (dry-run), then `em-promote --apply` (EXPERIMENTAL) | Re-learning it per project, or hand-copying lesson episodes to global |
+| User wants to SEE the store (dashboard, browse, drafts, hygiene) | `em-console` — hand the user the printed URL | Pasting walls of JSON at the user |
+| User wants guided maintenance in the terminal | `em-manage` (interactive menu) | Dictating flag-by-flag commands to a human |
 
 Default write scope is GLOBAL. Pass `--scope local` to keep an episode inside the
 current repo's `.episodic-memory/`. Searches read local and global together by
@@ -857,6 +859,25 @@ promotes under its new hash with a `Supersedes-promotion:` back-reference.
 Malformed existing promoted episodes (bad hash tag, missing `## Sources`)
 are reported in `warnings`, never fatal. Exit 1 only when an `--apply` write
 failed; usage errors exit 2.
+
+### em-console
+
+Local web console over the CLI contract: one page (dashboard, browse + history,
+recall preview, capture drafts, maintenance) whose every action POSTs to a closed
+command registry that spawns the sibling `em-*` scripts and returns their JSON.
+Loopback-only, per-launch token in the printed URL, read-only unless launched with
+`--allow-write`, idles out after `--idle-timeout` seconds (default 1800). Agent
+rule: this is a HUMAN surface — launch it for the user and hand over the URL;
+agents keep using the JSON CLI directly.
+
+### em-manage
+
+Interactive day-2 maintenance wizard: status (doctor + stats), hygiene
+(rebuild-index, fold-superseded, prune, doctor --fix — dry-run first, apply only
+on explicit confirm), backup, capture drafts, routines, and an em-console
+launcher. Prose menus for humans; every underlying operation is a spawned `em-*`
+script. Scriptable via piped stdin (EOF takes defaults). Agent rule: human
+surface — suggest it to users; agents call the underlying scripts directly.
 
 ### em-pattern-health
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -18,6 +18,7 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 8b: Running a Second-Opinion Review on a Plan or Diff](#scenario-8b-running-a-second-opinion-review-on-a-plan-or-diff)
 - [Scenario 8c: Running Routines on a Schedule (macOS)](#scenario-8c-running-routines-on-a-schedule-macos)
 - [Scenario 8d: One View Across Every Project](#scenario-8d-one-view-across-every-project)
+- [Scenario 8e: Looking at Your Memory Instead of Querying It](#scenario-8e-looking-at-your-memory-instead-of-querying-it)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
@@ -457,6 +458,43 @@ review, not gospel.
 **When you don't want this:** with a single registered project there is nothing to correlate —
 the commands say so and exit cleanly. Everything here is opt-in and manual; nothing scans your
 projects in the background.
+
+---
+
+## Scenario 8e: Looking at Your Memory Instead of Querying It
+
+**What happens:** Sometimes you want to see the store, not interrogate it through an
+assistant — skim what accumulated this month, check health at a glance, read a
+decision's full revision chain, or clean up without memorizing flags.
+
+```bash
+# Local web console: prints a URL with a one-time token — open it.
+node ~/.episodic-memory/scripts/em-console.mjs
+# {"status":"ok","url":"http://127.0.0.1:52341/?token=...","allow_write":false,...}
+```
+
+The page has a dashboard (per-scope analytics + doctor results), a browse tab
+(search and list with filters; click any row for its full revision history), a
+recall preview, pending auto-capture drafts, and a maintenance panel. It binds to
+127.0.0.1 only, requires the token from the printed URL, and by default is
+read-only — store/revise/pin/fix buttons stay disabled until you relaunch with
+`--allow-write`. Close the tab and forget it: the server shuts itself down after
+30 idle minutes.
+
+Prefer the terminal? The same day-2 chores come as a guided menu:
+
+```bash
+node ~/.episodic-memory/scripts/em-manage.mjs
+```
+
+Pick `status` for health + analytics, `hygiene` for rebuild-index / fold / prune
+(you always see the dry-run before anything is applied and confirm explicitly),
+`backup`, `capture` for pending drafts, `routines`, or `console` to launch the web
+page from the menu.
+
+**When you don't want this:** neither surface is for agents — they keep using the
+JSON CLI. And nothing here runs unattended: both exist only while you're looking
+at them.
 
 ---
 

--- a/docs/plans/em-console-em-manage.md
+++ b/docs/plans/em-console-em-manage.md
@@ -126,4 +126,14 @@ em.mjs DESCRIPTIONS entries.
 
 ## 8. Review dispositions
 
-Filled post-review (negative-scenario-reviewer on the implementation diff).
+negative-scenario-reviewer on the implementation diff (runtime probes on
+isolated fixture stores; verdict ACCEPT, no P1):
+
+| # | Finding | Sev | Disposition |
+|---|---|---|---|
+| F1 | Prototype-key flag names ride the allowlist (plain-object lookup as membership; `__proto__`/`valueOf`/`hasOwnProperty` resolve truthy) | P2 | FIXED — `Object.hasOwn` guard in buildArgs; regression test sends 5 prototype keys, expects 400 each. Same invariant class as #469. |
+| F2 | `str` kind accepted raw CR/LF/TAB in short token fields (tag/project/reason) | P3 | FIXED — control-byte reject split by kind: `multiline` (summary/body/query) keeps tab/LF/CR, plain `str` rejects all control bytes. Regression: newline-in-tag 400, multiline query 200. |
+| F3 | em-manage option 6 (console launch) blocks up to the 1800s idle window under piped stdin (no Ctrl-C path) | P2 | FIXED — non-TTY stdin refuses with the direct command printed; regression feeds `6` and asserts refusal + exit 0. |
+| F4 | Idle shutdown checked on a fixed 30s tick regardless of `--idle-timeout` | P3 | FIXED — interval = min(30s, idleTimeoutMs). |
+| F5 | Registry `write:false` classification had no conformance test tying it to actual non-mutation | P3 | FIXED — byte-stability sweep: every read command runs against a seeded sandbox and the full tree sha256 must be identical before/after; the case list is pinned to the registry so a new read command fails the sweep until added. |
+| F6 | CSP `script-src 'unsafe-inline'` means esc() is the only XSS layer (all sinks verified escaped) | P3 | PARTIAL — added `object-src 'none'; base-uri 'none'; form-action 'none'`. Script nonce deferred: single-page inline app, all sinks audited + hostile-payload probed by the reviewer. |

--- a/docs/plans/em-console-em-manage.md
+++ b/docs/plans/em-console-em-manage.md
@@ -1,0 +1,129 @@
+# Plan: em-console (local web UI) + em-manage (day-2 wizard)
+
+Status: implemented same-session under operator full-autonomy grant (2026-07-08).
+Workplan v166 item 1. Presentation layer per CAPABILITIES.md "Adjacent layers".
+
+## 1. Problem
+
+The substrate is CLI-JSON only. Two gaps:
+- No at-a-glance view of what memory holds (stats, health, browse, history chains,
+  pending capture drafts) without composing multiple CLI invocations.
+- No guided day-2 maintenance path (hygiene, backup, routines) for users who did
+  not memorize the script surface. install-wizard.mjs covers setup only and ships
+  nowhere (repo-dev).
+
+## 2. Principle grounding (governing-artifact consult)
+
+- **P11 (portable core contract)** — both surfaces spawn the sibling `em-*` scripts
+  and present their JSON verbatim. Zero decision logic server/wizard-side: they
+  validate request SHAPE, never interpret episode semantics.
+- **P6 (tokens/bounded background work)** — em-console is user-started, prints its
+  URL+cost model on startup, idle-times-out by default (30 min), burns zero tokens
+  (no LLM calls) and zero work when idle (no polling loops server-side; UI is
+  request-driven).
+- **P1 (memory is the substrate)** — no new data layer. The console holds no state
+  beyond the in-memory session token; everything read/written goes through the
+  existing scripts.
+- **P3/P10 (consent/reversibility)** — write operations require the explicit
+  `--allow-write` launch flag; default launch is read-only. Destructive-looking
+  maintenance (fold, prune) is dry-run-first in both surfaces.
+- **P9 (core never imports adapters)** — both scripts import only node stdlib +
+  sibling scripts via spawn. Nothing in core references them.
+- **P12** — both are substrate-tier presentation (no hooks, no gates, no markers);
+  they match the `em-*` substrate allowlist in install-manifest.mjs and ship to
+  `~/.episodic-memory/scripts/` automatically.
+- **CAPABILITIES.md** — "Presentation — skill wrappers, wizards, terminal and web
+  consoles... they spawn the same CLI contract and present its JSON; they never
+  decide." This plan implements exactly that sentence.
+
+## 3. em-console.mjs — design
+
+`node em-console.mjs [--port N] [--host 127.0.0.1] [--allow-write] [--idle-timeout SECS] [--token T]`
+
+- **Startup contract**: prints exactly one JSON object to stdout
+  (`{status:'ok', script, url, host, port, allow_write, idle_timeout_seconds, pid}`)
+  then serves. Shutdown/idle notices go to stderr so stdout stays one parseable
+  object (matches the scripts-print-JSON convention and the help gauntlet).
+- **--help contract**: standalone `--help`/`-h` anywhere in argv short-circuits to
+  `{script,status,usage}` exit 0 before any side effect.
+- **Bind policy**: loopback only. Non-loopback `--host` values are refused with
+  exit 2 (`status:'error'`). No override flag — remote exposure is out of scope.
+- **Auth**: per-launch token (`crypto.randomBytes(24)`, base64url) unless `--token`
+  provided (tests). First page load carries `?token=`; the page strips it from the
+  URL and holds it in JS memory; every API call sends `X-EM-Token`. All routes
+  except the token-carrying page load 401 without it. Comparison is
+  `crypto.timingSafeEqual` over sha256 digests (length-independent).
+- **API**: single `POST /api/run` `{cmd, flags}` against a closed declarative
+  registry: `cmd -> {script, fixedArgs, write, flagSpec}`. flagSpec types:
+  string (length-capped, NUL-rejected, leading-dash-rejected), int (bounded),
+  bool, enum, id (episode-id regex). Unknown cmd/flag/value shape -> 400.
+  `write:true` cmds -> 403 when the server was launched without `--allow-write`
+  (fail-closed). Children are spawned argv-array (no shell) with the launch cwd,
+  60s timeout, output parsed as JSON and returned verbatim under `result`.
+- **Commands v1**: read = stats, doctor, search (always `--no-track`), list,
+  recall, history, graph, semantic, capture-list, fold-preview, prune-preview;
+  write = store, revise, pin, feedback, move, doctor-fix, rebuild-index,
+  fold-apply, prune-apply.
+- **UI**: one self-contained inline HTML page (scripts/lib/console-page.mjs, no
+  external assets, dark/light aware). Tabs: Dashboard (stats + doctor),
+  Browse (search/list filters -> table -> episode history view), Recall,
+  Drafts (capture list), Maintenance (hygiene ops, dry-run first), New episode
+  (write mode only). Read-only launches render write controls disabled with the
+  enabling command shown.
+- **Idle lifetime**: default 1800s without a request -> graceful close, stderr
+  notice, exit 0. `--idle-timeout 0` disables. Timer is unref'd; activity
+  timestamp updates per request.
+
+## 4. em-manage.mjs — design
+
+Interactive day-2 maintenance wizard (menu loop), scriptable via piped stdin using
+the buffered line-reader pattern proven in install-wizard.mjs (EOF -> defaults,
+never hangs). Menu:
+
+1. status — doctor + stats (scope all; optional --all-projects view)
+2. hygiene — rebuild-index / consolidate fold (dry-run, then confirmed --apply) /
+   prune (dry-run, then confirmed --apply) / doctor --fix
+3. backup — config status; init/sync via em-backup
+4. capture — pending drafts list; spawns `em-capture review` on request
+5. routines — list; sync
+6. console — launches em-console (stdio inherit)
+q. quit
+
+All actions spawn sibling scripts and render their JSON as terse human output;
+raw JSON available via each action's `[j]` toggle. Interactive prose surface:
+the `em.mjs` "only non-JSON output surface" comment is amended to "non-interactive
+commands emit JSON; interactive surfaces (help, em-manage) print prose".
+
+## 5. Out of scope (v1)
+
+- Remote/binding beyond loopback; TLS; multi-user.
+- Store switching across registered stores in the console UI (per-store pages);
+  `--all-projects` toggles on stats/doctor cover the aggregate view.
+- Charts in the dashboard (tables/badges only).
+- em-capture confirm/discard via web UI (drafts are listed read-only; confirm
+  stays in `em-capture review`).
+- readonly-commands manifest entries (server + wizard are not one-shot readers).
+
+## 6. Tests
+
+- tests/test-em-console.mjs — spawns the server on an ephemeral port against an
+  isolated HOME+cwd fixture store: startup JSON shape; 401 unauth + wrong token;
+  page served with token; /api/run stats/search happy path; unknown cmd 400;
+  bad flag value 400; write cmd 403 without --allow-write (fail-closed negative);
+  write cmd works with --allow-write (store -> search roundtrip); non-loopback
+  host refused exit 2; leading-dash flag value rejected 400.
+- tests/test-em-manage.mjs — piped-stdin flows on a fixture store: status flow;
+  hygiene rebuild-index; fold dry-run with declined apply (store untouched);
+  EOF starvation exits cleanly; --help contract.
+- Both scripts join tests/test-em-help-flags.mjs SUBSTRATE list.
+- Both suites registered in .github/workflows/plan-marker-validate.yml.
+
+## 7. Docs
+
+EM_SCRIPTS_GUIDE.md full entries + intent-routing rows; README Scripts Reference;
+USER_MANUAL scenario (launch console read-only, browse, maintenance via wizard);
+em.mjs DESCRIPTIONS entries.
+
+## 8. Review dispositions
+
+Filled post-review (negative-scenario-reviewer on the implementation diff).

--- a/docs/plans/em-console-em-manage.md
+++ b/docs/plans/em-console-em-manage.md
@@ -148,3 +148,12 @@ HOLD, 3xP2 + 1xP3):
 | R1-2 | No concurrency bound on /api/run child fan-out (80 parallel calls -> 75 simultaneous children x 32MB maxBuffer) | P2 | FIXED — in-process semaphore: 4 running children max, 32 queued max, 429 beyond; 50-way burst regression asserts only 200/429 and post-burst responsiveness. |
 | R1-3 | em-manage dry-run consent TOCTOU: store mutated between preview and `y` applies unpreviewed state | P2 | FIXED — apply re-runs the dry-run; on any JSON difference it prints the refreshed preview and re-asks (loop until stable or declined). Regression drives a live wizard, injects a second chain mid-prompt, asserts re-confirmation fires and declined apply leaves bytes untouched. |
 | R1-4 | Query-string token accepted on every route, not just the bootstrap page | P3 | FIXED — `?token=` authorizes GET / only; /api/* requires the X-EM-Token header. Regression: query token on /api/meta and /api/run -> 401, page load -> 200. |
+
+codex round 2 (verify-the-folds + new-finding hunt): **VERDICT ACCEPT, blockers
+none.** Independent probes: error relay both polarities (invalid-category store
+-> wrapper error; corrupt-index doctor -> wrapper ok, status issues); token
+scope (page 200, /api/* query token 401, wrong-header + correct-query 401);
+100-way mixed burst -> 36 executed / 64x429, max 4 concurrent children,
+responsive after; re-preview loop stable on unchanged store (no false "store
+changed"), real apply archived the expected files; diff scan confirmed zero new
+enforcement surface. Suites 24/24 + 9/9 re-run by codex.

--- a/docs/plans/em-console-em-manage.md
+++ b/docs/plans/em-console-em-manage.md
@@ -137,3 +137,14 @@ isolated fixture stores; verdict ACCEPT, no P1):
 | F4 | Idle shutdown checked on a fixed 30s tick regardless of `--idle-timeout` | P3 | FIXED — interval = min(30s, idleTimeoutMs). |
 | F5 | Registry `write:false` classification had no conformance test tying it to actual non-mutation | P3 | FIXED — byte-stability sweep: every read command runs against a seeded sandbox and the full tree sha256 must be identical before/after; the case list is pinned to the registry so a new read command fails the sweep until added. |
 | F6 | CSP `script-src 'unsafe-inline'` means esc() is the only XSS layer (all sinks verified escaped) | P3 | PARTIAL — added `object-src 'none'; base-uri 'none'; form-action 'none'`. Script nonce deferred: single-page inline app, all sinks audited + hostile-payload probed by the reviewer. |
+
+codex (gpt-5.5, cmux interactive) round 1 on the same diff post-F1-F6
+(runtime probes incl. 80-way concurrency and a live TOCTOU injection; verdict
+HOLD, 3xP2 + 1xP3):
+
+| # | Finding | Sev | Disposition |
+|---|---|---|---|
+| R1-1 | Child CLI failures wrapped as top-level `status:"ok"` (invalid category store probed: wrapper ok, child error buried) | P2 | FIXED WITH MODIFICATION — wrapper relays `status:'error'` + message ONLY when the child self-declares `status:'error'`; exit code alone does not flip it, because em-doctor exits 1 with `status:'issues'` on an unhealthy store and that report must stay renderable (probed both polarities; both regression-tested). |
+| R1-2 | No concurrency bound on /api/run child fan-out (80 parallel calls -> 75 simultaneous children x 32MB maxBuffer) | P2 | FIXED — in-process semaphore: 4 running children max, 32 queued max, 429 beyond; 50-way burst regression asserts only 200/429 and post-burst responsiveness. |
+| R1-3 | em-manage dry-run consent TOCTOU: store mutated between preview and `y` applies unpreviewed state | P2 | FIXED — apply re-runs the dry-run; on any JSON difference it prints the refreshed preview and re-asks (loop until stable or declined). Regression drives a live wizard, injects a second chain mid-prompt, asserts re-confirmation fires and declined apply leaves bytes untouched. |
+| R1-4 | Query-string token accepted on every route, not just the bootstrap page | P3 | FIXED — `?token=` authorizes GET / only; /api/* requires the X-EM-Token header. Regression: query token on /api/meta and /api/run -> 401, page load -> 200. |

--- a/scripts/em-console.mjs
+++ b/scripts/em-console.mjs
@@ -91,7 +91,7 @@ const token = flag('--token') || crypto.randomBytes(24).toString('base64url')
 // ---------------------------------------------------------------------------
 const T = {
   str: { kind: 'str', max: 400 },
-  text: { kind: 'str', max: 20000 }, // summary/body/query prose
+  text: { kind: 'str', max: 20000, multiline: true }, // summary/body/query prose
   int: { kind: 'int', max: 1000 },
   bool: { kind: 'bool' },
   id: { kind: 'id' }, // episode id
@@ -148,8 +148,11 @@ function buildArgs(entry, flags) {
   if (typeof flags !== 'object' || Array.isArray(flags)) return { error: 'flags must be an object' }
   const args = [...(entry.fixed || [])]
   for (const name of Object.keys(flags)) {
+    // Object.hasOwn, not a plain lookup: prototype keys (__proto__, valueOf,
+    // hasOwnProperty, ...) resolve truthy through the chain and would ride the
+    // allowlist (same invariant class as the #469 null-proto index fix).
+    if (!Object.hasOwn(entry.flags, name)) return { error: `unknown flag "${name}" for this command` }
     const spec = entry.flags[name]
-    if (!spec) return { error: `unknown flag "${name}" for this command` }
     const v = flags[name]
     if (spec.kind === 'bool') {
       if (v !== true) return { error: `flag "${name}" is boolean: pass true or omit it` }
@@ -167,8 +170,12 @@ function buildArgs(entry, flags) {
     } else { // str
       if (s.length === 0 || s.length > spec.max) return { error: `flag "${name}" must be 1-${spec.max} characters` }
       if (s.startsWith('-')) return { error: `flag "${name}" may not start with "-"` }
+      // Prose fields (multiline: summary/body/query) keep tab/LF/CR; short
+      // token fields (tag, project, reason, ...) reject ALL control bytes so
+      // no embedded line break rides into episode metadata or index rows.
       // eslint-disable-next-line no-control-regex
-      if (/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(s)) return { error: `flag "${name}" contains control characters` }
+      const ctl = spec.multiline ? /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/ : /[\x00-\x1f\x7f]/
+      if (ctl.test(s)) return { error: `flag "${name}" contains control characters` }
     }
     args.push(`--${name}`, s)
   }
@@ -257,7 +264,7 @@ async function handle(req, res) {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
       'X-Content-Type-Options': 'nosniff',
-      'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; img-src data:",
+      'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; img-src data:; object-src 'none'; base-uri 'none'; form-action 'none'",
     })
     return res.end(renderPage())
   }
@@ -319,13 +326,14 @@ server.listen(port, host === 'localhost' ? '127.0.0.1' : host, () => {
 })
 
 if (idleTimeoutMs > 0) {
+  // Check at min(30s, timeout) so sub-30s timeouts fire near when the flag says.
   const timer = setInterval(() => {
     if (Date.now() - lastActivity > idleTimeoutMs) {
       process.stderr.write(`em-console: idle for ${idleTimeoutMs / 1000}s — shutting down\n`)
       server.close(() => process.exit(0))
       setTimeout(() => process.exit(0), 2000).unref()
     }
-  }, 30_000)
+  }, Math.min(30_000, idleTimeoutMs))
   timer.unref()
 }
 

--- a/scripts/em-console.mjs
+++ b/scripts/em-console.mjs
@@ -185,31 +185,56 @@ function buildArgs(entry, flags) {
   return { args }
 }
 
+// Child-process concurrency bound (P6: a burst of API calls must not fan out
+// an unbounded process storm — each child carries a 32MB output buffer).
+// Beyond MAX_CHILDREN running, requests queue; beyond MAX_QUEUE waiting, 429.
+const MAX_CHILDREN = 4
+const MAX_QUEUE = 32
+let activeChildren = 0
+const childQueue = []
+function drainChildQueue() {
+  while (childQueue.length && activeChildren < MAX_CHILDREN) childQueue.shift()()
+}
+
 function runCommand(cmd, flags) {
   return new Promise((resolve) => {
     const entry = COMMANDS[cmd]
     const built = buildArgs(entry, flags)
     if (built.error) return resolve({ code: 400, body: { status: 'error', cmd, message: built.error } })
     const scriptPath = path.join(SCRIPT_DIR, entry.script)
-    execFile(process.execPath, [scriptPath, ...built.args], {
-      cwd: process.cwd(),
-      timeout: 60_000,
-      maxBuffer: 32 * 1024 * 1024,
-      env: process.env,
-    }, (err, stdout, stderr) => {
-      let result
-      try { result = JSON.parse(String(stdout).trim()) } catch { result = { raw: String(stdout) } }
-      resolve({
-        code: 200,
-        body: {
-          status: 'ok',
-          cmd,
-          exit_code: err && typeof err.code === 'number' ? err.code : (err ? 1 : 0),
-          result,
-          ...(stderr && String(stderr).trim() ? { stderr: String(stderr).slice(0, 4000) } : {}),
-        },
+    const spawnChild = () => {
+      activeChildren++
+      execFile(process.execPath, [scriptPath, ...built.args], {
+        cwd: process.cwd(),
+        timeout: 60_000,
+        maxBuffer: 32 * 1024 * 1024,
+        env: process.env,
+      }, (err, stdout, stderr) => {
+        activeChildren--
+        drainChildQueue()
+        let result
+        try { result = JSON.parse(String(stdout).trim()) } catch { result = { raw: String(stdout) } }
+        // Relay the child's own verdict: the wrapper turns error ONLY when the
+        // child self-declares status:'error'. Exit code alone doesn't decide —
+        // em-doctor exits 1 with status:'issues' on an unhealthy store, and
+        // that report must still render (the server presents, never decides).
+        const childErrored = result && typeof result === 'object' && result.status === 'error'
+        resolve({
+          code: 200,
+          body: {
+            status: childErrored ? 'error' : 'ok',
+            cmd,
+            exit_code: err && typeof err.code === 'number' ? err.code : (err ? 1 : 0),
+            ...(childErrored && result.message ? { message: String(result.message) } : {}),
+            result,
+            ...(stderr && String(stderr).trim() ? { stderr: String(stderr).slice(0, 4000) } : {}),
+          },
+        })
       })
-    })
+    }
+    if (activeChildren < MAX_CHILDREN) spawnChild()
+    else if (childQueue.length >= MAX_QUEUE) resolve({ code: 429, body: { status: 'error', cmd, message: 'server busy — too many concurrent commands, retry shortly' } })
+    else childQueue.push(spawnChild)
   })
 }
 
@@ -252,7 +277,11 @@ let lastActivity = Date.now()
 async function handle(req, res) {
   lastActivity = Date.now()
   const url = new URL(req.url, `http://${host}`)
-  const candidate = req.headers['x-em-token'] || url.searchParams.get('token') || ''
+  // Query token authorizes ONLY the bootstrap page load (GET /), where the
+  // printed URL lands; every API route requires the X-EM-Token header so the
+  // token never rides referrers/history for data requests.
+  const queryToken = req.method === 'GET' && url.pathname === '/' ? url.searchParams.get('token') : ''
+  const candidate = req.headers['x-em-token'] || queryToken || ''
 
   if (!tokenOk(candidate)) {
     return sendJson(res, 401, { status: 'error', message: 'missing or invalid token — relaunch em-console and open the printed URL' })

--- a/scripts/em-console.mjs
+++ b/scripts/em-console.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+/**
+ * em-console.mjs — local web console over the episodic-memory CLI contract.
+ *
+ * Usage:
+ *   node em-console.mjs [--port <n>] [--host 127.0.0.1] [--allow-write]
+ *                       [--idle-timeout <secs>] [--token <t>]
+ *
+ * Presentation layer (CAPABILITIES.md "Adjacent layers", Principle 11): serves
+ * one self-contained HTML page and a single POST /api/run endpoint that spawns
+ * the sibling em-* scripts from a CLOSED command registry and returns their
+ * JSON verbatim. The server validates request SHAPE (command name, flag names,
+ * value types); it never interprets episode semantics — the spawned script
+ * decides everything, exactly as it would on the CLI.
+ *
+ * Bounded background work (Principle 6): user-started, loopback-only, prints
+ * its URL + lifetime on startup, idles out after --idle-timeout seconds
+ * (default 1800; 0 disables), does no polling and no work between requests.
+ *
+ * Consent (Principles 3/10): launched read-only by default. Commands that
+ * write (store, revise, pin, feedback, move, doctor --fix, rebuild-index,
+ * fold/prune apply) return 403 unless the server was started with
+ * --allow-write.
+ *
+ * Auth: a per-launch random token. The printed URL carries it once as
+ * ?token=; the page moves it to memory and sends X-EM-Token on every API
+ * call. Everything except the token-bearing page load is rejected without it.
+ *
+ * Outputs exactly one JSON object to stdout on startup:
+ *   { status, script, url, host, port, allow_write, idle_timeout_seconds, pid }
+ * Lifecycle notices (idle shutdown, SIGINT) go to stderr so stdout stays a
+ * single parseable object.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import http from 'http'
+import crypto from 'crypto'
+import { execFile } from 'child_process'
+import { fileURLToPath } from 'url'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({
+    status: 'help',
+    script: 'em-console.mjs',
+    usage: 'node em-console.mjs [--port <n>] [--host 127.0.0.1] [--allow-write] [--idle-timeout <secs>] [--token <t>] — local web console over the em-* CLI contract (loopback-only, per-launch token auth, read-only unless --allow-write; idles out after --idle-timeout seconds, default 1800, 0 disables). Prints one startup JSON object with the tokenized URL; open it in a browser.',
+  }))
+  process.exit(0)
+}
+
+function flag(name) {
+  const i = argv.indexOf(name)
+  if (i === -1 || i + 1 >= argv.length) return undefined
+  return argv[i + 1]
+}
+
+function die(message) {
+  console.log(JSON.stringify({ status: 'error', message }))
+  process.exit(2)
+}
+
+const host = flag('--host') || '127.0.0.1'
+// Loopback only, by design. Remote exposure (TLS, users, CSRF beyond the
+// token) is a different product; refusing here keeps the auth model honest.
+if (!['127.0.0.1', 'localhost', '::1'].includes(host)) {
+  die(`--host ${host} refused: em-console binds loopback only (127.0.0.1, localhost, ::1)`)
+}
+
+const portRaw = flag('--port') ?? '0'
+if (!/^\d+$/.test(portRaw) || parseInt(portRaw, 10) > 65535) {
+  die(`--port ${portRaw} invalid: expected an integer 0-65535 (0 = ephemeral)`)
+}
+const port = parseInt(portRaw, 10)
+
+const idleRaw = flag('--idle-timeout') ?? '1800'
+if (!/^\d+$/.test(idleRaw)) die(`--idle-timeout ${idleRaw} invalid: expected seconds (0 disables)`)
+const idleTimeoutMs = parseInt(idleRaw, 10) * 1000
+
+const allowWrite = argv.includes('--allow-write')
+const token = flag('--token') || crypto.randomBytes(24).toString('base64url')
+
+// ---------------------------------------------------------------------------
+// Command registry — the CLOSED set of spawnable shapes. Each entry names the
+// sibling script, fixed argv the command always carries, and the flags a
+// request may set. Flag types bound the value SHAPE only; semantic validation
+// (category vocabulary, id existence, scope rules) belongs to the spawned
+// script, which already enforces it for the CLI.
+// ---------------------------------------------------------------------------
+const T = {
+  str: { kind: 'str', max: 400 },
+  text: { kind: 'str', max: 20000 }, // summary/body/query prose
+  int: { kind: 'int', max: 1000 },
+  bool: { kind: 'bool' },
+  id: { kind: 'id' }, // episode id
+  scope3: { kind: 'enum', values: ['local', 'global', 'all'] },
+  scope2: { kind: 'enum', values: ['local', 'global'] },
+  taskType: { kind: 'enum', values: ['implementation', 'push', 'rule', 'general'] },
+}
+
+const COMMANDS = {
+  // read
+  stats: { script: 'em-stats.mjs', flags: { scope: T.scope3, top: T.int, 'all-projects': T.bool } },
+  doctor: { script: 'em-doctor.mjs', flags: { scope: T.scope3, 'all-projects': T.bool } },
+  search: {
+    script: 'em-search.mjs', fixed: ['--no-track'],
+    flags: { query: T.text, tag: T.str, category: T.str, project: T.str, scope: T.scope3, limit: T.int, since: T.str, full: T.bool, 'no-score': T.bool },
+  },
+  history: { script: 'em-search.mjs', fixed: ['--full', '--no-track'], flags: { history: T.id }, required: ['history'] },
+  list: { script: 'em-list.mjs', flags: { project: T.str, limit: T.int, scope: T.scope3, 'include-superseded': T.bool } },
+  recall: { script: 'em-recall.mjs', fixed: ['--no-track'], flags: { project: T.str, scope: T.scope3, limit: T.int, days: T.int, 'task-type': T.taskType } },
+  graph: { script: 'em-graph.mjs', flags: { from: T.id, depth: T.int, orphans: T.bool, hubs: T.bool, top: T.int, scope: T.scope3, limit: T.int } },
+  semantic: { script: 'em-semantic.mjs', fixed: ['--no-track'], flags: { query: T.text, scope: T.scope3, limit: T.int, project: T.str, full: T.bool }, required: ['query'] },
+  'capture-list': { script: 'em-capture.mjs', fixed: ['list'], flags: {} },
+  'fold-preview': { script: 'em-consolidate.mjs', fixed: ['--fold-superseded', '--dry-run'], flags: { scope: T.scope2, 'min-chain': T.int, 'all-projects': T.bool } },
+  'prune-preview': { script: 'em-prune.mjs', fixed: ['--dry-run'], flags: { scope: T.scope3 } },
+  // write (403 without --allow-write)
+  store: {
+    script: 'em-store.mjs', write: true,
+    flags: { project: T.str, category: T.str, summary: T.text, body: T.text, tags: T.str, scope: T.scope2, pin: T.bool },
+    required: ['project', 'category', 'summary', 'body'],
+  },
+  revise: {
+    script: 'em-revise.mjs', write: true,
+    flags: { original: T.id, project: T.str, summary: T.text, body: T.text, tags: T.str, scope: { kind: 'enum', values: ['inherit', 'local', 'global'] }, pin: T.bool },
+    required: ['original', 'project', 'summary', 'body'],
+  },
+  pin: { script: 'em-pin.mjs', write: true, flags: { id: T.id, unpin: T.bool }, required: ['id'] },
+  feedback: { script: 'em-feedback.mjs', write: true, flags: { id: T.id, useful: T.bool, noise: T.bool }, required: ['id'] },
+  move: { script: 'em-move.mjs', write: true, flags: { id: T.id, to: T.scope2, reason: T.str }, required: ['id', 'to'] },
+  'doctor-fix': { script: 'em-doctor.mjs', write: true, fixed: ['--fix'], flags: { scope: T.scope3 } },
+  'rebuild-index': { script: 'em-rebuild-index.mjs', write: true, flags: { scope: T.scope3 } },
+  // Apply forms are single-store on purpose: the multi-store fold's --confirm
+  // consent semantics stay a CLI-only surface in v1 (plan §5).
+  'fold-apply': { script: 'em-consolidate.mjs', write: true, fixed: ['--fold-superseded'], flags: { scope: T.scope2, 'min-chain': T.int } },
+  'prune-apply': { script: 'em-prune.mjs', write: true, flags: { scope: T.scope3 } },
+}
+
+// ---------------------------------------------------------------------------
+// Shape validation → argv array. No shell is ever involved (execFile with an
+// argv array), so the residual risk is flag smuggling — a value that a child
+// parser would read as a flag. Leading '-' values are rejected everywhere.
+// ---------------------------------------------------------------------------
+function buildArgs(entry, flags) {
+  if (flags === undefined || flags === null) flags = {}
+  if (typeof flags !== 'object' || Array.isArray(flags)) return { error: 'flags must be an object' }
+  const args = [...(entry.fixed || [])]
+  for (const name of Object.keys(flags)) {
+    const spec = entry.flags[name]
+    if (!spec) return { error: `unknown flag "${name}" for this command` }
+    const v = flags[name]
+    if (spec.kind === 'bool') {
+      if (v !== true) return { error: `flag "${name}" is boolean: pass true or omit it` }
+      args.push(`--${name}`)
+      continue
+    }
+    if (typeof v !== 'string' && typeof v !== 'number') return { error: `flag "${name}" must be a string or number` }
+    const s = String(v)
+    if (spec.kind === 'int') {
+      if (!/^\d+$/.test(s) || parseInt(s, 10) > spec.max) return { error: `flag "${name}" must be an integer 0-${spec.max}` }
+    } else if (spec.kind === 'enum') {
+      if (!spec.values.includes(s)) return { error: `flag "${name}" must be one of: ${spec.values.join(', ')}` }
+    } else if (spec.kind === 'id') {
+      if (!/^[0-9]{8}-[0-9]{6}-[A-Za-z0-9-]{1,200}$/.test(s)) return { error: `flag "${name}" is not an episode id` }
+    } else { // str
+      if (s.length === 0 || s.length > spec.max) return { error: `flag "${name}" must be 1-${spec.max} characters` }
+      if (s.startsWith('-')) return { error: `flag "${name}" may not start with "-"` }
+      // eslint-disable-next-line no-control-regex
+      if (/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(s)) return { error: `flag "${name}" contains control characters` }
+    }
+    args.push(`--${name}`, s)
+  }
+  for (const req of entry.required || []) {
+    if (!(req in flags)) return { error: `missing required flag "${req}"` }
+  }
+  return { args }
+}
+
+function runCommand(cmd, flags) {
+  return new Promise((resolve) => {
+    const entry = COMMANDS[cmd]
+    const built = buildArgs(entry, flags)
+    if (built.error) return resolve({ code: 400, body: { status: 'error', cmd, message: built.error } })
+    const scriptPath = path.join(SCRIPT_DIR, entry.script)
+    execFile(process.execPath, [scriptPath, ...built.args], {
+      cwd: process.cwd(),
+      timeout: 60_000,
+      maxBuffer: 32 * 1024 * 1024,
+      env: process.env,
+    }, (err, stdout, stderr) => {
+      let result
+      try { result = JSON.parse(String(stdout).trim()) } catch { result = { raw: String(stdout) } }
+      resolve({
+        code: 200,
+        body: {
+          status: 'ok',
+          cmd,
+          exit_code: err && typeof err.code === 'number' ? err.code : (err ? 1 : 0),
+          result,
+          ...(stderr && String(stderr).trim() ? { stderr: String(stderr).slice(0, 4000) } : {}),
+        },
+      })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Auth — constant-time compare over digests so length never leaks.
+// ---------------------------------------------------------------------------
+const tokenDigest = crypto.createHash('sha256').update(token).digest()
+function tokenOk(candidate) {
+  if (typeof candidate !== 'string' || candidate.length === 0) return false
+  const d = crypto.createHash('sha256').update(candidate).digest()
+  return crypto.timingSafeEqual(d, tokenDigest)
+}
+
+function sendJson(res, code, obj) {
+  const body = JSON.stringify(obj)
+  res.writeHead(code, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  })
+  res.end(body)
+}
+
+function readBody(req, limit = 1024 * 1024) {
+  return new Promise((resolve, reject) => {
+    let size = 0
+    const chunks = []
+    req.on('data', (c) => {
+      size += c.length
+      if (size > limit) { reject(new Error('body too large')); req.destroy(); return }
+      chunks.push(c)
+    })
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+}
+
+let lastActivity = Date.now()
+
+async function handle(req, res) {
+  lastActivity = Date.now()
+  const url = new URL(req.url, `http://${host}`)
+  const candidate = req.headers['x-em-token'] || url.searchParams.get('token') || ''
+
+  if (!tokenOk(candidate)) {
+    return sendJson(res, 401, { status: 'error', message: 'missing or invalid token — relaunch em-console and open the printed URL' })
+  }
+
+  if (req.method === 'GET' && url.pathname === '/') {
+    const { renderPage } = await import('./lib/console-page.mjs')
+    res.writeHead(200, {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; img-src data:",
+    })
+    return res.end(renderPage())
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/meta') {
+    let categories = []
+    try {
+      const { loadCategories } = await import('./lib/categories.mjs')
+      categories = loadCategories().categories.filter((c) => !c.deprecated_for).map((c) => c.name)
+    } catch { /* category vocab is presentation sugar here; the store enforces it */ }
+    return sendJson(res, 200, {
+      status: 'ok',
+      allow_write: allowWrite,
+      cwd: process.cwd(),
+      idle_timeout_seconds: idleTimeoutMs / 1000,
+      categories,
+      commands: Object.entries(COMMANDS).map(([name, e]) => ({ name, write: !!e.write })),
+    })
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/run') {
+    let parsed
+    try {
+      parsed = JSON.parse(await readBody(req))
+    } catch (e) {
+      return sendJson(res, e.message === 'body too large' ? 413 : 400, { status: 'error', message: `invalid request body: ${e.message}` })
+    }
+    const { cmd, flags } = parsed || {}
+    const entry = typeof cmd === 'string' ? COMMANDS[cmd] : undefined
+    if (!entry) return sendJson(res, 400, { status: 'error', message: `unknown command ${JSON.stringify(cmd)}` })
+    if (entry.write && !allowWrite) {
+      return sendJson(res, 403, { status: 'error', cmd, write_disabled: true, message: 'server is read-only — relaunch with --allow-write to enable write commands' })
+    }
+    const out = await runCommand(cmd, flags)
+    return sendJson(res, out.code, out.body)
+  }
+
+  return sendJson(res, 404, { status: 'error', message: 'not found' })
+}
+
+const server = http.createServer((req, res) => {
+  handle(req, res).catch((e) => {
+    try { sendJson(res, 500, { status: 'error', message: e.message }) } catch { /* socket gone */ }
+  })
+})
+
+server.listen(port, host === 'localhost' ? '127.0.0.1' : host, () => {
+  const actualPort = server.address().port
+  console.log(JSON.stringify({
+    status: 'ok',
+    script: 'em-console.mjs',
+    url: `http://${host === '::1' ? '[::1]' : host}:${actualPort}/?token=${token}`,
+    host,
+    port: actualPort,
+    allow_write: allowWrite,
+    idle_timeout_seconds: idleTimeoutMs / 1000,
+    pid: process.pid,
+  }))
+})
+
+if (idleTimeoutMs > 0) {
+  const timer = setInterval(() => {
+    if (Date.now() - lastActivity > idleTimeoutMs) {
+      process.stderr.write(`em-console: idle for ${idleTimeoutMs / 1000}s — shutting down\n`)
+      server.close(() => process.exit(0))
+      setTimeout(() => process.exit(0), 2000).unref()
+    }
+  }, 30_000)
+  timer.unref()
+}
+
+process.on('SIGINT', () => {
+  process.stderr.write('em-console: SIGINT — shutting down\n')
+  server.close(() => process.exit(0))
+  setTimeout(() => process.exit(0), 2000).unref()
+})

--- a/scripts/em-manage.mjs
+++ b/scripts/em-manage.mjs
@@ -139,15 +139,29 @@ async function actionStatus() {
 // what you run.
 async function dryRunThenApply(label, script, applyArgs, dryArgs) {
   console.log(`\n  [preview] ${label} (dry-run)`)
-  const dry = runJson(script, dryArgs)
+  let dry = runJson(script, dryArgs)
   printResult(`${label} dry-run`, dry, { rawRequested: true })
   if (dry.code !== 0 || !dry.json || dry.json.status === 'error') {
     console.log('  dry-run failed — not offering apply.')
     return
   }
-  if (!(await askYesNo(`Apply ${label}?`, false))) {
-    console.log('  left untouched (dry-run only).')
-    return
+  // Consent is to the PREVIEW (P3/P10): the store can change between the
+  // dry-run and the y answer, so re-run the dry-run at apply time and require
+  // fresh confirmation whenever the preview no longer matches.
+  for (;;) {
+    if (!(await askYesNo(`Apply ${label}?`, false))) {
+      console.log('  left untouched (dry-run only).')
+      return
+    }
+    const recheck = runJson(script, dryArgs)
+    if (JSON.stringify(recheck.json) === JSON.stringify(dry.json)) break
+    console.log('  store changed since the preview — refreshed dry-run:')
+    printResult(`${label} dry-run (refreshed)`, recheck, { rawRequested: true })
+    if (recheck.code !== 0 || !recheck.json || recheck.json.status === 'error') {
+      console.log('  refreshed dry-run failed — not offering apply.')
+      return
+    }
+    dry = recheck
   }
   const applied = runJson(script, applyArgs)
   printResult(`${label} apply`, applied, { rawRequested: true })

--- a/scripts/em-manage.mjs
+++ b/scripts/em-manage.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * em-manage.mjs — interactive day-2 maintenance wizard for the episodic
+ * memory stores.
+ *
+ * Usage:
+ *   node em-manage.mjs
+ *
+ * Presentation layer (CAPABILITIES.md "Adjacent layers", Principle 11): every
+ * action spawns a sibling em-* script and presents its JSON; the wizard never
+ * decides anything about episodes itself. Destructive-looking actions (fold,
+ * prune) always run the dry-run first and ask before applying (Principle 10).
+ *
+ * This is an interactive PROSE surface (like `em help`): menus and summaries
+ * are for humans. Every underlying operation still emits JSON — pick the raw
+ * option on any action to see it verbatim, or run the printed command
+ * directly.
+ *
+ * Scriptable via piped stdin (same buffered reader as install-wizard.mjs):
+ *   printf '1\nn\nq\n' | node em-manage.mjs
+ * EOF resolves any pending prompt to its default, so the wizard never hangs.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import readline from 'readline/promises'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const HOME = os.homedir()
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(JSON.stringify({
+    status: 'help',
+    script: 'em-manage.mjs',
+    usage: 'node em-manage.mjs — interactive day-2 maintenance wizard (status, hygiene: rebuild-index/fold/prune/doctor-fix, backup, capture drafts, routines, launch em-console). Dry-run first on destructive-looking actions; scriptable via piped stdin (EOF takes defaults).',
+  }))
+  process.exit(0)
+}
+
+// Buffered line reader (pattern proven in install-wizard.mjs): queue lines as
+// they arrive; EOF resolves pending/future asks to null so piped input can
+// never hang the wizard.
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: process.stdin.isTTY === true })
+const lineQueue = []
+let stdinClosed = false
+let lineWaiter = null
+rl.on('line', (line) => {
+  if (lineWaiter) { const w = lineWaiter; lineWaiter = null; w(line) }
+  else lineQueue.push(line)
+})
+rl.on('close', () => {
+  stdinClosed = true
+  if (lineWaiter) { const w = lineWaiter; lineWaiter = null; w(null) }
+})
+
+function nextLine() {
+  if (lineQueue.length) return Promise.resolve(lineQueue.shift())
+  if (stdinClosed) return Promise.resolve(null)
+  return new Promise((resolve) => { lineWaiter = resolve })
+}
+
+async function ask(question, def) {
+  const suffix = def !== undefined && def !== '' ? ` [${def}]` : ''
+  process.stdout.write(`${question}${suffix}: `)
+  const raw = await nextLine()
+  if (raw === null) { process.stdout.write('(eof — using default)\n'); return def ?? '' }
+  const answer = raw.trim()
+  return answer === '' ? (def ?? '') : answer
+}
+
+async function askYesNo(question, defYes = false) {
+  process.stdout.write(`${question} [${defYes ? 'Y/n' : 'y/N'}]: `)
+  const raw = await nextLine()
+  if (raw === null) { process.stdout.write('(eof — using default)\n'); return defYes }
+  const answer = raw.trim().toLowerCase()
+  if (answer === '') return defYes
+  return answer === 'y' || answer === 'yes'
+}
+
+function runJson(script, args) {
+  const r = spawnSync(process.execPath, [path.join(SCRIPT_DIR, script), ...args], { encoding: 'utf8' })
+  let json = null
+  try { json = JSON.parse((r.stdout || '').trim()) } catch { /* raw fallback below */ }
+  return { code: r.status, json, stdout: r.stdout || '', stderr: r.stderr || '' }
+}
+
+function printResult(label, r, { rawRequested = false } = {}) {
+  if (!r.json) {
+    console.log(`  ✗ ${label}: no JSON output (exit ${r.code})`)
+    if (r.stdout.trim()) console.log(r.stdout.trim().slice(0, 2000))
+    if (r.stderr.trim()) console.log(r.stderr.trim().slice(0, 2000))
+    return
+  }
+  const mark = r.code === 0 && r.json.status !== 'error' ? '✓' : '✗'
+  console.log(`  ${mark} ${label}: ${r.json.status}${r.json.message ? ` — ${r.json.message}` : ''}`)
+  if (rawRequested) console.log(JSON.stringify(r.json, null, 2))
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+async function actionStatus() {
+  const allProjects = await askYesNo('Include every registered project store (--all-projects)?', false)
+  const extra = allProjects ? ['--all-projects'] : []
+
+  const doctor = runJson('em-doctor.mjs', ['--scope', 'all', ...extra])
+  if (doctor.json && doctor.json.summary) {
+    const { ok, warn, error } = doctor.json.summary
+    console.log(`\n  doctor: ${doctor.json.status} (${ok} ok, ${warn} warn, ${error} error)`)
+    for (const c of (doctor.json.checks || []).filter((c) => c.level !== 'ok')) {
+      console.log(`    ${c.level.toUpperCase().padEnd(5)} [${c.id}${c.scope && c.scope !== '-' ? `:${c.scope}` : ''}] ${c.message}`)
+    }
+  } else {
+    printResult('doctor', doctor)
+  }
+
+  const stats = runJson('em-stats.mjs', ['--scope', 'all', ...extra])
+  if (stats.json && stats.json.scopes) {
+    console.log('  stats:')
+    for (const s of stats.json.scopes) {
+      console.log(`    ${String(s.scope || s.label || '?').padEnd(24)} active=${s.active ?? '?'} superseded=${s.superseded ?? '?'} pinned=${s.pinned ?? '?'}`)
+    }
+  } else {
+    printResult('stats', stats)
+  }
+
+  if (await askYesNo('Show raw JSON?', false)) {
+    if (doctor.json) console.log(JSON.stringify(doctor.json, null, 2))
+    if (stats.json) console.log(JSON.stringify(stats.json, null, 2))
+  }
+}
+
+// Dry-run first, show the impact, then ask before applying. The dry-run and
+// the apply are the SAME command shape minus the flag, so what you preview is
+// what you run.
+async function dryRunThenApply(label, script, applyArgs, dryArgs) {
+  console.log(`\n  [preview] ${label} (dry-run)`)
+  const dry = runJson(script, dryArgs)
+  printResult(`${label} dry-run`, dry, { rawRequested: true })
+  if (dry.code !== 0 || !dry.json || dry.json.status === 'error') {
+    console.log('  dry-run failed — not offering apply.')
+    return
+  }
+  if (!(await askYesNo(`Apply ${label}?`, false))) {
+    console.log('  left untouched (dry-run only).')
+    return
+  }
+  const applied = runJson(script, applyArgs)
+  printResult(`${label} apply`, applied, { rawRequested: true })
+}
+
+async function actionHygiene() {
+  console.log('\n  1. rebuild-index   regenerate index files (scope all)')
+  console.log('  2. fold            archive non-terminal supersedes-chain members (dry-run first)')
+  console.log('  3. prune           archive stale low-relevance episodes (dry-run first)')
+  console.log('  4. doctor-fix      run em-doctor --fix (scope all)')
+  const pick = await ask('Choose', '1')
+  if (pick === '1') {
+    printResult('rebuild-index', runJson('em-rebuild-index.mjs', ['--scope', 'all']), { rawRequested: true })
+  } else if (pick === '2') {
+    const scope = await ask('Scope (local|global)', 'local')
+    if (!['local', 'global'].includes(scope)) return console.log('  invalid scope — back to menu.')
+    await dryRunThenApply('fold-superseded', 'em-consolidate.mjs',
+      ['--fold-superseded', '--scope', scope],
+      ['--fold-superseded', '--dry-run', '--scope', scope])
+  } else if (pick === '3') {
+    const scope = await ask('Scope (local|global|all)', 'local')
+    if (!['local', 'global', 'all'].includes(scope)) return console.log('  invalid scope — back to menu.')
+    await dryRunThenApply('prune', 'em-prune.mjs',
+      ['--scope', scope],
+      ['--dry-run', '--scope', scope])
+  } else if (pick === '4') {
+    printResult('doctor --fix', runJson('em-doctor.mjs', ['--scope', 'all', '--fix']), { rawRequested: true })
+  } else {
+    console.log('  unknown choice — back to menu.')
+  }
+}
+
+async function actionBackup() {
+  const configPath = path.join(HOME, '.config/em-backup/config.json')
+  if (!fs.existsSync(configPath)) {
+    console.log(`\n  No backup config at ${configPath}.`)
+    console.log('  Set one up with the install wizard (node install.mjs --wizard) or see: em backup --help')
+    return
+  }
+  printResult('backup config', runJson('em-backup.mjs', ['--show-config']), { rawRequested: true })
+  if (await askYesNo('Run a backup sync now?', false)) {
+    printResult('backup --sync', runJson('em-backup.mjs', ['--sync']), { rawRequested: true })
+  }
+}
+
+async function actionCapture() {
+  const r = runJson('em-capture.mjs', ['list'])
+  printResult('pending drafts', r, { rawRequested: true })
+  console.log('  Review a draft (accept/reject episodes) with:')
+  console.log('    em capture review --draft <id> --accept <n,...>   (or --accept-all | --discard)')
+}
+
+async function actionRoutines() {
+  printResult('routines list', runJson('em-routines.mjs', ['list']), { rawRequested: true })
+  if (await askYesNo('Sync routines.json to the platform scheduler now?', false)) {
+    printResult('routines sync', runJson('em-routines.mjs', ['sync']), { rawRequested: true })
+  }
+}
+
+async function actionConsole() {
+  const write = await askYesNo('Enable write commands in the console (--allow-write)?', false)
+  console.log('  Launching em-console — open the printed URL; Ctrl+C returns here.\n')
+  const args = [path.join(SCRIPT_DIR, 'em-console.mjs'), ...(write ? ['--allow-write'] : [])]
+  spawnSync(process.execPath, args, { stdio: 'inherit' })
+}
+
+// ---------------------------------------------------------------------------
+// Menu loop
+// ---------------------------------------------------------------------------
+console.log('episodic-memory manager')
+console.log('═══════════════════════')
+
+const MENU = [
+  ['1', 'status', 'store health + analytics (doctor, stats)', actionStatus],
+  ['2', 'hygiene', 'rebuild-index / fold superseded / prune / doctor --fix', actionHygiene],
+  ['3', 'backup', 'show backup config, run a sync', actionBackup],
+  ['4', 'capture', 'pending session-capture drafts', actionCapture],
+  ['5', 'routines', 'scheduled maintenance (list, sync)', actionRoutines],
+  ['6', 'console', 'launch the local web console (em-console)', actionConsole],
+]
+
+let exit = 0
+try {
+  for (;;) {
+    console.log('')
+    for (const [key, name, desc] of MENU) console.log(`  ${key}. ${name.padEnd(9)} ${desc}`)
+    console.log('  q. quit')
+    const choice = (await ask('Choose', 'q')).toLowerCase()
+    if (choice === 'q' || choice === 'quit' || choice === '') break
+    const entry = MENU.find(([key, name]) => key === choice || name === choice)
+    if (!entry) { console.log(`  unknown choice "${choice}"`); continue }
+    await entry[3]()
+    if (stdinClosed && lineQueue.length === 0) break // piped input exhausted
+  }
+} catch (err) {
+  console.log(`  error: ${err.message}`)
+  exit = 1
+} finally {
+  rl.close()
+}
+process.exit(exit)

--- a/scripts/em-manage.mjs
+++ b/scripts/em-manage.mjs
@@ -121,7 +121,8 @@ async function actionStatus() {
   if (stats.json && stats.json.scopes) {
     console.log('  stats:')
     for (const s of stats.json.scopes) {
-      console.log(`    ${String(s.scope || s.label || '?').padEnd(24)} active=${s.active ?? '?'} superseded=${s.superseded ?? '?'} pinned=${s.pinned ?? '?'}`)
+      const ep = s.episodes || {}
+      console.log(`    ${String(s.scope || s.label || '?').padEnd(24)} active=${ep.active ?? '?'} superseded=${ep.superseded ?? '?'} pinned=${ep.pinned ?? '?'}`)
     }
   } else {
     printResult('stats', stats)

--- a/scripts/em-manage.mjs
+++ b/scripts/em-manage.mjs
@@ -208,6 +208,13 @@ async function actionRoutines() {
 }
 
 async function actionConsole() {
+  // Non-interactive stdin has no Ctrl-C path back to the menu: em-console
+  // never reads stdin, so spawnSync would block until the idle timeout.
+  if (process.stdin.isTTY !== true) {
+    console.log('  console needs an interactive terminal — run it directly:')
+    console.log(`    node ${path.join(SCRIPT_DIR, 'em-console.mjs')}`)
+    return
+  }
   const write = await askYesNo('Enable write commands in the console (--allow-write)?', false)
   console.log('  Launching em-console — open the printed URL; Ctrl+C returns here.\n')
   const args = [path.join(SCRIPT_DIR, 'em-console.mjs'), ...(write ? ['--allow-write'] : [])]

--- a/scripts/em.mjs
+++ b/scripts/em.mjs
@@ -12,8 +12,9 @@
  *   em recall
  *   em doctor --fix
  *
- * `em help` prints a human-readable command table (the only non-JSON output
- * surface in the substrate — every delegated command still emits JSON).
+ * `em help` prints a human-readable command table. Interactive presentation
+ * surfaces (this help table, the `em manage` wizard) print prose; every
+ * non-interactive command still emits JSON.
  * `em help --json` emits the same table as JSON for tooling.
  *
  * Command resolution is directory-driven: any em-<name>.mjs sitting next to
@@ -40,6 +41,8 @@ const DESCRIPTIONS = {
   revise: 'Correct a past episode via a revision chain',
   move: 'Relocate episodes between local and global scopes (RFC-005)',
   consolidate: 'Fold near-duplicate episodes into digest episodes (dry-run default)',
+  console: 'Local web console over the store (loopback-only, read-only by default)',
+  manage: 'Interactive day-2 maintenance wizard (status, hygiene, backup, drafts)',
   graph: 'Typed-edge traversal: lineage, clusters, orphans, hubs (RFC-007)',
   stats: 'Store analytics: totals, categories, age, tags, prunable estimate',
   embed: 'Build/update the embeddings sidecar for semantic search',

--- a/scripts/lib/console-page.mjs
+++ b/scripts/lib/console-page.mjs
@@ -159,15 +159,16 @@ function buildDashboard() {
 function renderStats(r) {
   if (!r.scopes) return '<p class="note">no scopes in output</p>';
   return r.scopes.map(s => {
-    const cats = (s.categories || []).slice ? s.categories : Object.entries(s.categories || {}).map(([key, count]) => ({ key, count }));
+    const ep = s.episodes || {};
+    const cats = Object.entries(s.by_category || {}).sort((a, b) => b[1] - a[1]).map(([key, count]) => ({ key, count }));
     return '<div class="panel"><h2>' + esc(s.scope || s.label || '') + (s.dir ? ' <span class="note">' + esc(s.dir) + '</span>' : '') + '</h2>' +
       '<div class="cards">' +
-      '<div class="card"><div class="k">active</div><div class="v">' + esc(s.active ?? s.total ?? '–') + '</div></div>' +
-      '<div class="card"><div class="k">superseded</div><div class="v">' + esc(s.superseded ?? '–') + '</div></div>' +
-      '<div class="card"><div class="k">pinned</div><div class="v">' + esc(s.pinned ?? '–') + '</div></div>' +
-      '<div class="card"><div class="k">prunable est.</div><div class="v">' + esc(s.prunable_estimate ?? s.prunable ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">active</div><div class="v">' + esc(ep.active ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">superseded</div><div class="v">' + esc(ep.superseded ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">pinned</div><div class="v">' + esc(ep.pinned ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">prunable est.</div><div class="v">' + esc(s.prunable_estimate ?? '–') + '</div></div>' +
       '</div>' +
-      (cats && cats.length ? '<p class="chips">' + cats.map(c => '<span>' + esc(c.key || c.category) + ' ' + esc(c.count) + '</span>').join('') + '</p>' : '') +
+      (cats.length ? '<p class="chips">' + cats.map(c => '<span>' + esc(c.key) + ' ' + esc(c.count) + '</span>').join('') + '</p>' : '') +
       '</div>';
   }).join('');
 }

--- a/scripts/lib/console-page.mjs
+++ b/scripts/lib/console-page.mjs
@@ -1,0 +1,370 @@
+/**
+ * console-page.mjs — the single self-contained HTML page em-console serves.
+ *
+ * Pure presentation (Principle 11): every panel is a thin form over one
+ * POST /api/run command; all data shown comes back from the spawned em-*
+ * script's JSON, rendered client-side. No external assets (CSP: default-src
+ * 'none'), no cookies — the token rides in from ?token=, is moved to JS
+ * memory, stripped from the URL, and sent as X-EM-Token on every call.
+ */
+
+export function renderPage() {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>em-console</title>
+<style>
+:root {
+  --bg: #f6f7f9; --panel: #ffffff; --ink: #1b2733; --muted: #5d6b7a;
+  --line: #dde3ea; --accent: #2563eb; --accent-ink: #ffffff;
+  --ok: #15803d; --warn: #b45309; --err: #b91c1c; --chip: #eef2f7;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #10151b; --panel: #171e26; --ink: #e6edf3; --muted: #93a4b4;
+    --line: #2b3641; --accent: #4f8ef7; --accent-ink: #0b1016;
+    --ok: #4ade80; --warn: #fbbf24; --err: #f87171; --chip: #202a35;
+  }
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--ink);
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+header { display: flex; align-items: center; gap: 12px; padding: 10px 18px;
+  background: var(--panel); border-bottom: 1px solid var(--line); flex-wrap: wrap; }
+header h1 { font-size: 16px; margin: 0; letter-spacing: .3px; }
+.badge { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--chip);
+  color: var(--muted); border: 1px solid var(--line); }
+.badge.write { color: var(--warn); }
+nav { display: flex; gap: 4px; flex-wrap: wrap; margin-left: auto; }
+nav button { background: none; border: 1px solid transparent; color: var(--muted);
+  padding: 6px 12px; border-radius: 8px; cursor: pointer; font: inherit; }
+nav button.active { background: var(--chip); color: var(--ink); border-color: var(--line); }
+main { max-width: 1100px; margin: 0 auto; padding: 18px; }
+section.tab { display: none; }
+section.tab.active { display: block; }
+.panel { background: var(--panel); border: 1px solid var(--line); border-radius: 12px;
+  padding: 14px 16px; margin-bottom: 14px; }
+.panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .8px;
+  color: var(--muted); margin: 0 0 10px; }
+.row { display: flex; gap: 8px; flex-wrap: wrap; align-items: end; margin-bottom: 10px; }
+label.field { display: flex; flex-direction: column; gap: 3px; font-size: 12px; color: var(--muted); }
+input, select, textarea { font: inherit; color: var(--ink); background: var(--bg);
+  border: 1px solid var(--line); border-radius: 8px; padding: 6px 9px; }
+textarea { width: 100%; min-height: 110px; resize: vertical; }
+button.act { background: var(--accent); color: var(--accent-ink); border: none;
+  border-radius: 8px; padding: 7px 14px; cursor: pointer; font: inherit; }
+button.act.secondary { background: var(--chip); color: var(--ink); border: 1px solid var(--line); }
+button.act:disabled { opacity: .45; cursor: not-allowed; }
+.cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 10px; }
+.card { border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px; background: var(--bg); }
+.card .k { font-size: 12px; color: var(--muted); }
+.card .v { font-size: 22px; font-weight: 600; }
+.tablewrap { overflow-x: auto; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { color: var(--muted); font-weight: 500; font-size: 12px; }
+tr.clickable { cursor: pointer; }
+tr.clickable:hover td { background: var(--chip); }
+.lvl-ok { color: var(--ok); } .lvl-warn { color: var(--warn); } .lvl-error { color: var(--err); }
+.chips span { display: inline-block; background: var(--chip); border: 1px solid var(--line);
+  border-radius: 999px; padding: 1px 8px; font-size: 11px; margin: 1px 3px 1px 0; color: var(--muted); }
+pre { background: var(--bg); border: 1px solid var(--line); border-radius: 8px;
+  padding: 10px; overflow-x: auto; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
+details.raw { margin-top: 8px; }
+details.raw summary { color: var(--muted); font-size: 12px; cursor: pointer; }
+.note { color: var(--muted); font-size: 12px; }
+.err { color: var(--err); }
+#toast { position: fixed; bottom: 16px; right: 16px; background: var(--panel);
+  border: 1px solid var(--line); border-radius: 10px; padding: 10px 14px; display: none;
+  max-width: 380px; box-shadow: 0 4px 18px rgba(0,0,0,.18); }
+</style>
+</head>
+<body>
+<header>
+  <h1>em-console</h1>
+  <span id="mode" class="badge">…</span>
+  <span id="cwd" class="badge"></span>
+  <nav id="nav"></nav>
+</header>
+<main id="main"></main>
+<div id="toast"></div>
+<script>
+'use strict';
+// --- token bootstrap: move ?token= into memory, scrub the URL --------------
+const qs = new URLSearchParams(location.search);
+const TOKEN = qs.get('token') || '';
+if (qs.has('token')) history.replaceState(null, '', location.pathname);
+
+async function api(path, opts) {
+  const r = await fetch(path, Object.assign({ headers: { 'X-EM-Token': TOKEN, 'Content-Type': 'application/json' } }, opts));
+  const body = await r.json().catch(() => ({ status: 'error', message: 'non-JSON response' }));
+  return { http: r.status, body };
+}
+async function run(cmd, flags) { return api('/api/run', { method: 'POST', body: JSON.stringify({ cmd, flags: flags || {} }) }); }
+
+function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+function el(id) { return document.getElementById(id); }
+function toast(msg, isErr) {
+  const t = el('toast');
+  t.textContent = msg; t.style.display = 'block'; t.className = isErr ? 'err' : '';
+  clearTimeout(t._h); t._h = setTimeout(() => { t.style.display = 'none'; }, 4000);
+}
+function raw(obj) { return '<details class="raw"><summary>raw JSON</summary><pre>' + esc(JSON.stringify(obj, null, 2)) + '</pre></details>'; }
+function resultOrError(res, renderFn, target) {
+  if (res.http !== 200 || res.body.status !== 'ok') {
+    target.innerHTML = '<p class="err">' + esc(res.body.message || ('HTTP ' + res.http)) + '</p>' + raw(res.body);
+    return;
+  }
+  target.innerHTML = renderFn(res.body.result) + raw(res.body);
+}
+
+// --- tabs -------------------------------------------------------------------
+let META = { allow_write: false, categories: [], cwd: '' };
+const TABS = [
+  ['dashboard', 'Dashboard'], ['browse', 'Browse'], ['recall', 'Recall'],
+  ['drafts', 'Drafts'], ['maintenance', 'Maintenance'], ['new', 'New episode'],
+];
+function show(tabId) {
+  document.querySelectorAll('section.tab').forEach(s => s.classList.toggle('active', s.id === 'tab-' + tabId));
+  document.querySelectorAll('nav button').forEach(b => b.classList.toggle('active', b.dataset.tab === tabId));
+}
+
+function buildShell() {
+  el('nav').innerHTML = TABS.map(([id, label]) =>
+    '<button data-tab="' + id + '">' + label + '</button>').join('');
+  document.querySelectorAll('nav button').forEach(b => b.onclick = () => show(b.dataset.tab));
+  el('main').innerHTML = TABS.map(([id]) => '<section class="tab" id="tab-' + id + '"></section>').join('');
+}
+
+// --- dashboard ---------------------------------------------------------------
+function buildDashboard() {
+  el('tab-dashboard').innerHTML =
+    '<div class="panel"><h2>Store analytics</h2>' +
+    '<div class="row"><label class="field">scope<select id="st-scope"><option>all</option><option>local</option><option>global</option></select></label>' +
+    '<label class="field"><span>all projects</span><input type="checkbox" id="st-all"></label>' +
+    '<button class="act" id="st-run">Refresh stats</button></div><div id="st-out"></div></div>' +
+    '<div class="panel"><h2>Health</h2>' +
+    '<div class="row"><button class="act" id="dr-run">Run doctor</button></div><div id="dr-out"></div></div>';
+  el('st-run').onclick = async () => {
+    const flags = { scope: el('st-scope').value };
+    if (el('st-all').checked) flags['all-projects'] = true;
+    resultOrError(await run('stats', flags), renderStats, el('st-out'));
+  };
+  el('dr-run').onclick = async () => {
+    resultOrError(await run('doctor', { scope: 'all' }), renderDoctor, el('dr-out'));
+  };
+}
+function renderStats(r) {
+  if (!r.scopes) return '<p class="note">no scopes in output</p>';
+  return r.scopes.map(s => {
+    const cats = (s.categories || []).slice ? s.categories : Object.entries(s.categories || {}).map(([key, count]) => ({ key, count }));
+    return '<div class="panel"><h2>' + esc(s.scope || s.label || '') + (s.dir ? ' <span class="note">' + esc(s.dir) + '</span>' : '') + '</h2>' +
+      '<div class="cards">' +
+      '<div class="card"><div class="k">active</div><div class="v">' + esc(s.active ?? s.total ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">superseded</div><div class="v">' + esc(s.superseded ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">pinned</div><div class="v">' + esc(s.pinned ?? '–') + '</div></div>' +
+      '<div class="card"><div class="k">prunable est.</div><div class="v">' + esc(s.prunable_estimate ?? s.prunable ?? '–') + '</div></div>' +
+      '</div>' +
+      (cats && cats.length ? '<p class="chips">' + cats.map(c => '<span>' + esc(c.key || c.category) + ' ' + esc(c.count) + '</span>').join('') + '</p>' : '') +
+      '</div>';
+  }).join('');
+}
+function renderDoctor(r) {
+  const sum = r.summary || {};
+  let html = '<div class="cards">' +
+    '<div class="card"><div class="k">status</div><div class="v lvl-' + esc(r.status) + '">' + esc(r.status) + '</div></div>' +
+    '<div class="card"><div class="k">ok</div><div class="v lvl-ok">' + esc(sum.ok ?? '–') + '</div></div>' +
+    '<div class="card"><div class="k">warn</div><div class="v lvl-warn">' + esc(sum.warn ?? '–') + '</div></div>' +
+    '<div class="card"><div class="k">error</div><div class="v lvl-error">' + esc(sum.error ?? '–') + '</div></div></div>';
+  const bad = (r.checks || []).filter(c => c.level !== 'ok');
+  if (bad.length) {
+    html += '<div class="tablewrap"><table><tr><th>level</th><th>check</th><th>scope</th><th>message</th></tr>' +
+      bad.map(c => '<tr><td class="lvl-' + esc(c.level) + '">' + esc(c.level) + '</td><td>' + esc(c.id) + '</td><td>' + esc(c.scope) + '</td><td>' + esc(c.message) + '</td></tr>').join('') +
+      '</table></div>';
+  } else { html += '<p class="note">all checks ok</p>'; }
+  return html;
+}
+
+// --- browse -------------------------------------------------------------------
+function buildBrowse() {
+  el('tab-browse').innerHTML =
+    '<div class="panel"><h2>Search episodes</h2>' +
+    '<div class="row">' +
+    '<label class="field">query<input id="q-query" size="24"></label>' +
+    '<label class="field">tag<input id="q-tag" size="14"></label>' +
+    '<label class="field">category<input id="q-cat" size="12" list="cats"></label>' +
+    '<label class="field">project<input id="q-proj" size="14"></label>' +
+    '<label class="field">scope<select id="q-scope"><option>all</option><option>local</option><option>global</option></select></label>' +
+    '<label class="field">limit<input id="q-limit" size="4" value="20"></label>' +
+    '<button class="act" id="q-run">Search</button>' +
+    '<button class="act secondary" id="q-list">List recent</button>' +
+    '</div><datalist id="cats">' + META.categories.map(c => '<option>' + esc(c) + '</option>').join('') + '</datalist>' +
+    '<div id="q-out"></div></div>' +
+    '<div class="panel"><h2>Episode history</h2><p class="note">click a row above, or enter an id</p>' +
+    '<div class="row"><label class="field">episode id<input id="h-id" size="52"></label>' +
+    '<button class="act" id="h-run">Load chain</button></div><div id="h-out"></div></div>';
+  el('q-run').onclick = async () => {
+    const flags = { scope: el('q-scope').value };
+    for (const [fid, name] of [['q-query','query'],['q-tag','tag'],['q-cat','category'],['q-proj','project'],['q-limit','limit']]) {
+      const v = el(fid).value.trim(); if (v) flags[name] = v;
+    }
+    resultOrError(await run('search', flags), renderEpisodes, el('q-out'));
+  };
+  el('q-list').onclick = async () => {
+    const flags = { scope: el('q-scope').value };
+    const lim = el('q-limit').value.trim(); if (lim) flags.limit = lim;
+    const proj = el('q-proj').value.trim(); if (proj) flags.project = proj;
+    resultOrError(await run('list', flags), renderEpisodes, el('q-out'));
+  };
+  el('h-run').onclick = async () => {
+    const id = el('h-id').value.trim(); if (!id) return toast('enter an episode id', true);
+    resultOrError(await run('history', { history: id }), renderHistory, el('h-out'));
+  };
+}
+function renderEpisodes(r) {
+  const eps = r.episodes || [];
+  if (!eps.length) return '<p class="note">no episodes</p>';
+  return '<div class="tablewrap"><table><tr><th>date</th><th>category</th><th>project</th><th>summary</th><th>src</th></tr>' +
+    eps.map(e => '<tr class="clickable" data-id="' + esc(e.id) + '"><td>' + esc(e.date) + '</td><td>' + esc(e.category) + '</td><td>' + esc(e.project) + '</td><td>' + esc(e.summary) + '</td><td>' + esc(e.source || '') + '</td></tr>').join('') +
+    '</table></div><p class="note">' + eps.length + ' shown</p>';
+}
+function renderHistory(r) {
+  const eps = r.episodes || r.history || [];
+  if (!eps.length) return '<p class="note">no chain found</p>';
+  return eps.map(e =>
+    '<div class="panel"><h2>' + esc(e.id) + (e.status ? ' <span class="badge">' + esc(e.status) + '</span>' : '') + '</h2>' +
+    '<p>' + esc(e.summary) + '</p>' +
+    (e.tags && e.tags.length ? '<p class="chips">' + e.tags.map(t => '<span>' + esc(t) + '</span>').join('') + '</p>' : '') +
+    (e.body ? '<pre>' + esc(e.body) + '</pre>' : '') + '</div>').join('');
+}
+document.addEventListener('click', (ev) => {
+  const tr = ev.target.closest && ev.target.closest('tr.clickable');
+  if (tr && tr.dataset.id) {
+    el('h-id').value = tr.dataset.id;
+    el('h-run').click();
+  }
+});
+
+// --- recall -------------------------------------------------------------------
+function buildRecall() {
+  el('tab-recall').innerHTML =
+    '<div class="panel"><h2>Session-start recall preview</h2>' +
+    '<div class="row"><label class="field">project<input id="rc-proj" size="18"></label>' +
+    '<label class="field">task type<select id="rc-task"><option value="">(default)</option><option>implementation</option><option>push</option><option>rule</option><option>general</option></select></label>' +
+    '<button class="act" id="rc-run">Recall</button></div><div id="rc-out"></div></div>';
+  el('rc-run').onclick = async () => {
+    const flags = {};
+    if (el('rc-proj').value.trim()) flags.project = el('rc-proj').value.trim();
+    if (el('rc-task').value) flags['task-type'] = el('rc-task').value;
+    resultOrError(await run('recall', flags), renderEpisodes, el('rc-out'));
+  };
+}
+
+// --- drafts -------------------------------------------------------------------
+function buildDrafts() {
+  el('tab-drafts').innerHTML =
+    '<div class="panel"><h2>Pending capture drafts</h2>' +
+    '<p class="note">confirm or discard via the CLI: em capture review --draft &lt;id&gt;</p>' +
+    '<div class="row"><button class="act" id="cp-run">Refresh</button></div><div id="cp-out"></div></div>';
+  el('cp-run').onclick = async () => {
+    resultOrError(await run('capture-list', {}), r => '<pre>' + esc(JSON.stringify(r, null, 2)) + '</pre>', el('cp-out'));
+  };
+}
+
+// --- maintenance ----------------------------------------------------------------
+function writeGate(btnHtml) {
+  return META.allow_write ? btnHtml
+    : btnHtml.replace('<button class="act"', '<button class="act" disabled title="relaunch with --allow-write"');
+}
+function buildMaintenance() {
+  const ro = META.allow_write ? '' : '<p class="note">read-only launch — apply/fix buttons need <code>--allow-write</code></p>';
+  el('tab-maintenance').innerHTML = ro +
+    '<div class="panel"><h2>Index</h2><div class="row">' +
+    writeGate('<button class="act" id="m-rebuild">Rebuild index (scope all)</button>') +
+    writeGate('<button class="act" id="m-fix">Doctor --fix (scope all)</button>') +
+    '</div><div id="m-idx-out"></div></div>' +
+    '<div class="panel"><h2>Fold superseded chains</h2><div class="row">' +
+    '<label class="field">scope<select id="m-fold-scope"><option>local</option><option>global</option></select></label>' +
+    '<button class="act secondary" id="m-fold-dry">Preview (dry-run)</button>' +
+    writeGate('<button class="act" id="m-fold-apply">Apply fold</button>') +
+    '</div><div id="m-fold-out"></div></div>' +
+    '<div class="panel"><h2>Prune stale episodes</h2><div class="row">' +
+    '<label class="field">scope<select id="m-prune-scope"><option>local</option><option>global</option><option>all</option></select></label>' +
+    '<button class="act secondary" id="m-prune-dry">Preview (dry-run)</button>' +
+    writeGate('<button class="act" id="m-prune-apply">Apply prune</button>') +
+    '</div><div id="m-prune-out"></div></div>';
+  const jsonR = r => '<pre>' + esc(JSON.stringify(r, null, 2)) + '</pre>';
+  const wire = (id, cmd, flagsFn, out) => {
+    const b = el(id); if (!b) return;
+    b.onclick = async () => resultOrError(await run(cmd, flagsFn()), jsonR, el(out));
+  };
+  wire('m-rebuild', 'rebuild-index', () => ({ scope: 'all' }), 'm-idx-out');
+  wire('m-fix', 'doctor-fix', () => ({ scope: 'all' }), 'm-idx-out');
+  wire('m-fold-dry', 'fold-preview', () => ({ scope: el('m-fold-scope').value }), 'm-fold-out');
+  wire('m-fold-apply', 'fold-apply', () => ({ scope: el('m-fold-scope').value }), 'm-fold-out');
+  wire('m-prune-dry', 'prune-preview', () => ({ scope: el('m-prune-scope').value }), 'm-prune-out');
+  wire('m-prune-apply', 'prune-apply', () => ({ scope: el('m-prune-scope').value }), 'm-prune-out');
+}
+
+// --- new episode -----------------------------------------------------------------
+function buildNew() {
+  if (!META.allow_write) {
+    el('tab-new').innerHTML = '<div class="panel"><h2>New episode</h2><p class="note">read-only launch — relaunch with <code>--allow-write</code> to store or revise episodes.</p></div>';
+    return;
+  }
+  const catOpts = META.categories.map(c => '<option>' + esc(c) + '</option>').join('');
+  el('tab-new').innerHTML =
+    '<div class="panel"><h2>Store episode</h2>' +
+    '<div class="row"><label class="field">project<input id="n-proj" size="16"></label>' +
+    '<label class="field">category<select id="n-cat">' + catOpts + '</select></label>' +
+    '<label class="field">scope<select id="n-scope"><option>global</option><option>local</option></select></label>' +
+    '<label class="field">tags (comma-sep)<input id="n-tags" size="26"></label>' +
+    '<label class="field"><span>pin</span><input type="checkbox" id="n-pin"></label></div>' +
+    '<div class="row"><label class="field" style="flex:1">summary<input id="n-sum" style="width:100%"></label></div>' +
+    '<label class="field">body<textarea id="n-body"></textarea></label>' +
+    '<div class="row"><button class="act" id="n-store">Store</button></div><div id="n-out"></div></div>' +
+    '<div class="panel"><h2>Revise episode</h2>' +
+    '<div class="row"><label class="field">original id<input id="v-orig" size="52"></label>' +
+    '<label class="field">project<input id="v-proj" size="16"></label></div>' +
+    '<div class="row"><label class="field" style="flex:1">summary<input id="v-sum" style="width:100%"></label></div>' +
+    '<label class="field">body<textarea id="v-body"></textarea></label>' +
+    '<div class="row"><button class="act" id="v-run">Revise</button></div><div id="v-out"></div></div>';
+  el('n-store').onclick = async () => {
+    const flags = { project: el('n-proj').value.trim(), category: el('n-cat').value, summary: el('n-sum').value.trim(), body: el('n-body').value, scope: el('n-scope').value };
+    if (el('n-tags').value.trim()) flags.tags = el('n-tags').value.trim();
+    if (el('n-pin').checked) flags.pin = true;
+    const res = await run('store', flags);
+    resultOrError(res, r => '<p>stored: <code>' + esc(r.id || '') + '</code></p>', el('n-out'));
+    if (res.http === 200 && res.body.status === 'ok') toast('episode stored');
+  };
+  el('v-run').onclick = async () => {
+    const flags = { original: el('v-orig').value.trim(), project: el('v-proj').value.trim(), summary: el('v-sum').value.trim(), body: el('v-body').value };
+    const res = await run('revise', flags);
+    resultOrError(res, r => '<p>revised: <code>' + esc(r.id || '') + '</code></p>', el('v-out'));
+  };
+}
+
+// --- boot ------------------------------------------------------------------------
+(async function boot() {
+  buildShell();
+  const meta = await api('/api/meta');
+  if (meta.http !== 200) {
+    el('main').innerHTML = '<div class="panel"><p class="err">' + esc(meta.body.message || 'auth failed') + '</p></div>';
+    return;
+  }
+  META = meta.body;
+  el('mode').textContent = META.allow_write ? 'WRITE ENABLED' : 'READ-ONLY';
+  el('mode').classList.toggle('write', META.allow_write);
+  el('cwd').textContent = META.cwd;
+  buildDashboard(); buildBrowse(); buildRecall(); buildDrafts(); buildMaintenance(); buildNew();
+  show('dashboard');
+  el('st-run').click();
+  el('dr-run').click();
+})();
+</script>
+</body>
+</html>
+`
+}

--- a/tests/test-em-console.mjs
+++ b/tests/test-em-console.mjs
@@ -291,6 +291,41 @@ await (async () => {
       const r = await req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'pin', flags: { id: 'not-an-id' } } })
       assert.strictEqual(r.status, 400)
     })
+    await test('child self-declared error relays as wrapper status error (codex R1-1)', async () => {
+      const r = await req(rw.port, '/api/run', {
+        method: 'POST', token: TOKEN,
+        body: { cmd: 'store', flags: { project: 'x', category: 'not-a-category', summary: 's', body: 'b', scope: 'local' } },
+      })
+      assert.strictEqual(r.status, 200, 'transport still 200')
+      assert.strictEqual(r.json.status, 'error', `wrapper hid the child failure: ${JSON.stringify(r.json).slice(0, 200)}`)
+      assert.ok(/Invalid category/.test(r.json.message), r.json.message)
+      assert.strictEqual(r.json.result.status, 'error', 'child JSON still verbatim under result')
+    })
+    await test('doctor exit-1-with-issues does NOT relay as wrapper error (report stays renderable)', async () => {
+      // em-doctor exits 1 with status:'issues' on an unhealthy store — that is
+      // a renderable report, not an invocation failure. Wrapper must stay ok.
+      const r = await req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'doctor', flags: { scope: 'local' } } })
+      assert.strictEqual(r.json.status, 'ok', `doctor report misrelayed: ${JSON.stringify(r.json).slice(0, 200)}`)
+      assert.ok(r.json.result.summary, 'doctor summary missing')
+    })
+    await test('concurrent burst is bounded, never 5xx, server stays responsive (codex R1-2)', async () => {
+      const burst = await Promise.all(Array.from({ length: 50 }, () =>
+        req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'stats', flags: { scope: 'local' } } })))
+      for (const r of burst) assert.ok(r.status === 200 || r.status === 429, `unexpected status ${r.status}`)
+      const after = await req(rw.port, '/api/meta', { token: TOKEN })
+      assert.strictEqual(after.status, 200, 'server unresponsive after burst')
+    })
+    await test('query token authorizes ONLY the page load, never /api/* (codex R1-4)', async () => {
+      const meta = await req(rw.port, `/api/meta?token=${TOKEN}`)
+      assert.strictEqual(meta.status, 401, 'query token rode /api/meta')
+      const run = await fetch(`http://127.0.0.1:${rw.port}/api/run?token=${TOKEN}`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cmd: 'stats', flags: {} }),
+      })
+      assert.strictEqual(run.status, 401, 'query token rode /api/run')
+      const page = await req(rw.port, `/?token=${TOKEN}`)
+      assert.strictEqual(page.status, 200, 'page bootstrap broke')
+    })
   } finally {
     rw.proc.kill()
     s1.cleanup()

--- a/tests/test-em-console.mjs
+++ b/tests/test-em-console.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * test-em-console.mjs — behavioral tests for the em-console local web server.
+ *
+ * Spawns the real server against an isolated HOME + non-git cwd fixture (its
+ * own local store), then exercises the HTTP surface:
+ *   - startup JSON contract (url, port, allow_write, pid)
+ *   - auth: no token → 401; wrong token → 401; header token → 200
+ *   - loopback-only bind policy: non-loopback --host refused exit 2
+ *   - /api/meta shape (allow_write, categories, commands)
+ *   - /api/run read path (stats) returns the child script's JSON verbatim
+ *   - unknown command → 400; unknown flag → 400; bad int → 400;
+ *     leading-dash string value → 400 (flag-smuggling guard)
+ *   - write command on a read-only server → 403 AND no store mutation
+ *     (fail-closed negative, verified on disk)
+ *   - write command on an --allow-write server: store → search roundtrip
+ *   - --help contract short-circuit
+ *
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import assert from 'assert'
+import { spawn, spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const CONSOLE = path.join(REPO, 'scripts', 'em-console.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+async function test(name, fn) {
+  try {
+    await fn()
+    passed++
+    console.log(`  ok ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  FAIL ${name}: ${e.message}`)
+  }
+}
+
+function makeSandbox() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'em-console-test-')))
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  return { root, home, cwd, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) }
+}
+
+const TOKEN = 'test-token-0123456789'
+
+// Start a server; resolve {proc, port, startup} once the startup JSON arrives.
+function startServer(sandbox, extraArgs = []) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [CONSOLE, '--port', '0', '--token', TOKEN, ...extraArgs], {
+      cwd: sandbox.cwd,
+      env: { ...process.env, HOME: sandbox.home },
+    })
+    let out = ''
+    const timer = setTimeout(() => { proc.kill(); reject(new Error(`server startup timeout; output: ${out}`)) }, 10000)
+    proc.stdout.on('data', (c) => {
+      out += c
+      try {
+        const startup = JSON.parse(out.trim())
+        clearTimeout(timer)
+        resolve({ proc, port: startup.port, startup })
+      } catch { /* partial line — keep buffering */ }
+    })
+    proc.on('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`server exited early (code ${code}): ${out}`))
+    })
+  })
+}
+
+async function req(port, pathname, { method = 'GET', token, body } = {}) {
+  const headers = {}
+  if (token) headers['X-EM-Token'] = token
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const r = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method, headers, body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const text = await r.text()
+  let json = null
+  try { json = JSON.parse(text) } catch { /* html pages */ }
+  return { status: r.status, json, text }
+}
+
+function seedEpisode(sandbox) {
+  const r = spawnSync(process.execPath, [path.join(REPO, 'scripts', 'em-store.mjs'),
+    '--project', 'console-fixture', '--category', 'decision', '--scope', 'local',
+    '--summary', 'fixture decision for console tests', '--body', 'seeded by test-em-console'], {
+    cwd: sandbox.cwd, env: { ...process.env, HOME: sandbox.home }, encoding: 'utf8',
+  })
+  const json = JSON.parse(r.stdout.trim())
+  assert.strictEqual(json.status, 'ok', `seed store failed: ${r.stdout}`)
+  return json
+}
+
+function localStoreSnapshot(sandbox) {
+  const dir = path.join(sandbox.cwd, '.episodic-memory', 'episodes')
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir).sort()
+}
+
+// ---------------------------------------------------------------------------
+await (async () => {
+  console.log('--help contract:')
+  await test('em-console.mjs --help short-circuits with the exact contract', () => {
+    const s = makeSandbox()
+    try {
+      const r = spawnSync(process.execPath, [CONSOLE, '--help'], {
+        cwd: s.cwd, env: { ...process.env, HOME: s.home }, encoding: 'utf8',
+      })
+      assert.strictEqual(r.status, 0)
+      const json = JSON.parse(r.stdout.trim())
+      assert.deepStrictEqual(Object.keys(json).sort(), ['script', 'status', 'usage'])
+      assert.strictEqual(json.status, 'help')
+      assert.strictEqual(json.script, 'em-console.mjs')
+      assert.strictEqual(fs.existsSync(path.join(s.cwd, '.episodic-memory')), false, 'help created a store')
+    } finally { s.cleanup() }
+  })
+
+  console.log('bind policy:')
+  await test('non-loopback --host refused with exit 2', () => {
+    const s = makeSandbox()
+    try {
+      const r = spawnSync(process.execPath, [CONSOLE, '--host', '0.0.0.0'], {
+        cwd: s.cwd, env: { ...process.env, HOME: s.home }, encoding: 'utf8', timeout: 10000,
+      })
+      assert.strictEqual(r.status, 2, `expected exit 2, got ${r.status}: ${r.stdout}`)
+      const json = JSON.parse(r.stdout.trim())
+      assert.strictEqual(json.status, 'error')
+      assert.ok(/loopback/.test(json.message), json.message)
+    } finally { s.cleanup() }
+  })
+
+  console.log('read-only server:')
+  const s1 = makeSandbox()
+  const seeded = seedEpisode(s1)
+  const ro = await startServer(s1)
+  try {
+    await test('startup JSON carries url/port/allow_write/pid', () => {
+      assert.strictEqual(ro.startup.status, 'ok')
+      assert.strictEqual(ro.startup.script, 'em-console.mjs')
+      assert.ok(ro.startup.url.includes(`:${ro.port}/?token=`), ro.startup.url)
+      assert.strictEqual(ro.startup.allow_write, false)
+      assert.strictEqual(typeof ro.startup.pid, 'number')
+    })
+    await test('no token → 401', async () => {
+      const r = await req(ro.port, '/api/meta')
+      assert.strictEqual(r.status, 401)
+    })
+    await test('wrong token → 401', async () => {
+      const r = await req(ro.port, '/api/meta', { token: 'wrong-token' })
+      assert.strictEqual(r.status, 401)
+    })
+    await test('page load with query token serves HTML', async () => {
+      const r = await req(ro.port, `/?token=${TOKEN}`)
+      assert.strictEqual(r.status, 200)
+      assert.ok(r.text.includes('<title>em-console</title>'), 'page HTML missing')
+    })
+    await test('/api/meta reports read-only + categories + commands', async () => {
+      const r = await req(ro.port, '/api/meta', { token: TOKEN })
+      assert.strictEqual(r.status, 200)
+      assert.strictEqual(r.json.allow_write, false)
+      assert.ok(Array.isArray(r.json.categories) && r.json.categories.includes('decision'), JSON.stringify(r.json.categories))
+      assert.ok(r.json.commands.some((c) => c.name === 'stats' && c.write === false))
+      assert.ok(r.json.commands.some((c) => c.name === 'store' && c.write === true))
+    })
+    await test('/api/run stats returns the child JSON verbatim under result', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'stats', flags: { scope: 'local' } } })
+      assert.strictEqual(r.status, 200)
+      assert.strictEqual(r.json.status, 'ok')
+      assert.strictEqual(r.json.exit_code, 0)
+      assert.ok(Array.isArray(r.json.result.scopes), 'stats scopes missing')
+    })
+    await test('/api/run search finds the seeded episode', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: 'fixture decision', scope: 'local' } } })
+      assert.strictEqual(r.status, 200)
+      assert.ok(r.json.result.episodes.some((e) => e.id === seeded.id), JSON.stringify(r.json.result).slice(0, 400))
+    })
+    await test('unknown command → 400', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'rm-rf', flags: {} } })
+      assert.strictEqual(r.status, 400)
+    })
+    await test('unknown flag → 400', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'stats', flags: { evil: 'x' } } })
+      assert.strictEqual(r.status, 400)
+    })
+    await test('non-integer limit → 400', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: 'x', limit: 'abc' } } })
+      assert.strictEqual(r.status, 400)
+    })
+    await test('leading-dash string value → 400 (flag smuggling guard)', async () => {
+      const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: '--scope' } } })
+      assert.strictEqual(r.status, 400)
+      assert.ok(/may not start/.test(r.json.message), r.json.message)
+    })
+    await test('write command on read-only server → 403 and no disk mutation', async () => {
+      const before = localStoreSnapshot(s1)
+      const r = await req(ro.port, '/api/run', {
+        method: 'POST', token: TOKEN,
+        body: { cmd: 'store', flags: { project: 'x', category: 'decision', summary: 'nope', body: 'nope', scope: 'local' } },
+      })
+      assert.strictEqual(r.status, 403)
+      assert.strictEqual(r.json.write_disabled, true)
+      assert.deepStrictEqual(localStoreSnapshot(s1), before, 'store mutated despite 403')
+    })
+  } finally {
+    ro.proc.kill()
+  }
+
+  console.log('write-enabled server:')
+  const rw = await startServer(s1, ['--allow-write'])
+  try {
+    await test('store → search roundtrip through the API', async () => {
+      const st = await req(rw.port, '/api/run', {
+        method: 'POST', token: TOKEN,
+        body: { cmd: 'store', flags: { project: 'console-fixture', category: 'discovery', summary: 'stored via web api', body: 'roundtrip body', scope: 'local' } },
+      })
+      assert.strictEqual(st.status, 200)
+      assert.strictEqual(st.json.exit_code, 0, JSON.stringify(st.json).slice(0, 400))
+      const id = st.json.result.id
+      assert.ok(id, 'no id returned from store')
+      const se = await req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: 'stored via web api', scope: 'local' } } })
+      assert.ok(se.json.result.episodes.some((e) => e.id === id), 'stored episode not found via search')
+    })
+    await test('history command walks the chain of a seeded episode', async () => {
+      const r = await req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'history', flags: { history: seeded.id } } })
+      assert.strictEqual(r.status, 200)
+      assert.strictEqual(r.json.exit_code, 0)
+    })
+    await test('write flag on wrong shape still validated (bad episode id → 400)', async () => {
+      const r = await req(rw.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'pin', flags: { id: 'not-an-id' } } })
+      assert.strictEqual(r.status, 400)
+    })
+  } finally {
+    rw.proc.kill()
+    s1.cleanup()
+  }
+})()
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-em-console.mjs
+++ b/tests/test-em-console.mjs
@@ -23,6 +23,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import assert from 'assert'
+import crypto from 'crypto'
 import { spawn, spawnSync } from 'child_process'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
@@ -101,6 +102,21 @@ function seedEpisode(sandbox) {
   const json = JSON.parse(r.stdout.trim())
   assert.strictEqual(json.status, 'ok', `seed store failed: ${r.stdout}`)
   return json
+}
+
+// Content hash of every FILE under root (relative path + bytes), so any
+// mutation by a supposedly-read-only command flips the digest.
+function treeHash(root) {
+  const h = crypto.createHash('sha256')
+  const walk = (dir) => {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const p = path.join(dir, ent.name)
+      if (ent.isDirectory()) walk(p)
+      else if (ent.isFile()) { h.update(path.relative(root, p)); h.update(fs.readFileSync(p)) }
+    }
+  }
+  walk(root)
+  return h.digest('hex')
 }
 
 function localStoreSnapshot(sandbox) {
@@ -202,6 +218,40 @@ await (async () => {
       const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: '--scope' } } })
       assert.strictEqual(r.status, 400)
       assert.ok(/may not start/.test(r.json.message), r.json.message)
+    })
+    await test('prototype-chain flag names are rejected (F1 regression)', async () => {
+      // Plain-object lookup as allowlist membership resolves prototype keys
+      // truthy (same class as the #469 null-proto index fix). JSON.parse is
+      // used so "__proto__" lands as an OWN property of the flags object.
+      for (const name of ['__proto__', 'hasOwnProperty', 'valueOf', 'constructor', 'toString']) {
+        const flags = JSON.parse(`{"query":"x","${name}":"x"}`)
+        const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags } })
+        assert.strictEqual(r.status, 400, `prototype key "${name}" rode the allowlist (got ${r.status})`)
+      }
+    })
+    await test('newline in a short token field is rejected; multiline body accepted (F2 regression)', async () => {
+      const bad = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: 'x', tag: 'a\nb' } } })
+      assert.strictEqual(bad.status, 400, `newline in tag accepted (got ${bad.status})`)
+      const good = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd: 'search', flags: { query: 'line one\nline two' } } })
+      assert.strictEqual(good.status, 200, 'multiline prose query rejected')
+    })
+    await test('every write:false command leaves the store byte-identical (F5 conformance)', async () => {
+      const READ_CASES = [
+        ['stats', {}], ['doctor', {}], ['search', { query: 'fixture' }], ['list', {}],
+        ['recall', {}], ['graph', { orphans: true }], ['semantic', { query: 'fixture' }],
+        ['capture-list', {}], ['fold-preview', { scope: 'local' }], ['prune-preview', { scope: 'local' }],
+        ['history', { history: seeded.id }],
+      ]
+      const meta = await req(ro.port, '/api/meta', { token: TOKEN })
+      const readCmds = meta.json.commands.filter((c) => !c.write).map((c) => c.name).sort()
+      assert.deepStrictEqual(readCmds, READ_CASES.map(([n]) => n).sort(),
+        'READ_CASES drifted from the registry — add the new read command to this sweep')
+      for (const [cmd, flags] of READ_CASES) {
+        const before = treeHash(s1.root)
+        const r = await req(ro.port, '/api/run', { method: 'POST', token: TOKEN, body: { cmd, flags } })
+        assert.strictEqual(r.status, 200, `${cmd} HTTP ${r.status}`)
+        assert.strictEqual(treeHash(s1.root), before, `read command "${cmd}" mutated the sandbox`)
+      }
     })
     await test('write command on read-only server → 403 and no disk mutation', async () => {
       const before = localStoreSnapshot(s1)

--- a/tests/test-em-help-flags.mjs
+++ b/tests/test-em-help-flags.mjs
@@ -144,7 +144,8 @@ function assertNoStore(sandbox, label) {
 // The installed substrate set: every script that got a --help handler.
 // ---------------------------------------------------------------------------
 const SUBSTRATE = [
-  'em-audit-compliance.mjs', 'em-backup.mjs', 'em-check-stale.mjs', 'em-list.mjs',
+  'em-audit-compliance.mjs', 'em-backup.mjs', 'em-check-stale.mjs',
+  'em-console.mjs', 'em-manage.mjs', 'em-list.mjs',
   'em-lock.mjs', 'em-mine-transcripts.mjs', 'em-pattern-health.mjs', 'em-prune.mjs',
   'em-rebuild-index.mjs', 'em-recall.mjs', 'em-restore.mjs', 'em-review-request.mjs',
   'em-revise.mjs', 'em-rfc-validate.mjs', 'em-search.mjs', 'em-seed-patterns.mjs',

--- a/tests/test-em-manage.mjs
+++ b/tests/test-em-manage.mjs
@@ -19,7 +19,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import assert from 'assert'
-import { spawnSync } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 const MANAGE = path.join(REPO, 'scripts', 'em-manage.mjs')
@@ -160,6 +160,74 @@ test('fold dry-run with declined apply leaves the store untouched', () => {
     assert.deepStrictEqual(episodeFiles(s), before, 'store changed on declined apply')
   } finally { s.cleanup() }
 })
+
+console.log('TOCTOU guard:')
+await (async function toctouTest() {
+  const name = 'store mutation between fold preview and apply forces re-confirmation (codex R1-3)'
+  const s = makeSandbox()
+  const wiz = spawn(process.execPath, [MANAGE], {
+    cwd: s.cwd, env: { ...process.env, HOME: s.home }, stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  try {
+    // Build a long supersedes chain so the fold dry-run has something to say.
+    const first = seedEpisodes(s, 1)[0]
+    let prev = first
+    for (let i = 0; i < 11; i++) {
+      const r = spawnSync(process.execPath, [path.join(REPO, 'scripts', 'em-revise.mjs'),
+        '--original', prev, '--project', 'manage-fixture',
+        '--summary', `rev ${i}`, '--body', `rev body ${i}`], {
+        cwd: s.cwd, env: { ...process.env, HOME: s.home }, encoding: 'utf8',
+      })
+      prev = JSON.parse(r.stdout.trim()).id
+    }
+
+    let out = ''
+    wiz.stdout.on('data', (c) => { out += c })
+    // Occurrence-count waits: prompts can arrive in the same chunk as the
+    // message before them, so position markers race — counts don't.
+    const countOf = (re) => (out.match(re) || []).length
+    const waitForCount = (re, n) => new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error(`timeout waiting for ${n}x ${re}; output:\n${out}`)), 30000)
+      const check = () => {
+        if (countOf(re) >= n) { clearTimeout(t); resolve() }
+        else setTimeout(check, 100)
+      }
+      check()
+    })
+    const APPLY_RE = /Apply fold-superseded\? \[y\/N\]/g
+
+    wiz.stdin.write('2\n2\n\n') // hygiene → fold → scope local (default)
+    await waitForCount(APPLY_RE, 1)
+    // Mutate the store BETWEEN preview and consent: a second long chain.
+    const second = seedEpisodes(s, 1)[0]
+    let p2 = second
+    for (let i = 0; i < 11; i++) {
+      const r = spawnSync(process.execPath, [path.join(REPO, 'scripts', 'em-revise.mjs'),
+        '--original', p2, '--project', 'manage-fixture',
+        '--summary', `b rev ${i}`, '--body', `b rev body ${i}`], {
+        cwd: s.cwd, env: { ...process.env, HOME: s.home }, encoding: 'utf8',
+      })
+      p2 = JSON.parse(r.stdout.trim()).id
+    }
+    const filesAfterMutation = episodeFiles(s)
+    wiz.stdin.write('y\n') // consent to the STALE preview
+    await waitForCount(/store changed since the preview/g, 1)
+    await waitForCount(APPLY_RE, 2) // the refreshed preview must re-ask
+    wiz.stdin.write('n\nq\n') // decline the refreshed preview, quit
+    const code = await new Promise((r) => wiz.on('exit', r))
+    assert.strictEqual(code, 0, `exit ${code}; output:\n${out}`)
+    assert.deepStrictEqual(episodeFiles(s), filesAfterMutation, 'stale consent applied a fold')
+    passed++
+    console.log(`  ok ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  FAIL ${name}: ${e.message}`)
+  } finally {
+    wiz.kill()
+    s.cleanup()
+  }
+})()
 
 console.log('console launcher:')
 test('option 6 under piped stdin refuses instead of blocking (F3 regression)', () => {

--- a/tests/test-em-manage.mjs
+++ b/tests/test-em-manage.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * test-em-manage.mjs — behavioral tests for the em-manage day-2 wizard.
+ *
+ * Drives the real wizard over piped stdin against an isolated HOME + non-git
+ * cwd fixture store:
+ *   - --help contract short-circuit (no store created)
+ *   - immediate quit exits 0
+ *   - EOF starvation (empty stdin) exits cleanly, never hangs
+ *   - status flow runs doctor + stats and renders their summaries
+ *   - hygiene rebuild-index runs against the fixture store
+ *   - fold dry-run with declined apply leaves the store untouched
+ *   - unknown menu choice is rejected and the loop continues
+ *
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import assert from 'assert'
+import { spawnSync } from 'child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const MANAGE = path.join(REPO, 'scripts', 'em-manage.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ok ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.message })
+    console.log(`  FAIL ${name}: ${e.message}`)
+  }
+}
+
+function makeSandbox() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'em-manage-test-')))
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  return { root, home, cwd, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) }
+}
+
+function runWizard(sandbox, input) {
+  return spawnSync(process.execPath, [MANAGE], {
+    cwd: sandbox.cwd,
+    env: { ...process.env, HOME: sandbox.home },
+    input,
+    encoding: 'utf8',
+    timeout: 60000,
+  })
+}
+
+function seedEpisodes(sandbox, n) {
+  const ids = []
+  for (let i = 0; i < n; i++) {
+    const r = spawnSync(process.execPath, [path.join(REPO, 'scripts', 'em-store.mjs'),
+      '--project', 'manage-fixture', '--category', 'decision', '--scope', 'local',
+      '--summary', `fixture decision ${i}`, '--body', `fixture body ${i}`], {
+      cwd: sandbox.cwd, env: { ...process.env, HOME: sandbox.home }, encoding: 'utf8',
+    })
+    ids.push(JSON.parse(r.stdout.trim()).id)
+  }
+  return ids
+}
+
+function episodeFiles(sandbox) {
+  const dir = path.join(sandbox.cwd, '.episodic-memory', 'episodes')
+  if (!fs.existsSync(dir)) return []
+  return fs.readdirSync(dir).sort()
+}
+
+console.log('--help contract:')
+test('em-manage.mjs --help short-circuits, exit 0, no store', () => {
+  const s = makeSandbox()
+  try {
+    const h = spawnSync(process.execPath, [MANAGE, '--help'], {
+      cwd: s.cwd, env: { ...process.env, HOME: s.home }, encoding: 'utf8',
+    })
+    assert.strictEqual(h.status, 0)
+    const json = JSON.parse(h.stdout.trim())
+    assert.deepStrictEqual(Object.keys(json).sort(), ['script', 'status', 'usage'])
+    assert.strictEqual(json.status, 'help')
+    assert.strictEqual(json.script, 'em-manage.mjs')
+    assert.strictEqual(fs.existsSync(path.join(s.cwd, '.episodic-memory')), false, 'help created a store')
+  } finally { s.cleanup() }
+})
+
+console.log('menu loop:')
+test('immediate quit exits 0', () => {
+  const s = makeSandbox()
+  try {
+    const r = runWizard(s, 'q\n')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+    assert.ok(r.stdout.includes('episodic-memory manager'), 'banner missing')
+  } finally { s.cleanup() }
+})
+
+test('EOF starvation (empty stdin) exits cleanly, never hangs', () => {
+  const s = makeSandbox()
+  try {
+    const r = runWizard(s, '')
+    assert.notStrictEqual(r.status, null, 'wizard timed out on empty stdin')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+  } finally { s.cleanup() }
+})
+
+test('unknown menu choice is rejected and the loop continues to quit', () => {
+  const s = makeSandbox()
+  try {
+    const r = runWizard(s, 'zz\nq\n')
+    assert.strictEqual(r.status, 0)
+    assert.ok(r.stdout.includes('unknown choice'), 'no rejection message')
+  } finally { s.cleanup() }
+})
+
+console.log('status flow:')
+test('status runs doctor + stats and renders summaries', () => {
+  const s = makeSandbox()
+  try {
+    seedEpisodes(s, 1)
+    // 1 = status, n = not all-projects, n = no raw JSON, q = quit
+    const r = runWizard(s, '1\nn\nn\nq\n')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+    assert.ok(/doctor: /.test(r.stdout), `doctor summary missing:\n${r.stdout}`)
+    assert.ok(/stats:/.test(r.stdout), 'stats summary missing')
+    assert.ok(/active=/.test(r.stdout), 'scope lines missing')
+  } finally { s.cleanup() }
+})
+
+console.log('hygiene flows:')
+test('rebuild-index runs against the fixture store', () => {
+  const s = makeSandbox()
+  try {
+    seedEpisodes(s, 1)
+    // 2 = hygiene, 1 = rebuild-index, q = quit
+    const r = runWizard(s, '2\n1\nq\n')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+    assert.ok(/rebuild-index: ok/.test(r.stdout), `rebuild result missing:\n${r.stdout}`)
+  } finally { s.cleanup() }
+})
+
+test('fold dry-run with declined apply leaves the store untouched', () => {
+  const s = makeSandbox()
+  try {
+    seedEpisodes(s, 2)
+    const before = episodeFiles(s)
+    // 2 = hygiene, 2 = fold, local scope (default), n = decline apply, q = quit
+    const r = runWizard(s, '2\n2\n\nn\nq\n')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+    assert.ok(/dry-run/.test(r.stdout), 'no dry-run output')
+    assert.deepStrictEqual(episodeFiles(s), before, 'store changed on declined apply')
+  } finally { s.cleanup() }
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-em-manage.mjs
+++ b/tests/test-em-manage.mjs
@@ -132,7 +132,7 @@ test('status runs doctor + stats and renders summaries', () => {
     assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
     assert.ok(/doctor: /.test(r.stdout), `doctor summary missing:\n${r.stdout}`)
     assert.ok(/stats:/.test(r.stdout), 'stats summary missing')
-    assert.ok(/active=/.test(r.stdout), 'scope lines missing')
+    assert.ok(/active=\d/.test(r.stdout), `scope lines missing real counts:\n${r.stdout}`)
   } finally { s.cleanup() }
 })
 

--- a/tests/test-em-manage.mjs
+++ b/tests/test-em-manage.mjs
@@ -161,6 +161,17 @@ test('fold dry-run with declined apply leaves the store untouched', () => {
   } finally { s.cleanup() }
 })
 
+console.log('console launcher:')
+test('option 6 under piped stdin refuses instead of blocking (F3 regression)', () => {
+  const s = makeSandbox()
+  try {
+    const r = runWizard(s, '6\nq\n')
+    assert.notStrictEqual(r.status, null, 'wizard hung on console launch under piped stdin')
+    assert.strictEqual(r.status, 0, `exit ${r.status}; stderr: ${r.stderr}`)
+    assert.ok(/interactive terminal/.test(r.stdout), `no refusal message:\n${r.stdout}`)
+  } finally { s.cleanup() }
+})
+
 console.log(`\n${passed} passed, ${failed} failed`)
 if (failed > 0) {
   for (const f of failures) console.log(`  - ${f.name}: ${f.error}`)


### PR DESCRIPTION
## Summary
- **em-console.mjs** — loopback-only local web console (per-launch token, `timingSafeEqual`; read-only unless `--allow-write`; idle shutdown, default 1800s). Single `POST /api/run` endpoint spawns sibling `em-*` scripts from a **closed command registry** (shape-validated flag names/types, `execFile` argv arrays, no shell; 4-child semaphore with 32-deep queue + 429) and relays their JSON verbatim. Self-contained inline page (`scripts/lib/console-page.mjs`): dashboard (stats + doctor), browse + history chains, recall preview, capture drafts, maintenance panel, write forms (write mode only).
- **em-manage.mjs** — interactive day-2 wizard: status, hygiene (rebuild-index / fold / prune / doctor --fix; dry-run first, **apply-time re-preview** on store change), backup, capture drafts, routines, console launcher. Piped-stdin scriptable, EOF-safe.
- Both classify as substrate (`em-*` allowlist) and auto-ship globally; `em console` / `em manage` dispatch via the existing directory-driven `em.mjs`.
- Docs: README Scripts Reference section, EM_SCRIPTS_GUIDE intent rows + full entries (agent rule: human surfaces — agents keep using the JSON CLI), USER_MANUAL Scenario 8e.

## Principle grounding
P11 (presentation spawns the CLI contract, never decides), P6 (user-started, visible, idle-bounded, zero polling), P3/P10 (write ops behind explicit `--allow-write`; destructive ops dry-run-first with consent-to-the-preview), P9/P12 (no substrate change, zero enforcement surface). Plan + full review dispositions: `docs/plans/em-console-em-manage.md`.

## Reviews (both empirical, isolated fixture stores)
- **negative-scenario-reviewer**: ACCEPT; F1-F6 all folded (prototype-key allowlist bypass -> `Object.hasOwn`; control bytes in token fields; wizard option-6 hang; idle granularity; write:false byte-stability conformance sweep; CSP hardening).
- **codex gpt-5.5 (cmux interactive), 2 rounds**: R1 HOLD (child-error relay, unbounded child fan-out — 75 concurrent children observed, dry-run->apply TOCTOU, query-token scope) -> all folded with regressions; **R2 ACCEPT, blockers none** (independent probes: max 4 children under 100-way burst w/ 64x429, token scope, both error-relay polarities, re-preview stability).

## Tests
`tests/test-em-console.mjs` (24) + `tests/test-em-manage.mjs` (9), registered in plan-marker-validate.yml; both scripts added to the `--help` gauntlet. Guard suites re-run green: help-flags 31/31, control-bytes, em-cli, lib-closure, install-manifest 57/57, readonly-manifest, install-scripts-guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)