### PR TITLE
RFC-009 P1b: lesson-activation schema + trigger index + R9a + T6 + contract mirror

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -282,6 +282,27 @@ jobs:
       - name: Run SessionStart drift-notice + opt-in auto-update suite (Layer 1)
         run: node tests/test-install-drift-notice.mjs
 
+      - name: Run activation lib + activity-class vocab suite (RFC-009 P1b S1)
+        run: node tests/test-activation-lib.mjs
+
+      - name: Run R1 activation write + R9a collision suite (RFC-009 P1b S2/S3/S7)
+        run: node tests/test-activation-write.mjs
+
+      - name: Run violation linkage + T6 write suite (RFC-009 P1b S3)
+        run: node tests/test-violation-linkage.mjs
+
+      - name: Run T6 migration + T2 grep-gate suite (RFC-009 P1b S4)
+        run: node tests/test-t6-migration.mjs
+
+      - name: Run trigger-index core suite (RFC-009 P1b S5)
+        run: node tests/test-trigger-index.mjs
+
+      - name: Run trigger-index session_start suite (RFC-009 P1b S6)
+        run: node tests/test-trigger-session-start.mjs
+
+      - name: Run install activation-classes deploy E2E (RFC-009 P1b S9)
+        run: node tests/test-install-activation.mjs
+
   p12-invariant-gate:
     # RFC-008 P4d S8 (REQ-10 / REQ-11): the three Principle-12 invariants as ONE
     # separately-named REQUIRED check. Membership is defined in code

--- a/.github/workflows/rfc-validate.yml
+++ b/.github/workflows/rfc-validate.yml
@@ -11,6 +11,11 @@ on:
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/validate-rfc-canonical-fields.mjs'
       - 'scripts/validate-rfc-contract-mirror.mjs'
+      - 'scripts/validate-rfc-009-contract-mirror.mjs'
+      - 'scripts/lib/activation.mjs'
+      - 'scripts/em-trigger-index.mjs'
+      - 'activation-classes.json'
+      - 'tests/test-contract-mirror-009.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
       - 'scripts/lib/bp1-sweep.mjs'
       - 'scripts/lib/bp1-probe.mjs'
@@ -60,6 +65,11 @@ on:
       - 'scripts/validate-rfc-artifact-manifest.mjs'
       - 'scripts/validate-rfc-canonical-fields.mjs'
       - 'scripts/validate-rfc-contract-mirror.mjs'
+      - 'scripts/validate-rfc-009-contract-mirror.mjs'
+      - 'scripts/lib/activation.mjs'
+      - 'scripts/em-trigger-index.mjs'
+      - 'activation-classes.json'
+      - 'tests/test-contract-mirror-009.mjs'
       - 'scripts/lib/bp1-manifest.mjs'
       - 'scripts/lib/bp1-sweep.mjs'
       - 'scripts/lib/bp1-probe.mjs'
@@ -155,6 +165,12 @@ jobs:
 
       - name: Run RFC contract-mirror validator self-tests
         run: node tests/test-validate-rfc-contract-mirror.mjs
+
+      - name: Validate RFC-009 contract.json mirror (P1b)
+        run: node scripts/validate-rfc-009-contract-mirror.mjs
+
+      - name: Run RFC-009 contract-mirror validator self-tests
+        run: node tests/test-contract-mirror-009.mjs
 
       - name: Run bp1-hmac live tests (H1-H7 + I3a/b + TB1/TB2)
         run: node tests/test-bp1-hmac-live.mjs

--- a/README.md
+++ b/README.md
@@ -232,15 +232,18 @@ script through `scripts/lib/categories.mjs`. Filter by category with `em-search 
 ├── episodes/                 # Global episode .md files
 ├── patterns/                 # Pattern registry (_index.json)
 ├── categories.json           # Category vocabulary (RFC-009 R10b)
+├── activation-classes.json   # Activity-class vocabulary for lesson triggers (RFC-009 R1)
 ├── index.jsonl               # Global index
 ├── tags.json                 # Inverted tag index
-└── category-index.json       # Category -> episode-ids index
+├── category-index.json       # Category -> episode-ids index
+└── trigger-index.json        # Derived lesson-activation index (RFC-009 R2, lazy-built)
 
 <project>/.episodic-memory/   # Per-project (local)
 ├── episodes/                 # Project-local episode .md files
 ├── index.jsonl               # Project-local index
 ├── tags.json                 # Inverted tag index
-└── category-index.json       # Category -> episode-ids index
+├── category-index.json       # Category -> episode-ids index
+└── trigger-index.json        # Derived lesson-activation index (RFC-009 R2, lazy-built)
 
 patterns/                     # Behavioral patterns (shipped with repo)
 ├── _index.json               # Machine-readable pattern registry
@@ -365,6 +368,14 @@ node ~/.episodic-memory/scripts/em-store.mjs \
 node ~/.episodic-memory/scripts/em-store.mjs \
   --project my-project --category decision --summary "..." \
   --body-file ./decision-body.md
+
+# Lesson activation (RFC-009 R1, lesson-only): triggers + scoping + declared priority 1-7
+# (8-9 is EARNED from linked violations, never declarable) + expiry + violation back-links
+node ~/.episodic-memory/scripts/em-store.mjs \
+  --project my-project --category lesson --summary "..." --body "..." \
+  --trigger "second opinion" --trigger "activity:review" \
+  --applies-to-project "*" --applies-to-tool claude-code \
+  --priority 6 --review-by 2027-01-01 --evidence <violation-episode-id>
 ```
 
 ### Revise
@@ -753,6 +764,24 @@ node ~/.episodic-memory/scripts/em-session-end-prompt.mjs
 ```bash
 node ~/.episodic-memory/scripts/em-rebuild-index.mjs --scope all
 ```
+
+### Trigger Index (RFC-009 R2)
+Derived lesson-activation index: one `trigger-index.json` per store, built lazily from
+`status: active` lessons carrying `--trigger` frontmatter. Entries carry an explicit
+`trigger_kind` (`phrase`|`tool`|`activity`) and a DERIVED `effective_priority` 1-9 —
+the 8-9 critical band is earned from linked violations (`em-violation --lesson` /
+`em-store --evidence`), never writer-declared. Freshness via an mtime+size+sha256
+fingerprint of `index.jsonl`; the `session_start` section (critical band, static-score
+top-10, `violated_pattern` preflight counts) is the artifact the P2 session-start hook reads.
+```bash
+node ~/.episodic-memory/scripts/em-trigger-index.mjs                     # build the local store's index
+node ~/.episodic-memory/scripts/em-trigger-index.mjs --scope all         # build both stores
+node ~/.episodic-memory/scripts/em-trigger-index.mjs --merged            # deduped local-precedence view
+node ~/.episodic-memory/scripts/em-trigger-index.mjs --project /path/to/repo   # PATH binding to another project's store
+```
+The `activation-classes.json` vocabulary (deployed to `~/.episodic-memory/`) closes the
+`activity:<class>` trigger set; `validate-rfc-009-contract-mirror.mjs` diffs the shipped
+surfaces against `docs/rfcs/RFC-009-lesson-activation.contract.json` in CI.
 
 ### BP-1 Auto-Pilot (RFC-004)
 

--- a/activation-classes.json
+++ b/activation-classes.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0.0",
+  "classes": [
+    {
+      "name": "plan",
+      "description": "planning / plan-approval work mode",
+      "phrases": []
+    },
+    {
+      "name": "design",
+      "description": "architecture and design discussion, trade-off weighing",
+      "phrases": []
+    },
+    {
+      "name": "review",
+      "description": "code, plan, or PR review activity",
+      "phrases": []
+    },
+    {
+      "name": "troubleshoot",
+      "description": "debugging, failure diagnosis, root-cause work",
+      "phrases": []
+    },
+    {
+      "name": "implement",
+      "description": "writing or modifying code against a plan or spec",
+      "phrases": []
+    },
+    {
+      "name": "push",
+      "description": "commit, merge, release, or deploy activity",
+      "phrases": []
+    },
+    {
+      "name": "rule",
+      "description": "rule, enforcement, or behavioral-pattern work",
+      "phrases": []
+    }
+  ]
+}

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -256,8 +256,9 @@ Flags that matter:
   original). Only pass `local` or `global` to force a cross-store move.
 - Tags are inherited from the original and merged with any you pass.
 - The same lesson-only activation flags as `em-store` apply (validated against the
-  INHERITED category); activation fields are NOT inherited — re-pass `--trigger`
-  etc. on the revision if the lesson should keep firing.
+  INHERITED category). Activation, linkage, and `violated_pattern` are INHERITED
+  from the original — like tags — so a typo-revision never demotes a lesson to
+  freeform; a flag passed on the revise OVERRIDES that one field (replace, not merge).
 
 Common mistakes: inventing a new episode with `em-store` instead of revising, which
 leaves both versions active and searchable.
@@ -757,8 +758,12 @@ Flags that matter:
 - `--project <root>` is a PATH binding (unique among em-* scripts, where
   `--project` is a name filter): when `<root>` is an existing directory the local
   store is `<root>/.episodic-memory` regardless of caller cwd.
-- `--merged` prints the local-precedence merged entries (one store failing
-  degrades to the other with a stderr note, never fatal).
+- `--merged` prints the local-precedence merged view (one store failing degrades
+  to the other with a stderr note, never fatal). The merged view RECOMPUTES
+  `effective_priority` and `session_start` against BOTH stores' rows, so a
+  cross-scope link (local lesson, global violation) earns the band there; the
+  per-store artifact keeps a per-store band (deterministic per store). Consumers
+  read the merged view.
 
 The artifact: `trigger-index.json` carries `schema_version`, a `source` fingerprint
 (`index_mtime_ms` + `index_size` + `index_sha256`, TOCTOU-safe), a `build_report`

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -54,6 +54,7 @@ Match your intent to the command. The third column is the wrong habit it replace
 | The same lesson keeps recurring across projects | `em-promote` (dry-run), then `em-promote --apply` (EXPERIMENTAL) | Re-learning it per project, or hand-copying lesson episodes to global |
 | User wants to SEE the store (dashboard, browse, drafts, hygiene) | `em-console` — hand the user the printed URL | Pasting walls of JSON at the user |
 | User wants guided maintenance in the terminal | `em-manage` (interactive menu) | Dictating flag-by-flag commands to a human |
+| Make a lesson surface on a phrase / tool / activity (or rebuild that index) | `em-store --category lesson --trigger ...` then `em-trigger-index` | Hoping search recall happens to resurface the lesson |
 
 Default write scope is GLOBAL. Pass `--scope local` to keep an episode inside the
 current repo's `.episodic-memory/`. Searches read local and global together by
@@ -141,6 +142,42 @@ every script through `scripts/lib/categories.mjs`. Do not hardcode category name
 
 ---
 
+## Lesson activation (RFC-009 R1/R2, shipped in P1b)
+
+Lesson episodes may carry OPTIONAL activation frontmatter, written through flags on
+`em-store`/`em-revise` (lesson-only; any other category rejects them):
+
+- `--trigger <value>` (repeatable) — three explicit kinds: a plain **phrase**
+  (`"second opinion"`), a **tool** binding (`tool:Bash:git*`), or an **activity**
+  class (`activity:plan`). Activity classes come from the closed vocabulary in
+  `activation-classes.json` (repo root; deployed to `~/.episodic-memory/`) —
+  `plan|design|review|troubleshoot|implement|push|rule`; an unknown or deprecated
+  class is rejected at write time. (Phrase sets inside the vocabulary are empty in
+  P1b; the P2 activation adapter populates and consumes them.)
+- `--applies-to-project <slug|*>` / `--applies-to-tool <id>` (repeatable) — scoping;
+  tool ids are the fixed set `claude-code|codex|opencode|pi-agent|cursor|windsurf`.
+- `--priority <1-7>` (default 5) — the DECLARED priority. **8-9 is the EARNED
+  critical band and is never writer-declarable**: it is derived at trigger-index
+  build time from linked violations (one linked violation → `effective_priority` 8,
+  two or more → 9). Stored episode bytes are never mutated by the band.
+- `--review-by <YYYY-MM-DD>` — expiry; an expired lesson drops out of the trigger index.
+- `--evidence <violation-id>` (repeatable) — back-link a lesson to the violations
+  that prove it matters. Validated at write time against the MERGED local+global
+  index (existence + `category: violation`).
+
+`em-violation` gains the symmetric `--lesson <lesson-id>` (repeatable) forward-link and
+now writes a typed `violated_pattern: <pattern-id>` frontmatter scalar (T6): `em-recall`'s
+violation preflight and `em-pattern-health`'s strike counting read the typed field,
+dual-read with the legacy `violated:<id>` tag during the burn-in window (issue #457).
+
+`em-trigger-index` builds ONE derived `trigger-index.json` per store (see its full
+entry); writes of trigger-bearing lessons print an informational R9a collision report
+on stderr when another active lesson shares a trigger phrase (the write always proceeds).
+The `RFC-009-lesson-activation.contract.json` mirror + `validate-rfc-009-contract-mirror.mjs`
+diff these surfaces against code in CI.
+
+---
+
 ## Full entries
 
 ### em-store
@@ -183,9 +220,13 @@ Flags that matter:
   permission gate. Mutually exclusive with `--body`.
 - Tags accept `--tags a,b`, repeated `--tag a --tag b`, or a mix. They are merged,
   deduplicated, lowercased, and sorted.
+- Lesson-only activation flags (`--trigger`, `--applies-to-project`, `--applies-to-tool`,
+  `--priority`, `--review-by`, `--evidence`) — see "Lesson activation" above. Inline-array
+  values may not contain `,` `[` `]` `"` (rejected before any write).
 
 Common mistakes: forgetting `--category`; passing `--scope local` when you meant the
-default global; hand-writing the file instead of calling this script.
+default global; hand-writing the file instead of calling this script; trying
+`--priority 8` (the 8-9 band is earned, not declared).
 
 ### em-revise
 
@@ -214,6 +255,9 @@ Flags that matter:
 - `--scope` defaults to `inherit` (the revision lands in the same store as the
   original). Only pass `local` or `global` to force a cross-store move.
 - Tags are inherited from the original and merged with any you pass.
+- The same lesson-only activation flags as `em-store` apply (validated against the
+  INHERITED category); activation fields are NOT inherited — re-pass `--trigger`
+  etc. on the revision if the lesson should keep firing.
 
 Common mistakes: inventing a new episode with `em-store` instead of revising, which
 leaves both versions active and searchable.
@@ -693,6 +737,41 @@ node ~/.episodic-memory/scripts/em-rebuild-index.mjs --check --scope all
 Note: `--help` short-circuits safely (PR #449), but any OTHER unknown argument is
 ignored and a rebuild runs. `--scope all` rebuilds both local and global.
 
+### em-trigger-index
+
+Build the derived lesson-activation trigger index (RFC-009 R2).
+
+- WHEN TO USE: after storing/revising trigger-bearing lessons, to (re)build
+  `trigger-index.json`; or `--merged` to see the deduped local+global view a
+  consumer would read. Builds are lazy — an unchanged store is a cache hit.
+- WHEN NOT TO USE: as a search surface (use `em-search`); to mutate episodes (it
+  is read-only over the store and never rewrites stored bytes).
+
+```
+node ~/.episodic-memory/scripts/em-trigger-index.mjs [--project <root>] [--scope local|global|all] [--merged]
+```
+
+Output: `{"status":"ok","built":[{"scope":"local","store":".../.episodic-memory","entries":3,"cache_hit":false}]}`
+
+Flags that matter:
+- `--project <root>` is a PATH binding (unique among em-* scripts, where
+  `--project` is a name filter): when `<root>` is an existing directory the local
+  store is `<root>/.episodic-memory` regardless of caller cwd.
+- `--merged` prints the local-precedence merged entries (one store failing
+  degrades to the other with a stderr note, never fatal).
+
+The artifact: `trigger-index.json` carries `schema_version`, a `source` fingerprint
+(`index_mtime_ms` + `index_size` + `index_sha256`, TOCTOU-safe), a `build_report`
+(excluded unknown/deprecated activity classes), `entries` (per-trigger rows with
+`trigger_kind` phrase|tool|activity and the DERIVED `effective_priority` 1-9), and a
+`session_start` section (`critical_entries` = every band-8/9 lesson, trigger-independent;
+`entries` = top-10 by the `static_score` blend; `preflight` = per-task-type recent
+violation counts keyed by `violated_pattern`) that the P2 session-start hook will read.
+
+Common mistakes: confusing the stored `priority` (1-7, declared) with
+`effective_priority` (1-9, derived — the 8-9 band is earned from linked violations,
+never written); expecting `--project` to filter by name like other scripts.
+
 ### em-doctor
 
 Health check + repair for the stores and the installation. One command answers
@@ -922,8 +1001,16 @@ node ~/.episodic-memory/scripts/em-violation.mjs \
   --pattern <pattern-id> \
   --summary "<what happened>" \
   --body "<detail>" \
-  [--sequence "<actual actions>"] [--correct "<correct actions>"] [--scope global|local]
+  [--sequence "<actual actions>"] [--correct "<correct actions>"] [--scope global|local] \
+  [--lesson <lesson-episode-id>]...
 ```
+
+Flags that matter:
+- `--lesson <id>` (repeatable) forward-links the violation to the lesson(s) whose
+  surfacing failed — this is what feeds a lesson's earned 8-9 band (see "Lesson
+  activation"). Each id must resolve to an existing `category: lesson` episode.
+- The episode carries a typed `violated_pattern: <pattern-id>` field (T6); the
+  legacy `violated:<id>` tag remains as a burn-in shim only.
 
 Missing-args output:
 

--- a/docs/rfcs/RFC-009-lesson-activation.contract.json
+++ b/docs/rfcs/RFC-009-lesson-activation.contract.json
@@ -1,0 +1,72 @@
+{
+  "version": "1.0.0",
+  "_doc": "RFC-009 P1b data-artifact contract mirror — P1b-shipped surfaces ONLY. Later phases EXTEND it: P2 adds the activity-class phrase sets + lesson-suppress.json consumption, P3+ adds the R9b/c/d clerk surfaces. Validated in CI by scripts/validate-rfc-009-contract-mirror.mjs.",
+  "activation_flags": {
+    "em-store": [
+      "--trigger",
+      "--applies-to-project",
+      "--applies-to-tool",
+      "--priority",
+      "--review-by",
+      "--evidence",
+      "--lesson",
+      "--violated-pattern"
+    ],
+    "em-revise": [
+      "--trigger",
+      "--applies-to-project",
+      "--applies-to-tool",
+      "--priority",
+      "--review-by",
+      "--evidence"
+    ],
+    "em-violation": [
+      "--lesson"
+    ]
+  },
+  "activation_fields": [
+    "triggers",
+    "applies_to_projects",
+    "applies_to_tools",
+    "evidence",
+    "lessons",
+    "priority",
+    "review_by",
+    "violated_pattern"
+  ],
+  "tool_ids": [
+    "claude-code",
+    "codex",
+    "opencode",
+    "pi-agent",
+    "cursor",
+    "windsurf"
+  ],
+  "activity_classes": [
+    "plan",
+    "design",
+    "review",
+    "troubleshoot",
+    "implement",
+    "push",
+    "rule"
+  ],
+  "trigger_index_shape": {
+    "schema_version": 1,
+    "entry_fields": [
+      "trigger_kind",
+      "value",
+      "episode_id",
+      "summary",
+      "effective_priority",
+      "applies_to_projects",
+      "applies_to_tools",
+      "review_by"
+    ],
+    "trigger_kind_enum": [
+      "phrase",
+      "tool",
+      "activity"
+    ]
+  }
+}

--- a/install.mjs
+++ b/install.mjs
@@ -498,6 +498,17 @@ if (fs.existsSync(repoCategories)) {
   console.log(`Installed categories.json to ${GLOBAL_DIR}`)
 }
 
+// 1b''. Copy activation-classes.json — the activity-class vocabulary for lesson
+// activation triggers (RFC-009 R1/P1b). Same substrate rule as categories.json:
+// DATA read via `../../activation-classes.json` from scripts/lib/, deployed at
+// the global root and NEVER under ~/.claude/ (P12).
+const repoActivationClasses = path.join(REPO_DIR, 'activation-classes.json')
+if (fs.existsSync(repoActivationClasses)) {
+  fs.mkdirSync(GLOBAL_DIR, { recursive: true })
+  fs.copyFileSync(repoActivationClasses, path.join(GLOBAL_DIR, 'activation-classes.json'))
+  console.log(`Installed activation-classes.json to ${GLOBAL_DIR}`)
+}
+
 // 1c. Copy the agent-facing per-script reference to the global root so any tool
 // can read it before first script use (deployed on every install, all tools).
 const repoScriptsGuide = path.join(REPO_DIR, 'docs', 'EM_SCRIPTS_GUIDE.md')

--- a/schemas/activation-classes.schema.json
+++ b/schemas/activation-classes.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://episodic-memory/schemas/activation-classes.schema.json",
+  "title": "Activity-class vocabulary for lesson activation triggers (RFC-009 R1/R3)",
+  "description": "Meta-schema for activation-classes.json — the closed activity-class set that `activity:<class>` triggers name. P1b ships names + descriptions with empty `phrases` arrays; P2/R3 populates phrases when the matching code that consumes them lands (plan §17-A, F5c).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "classes"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+      "description": "Editorial semver of the vocabulary document."
+    },
+    "classes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/activityClass"
+      }
+    }
+  },
+  "$defs": {
+    "className": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "activityClass": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "phrases"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/className"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "phrases": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Prompt-matching phrase set. EMPTY in P1b by design; consumed by the R3 activation adapter in P2."
+        },
+        "deprecated_for": {
+          "$ref": "#/$defs/className"
+        }
+      }
+    }
+  }
+}

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -191,7 +191,7 @@ const warnings = []
 let usedFallback = false
 
 function violationIdsFromTags(patternId) {
-  const key = `violated:${patternId}`.toLowerCase()
+  const key = `violated:${patternId}`.toLowerCase() // T6 burn-in shim — legacy tag leg; sunset after dual-read window (issue #457)
   const ids = new Set()
   let anyTagsFile = false
   let foundKey = false
@@ -207,7 +207,7 @@ function violationIdsFromTags(patternId) {
 }
 
 function violationIdsLinearScan(patternId) {
-  const key = `violated:${patternId}`.toLowerCase()
+  const key = `violated:${patternId}`.toLowerCase() // T6 burn-in shim — legacy tag leg; sunset after dual-read window (issue #457)
   const ids = new Set()
   for (const e of dedupedEntries) {
     // Tolerate-and-skip a non-array `tags` (a hand-written row with
@@ -242,6 +242,18 @@ function parseDateMs(s) {
   return Number.isNaN(ms) ? null : ms
 }
 
+// T6 dual-read burn-in — the typed `violated_pattern` index field is the
+// load-bearing surface; the tag fast-path/linear-scan legs stay until the
+// sunset window closes (issue #457), then this becomes the only leg.
+function violationIdsFromTypedField(patternId) {
+  const key = String(patternId).toLowerCase()
+  const ids = new Set()
+  for (const e of dedupedEntries) {
+    if (typeof e.violated_pattern === 'string' && e.violated_pattern.toLowerCase() === key) ids.add(e.id)
+  }
+  return ids
+}
+
 function countViolationsForPattern(patternId) {
   const { ids: tagIds, anyTagsFile, foundKey } = violationIdsFromTags(patternId)
   let candidateIds = tagIds
@@ -257,6 +269,10 @@ function countViolationsForPattern(patternId) {
       warnings.push('tags.json missing or stale. Falling back to linear scan. Run em-rebuild-index.mjs to regenerate.')
     }
   }
+  // T6 dual-read: UNION the typed-field matches with the tag-derived candidate
+  // set, deduped by episode id (a Set), so pre-migration tag-only violations
+  // and post-migration typed-only violations both count (issue #457).
+  for (const id of violationIdsFromTypedField(patternId)) candidateIds.add(id)
   let count = 0
   let lastViolated = null
   for (const id of candidateIds) {

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -178,6 +178,10 @@ function rebuildDir(dataDir, label) {
       }
     }
 
+    // RFC-009 P1b: numeric priority round-trip — the frontmatter parser yields a
+    // string; the writers index a Number. Malformed (hand-authored) values pass
+    // through raw so the row still mirrors the file.
+    const priorityNum = fm.priority !== undefined ? Number(fm.priority) : undefined
     entries.push(JSON.stringify({
       id: fm.id,
       date,
@@ -190,6 +194,17 @@ function rebuildDir(dataDir, label) {
       ...(typeof fm.superseded_by === 'string' ? { superseded_by: fm.superseded_by } : {}),
       tags: normalizedTags,
       summary: fm.summary,
+      // RFC-009 R1/R2/T6 activation + linkage carry (REQ-9) — present-only, no
+      // null spam; keep this list in LOCKSTEP with em-store/em-revise's
+      // activationIndexFields (step 2.3 parity note).
+      ...(Array.isArray(fm.triggers) ? { triggers: fm.triggers } : {}),
+      ...(Array.isArray(fm.applies_to_projects) ? { applies_to_projects: fm.applies_to_projects } : {}),
+      ...(Array.isArray(fm.applies_to_tools) ? { applies_to_tools: fm.applies_to_tools } : {}),
+      ...(Array.isArray(fm.evidence) ? { evidence: fm.evidence } : {}),
+      ...(Array.isArray(fm.lessons) ? { lessons: fm.lessons } : {}),
+      ...(fm.priority !== undefined ? { priority: Number.isFinite(priorityNum) ? priorityNum : fm.priority } : {}),
+      ...(typeof fm.review_by === 'string' ? { review_by: fm.review_by } : {}),
+      ...(typeof fm.violated_pattern === 'string' ? { violated_pattern: fm.violated_pattern } : {}),
       ...(fm.pinned === true || fm.pinned === 'true' ? { pinned: true } : {}),
       access_count: accessCount,
       last_accessed: lastAccessed,

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -161,11 +161,14 @@ function runViolationPreflight(activeEntries, taskType, patterns) {
 
   const warnings = []
   for (const patternId of filterIds) {
-    const violationTag = `violated:${patternId}`
+    // T6 dual-read burn-in — typed `violated_pattern` field ∪ legacy
+    // `violated:<id>` tag, per-entry OR so each episode counts once; sunset the
+    // tag leg after the burn-in window (issue #457).
+    const violationTag = `violated:${patternId}` // T6 burn-in shim (legacy tag construction)
     const matching = activeEntries.filter(e =>
       e.category === 'violation' &&
-      Array.isArray(e.tags) &&
-      e.tags.includes(violationTag) &&
+      (e.violated_pattern === patternId ||
+        (Array.isArray(e.tags) && e.tags.includes(violationTag))) &&
       typeof e.date === 'string' &&
       e.date >= cutoffStr
     )

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, parseActivationFromFrontmatter } from './lib/activation.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, parseActivationFromFrontmatter, illegalScalarChar } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
@@ -110,6 +110,25 @@ if (!originalId || !summary || !body) {
     message: 'Missing required args. Usage: --original <id> --project <name> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global]'
   }))
   process.exit(1)
+}
+
+// Reviewer F1 (round 2): user-controlled serialized scalars reject line-breaking
+// chars BEFORE the supersede mutation below (I4). Inherited project/tags come
+// from an already-written (write-validated) episode via the `^(\w+):\s*(.*)$`
+// regex, which cannot capture a newline, so only the user inputs need guarding.
+for (const [label, value] of [['summary', summary], ...(project !== undefined ? [['project', project]] : [])]) {
+  const bad = illegalScalarChar(value)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--${label} contains illegal line-breaking character ${JSON.stringify(bad)}` }))
+    process.exit(1)
+  }
+}
+for (const tag of [...(tagsRaw ? tagsRaw.split(',') : []), ...tagRepeats]) {
+  const bad = illegalScalarChar(tag)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--tag/--tags value contains illegal line-breaking character ${JSON.stringify(bad)}` }))
+    process.exit(1)
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -30,6 +30,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
+import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -382,6 +383,24 @@ if (original.dir !== dataDir) {
   updateTagsIndex(original.dir, id, mergedTags)
   updateCategoryIndex(original.dir, id, origCategory)
   updateTokensIndex(original.dir, id, episodeTokens({ summary, tags: mergedTags, body: episodeContent }))
+}
+
+// R9a write-time collision report (REQ-18) — mirrors em-store's post-write
+// block (revise-side parity): stderr-only, self-excluded, never fatal.
+if (activation && Array.isArray(activation.triggers) && activation.triggers.length) {
+  try {
+    const merged = loadMergedTriggerIndex()
+    const mine = new Set(activation.triggers)
+    const reported = new Set()
+    for (const e of merged.entries) {
+      if (e.episode_id === id) continue // self-exclusion (CX5)
+      if (!mine.has(e.value)) continue
+      const key = `${e.episode_id} ${e.value}`
+      if (reported.has(key)) continue
+      reported.add(key)
+      process.stderr.write(`collision: trigger "${e.value}" also on ${e.episode_id}: ${e.summary}\n`)
+    }
+  } catch {}
 }
 
 console.log(JSON.stringify({

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, parseActivationFromFrontmatter } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
@@ -138,6 +138,8 @@ if (!original) {
 // so validation has to precede that mutation, not follow the later metadata parse).
 // ---------------------------------------------------------------------------
 let activation = null // normalized RFC-009 activation fields (set in the block below)
+let inheritedLessons = [] // violation-side forward-links, inherited verbatim (F3)
+let inheritedViolatedPattern // T6 typed scalar, inherited verbatim (F3)
 {
   const origRaw = fs.readFileSync(original.filePath, 'utf8')
   const fm = origRaw.match(/^---\n([\s\S]*?)\n---/)
@@ -164,26 +166,36 @@ let activation = null // normalized RFC-009 activation fields (set in the block 
     process.exit(1)
   }
 
-  // RFC-009 R1: validate activation fields against the INHERITED category
-  // BEFORE the supersede mutation below (I4 — a rejected revise leaves the
-  // original active and the store byte-unchanged).
-  const av = validateActivation({
-    ...(triggers.length ? { triggers } : {}),
-    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects } : {}),
-    ...(appliesToTools.length ? { applies_to_tools: appliesToTools } : {}),
-    ...(evidence.length ? { evidence } : {}),
-    ...(priorityFlag !== undefined ? { priority: Number(priorityFlag) } : {}),
-    ...(reviewBy !== undefined ? { review_by: reviewBy } : {}),
-  }, { category: cat })
+  // RFC-009 R1 + reviewer F3: activation, linkage, and the T6 typed field are
+  // INHERITED from the original (tags already inherit — silent activation loss
+  // on a typo-revision demoted lessons to freeform and dropped violation band
+  // links). A flag passed on the revise OVERRIDES that field; absent flags keep
+  // the original's values. Validation runs on the MERGED result against the
+  // inherited category, BEFORE the supersede mutation below (I4).
+  const inherited = parseActivationFromFrontmatter(origRaw)
+  inheritedLessons = Array.isArray(inherited.lessons) ? inherited.lessons : []
+  inheritedViolatedPattern = inherited.violated_pattern
+  const merged = {
+    ...(triggers.length ? { triggers } : (inherited.triggers ? { triggers: inherited.triggers } : {})),
+    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects } : (inherited.applies_to_projects ? { applies_to_projects: inherited.applies_to_projects } : {})),
+    ...(appliesToTools.length ? { applies_to_tools: appliesToTools } : (inherited.applies_to_tools ? { applies_to_tools: inherited.applies_to_tools } : {})),
+    ...(evidence.length ? { evidence } : (inherited.evidence ? { evidence: inherited.evidence } : {})),
+    ...(priorityFlag !== undefined ? { priority: Number(priorityFlag) } : (inherited.priority !== undefined ? { priority: inherited.priority } : {})),
+    ...(reviewBy !== undefined ? { review_by: reviewBy } : (inherited.review_by !== undefined ? { review_by: inherited.review_by } : {})),
+  }
+  const av = validateActivation(merged, { category: cat })
   if (!av.ok) {
     console.log(JSON.stringify({ status: 'error', errors: av.errors, message: av.errors.map(e => e.message).join('; ') }))
     process.exit(1)
   }
-  activation = av.fields // null when the revise carries no activation flags
+  activation = av.fields // null when neither flags nor the original carry activation
 
-  // REQ-6 (revise-side parity): merged-index resolution, never per-active-scope (F1).
-  if (activation && Array.isArray(activation.evidence) && activation.evidence.length) {
-    const lv = resolveLinkage(activation.evidence, { requireCategory: 'violation', index: loadMergedIndex() })
+  // REQ-6 (revise-side parity): merged-index resolution, never per-active-scope
+  // (F1). Only NEWLY passed --evidence re-validates — inherited links carry
+  // verbatim (a linked violation may have been legitimately retracted since;
+  // the band derivation, not the write gate, is what discounts it).
+  if (evidence.length) {
+    const lv = resolveLinkage(evidence, { requireCategory: 'violation', index: loadMergedIndex() })
     if (!lv.ok) {
       console.log(JSON.stringify({
         status: 'error',
@@ -330,6 +342,9 @@ if (activation) {
   activationFmLines.push(`priority: ${activation.priority}`)
   if (activation.review_by !== undefined) activationFmLines.push(`review_by: ${activation.review_by}`)
 }
+// F3: violation-side fields inherit verbatim (no revise-side flags exist for them)
+if (inheritedLessons.length) activationFmLines.push(`lessons: [${serializeInlineArray(inheritedLessons)}]`)
+if (inheritedViolatedPattern !== undefined) activationFmLines.push(`violated_pattern: ${inheritedViolatedPattern}`)
 
 const frontmatter = [
   '---',
@@ -360,8 +375,10 @@ const activationIndexFields = {
     ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
       .map(f => [f, activation[f]])
   ) : {}),
+  ...(inheritedLessons.length ? { lessons: inheritedLessons } : {}),
   ...(activation ? { priority: activation.priority } : {}),
   ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
+  ...(inheritedViolatedPattern !== undefined ? { violated_pattern: inheritedViolatedPattern } : {}),
 }
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project: resolvedProject,

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -29,6 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { validateCategory, canonicalCategory } from './lib/categories.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -40,7 +41,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-revise.mjs', usage: 'node em-revise.mjs --original <id> --project <name> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global] [--pin]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-revise.mjs', usage: 'node em-revise.mjs --original <id> --project <name> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope inherit|local|global] [--pin] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...' }))
   process.exit(0)
 }
 
@@ -74,6 +75,14 @@ const summary = flag('--summary')
 const bodyArg = flag('--body')
 const bodyFile = flag('--body-file')
 const scope = flag('--scope') || 'inherit'
+// RFC-009 R1 activation flags (lesson-only; validated against the INHERITED
+// category below, before the supersede mutation, via lib/activation.mjs)
+const triggers = flagAll('--trigger')
+const appliesToProjects = flagAll('--applies-to-project')
+const appliesToTools = flagAll('--applies-to-tool')
+const priorityFlag = flag('--priority')
+const reviewBy = flag('--review-by')
+const evidence = flagAll('--evidence')
 
 const VALID_SCOPES_REVISE = ['inherit', 'local', 'global']
 if (!VALID_SCOPES_REVISE.includes(scope)) {
@@ -127,6 +136,7 @@ if (!original) {
 // must leave the store byte-unchanged; the original is marked superseded just below,
 // so validation has to precede that mutation, not follow the later metadata parse).
 // ---------------------------------------------------------------------------
+let activation = null // normalized RFC-009 activation fields (set in the block below)
 {
   const origRaw = fs.readFileSync(original.filePath, 'utf8')
   const fm = origRaw.match(/^---\n([\s\S]*?)\n---/)
@@ -151,6 +161,36 @@ if (!original) {
       : `Inherited category "${cat}" is not in the vocabulary`
     console.log(JSON.stringify({ status: 'error', message }))
     process.exit(1)
+  }
+
+  // RFC-009 R1: validate activation fields against the INHERITED category
+  // BEFORE the supersede mutation below (I4 — a rejected revise leaves the
+  // original active and the store byte-unchanged).
+  const av = validateActivation({
+    ...(triggers.length ? { triggers } : {}),
+    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects } : {}),
+    ...(appliesToTools.length ? { applies_to_tools: appliesToTools } : {}),
+    ...(evidence.length ? { evidence } : {}),
+    ...(priorityFlag !== undefined ? { priority: Number(priorityFlag) } : {}),
+    ...(reviewBy !== undefined ? { review_by: reviewBy } : {}),
+  }, { category: cat })
+  if (!av.ok) {
+    console.log(JSON.stringify({ status: 'error', errors: av.errors, message: av.errors.map(e => e.message).join('; ') }))
+    process.exit(1)
+  }
+  activation = av.fields // null when the revise carries no activation flags
+
+  // REQ-6 (revise-side parity): merged-index resolution, never per-active-scope (F1).
+  if (activation && Array.isArray(activation.evidence) && activation.evidence.length) {
+    const lv = resolveLinkage(activation.evidence, { requireCategory: 'violation', index: loadMergedIndex() })
+    if (!lv.ok) {
+      console.log(JSON.stringify({
+        status: 'error',
+        message: `--evidence must name existing violation episodes; missing: [${lv.missing.join(', ')}] wrong-category: [${lv.wrongCategory.join(', ')}]`,
+        missing: lv.missing, wrong_category: lv.wrongCategory
+      }))
+      process.exit(1)
+    }
   }
 }
 
@@ -277,6 +317,19 @@ const mergedTags = normalizeTags([...origTagsFromIndex, ...tags])
 // decision. --pin additionally pins an unpinned chain at revision time.
 const pinned = origPinned || argv.includes('--pin')
 
+// RFC-009 R1 activation frontmatter — present-only, arrays UNQUOTED inline
+// (REQ-2/I4); mirrors em-store's serialization (revise-side parity).
+const activationFmLines = []
+if (activation) {
+  for (const field of ACTIVATION_ARRAY_FIELDS) {
+    if (Array.isArray(activation[field]) && activation[field].length) {
+      activationFmLines.push(`${field}: [${serializeInlineArray(activation[field])}]`)
+    }
+  }
+  activationFmLines.push(`priority: ${activation.priority}`)
+  if (activation.review_by !== undefined) activationFmLines.push(`review_by: ${activation.review_by}`)
+}
+
 const frontmatter = [
   '---',
   `id: ${id}`,
@@ -288,6 +341,7 @@ const frontmatter = [
   `supersedes: ${originalId}`,
   `tags: [${mergedTags.join(', ')}]`,
   `summary: ${summary}`,
+  ...activationFmLines,
   ...(pinned ? ['pinned: true'] : []),
   '---',
 ].join('\n')
@@ -299,10 +353,20 @@ fs.mkdirSync(episodesDir, { recursive: true })
 const filePath = path.join(episodesDir, `${id}.md`)
 fs.writeFileSync(filePath, episodeContent, 'utf8')
 
+// Keep in LOCKSTEP with em-rebuild-index.mjs's emit (REQ-9 parity note).
+const activationIndexFields = {
+  ...(activation ? Object.fromEntries(
+    ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
+      .map(f => [f, activation[f]])
+  ) : {}),
+  ...(activation ? { priority: activation.priority } : {}),
+  ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
+}
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project: resolvedProject,
   category: origCategory, status: 'active', supersedes: originalId,
   tags: mergedTags, summary,
+  ...activationIndexFields,
   ...(pinned ? { pinned: true } : {})
 })
 fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -29,6 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -40,7 +41,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-store.mjs', usage: 'node em-store.mjs --project <name> --category <cat> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope local|global] [--pin]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-store.mjs', usage: 'node em-store.mjs --project <name> --category <cat> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path>) [--scope local|global] [--pin] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...' }))
   process.exit(0)
 }
 
@@ -79,6 +80,16 @@ const bodyArg = flag('--body')
 const bodyFile = flag('--body-file')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
+// RFC-009 R1 activation flags (lesson-only; validated below via lib/activation.mjs)
+const triggers = flagAll('--trigger')
+const appliesToProjects = flagAll('--applies-to-project')
+const appliesToTools = flagAll('--applies-to-tool')
+const priorityFlag = flag('--priority')
+const reviewBy = flag('--review-by')
+const evidence = flagAll('--evidence')
+// Typed T6 passthrough scalar (REQ-8): set by em-violation's handoff; generic
+// flag, violation-only in practice.
+const violatedPattern = flag('--violated-pattern')
 // --pin: exempt from time decay (recall floor 0.6 instead of 0.1) and from
 // em-prune archival. For foundational decisions that must not fade.
 const pinned = argv.includes('--pin')
@@ -125,6 +136,38 @@ if (!catV.ok) {
     : `Invalid category "${category}". Must be one of: ${(() => { try { return loadCategories().categories.map(c => c.name).join(', ') } catch { return 'see categories.json' } })()}`
   console.log(JSON.stringify({ status: 'error', message }))
   process.exit(1)
+}
+
+// RFC-009 R1: validate activation fields BEFORE any write (I4 — a rejected
+// write leaves the store byte-unchanged). Present-only input; the lib applies
+// the priority default (5) only when activation is actually in play, so a
+// freeform write of ANY category carries no activation fields (EC15).
+const av = validateActivation({
+  ...(triggers.length ? { triggers } : {}),
+  ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects } : {}),
+  ...(appliesToTools.length ? { applies_to_tools: appliesToTools } : {}),
+  ...(evidence.length ? { evidence } : {}),
+  ...(priorityFlag !== undefined ? { priority: Number(priorityFlag) } : {}),
+  ...(reviewBy !== undefined ? { review_by: reviewBy } : {}),
+}, { category })
+if (!av.ok) {
+  console.log(JSON.stringify({ status: 'error', errors: av.errors, message: av.errors.map(e => e.message).join('; ') }))
+  process.exit(1)
+}
+const activation = av.fields // null for freeform writes
+
+// REQ-6 (S3): each --evidence id must resolve to an EXISTING category:violation
+// episode in the MERGED (local+global) index — never per-active-scope (F1).
+if (activation && Array.isArray(activation.evidence) && activation.evidence.length) {
+  const lv = resolveLinkage(activation.evidence, { requireCategory: 'violation', index: loadMergedIndex() })
+  if (!lv.ok) {
+    console.log(JSON.stringify({
+      status: 'error',
+      message: `--evidence must name existing violation episodes; missing: [${lv.missing.join(', ')}] wrong-category: [${lv.wrongCategory.join(', ')}]`,
+      missing: lv.missing, wrong_category: lv.wrongCategory
+    }))
+    process.exit(1)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -182,6 +225,20 @@ const fmLines = [
   `tags: [${tags.join(', ')}]`,
   `summary: ${summary}`,
 ]
+// RFC-009 R1 activation frontmatter — present-only, arrays UNQUOTED inline
+// (REQ-2/I4: items are char-rejected above, so the round-trip through
+// em-rebuild-index's generic parser needs no parser change).
+if (activation) {
+  for (const field of ACTIVATION_ARRAY_FIELDS) {
+    if (Array.isArray(activation[field]) && activation[field].length) {
+      fmLines.push(`${field}: [${serializeInlineArray(activation[field])}]`)
+    }
+  }
+  fmLines.push(`priority: ${activation.priority}`)
+  if (activation.review_by !== undefined) fmLines.push(`review_by: ${activation.review_by}`)
+}
+// T6 typed scalar (REQ-8): violation-side passthrough from em-violation's handoff.
+if (violatedPattern !== undefined) fmLines.push(`violated_pattern: ${violatedPattern}`)
 if (pinned) fmLines.push('pinned: true')
 if (url) {
   fmLines.push(`url: ${url}`)
@@ -200,9 +257,22 @@ fs.mkdirSync(episodesDir, { recursive: true })
 const filePath = path.join(episodesDir, `${id}.md`)
 fs.writeFileSync(filePath, episodeContent, 'utf8')
 
+// Activation/T6 index fields — keep this list in LOCKSTEP with
+// em-rebuild-index.mjs's emit object (present-only, same key names) so a
+// store-then-rebuild round-trip preserves the fields (REQ-9, step 2.3 parity note).
+const activationIndexFields = {
+  ...(activation ? Object.fromEntries(
+    ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
+      .map(f => [f, activation[f]])
+  ) : {}),
+  ...(activation ? { priority: activation.priority } : {}),
+  ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
+  ...(violatedPattern !== undefined ? { violated_pattern: violatedPattern } : {}),
+}
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project, category,
   status: 'active', supersedes: null, tags, summary,
+  ...activationIndexFields,
   ...(pinned ? { pinned: true } : {}),
   ...(url ? { url, fetched: dateStr } : {})
 })

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, illegalValueChar } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
@@ -171,6 +171,24 @@ if (activation && Array.isArray(activation.evidence) && activation.evidence.leng
       message: `--evidence must name existing violation episodes; missing: [${lv.missing.join(', ')}] wrong-category: [${lv.wrongCategory.join(', ')}]`,
       missing: lv.missing, wrong_category: lv.wrongCategory
     }))
+    process.exit(1)
+  }
+}
+
+// Reviewer F1/F6: the handoff passthroughs are serialized into frontmatter too —
+// a control char (esp. \n/\r) in either would FABRICATE adjacent frontmatter
+// keys (chain/band forgery). Same one-serialization-class rule as REQ-2 (I4).
+if (violatedPattern !== undefined) {
+  const bad = illegalValueChar(violatedPattern)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--violated-pattern value contains illegal character ${JSON.stringify(bad)} — values may not contain , [ ] " or control characters` }))
+    process.exit(1)
+  }
+}
+for (const l of lessonLinks) {
+  const bad = illegalValueChar(l)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--lesson value contains illegal character ${JSON.stringify(bad)}` }))
     process.exit(1)
   }
 }

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -90,6 +90,10 @@ const evidence = flagAll('--evidence')
 // Typed T6 passthrough scalar (REQ-8): set by em-violation's handoff; generic
 // flag, violation-only in practice.
 const violatedPattern = flag('--violated-pattern')
+// REQ-7 violation-side forward-links, set by em-violation's handoff. Guarded +
+// re-validated below: em-store is also a direct write surface, and every
+// surface that feeds the earned band carries the SAME check (I2).
+const lessonLinks = flagAll('--lesson')
 // --pin: exempt from time decay (recall floor 0.6 instead of 0.1) and from
 // em-prune archival. For foundational decisions that must not fade.
 const pinned = argv.includes('--pin')
@@ -170,6 +174,25 @@ if (activation && Array.isArray(activation.evidence) && activation.evidence.leng
   }
 }
 
+// REQ-7 (S3): --lesson is the violation-side forward-link — valid only on
+// category:violation writes, and SYMMETRIC with --evidence (I2): each id must
+// resolve to an EXISTING category:lesson episode in the MERGED index.
+if (lessonLinks.length) {
+  if (category !== 'violation') {
+    console.log(JSON.stringify({ status: 'error', message: `--lesson is a violation-side linkage field, valid only with --category violation (got "${category}")` }))
+    process.exit(1)
+  }
+  const lv = resolveLinkage(lessonLinks, { requireCategory: 'lesson', index: loadMergedIndex() })
+  if (!lv.ok) {
+    console.log(JSON.stringify({
+      status: 'error',
+      message: `--lesson must name existing lesson episodes; missing: [${lv.missing.join(', ')}] wrong-category: [${lv.wrongCategory.join(', ')}]`,
+      missing: lv.missing, wrong_category: lv.wrongCategory
+    }))
+    process.exit(1)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Resolve data directory
 // ---------------------------------------------------------------------------
@@ -237,6 +260,8 @@ if (activation) {
   fmLines.push(`priority: ${activation.priority}`)
   if (activation.review_by !== undefined) fmLines.push(`review_by: ${activation.review_by}`)
 }
+// REQ-7 violation-side forward-links (validated above; unquoted inline array).
+if (lessonLinks.length) fmLines.push(`lessons: [${serializeInlineArray(lessonLinks)}]`)
 // T6 typed scalar (REQ-8): violation-side passthrough from em-violation's handoff.
 if (violatedPattern !== undefined) fmLines.push(`violated_pattern: ${violatedPattern}`)
 if (pinned) fmLines.push('pinned: true')
@@ -265,6 +290,7 @@ const activationIndexFields = {
     ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
       .map(f => [f, activation[f]])
   ) : {}),
+  ...(lessonLinks.length ? { lessons: lessonLinks.map(s => s.trim()) } : {}),
   ...(activation ? { priority: activation.priority } : {}),
   ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
   ...(violatedPattern !== undefined ? { violated_pattern: violatedPattern } : {}),

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -323,7 +323,7 @@ if (activation && Array.isArray(activation.triggers) && activation.triggers.leng
     for (const e of merged.entries) {
       if (e.episode_id === id) continue // self-exclusion: the just-written episode
       if (!mine.has(e.value)) continue
-      const key = `${e.episode_id} ${e.value}`
+      const key = `${e.episode_id} ${e.value}`
       if (reported.has(key)) continue
       reported.add(key)
       process.stderr.write(`collision: trigger "${e.value}" also on ${e.episode_id}: ${e.summary}\n`)

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -30,6 +30,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
+import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
@@ -309,6 +310,26 @@ updateCategoryIndex(dataDir, id, category)
 // Token source is the FULL FILE content (frontmatter + body): the search
 // body tier greps the whole file, so pruning must see the same text.
 updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeContent }))
+
+// R9a write-time collision report (REQ-18) — INFORMATIONAL, stderr-only, runs
+// AFTER the write so the lazy R2 rebuild it triggers already contains this
+// episode (self-excluded, CX5). Best-effort: any failure means NO report,
+// never a blocked write; stdout JSON below is untouched.
+if (activation && Array.isArray(activation.triggers) && activation.triggers.length) {
+  try {
+    const merged = loadMergedTriggerIndex()
+    const mine = new Set(activation.triggers)
+    const reported = new Set()
+    for (const e of merged.entries) {
+      if (e.episode_id === id) continue // self-exclusion: the just-written episode
+      if (!mine.has(e.value)) continue
+      const key = `${e.episode_id} ${e.value}`
+      if (reported.has(key)) continue
+      reported.add(key)
+      process.stderr.write(`collision: trigger "${e.value}" also on ${e.episode_id}: ${e.summary}\n`)
+    }
+  } catch {}
+}
 
 console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope }))
 

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -29,7 +29,7 @@ import crypto from 'crypto'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
-import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, illegalValueChar } from './lib/activation.mjs'
+import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, illegalValueChar, illegalScalarChar } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 
@@ -126,6 +126,26 @@ if (!project || !category || !summary || !body) {
     message: `Missing required args. Usage: ${USAGE}`
   }))
   process.exit(1)
+}
+
+// Reviewer F1 (round 2): EVERY serialized frontmatter scalar rejects
+// line-breaking chars before any write — a raw \n in summary/project/url/a tag
+// fabricates an adjacent key (a forged `evidence:`/`superseded_by:` is the exact
+// earned-band forge the linkage gate exists to stop). One reject class across
+// the whole write surface (fractal #9); fail-closed, no partial write.
+for (const [label, value] of [['summary', summary], ['project', project], ...(url !== undefined ? [['url', url]] : [])]) {
+  const bad = illegalScalarChar(value)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--${label} contains illegal line-breaking character ${JSON.stringify(bad)}` }))
+    process.exit(1)
+  }
+}
+for (const tag of [...(tagsRaw ? tagsRaw.split(',') : []), ...tagRepeats]) {
+  const bad = illegalScalarChar(tag)
+  if (bad !== null) {
+    console.log(JSON.stringify({ status: 'error', message: `--tag/--tags value contains illegal line-breaking character ${JSON.stringify(bad)}` }))
+    process.exit(1)
+  }
 }
 let catV
 try {

--- a/scripts/em-trigger-index.mjs
+++ b/scripts/em-trigger-index.mjs
@@ -359,14 +359,19 @@ export function buildSessionStart(rows, now = new Date()) {
 
   // preflight — per-task-type recent-violation counts keyed by the TYPED
   // violated_pattern field (why T6 is a hard dep of REQ-15). 30-day window.
+  // Reviewer F4: this is the THIRD violated_pattern read site — same T6
+  // dual-read as em-recall/em-pattern-health (typed field ∪ legacy tag, one
+  // count per row); sunset the tag leg after the burn-in window (issue #457).
   const cutoff = new Date(nowMs - 30 * DAY).toISOString().slice(0, 10)
   const preflight = {}
   for (const [taskType, patternIds] of Object.entries(TASK_TYPE_PATTERNS)) {
     const counts = {}
     for (const pid of patternIds) {
+      const legacyTag = `violated:${pid}` // T6 burn-in shim (legacy tag construction)
       const n = rows.filter(r =>
         r && r.category === 'violation' && r.status !== 'superseded' &&
-        r.violated_pattern === pid &&
+        (r.violated_pattern === pid ||
+          (Array.isArray(r.tags) && r.tags.includes(legacyTag))) &&
         typeof r.date === 'string' && r.date >= cutoff).length
       if (n > 0) counts[pid] = n
     }
@@ -385,6 +390,15 @@ export function buildSessionStart(rows, now = new Date()) {
  * precedence (mirrors em-search). One store failing degrades to the other with
  * a single stderr note — never throws (I5). Consumers (R9a, the P2 R4 hook)
  * call THIS, never buildTriggerIndex directly.
+ *
+ * Reviewer F2: the earned band is RECOMPUTED here against the UNION of both
+ * stores' rows, so a cross-scope link (local lesson --evidence global
+ * violation — legitimate per REQ-6/F1) earns the band a per-store artifact
+ * cannot see. The per-store trigger-index.json keeps its per-store band (a
+ * cached global artifact must stay deterministic — it cannot depend on
+ * whichever local store a caller sits in); every consumer reads THIS merged
+ * view, so the band consumers see is the cross-store one. `session_start` is
+ * rebuilt from the merged rows for the same reason.
  */
 export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
   let local = null
@@ -395,17 +409,36 @@ export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
   try { global = buildTriggerIndex({ scope: 'global', now }).index } catch (e) {
     process.stderr.write(`em-trigger-index: global build failed (${e.message}); proceeding with local only\n`)
   }
+
+  // union of both stores' rows, deduped by id with LOCAL precedence — the row
+  // set the cross-store band and the merged session_start are computed from.
+  // Read errors degrade to whatever loaded (matching the per-store degrades).
+  const mergedRows = []
+  const seenRows = new Set()
+  for (const scope of ['local', 'global']) {
+    let raw = ''
+    try {
+      const dir = resolveStoreDir({ project, scope })
+      raw = fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8')
+    } catch { continue }
+    for (const row of parseRows(raw)) {
+      if (!row || typeof row.id !== 'string' || seenRows.has(row.id)) continue
+      seenRows.add(row.id)
+      mergedRows.push(row)
+    }
+  }
+
   const seenEpisodes = new Set()
   const entries = []
   for (const idx of [local, global]) { // local first -> local precedence
     if (!idx || !Array.isArray(idx.entries)) continue
     for (const e of idx.entries) {
       if (seenEpisodes.has(e.episode_id)) continue // earlier store won this episode
-      entries.push(e)
+      entries.push({ ...e, effective_priority: effectivePriority(e.episode_id, mergedRows) })
     }
     for (const e of idx.entries) seenEpisodes.add(e.episode_id)
   }
-  return { entries, local, global }
+  return { entries, session_start: buildSessionStart(mergedRows, now), local, global }
 }
 
 // ---------------------------------------------------------------------------
@@ -435,7 +468,7 @@ if (isMainModule()) {
   }
   if (argv.includes('--merged')) {
     const merged = loadMergedTriggerIndex({ project })
-    console.log(JSON.stringify({ status: 'ok', entries: merged.entries }))
+    console.log(JSON.stringify({ status: 'ok', entries: merged.entries, session_start: merged.session_start }))
     process.exit(0)
   }
   const built = []

--- a/scripts/em-trigger-index.mjs
+++ b/scripts/em-trigger-index.mjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+/**
+ * em-trigger-index.mjs — build the derived lesson-activation trigger index (RFC-009 R2).
+ *
+ * Usage:
+ *   node em-trigger-index.mjs [--project <root>] [--scope local|global|all] [--merged]
+ *
+ * Builds ONE `trigger-index.json` per store from `status: active` lessons that
+ * carry `triggers` frontmatter. DATA-plane substrate only: registers no hook,
+ * writes nothing under ~/.claude/ (P12); the P2 R4 hook reads the artifact.
+ *
+ * Store binding (REQ-16/F6): `--project <root>` is a NEW explicit PATH binding —
+ * when <root> is an existing directory, the local store is `<root>/.episodic-memory`
+ * regardless of caller cwd (a linked worktree cwd converges to its MAIN root via
+ * resolveLocalDir, so cwd-based resolution cannot target another project).
+ * Without --project, the local store resolves from cwd as every other script.
+ *
+ * Freshness (REQ-14): lazy build with an mtime+size+sha256 fingerprint computed
+ * from the BYTES THE BUILD READ (stat -> read -> re-stat; one re-read on
+ * mismatch) — closes the TOCTOU window and the same-size-same-mtime rewrite
+ * case. Cache hit (all three match) returns the existing file without a write.
+ * Atomic write via a UNIQUE temp name `trigger-index.json.tmp.<pid>.<rand>`
+ * (F2: the fixed `.tmp` convention collides when two lazy builds race).
+ *
+ * Earned band (REQ-13, I1/I3): `effective_priority` is DERIVED here from
+ * linked-violation counts (violation-side `lessons` ∪ lesson-side `evidence`,
+ * deduped by terminal violation id, chain-resolved in both directions);
+ * 0 links -> stored priority (1-7), 1 -> 8, >=2 -> 9. Stored bytes are never
+ * mutated; no writer can declare 8-9 (em-store rejects it).
+ *
+ * Degrade-not-throw (I5): malformed store index rows are skipped; an unreadable
+ * activity-class vocab excludes+counts every `activity:` trigger; a failed
+ * per-store build inside loadMergedTriggerIndex() degrades to the other store
+ * with one stderr note. Build failures never take down a consumer read.
+ *
+ * Outputs JSON to stdout: { status, built: [{scope, store, entries, cache_hit}] }
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import { pathToFileURL } from 'node:url'
+import { resolveLocalDir } from './lib/local-dir.mjs'
+import { loadActivationClasses, parseTriggerKind } from './lib/activation.mjs'
+
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+
+export const TRIGGER_INDEX_SCHEMA_VERSION = 1
+export const TRIGGER_ENTRY_FIELDS = ['trigger_kind', 'value', 'episode_id', 'summary', 'effective_priority', 'applies_to_projects', 'applies_to_tools', 'review_by']
+export const TRIGGER_KIND_ENUM = ['phrase', 'tool', 'activity']
+
+// ---------------------------------------------------------------------------
+// Store resolution (REQ-16/F6 — a real path binding, NOT the --project name filter)
+// ---------------------------------------------------------------------------
+export function resolveStoreDir({ project, scope } = {}) {
+  if (scope === 'global') return GLOBAL_DIR
+  if (project !== undefined) {
+    let st = null
+    try { st = fs.statSync(project) } catch {}
+    if (st && st.isDirectory()) return path.join(project, '.episodic-memory')
+  }
+  return resolveLocalDir()
+}
+
+// ---------------------------------------------------------------------------
+// Index rows + fingerprint
+// ---------------------------------------------------------------------------
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex')
+}
+
+/**
+ * Read a store's index.jsonl with a TOCTOU-safe fingerprint: stat, read,
+ * re-stat; on a stat mismatch re-read ONCE and fingerprint the bytes actually
+ * read (REQ-14/EC9). A missing index file fingerprints as the empty store.
+ */
+function readIndexWithFingerprint(storeDir) {
+  const indexPath = path.join(storeDir, 'index.jsonl')
+  let st1 = null
+  try { st1 = fs.statSync(indexPath) } catch {}
+  if (!st1) {
+    return { raw: '', fingerprint: { index_mtime_ms: 0, index_size: 0, index_sha256: sha256('') } }
+  }
+  let raw = fs.readFileSync(indexPath, 'utf8')
+  let st2 = null
+  try { st2 = fs.statSync(indexPath) } catch {}
+  if (!st2 || st2.mtimeMs !== st1.mtimeMs || st2.size !== st1.size) {
+    // mid-read rewrite: one re-read, fingerprint what we actually consumed (EC9)
+    try { raw = fs.readFileSync(indexPath, 'utf8') } catch { raw = '' }
+    try { st2 = fs.statSync(indexPath) } catch { st2 = null }
+  }
+  const bytes = Buffer.byteLength(raw, 'utf8')
+  return {
+    raw,
+    fingerprint: {
+      index_mtime_ms: st2 ? st2.mtimeMs : 0,
+      index_size: bytes,
+      index_sha256: sha256(raw),
+    },
+  }
+}
+
+function parseRows(raw) {
+  const rows = []
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    try { rows.push(JSON.parse(line)) } catch {}
+  }
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+// Chain resolution + the earned band (REQ-13)
+// ---------------------------------------------------------------------------
+
+/** Follow the supersession chain FORWARD to the terminal row (cycle-safe). */
+function terminalOf(id, byId, successorOf) {
+  const seen = new Set()
+  let cur = id
+  while (!seen.has(cur)) {
+    seen.add(cur)
+    const row = byId.get(cur)
+    const next = (row && typeof row.superseded_by === 'string' && row.superseded_by) || successorOf.get(cur)
+    if (!next || !byId.has(next)) return byId.get(cur)
+    cur = next
+  }
+  return byId.get(cur) // cycle: return where we stopped
+}
+
+function buildChainMaps(rows) {
+  const byId = new Map()
+  const successorOf = new Map() // predecessor id -> successor id (via `supersedes`)
+  for (const row of rows) {
+    if (!row || typeof row.id !== 'string') continue
+    if (!byId.has(row.id)) byId.set(row.id, row)
+    if (typeof row.supersedes === 'string' && row.supersedes) successorOf.set(row.supersedes, row.id)
+  }
+  return { byId, successorOf }
+}
+
+/**
+ * effectivePriority(lessonId, rows) -> 1..9 (REQ-13). Counts violations linked
+ * to the lesson: violation-side `lessons` ∪ lesson-side `evidence`, deduped by
+ * TERMINAL violation id; links to since-revised episodes follow to their active
+ * terminals in BOTH directions; a retracted violation (chain terminates on a
+ * non-violation or non-active row) stops counting. Reads only (I3).
+ */
+export function effectivePriority(lessonId, rows) {
+  const { byId, successorOf } = buildChainMaps(rows)
+  const lessonRow = byId.get(lessonId)
+  if (!lessonRow) return 5
+  const lessonTerminal = terminalOf(lessonId, byId, successorOf)
+  const lessonChainIds = new Set()
+  {
+    // every id whose terminal IS this lesson belongs to its chain
+    for (const row of byId.values()) {
+      const t = terminalOf(row.id, byId, successorOf)
+      if (t && lessonTerminal && t.id === lessonTerminal.id) lessonChainIds.add(row.id)
+    }
+  }
+  const linked = new Set()
+  const countViolationTerminal = (violationId) => {
+    const t = terminalOf(violationId, byId, successorOf)
+    if (!t) return
+    if (t.category !== 'violation') return // retracted (EC7)
+    if (t.status === 'superseded') return
+    linked.add(t.id)
+  }
+  // forward direction: ACTIVE violation rows naming any id in the lesson's chain
+  for (const row of byId.values()) {
+    if (row.category !== 'violation' || !Array.isArray(row.lessons)) continue
+    if (row.status === 'superseded') continue
+    for (const lid of row.lessons) {
+      const lt = terminalOf(lid, byId, successorOf)
+      if (lt && lessonTerminal && lt.id === lessonTerminal.id) { countViolationTerminal(row.id); break }
+    }
+  }
+  // back direction: the lesson chain's `evidence` links, chain-resolved
+  for (const cid of lessonChainIds) {
+    const row = byId.get(cid)
+    if (!row || !Array.isArray(row.evidence)) continue
+    for (const vid of row.evidence) countViolationTerminal(vid)
+  }
+  const stored = Number.isInteger(Number(lessonRow.priority)) ? Number(lessonRow.priority) : 5
+  if (linked.size === 0) return Math.min(Math.max(stored, 1), 7)
+  return linked.size === 1 ? 8 : 9
+}
+
+// ---------------------------------------------------------------------------
+// Per-store build (REQ-12/14 — NO cross-store logic here, CX4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build (or return the cached) trigger-index.json for ONE store. Lazy: a cache
+ * whose `source` fingerprint matches the store's index.jsonl on all three
+ * legs is returned WITHOUT a rewrite. Never throws for store-content reasons;
+ * IO errors on the store dir itself surface to the caller (loadMergedTriggerIndex
+ * degrades them).
+ *
+ * @param {{project?:string, scope?:'local'|'global', now?:Date}} opts
+ * @returns {{index:object, cacheHit:boolean, storeDir:string}}
+ */
+export function buildTriggerIndex({ project, scope = 'local', now = new Date() } = {}) {
+  const storeDir = resolveStoreDir({ project, scope })
+  const indexPath = path.join(storeDir, 'trigger-index.json')
+  const { raw, fingerprint } = readIndexWithFingerprint(storeDir)
+
+  // cache probe — malformed cache is simply a miss (rebuilt below)
+  try {
+    const cached = JSON.parse(fs.readFileSync(indexPath, 'utf8'))
+    const s = cached && cached.source
+    if (s && s.index_mtime_ms === fingerprint.index_mtime_ms &&
+        s.index_size === fingerprint.index_size &&
+        s.index_sha256 === fingerprint.index_sha256 &&
+        cached.schema_version === TRIGGER_INDEX_SCHEMA_VERSION) {
+      return { index: cached, cacheHit: true, storeDir }
+    }
+  } catch {}
+
+  const rows = parseRows(raw)
+  const todayStr = now.toISOString().slice(0, 10)
+
+  // activity-class vocab — degrade-not-throw at BUILD (F4/I5): unreadable vocab
+  // means every `activity:` trigger is excluded+counted, never fatal.
+  let classNames = null
+  try {
+    classNames = new Map(loadActivationClasses().classes.map(c => [c.name, c]))
+  } catch {
+    classNames = null
+  }
+
+  const excludedActivity = Object.create(null)
+  const entries = []
+  for (const row of rows) {
+    if (!row || row.category !== 'lesson') continue
+    if (row.status !== 'active') continue // superseded excluded
+    if (!Array.isArray(row.triggers) || row.triggers.length === 0) continue
+    if (typeof row.review_by === 'string' && row.review_by < todayStr) continue // expired
+    const ep = effectivePriority(row.id, rows)
+    for (const value of row.triggers) {
+      const kind = parseTriggerKind(String(value))
+      if (kind === 'activity') {
+        const cls = String(value).slice('activity:'.length)
+        const member = classNames ? classNames.get(cls) : undefined
+        if (!member || member.deprecated_for) {
+          excludedActivity[cls] = (excludedActivity[cls] || 0) + 1
+          continue // excluded + counted (EC11), never silently matched
+        }
+      }
+      entries.push({
+        trigger_kind: kind,
+        value: String(value),
+        episode_id: row.id,
+        summary: row.summary,
+        effective_priority: ep, // DERIVED 1-9; never the stored `priority`
+        applies_to_projects: Array.isArray(row.applies_to_projects) ? row.applies_to_projects : [],
+        applies_to_tools: Array.isArray(row.applies_to_tools) ? row.applies_to_tools : [],
+        ...(typeof row.review_by === 'string' ? { review_by: row.review_by } : {}),
+      })
+    }
+  }
+
+  const index = {
+    schema_version: TRIGGER_INDEX_SCHEMA_VERSION,
+    source: fingerprint,
+    build_report: { excluded_activity_classes: { ...excludedActivity } },
+    entries,
+    session_start: buildSessionStart(rows, now),
+  }
+
+  // Atomic write, UNIQUE temp name (F2) — two racing lazy builds must not share
+  // a temp path (fixed `.tmp` yields a torn temp / ENOENT on the loser).
+  try {
+    fs.mkdirSync(storeDir, { recursive: true })
+    const tmp = `${indexPath}.tmp.${process.pid}.${crypto.randomBytes(4).toString('hex')}`
+    fs.writeFileSync(tmp, JSON.stringify(index, null, 2), 'utf8')
+    fs.renameSync(tmp, indexPath)
+  } catch (e) {
+    // degrade: the in-memory index is still valid for this consumer read (I5)
+    process.stderr.write(`em-trigger-index: could not persist ${indexPath}: ${e.message}\n`)
+  }
+  return { index, cacheHit: false, storeDir }
+}
+
+// ---------------------------------------------------------------------------
+// session_start section (REQ-15, S6) — pure function of index rows + `now`;
+// NO environment inputs (I6: the P2 R4 hook reads only this purpose-built data).
+// ---------------------------------------------------------------------------
+const SESSION_START_TOP_N = 10
+
+// Mirrors em-recall's TASK_TYPE_PATTERNS (RFC-002 Phase 3); duplicated as DATA
+// here so the builder stays environment-free — keep in lockstep.
+const TASK_TYPE_PATTERNS = {
+  implementation: ['bp-001-implementation-workflow', 'bp-006-push-after-verify'],
+  push: ['bp-006-push-after-verify'],
+  rule: ['bp-010-habits-override-knowledge'],
+}
+
+export function buildSessionStart(rows, now = new Date()) {
+  const todayStr = now.toISOString().slice(0, 10)
+  const nowMs = now.getTime()
+  const activeLessons = rows.filter(r =>
+    r && r.category === 'lesson' && r.status === 'active' &&
+    !(typeof r.review_by === 'string' && r.review_by < todayStr))
+
+  const epCache = new Map()
+  const ep = (id) => {
+    if (!epCache.has(id)) epCache.set(id, effectivePriority(id, rows))
+    return epCache.get(id)
+  }
+
+  // critical_entries — EVERY active band-8/9 lesson, TRIGGER-INDEPENDENT (EC14:
+  // R8 always-tier content carries no trigger; the band scan covers ALL lessons).
+  const critical_entries = activeLessons
+    .filter(r => ep(r.id) >= 8)
+    .map(r => ({
+      episode_id: r.id,
+      summary: r.summary,
+      category: r.category,
+      effective_priority: ep(r.id),
+      applies_to_projects: Array.isArray(r.applies_to_projects) ? r.applies_to_projects : [],
+      applies_to_tools: Array.isArray(r.applies_to_tools) ? r.applies_to_tools : [],
+    }))
+    .sort((a, b) => b.effective_priority - a.effective_priority || (a.episode_id < b.episode_id ? -1 : 1))
+
+  // entries — top-N by the explicit static_score blend (REQ-15):
+  //   0.5*recency + 0.3*staleness + 0.2*priority
+  //   recencyScore  = 1/(1 + ageDays/30)                (newer -> higher)
+  //   stalenessScore= min(daysSinceAccess,365)/365; null last_accessed -> 1.0
+  //   priorityScore = storedPriority/7 (default 5)
+  const DAY = 24 * 60 * 60 * 1000
+  const scored = activeLessons.map(r => {
+    const dateMs = Date.parse(`${r.date}T00:00:00Z`)
+    const ageDays = Number.isNaN(dateMs) ? 365 : Math.max(0, (nowMs - dateMs) / DAY)
+    const recencyScore = 1 / (1 + ageDays / 30)
+    let stalenessScore = 1.0 // never-accessed ranks highest (the R6 intent)
+    if (r.last_accessed) {
+      const laMs = Date.parse(r.last_accessed)
+      const daysSince = Number.isNaN(laMs) ? 365 : Math.max(0, (nowMs - laMs) / DAY)
+      stalenessScore = Math.min(daysSince, 365) / 365
+    }
+    const stored = Number.isInteger(Number(r.priority)) ? Number(r.priority) : 5
+    const priorityScore = stored / 7
+    const static_score = 0.5 * recencyScore + 0.3 * stalenessScore + 0.2 * priorityScore
+    return { r, static_score, recencyScore }
+  })
+  scored.sort((a, b) =>
+    b.static_score - a.static_score ||
+    b.recencyScore - a.recencyScore ||
+    (a.r.id < b.r.id ? -1 : 1))
+  const entries = scored.slice(0, SESSION_START_TOP_N).map(({ r, static_score }) => ({
+    episode_id: r.id,
+    summary: r.summary,
+    static_score: Number(static_score.toFixed(6)),
+    applies_to_projects: Array.isArray(r.applies_to_projects) ? r.applies_to_projects : [],
+    applies_to_tools: Array.isArray(r.applies_to_tools) ? r.applies_to_tools : [],
+  }))
+
+  // preflight — per-task-type recent-violation counts keyed by the TYPED
+  // violated_pattern field (why T6 is a hard dep of REQ-15). 30-day window.
+  const cutoff = new Date(nowMs - 30 * DAY).toISOString().slice(0, 10)
+  const preflight = {}
+  for (const [taskType, patternIds] of Object.entries(TASK_TYPE_PATTERNS)) {
+    const counts = {}
+    for (const pid of patternIds) {
+      const n = rows.filter(r =>
+        r && r.category === 'violation' && r.status !== 'superseded' &&
+        r.violated_pattern === pid &&
+        typeof r.date === 'string' && r.date >= cutoff).length
+      if (n > 0) counts[pid] = n
+    }
+    preflight[taskType] = counts
+  }
+
+  return { critical_entries, entries, preflight }
+}
+
+// ---------------------------------------------------------------------------
+// Merged read (REQ-16, CX4 — the ONLY merge site)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build/load BOTH stores' indexes and merge: dedupe by EPISODE id with LOCAL
+ * precedence (mirrors em-search). One store failing degrades to the other with
+ * a single stderr note — never throws (I5). Consumers (R9a, the P2 R4 hook)
+ * call THIS, never buildTriggerIndex directly.
+ */
+export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
+  let local = null
+  let global = null
+  try { local = buildTriggerIndex({ project, scope: 'local', now }).index } catch (e) {
+    process.stderr.write(`em-trigger-index: local build failed (${e.message}); proceeding with global only\n`)
+  }
+  try { global = buildTriggerIndex({ scope: 'global', now }).index } catch (e) {
+    process.stderr.write(`em-trigger-index: global build failed (${e.message}); proceeding with local only\n`)
+  }
+  const seenEpisodes = new Set()
+  const entries = []
+  for (const idx of [local, global]) { // local first -> local precedence
+    if (!idx || !Array.isArray(idx.entries)) continue
+    for (const e of idx.entries) {
+      if (seenEpisodes.has(e.episode_id)) continue // earlier store won this episode
+      entries.push(e)
+    }
+    for (const e of idx.entries) seenEpisodes.add(e.episode_id)
+  }
+  return { entries, local, global }
+}
+
+// ---------------------------------------------------------------------------
+// CLI (main-module guarded so writers can import the helpers without running it)
+// ---------------------------------------------------------------------------
+function isMainModule() {
+  try { return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href } catch { return false }
+}
+
+if (isMainModule()) {
+  const argv = process.argv.slice(2)
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(JSON.stringify({ status: 'help', script: 'em-trigger-index.mjs', usage: 'node em-trigger-index.mjs [--project <root>] [--scope local|global|all] [--merged] — builds trigger-index.json per store; --project <root> binds the LOCAL store to <root>/.episodic-memory (path binding, not a name filter); --merged prints the deduped local-precedence merged view' }))
+    process.exit(0)
+  }
+  const flag = (name) => {
+    const i = argv.indexOf(name)
+    if (i === -1 || i + 1 >= argv.length) return undefined
+    return argv[i + 1]
+  }
+  const project = flag('--project')
+  const scope = flag('--scope') || 'local'
+  const VALID = ['local', 'global', 'all']
+  if (!VALID.includes(scope)) {
+    console.log(JSON.stringify({ status: 'error', message: `Invalid --scope "${scope}". Must be one of: ${VALID.join(', ')}` }))
+    process.exit(1)
+  }
+  if (argv.includes('--merged')) {
+    const merged = loadMergedTriggerIndex({ project })
+    console.log(JSON.stringify({ status: 'ok', entries: merged.entries }))
+    process.exit(0)
+  }
+  const built = []
+  for (const s of scope === 'all' ? ['local', 'global'] : [scope]) {
+    try {
+      const { index, cacheHit, storeDir } = buildTriggerIndex({ project, scope: s })
+      built.push({ scope: s, store: storeDir, entries: index.entries.length, cache_hit: cacheHit })
+    } catch (e) {
+      // per-store IO failure degrades to a named report, never a stack trace (I5)
+      built.push({ scope: s, error: e.message })
+      process.stderr.write(`em-trigger-index: ${s} build failed: ${e.message}\n`)
+    }
+  }
+  console.log(JSON.stringify({ status: built.some(b => b.error) ? 'partial' : 'ok', built }))
+}

--- a/scripts/em-violation.mjs
+++ b/scripts/em-violation.mjs
@@ -24,6 +24,7 @@ import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
 import { readBodyFile } from './lib/body-file.mjs'
+import { loadMergedIndex, resolveLinkage } from './lib/activation.mjs'
 
 const SCRIPTS_DIR = path.dirname(new URL(import.meta.url).pathname)
 const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
@@ -34,7 +35,7 @@ const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-violation.mjs', usage: 'node em-violation.mjs --pattern <pattern_id> --summary <text> (--body <text> | --body-file <path>) [--sequence <a,b>] [--correct <a,b>] [--project <name>] [--tags <extra>] [--scope global|local]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-violation.mjs', usage: 'node em-violation.mjs --pattern <pattern_id> --summary <text> (--body <text> | --body-file <path>) [--sequence <a,b>] [--correct <a,b>] [--project <name>] [--tags <extra>] [--scope global|local] [--lesson <lesson-episode-id>]...' }))
   process.exit(0)
 }
 
@@ -42,6 +43,22 @@ function flag(name) {
   const i = argv.indexOf(name)
   if (i === -1 || i + 1 >= argv.length) return undefined
   return argv[i + 1]
+}
+
+// flagAll(name) — collect every value of a repeated flag (copies em-store's
+// shape; introduced for --lesson, RFC-009 REQ-7). Skips a position whose value
+// starts with `--` (the next flag, not a value).
+function flagAll(name) {
+  const out = []
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === name && i + 1 < argv.length) {
+      const val = argv[i + 1]
+      if (val.startsWith('--')) continue
+      out.push(val)
+      i++
+    }
+  }
+  return out
 }
 
 const patternId = flag('--pattern')
@@ -53,6 +70,8 @@ const correct = flag('--correct')
 const project = flag('--project') || path.basename(process.cwd())
 const extraTags = flag('--tags')
 const scope = flag('--scope') || 'global'
+// RFC-009 REQ-7: forward-link the violation to the lesson(s) whose surfacing failed.
+const lessons = flagAll('--lesson')
 
 if (bodyArg !== undefined && bodyFile !== undefined) {
   console.log(JSON.stringify({
@@ -120,8 +139,29 @@ if (!patterns) {
 }
 
 // ---------------------------------------------------------------------------
+// RFC-009 REQ-7: validate --lesson linkage BEFORE any write — SYMMETRIC with
+// em-store's --evidence check (I2: same existence + exact-category check, same
+// MERGED local+global resolution, F1). Asymmetry here is the earned-band forge
+// path (§7): fail closed, no partial write.
+// ---------------------------------------------------------------------------
+if (lessons.length) {
+  const lv = resolveLinkage(lessons, { requireCategory: 'lesson', index: loadMergedIndex() })
+  if (!lv.ok) {
+    console.log(JSON.stringify({
+      status: 'error',
+      message: `--lesson must name existing lesson episodes; missing: [${lv.missing.join(', ')}] wrong-category: [${lv.wrongCategory.join(', ')}]`,
+      missing: lv.missing, wrong_category: lv.wrongCategory
+    }))
+    process.exit(1)
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Build auto-tags
 // ---------------------------------------------------------------------------
+// T6 burn-in shim — the `violated:<id>` TAG is descriptive-only now; the typed
+// `violated_pattern` frontmatter field (below) is the load-bearing surface.
+// Sunset the tag after the dual-read window (issue #457).
 const autoTags = ['violation', 'behavioral-pattern', `violated:${patternId}`]
 if (extraTags) {
   const extras = extraTags.split(',').map(t => t.trim()).filter(Boolean)
@@ -157,8 +197,13 @@ const args = [
   `--tags`, tagsStr,
   `--summary`, summary,
   `--body`, structuredBody,
-  `--scope`, scope
+  `--scope`, scope,
+  // T6 (REQ-8): typed scalar — em-recall preflight + em-pattern-health strikes
+  // read THIS field (dual-read with the legacy tag during burn-in).
+  `--violated-pattern`, patternId,
 ]
+// REQ-7: forward the (already-validated) lesson links as repeated flags.
+for (const l of lessons) args.push('--lesson', l)
 
 try {
   const result = execFileSync('node', [STORE_SCRIPT, ...args], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim()

--- a/scripts/em.mjs
+++ b/scripts/em.mjs
@@ -54,6 +54,7 @@ const DESCRIPTIONS = {
   routines: 'Scheduled maintenance manager (sync/list/run/enable/disable)',
   prune: 'Archive stale low-relevance episodes',
   'rebuild-index': 'Regenerate index.jsonl, tags.json, category-index.json',
+  'trigger-index': 'Build the derived lesson-activation trigger index (RFC-009 R2)',
   backup: 'Sync stores to a backup git repository',
   restore: 'Restore stores from a backup repository',
   violation: 'Record a behavioral-pattern violation',

--- a/scripts/lib/activation.mjs
+++ b/scripts/lib/activation.mjs
@@ -41,7 +41,27 @@ export function illegalValueChar(s) {
   }
   for (let i = 0; i < str.length; i++) {
     const code = str.charCodeAt(i)
-    if (code < 0x20 || code === 0x7f) return `\\x${code.toString(16).padStart(2, '0')}`
+    // control chars + the Unicode line/paragraph separators (U+2028/U+2029):
+    // both break em-rebuild-index's `split('\n')` + `/^(\w+):\s*(.*)$/` — a raw
+    // \n forges an adjacent key, U+2028 drops the field on rebuild (F1/F2 r2).
+    if (code < 0x20 || code === 0x7f || code === 0x2028 || code === 0x2029) return `\\x${code.toString(16).padStart(2, '0')}`
+  }
+  return null
+}
+
+// Scalar frontmatter values (summary, project, url, each tag) legitimately carry
+// prose punctuation — , [ ] " are fine — but NEVER a line-breaking char: a raw
+// \n fabricates an adjacent frontmatter key (a forged `evidence:`/`superseded_by:`
+// is an earned-band / chain forge that bypasses the linkage gate), and \r or the
+// Unicode separators drop the field on rebuild. This is the same forge class as
+// illegalValueChar, minus the structural , [ ] " that prose may contain
+// (reviewer F1 round 2 — the class spans every serialized value, not just
+// activation fields). Returns the offending char (escaped) or null.
+export function illegalScalarChar(s) {
+  const str = String(s)
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i)
+    if (code === 0x0a || code === 0x0d || code === 0x2028 || code === 0x2029) return `\\x${code.toString(16).padStart(2, '0')}`
   }
   return null
 }

--- a/scripts/lib/activation.mjs
+++ b/scripts/lib/activation.mjs
@@ -1,0 +1,287 @@
+// activation.mjs — the single home for the lesson-activation vocabularies and shared
+// validators (RFC-009 R1, plan REQ-16b). Both em-store/em-revise (lesson side) and
+// em-violation (violation side) import from here so the linkage/validation logic is
+// never duplicated — mirroring how P1a's lib/categories.mjs became the single
+// category-vocab source.
+//
+// Fail direction follows the categories.mjs convention:
+//   - WRITERS call validateActivation / resolveLinkage → reject the write on !ok
+//     (fail CLOSED). validateActivation loads the activity-class vocab LAZILY —
+//     only when the fields carry an `activity:` trigger — so a freeform or
+//     phrase/tool-only lesson write never depends on the vocab being present (F4).
+//   - READERS/builders (em-trigger-index) wrap loadActivationClasses() in try/catch
+//     and DEGRADE (exclude + count), never throw (I5).
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { resolveLocalDir } from './local-dir.mjs'
+
+// Resolved relative to this file so the path is symmetric in-repo
+// (<repo>/activation-classes.json) and deployed (~/.episodic-memory/activation-classes.json).
+export const ACTIVATION_CLASSES_PATH = new URL('../../activation-classes.json', import.meta.url)
+
+// Fixed tool vocabulary (REQ-5, P5) — a small closed constant, NOT a per-project extension.
+export const TOOL_IDS = ['claude-code', 'codex', 'opencode', 'pi-agent', 'cursor', 'windsurf']
+
+// One serialization class for every inline-array field this RFC introduces (REQ-2, I4):
+// items containing any of these characters would break the unquoted inline-array
+// round-trip through em-rebuild-index's generic frontmatter parser.
+export const ILLEGAL_ARRAY_CHARS = [',', '[', ']', '"']
+
+// The activation frontmatter fields (R1). Arrays serialize as unquoted inline arrays;
+// scalars as plain values. `evidence` is the lesson→violation back-link; `lessons` is
+// the violation→lesson forward-link (REQ-6/7).
+export const ACTIVATION_ARRAY_FIELDS = ['triggers', 'applies_to_projects', 'applies_to_tools', 'evidence', 'lessons']
+export const ACTIVATION_SCALAR_FIELDS = ['priority', 'review_by']
+
+/**
+ * Resolve + parse the activity-class vocabulary. THROWS on any read/parse/shape
+ * failure (writer callers fail closed; reader callers catch and degrade).
+ * @returns {{version:string, classes:Array<{name:string,description:string,phrases:string[],deprecated_for?:string}>}}
+ */
+export function loadActivationClasses() {
+  const p = process.env.EM_ACTIVATION_CLASSES_PATH || ACTIVATION_CLASSES_PATH
+  let raw
+  try {
+    raw = fs.readFileSync(p, 'utf8')
+  } catch (e) {
+    throw new Error(`activation-classes.json unloadable: ${e.message}`)
+  }
+  let doc
+  try {
+    doc = JSON.parse(raw)
+  } catch (e) {
+    throw new Error(`activation-classes.json unloadable: ${e.message}`)
+  }
+  if (!doc || !Array.isArray(doc.classes)) {
+    throw new Error('activation-classes.json unloadable: missing classes array')
+  }
+  return doc
+}
+
+/**
+ * Discriminate the trigger kind EXPLICITLY from the value prefix (REQ-12: the
+ * index carries trigger_kind; kind is never inferred downstream from value syntax).
+ * @param {string} value
+ * @returns {"phrase"|"tool"|"activity"}
+ */
+export function parseTriggerKind(value) {
+  if (typeof value === 'string' && value.startsWith('tool:')) return 'tool'
+  if (typeof value === 'string' && value.startsWith('activity:')) return 'activity'
+  return 'phrase'
+}
+
+/**
+ * Serialize an inline-array field as UNQUOTED comma-joined items (REQ-2, I4).
+ * THROWS naming the field-breaking character when an item would corrupt the
+ * round-trip — a backstop behind validateActivation's state B, which rejects
+ * the same class at the write surface with a JSON error.
+ * @param {string[]} items
+ * @returns {string} e.g. "a, b, c" (caller wraps in [ ])
+ */
+export function serializeInlineArray(items) {
+  const out = []
+  for (const item of items) {
+    const s = String(item).trim()
+    for (const c of ILLEGAL_ARRAY_CHARS) {
+      if (s.includes(c)) throw new Error(`inline-array item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(c)}`)
+    }
+    if (s) out.push(s)
+  }
+  return out.join(', ')
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+// The earned-band explanation (REQ-3) — fixture-asserted; keep the wording stable.
+export const EARNED_BAND_MESSAGE = '--priority must be an integer 1-7. The 8-9 critical band is EARNED from linked violations at trigger-index build time (RFC-009 R1/R2), never writer-declarable.'
+
+/**
+ * WRITE-path activation validation (§12 states A-G) — fail-closed.
+ *
+ * `fields` carries ONLY the values the caller actually received (present-only;
+ * an omitted flag is absent/undefined, never defaulted before this call). When
+ * no activation input is present at all the write is freeform: `{ok:true,
+ * fields:null}` and the caller stores exactly as today (EC15).
+ *
+ * On success with activation input, returns `{ok:true, fields}` where `fields`
+ * is the normalized present-only object with `priority` defaulted to 5 (REQ-3:
+ * the default is materialized into frontmatter/index whenever activation is in
+ * play, so the R2 build always has a stored priority to start from).
+ *
+ * @param {{triggers?:string[], applies_to_projects?:string[], applies_to_tools?:string[],
+ *          priority?:number|string, review_by?:string, evidence?:string[]}} fields
+ * @param {{category:string}} opts
+ * @returns {{ok:true, fields:object|null}|{ok:false, errors:Array<{field:string, reason:string, message:string}>}}
+ */
+export function validateActivation(fields, { category } = {}) {
+  const f = fields || {}
+  const arrays = {
+    triggers: Array.isArray(f.triggers) ? f.triggers : [],
+    applies_to_projects: Array.isArray(f.applies_to_projects) ? f.applies_to_projects : [],
+    applies_to_tools: Array.isArray(f.applies_to_tools) ? f.applies_to_tools : [],
+    evidence: Array.isArray(f.evidence) ? f.evidence : [],
+  }
+  const hasAny =
+    arrays.triggers.length > 0 ||
+    arrays.applies_to_projects.length > 0 ||
+    arrays.applies_to_tools.length > 0 ||
+    arrays.evidence.length > 0 ||
+    f.priority !== undefined ||
+    f.review_by !== undefined
+
+  if (!hasAny) return { ok: true, fields: null }
+
+  const errors = []
+
+  // State A — activation fields are lesson-only (REQ-1).
+  if (category !== 'lesson') {
+    const offending = []
+    if (arrays.triggers.length) offending.push('triggers')
+    if (arrays.applies_to_projects.length) offending.push('applies_to_projects')
+    if (arrays.applies_to_tools.length) offending.push('applies_to_tools')
+    if (arrays.evidence.length) offending.push('evidence')
+    if (f.priority !== undefined) offending.push('priority')
+    if (f.review_by !== undefined) offending.push('review_by')
+    for (const field of offending) {
+      errors.push({ field, reason: 'activation-fields-lesson-only', message: `"${field}" is an activation field, valid only with --category lesson (got "${category}")` })
+    }
+    return { ok: false, errors }
+  }
+
+  // State B — inline-array items must survive the unquoted round-trip (REQ-2).
+  for (const [field, items] of Object.entries(arrays)) {
+    for (const item of items) {
+      const s = String(item)
+      for (const c of ILLEGAL_ARRAY_CHARS) {
+        if (s.includes(c)) {
+          errors.push({ field, reason: `illegal-char:${c}`, message: `"${field}" item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(c)} — inline-array items may not contain , [ ] or "` })
+        }
+      }
+      if (!s.trim()) {
+        errors.push({ field, reason: 'empty-item', message: `"${field}" contains an empty item` })
+      }
+    }
+  }
+
+  // State C — priority is an integer 1-7; 8-9 is the EARNED band (REQ-3, P4/I1).
+  let priority = 5
+  if (f.priority !== undefined) {
+    const n = typeof f.priority === 'number' ? f.priority : Number(f.priority)
+    if (!Number.isInteger(n) || n < 1 || n > 7) {
+      errors.push({ field: 'priority', reason: 'earned-band', message: EARNED_BAND_MESSAGE })
+    } else {
+      priority = n
+    }
+  }
+
+  // State D — review_by is a real YYYY-MM-DD date (REQ-4).
+  if (f.review_by !== undefined) {
+    const s = String(f.review_by)
+    if (!DATE_RE.test(s) || Number.isNaN(Date.parse(`${s}T00:00:00Z`))) {
+      errors.push({ field: 'review_by', reason: 'bad-date', message: `--review-by "${s}" is not a valid date; accepted shape: YYYY-MM-DD` })
+    }
+  }
+
+  // State E — tool ids come from the fixed vocabulary (REQ-5).
+  for (const tool of arrays.applies_to_tools) {
+    if (!TOOL_IDS.includes(String(tool).trim())) {
+      errors.push({ field: 'applies_to_tools', reason: 'unknown-tool', message: `unknown tool id "${tool}"; the fixed vocabulary is: ${TOOL_IDS.join(', ')}` })
+    }
+  }
+
+  // State F — activity-class triggers name a known, non-deprecated class (REQ-17).
+  // LAZY vocab load (F4): only when an `activity:` trigger is present. An
+  // unloadable vocab at this point fails CLOSED (unknown class), like every
+  // other writer path.
+  const activityTriggers = arrays.triggers.filter(t => parseTriggerKind(String(t)) === 'activity')
+  if (activityTriggers.length > 0) {
+    let classes = null
+    try {
+      classes = loadActivationClasses().classes
+    } catch {
+      classes = null
+    }
+    for (const t of activityTriggers) {
+      const cls = String(t).slice('activity:'.length)
+      const member = classes ? classes.find(k => k && k.name === cls) : undefined
+      if (!member || member.deprecated_for) {
+        errors.push({ field: 'triggers', reason: 'unknown-activity-class', message: `activity class "${cls}" is ${member ? 'deprecated' : 'unknown'} in activation-classes.json; known classes: ${classes ? classes.filter(k => !k.deprecated_for).map(k => k.name).join(', ') : '(vocabulary unloadable)'}` })
+      }
+    }
+  }
+
+  if (errors.length) return { ok: false, errors }
+
+  // State G — normalized present-only output; priority is materialized (default 5).
+  const out = { priority }
+  if (arrays.triggers.length) out.triggers = arrays.triggers.map(t => String(t).trim())
+  if (arrays.applies_to_projects.length) out.applies_to_projects = arrays.applies_to_projects.map(t => String(t).trim())
+  if (arrays.applies_to_tools.length) out.applies_to_tools = arrays.applies_to_tools.map(t => String(t).trim())
+  if (arrays.evidence.length) out.evidence = arrays.evidence.map(t => String(t).trim())
+  if (f.review_by !== undefined) out.review_by = String(f.review_by)
+  return { ok: true, fields: out }
+}
+
+/**
+ * Read BOTH scopes' index.jsonl and concat into one row array (F1: em-store and
+ * em-violation have no index reader of their own; linkage resolution MUST be
+ * merged, never per-active-scope — a local lesson legitimately links a global
+ * violation and vice-versa). Malformed lines are skipped; a missing index file
+ * contributes zero rows. Local rows come first so a local row wins any
+ * first-match-by-id lookup, mirroring em-search's local precedence.
+ *
+ * @param {{localDir?:string, globalDir?:string}} [opts] test injection points;
+ *   defaults resolve the same way the em-* writers do.
+ * @returns {Array<object>}
+ */
+export function loadMergedIndex({ localDir, globalDir } = {}) {
+  const dirs = [
+    localDir !== undefined ? localDir : resolveLocalDir(),
+    globalDir !== undefined ? globalDir : path.join(os.homedir(), '.episodic-memory'),
+  ]
+  const rows = []
+  for (const dir of dirs) {
+    if (!dir) continue
+    let raw
+    try {
+      raw = fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8')
+    } catch {
+      continue
+    }
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue
+      try {
+        rows.push(JSON.parse(line))
+      } catch {}
+    }
+  }
+  return rows
+}
+
+/**
+ * WRITE-path linkage resolution (REQ-6/7, I2) — fail-closed and SYMMETRIC
+ * across both directions: `--evidence` requires each id to resolve to an
+ * existing `category: violation` row; `--lesson` to an existing
+ * `category: lesson` row. The caller passes the MERGED index rows
+ * (loadMergedIndex()); resolution is never per-active-scope (F1).
+ *
+ * @param {string[]} ids
+ * @param {{requireCategory:string, index:Array<object>}} opts
+ * @returns {{ok:boolean, missing:string[], wrongCategory:string[]}}
+ */
+export function resolveLinkage(ids, { requireCategory, index }) {
+  const byId = new Map()
+  for (const row of index) {
+    if (row && typeof row.id === 'string' && !byId.has(row.id)) byId.set(row.id, row)
+  }
+  const missing = []
+  const wrongCategory = []
+  for (const id of ids) {
+    const row = byId.get(id)
+    if (!row) missing.push(id)
+    else if (row.category !== requireCategory) wrongCategory.push(id)
+  }
+  return { ok: missing.length === 0 && wrongCategory.length === 0, missing, wrongCategory }
+}

--- a/scripts/lib/activation.mjs
+++ b/scripts/lib/activation.mjs
@@ -29,6 +29,23 @@ export const TOOL_IDS = ['claude-code', 'codex', 'opencode', 'pi-agent', 'cursor
 // round-trip through em-rebuild-index's generic frontmatter parser.
 export const ILLEGAL_ARRAY_CHARS = [',', '[', ']', '"']
 
+// Reviewer F1 (2026-07-08): the four structural chars are not the whole class —
+// a raw newline/CR (or any control char) in a serialized value FABRICATES
+// adjacent frontmatter keys (e.g. a forged `superseded_by:` line that the band's
+// chain resolver then walks). Every serialized activation value rejects control
+// chars too; returns the offending char (escaped name) or null.
+export function illegalValueChar(s) {
+  const str = String(s)
+  for (const c of ILLEGAL_ARRAY_CHARS) {
+    if (str.includes(c)) return c
+  }
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) return `\\x${code.toString(16).padStart(2, '0')}`
+  }
+  return null
+}
+
 // The activation frontmatter fields (R1). Arrays serialize as unquoted inline arrays;
 // scalars as plain values. `evidence` is the lesson→violation back-link; `lessons` is
 // the violation→lesson forward-link (REQ-6/7).
@@ -84,9 +101,8 @@ export function serializeInlineArray(items) {
   const out = []
   for (const item of items) {
     const s = String(item).trim()
-    for (const c of ILLEGAL_ARRAY_CHARS) {
-      if (s.includes(c)) throw new Error(`inline-array item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(c)}`)
-    }
+    const bad = illegalValueChar(s)
+    if (bad !== null) throw new Error(`inline-array item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(bad)}`)
     if (s) out.push(s)
   }
   return out.join(', ')
@@ -151,13 +167,14 @@ export function validateActivation(fields, { category } = {}) {
   }
 
   // State B — inline-array items must survive the unquoted round-trip (REQ-2).
+  // Reviewer F1: control chars (\n, \r, ...) are in the same class as the four
+  // structural chars — a newline fabricates adjacent frontmatter keys.
   for (const [field, items] of Object.entries(arrays)) {
     for (const item of items) {
       const s = String(item)
-      for (const c of ILLEGAL_ARRAY_CHARS) {
-        if (s.includes(c)) {
-          errors.push({ field, reason: `illegal-char:${c}`, message: `"${field}" item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(c)} — inline-array items may not contain , [ ] or "` })
-        }
+      const bad = illegalValueChar(s)
+      if (bad !== null) {
+        errors.push({ field, reason: `illegal-char:${bad}`, message: `"${field}" item ${JSON.stringify(s)} contains illegal character ${JSON.stringify(bad)} — inline-array items may not contain , [ ] " or control characters` })
       }
       if (!s.trim()) {
         errors.push({ field, reason: 'empty-item', message: `"${field}" contains an empty item` })
@@ -222,6 +239,39 @@ export function validateActivation(fields, { category } = {}) {
   if (arrays.evidence.length) out.evidence = arrays.evidence.map(t => String(t).trim())
   if (f.review_by !== undefined) out.review_by = String(f.review_by)
   return { ok: true, fields: out }
+}
+
+/**
+ * Parse the activation/linkage/T6 fields out of an episode file's frontmatter
+ * (reviewer F3: em-revise INHERITS these from the original unless overridden —
+ * tags already inherit, so silent activation loss on revision was an asymmetry).
+ * Mirrors em-rebuild-index's generic parser for the subset the writers emit.
+ * @param {string} content full episode .md content
+ * @returns {{triggers?:string[], applies_to_projects?:string[], applies_to_tools?:string[],
+ *            evidence?:string[], lessons?:string[], priority?:number, review_by?:string,
+ *            violated_pattern?:string}}
+ */
+export function parseActivationFromFrontmatter(content) {
+  const out = {}
+  const match = String(content).match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return out
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^(\w+):\s*(.*)$/)
+    if (!m) continue
+    const [, key, raw] = m
+    if (ACTIVATION_ARRAY_FIELDS.includes(key)) {
+      const arr = raw.match(/^\[(.*)\]$/)
+      if (arr) out[key] = arr[1].split(',').map(s => s.trim()).filter(Boolean)
+    } else if (key === 'priority') {
+      const n = Number(raw)
+      if (Number.isInteger(n)) out.priority = n
+    } else if (key === 'review_by') {
+      out.review_by = raw
+    } else if (key === 'violated_pattern') {
+      out.violated_pattern = raw
+    }
+  }
+  return out
 }
 
 /**

--- a/scripts/validate-rfc-009-contract-mirror.mjs
+++ b/scripts/validate-rfc-009-contract-mirror.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * validate-rfc-009-contract-mirror.mjs — CI gate for RFC-009 contract.json drift
+ * (P1b S8, REQ-19).
+ *
+ * A SIBLING of validate-rfc-contract-mirror.mjs (which is hardcoded to RFC-004
+ * — verified at plan time; this validator follows its pattern rather than
+ * editing it). Diffs `docs/rfcs/RFC-009-lesson-activation.contract.json`
+ * against the code + data surfaces it mirrors:
+ *
+ *   - activation_flags        ↔ string-match on the long-flag literals in
+ *                               em-store / em-revise / em-violation source
+ *   - activation_fields       ↔ ACTIVATION_ARRAY_FIELDS + ACTIVATION_SCALAR_FIELDS
+ *                               (+ the T6 `violated_pattern` scalar) in lib/activation.mjs
+ *   - tool_ids                ↔ TOOL_IDS in lib/activation.mjs
+ *   - activity_classes        ↔ activation-classes.json class names
+ *   - trigger_index_shape     ↔ em-trigger-index.mjs exported schema constants
+ *                               + parseTriggerKind's actual returns (functional)
+ *
+ * Exit 0 → contract matches code (silent ok in CI).
+ * Exit 1 → drift detected; structured report printed to stdout.
+ * Exit 2 → bad argv / can't find files.
+ *
+ * Usage: validate-rfc-009-contract-mirror.mjs [--repo <path>] [--contract <path>]
+ *   --contract overrides the contract file (tests plant drifted copies).
+ *
+ * Zero deps; Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
+const DEFAULT_REPO = path.resolve(SCRIPT_DIR, '..')
+
+function parseArgs(argv) {
+  const out = { repo: DEFAULT_REPO, contract: null }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--repo' && i + 1 < argv.length) {
+      out.repo = path.resolve(argv[++i])
+    } else if (argv[i] === '--contract' && i + 1 < argv.length) {
+      out.contract = path.resolve(argv[++i])
+    } else if (argv[i] === '--help' || argv[i] === '-h') {
+      process.stdout.write('usage: validate-rfc-009-contract-mirror.mjs [--repo <path>] [--contract <path>]\n')
+      process.exit(0)
+    } else {
+      process.stderr.write(`unknown argv: ${argv[i]}\n`)
+      process.exit(2)
+    }
+  }
+  return out
+}
+
+const args = parseArgs(process.argv.slice(2))
+const repoRoot = args.repo
+const CONTRACT_PATH = args.contract || path.join(repoRoot, 'docs', 'rfcs', 'RFC-009-lesson-activation.contract.json')
+
+const errors = []
+
+function loadJson(p, label) {
+  if (!fs.existsSync(p)) {
+    process.stderr.write(`error: ${label} not found at ${p}\n`)
+    process.exit(2)
+  }
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'))
+  } catch (e) {
+    process.stderr.write(`error: ${label} parse failed: ${e.message}\n`)
+    process.exit(2)
+  }
+}
+
+function setDiff(a, b) {
+  return [...a].filter(x => !b.includes(x))
+}
+function diffBoth(label, contractList, codeList) {
+  const notInCode = setDiff(contractList, codeList)
+  const notInContract = setDiff(codeList, contractList)
+  if (notInCode.length) errors.push(`${label}: contract has entries not in code/data: [${notInCode.join(', ')}]`)
+  if (notInContract.length) errors.push(`${label}: code/data has entries not in contract: [${notInContract.join(', ')}]`)
+}
+
+function checkActivationFlags(contract) {
+  // String-match on the long-flag literals (drift detection, not a type-check —
+  // the RFC-004 checkSubcommandContracts pattern).
+  for (const [script, flags] of Object.entries(contract.activation_flags ?? {})) {
+    const p = path.join(repoRoot, 'scripts', `${script}.mjs`)
+    if (!fs.existsSync(p)) {
+      errors.push(`activation-flags: script "${script}" not found at ${p}`)
+      continue
+    }
+    const src = fs.readFileSync(p, 'utf8')
+    for (const f of flags) {
+      if (!src.includes(`'${f}'`) && !src.includes(`"${f}"`)) {
+        errors.push(`activation-flags: ${script}.mjs missing flag literal "${f}"`)
+      }
+    }
+  }
+}
+
+async function main() {
+  const contract = loadJson(CONTRACT_PATH, 'contract.json')
+
+  const activationLib = await import(pathToFileURL(path.join(repoRoot, 'scripts', 'lib', 'activation.mjs')).href)
+  const triggerIndex = await import(pathToFileURL(path.join(repoRoot, 'scripts', 'em-trigger-index.mjs')).href)
+  const classesDoc = loadJson(path.join(repoRoot, 'activation-classes.json'), 'activation-classes.json')
+
+  checkActivationFlags(contract)
+
+  const codeFields = [...activationLib.ACTIVATION_ARRAY_FIELDS, ...activationLib.ACTIVATION_SCALAR_FIELDS, 'violated_pattern']
+  diffBoth('activation-fields', contract.activation_fields ?? [], codeFields)
+
+  diffBoth('tool-ids', contract.tool_ids ?? [], activationLib.TOOL_IDS)
+
+  diffBoth('activity-classes', contract.activity_classes ?? [], classesDoc.classes.map(c => c.name))
+
+  const shape = contract.trigger_index_shape ?? {}
+  if (shape.schema_version !== triggerIndex.TRIGGER_INDEX_SCHEMA_VERSION) {
+    errors.push(`trigger-index-shape: schema_version contract=${shape.schema_version} code=${triggerIndex.TRIGGER_INDEX_SCHEMA_VERSION}`)
+  }
+  diffBoth('trigger-index-entry-fields', shape.entry_fields ?? [], triggerIndex.TRIGGER_ENTRY_FIELDS)
+  diffBoth('trigger-kind-enum', shape.trigger_kind_enum ?? [], triggerIndex.TRIGGER_KIND_ENUM)
+  // Functional cross-check: the enum members are what parseTriggerKind actually returns.
+  const observed = [
+    activationLib.parseTriggerKind('plain phrase value'),
+    activationLib.parseTriggerKind('tool:Bash:git*'),
+    activationLib.parseTriggerKind('activity:plan'),
+  ]
+  for (const kind of observed) {
+    if (!(shape.trigger_kind_enum ?? []).includes(kind)) {
+      errors.push(`trigger-kind-enum: parseTriggerKind returns "${kind}" which the contract enum does not carry`)
+    }
+  }
+
+  if (errors.length > 0) {
+    process.stdout.write(JSON.stringify({
+      status: 'drift',
+      contract_path: CONTRACT_PATH,
+      error_count: errors.length,
+      errors,
+    }, null, 2) + '\n')
+    process.exit(1)
+  }
+  process.stdout.write(JSON.stringify({ status: 'ok', contract_path: CONTRACT_PATH }) + '\n')
+  process.exit(0)
+}
+
+main().catch(e => {
+  process.stderr.write(`internal error: ${e.stack || e.message}\n`)
+  process.exit(2)
+})

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -48,7 +48,7 @@ import { UsageError } from "./lib/path-contain.mjs";
 
 const SCAN_ROOTS = ["patterns", "plugins", "schemas"];
 const CORPUS_REL = "tests/fixtures/schema-negative-corpus.json";
-const MIN_SCHEMA_DOCS = 19; // P0 floor 17 + one post-P0 doc (18 pre-existing) + categories.schema.json (P1a) = 19
+const MIN_SCHEMA_DOCS = 21; // 20 pre-P1b (P0 floor 17 + post-P0 doc + categories.schema.json (P1a) + runbook-agent-manifest.schema.json) + activation-classes.schema.json (P1b) = 21
 const MIN_CORPUS_ENTRIES = 14; // #368 non-vacuity floor (the 14 P0 negatives)
 
 function isSchemaDocName(name) {

--- a/tests/test-activation-lib.mjs
+++ b/tests/test-activation-lib.mjs
@@ -1,0 +1,289 @@
+/**
+ * test-activation-lib.mjs — RFC-009 P1b S1: activation lib + activity-class vocab (Group 1, §14).
+ *
+ * REQ-2 (char reject), REQ-3 (priority band), REQ-4 (review_by), REQ-5 (tool vocab),
+ * REQ-16b (single validator home), REQ-17 (activity-class vocabulary, names-only).
+ *
+ * Every test asserts a captured return value / throw — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  TOOL_IDS,
+  ILLEGAL_ARRAY_CHARS,
+  EARNED_BAND_MESSAGE,
+  loadActivationClasses,
+  validateActivation,
+  parseTriggerKind,
+  serializeInlineArray,
+  resolveLinkage,
+} from '../scripts/lib/activation.mjs';
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function errReasons(r) { return (r.errors || []).map(e => e.reason); }
+function errFields(r) { return (r.errors || []).map(e => e.field); }
+
+// --- activity-class vocabulary (REQ-17) ---
+
+t('testActivationClassesValidates', () => {
+  const doc = JSON.parse(fs.readFileSync(path.join(REPO, 'activation-classes.json'), 'utf8'));
+  const schema = JSON.parse(fs.readFileSync(path.join(REPO, 'schemas/activation-classes.schema.json'), 'utf8'));
+  const res = validateInstance(doc, schema);
+  assert.equal(res.valid, true, `instance must validate: ${JSON.stringify(res.errors)}`);
+  assert.equal(doc.classes.length, 7, 'exactly the 7 launch classes');
+  const names = doc.classes.map(c => c.name).sort();
+  assert.deepEqual(names, ['design', 'implement', 'plan', 'push', 'review', 'rule', 'troubleshoot']);
+  for (const c of doc.classes) assert.deepEqual(c.phrases, [], `phrases EMPTY in P1b (F5c): ${c.name}`);
+});
+
+t('testActivationLibValidators', () => {
+  // state G — a fully valid activation set normalizes with default priority 5
+  const ok = validateActivation({ triggers: ['second opinion'], applies_to_projects: ['*'] }, { category: 'lesson' });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.fields.priority, 5, 'priority materialized to default 5');
+  assert.deepEqual(ok.fields.triggers, ['second opinion']);
+  // no activation input at all → freeform (fields null), any category fine
+  const freeform = validateActivation({}, { category: 'decision' });
+  assert.equal(freeform.ok, true);
+  assert.equal(freeform.fields, null);
+  // state A — activation on non-lesson rejected naming the field
+  const nonLesson = validateActivation({ triggers: ['x'] }, { category: 'decision' });
+  assert.equal(nonLesson.ok, false);
+  assert.ok(errReasons(nonLesson).includes('activation-fields-lesson-only'));
+  assert.ok(errFields(nonLesson).includes('triggers'));
+});
+
+// --- REQ-2 inline-array char rejection ---
+
+t('testTriggerRejectsComma', () => {
+  const r = validateActivation({ triggers: ['a, b'] }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  assert.ok(errReasons(r).includes('illegal-char:,'), JSON.stringify(r.errors));
+  assert.ok(errFields(r).includes('triggers'));
+});
+
+t('testTriggerRejectsBracket', () => {
+  const r1 = validateActivation({ triggers: ['a[b'] }, { category: 'lesson' });
+  assert.equal(r1.ok, false);
+  assert.ok(errReasons(r1).includes('illegal-char:['));
+  const r2 = validateActivation({ triggers: ['a]b'] }, { category: 'lesson' });
+  assert.equal(r2.ok, false);
+  assert.ok(errReasons(r2).includes('illegal-char:]'));
+});
+
+t('testTriggerRejectsQuote', () => {
+  const r = validateActivation({ triggers: ['a"b'] }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  assert.ok(errReasons(r).includes('illegal-char:"'));
+});
+
+t('testAppliesToRejectsBadChar', () => {
+  const r = validateActivation({ applies_to_projects: ['proj,2'] }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  assert.ok(errFields(r).includes('applies_to_projects'));
+  assert.ok(errReasons(r).includes('illegal-char:,'));
+});
+
+t('testSerializeInlineArrayThrowsOnIllegal', () => {
+  for (const c of ILLEGAL_ARRAY_CHARS) {
+    let threw = false;
+    try { serializeInlineArray([`x${c}y`]); } catch (e) { threw = true; assert.match(e.message, /illegal character/); }
+    assert.equal(threw, true, `must throw on ${JSON.stringify(c)}`);
+  }
+  assert.equal(serializeInlineArray([' a ', 'b']), 'a, b', 'trims + joins unquoted');
+});
+
+// --- REQ-3 priority ---
+
+t('testPriorityDefault5', () => {
+  const r = validateActivation({ triggers: ['x'] }, { category: 'lesson' });
+  assert.equal(r.ok, true);
+  assert.equal(r.fields.priority, 5);
+});
+
+t('testPriorityRejectsNonInt', () => {
+  const r = validateActivation({ priority: 3.5 }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  assert.ok(errReasons(r).includes('earned-band'));
+  const r2 = validateActivation({ priority: 'high' }, { category: 'lesson' });
+  assert.equal(r2.ok, false);
+});
+
+t('testPriorityRejects8Earned', () => {
+  const r = validateActivation({ priority: 8 }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  const err = r.errors.find(e => e.field === 'priority');
+  assert.equal(err.reason, 'earned-band');
+  assert.equal(err.message, EARNED_BAND_MESSAGE, 'the earned-band explanation string is stable');
+  assert.match(err.message, /8-9/);
+  assert.match(err.message, /EARNED/);
+  const r9 = validateActivation({ priority: 9 }, { category: 'lesson' });
+  assert.equal(r9.ok, false);
+});
+
+t('testPriorityRejectsOutOfRange', () => {
+  for (const p of [0, -1, 10]) {
+    const r = validateActivation({ priority: p }, { category: 'lesson' });
+    assert.equal(r.ok, false, `priority ${p} must reject`);
+    assert.ok(errReasons(r).includes('earned-band'));
+  }
+  for (const p of [1, 7]) {
+    const r = validateActivation({ priority: p }, { category: 'lesson' });
+    assert.equal(r.ok, true, `priority ${p} must accept`);
+    assert.equal(r.fields.priority, p);
+  }
+});
+
+// --- REQ-4 review_by ---
+
+t('testReviewByValidDate', () => {
+  const r = validateActivation({ review_by: '2027-01-31' }, { category: 'lesson' });
+  assert.equal(r.ok, true);
+  assert.equal(r.fields.review_by, '2027-01-31');
+});
+
+t('testReviewByRejectsMalformed', () => {
+  for (const bad of ['31-01-2027', '2027/01/31', '2027-13-99', 'soon', '2027-1-3']) {
+    const r = validateActivation({ review_by: bad }, { category: 'lesson' });
+    assert.equal(r.ok, false, `review_by ${bad} must reject`);
+    const err = r.errors.find(e => e.field === 'review_by');
+    assert.equal(err.reason, 'bad-date');
+    assert.match(err.message, /YYYY-MM-DD/, 'names the accepted shape');
+  }
+});
+
+// --- REQ-5 tool vocabulary ---
+
+t('testAppliesToToolRejectsUnknown', () => {
+  const r = validateActivation({ applies_to_tools: ['vim'] }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  const err = r.errors.find(e => e.field === 'applies_to_tools');
+  assert.equal(err.reason, 'unknown-tool');
+  for (const id of TOOL_IDS) assert.ok(err.message.includes(id), `message lists vocabulary member ${id}`);
+});
+
+t('testAppliesToToolAccepts', () => {
+  const r = validateActivation({ applies_to_tools: [...TOOL_IDS] }, { category: 'lesson' });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.fields.applies_to_tools, TOOL_IDS);
+});
+
+t('testAppliesToProjectWildcard', () => {
+  const r = validateActivation({ applies_to_projects: ['*', 'episodic-memory'] }, { category: 'lesson' });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.fields.applies_to_projects, ['*', 'episodic-memory']);
+});
+
+// --- REQ-17 activity-class triggers ---
+
+t('testActivityTriggerRejectsUnknownClass', () => {
+  const r = validateActivation({ triggers: ['activity:bogus'] }, { category: 'lesson' });
+  assert.equal(r.ok, false);
+  const err = r.errors.find(e => e.field === 'triggers');
+  assert.equal(err.reason, 'unknown-activity-class');
+  assert.match(err.message, /bogus/);
+  // every launch class accepted
+  const ok = validateActivation({ triggers: ['activity:plan', 'activity:review'] }, { category: 'lesson' });
+  assert.equal(ok.ok, true, JSON.stringify(ok));
+});
+
+t('testActivityTriggerRejectsDeprecatedClass', () => {
+  // plant a vocab where 'plan' is deprecated → reject (same class as unknown, state F)
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'actvocab-'));
+  const p = path.join(d, 'activation-classes.json');
+  fs.writeFileSync(p, JSON.stringify({
+    version: '1.0.0',
+    classes: [
+      { name: 'plan', description: 'd', phrases: [], deprecated_for: 'design' },
+      { name: 'design', description: 'd', phrases: [] },
+    ],
+  }));
+  const prev = process.env.EM_ACTIVATION_CLASSES_PATH;
+  process.env.EM_ACTIVATION_CLASSES_PATH = p;
+  try {
+    const r = validateActivation({ triggers: ['activity:plan'] }, { category: 'lesson' });
+    assert.equal(r.ok, false);
+    assert.equal(r.errors[0].reason, 'unknown-activity-class');
+    assert.match(r.errors[0].message, /deprecated/);
+    const ok = validateActivation({ triggers: ['activity:design'] }, { category: 'lesson' });
+    assert.equal(ok.ok, true);
+  } finally {
+    if (prev === undefined) delete process.env.EM_ACTIVATION_CLASSES_PATH;
+    else process.env.EM_ACTIVATION_CLASSES_PATH = prev;
+  }
+});
+
+t('testValidateActivationFailsClosedOnUnloadableVocab', () => {
+  // F4 write-side: activity trigger + unreachable vocab → rejected (fail closed)…
+  const prev = process.env.EM_ACTIVATION_CLASSES_PATH;
+  process.env.EM_ACTIVATION_CLASSES_PATH = '/nonexistent/activation-classes.json';
+  try {
+    const r = validateActivation({ triggers: ['activity:plan'] }, { category: 'lesson' });
+    assert.equal(r.ok, false);
+    assert.equal(r.errors[0].reason, 'unknown-activity-class');
+    // …but a phrase/tool-only write never touches the vocab (lazy load, F4)
+    const ok = validateActivation({ triggers: ['just a phrase', 'tool:Bash:git*'] }, { category: 'lesson' });
+    assert.equal(ok.ok, true, 'phrase/tool-only write must not depend on the vocab');
+  } finally {
+    if (prev === undefined) delete process.env.EM_ACTIVATION_CLASSES_PATH;
+    else process.env.EM_ACTIVATION_CLASSES_PATH = prev;
+  }
+});
+
+t('testLoadActivationClassesThrowsOnUnloadable', () => {
+  const prev = process.env.EM_ACTIVATION_CLASSES_PATH;
+  process.env.EM_ACTIVATION_CLASSES_PATH = '/nonexistent/activation-classes.json';
+  try {
+    let threw = false;
+    try { loadActivationClasses(); } catch (e) { threw = true; assert.match(e.message, /unloadable/); }
+    assert.equal(threw, true);
+  } finally {
+    if (prev === undefined) delete process.env.EM_ACTIVATION_CLASSES_PATH;
+    else process.env.EM_ACTIVATION_CLASSES_PATH = prev;
+  }
+});
+
+// --- parseTriggerKind (REQ-12 discriminator) ---
+
+t('testParseTriggerKind', () => {
+  assert.equal(parseTriggerKind('tool:Bash:git*'), 'tool');
+  assert.equal(parseTriggerKind('activity:plan'), 'activity');
+  assert.equal(parseTriggerKind('second opinion'), 'phrase');
+  assert.equal(parseTriggerKind('toolbox phrase'), 'phrase', 'prefix must be exact "tool:"');
+});
+
+// --- resolveLinkage (REQ-6/7 symmetric, pure-lib leg) ---
+
+t('testResolveLinkageSymmetric', () => {
+  const idx = [
+    { id: 'v1', category: 'violation' },
+    { id: 'l1', category: 'lesson' },
+  ];
+  assert.equal(resolveLinkage(['v1'], { requireCategory: 'violation', index: idx }).ok, true);
+  const wrong = resolveLinkage(['l1'], { requireCategory: 'violation', index: idx });
+  assert.equal(wrong.ok, false);
+  assert.deepEqual(wrong.wrongCategory, ['l1']);
+  const missing = resolveLinkage(['nope'], { requireCategory: 'lesson', index: idx });
+  assert.equal(missing.ok, false);
+  assert.deepEqual(missing.missing, ['nope']);
+  // symmetric: same shape both directions
+  assert.equal(resolveLinkage(['l1'], { requireCategory: 'lesson', index: idx }).ok, true);
+  assert.deepEqual(resolveLinkage(['v1'], { requireCategory: 'lesson', index: idx }).wrongCategory, ['v1']);
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -177,5 +177,54 @@ t('testReviseActivationFields', () => {
   assert.match(revMd, /^status: active$/m, 'rejected revise leaves the target active (no supersede mutation)');
 });
 
+// --- S3: REQ-6 evidence linkage ---
+
+function storeViolation(cwd, home, { scope = 'local' } = {}) {
+  const r = run(path.join(REPO, 'scripts/em-violation.mjs'),
+    ['--pattern', 'bp-001-implementation-workflow', '--summary', 'v', '--body', 'b', '--scope', scope], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+
+t('testEvidenceValidViolation', () => {
+  const { cwd, home } = mkStore();
+  const vid = storeViolation(cwd, home);
+  const r = run(EM_STORE, [...LESSON, '--evidence', vid], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const md = readEpisode(cwd, r.json.id);
+  assert.match(md, new RegExp(`^evidence: \\[${vid}\\]$`, 'm'));
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  assert.deepEqual(row.evidence, [vid]);
+});
+
+t('testEvidenceRejectsMissing', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--evidence', 'no-such-violation'], { cwd, home });
+  assert.equal(r.code, 1);
+  assert.match(r.json.message, /no-such-violation/);
+  assert.equal(episodeFiles(cwd).length, 0, 'no partial write');
+});
+
+t('testEvidenceRejectsNonViolation', () => {
+  const { cwd, home } = mkStore();
+  const other = run(EM_STORE, [...LESSON], { cwd, home });
+  assert.equal(other.code, 0);
+  const r = run(EM_STORE, [...LESSON, '--evidence', other.json.id], { cwd, home });
+  assert.equal(r.code, 1, 'EC4: lesson id as --evidence is wrong-category');
+  assert.match(r.json.message, /wrong-category/);
+  assert.equal(episodeFiles(cwd).length, 1, 'only the first lesson exists');
+});
+
+t('testEvidenceCrossScopeResolves', () => {
+  // F1: a LOCAL lesson may link a GLOBAL violation — resolution is MERGED, never per-active-scope.
+  const { cwd, home } = mkStore();
+  const globalVid = storeViolation(cwd, home, { scope: 'global' });
+  assert.ok(fs.existsSync(path.join(home, '.episodic-memory', 'episodes', `${globalVid}.md`)), 'violation landed in the fake-HOME global store');
+  const r = run(EM_STORE, [...LESSON, '--evidence', globalVid], { cwd, home });
+  assert.equal(r.code, 0, `cross-scope evidence must resolve: ${r.stdout}`);
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  assert.deepEqual(row.evidence, [globalVid]);
+});
+
 console.log(`\n${pass}/${pass + fail} pass`);
 process.exit(fail ? 1 : 0);

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -226,5 +226,75 @@ t('testEvidenceCrossScopeResolves', () => {
   assert.deepEqual(row.evidence, [globalVid]);
 });
 
+// --- S7: REQ-18 R9a collision report ---
+
+t('testFirstLessonNoSelfCollision', () => {
+  // CX5: the post-write lazy rebuild contains the just-written episode; without
+  // self-exclusion the FIRST trigger-bearing lesson would collide with itself.
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--trigger', 'second opinion'], { cwd, home });
+  assert.equal(r.code, 0);
+  assert.ok(!/collision:/.test(r.stderr), `first trigger-bearing lesson emits NO collision: ${r.stderr}`);
+});
+
+t('testCollisionReportOnSharedTrigger', () => {
+  const { cwd, home } = mkStore();
+  const a = run(EM_STORE, [...LESSON, '--trigger', 'second opinion'], { cwd, home });
+  assert.equal(a.code, 0);
+  const b = run(EM_STORE, [...LESSON, '--trigger', 'second opinion'], { cwd, home });
+  assert.equal(b.code, 0, 'the write ALWAYS proceeds');
+  assert.match(b.stderr, /collision: trigger "second opinion" also on /, 'collision line on STDERR');
+  assert.ok(b.stderr.includes(a.json.id), "names the EXISTING lesson's id");
+  assert.ok(!b.stderr.includes(b.json.id), 'never names the just-written episode (self-exclusion)');
+});
+
+t('testCollisionStdoutUnchanged', () => {
+  const { cwd, home } = mkStore();
+  run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
+  const b = run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
+  assert.equal(b.code, 0);
+  const parsed = JSON.parse(b.stdout.trim()); // stdout is EXACTLY the normal success JSON
+  assert.equal(parsed.status, 'ok');
+  assert.ok(parsed.id && parsed.file);
+  assert.ok(!/collision/.test(b.stdout), 'report never leaks into stdout');
+});
+
+t('testNoCollisionNoReport', () => {
+  const { cwd, home } = mkStore();
+  run(EM_STORE, [...LESSON, '--trigger', 'phrase one'], { cwd, home });
+  const b = run(EM_STORE, [...LESSON, '--trigger', 'phrase two'], { cwd, home });
+  assert.equal(b.code, 0);
+  assert.ok(!/collision:/.test(b.stderr), 'disjoint triggers -> no report');
+});
+
+t('testCollisionWriteProceeds', () => {
+  // EC13: the collision READ fails (index.jsonl write-only -> the lazy build
+  // cannot read it) -> NO report, write proceeds, exit unchanged, stdout normal.
+  const { cwd, home } = mkStore();
+  run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
+  const idxPath = path.join(storeDir(cwd), 'index.jsonl');
+  fs.chmodSync(idxPath, 0o200); // append still works; reads fail
+  try {
+    const b = run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
+    assert.equal(b.code, 0, `write proceeds when the collision read fails: ${b.stdout}`);
+    assert.equal(b.json.status, 'ok');
+    assert.ok(!/collision:/.test(b.stderr), 'unreadable index -> no report, never fatal');
+  } finally {
+    fs.chmodSync(idxPath, 0o644);
+  }
+});
+
+t('testReviseCollisionReport', () => {
+  const { cwd, home } = mkStore();
+  const a = run(EM_STORE, [...LESSON, '--trigger', 'revise phrase'], { cwd, home });
+  const b = run(EM_STORE, [...LESSON], { cwd, home });
+  const rev = run(EM_REVISE, ['--original', b.json.id, '--project', 't', '--summary', 'r', '--body', 'c',
+    '--scope', 'local', '--trigger', 'revise phrase'], { cwd, home });
+  assert.equal(rev.code, 0, 'revise write proceeds');
+  assert.match(rev.stderr, /collision: trigger "revise phrase" also on /);
+  assert.ok(rev.stderr.includes(a.json.id));
+  assert.ok(!rev.stderr.includes(rev.json.id), 'self-excluded on the revise path too');
+});
+
 console.log(`\n${pass}/${pass + fail} pass`);
 process.exit(fail ? 1 : 0);

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -150,6 +150,33 @@ t('testStoreRejectsControlCharInjection', () => {
   assert.equal(indexRows(cwd).length, 0, 'nothing to rebuild — store byte-unchanged');
 });
 
+t('testStoreRejectsForgeAcrossAllSerializedScalars', () => {
+  // Reviewer F1 round 2: the forge class spans EVERY serialized frontmatter
+  // value, not just activation fields — a freeform lesson (no --evidence flag)
+  // could inject `evidence: [<real-violation>]` via --summary/--project/--url/--tag
+  // and earn the band, bypassing the linkage gate. Parameterize over the class.
+  const victim = '20990101-000000-real-violation-0001';
+  const payload = `x\nevidence: [${victim}]\nsuperseded_by: ${victim}`;
+  const cases = [
+    { label: '--summary', args: ['--project', 't', '--category', 'lesson', '--summary', payload, '--body', 'b', '--scope', 'local'] },
+    { label: '--project', args: ['--project', payload, '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'] },
+    { label: '--url', args: [...LESSON, '--url', payload] },
+    { label: '--tags', args: ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local', '--tags', payload] },
+    { label: '--tag', args: ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local', '--tag', payload] },
+  ];
+  for (const c of cases) {
+    const { cwd, home } = mkStore();
+    const r = run(EM_STORE, c.args, { cwd, home });
+    assert.equal(r.code, 1, `${c.label} newline payload rejected`);
+    assert.match(r.json.message, /illegal/, `${c.label} names the illegal char`);
+    assert.equal(episodeFiles(cwd).length, 0, `${c.label}: no partial write`);
+    // even after a rebuild attempt, nothing forged reached an index row
+    run(path.join(REPO, 'scripts/em-rebuild-index.mjs'), ['--scope', 'local'], { cwd, home });
+    const rows = indexRows(cwd);
+    assert.equal(rows.length, 0, `${c.label}: store byte-unchanged, no forged row`);
+  }
+});
+
 t('testStoreRejectsCommaTrigger', () => {
   const { cwd, home } = mkStore();
   const r = run(EM_STORE, [...LESSON, '--trigger', 'a, b'], { cwd, home });

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -177,6 +177,29 @@ t('testStoreRejectsForgeAcrossAllSerializedScalars', () => {
   }
 });
 
+t('testReviseRejectsForgeAcrossSerializedScalars', () => {
+  // Reviewer round-3 NIT: cover the em-revise I4 surface too, so a future
+  // refactor of the pre-supersede guard block cannot silently regress it.
+  const victim = '20990101-000000-real-violation-0001';
+  const payload = `x\nevidence: [${victim}]`;
+  for (const label of ['--summary', '--project', '--tags', '--tag']) {
+    const { cwd, home } = mkStore();
+    const s = run(EM_STORE, [...LESSON], { cwd, home });
+    assert.equal(s.code, 0);
+    const base = ['--original', s.json.id, '--project', 't', '--summary', 'r', '--body', 'c', '--scope', 'local'];
+    const args = label === '--summary' ? ['--original', s.json.id, '--project', 't', '--summary', payload, '--body', 'c', '--scope', 'local']
+      : label === '--project' ? ['--original', s.json.id, '--project', payload, '--summary', 'r', '--body', 'c', '--scope', 'local']
+        : [...base, label, payload];
+    const r = run(EM_REVISE, args, { cwd, home });
+    assert.equal(r.code, 1, `revise ${label} newline rejected`);
+    assert.match(r.json.message, /illegal/);
+    // I4: the original stays active, no revision written
+    const md = readEpisode(cwd, s.json.id);
+    assert.match(md, /^status: active$/m, `${label}: original untouched (pre-supersede guard)`);
+    assert.equal(episodeFiles(cwd).length, 1, `${label}: no revision episode`);
+  }
+});
+
 t('testStoreRejectsCommaTrigger', () => {
   const { cwd, home } = mkStore();
   const r = run(EM_STORE, [...LESSON, '--trigger', 'a, b'], { cwd, home });

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -1,0 +1,181 @@
+/**
+ * test-activation-write.mjs — RFC-009 P1b S2/S3/S7: R1 write flags + linkage + R9a (Group 2, §14).
+ *
+ * S2: REQ-1 (lesson-only flags), REQ-2 (round-trip), REQ-3/4/5 via the CLI, EC1/EC15.
+ * S3: REQ-6 evidence linkage (merged-scope resolution, F1).
+ * S7: REQ-18 R9a collision report (stderr-only, write always proceeds, self-exclusion).
+ *
+ * Every test asserts captured stdout JSON + on-disk contents — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_REVISE = path.join(REPO, 'scripts/em-revise.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// Fresh non-git dir → resolveLocalDir() lands at <dir>/.episodic-memory. A fake
+// HOME isolates the GLOBAL store too (loadMergedIndex reads ~/.episodic-memory).
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'actwrite-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return { cwd: d, home };
+}
+function storeDir(cwd) { return path.join(cwd, '.episodic-memory'); }
+
+function run(script, args, { cwd, home, env } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, ...(home ? { HOME: home, USERPROFILE: home } : {}), ...env },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); }
+  catch { try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {} }
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+
+function episodeFiles(cwd) {
+  try { return fs.readdirSync(path.join(storeDir(cwd), 'episodes')).filter((f) => f.endsWith('.md')); }
+  catch { return []; }
+}
+function readEpisode(cwd, id) {
+  return fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${id}.md`), 'utf8');
+}
+function indexRows(cwd) {
+  try {
+    return fs.readFileSync(path.join(storeDir(cwd), 'index.jsonl'), 'utf8')
+      .trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch { return []; }
+}
+const LESSON = ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'];
+
+// --- S2: R1 write flags ---
+
+t('testStoreActivationFieldsWritten', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON,
+    '--trigger', 'second opinion', '--trigger', 'tool:Bash:git*', '--trigger', 'activity:plan',
+    '--applies-to-project', '*', '--applies-to-tool', 'claude-code',
+    '--priority', '3', '--review-by', '2027-01-01'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const md = readEpisode(cwd, r.json.id);
+  assert.match(md, /^triggers: \[second opinion, tool:Bash:git\*, activity:plan\]$/m, 'unquoted inline array');
+  assert.match(md, /^applies_to_projects: \[\*\]$/m);
+  assert.match(md, /^applies_to_tools: \[claude-code\]$/m);
+  assert.match(md, /^priority: 3$/m);
+  assert.match(md, /^review_by: 2027-01-01$/m);
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  assert.deepEqual(row.triggers, ['second opinion', 'tool:Bash:git*', 'activity:plan']);
+  assert.deepEqual(row.applies_to_projects, ['*']);
+  assert.deepEqual(row.applies_to_tools, ['claude-code']);
+  assert.equal(row.priority, 3);
+  assert.equal(row.review_by, '2027-01-01');
+});
+
+t('testActivationFlagsRejectedNonLesson', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'decision', '--trigger', 'x',
+    '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 1);
+  assert.equal(r.json.status, 'error');
+  assert.equal(r.json.errors[0].reason, 'activation-fields-lesson-only');
+  assert.equal(r.json.errors[0].field, 'triggers', 'names the field');
+  assert.equal(episodeFiles(cwd).length, 0, 'EC1: no partial write');
+});
+
+t('testFreeformLessonUnchanged', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON], { cwd, home });
+  assert.equal(r.code, 0);
+  const md = readEpisode(cwd, r.json.id);
+  for (const key of ['triggers', 'applies_to_projects', 'applies_to_tools', 'priority', 'review_by', 'evidence']) {
+    assert.ok(!new RegExp(`^${key}:`, 'm').test(md), `EC15: freeform lesson has no ${key} line`);
+  }
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  for (const key of ['triggers', 'applies_to_projects', 'applies_to_tools', 'priority', 'review_by', 'evidence']) {
+    assert.ok(!(key in row), `EC15: freeform index row has no ${key}`);
+  }
+  // non-lesson freeform still writes (the activation guard fires on activation INPUT only)
+  const r2 = run(EM_STORE, ['--project', 't', '--category', 'decision', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r2.code, 0, 'freeform non-lesson store unaffected');
+});
+
+t('testUnquotedRoundTrip', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--trigger', 'plan review gate', '--applies-to-project', 'episodic-memory'], { cwd, home });
+  assert.equal(r.code, 0);
+  const storedRow = indexRows(cwd).find((e) => e.id === r.json.id);
+  // rebuild from the .md and compare field values (REQ-9 parity, store-side leg)
+  const rb = run(path.join(REPO, 'scripts/em-rebuild-index.mjs'), ['--scope', 'local'], { cwd, home });
+  assert.equal(rb.code, 0);
+  const rebuiltRow = indexRows(cwd).find((e) => e.id === r.json.id);
+  assert.deepEqual(rebuiltRow.triggers, storedRow.triggers, 'triggers survive rebuild byte-equal');
+  assert.deepEqual(rebuiltRow.applies_to_projects, storedRow.applies_to_projects);
+  assert.equal(rebuiltRow.priority, storedRow.priority);
+});
+
+t('testStoreRejectsCommaTrigger', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--trigger', 'a, b'], { cwd, home });
+  assert.equal(r.code, 1);
+  assert.equal(r.json.errors[0].reason, 'illegal-char:,');
+  assert.equal(episodeFiles(cwd).length, 0, 'EC3: rejected write leaves store byte-unchanged');
+});
+
+t('testStoreRejectsPriority8ViaCli', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--priority', '8'], { cwd, home });
+  assert.equal(r.code, 1);
+  assert.equal(r.json.errors[0].reason, 'earned-band');
+  assert.match(r.json.message, /EARNED/, 'EC2: explains the earned band');
+  assert.equal(episodeFiles(cwd).length, 0);
+});
+
+t('testStoreRejectsBadDateAndUnknownToolViaCli', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, [...LESSON, '--review-by', 'someday'], { cwd, home });
+  assert.equal(r.code, 1);
+  assert.equal(r.json.errors[0].reason, 'bad-date');
+  const r2 = run(EM_STORE, [...LESSON, '--applies-to-tool', 'emacs'], { cwd, home });
+  assert.equal(r2.code, 1);
+  assert.equal(r2.json.errors[0].reason, 'unknown-tool');
+  assert.equal(episodeFiles(cwd).length, 0);
+});
+
+t('testReviseActivationFields', () => {
+  const { cwd, home } = mkStore();
+  const s = run(EM_STORE, [...LESSON], { cwd, home });
+  assert.equal(s.code, 0);
+  const rev = run(EM_REVISE, ['--original', s.json.id, '--project', 't', '--summary', 'r', '--body', 'c',
+    '--scope', 'local', '--trigger', 'activity:plan'], { cwd, home });
+  assert.equal(rev.code, 0, rev.stdout);
+  const md = readEpisode(cwd, rev.json.id);
+  assert.match(md, /^triggers: \[activity:plan\]$/m);
+  assert.match(md, /^priority: 5$/m, 'priority materialized to default 5');
+  const row = indexRows(cwd).find((e) => e.id === rev.json.id);
+  assert.deepEqual(row.triggers, ['activity:plan']);
+  assert.equal(row.priority, 5);
+  // revise-side rejection: priority 9 → no write, original chain intact
+  const bad = run(EM_REVISE, ['--original', rev.json.id, '--project', 't', '--summary', 'r2', '--body', 'c',
+    '--scope', 'local', '--priority', '9'], { cwd, home });
+  assert.equal(bad.code, 1);
+  assert.equal(bad.json.errors[0].reason, 'earned-band');
+  const revMd = readEpisode(cwd, rev.json.id);
+  assert.match(revMd, /^status: active$/m, 'rejected revise leaves the target active (no supersede mutation)');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -127,6 +127,29 @@ t('testUnquotedRoundTrip', () => {
   assert.equal(rebuiltRow.priority, storedRow.priority);
 });
 
+t('testStoreRejectsControlCharInjection', () => {
+  // Reviewer F1: a raw newline in ANY serialized value fabricates adjacent
+  // frontmatter keys (a forged superseded_by is chain/band forgery). The whole
+  // control-char class rejects BEFORE any write, on every serialized surface.
+  const { cwd, home } = mkStore();
+  const victim = '20990101-000000-victim-lesson-0001';
+  const r = run(EM_STORE, [...LESSON, '--trigger', `atk\nsuperseded_by: ${victim}\nx`], { cwd, home });
+  assert.equal(r.code, 1, 'newline trigger rejected');
+  assert.equal(r.json.errors[0].reason, 'illegal-char:\\x0a');
+  assert.equal(episodeFiles(cwd).length, 0, 'no partial write');
+  const r2 = run(EM_STORE, ['--project', 't', '--category', 'violation',
+    '--violated-pattern', `x\ntriggers: [forged]\npriority: 9`,
+    '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r2.code, 1, 'newline in --violated-pattern rejected (passthrough scalar is the same class)');
+  assert.match(r2.json.message, /illegal character/);
+  assert.equal(episodeFiles(cwd).length, 0);
+  const r3 = run(EM_STORE, [...LESSON, '--trigger', 'cr\rattack'], { cwd, home });
+  assert.equal(r3.code, 1, 'CR rejected too');
+  // rebuild proves no forged keys ever reached an index row
+  run(path.join(REPO, 'scripts/em-rebuild-index.mjs'), ['--scope', 'local'], { cwd, home });
+  assert.equal(indexRows(cwd).length, 0, 'nothing to rebuild — store byte-unchanged');
+});
+
 t('testStoreRejectsCommaTrigger', () => {
   const { cwd, home } = mkStore();
   const r = run(EM_STORE, [...LESSON, '--trigger', 'a, b'], { cwd, home });
@@ -175,6 +198,30 @@ t('testReviseActivationFields', () => {
   assert.equal(bad.json.errors[0].reason, 'earned-band');
   const revMd = readEpisode(cwd, rev.json.id);
   assert.match(revMd, /^status: active$/m, 'rejected revise leaves the target active (no supersede mutation)');
+});
+
+t('testReviseInheritsActivation', () => {
+  // Reviewer F3: a typo-revision must not demote a lesson to freeform — tags
+  // inherit, so activation inherits too; a passed flag OVERRIDES per field.
+  const { cwd, home } = mkStore();
+  const s = run(EM_STORE, [...LESSON, '--trigger', 'keep me', '--applies-to-tool', 'codex',
+    '--priority', '3', '--review-by', '2099-01-01'], { cwd, home });
+  assert.equal(s.code, 0);
+  const rev = run(EM_REVISE, ['--original', s.json.id, '--project', 't', '--summary', 'typo fix', '--body', 'c', '--scope', 'local'], { cwd, home });
+  assert.equal(rev.code, 0, rev.stdout);
+  const md = readEpisode(cwd, rev.json.id);
+  assert.match(md, /^triggers: \[keep me\]$/m, 'triggers inherited');
+  assert.match(md, /^applies_to_tools: \[codex\]$/m, 'scoping inherited');
+  assert.match(md, /^priority: 3$/m, 'declared priority inherited');
+  assert.match(md, /^review_by: 2099-01-01$/m, 'expiry inherited');
+  // per-field override: new trigger replaces, priority stays inherited
+  const rev2 = run(EM_REVISE, ['--original', rev.json.id, '--project', 't', '--summary', 'retarget', '--body', 'c',
+    '--scope', 'local', '--trigger', 'new phrase'], { cwd, home });
+  assert.equal(rev2.code, 0);
+  const md2 = readEpisode(cwd, rev2.json.id);
+  assert.match(md2, /^triggers: \[new phrase\]$/m, 'passed flag overrides the field');
+  assert.ok(!/keep me/.test(md2), 'override replaces, not merges');
+  assert.match(md2, /^priority: 3$/m, 'unpassed fields keep inheriting');
 });
 
 // --- S3: REQ-6 evidence linkage ---

--- a/tests/test-contract-mirror-009.mjs
+++ b/tests/test-contract-mirror-009.mjs
@@ -1,0 +1,86 @@
+/**
+ * test-contract-mirror-009.mjs — RFC-009 P1b S8: contract mirror (Group 7, §14).
+ *
+ * REQ-19: the shipped contract matches code (exit 0) AND a planted drift is
+ * DETECTED (exit 1 naming it) — a validator never observed failing guards nothing.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const VALIDATOR = path.join(REPO, 'scripts/validate-rfc-009-contract-mirror.mjs');
+const CONTRACT = path.join(REPO, 'docs/rfcs/RFC-009-lesson-activation.contract.json');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function run(args) {
+  const r = spawnSync('node', [VALIDATOR, ...args], { encoding: 'utf8' });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+
+t('testContractMirrorMatchesCode', () => {
+  const r = run([]);
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  assert.equal(r.json.status, 'ok');
+});
+
+t('testContractMirrorDetectsDrift', () => {
+  const doc = JSON.parse(fs.readFileSync(CONTRACT, 'utf8'));
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'ctr009-'));
+
+  // (a) bogus flag on em-store
+  const withFlag = structuredClone(doc);
+  withFlag.activation_flags['em-store'].push('--bogus-flag');
+  const p1 = path.join(d, 'flag.json');
+  fs.writeFileSync(p1, JSON.stringify(withFlag));
+  const r1 = run(['--contract', p1]);
+  assert.equal(r1.code, 1, 'drift exits 1');
+  assert.ok(r1.json.errors.some((e) => e.includes('--bogus-flag')), `names the bogus flag: ${r1.stdout}`);
+
+  // (b) missing activity class
+  const withoutClass = structuredClone(doc);
+  withoutClass.activity_classes = withoutClass.activity_classes.filter((c) => c !== 'plan');
+  const p2 = path.join(d, 'class.json');
+  fs.writeFileSync(p2, JSON.stringify(withoutClass));
+  const r2 = run(['--contract', p2]);
+  assert.equal(r2.code, 1);
+  assert.ok(r2.json.errors.some((e) => e.includes('plan')), 'names the missing class');
+
+  // (c) wrong trigger-kind enum
+  const withKind = structuredClone(doc);
+  withKind.trigger_index_shape.trigger_kind_enum = ['phrase', 'tool'];
+  const p3 = path.join(d, 'kind.json');
+  fs.writeFileSync(p3, JSON.stringify(withKind));
+  const r3 = run(['--contract', p3]);
+  assert.equal(r3.code, 1);
+  assert.ok(r3.json.errors.some((e) => e.includes('activity')), 'functional parseTriggerKind cross-check fires');
+
+  // (d) dropped field
+  const withoutField = structuredClone(doc);
+  withoutField.activation_fields = withoutField.activation_fields.filter((f) => f !== 'violated_pattern');
+  const p4 = path.join(d, 'field.json');
+  fs.writeFileSync(p4, JSON.stringify(withoutField));
+  const r4 = run(['--contract', p4]);
+  assert.equal(r4.code, 1);
+  assert.ok(r4.json.errors.some((e) => e.includes('violated_pattern')), 'names the dropped field');
+});
+
+t('testContractMirrorBadArgvExits2', () => {
+  const r = run(['--nonsense']);
+  assert.equal(r.code, 2, 'bad argv is exit 2, never a fake drift');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-em-help-flags.mjs
+++ b/tests/test-em-help-flags.mjs
@@ -149,7 +149,8 @@ const SUBSTRATE = [
   'em-lock.mjs', 'em-mine-transcripts.mjs', 'em-pattern-health.mjs', 'em-prune.mjs',
   'em-rebuild-index.mjs', 'em-recall.mjs', 'em-restore.mjs', 'em-review-request.mjs',
   'em-revise.mjs', 'em-rfc-validate.mjs', 'em-search.mjs', 'em-seed-patterns.mjs',
-  'em-store.mjs', 'em-violation.mjs', 'em-watch-codex.mjs', 'em-workflow-validate.mjs',
+  'em-store.mjs', 'em-trigger-index.mjs', 'em-violation.mjs', 'em-watch-codex.mjs',
+  'em-workflow-validate.mjs',
   'second-opinion.mjs',
 ]
 

--- a/tests/test-install-activation.mjs
+++ b/tests/test-install-activation.mjs
@@ -1,0 +1,114 @@
+/**
+ * test-install-activation.mjs — RFC-009 P1b S9: global deploy of activation-classes.json
+ * (REQ-20) + docs grep gate (REQ-21). Mock-project isolated-HOME E2E with the REAL
+ * install.mjs — never mental-trace (mirrors test-install-categories.mjs).
+ *
+ * The strong claim is not "the file was copied" but "the DEPLOYED em-store resolves the
+ * DEPLOYED activity-class vocab": testInstallDeployedStoreLoadsClassVocab RUNS the deployed
+ * script with an unknown `activity:` trigger and asserts the unknown-class rejection.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// --- one real install into an isolated HOME ---
+const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'actinstall-home-')));
+const proj = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'actinstall-proj-')));
+const install = spawnSync('node', [path.join(REPO, 'install.mjs'), '--tool', 'claude-code', '--project', proj], {
+  env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8',
+});
+
+const emHome = path.join(home, '.episodic-memory');
+
+function findFile(root, name) {
+  const hits = [];
+  const walk = (d) => {
+    let ents = [];
+    try { ents = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of ents) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.name === name) hits.push(full);
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+t('installSucceeded', () => {
+  assert.equal(install.status, 0, `install.mjs must succeed; stderr: ${install.stderr}`);
+});
+
+t('testInstallDeploysActivationClasses', () => {
+  assert.ok(fs.existsSync(path.join(emHome, 'activation-classes.json')), 'activation-classes.json deployed to ~/.episodic-memory/');
+  const doc = JSON.parse(fs.readFileSync(path.join(emHome, 'activation-classes.json'), 'utf8'));
+  assert.equal(doc.classes.length, 7, 'the 7 launch classes deployed');
+});
+
+t('testActivationClassesNotInClaudeHome', () => {
+  const claudeHome = path.join(home, '.claude');
+  const hits = fs.existsSync(claudeHome) ? findFile(claudeHome, 'activation-classes.json') : [];
+  assert.deepEqual(hits, [], `activation-classes.json must NOT be under ~/.claude/ (P12); found: ${hits.join(', ')}`);
+});
+
+t('testInstallDeployedStoreLoadsClassVocab', () => {
+  // Run the DEPLOYED em-store (not the repo copy) with an unknown activity class,
+  // EM_ACTIVATION_CLASSES_PATH unset — it must resolve ../../activation-classes.json
+  // from the deployed tree and reject the unknown class (fail-closed write).
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  delete env.EM_ACTIVATION_CLASSES_PATH;
+  const deployedStore = path.join(emHome, 'scripts', 'em-store.mjs');
+  assert.ok(fs.existsSync(deployedStore), 'deployed em-store.mjs present');
+  const r = spawnSync('node', [deployedStore, '--project', 't', '--category', 'lesson',
+    '--trigger', 'activity:bogus', '--summary', 's', '--body', 'b', '--scope', 'global'], {
+    cwd: proj, env, encoding: 'utf8',
+  });
+  assert.notEqual(r.status, 0, `deployed store must reject the unknown class; stdout: ${r.stdout}`);
+  let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+  assert.ok(json && json.errors && json.errors[0].reason === 'unknown-activity-class', `unknown-activity-class expected; got: ${r.stdout}`);
+  assert.match(json.errors[0].message, /plan/, 'the message lists the DEPLOYED class vocabulary');
+  // positive control: a KNOWN class stores clean against the deployed vocab
+  const ok = spawnSync('node', [deployedStore, '--project', 't', '--category', 'lesson',
+    '--trigger', 'activity:plan', '--summary', 's', '--body', 'b', '--scope', 'global'], {
+    cwd: proj, env, encoding: 'utf8',
+  });
+  assert.equal(ok.status, 0, `known class must store: ${ok.stdout} ${ok.stderr}`);
+});
+
+t('testDeployedTriggerIndexBuilds', () => {
+  // the deployed em-trigger-index builds against the global store just written above
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  const deployed = path.join(emHome, 'scripts', 'em-trigger-index.mjs');
+  assert.ok(fs.existsSync(deployed), 'deployed em-trigger-index.mjs present');
+  const r = spawnSync('node', [deployed, '--scope', 'global'], { cwd: proj, env, encoding: 'utf8' });
+  assert.equal(r.status, 0, `${r.stdout} ${r.stderr}`);
+  const ti = JSON.parse(fs.readFileSync(path.join(emHome, 'trigger-index.json'), 'utf8'));
+  assert.equal(ti.entries.length, 1, 'the activity:plan lesson indexed by the DEPLOYED builder');
+});
+
+t('testDocsGrepGate', () => {
+  const guide = fs.readFileSync(path.join(REPO, 'docs/EM_SCRIPTS_GUIDE.md'), 'utf8');
+  for (const needle of ['trigger-index.json', 'violated_pattern', 'activation-classes.json', 'em-trigger-index', '--evidence', '--lesson', 'effective_priority']) {
+    assert.ok(guide.includes(needle), `EM_SCRIPTS_GUIDE.md must document ${needle}`);
+  }
+  const readme = fs.readFileSync(path.join(REPO, 'README.md'), 'utf8');
+  for (const needle of ['em-trigger-index', 'activation-classes.json']) {
+    assert.ok(readme.includes(needle), `README.md must reference ${needle}`);
+  }
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-t6-migration.mjs
+++ b/tests/test-t6-migration.mjs
@@ -1,0 +1,258 @@
+/**
+ * test-t6-migration.mjs — RFC-009 P1b S4: index carry + T6 read retarget + T2 grep (Group 4, §14).
+ *
+ * REQ-9 (rebuild carries all new fields), REQ-10 (dual-read at both read sites),
+ * REQ-11 (T2 construction-site grep gate, non-vacuous).
+ *
+ * Every test asserts captured output / on-disk contents — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+const EM_RECALL = path.join(REPO, 'scripts/em-recall.mjs');
+const EM_HEALTH = path.join(REPO, 'scripts/em-pattern-health.mjs');
+
+const PATTERN = 'bp-001-implementation-workflow';
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 't6mig-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  // patterns/_index.json so the preflight/pattern-health pattern set resolves in the fixture
+  const pdir = path.join(d, 'patterns');
+  fs.mkdirSync(pdir, { recursive: true });
+  fs.writeFileSync(path.join(pdir, '_index.json'), JSON.stringify({
+    patterns: [
+      { pattern_id: PATTERN, name: 'impl workflow' },
+      { pattern_id: 'bp-006-push-after-verify', name: 'push after verify' },
+      { pattern_id: 'bp-010-habits-override-knowledge', name: 'habits' },
+    ],
+  }));
+  return { cwd: d, home };
+}
+function storeDir(cwd) { return path.join(cwd, '.episodic-memory'); }
+
+function run(script, args, { cwd, home } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, ...(home ? { HOME: home, USERPROFILE: home } : {}) },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); }
+  catch { try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {} }
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+function indexRows(cwd) {
+  try {
+    return fs.readFileSync(path.join(storeDir(cwd), 'index.jsonl'), 'utf8')
+      .trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch { return []; }
+}
+function readIndexBytes(cwd) {
+  return fs.readFileSync(path.join(storeDir(cwd), 'index.jsonl'), 'utf8');
+}
+// Typed-only violation: em-store direct write with --violated-pattern and NO violated: tag.
+function storeTypedOnlyViolation(cwd, home) {
+  const r = run(EM_STORE, ['--project', 't', '--category', 'violation', '--violated-pattern', PATTERN,
+    '--summary', 'typed-only', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+// Legacy-tag-only violation: pre-migration shape (tag, no typed field).
+function storeTagOnlyViolation(cwd, home) {
+  const r = run(EM_STORE, ['--project', 't', '--category', 'violation', '--tags', `violated:${PATTERN}`,
+    '--summary', 'tag-only', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+
+// --- REQ-9: rebuild carry ---
+
+t('testRebuildCarriesActivationFields', () => {
+  const { cwd, home } = mkStore();
+  // plant a lesson .md with ALL activation fields, bypass the writers (rebuild reads files)
+  const epDir = path.join(storeDir(cwd), 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  const id = '20260708-000000-planted-lesson-0001';
+  fs.writeFileSync(path.join(epDir, `${id}.md`), [
+    '---', `id: ${id}`, 'date: 2026-07-08', 'time: "00:00"', 'project: t', 'category: lesson',
+    'status: active', 'tags: []', 'summary: planted',
+    'triggers: [second opinion, tool:Bash:git*, activity:plan]',
+    'applies_to_projects: [*]',
+    'applies_to_tools: [claude-code, codex]',
+    'evidence: [20260101-000000-v-0001]',
+    'priority: 4',
+    'review_by: 2027-06-30',
+    '---', '', '# planted', '', 'b', '',
+  ].join('\n'));
+  const vid = '20260708-000001-planted-violation-0001';
+  fs.writeFileSync(path.join(epDir, `${vid}.md`), [
+    '---', `id: ${vid}`, 'date: 2026-07-08', 'time: "00:00"', 'project: t', 'category: violation',
+    'status: active', 'tags: []', 'summary: planted v',
+    `lessons: [${id}]`,
+    `violated_pattern: ${PATTERN}`,
+    '---', '', '# planted v', '', 'b', '',
+  ].join('\n'));
+  const rb = run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  assert.equal(rb.code, 0, rb.stdout);
+  const row = indexRows(cwd).find((e) => e.id === id);
+  assert.deepEqual(row.triggers, ['second opinion', 'tool:Bash:git*', 'activity:plan']);
+  assert.deepEqual(row.applies_to_projects, ['*']);
+  assert.deepEqual(row.applies_to_tools, ['claude-code', 'codex']);
+  assert.deepEqual(row.evidence, ['20260101-000000-v-0001']);
+  assert.equal(row.priority, 4, 'priority carried as a NUMBER');
+  assert.equal(row.review_by, '2027-06-30');
+  const vrow = indexRows(cwd).find((e) => e.id === vid);
+  assert.deepEqual(vrow.lessons, [id]);
+  assert.equal(vrow.violated_pattern, PATTERN);
+});
+
+t('testRebuildRoundTripByteEqual', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b',
+    '--scope', 'local', '--trigger', 'x phrase', '--priority', '2', '--review-by', '2027-01-01'], { cwd, home });
+  assert.equal(r.code, 0);
+  const rb1 = run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  assert.equal(rb1.code, 0);
+  const bytes1 = readIndexBytes(cwd);
+  const rb2 = run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  assert.equal(rb2.code, 0);
+  assert.equal(readIndexBytes(cwd), bytes1, 'rebuild is idempotent byte-equal');
+  // and the rebuilt row's activation values equal the store-time row's
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  assert.deepEqual(row.triggers, ['x phrase']);
+  assert.equal(row.priority, 2);
+  assert.equal(row.review_by, '2027-01-01');
+});
+
+t('testRebuildOmitsAbsentFields', () => {
+  const { cwd, home } = mkStore();
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0);
+  run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  const row = indexRows(cwd).find((e) => e.id === r.json.id);
+  for (const key of ['triggers', 'applies_to_projects', 'applies_to_tools', 'evidence', 'lessons', 'priority', 'review_by', 'violated_pattern']) {
+    assert.ok(!(key in row), `absent field ${key} never appears (no null spam)`);
+  }
+});
+
+// --- REQ-10: dual-read at both read sites ---
+
+t('testRecallPreflightReadsTypedField', () => {
+  const { cwd, home } = mkStore();
+  storeTypedOnlyViolation(cwd, home);
+  const r = run(EM_RECALL, ['--task-type', 'implementation', '--scope', 'local', '--no-track'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const w = (r.json.preflight_warnings || []).find((x) => x.type === 'violation' && x.pattern_id === PATTERN);
+  assert.ok(w, `typed-only violation must warn: ${JSON.stringify(r.json.preflight_warnings)}`);
+  assert.equal(w.violations_last_30d, 1);
+});
+
+t('testRecallPreflightDualReadLegacyTag', () => {
+  const { cwd, home } = mkStore();
+  storeTypedOnlyViolation(cwd, home);
+  storeTagOnlyViolation(cwd, home);
+  const r = run(EM_RECALL, ['--task-type', 'implementation', '--scope', 'local', '--no-track'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const w = (r.json.preflight_warnings || []).find((x) => x.type === 'violation' && x.pattern_id === PATTERN);
+  assert.ok(w, 'warning present');
+  assert.equal(w.violations_last_30d, 2, 'EC12: typed-only AND tag-only both count, deduped per episode');
+});
+
+t('testPatternHealthCountsTypedField', () => {
+  const { cwd, home } = mkStore();
+  storeTypedOnlyViolation(cwd, home);
+  const r = run(EM_HEALTH, ['--pattern', PATTERN, '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const rep = r.json.patterns.find((p) => p.pattern_id === PATTERN);
+  assert.equal(rep.violations, 1, 'typed-only violation strikes');
+});
+
+t('testPatternHealthDualRead', () => {
+  const { cwd, home } = mkStore();
+  const typedId = storeTypedOnlyViolation(cwd, home);
+  const tagId = storeTagOnlyViolation(cwd, home);
+  assert.notEqual(typedId, tagId);
+  const r = run(EM_HEALTH, ['--pattern', PATTERN, '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const rep = r.json.patterns.find((p) => p.pattern_id === PATTERN);
+  assert.equal(rep.violations, 2, 'EC12: union of typed field and legacy tag, deduped by id');
+  // dedupe leg: a DUAL-written violation (tag + typed, the em-violation shape) counts ONCE
+  const dual = run(EM_STORE, ['--project', 't', '--category', 'violation', '--violated-pattern', PATTERN,
+    '--tags', `violated:${PATTERN}`, '--summary', 'dual', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(dual.code, 0);
+  const r2 = run(EM_HEALTH, ['--pattern', PATTERN, '--scope', 'local'], { cwd, home });
+  const rep2 = r2.json.patterns.find((p) => p.pattern_id === PATTERN);
+  assert.equal(rep2.violations, 3, 'dual-written violation counts once, not twice');
+});
+
+t('testViolatedPatternRoundTrip', () => {
+  const { cwd, home } = mkStore();
+  const id = storeTypedOnlyViolation(cwd, home);
+  const before = indexRows(cwd).find((e) => e.id === id);
+  run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  const after = indexRows(cwd).find((e) => e.id === id);
+  assert.equal(after.violated_pattern, before.violated_pattern, 'typed field survives rebuild');
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${id}.md`), 'utf8');
+  assert.match(md, new RegExp(`^violated_pattern: ${PATTERN}$`, 'm'));
+});
+
+// --- REQ-11: T2 conformance grep gate (construction site, non-vacuous) ---
+
+const CONSTRUCTION_RE = /`violated:\$\{/;
+const EXPECTED_SHIM_FILES = {
+  'em-recall.mjs': 1,
+  'em-pattern-health.mjs': 2, // the key is built TWICE (fromTags + linearScan), codex r2
+  'em-violation.mjs': 1, // WRITE-side construction — allow-listed marked shim
+};
+
+function grepConstructionLines(scriptsDir) {
+  const out = [];
+  for (const f of fs.readdirSync(scriptsDir).filter((x) => x.endsWith('.mjs'))) {
+    const lines = fs.readFileSync(path.join(scriptsDir, f), 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      if (CONSTRUCTION_RE.test(line)) out.push({ file: f, lineNo: i + 1, line, context: lines.slice(Math.max(0, i - 3), i + 1).join('\n') });
+    });
+  }
+  return out;
+}
+
+t('testT2NoTagValueBranching', () => {
+  const matches = grepConstructionLines(path.join(REPO, 'scripts'));
+  assert.equal(matches.length, 4, `exactly 4 marked construction lines expected, got ${matches.length}: ${matches.map((m) => `${m.file}:${m.lineNo}`).join(', ')}`);
+  const byFile = {};
+  for (const m of matches) byFile[m.file] = (byFile[m.file] || 0) + 1;
+  assert.deepEqual(byFile, EXPECTED_SHIM_FILES, 'the allow-listed shim distribution across the three files');
+  for (const m of matches) {
+    assert.ok(/T6/.test(m.context), `T6 sunset marker on/adjacent to ${m.file}:${m.lineNo}`);
+  }
+  // NON-VACUITY: an unmarked planted construction branch in a scratch copy MUST fail the gate
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 't2gate-'));
+  for (const f of fs.readdirSync(path.join(REPO, 'scripts')).filter((x) => x.endsWith('.mjs'))) {
+    fs.copyFileSync(path.join(REPO, 'scripts', f), path.join(scratch, f));
+  }
+  fs.appendFileSync(path.join(scratch, 'em-recall.mjs'),
+    '\nfunction plantedUnmarkedBranch(patternId, tags) { return tags.includes(`violated:${patternId}`) }\n');
+  const planted = grepConstructionLines(scratch);
+  assert.equal(planted.length, 5, 'planted branch is discovered');
+  const unmarked = planted.filter((m) => !/T6/.test(m.context));
+  assert.equal(unmarked.length, 1, 'the planted line has no T6 marker → the gate would fail on it (non-vacuous)');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-t6-migration.mjs
+++ b/tests/test-t6-migration.mjs
@@ -219,7 +219,9 @@ const EXPECTED_SHIM_FILES = {
   'em-recall.mjs': 1,
   'em-pattern-health.mjs': 2, // the key is built TWICE (fromTags + linearScan), codex r2
   'em-violation.mjs': 1, // WRITE-side construction — allow-listed marked shim
+  'em-trigger-index.mjs': 1, // session_start.preflight dual-read leg (reviewer F4)
 };
+const EXPECTED_SHIM_LINES = 5;
 
 function grepConstructionLines(scriptsDir) {
   const out = [];
@@ -234,10 +236,10 @@ function grepConstructionLines(scriptsDir) {
 
 t('testT2NoTagValueBranching', () => {
   const matches = grepConstructionLines(path.join(REPO, 'scripts'));
-  assert.equal(matches.length, 4, `exactly 4 marked construction lines expected, got ${matches.length}: ${matches.map((m) => `${m.file}:${m.lineNo}`).join(', ')}`);
+  assert.equal(matches.length, EXPECTED_SHIM_LINES, `exactly ${EXPECTED_SHIM_LINES} marked construction lines expected, got ${matches.length}: ${matches.map((m) => `${m.file}:${m.lineNo}`).join(', ')}`);
   const byFile = {};
   for (const m of matches) byFile[m.file] = (byFile[m.file] || 0) + 1;
-  assert.deepEqual(byFile, EXPECTED_SHIM_FILES, 'the allow-listed shim distribution across the three files');
+  assert.deepEqual(byFile, EXPECTED_SHIM_FILES, 'the allow-listed shim distribution across the four files');
   for (const m of matches) {
     assert.ok(/T6/.test(m.context), `T6 sunset marker on/adjacent to ${m.file}:${m.lineNo}`);
   }
@@ -249,7 +251,7 @@ t('testT2NoTagValueBranching', () => {
   fs.appendFileSync(path.join(scratch, 'em-recall.mjs'),
     '\nfunction plantedUnmarkedBranch(patternId, tags) { return tags.includes(`violated:${patternId}`) }\n');
   const planted = grepConstructionLines(scratch);
-  assert.equal(planted.length, 5, 'planted branch is discovered');
+  assert.equal(planted.length, EXPECTED_SHIM_LINES + 1, 'planted branch is discovered');
   const unmarked = planted.filter((m) => !/T6/.test(m.context));
   assert.equal(unmarked.length, 1, 'the planted line has no T6 marker → the gate would fail on it (non-vacuous)');
 });

--- a/tests/test-trigger-index.mjs
+++ b/tests/test-trigger-index.mjs
@@ -189,6 +189,24 @@ t('testBandChainResolvedViolation', () => {
     'evidence naming the superseded violation resolves to its active terminal (counts once)');
 });
 
+t('testBandCrossStoreMergedView', () => {
+  // Reviewer F2: a LOCAL lesson linking a GLOBAL violation (legitimate, REQ-6/F1)
+  // earns the band in the MERGED consumer view. The per-store artifact keeps a
+  // per-store band by design (a cached global index must not depend on the
+  // caller's local store); consumers read loadMergedTriggerIndex.
+  const { cwd, home } = mkStore();
+  const gv = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'gv', '--body', 'b', '--scope', 'global'], { cwd, home });
+  assert.equal(gv.code, 0);
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase', '--evidence', gv.json.id]);
+  const merged = run(EM_TRIGGER, ['--merged'], { cwd, home });
+  assert.equal(merged.code, 0, merged.stdout);
+  const entry = merged.json.entries.find((e) => e.episode_id === id);
+  assert.equal(entry.effective_priority, 8, 'cross-store link earns the band in the merged view');
+  const crit = merged.json.session_start.critical_entries.find((e) => e.episode_id === id);
+  assert.ok(crit, 'merged session_start critical band sees the cross-store link');
+  assert.equal(crit.effective_priority, 8);
+});
+
 t('testBandRetractedStops', () => {
   const { cwd, home } = mkStore();
   const v1 = storeViolation(cwd, home);

--- a/tests/test-trigger-index.mjs
+++ b/tests/test-trigger-index.mjs
@@ -217,6 +217,9 @@ t('testBandRetractedStops', () => {
 t('testCacheHitUnchanged', () => {
   const { cwd, home } = mkStore();
   storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  // the R9a collision read already lazy-built the index at store time (S7);
+  // clear it so this test controls the first build itself
+  fs.rmSync(tiPath(cwd), { force: true });
   const r1 = build(cwd, home);
   assert.equal(r1.json.built[0].cache_hit, false);
   const mtime1 = fs.statSync(tiPath(cwd)).mtimeMs;
@@ -228,10 +231,19 @@ t('testCacheHitUnchanged', () => {
 t('testCacheInvalidatedByStore', () => {
   const { cwd, home } = mkStore();
   storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  fs.rmSync(tiPath(cwd), { force: true });
   build(cwd, home);
-  const id2 = storeLesson(cwd, home, ['--trigger', 'y phrase']);
+  // plant the second lesson WITHOUT the writers (no R9a lazy rebuild), so the
+  // explicit build below is what observes the fingerprint invalidation
+  const id2 = '20260708-000000-planted-second-0001';
+  fs.writeFileSync(path.join(storeDir(cwd), 'episodes', `${id2}.md`), [
+    '---', `id: ${id2}`, 'date: 2026-07-08', 'time: "00:00"', 'project: t', 'category: lesson',
+    'status: active', 'tags: []', 'summary: second', 'triggers: [y phrase]', 'priority: 5',
+    '---', '', '# x', '', 'b', '',
+  ].join('\n'));
+  assert.equal(run(EM_REBUILD, ['--scope', 'local'], { cwd, home }).code, 0);
   const r = build(cwd, home);
-  assert.equal(r.json.built[0].cache_hit, false, 'mid-session store invalidates the cache');
+  assert.equal(r.json.built[0].cache_hit, false, 'mid-session store invalidates the cache (sha/mtime/size moved)');
   assert.equal(entryFor(cwd, id2).length, 1, 'the new lesson is in the rebuilt index');
 });
 
@@ -430,6 +442,9 @@ t('testTriggerBuildExcludesUnknownClass', () => {
 t('testBuildDegradesOnUnloadableVocab', () => {
   const { cwd, home } = mkStore();
   storeLesson(cwd, home, ['--trigger', 'activity:plan', '--trigger', 'still here phrase']);
+  // clear the R9a-built cache (built with a LOADABLE vocab at store time) so
+  // the degraded build below actually rebuilds
+  fs.rmSync(tiPath(cwd), { force: true });
   const r = run(EM_TRIGGER, ['--scope', 'local'], { cwd, home, env: { EM_ACTIVATION_CLASSES_PATH: '/nonexistent/x.json' } });
   assert.equal(r.code, 0, 'F4: unreadable vocab at BUILD degrades, never throws');
   const ti = readTi(cwd);

--- a/tests/test-trigger-index.mjs
+++ b/tests/test-trigger-index.mjs
@@ -1,0 +1,441 @@
+/**
+ * test-trigger-index.mjs — RFC-009 P1b S5: trigger index core (Group 5, §14).
+ *
+ * REQ-12 (build, three kinds, exclusions), REQ-13 (earned band, chain-resolved,
+ * dedup, retracted), REQ-14 (fingerprint cache, TOCTOU, same-size rewrite,
+ * concurrent builds), REQ-16 (merge local precedence, target binding, degrade).
+ *
+ * Every test asserts captured output / on-disk contents — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import { spawn, spawnSync, execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_REVISE = path.join(REPO, 'scripts/em-revise.mjs');
+const EM_VIOLATION = path.join(REPO, 'scripts/em-violation.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+const EM_TRIGGER = path.join(REPO, 'scripts/em-trigger-index.mjs');
+
+const PATTERN = 'bp-001-implementation-workflow';
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+async function ta(name, fn) {
+  try { await fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trigidx-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return { cwd: d, home };
+}
+function storeDir(cwd) { return path.join(cwd, '.episodic-memory'); }
+function tiPath(cwd) { return path.join(storeDir(cwd), 'trigger-index.json'); }
+function readTi(cwd) { return JSON.parse(fs.readFileSync(tiPath(cwd), 'utf8')); }
+
+function run(script, args, { cwd, home, env } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, ...(home ? { HOME: home, USERPROFILE: home } : {}), ...env },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); }
+  catch { try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {} }
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+function storeLesson(cwd, home, extra = []) {
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', extra.includes('--summary') ? undefined : 'l',
+    '--body', 'b', '--scope', 'local', ...extra].filter((x) => x !== undefined), { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+function storeViolation(cwd, home, extra = []) {
+  const r = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'v', '--body', 'b', '--scope', 'local', ...extra], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+function build(cwd, home, extra = []) {
+  const r = run(EM_TRIGGER, ['--scope', 'local', ...extra], { cwd, home });
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  return r;
+}
+function entryFor(cwd, episodeId) {
+  return readTi(cwd).entries.filter((e) => e.episode_id === episodeId);
+}
+
+// --- REQ-12: build + kinds + exclusions ---
+
+t('testTriggerIndexBuilds', () => {
+  const { cwd, home } = mkStore();
+  const id = storeLesson(cwd, home, ['--trigger', 'second opinion']);
+  const r = build(cwd, home);
+  assert.equal(r.json.built[0].entries, 1);
+  const ti = readTi(cwd);
+  assert.equal(ti.schema_version, 1);
+  assert.ok(ti.source.index_sha256.match(/^[0-9a-f]{64}$/), 'sha256 fingerprint present');
+  assert.equal(ti.entries[0].episode_id, id);
+  assert.equal(ti.entries[0].value, 'second opinion');
+  assert.equal(ti.entries[0].effective_priority, 5, 'field is effective_priority, derived');
+  assert.ok(!('priority' in ti.entries[0]), 'entry never carries the stored `priority` name');
+});
+
+t('testTriggerIndexThreeKinds', () => {
+  const { cwd, home } = mkStore();
+  const id = storeLesson(cwd, home, ['--trigger', 'a phrase', '--trigger', 'tool:Bash:git*', '--trigger', 'activity:plan']);
+  build(cwd, home);
+  const kinds = entryFor(cwd, id).map((e) => e.trigger_kind).sort();
+  assert.deepEqual(kinds, ['activity', 'phrase', 'tool'], 'all three kinds discriminated EXPLICITLY');
+  const byKind = Object.fromEntries(entryFor(cwd, id).map((e) => [e.trigger_kind, e.value]));
+  assert.equal(byKind.phrase, 'a phrase');
+  assert.equal(byKind.tool, 'tool:Bash:git*');
+  assert.equal(byKind.activity, 'activity:plan');
+});
+
+t('testTriggerIndexExcludesExpired', () => {
+  const { cwd, home } = mkStore();
+  const past = storeLesson(cwd, home, ['--trigger', 'stale phrase', '--review-by', '2020-01-01']);
+  const live = storeLesson(cwd, home, ['--trigger', 'live phrase', '--review-by', '2099-01-01']);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, past).length, 0, 'expired (review_by past) excluded');
+  assert.equal(entryFor(cwd, live).length, 1);
+});
+
+t('testTriggerIndexExcludesSuperseded', () => {
+  const { cwd, home } = mkStore();
+  const orig = storeLesson(cwd, home, ['--trigger', 'old phrase']);
+  const rev = run(EM_REVISE, ['--original', orig, '--project', 't', '--summary', 'r', '--body', 'c',
+    '--scope', 'local', '--trigger', 'new phrase'], { cwd, home });
+  assert.equal(rev.code, 0);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, orig).length, 0, 'superseded lesson excluded');
+  assert.equal(entryFor(cwd, rev.json.id).length, 1);
+});
+
+// --- REQ-13: earned band ---
+
+t('testBandZeroLinks', () => {
+  const { cwd, home } = mkStore();
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase', '--priority', '3']);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 3, 'zero links -> stored priority');
+});
+
+t('testBandOneLink8', () => {
+  const { cwd, home } = mkStore();
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  storeViolation(cwd, home, ['--lesson', id]);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 8, 'one linked violation -> 8');
+  // stored bytes untouched (I3)
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${id}.md`), 'utf8');
+  assert.ok(!/^priority: 8$/m.test(md), 'stored frontmatter never mutated to the band');
+});
+
+t('testBandTwoLinks9', () => {
+  const { cwd, home } = mkStore();
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  storeViolation(cwd, home, ['--lesson', id]);
+  storeViolation(cwd, home, ['--lesson', id]);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 9, 'two linked violations -> 9');
+});
+
+t('testBandForwardBackDedup', () => {
+  const { cwd, home } = mkStore();
+  const l1 = storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  const vid = storeViolation(cwd, home, ['--lesson', l1]);
+  // revise the lesson adding the BACK-link to the SAME violation (EC6)
+  const rev = run(EM_REVISE, ['--original', l1, '--project', 't', '--summary', 'r', '--body', 'c',
+    '--scope', 'local', '--trigger', 'x phrase', '--evidence', vid], { cwd, home });
+  assert.equal(rev.code, 0, rev.stdout);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, rev.json.id)[0].effective_priority, 8, 'forward + back link to ONE violation counts once');
+});
+
+t('testBandChainResolvedLesson', () => {
+  const { cwd, home } = mkStore();
+  const l1 = storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  const vid = storeViolation(cwd, home, ['--lesson', l1]);
+  assert.ok(vid);
+  const rev = run(EM_REVISE, ['--original', l1, '--project', 't', '--summary', 'r2', '--body', 'c',
+    '--scope', 'local', '--trigger', 'x phrase'], { cwd, home });
+  assert.equal(rev.code, 0);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, rev.json.id)[0].effective_priority, 8,
+    'violation linked to the SUPERSEDED lesson follows the chain to the active terminal');
+});
+
+t('testBandChainResolvedViolation', () => {
+  const { cwd, home } = mkStore();
+  const v1 = storeViolation(cwd, home);
+  const rev = run(EM_REVISE, ['--original', v1, '--project', 't', '--summary', 'v2', '--body', 'c', '--scope', 'local'], { cwd, home });
+  assert.equal(rev.code, 0);
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase', '--evidence', v1]);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 8,
+    'evidence naming the superseded violation resolves to its active terminal (counts once)');
+});
+
+t('testBandRetractedStops', () => {
+  const { cwd, home } = mkStore();
+  const v1 = storeViolation(cwd, home);
+  const id = storeLesson(cwd, home, ['--trigger', 'x phrase', '--evidence', v1]);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 8, 'pre-retraction: band 8');
+  // retract: hand-plant a NON-violation revision superseding v1 (EC7 — the chain
+  // terminates on a non-violation category), then rebuild the store index.
+  const epDir = path.join(storeDir(cwd), 'episodes');
+  const rid = '20990101-000000-retraction-0001';
+  fs.writeFileSync(path.join(epDir, `${rid}.md`), [
+    '---', `id: ${rid}`, 'date: 2026-07-08', 'time: "00:00"', 'project: t', 'category: temporary',
+    'status: active', `supersedes: ${v1}`, 'tags: []', 'summary: retracted', '---', '', '# retracted', '', 'b', '',
+  ].join('\n'));
+  const v1md = path.join(epDir, `${v1}.md`);
+  fs.writeFileSync(v1md, fs.readFileSync(v1md, 'utf8').replace(/^status: active$/m, 'status: superseded'));
+  assert.equal(run(EM_REBUILD, ['--scope', 'local'], { cwd, home }).code, 0);
+  build(cwd, home);
+  assert.equal(entryFor(cwd, id)[0].effective_priority, 5, 'retracted violation stops counting; band drops at next build');
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${id}.md`), 'utf8');
+  assert.match(md, new RegExp(`^evidence: \\[${v1}\\]$`, 'm'), 'stored bytes unchanged (I3)');
+});
+
+// --- REQ-14: fingerprint + cache ---
+
+t('testCacheHitUnchanged', () => {
+  const { cwd, home } = mkStore();
+  storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  const r1 = build(cwd, home);
+  assert.equal(r1.json.built[0].cache_hit, false);
+  const mtime1 = fs.statSync(tiPath(cwd)).mtimeMs;
+  const r2 = build(cwd, home);
+  assert.equal(r2.json.built[0].cache_hit, true, 'second build on an unchanged store is a cache hit');
+  assert.equal(fs.statSync(tiPath(cwd)).mtimeMs, mtime1, 'no rewrite on cache hit');
+});
+
+t('testCacheInvalidatedByStore', () => {
+  const { cwd, home } = mkStore();
+  storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  build(cwd, home);
+  const id2 = storeLesson(cwd, home, ['--trigger', 'y phrase']);
+  const r = build(cwd, home);
+  assert.equal(r.json.built[0].cache_hit, false, 'mid-session store invalidates the cache');
+  assert.equal(entryFor(cwd, id2).length, 1, 'the new lesson is in the rebuilt index');
+});
+
+t('testFingerprintCatchesSameSizeRewrite', () => {
+  const { cwd, home } = mkStore();
+  storeLesson(cwd, home, ['--trigger', 'aaa phrase']);
+  build(cwd, home);
+  const idxPath = path.join(storeDir(cwd), 'index.jsonl');
+  const st = fs.statSync(idxPath);
+  const raw = fs.readFileSync(idxPath, 'utf8');
+  const rewritten = raw.replace('aaa phrase', 'bbb phrase');
+  assert.equal(Buffer.byteLength(rewritten), Buffer.byteLength(raw), 'SAME byte length');
+  fs.writeFileSync(idxPath, rewritten);
+  fs.utimesSync(idxPath, st.atime, st.mtime); // SAME mtime — only the bytes differ (EC8)
+  const r = build(cwd, home);
+  assert.equal(r.json.built[0].cache_hit, false, 'sha256 leg catches the same-size-same-mtime rewrite');
+  const values = readTi(cwd).entries.map((e) => e.value);
+  assert.deepEqual(values, ['bbb phrase'], 'rebuilt from the NEW bytes');
+});
+
+await ta('testFingerprintTOCTOUReReadOnStatMismatch', async () => {
+  // EC9 in-process: patch fs.readFileSync so the FIRST read of index.jsonl
+  // returns STALE bytes while the file on disk has already moved on (a
+  // concurrent writer landing between stat and read). The builder must detect
+  // the stat mismatch, re-read once, and fingerprint the bytes it actually used.
+  const { cwd, home } = mkStore();
+  void home;
+  const epDir = path.join(storeDir(cwd), 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  const idxPath = path.join(storeDir(cwd), 'index.jsonl');
+  const rowOld = JSON.stringify({ id: 'l-old', date: '2026-07-08', time: '00:00', project: 't', category: 'lesson', status: 'active', supersedes: null, tags: [], summary: 'old', triggers: ['old phrase'], priority: 5 }) + '\n';
+  const rowNew = JSON.stringify({ id: 'l-new', date: '2026-07-08', time: '00:00', project: 't', category: 'lesson', status: 'active', supersedes: null, tags: [], summary: 'new', triggers: ['new phrase'], priority: 5 }) + '\n';
+  fs.writeFileSync(idxPath, rowOld);
+  const mod = await import('../scripts/em-trigger-index.mjs');
+  const realRead = fs.readFileSync;
+  let firstIndexRead = true;
+  fs.readFileSync = function (p, ...rest) {
+    if (String(p) === idxPath && firstIndexRead) {
+      firstIndexRead = false;
+      const stale = realRead.call(fs, p, ...rest); // the bytes as of the first stat
+      // concurrent writer lands AFTER our read: file changes size + mtime
+      fs.writeFileSync(idxPath, rowNew);
+      return stale;
+    }
+    return realRead.call(fs, p, ...rest);
+  };
+  try {
+    const { index } = mod.buildTriggerIndex({ project: cwd, scope: 'local', now: new Date('2026-07-08T12:00:00Z') });
+    const expectedSha = crypto.createHash('sha256').update(rowNew).digest('hex');
+    assert.equal(index.source.index_sha256, expectedSha, 'fingerprint is of the RE-READ bytes');
+    assert.deepEqual(index.entries.map((e) => e.value), ['new phrase'], 'entries built from the re-read bytes');
+  } finally {
+    fs.readFileSync = realRead;
+  }
+});
+
+await ta('testConcurrentBuildsNoTornTemp', async () => {
+  const { cwd, home } = mkStore();
+  for (let i = 0; i < 8; i++) storeLesson(cwd, home, ['--trigger', `phrase number ${i}`]);
+  fs.rmSync(tiPath(cwd), { force: true });
+  const runs = [0, 1].map(() => new Promise((resolve) => {
+    const c = spawn('node', [EM_TRIGGER, '--scope', 'local'], {
+      cwd, env: { ...process.env, HOME: home, USERPROFILE: home },
+    });
+    let out = '';
+    c.stdout.on('data', (d) => { out += d; });
+    c.on('close', (code) => resolve({ code, out }));
+  }));
+  const results = await Promise.all(runs);
+  for (const r of results) assert.equal(r.code, 0, `both concurrent builds exit 0: ${r.out}`);
+  const ti = readTi(cwd); // parses -> not torn
+  assert.equal(ti.entries.length, 8);
+  const leftovers = fs.readdirSync(storeDir(cwd)).filter((f) => f.startsWith('trigger-index.json.tmp.'));
+  assert.deepEqual(leftovers, [], 'no torn/leftover temp files');
+});
+
+// --- REQ-16: merge + binding + degrade ---
+
+t('testMergeLocalPrecedence', () => {
+  const { cwd, home } = mkStore();
+  // SAME episode id planted in both stores with different summaries
+  const id = '20260708-000000-shared-lesson-0001';
+  for (const [dir, summary] of [[storeDir(cwd), 'LOCAL wins'], [path.join(home, '.episodic-memory'), 'GLOBAL loses']]) {
+    const ep = path.join(dir, 'episodes');
+    fs.mkdirSync(ep, { recursive: true });
+    fs.writeFileSync(path.join(ep, `${id}.md`), [
+      '---', `id: ${id}`, 'date: 2026-07-08', 'time: "00:00"', 'project: t', 'category: lesson',
+      'status: active', 'tags: []', `summary: ${summary}`, 'triggers: [shared phrase]', 'priority: 5',
+      '---', '', '# x', '', 'b', '',
+    ].join('\n'));
+  }
+  assert.equal(run(EM_REBUILD, ['--scope', 'all'], { cwd, home }).code, 0);
+  const r = run(EM_TRIGGER, ['--merged'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  const mine = r.json.entries.filter((e) => e.episode_id === id);
+  assert.equal(mine.length, 1, 'deduped by episode id');
+  assert.equal(mine[0].summary, 'LOCAL wins', 'LOCAL precedence');
+});
+
+t('testTargetStoreBindingWorktree', () => {
+  // F6/EC16: caller cwd is a LINKED WORKTREE of an unrelated repo; --project
+  // <target-root> must write under the TARGET's store, not the worktree's main root.
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'wtbind-')));
+  const home = path.join(base, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  const repoA = path.join(base, 'repoA');
+  fs.mkdirSync(repoA);
+  execFileSync('git', ['init', '-b', 'main'], { cwd: repoA });
+  execFileSync('git', ['config', 'user.email', 'juan.delacruz@acme.com'], { cwd: repoA });
+  execFileSync('git', ['config', 'user.name', 'jd'], { cwd: repoA });
+  fs.writeFileSync(path.join(repoA, 'f.txt'), 'x');
+  execFileSync('git', ['add', '-A'], { cwd: repoA });
+  execFileSync('git', ['commit', '-q', '-m', 'x'], { cwd: repoA });
+  const wt = path.join(base, 'wt');
+  execFileSync('git', ['worktree', 'add', '-q', wt], { cwd: repoA });
+  // target project (non-git) with one trigger-bearing lesson
+  const target = path.join(base, 'target');
+  fs.mkdirSync(target);
+  const tEp = path.join(target, '.episodic-memory', 'episodes');
+  fs.mkdirSync(tEp, { recursive: true });
+  fs.writeFileSync(path.join(tEp, '20260708-000000-target-lesson-0001.md'), [
+    '---', 'id: 20260708-000000-target-lesson-0001', 'date: 2026-07-08', 'time: "00:00"', 'project: tgt',
+    'category: lesson', 'status: active', 'tags: []', 'summary: tgt', 'triggers: [target phrase]', 'priority: 5',
+    '---', '', '# x', '', 'b', '',
+  ].join('\n'));
+  const rb = spawnSync('node', [EM_REBUILD, '--scope', 'local'], { cwd: target, encoding: 'utf8', env: { ...process.env, HOME: home, USERPROFILE: home } });
+  assert.equal(rb.status, 0);
+  const r = spawnSync('node', [EM_TRIGGER, '--scope', 'local', '--project', target], {
+    cwd: wt, encoding: 'utf8', env: { ...process.env, HOME: home, USERPROFILE: home },
+  });
+  assert.equal(r.status, 0, r.stdout);
+  assert.ok(fs.existsSync(path.join(target, '.episodic-memory', 'trigger-index.json')),
+    'trigger-index.json lands under the TARGET store (asserted by on-disk location)');
+  assert.ok(!fs.existsSync(path.join(repoA, '.episodic-memory', 'trigger-index.json')),
+    'nothing written under the worktree MAIN root');
+  const ti = JSON.parse(fs.readFileSync(path.join(target, '.episodic-memory', 'trigger-index.json'), 'utf8'));
+  assert.equal(ti.entries[0].value, 'target phrase');
+});
+
+t('testMalformedIndexRebuildsOnce', () => {
+  const { cwd, home } = mkStore();
+  storeLesson(cwd, home, ['--trigger', 'x phrase']);
+  build(cwd, home);
+  fs.writeFileSync(tiPath(cwd), '{ not json ///');
+  const r = build(cwd, home);
+  assert.equal(r.json.built[0].cache_hit, false, 'malformed cache is a miss');
+  const ti = readTi(cwd);
+  assert.equal(ti.entries.length, 1, 'rebuilt to a valid index');
+});
+
+t('testMalformedIndexDegrades', () => {
+  // EC10: local store's index.jsonl unreadable -> merged view proceeds with
+  // global + ONE stderr note, exit 0, never throws.
+  const { cwd, home } = mkStore();
+  const gEp = path.join(home, '.episodic-memory', 'episodes');
+  fs.mkdirSync(gEp, { recursive: true });
+  fs.writeFileSync(path.join(gEp, '20260708-000000-global-lesson-0001.md'), [
+    '---', 'id: 20260708-000000-global-lesson-0001', 'date: 2026-07-08', 'time: "00:00"', 'project: g',
+    'category: lesson', 'status: active', 'tags: []', 'summary: g', 'triggers: [global phrase]', 'priority: 5',
+    '---', '', '# x', '', 'b', '',
+  ].join('\n'));
+  assert.equal(run(EM_REBUILD, ['--scope', 'global'], { cwd, home }).code, 0);
+  // make the LOCAL index unreadable
+  const idxPath = path.join(storeDir(cwd), 'index.jsonl');
+  fs.mkdirSync(storeDir(cwd), { recursive: true });
+  fs.writeFileSync(idxPath, 'x');
+  fs.chmodSync(idxPath, 0o000);
+  try {
+    const r = run(EM_TRIGGER, ['--merged'], { cwd, home });
+    assert.equal(r.code, 0, 'merged read never blocks');
+    assert.match(r.stderr, /local build failed/, 'one stderr note');
+    assert.deepEqual(r.json.entries.map((e) => e.value), ['global phrase'], 'global entries still served');
+  } finally {
+    fs.chmodSync(idxPath, 0o644);
+  }
+});
+
+t('testTriggerBuildExcludesUnknownClass', () => {
+  const { cwd, home } = mkStore();
+  // unknown class enters via hand-authoring / vocab drift (the writers reject it)
+  const epDir = path.join(storeDir(cwd), 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  fs.writeFileSync(path.join(epDir, '20260708-000000-drift-lesson-0001.md'), [
+    '---', 'id: 20260708-000000-drift-lesson-0001', 'date: 2026-07-08', 'time: "00:00"', 'project: t',
+    'category: lesson', 'status: active', 'tags: []', 'summary: drift',
+    'triggers: [activity:bogus, ok phrase]', 'priority: 5',
+    '---', '', '# x', '', 'b', '',
+  ].join('\n'));
+  assert.equal(run(EM_REBUILD, ['--scope', 'local'], { cwd, home }).code, 0);
+  build(cwd, home);
+  const ti = readTi(cwd);
+  assert.deepEqual(ti.entries.map((e) => e.value), ['ok phrase'], 'EC11: unknown class excluded, sibling trigger kept');
+  assert.equal(ti.build_report.excluded_activity_classes.bogus, 1, 'counted in the build report (the drift surface)');
+});
+
+t('testBuildDegradesOnUnloadableVocab', () => {
+  const { cwd, home } = mkStore();
+  storeLesson(cwd, home, ['--trigger', 'activity:plan', '--trigger', 'still here phrase']);
+  const r = run(EM_TRIGGER, ['--scope', 'local'], { cwd, home, env: { EM_ACTIVATION_CLASSES_PATH: '/nonexistent/x.json' } });
+  assert.equal(r.code, 0, 'F4: unreadable vocab at BUILD degrades, never throws');
+  const ti = readTi(cwd);
+  assert.deepEqual(ti.entries.map((e) => e.value), ['still here phrase']);
+  assert.equal(ti.build_report.excluded_activity_classes.plan, 1, 'every activity trigger excluded+counted');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-trigger-session-start.mjs
+++ b/tests/test-trigger-session-start.mjs
@@ -1,0 +1,168 @@
+/**
+ * test-trigger-session-start.mjs — RFC-009 P1b S6: session_start section (Group 6, §14).
+ *
+ * REQ-15: critical_entries (band, TRIGGER-INDEPENDENT), entries (explicit
+ * static_score blend, deterministic under a fixed `now`), preflight (typed
+ * violated_pattern counts), NO environment inputs (I6).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildTriggerIndex, buildSessionStart } from '../scripts/em-trigger-index.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_VIOLATION = path.join(REPO, 'scripts/em-violation.mjs');
+
+const PATTERN = 'bp-001-implementation-workflow';
+const NOW = new Date('2026-07-08T00:00:00Z');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sess-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return { cwd: d, home };
+}
+function run(script, args, { cwd, home } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, ...(home ? { HOME: home, USERPROFILE: home } : {}) },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); } catch {}
+  return { code: r.status, stdout: r.stdout, json };
+}
+function lessonRow(id, { date = '2026-07-08', priority = 5, last_accessed = null, triggers, summary = id } = {}) {
+  return {
+    id, date, time: '00:00', project: 't', category: 'lesson', status: 'active',
+    supersedes: null, tags: [], summary,
+    ...(triggers ? { triggers } : {}), priority, last_accessed,
+  };
+}
+
+t('testSessionStartCriticalEntriesBand', () => {
+  const { cwd, home } = mkStore();
+  const s = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 'banded', '--body', 'b',
+    '--scope', 'local', '--trigger', 'x phrase'], { cwd, home });
+  assert.equal(s.code, 0);
+  for (let i = 0; i < 2; i++) {
+    const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', s.json.id, '--summary', `v${i}`, '--body', 'b', '--scope', 'local'], { cwd, home });
+    assert.equal(v.code, 0);
+  }
+  const { index } = buildTriggerIndex({ project: cwd, scope: 'local', now: NOW });
+  const crit = index.session_start.critical_entries.find((e) => e.episode_id === s.json.id);
+  assert.ok(crit, 'band-9 lesson in critical_entries');
+  assert.equal(crit.effective_priority, 9);
+});
+
+t('testSessionStartTriggerIndependent', () => {
+  // EC14: a band lesson with NO triggers (R8 always-tier class) is in
+  // critical_entries but NOT in trigger entries.
+  const { cwd, home } = mkStore();
+  const s = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 'no-trigger band', '--body', 'b',
+    '--scope', 'local', '--priority', '6'], { cwd, home });
+  assert.equal(s.code, 0);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', s.json.id, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0);
+  const { index } = buildTriggerIndex({ project: cwd, scope: 'local', now: NOW });
+  const crit = index.session_start.critical_entries.find((e) => e.episode_id === s.json.id);
+  assert.ok(crit, 'trigger-less band lesson scanned from ALL active lessons');
+  assert.equal(crit.effective_priority, 8);
+  assert.equal(index.entries.filter((e) => e.episode_id === s.json.id).length, 0, 'absent from trigger entries');
+});
+
+t('testSessionStartStaticBlendOrder', () => {
+  // Fixed fixture -> hand-derived exact scores (formula REQ-15):
+  //   A: age 0 (recency 1.0), never accessed (1.0), priority 7 (1.0)      -> 1.000000
+  //   C: age 0 (recency 1.0), never accessed (1.0), priority 1 (1/7)      -> 0.828571
+  //   B: age 30 (recency 0.5), accessed 1d ago (1/365), priority 5 (5/7)  -> 0.393679
+  const rows = [
+    lessonRow('b-lesson', { date: '2026-06-08', priority: 5, last_accessed: '2026-07-07T00:00:00Z' }),
+    lessonRow('a-lesson', { date: '2026-07-08', priority: 7 }),
+    lessonRow('c-lesson', { date: '2026-07-08', priority: 1 }),
+  ];
+  const ss = buildSessionStart(rows, NOW);
+  assert.deepEqual(ss.entries.map((e) => e.episode_id), ['a-lesson', 'c-lesson', 'b-lesson'], 'deterministic blend order');
+  const byId = Object.fromEntries(ss.entries.map((e) => [e.episode_id, e.static_score]));
+  assert.equal(byId['a-lesson'], 1, 'exact score A');
+  assert.equal(byId['c-lesson'], 0.828571, 'exact score C');
+  assert.equal(byId['b-lesson'], 0.393679, 'exact score B');
+});
+
+t('testSessionStartTopNAndTieBreak', () => {
+  // ties break by recency then episode id; list capped at N=10
+  const rows = [];
+  for (let i = 0; i < 12; i++) rows.push(lessonRow(`tie-${String(i).padStart(2, '0')}`, { date: '2026-07-08', priority: 5 }));
+  const ss = buildSessionStart(rows, NOW);
+  assert.equal(ss.entries.length, 10, 'top-N cap (N=10)');
+  assert.deepEqual(ss.entries.map((e) => e.episode_id), [
+    'tie-00', 'tie-01', 'tie-02', 'tie-03', 'tie-04', 'tie-05', 'tie-06', 'tie-07', 'tie-08', 'tie-09',
+  ], 'equal scores + equal recency -> episode-id order');
+});
+
+t('testSessionStartPreflightByViolatedPattern', () => {
+  const { cwd, home } = mkStore();
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0);
+  // legacy-tag-only row must NOT count here: preflight is keyed by the TYPED field (REQ-15/T6 dep)
+  const tagOnly = run(EM_STORE, ['--project', 't', '--category', 'violation', '--tags', `violated:${PATTERN}`,
+    '--summary', 'tag-only', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(tagOnly.code, 0);
+  const { index } = buildTriggerIndex({ project: cwd, scope: 'local', now: new Date() });
+  const pf = index.session_start.preflight;
+  assert.equal(pf.implementation[PATTERN], 1, 'typed violated_pattern rows counted per task type');
+  assert.deepEqual(pf.push, {}, 'no bp-006 violations');
+});
+
+t('testSessionStartExcludesExpiredAndSuperseded', () => {
+  const rows = [
+    lessonRow('live-lesson'),
+    { ...lessonRow('gone-lesson'), status: 'superseded' },
+    lessonRow('expired-lesson', { }),
+  ];
+  rows[2].review_by = '2020-01-01';
+  const ss = buildSessionStart(rows, NOW);
+  assert.deepEqual(ss.entries.map((e) => e.episode_id), ['live-lesson'], 'expired/superseded never appear');
+});
+
+t('testSessionStartNoEnvInputs', () => {
+  // I6: identical store content, one dir carrying git metadata + package.json,
+  // the other bare -> byte-identical session_start under the same `now`.
+  const mk = (withEnvNoise) => {
+    const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'envfree-')));
+    const ep = path.join(d, '.episodic-memory', 'episodes');
+    fs.mkdirSync(ep, { recursive: true });
+    fs.writeFileSync(path.join(ep, '20260708-000000-env-lesson-0001.md'), [
+      '---', 'id: 20260708-000000-env-lesson-0001', 'date: 2026-07-08', 'time: "00:00"', 'project: t',
+      'category: lesson', 'status: active', 'tags: []', 'summary: env', 'triggers: [env phrase]', 'priority: 5',
+      '---', '', '# x', '', 'b', '',
+    ].join('\n'));
+    const rb = spawnSync('node', [path.join(REPO, 'scripts/em-rebuild-index.mjs'), '--scope', 'local'], { cwd: d, encoding: 'utf8' });
+    assert.equal(rb.status, 0);
+    if (withEnvNoise) {
+      execFileSync('git', ['init', '-q', '-b', 'main'], { cwd: d });
+      fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({ name: 'noise-project' }));
+    }
+    return d;
+  };
+  const bare = mk(false);
+  const noisy = mk(true);
+  const a = buildTriggerIndex({ project: bare, scope: 'local', now: NOW }).index.session_start;
+  const b = buildTriggerIndex({ project: noisy, scope: 'local', now: NOW }).index.session_start;
+  assert.equal(JSON.stringify(a), JSON.stringify(b), 'session_start is a pure function of index rows + now');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);

--- a/tests/test-trigger-session-start.mjs
+++ b/tests/test-trigger-session-start.mjs
@@ -116,14 +116,22 @@ t('testSessionStartPreflightByViolatedPattern', () => {
   const { cwd, home } = mkStore();
   const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
   assert.equal(v.code, 0);
-  // legacy-tag-only row must NOT count here: preflight is keyed by the TYPED field (REQ-15/T6 dep)
+  // reviewer F4: preflight is the THIRD violated_pattern read site — it
+  // dual-reads (typed field ∪ legacy tag) like em-recall/em-pattern-health,
+  // so a pre-migration tag-only violation still counts.
   const tagOnly = run(EM_STORE, ['--project', 't', '--category', 'violation', '--tags', `violated:${PATTERN}`,
     '--summary', 'tag-only', '--body', 'b', '--scope', 'local'], { cwd, home });
   assert.equal(tagOnly.code, 0);
   const { index } = buildTriggerIndex({ project: cwd, scope: 'local', now: new Date() });
   const pf = index.session_start.preflight;
-  assert.equal(pf.implementation[PATTERN], 1, 'typed violated_pattern rows counted per task type');
+  assert.equal(pf.implementation[PATTERN], 2, 'typed-only AND tag-only violations both count (dual-read)');
   assert.deepEqual(pf.push, {}, 'no bp-006 violations');
+  // a DUAL-written violation (the em-violation shape: tag + typed) counts ONCE
+  const dual = run(EM_STORE, ['--project', 't', '--category', 'violation', '--violated-pattern', PATTERN,
+    '--tags', `violated:${PATTERN}`, '--summary', 'dual', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(dual.code, 0);
+  const { index: i2 } = buildTriggerIndex({ project: cwd, scope: 'local', now: new Date() });
+  assert.equal(i2.session_start.preflight.implementation[PATTERN], 3, 'dual-written row counts once, not twice');
 });
 
 t('testSessionStartExcludesExpiredAndSuperseded', () => {

--- a/tests/test-violation-linkage.mjs
+++ b/tests/test-violation-linkage.mjs
@@ -123,6 +123,24 @@ t('testViolationKeepsTagShim', () => {
   assert.equal(row.violated_pattern, PATTERN, 'dual-write: shim AND typed field');
 });
 
+t('testReviseViolationKeepsTypedFieldAndLessons', () => {
+  // Reviewer F3: revising a violation (e.g. a summary correction) must not
+  // strip its typed violated_pattern or its --lesson forward-links.
+  const { cwd, home } = mkStore();
+  const lessonId = storeLesson(cwd, home);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', lessonId, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0);
+  const EM_REVISE = path.join(REPO, 'scripts/em-revise.mjs');
+  const rev = run(EM_REVISE, ['--original', v.json.id, '--project', 't', '--summary', 'typo fix', '--body', 'c', '--scope', 'local'], { cwd, home });
+  assert.equal(rev.code, 0, rev.stdout);
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${rev.json.id}.md`), 'utf8');
+  assert.match(md, new RegExp(`^violated_pattern: ${PATTERN}$`, 'm'), 'typed field inherited');
+  assert.match(md, new RegExp(`^lessons: \\[${lessonId}\\]$`, 'm'), 'forward-links inherited');
+  const row = indexRows(cwd).find((e) => e.id === rev.json.id);
+  assert.equal(row.violated_pattern, PATTERN);
+  assert.deepEqual(row.lessons, [lessonId]);
+});
+
 t('testStoreDirectLessonGuard', () => {
   // I2 forge control: --lesson through em-store directly is category-guarded +
   // linkage-validated the same as the em-violation surface.

--- a/tests/test-violation-linkage.mjs
+++ b/tests/test-violation-linkage.mjs
@@ -1,0 +1,140 @@
+/**
+ * test-violation-linkage.mjs — RFC-009 P1b S3: violation linkage + T6 write side (Group 3, §14).
+ *
+ * REQ-7 (--lesson symmetric validation), REQ-8 (typed violated_pattern + tag shim).
+ * Every test asserts captured stdout JSON + on-disk contents — no assert(true).
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_VIOLATION = path.join(REPO, 'scripts/em-violation.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+
+const PATTERN = 'bp-001-implementation-workflow';
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'viollink-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return { cwd: d, home };
+}
+function storeDir(cwd) { return path.join(cwd, '.episodic-memory'); }
+
+function run(script, args, { cwd, home } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, ...(home ? { HOME: home, USERPROFILE: home } : {}) },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); }
+  catch { try { json = JSON.parse(r.stdout.trim().split('\n').pop()); } catch {} }
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+function indexRows(cwd) {
+  try {
+    return fs.readFileSync(path.join(storeDir(cwd), 'index.jsonl'), 'utf8')
+      .trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch { return []; }
+}
+function episodeCount(cwd) {
+  try { return fs.readdirSync(path.join(storeDir(cwd), 'episodes')).filter((f) => f.endsWith('.md')).length; }
+  catch { return 0; }
+}
+function storeLesson(cwd, home) {
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 'l', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+
+t('testViolationLessonValid', () => {
+  const { cwd, home } = mkStore();
+  const lessonId = storeLesson(cwd, home);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', lessonId, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0, v.stdout);
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${v.json.id}.md`), 'utf8');
+  assert.match(md, new RegExp(`^lessons: \\[${lessonId}\\]$`, 'm'), 'lessons inline array in frontmatter');
+  const row = indexRows(cwd).find((e) => e.id === v.json.id);
+  assert.deepEqual(row.lessons, [lessonId], 'lessons in the store-time index row');
+});
+
+t('testViolationLessonRejectsMissing', () => {
+  const { cwd, home } = mkStore();
+  const before = episodeCount(cwd);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', 'no-such-episode', '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 1);
+  assert.match(v.json.message, /no-such-episode/);
+  assert.equal(episodeCount(cwd), before, 'EC5: no violation written');
+});
+
+t('testViolationLessonRejectsNonLesson', () => {
+  const { cwd, home } = mkStore();
+  const d = run(EM_STORE, ['--project', 't', '--category', 'decision', '--summary', 'd', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(d.code, 0);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', d.json.id, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 1);
+  assert.match(v.json.message, /wrong-category/);
+  assert.equal(episodeCount(cwd), 1, 'only the decision episode exists');
+});
+
+t('testViolationLessonRoundTrip', () => {
+  const { cwd, home } = mkStore();
+  const lessonId = storeLesson(cwd, home);
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--lesson', lessonId, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0);
+  const storedRow = indexRows(cwd).find((e) => e.id === v.json.id);
+  const rb = run(EM_REBUILD, ['--scope', 'local'], { cwd, home });
+  assert.equal(rb.code, 0);
+  const rebuiltRow = indexRows(cwd).find((e) => e.id === v.json.id);
+  assert.deepEqual(rebuiltRow.lessons, storedRow.lessons, 'lessons survive rebuild');
+  assert.equal(rebuiltRow.violated_pattern, storedRow.violated_pattern, 'violated_pattern survives rebuild');
+});
+
+t('testViolationWritesViolatedPatternField', () => {
+  const { cwd, home } = mkStore();
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0, v.stdout);
+  assert.equal(v.json.violated_pattern, PATTERN, 'stdout echo unchanged');
+  const md = fs.readFileSync(path.join(storeDir(cwd), 'episodes', `${v.json.id}.md`), 'utf8');
+  assert.match(md, new RegExp(`^violated_pattern: ${PATTERN}$`, 'm'), 'REQ-8: typed scalar in frontmatter');
+  const row = indexRows(cwd).find((e) => e.id === v.json.id);
+  assert.equal(row.violated_pattern, PATTERN, 'typed field indexed at store time');
+});
+
+t('testViolationKeepsTagShim', () => {
+  const { cwd, home } = mkStore();
+  const v = run(EM_VIOLATION, ['--pattern', PATTERN, '--summary', 'v', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(v.code, 0);
+  const row = indexRows(cwd).find((e) => e.id === v.json.id);
+  assert.ok(row.tags.includes(`violated:${PATTERN}`), 'legacy tag kept as the T6 burn-in shim');
+  assert.equal(row.violated_pattern, PATTERN, 'dual-write: shim AND typed field');
+});
+
+t('testStoreDirectLessonGuard', () => {
+  // I2 forge control: --lesson through em-store directly is category-guarded +
+  // linkage-validated the same as the em-violation surface.
+  const { cwd, home } = mkStore();
+  const lessonId = storeLesson(cwd, home);
+  const bad = run(EM_STORE, ['--project', 't', '--category', 'decision', '--lesson', lessonId, '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(bad.code, 1);
+  assert.match(bad.json.message, /violation/, 'lessons is violation-only');
+  const bad2 = run(EM_STORE, ['--project', 't', '--category', 'violation', '--lesson', 'missing-id', '--summary', 's', '--body', 'b', '--scope', 'local'], { cwd, home });
+  assert.equal(bad2.code, 1);
+  assert.match(bad2.json.message, /missing-id/);
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## RFC-009 P1b — lesson-activation schema + trigger index + R9a + T6 + contract mirror

Implements the activation half of RFC-009 Phase 1 from the converged plan `docs/plans/rfc-009-p1b.md`. All deliverables are **data-plane substrate** (RFC-008 R1, P12, CAPABILITIES families 1/3): no hook, no gate, no adapter, nothing under `~/.claude/`.

### What ships (slices S1–S9)
- **`scripts/lib/activation.mjs`** — the single activation-vocab + validator home: tool-id set, inline-array char reject (`, [ ] "` + all control chars + U+2028/U+2029), `illegalScalarChar` for serialized scalars, priority 1-7 with the earned-band rejection of 8/9, `review_by` date, lazy activity-class validation, `loadMergedIndex`, symmetric `resolveLinkage`, `parseActivationFromFrontmatter`.
- **`em-store` / `em-revise`** — lesson-only activation flags (`--trigger`/`--applies-to-project`/`--applies-to-tool`/`--priority`/`--review-by`/`--evidence`), validated before any write; unquoted inline-array frontmatter; index-row carry; em-revise **inherits** activation/linkage/`violated_pattern` (per-field flag override); R9a post-write collision report (stderr, self-excluded, never-fatal).
- **`em-violation`** — repeatable `--lesson` (symmetric merged-scope validation with `--evidence`), typed `violated_pattern` write + legacy tag kept as a marked T6 shim.
- **`em-rebuild-index`** — present-only carry of the 8 new fields.
- **`em-recall` preflight + `em-pattern-health` strikes** — T6 dual-read (typed field ∪ legacy tag, deduped).
- **`scripts/em-trigger-index.mjs`** (new) — per-store lazy `trigger-index.json`: mtime+size+sha256 fingerprint (TOCTOU-safe), unique-temp atomic write, three explicit trigger kinds, expired/superseded exclusion, unknown/deprecated activity-class exclude+count, **earned band** derived at build (0 links → stored 1-7, 1 → 8, ≥2 → 9; chain-resolved both directions; retracted violations drop), NEW `--project <root>` path binding, `session_start` section (trigger-independent critical band + static-score top-10 + dual-read preflight), `loadMergedTriggerIndex` as the only merge site (local precedence, cross-store band recompute, per-store degrade).
- **`activation-classes.json`** (7 classes, phrases empty by design — P2 populates) + schema; `MIN_SCHEMA_DOCS` 20→21.
- **`RFC-009-lesson-activation.contract.json`** + `validate-rfc-009-contract-mirror.mjs` wired into `rfc-validate.yml`; 7 suites wired into `plan-marker-validate.yml`; `install.mjs` deploys the vocab to `~/.episodic-memory` (never `~/.claude`); docs (EM_SCRIPTS_GUIDE + README) + `em` dispatcher entry.

### Invariants
- **I1** the band is earned, never declared (no write surface sets 8-9). **I2** linkage validation is symmetric across `--evidence`/`--lesson`. **I3** stored bytes never mutated for the band. **I4** one serialization class (now closed across *every* serialized value, not just activation fields). **I5** the derived index degrades, never throws. **I6** the event plane reads only purpose-built artifacts. **I7** T6 dual-read until sunset.

### Review trail
`negative-scenario-reviewer` × 3 rounds (behavior-simulation, isolated fixture stores):
- **R1 HOLD** → F1 (control-char frontmatter-key fabrication), F2 (cross-store link never earned the band), F3 (revise stripped activation/linkage), F4 (session_start preflight missing dual-read), F5 (deferred), F6 (folded).
- **R2 HOLD** → F2/F3/F4 verified fixed; F1 half-closed (sibling scalars `summary`/`project`/`url`/`tags`).
- **R3 ACCEPT** → F1 fully closed (complete serialized-value forge class), one NIT (revise-surface test coverage) folded.

### Tests
~70 new tests across 8 suites, all green; base regressions (category-write, tag-flags, recall-v2, recall-purity, help-gauntlet, control-bytes, p12-invariant) green. Every negative scenario is a real script run against an isolated fixture store with captured output.

### Deferred (tracking issues filed, Rule 18 step 9)
- **#487** (F5) — `trigger-index.json` has no JSON schema / backup-exclude lifecycle owner.
- **#488** (§17-G) — `lesson-suppress.json` consumption → P2 (injection layer, RFC gate row :400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
