### PR TITLE
#487 + #492: schemas for the derived trigger index + consumer registry

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -297,6 +297,9 @@ jobs:
       - name: Run trigger-index core suite (RFC-009 P1b S5)
         run: node tests/test-trigger-index.mjs
 
+      - name: Run trigger-index schema gate (#487 — derived-file schema)
+        run: node tests/test-trigger-index-schema.mjs
+
       - name: Run trigger-index session_start suite (RFC-009 P1b S6)
         run: node tests/test-trigger-session-start.mjs
 

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run P0 schema gate (corpus co-consumer — #368 divergence lock)
         run: node tests/test-p0-schemas.mjs
 
+      - name: Run consumer-registry schema gate (#492 — installs.json flag family)
+        run: node tests/test-consumer-registry-schema.mjs
+
       - name: Run path-contain axis tests
         run: node tests/test-path-contain.mjs
 

--- a/plugins/consumer-registry.schema.json
+++ b/plugins/consumer-registry.schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://episodic-memory/plugins/consumer-registry.schema.json",
+  "title": "Consumer registry (~/.episodic-memory/installs.json) — RFC-009 P2 / #492",
+  "description": "Closed, versioned contract for the consumer registry rows that carry the enforcement_installed / activation_installed install flags. installed-state.schema.json covers a DIFFERENT artifact (the per-project installed_state block); this schema covers the registry rows. schema_version is const 1; a new row field is an additive schema_version bump, not a silent extension (not future-tolerant by design).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "entries"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/registryEntry" }
+    }
+  },
+  "$defs": {
+    "registryEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project_path", "tool", "version", "enforcement_installed", "activation_installed", "last_install_ts"],
+      "properties": {
+        "project_path": { "type": "string", "minLength": 1 },
+        "tool": { "type": "string", "minLength": 1 },
+        "version": { "type": "string" },
+        "enforcement_installed": { "type": "boolean" },
+        "activation_installed": { "type": "boolean" },
+        "last_install_ts": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}

--- a/schemas/trigger-index.schema.json
+++ b/schemas/trigger-index.schema.json
@@ -1,0 +1,64 @@
+{
+  "$id": "https://episodic-memory/schemas/trigger-index.schema.json",
+  "title": "Trigger index (per-store <store>/trigger-index.json) — RFC-009 R2 / #487",
+  "description": "Closed, versioned contract for the DERIVED trigger index emitted by em-trigger-index.mjs. schema_version is const 2 (the live producer, em-trigger-index.mjs TRIGGER_INDEX_SCHEMA_VERSION); a new top-level field or entry field is an additive schema_version bump, not a silent extension. review_by is emitted only when the lesson carries one (em-trigger-index.mjs:262), so it is optional.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "source", "build_report", "entries", "activity_phrases", "session_start"],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index_mtime_ms", "index_size", "index_sha256"],
+      "properties": {
+        "index_mtime_ms": { "type": "number" },
+        "index_size": { "type": "integer", "minimum": 0 },
+        "index_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "build_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["excluded_activity_classes"],
+      "properties": {
+        "excluded_activity_classes": { "type": "object" }
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/triggerEntry" }
+    },
+    "activity_phrases": {
+      "type": "object",
+      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+    },
+    "session_start": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["critical_entries", "entries", "preflight"],
+      "properties": {
+        "critical_entries": { "type": "array" },
+        "entries": { "type": "array" },
+        "preflight": { "type": "object" }
+      }
+    }
+  },
+  "$defs": {
+    "triggerEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trigger_kind", "value", "episode_id", "summary", "effective_priority", "applies_to_projects", "applies_to_tools"],
+      "properties": {
+        "trigger_kind": { "enum": ["phrase", "tool", "activity"] },
+        "value": { "type": "string" },
+        "episode_id": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string" },
+        "effective_priority": { "type": "integer", "minimum": 1 },
+        "applies_to_projects": { "type": "array", "items": { "type": "string" } },
+        "applies_to_tools": { "type": "array", "items": { "type": "string" } },
+        "review_by": { "type": "string" }
+      }
+    }
+  }
+}

--- a/scripts/em-backup.mjs
+++ b/scripts/em-backup.mjs
@@ -184,6 +184,15 @@ const SKIP_FRAGMENTS = [
 const SKIP_FILE_PATTERNS = [/\.tmp$/, /\.log$/, /\.swp$/, /^\..*\.swp$/]
 const MAX_FILE_BYTES = 1024 * 1024 // 1 MB
 
+// DERIVED-INDEX BACKUP POSTURE (#487): the derived indexes — index.jsonl,
+// tags.json, tokens.json, category-index.json, trigger-index.json — are
+// intentionally backed up as-is (not excluded here). They are deterministically
+// rebuilt from the episodes on the next consumer read (via the fingerprint /
+// em-rebuild-index), so a stale derived file in a backup is harmless, and
+// index.jsonl is required for a clean restore. Excluding trigger-index.json in
+// isolation would make it the odd one out; a full derived-file exclude sweep
+// (coupled with a restore-time rebuild) is tracked separately, not done here.
+
 // ---------------------------------------------------------------------------
 // Redaction patterns
 //

--- a/tests/test-consumer-registry-schema.mjs
+++ b/tests/test-consumer-registry-schema.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * test-consumer-registry-schema.mjs — #492
+ *
+ * The consumer registry (~/.episodic-memory/installs.json) rows that carry the
+ * enforcement_installed / activation_installed flags now have a discovered JSON
+ * Schema (plugins/consumer-registry.schema.json). installed-state.schema.json
+ * covers a DIFFERENT artifact. This proves the schema validates the REAL
+ * registry and is a CLOSED contract (not future-tolerant — codex nit).
+ *
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert';
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins/consumer-registry.schema.json'), 'utf8'));
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function validRow(over = {}) {
+  return {
+    project_path: '/Users/juan.delacruz/proj',
+    tool: 'claude-code',
+    version: 'abc123',
+    enforcement_installed: false,
+    activation_installed: true,
+    last_install_ts: '2026-07-09T08:13:03.434Z',
+    ...over,
+  };
+}
+const validRegistry = () => ({ schema_version: 1, entries: [validRow()] });
+
+// --- The REAL registry validates (if one exists on this machine) ---
+
+t('the real ~/.episodic-memory/installs.json validates (when present)', () => {
+  const p = path.join(os.homedir(), '.episodic-memory', 'installs.json');
+  if (!fs.existsSync(p)) { console.log('    (skipped — no real registry on this machine)'); return; }
+  const reg = JSON.parse(fs.readFileSync(p, 'utf8'));
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(res.valid, `real installs.json rejected: ${JSON.stringify(res.errors).slice(0, 400)}`);
+});
+
+t('a synthetic minimal registry validates', () => {
+  const res = validateInstance(validRegistry(), SCHEMA);
+  assert.ok(res.valid, `synthetic registry rejected: ${JSON.stringify(res.errors)}`);
+});
+
+// --- Negative controls (each must be REJECTED) ---
+
+t('a row missing project_path is REJECTED', () => {
+  const reg = validRegistry();
+  delete reg.entries[0].project_path;
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(!res.valid, 'a row without project_path must be rejected');
+});
+
+t('a row with an unknown field is REJECTED (closed contract, not future-tolerant)', () => {
+  const reg = { schema_version: 1, entries: [validRow({ repair_notes: 'oops' })] };
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(!res.valid, 'an extra field must be rejected — the schema is versioned/closed');
+  assert.ok(res.errors.some((e) => e.keyword === 'additionalProperties'), `wrong error: ${JSON.stringify(res.errors)}`);
+});
+
+t('a wrong schema_version is REJECTED (const 1)', () => {
+  const reg = { schema_version: 2, entries: [validRow()] };
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(!res.valid, 'schema_version must be const 1');
+});
+
+t('a non-boolean install flag is REJECTED', () => {
+  const reg = { schema_version: 1, entries: [validRow({ activation_installed: 'yes' })] };
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(!res.valid, 'activation_installed must be a boolean');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/tests/test-trigger-index-schema.mjs
+++ b/tests/test-trigger-index-schema.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * test-trigger-index-schema.mjs — #487
+ *
+ * The DERIVED trigger index (per-store trigger-index.json, emitted by
+ * em-trigger-index.mjs) now has a discovered JSON Schema
+ * (schemas/trigger-index.schema.json). This proves the schema matches the REAL
+ * emitted v2 file — seeded with representative data so entries[] is non-empty
+ * (codex-B2: a schema that only ever sees an empty entries[] never exercises
+ * the entry subschema, and a `const:1` draft would reject the live v2 file).
+ *
+ * Zero deps — Node stdlib only.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const EM_STORE = path.join(REPO, 'scripts/em-store.mjs');
+const EM_TRIGGER = path.join(REPO, 'scripts/em-trigger-index.mjs');
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'schemas/trigger-index.schema.json'), 'utf8'));
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+function mkStore() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'trigidx-schema-')));
+  const home = path.join(d, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  return { cwd: d, home };
+}
+function run(script, args, { cwd, home } = {}) {
+  const r = spawnSync('node', [script, ...args], {
+    cwd, encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  });
+  let json = null;
+  try { json = JSON.parse(r.stdout.trim()); } catch { /* non-json */ }
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr, json };
+}
+function storeLesson(cwd, home, extra) {
+  const r = run(EM_STORE, ['--project', 't', '--category', 'lesson', '--summary', 'l',
+    '--body', 'b', '--scope', 'local', ...extra], { cwd, home });
+  assert.equal(r.code, 0, r.stdout);
+  return r.json.id;
+}
+function seededIndex() {
+  const { cwd, home } = mkStore();
+  // Two lessons: one with all three trigger kinds + a review_by (exercises the
+  // optional review_by field), one without (exercises its absence).
+  storeLesson(cwd, home, ['--trigger', 'a phrase', '--trigger', 'tool:Bash:git*',
+    '--trigger', 'activity:plan', '--applies-to-tool', 'claude-code', '--review-by', '2099-01-01']);
+  storeLesson(cwd, home, ['--trigger', 'another phrase', '--priority', '3']);
+  const r = run(EM_TRIGGER, ['--scope', 'local'], { cwd, home });
+  assert.equal(r.code, 0, `${r.stdout}\n${r.stderr}`);
+  return JSON.parse(fs.readFileSync(path.join(cwd, '.episodic-memory', 'trigger-index.json'), 'utf8'));
+}
+
+// --- The real seeded v2 index validates, with entries exercised ---
+
+t('schema validates a REAL seeded v2 trigger-index with non-empty entries', () => {
+  const idx = seededIndex();
+  assert.equal(idx.schema_version, 2, 'live producer emits v2');
+  assert.ok(idx.entries.length > 0, `entries[] must be non-empty to exercise the entry subschema, got ${idx.entries.length}`);
+  const res = validateInstance(idx, SCHEMA);
+  assert.ok(res.valid, `real seeded index rejected: ${JSON.stringify(res.errors).slice(0, 400)}`);
+  // All three trigger kinds are present and validated.
+  const kinds = new Set(idx.entries.map((e) => e.trigger_kind));
+  assert.ok(kinds.has('phrase') && kinds.has('tool') && kinds.has('activity'),
+    `expected all three kinds, got ${[...kinds].join(',')}`);
+  // Top-level sections the contract mirror does NOT pin are still schema-covered.
+  assert.ok(Object.keys(idx.activity_phrases).length > 0, 'activity_phrases baked + covered');
+  assert.ok(idx.build_report && typeof idx.build_report.excluded_activity_classes === 'object', 'build_report covered');
+  assert.ok(idx.session_start && Array.isArray(idx.session_start.critical_entries)
+    && Array.isArray(idx.session_start.entries) && idx.session_start.preflight, 'session_start covered');
+  // An entry carrying review_by validates (optional field present).
+  assert.ok(idx.entries.some((e) => e.review_by === '2099-01-01'), 'review_by-bearing entry present + accepted');
+});
+
+// --- Negative controls (each must be REJECTED) ---
+
+t('a schema_version:1 index is REJECTED (const 2)', () => {
+  const idx = seededIndex();
+  idx.schema_version = 1;
+  const res = validateInstance(idx, SCHEMA);
+  assert.ok(!res.valid, 'a v1 index must not validate against the v2 schema');
+  assert.ok(res.errors.some((e) => e.path.includes('schema_version')), `wrong error: ${JSON.stringify(res.errors)}`);
+});
+
+t('a malformed entry (bad trigger_kind) is REJECTED', () => {
+  const idx = seededIndex();
+  idx.entries[0].trigger_kind = 'bogus';
+  const res = validateInstance(idx, SCHEMA);
+  assert.ok(!res.valid, 'an entry with an out-of-enum trigger_kind must be rejected');
+});
+
+t('a missing required top-level section (session_start) is REJECTED', () => {
+  const idx = seededIndex();
+  delete idx.session_start;
+  const res = validateInstance(idx, SCHEMA);
+  assert.ok(!res.valid, 'a trigger-index without session_start must be rejected');
+});
+
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);


### PR DESCRIPTION
## #487 + #492 — JSON schemas for the derived trigger index + the consumer registry

Two derived/registry JSON artifacts had no schema. `installed-state.schema.json` covers a **different** artifact (the per-project `installed_state` block), not these.

### Changes
- `schemas/trigger-index.schema.json` (#487): closed, versioned contract for the derived per-store `trigger-index.json`. `schema_version` is **const 2** (the live producer — a `const:1` draft would reject every real file). `review_by` is optional (emitted only when the lesson carries one).
- `plugins/consumer-registry.schema.json` (#492): closed, versioned contract for the `installs.json` rows carrying `enforcement_installed` / `activation_installed`. Not future-tolerant by design.
- Both auto-discovered by `validate-schemas` (docs 24→26; no floor bump — the floor is a `>=` non-vacuity check per the existing convention).
- `tests/test-trigger-index-schema.mjs` (4): validates a **real seeded v2 index** with a non-empty `entries[]` (all three trigger kinds exercised) + `activity_phrases`/`build_report`/`session_start`; negatives reject v1, a bad `trigger_kind`, a missing section.
- `tests/test-consumer-registry-schema.mjs` (6): validates the **real `installs.json`**; negatives reject a missing `project_path`, an unknown field (proves closed), a wrong `schema_version`, a non-boolean flag.
- Both wired into CI (`plan-marker-validate.yml`, `plugin-validate.yml`).
- `em-backup.mjs`: documents the derived-index backup posture (rebuilt-on-read; no behavior change).

### Verification
`validate-schemas` → 26 docs, `violations: []`; the two new tests → 4/4 + 6/6; `test-trigger-index` 23/23 and `validate-plugin-registry` OK (no regression).

### Deferred (5-field, filed)
Full derived-file backup-exclude sweep (coupled with restore-time rebuild) → **#495**.

Closes #487
Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
