### PR TITLE
#484: em-console per-load CSP script nonce

### DIFF
--- a/scripts/em-console.mjs
+++ b/scripts/em-console.mjs
@@ -289,13 +289,20 @@ async function handle(req, res) {
 
   if (req.method === 'GET' && url.pathname === '/') {
     const { renderPage } = await import('./lib/console-page.mjs')
+    // Per-load CSP script nonce (#484): the page ships inline JS, so instead of
+    // `script-src 'unsafe-inline'` we mint a fresh nonce per request and admit
+    // ONLY `script-src 'nonce-<v>'`. A future missed sink is then inert (not
+    // executable) because it lacks the nonce — esc() stays the first line of
+    // defense, the nonce is the backstop. Page render is fresh per GET, so the
+    // nonce is never reused across loads.
+    const nonce = crypto.randomBytes(16).toString('base64')
     res.writeHead(200, {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
       'X-Content-Type-Options': 'nosniff',
-      'Content-Security-Policy': "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'; img-src data:; object-src 'none'; base-uri 'none'; form-action 'none'",
+      'Content-Security-Policy': `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; connect-src 'self'; img-src data:; object-src 'none'; base-uri 'none'; form-action 'none'`,
     })
-    return res.end(renderPage())
+    return res.end(renderPage(nonce))
   }
 
   if (req.method === 'GET' && url.pathname === '/api/meta') {

--- a/scripts/lib/console-page.mjs
+++ b/scripts/lib/console-page.mjs
@@ -18,7 +18,7 @@
  * installed, system serif/sans/mono otherwise) — the CSP forbids webfonts.
  */
 
-export function renderPage() {
+export function renderPage(nonce = '') {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -282,7 +282,7 @@ details.more summary { color: var(--accent-dark); font-size: 13px; cursor: point
   <div class="d-body" id="d-body"></div>
 </aside>
 <div id="toast"></div>
-<script>
+<script nonce="${nonce}">
 'use strict';
 // --- token bootstrap: move ?token= into memory, scrub the URL --------------
 const qs = new URLSearchParams(location.search);

--- a/tests/test-em-console.mjs
+++ b/tests/test-em-console.mjs
@@ -339,7 +339,8 @@ await (async () => {
       assert.ok(Array.isArray(hist.json.result.chain) && hist.json.result.chain.length === 1, 'chain missing for hostile episode')
 
       const page = (await req(rw.port, `/?token=${TOKEN}`)).text
-      const script = page.match(/<script>([\s\S]*?)<\/script>/)[1]
+      // Tolerate attributes on the <script> tag (#484 adds `nonce="…"`).
+      const script = page.match(/<script[^>]*>([\s\S]*?)<\/script>/)[1]
       // The drawer must resolve result.chain first (regression pin for the
       // "no chain found" bug: the page read .episodes, which history never emits).
       assert.ok(script.includes('res.body.result.chain ||'), 'drawer no longer resolves result.chain first')
@@ -399,6 +400,36 @@ await (async () => {
       assert.strictEqual(run.status, 401, 'query token rode /api/run')
       const page = await req(rw.port, `/?token=${TOKEN}`)
       assert.strictEqual(page.status, 200, 'page bootstrap broke')
+    })
+    await test('CSP script nonce: header nonce matches the <script> tag, is fresh per load, and script-src has no unsafe-inline (#484)', async () => {
+      // Raw fetch — req() drops response headers, and the CSP header is the
+      // artifact under test.
+      const load = async () => {
+        const r = await fetch(`http://127.0.0.1:${rw.port}/?token=${TOKEN}`)
+        const csp = r.headers.get('content-security-policy') || ''
+        const body = await r.text()
+        return { csp, body }
+      }
+      const a = await load()
+      const b = await load()
+      // 1. script-src is nonce-based and carries NO 'unsafe-inline'.
+      const scriptSrcA = (a.csp.match(/script-src ([^;]*)/) || [])[1] || ''
+      assert.ok(/'nonce-[^']+'/.test(scriptSrcA), `script-src not nonce-based: ${scriptSrcA}`)
+      assert.ok(!/'unsafe-inline'/.test(scriptSrcA), `script-src still allows unsafe-inline: ${scriptSrcA}`)
+      // 2. The header nonce equals the nonce on the served <script> tag.
+      const headerNonce = a.csp.match(/script-src 'nonce-([^']+)'/)[1]
+      const tagNonce = a.body.match(/<script nonce="([^"]+)">/)[1]
+      assert.strictEqual(tagNonce, headerNonce, 'served <script> nonce != CSP header nonce')
+      assert.ok(headerNonce.length >= 20, `nonce too short to be 16 CSPRNG bytes: ${headerNonce}`)
+      // 3. Fresh per load — the second GET has a different nonce.
+      const headerNonceB = b.csp.match(/script-src 'nonce-([^']+)'/)[1]
+      assert.notStrictEqual(headerNonceB, headerNonce, 'nonce reused across loads (not per-request)')
+    })
+    await test('nonce edit did not disturb the escaping sink: served <script> still defines esc() and carries the nonce (#484 REQ-2)', async () => {
+      const page = (await req(rw.port, `/?token=${TOKEN}`)).text
+      assert.ok(/<script nonce="[^"]+">/.test(page), 'nonce attribute missing on served <script>')
+      const script = page.match(/<script[^>]*>([\s\S]*?)<\/script>/)[1]
+      assert.ok(script.includes('function esc('), 'esc() sink no longer present in the served script')
     })
   } finally {
     rw.proc.kill()


### PR DESCRIPTION
## #484 — em-console per-load CSP script nonce

The em-console page ships inline JS, so its CSP was `script-src 'unsafe-inline'` — `esc()` was the only layer between attacker-influenced episode content and script execution. This adds a per-request nonce so a **future missed sink is inert** (lacks the nonce) instead of executable.

### Changes
- `em-console.mjs` GET /: mint `crypto.randomBytes(16).toString('base64')` per request (crypto already imported; page render is fresh per GET so the nonce is never reused), emit `script-src 'nonce-<v>'` (drops `'unsafe-inline'` for scripts).
- `console-page.mjs`: `renderPage(nonce)` emits `<script nonce="<v>">` (default `''` → a nonce-less call fails safe: the tag matches no CSP source and the browser blocks it).
- `test-em-console.mjs`: script-extraction regex tolerates attributes; **+2 tests against the real spawned server** — the CSP header nonce equals the served tag nonce, is fresh per load, script-src has no `'unsafe-inline'`, and the `esc()` sink is intact.

### Verification
`node tests/test-em-console.mjs` → **28/28** (live server + curl, not a mock).

### Deferred (5-field, filed)
`style-src 'unsafe-inline'` residual (48 inline `style=` attrs) — out of scope for #484 (script vector) → **#494**.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)
