### PR TITLE
#490 + #491: activation install/registry bind to the literal --project

### DIFF
--- a/docs/plans/rfc-009-p2.md
+++ b/docs/plans/rfc-009-p2.md
@@ -110,8 +110,8 @@ install. Every mitigation carries ≥1 negative control (§A.9 red-then-green).
 
 | Surface | Authority root (must bind to) | Never |
 |---|---|---|
-| `--install-activation` / `--uninstall-activation` HOOK set | explicit `--project` root → `<project>/.claude/` | caller cwd, `~/.claude/` |
-| install METADATA — consumer registry | `HOME` → `~/.episodic-memory/installs.json` (`activation_installed` flag) | `~/.claude/` (P12: payload cache is not a registration) |
+| `--install-activation` / `--uninstall-activation` HOOK set | LITERAL `--project` (`projectAbs = path.resolve(--project)`) → `<project>/.claude/` — same root as enforcement + em-sync-install (#490/#491) | `resolveRepoRoot` walk-up/converge (that is IDENTITY, not registration), caller cwd, `~/.claude/` |
+| install METADATA — consumer registry | `HOME` → `~/.episodic-memory/installs.json` row keyed + healed on `normalizeProjectPath(projectAbs)` (the literal `--project`) | `~/.claude/`; a resolved authority root (would split key from artifacts — #490) |
 | install METADATA — per-project manifest | explicit `--project` → `<project>/.episodic-memory-install.json` | caller cwd |
 | install METADATA — dist cache | `HOME` → `~/.episodic-memory/` dist cache | `~/.claude/` |
 | adapter scope identity | **manifest `project_identity`** (written by install from `--project`) | stdin cwd, environment |
@@ -122,7 +122,7 @@ install. Every mitigation carries ≥1 negative control (§A.9 red-then-green).
 | `activation-classes.json` | repo/installed runtime artifact, **build-plane only** | event-plane env-controlled read |
 | registry/schema/manifest edits | repo root | — |
 
-> **Open (S6 review panel, 2026-07-09):** rows 113–114 have unresolved divergences between this table and the shipped impl. Row 113 reads `<project>/.claude/`; the impl binds the *resolved* authority root (`resolveRepoRoot`), so a linked-worktree `--project` wires the main checkout — tracked in #491 (converge-on-main vs worktree-local registration). Row 114's `installs.json` flag is keyed by the literal `--project` path, not the resolved root — tracked in #490. Do not treat rows 113/114 as settled until those issues close.
+> **Resolved (2026-07-09, #490/#491):** the S6-flagged divergences are closed. Activation registration + hook files + the `installs.json` row key + heal all bind to the LITERAL `--project` (`projectAbs`) — the same root as enforcement + `em-sync-install` — so key == artifacts == heal (no #490 mistarget/duplicate) and a linked-worktree `--project` installs at (and fires from) the worktree (#491). Store IDENTITY (`manifest.project_identity.root`, rows 117–118) stays on `resolveRepoRoot` so a worktree still shares main's store — the one surface that resolves up. Codex proved keying the row at a *resolved* root instead would break `em-sync-install` (which matches `projectAbs`); aligning activation to `projectAbs` avoids that. See `docs/plans/issues-484-487-490-491-492.md`.
 
 ### 7.2 Threat table
 

--- a/install.mjs
+++ b/install.mjs
@@ -71,8 +71,9 @@ const installEnforcement = argv.includes('--install-enforcement')
 const uninstallEnforcement = argv.includes('--uninstall-enforcement')
 const purgeConfig = argv.includes('--purge-config')
 // RFC-009 P2-S6: the advisory activation adapter (R3 UserPromptSubmit/PreToolUse
-// + R4 SessionStart hooks) installs PER-PROJECT (Principle 12) under
-// <authorityRoot>/.claude/, NEVER global, and NEVER touches enforcement.
+// + R4 SessionStart hooks) installs PER-PROJECT (Principle 12) under the literal
+// <project>/.claude/ (the resolved --project; store identity resolves up), NEVER
+// global, and NEVER touches enforcement.
 // Advisory-only: the hooks emit additionalContext and always exit 0 — no gate,
 // no block. Independent of --install-enforcement (separate capability family).
 const installActivation = argv.includes('--install-activation')
@@ -241,13 +242,15 @@ Hook flags (claude-code / RFC-008 P4d — enforcement is PER-PROJECT, never glob
 
 Activation flags (claude-code / RFC-009 P2 — advisory, PER-PROJECT, never global):
   --install-activation    Install the PER-PROJECT advisory activation adapter
-                          under <authorityRoot>/.claude/ (NEVER ~/.claude): the
-                          3 thin hooks (activation-prompt UserPromptSubmit,
+                          under the literal <project>/.claude/ (the resolved
+                          --project, same root as enforcement; NEVER ~/.claude):
+                          the 3 thin hooks (activation-prompt UserPromptSubmit,
                           activation-tool PreToolUse, activation-sessionstart
                           SessionStart) + the shared activation-hook-run.mjs
                           runner + a co-located manifest.json carrying the
-                          project scope identity (slug + resolved root), and
-                          register them in <authorityRoot>/.claude/settings.json.
+                          project scope identity (slug + RESOLVED store root,
+                          which for a worktree stays the main checkout), and
+                          register them in <project>/.claude/settings.json.
                           Advisory-ONLY: the hooks emit additionalContext and
                           always exit 0 — no gate, no block. Independent of
                           --install-enforcement. Skips divergent local hook
@@ -1655,13 +1658,19 @@ function activationOwnedFiles() {
 // { root, slug, installedFiles, registrations, manifest, withheld, warnings }.
 function runInstallActivation(projectDir) {
   const report = { root: null, slug: null, installedFiles: [], registrations: [], manifest: null, withheld: [], warnings: [], runnerReady: false }
+  // Registration binds to the LITERAL --project (registrationRoot = the resolved
+  // --project path), exactly like enforcement + em-sync-install (#490/#491): a
+  // worktree --project installs at the worktree (and fires there), a nested
+  // --project at the subdir. Store IDENTITY stays on the resolved authority root
+  // (authorityRoot) so a worktree still shares main's episodic store.
+  const registrationRoot = path.resolve(projectDir)
   const authorityRoot = resolveRepoRoot(projectDir)
   const slug = path.basename(authorityRoot)
-  report.root = authorityRoot
+  report.root = registrationRoot
   report.slug = slug
 
-  const userHooksDir = path.join(authorityRoot, '.claude', 'hooks')
-  const settingsPath = path.join(authorityRoot, '.claude', 'settings.json')
+  const userHooksDir = path.join(registrationRoot, '.claude', 'hooks')
+  const settingsPath = path.join(registrationRoot, '.claude', 'settings.json')
   const srcHooksDir = path.join(REPO_DIR, 'plugins', 'claude-code-activation', 'hooks')
   const srcManifest = path.join(REPO_DIR, 'plugins', 'claude-code-activation', 'manifest.json')
 
@@ -1783,10 +1792,14 @@ function runInstallActivation(projectDir) {
 // warn (never delete unverifiable files). Throws ONLY on a containment violation.
 function runUninstallActivation(projectDir) {
   const report = { removedRegistrations: [], removedFiles: [], preserved: [], warnings: [] }
-  const authorityRoot = resolveRepoRoot(projectDir)
-  const userHooksDir = path.join(authorityRoot, '.claude', 'hooks')
+  // Root-symmetric with install (#490/#491 B1): registration was installed at the
+  // LITERAL --project (registrationRoot), so uninstall must target the same root,
+  // NOT resolveRepoRoot — else a worktree/nested uninstall would look at the wrong
+  // tree and orphan the registration it was asked to remove.
+  const registrationRoot = path.resolve(projectDir)
+  const userHooksDir = path.join(registrationRoot, '.claude', 'hooks')
   const hooksRoot = userHooksDir
-  const settingsPath = path.join(authorityRoot, '.claude', 'settings.json')
+  const settingsPath = path.join(registrationRoot, '.claude', 'settings.json')
   const realpathOrLexical = (p) => { try { return fs.realpathSync(p) } catch { return path.resolve(p) } }
 
   // (a) PARSE FIRST — atomic on malformed settings. On SyntaxError, abort the
@@ -1839,17 +1852,17 @@ function runUninstallActivation(projectDir) {
         const cmds = (entry && Array.isArray(entry.hooks)) ? entry.hooks : []
         for (const h of cmds) {
           if (!h || typeof h.command !== 'string') continue
-          // (F3) Resolve a legacy RELATIVE command against authorityRoot — the
+          // (F3) Resolve a legacy RELATIVE command against registrationRoot — the
           //      root whose settings.json we are editing and the SAME base the
           //      install side builds the canonical command from (userHooksDir =
-          //      authorityRoot/.claude/hooks). Using projectDir here mis-resolved
-          //      a nested `--project <subdir>` invocation: the legacy relative
-          //      `.claude/hooks/activation-prompt.sh` bound under the subdir,
-          //      compared unequal to the canonical path, was judged foreign and
-          //      LEFT — yet its canonical file was still deleted below, stranding
-          //      a dangling registration. A genuinely foreign absolute path still
-          //      resolves ELSEWHERE → warn + leave (operator's own hook).
-          const tgt = hookCommandTargetPath(h.command, authorityRoot)
+          //      registrationRoot/.claude/hooks). The base MUST match install's
+          //      registration root exactly, else a legacy relative
+          //      `.claude/hooks/activation-prompt.sh` resolves elsewhere, compares
+          //      unequal to the canonical path, is judged foreign and LEFT — yet
+          //      its canonical file is still deleted below, stranding a dangling
+          //      registration. A genuinely foreign absolute path still resolves
+          //      ELSEWHERE → warn + leave (operator's own hook).
+          const tgt = hookCommandTargetPath(h.command, registrationRoot)
           if (!tgt || path.basename(tgt) !== reg.file) continue
           if (realpathOrLexical(tgt) === canonicalResolved) {
             if (removeHookCommandFromEvent(settings.hooks, reg.event, h.command) > 0) {
@@ -2466,8 +2479,8 @@ if (uninstallActivation && (tool === 'claude-code' || tool === 'all')) {
 }
 
 if (installActivation && (tool === 'claude-code' || tool === 'all')) {
-  // RFC-009 P2-S6: deploy the per-project advisory activation adapter under
-  // <authorityRoot>/.claude/. Independent of --install-enforcement.
+  // RFC-009 P2-S6: deploy the per-project advisory activation adapter under the
+  // literal <project>/.claude/. Independent of --install-enforcement.
   const rep = runInstallActivation(projectDir)
   // (F1) Carry INSTALL-TIME truth to the registry companion gate below: it must
   //      record activation_installed:true ONLY when this run actually wired the
@@ -3333,9 +3346,12 @@ try {
   // heals here on the next regular install: engine gone ⇒ false).
   if (!uninstallEnforcement && !uninstallActivation) {
     const projectKey = normalizeProjectPath(projectAbs)
-    // Activation binds to the resolved authority root (may differ from projectAbs
-    // for a nested/worktree --project); heal its flag from disk truth there.
-    const activationRoot = resolveRepoRoot(projectAbs)
+    // Activation binds to the LITERAL --project (projectAbs) — the SAME root as
+    // the row key + enforcement + em-sync-install (#490). Heal its flag from disk
+    // truth there, so key == artifacts == heal with no nested/worktree divergence
+    // (was resolveRepoRoot(projectAbs), which mistargeted the flag and duplicated
+    // the row for a nested/worktree --project).
+    const activationRoot = projectAbs
     const { entries: existingEntries } = readRegistry(registryPath(GLOBAL_DIR))
     const nowIso = new Date().toISOString()
     const registryUpdates = tools.map((t) => {

--- a/tests/test-uninstall-activation.mjs
+++ b/tests/test-uninstall-activation.mjs
@@ -430,8 +430,10 @@ test('cwd_independent', () => {
   ok('cwd_independent — caller cwd ≠ project ≠ repo; activation delta lands in the mock project')
 })
 
-// ── authority_root_linked_worktree: --project=worktree binds to MAIN checkout ─
-test('authority_root_linked_worktree', () => {
+// ── worktree_local_registration: --project=worktree installs AT the worktree ──
+//    (#491 — was authority_root_linked_worktree, which asserted converge-on-main;
+//    the projectAbs design installs registration where Claude Code reads it.)
+test('worktree_local_registration', () => {
   const M = mkMock('act-wt')
   const mainRepo = path.join(M.base, 'wt-main')
   mkGitRepo(mainRepo)
@@ -439,31 +441,47 @@ test('authority_root_linked_worktree', () => {
   const w = git(mainRepo, ['worktree', 'add', '-q', wt])
   assert.strictEqual(w.status, 0, `git worktree add must succeed: ${w.stderr}`)
   installActivation(M, wt)
-  const resolved = resolveRepoRoot(wt)
-  assert.notStrictEqual(resolved, wt, 'authority root must resolve UP to the main checkout, not the worktree')
-  const m = readParsed(MANIFEST(resolved))
-  assert.ok(m, `manifest must land under the resolved main root ${resolved}/.claude/hooks/`)
-  assert.strictEqual(m.project_identity.root, resolved, 'manifest project_identity.root == resolved main checkout')
-  assert.ok(fs.existsSync(path.join(HOOKS(resolved), 'activation-hook-run.mjs')), 'hooks deployed under the resolved main root')
-  ok('authority_root_linked_worktree — --project=worktree deploys under the MAIN checkout (resolveRepoRoot)')
+  const wtReal = fs.realpathSync(wt)
+  const mainReal = resolveRepoRoot(wt)
+  assert.notStrictEqual(mainReal, wtReal, 'sanity: resolveRepoRoot(worktree) converges to the main checkout')
+  // Registration + hooks land AT the worktree (the literal --project), where
+  // Claude Code run from the worktree reads settings.json — NOT under main (#491).
+  assert.ok(fs.existsSync(path.join(HOOKS(wtReal), 'activation-hook-run.mjs')),
+    'hooks must deploy under the worktree, not the main checkout')
+  const s = readParsed(SETTINGS(wtReal))
+  assert.ok(s && hasActivationCommand(s), 'settings.json at the worktree carries the activation registrations')
+  assert.ok(!fs.existsSync(path.join(HOOKS(mainReal), 'activation-hook-run.mjs')),
+    'nothing activation lands under the main checkout')
+  // But store IDENTITY stays main so the worktree still shares main's episodic store.
+  const m = readParsed(MANIFEST(wtReal))
+  assert.ok(m, `manifest must land at the worktree ${wtReal}/.claude/hooks/`)
+  assert.strictEqual(m.project_identity.root, mainReal, 'project_identity.root stays the resolved main checkout (shared store)')
+  ok('worktree_local_registration — --project=worktree installs at the worktree; identity stays main')
 })
 
-// ── authority_root_nested_cwd: --project=subdir resolves UP to the git toplevel ─
-test('authority_root_nested_cwd', () => {
+// ── nested_local_registration: --project=subdir installs AT the subdir ────────
+//    (#490 — was authority_root_nested_cwd, which asserted walk-up; the projectAbs
+//    design honors the literal --project, consistent with enforcement.)
+test('nested_local_registration', () => {
   const M = mkMock('act-nested')
   const gitRoot = path.join(M.base, 'nested-main')
   mkGitRepo(gitRoot)
   const sub = path.join(gitRoot, 'a', 'b')
   fs.mkdirSync(sub, { recursive: true })
   installActivation(M, sub)
-  const resolved = resolveRepoRoot(sub)
-  assert.notStrictEqual(resolved, sub, 'authority root must resolve UP to the git toplevel, not the nested subdir')
-  const m = readParsed(MANIFEST(resolved))
-  assert.ok(m, `manifest must land under the git toplevel ${resolved}/.claude/hooks/`)
-  assert.strictEqual(m.project_identity.root, resolved, 'manifest project_identity.root == git toplevel')
-  assert.strictEqual(resolved, fs.realpathSync(gitRoot), 'resolved root == the repo toplevel')
-  assert.ok(fs.existsSync(path.join(HOOKS(resolved), 'activation-hook-run.mjs')), 'hooks deployed under the git toplevel')
-  ok('authority_root_nested_cwd — --project=subdir deploys under the git toplevel (resolveRepoRoot)')
+  const subReal = fs.realpathSync(sub)
+  const toplevel = resolveRepoRoot(sub)
+  assert.notStrictEqual(toplevel, subReal, 'sanity: resolveRepoRoot(subdir) resolves UP to the git toplevel')
+  // Registration + hooks land AT the literal --project subdir, not walked up.
+  assert.ok(fs.existsSync(path.join(HOOKS(subReal), 'activation-hook-run.mjs')),
+    'hooks must deploy under the literal --project subdir')
+  const s = readParsed(SETTINGS(subReal))
+  assert.ok(s && hasActivationCommand(s), 'settings.json at the subdir carries the activation registrations')
+  // Store IDENTITY stays the git toplevel (shared repo store).
+  const m = readParsed(MANIFEST(subReal))
+  assert.ok(m, `manifest must land at the subdir ${subReal}/.claude/hooks/`)
+  assert.strictEqual(m.project_identity.root, toplevel, 'project_identity.root stays the git toplevel (shared store)')
+  ok('nested_local_registration — --project=subdir installs at the subdir; identity stays git toplevel')
 })
 
 // ── authority_root_non_git_cwd: --project=plain dir binds to the dir itself ───
@@ -479,6 +497,82 @@ test('authority_root_non_git_cwd', () => {
   assert.strictEqual(m.project_identity.root, resolved, 'manifest project_identity.root == the plain dir')
   assert.ok(fs.existsSync(path.join(HOOKS(plain), 'activation-hook-run.mjs')), 'hooks deployed under the plain dir')
   ok('authority_root_non_git_cwd — --project=non-git dir deploys under the dir itself (resolveRepoRoot)')
+})
+
+// ── single_row_per_project: one --project → one row, keyed + healed there ─────
+//    (#490 core: key == artifacts == heal at projectAbs; re-install is idempotent,
+//    the flag is never mistargeted, and there is no duplicate row.)
+test('single_row_per_project', () => {
+  const M = mkMock('act-onerow')
+  const gitRoot = path.join(M.base, 'onerow-main')
+  mkGitRepo(gitRoot)
+  const sub = path.join(gitRoot, 'x', 'y')
+  fs.mkdirSync(sub, { recursive: true })
+  installActivation(M, sub)
+  installActivation(M, sub) // idempotent — same literal --project
+  const reg = readParsed(path.join(M.home, '.episodic-memory', 'installs.json'))
+  const subReal = fs.realpathSync(sub)
+  const rows = reg.entries.filter((e) => e.tool === 'claude-code')
+  assert.strictEqual(rows.length, 1, `exactly one claude-code row for one --project, got ${rows.length}: ${JSON.stringify(rows.map((r) => r.project_path))}`)
+  assert.strictEqual(rows[0].project_path, subReal, 'row keyed at the literal --project (realpath), not the git toplevel')
+  assert.strictEqual(rows[0].activation_installed, true, 'activation_installed healed true at the row-key root')
+  ok('single_row_per_project — one --project → one row keyed there, activation_installed true (#490)')
+})
+
+// ── one_row_both_adapters: activation + enforcement share ONE row (both projectAbs)
+//    (B2 dissolved: both adapters key on the same literal --project.)
+test('one_row_both_adapters', () => {
+  const M = mkMock('act-bothrow')
+  const r = runInstall({ home: M.home, project: M.project, callerCwd: M.callerCwd, flags: ['--install-activation', '--install-enforcement'] })
+  assert.strictEqual(r.status, 0, `install must succeed: ${r.stderr}`)
+  const reg = readParsed(path.join(M.home, '.episodic-memory', 'installs.json'))
+  const rows = reg.entries.filter((e) => e.tool === 'claude-code')
+  assert.strictEqual(rows.length, 1, `both adapters must share ONE claude-code row, got ${rows.length}`)
+  assert.strictEqual(rows[0].activation_installed, true, 'activation_installed:true on the shared row')
+  assert.strictEqual(rows[0].enforcement_installed, true, 'enforcement_installed:true on the SAME row (no split)')
+  ok('one_row_both_adapters — activation + enforcement carried on one row (B2)')
+})
+
+// ── em_sync_recognizes_registered: the row stays findable by em-sync-install ───
+//    (codex-B1 guard: em-sync-install matches the row by the literal --project;
+//    keying activation there — not at a resolved root — keeps it recognizable.)
+test('em_sync_recognizes_registered', () => {
+  const M = mkMock('act-emsync')
+  const gitRoot = path.join(M.base, 'emsync-main')
+  mkGitRepo(gitRoot)
+  const sub = path.join(gitRoot, 'p', 'q')
+  fs.mkdirSync(sub, { recursive: true })
+  installActivation(M, sub)
+  const r = spawnSync('node', [path.join(REPO_ROOT, 'scripts', 'em-sync-install.mjs'), '--project', sub, '--dry-run'],
+    { cwd: M.callerCwd, env: { ...process.env, HOME: M.home }, encoding: 'utf8' })
+  const out = JSON.parse(r.stdout.trim().split('\n').pop())
+  assert.notStrictEqual(out.status, 'unregistered',
+    `em-sync-install must recognize the activation-registered nested project, got status=${out.status}`)
+  ok(`em_sync_recognizes_registered — em-sync-install found the row (status=${out.status}, not unregistered)`)
+})
+
+// ── worktree_roundtrip: install then uninstall at the worktree restores it ─────
+//    (B1: uninstall binds to the same literal --project install used — the
+//    worktree, NOT main — so nothing is orphaned.)
+test('worktree_roundtrip', () => {
+  const M = mkMock('act-wt-rt')
+  const mainRepo = path.join(M.base, 'rt-main')
+  mkGitRepo(mainRepo)
+  const wt = path.join(M.base, 'rt-wt')
+  const w = git(mainRepo, ['worktree', 'add', '-q', wt])
+  assert.strictEqual(w.status, 0, `git worktree add must succeed: ${w.stderr}`)
+  const wtReal = fs.realpathSync(wt)
+  installActivation(M, wt)
+  assert.ok(fs.existsSync(path.join(HOOKS(wtReal), 'activation-hook-run.mjs')), 'runner deployed at the worktree pre-uninstall')
+  const u = uninstallActivation(M, wt)
+  assert.strictEqual(u.status, 0, `uninstall must exit cleanly: ${u.stderr}`)
+  // Registration + runner removed FROM the worktree (uninstall targeted the same
+  // root install used, not main).
+  assert.ok(!fs.existsSync(path.join(HOOKS(wtReal), 'activation-hook-run.mjs')),
+    'runner must be removed from the worktree by uninstall (B1: no orphan)')
+  const s = readParsed(SETTINGS(wtReal))
+  assert.ok(!s || !hasActivationCommand(s), 'no activation registration left in the worktree settings.json')
+  ok('worktree_roundtrip — install+uninstall at the worktree round-trips cleanly (B1)')
 })
 
 // ── pre_amendment_schema_rejects: the 1.1.0 MINOR bump is load-bearing ───────
@@ -596,28 +690,29 @@ test('install_nonobject_settings_atomic', () => {
   ok('install_nonobject_settings_atomic — settings=[] on install AND uninstall: clean exit, ZERO footprint, byte-identical (F2)')
 })
 
-// ── uninstall_legacy_relative_nested_project (Finding F3) ─────────────────────
+// ── uninstall_legacy_relative_registration (Finding F3, projectAbs) ───────────
 //    A legacy RELATIVE activation command (`.claude/hooks/activation-prompt.sh`)
-//    in the authority-root settings.json must resolve against the AUTHORITY ROOT
-//    whose settings.json is being edited — NOT projectDir. Under a nested
-//    `--project <subdir>` uninstall, resolving against projectDir bound the
-//    relative command under the subdir, judged it foreign, LEFT the registration
-//    — yet still DELETED the canonical file → a dangling registration. The fix
-//    makes registration-removal and file-deletion AGREE.
-test('uninstall_legacy_relative_nested_project', () => {
+//    must resolve against the SAME registration root install used — the literal
+//    --project (projectAbs) — so uninstall REMOVES it instead of judging it
+//    foreign, leaving the registration while deleting the canonical file (a
+//    dangling registration). Under the projectAbs design install+uninstall both
+//    bind to the literal --project, so registration-removal and file-deletion
+//    AGREE. (Nested inside a git repo to prove the resolution is projectAbs, not
+//    the git toplevel.)
+test('uninstall_legacy_relative_registration', () => {
   const M = mkMock('act-legacy-nested')
   const gitRoot = path.join(M.base, 'legacy-main')
   mkGitRepo(gitRoot)
-  const resolved = resolveRepoRoot(gitRoot)
   const sub = path.join(gitRoot, 'a', 'b')
   fs.mkdirSync(sub, { recursive: true })
-  // Install activation (authority root = gitRoot): absolute canonical commands +
-  // files + manifest land under the resolved main root.
+  // Install activation at the literal --project sub: canonical commands + files +
+  // manifest land under sub (NOT the git toplevel).
   installActivation(M, sub)
-  const canonical = path.join(HOOKS(resolved), 'activation-prompt.sh')
-  assert.ok(fs.existsSync(canonical), 'precondition: canonical hook file deployed')
+  const subReal = fs.realpathSync(sub)
+  const canonical = path.join(HOOKS(subReal), 'activation-prompt.sh')
+  assert.ok(fs.existsSync(canonical), 'precondition: canonical hook file deployed under the literal --project')
   // Rewrite the UserPromptSubmit registration to the LEGACY RELATIVE spelling.
-  const s = readParsed(SETTINGS(resolved))
+  const s = readParsed(SETTINGS(subReal))
   let rewrote = false
   for (const m of (s.hooks.UserPromptSubmit || [])) {
     for (const h of (m.hooks || [])) {
@@ -628,18 +723,17 @@ test('uninstall_legacy_relative_nested_project', () => {
     }
   }
   assert.ok(rewrote, 'precondition: rewrote the UserPromptSubmit registration to legacy relative spelling')
-  fs.writeFileSync(SETTINGS(resolved), JSON.stringify(s, null, 2))
-  // Uninstall via the NESTED subdir — authority root still resolves to gitRoot.
+  fs.writeFileSync(SETTINGS(subReal), JSON.stringify(s, null, 2))
   const u = uninstallActivation(M, sub)
-  assert.strictEqual(u.status, 0, `nested uninstall must exit 0 (got ${u.status}: ${u.stderr})`)
+  assert.strictEqual(u.status, 0, `uninstall must exit 0 (got ${u.status}: ${u.stderr})`)
   // (a) the legacy relative registration is REMOVED (not left dangling)…
-  const after = readParsed(SETTINGS(resolved)) || { hooks: {} }
+  const after = readParsed(SETTINGS(subReal)) || { hooks: {} }
   assert.ok(!commandsForEvent(after, 'UserPromptSubmit').some((c) => c.includes('activation-prompt.sh')),
-    'the legacy relative registration must be REMOVED under a nested-project uninstall (F3)')
-  assert.ok(!hasActivationCommand(after), 'no activation registration may survive the nested uninstall')
+    'the legacy relative registration must be REMOVED (F3)')
+  assert.ok(!hasActivationCommand(after), 'no activation registration may survive the uninstall')
   // (b) …AND its canonical file is deleted — removal and deletion AGREE.
   assert.ok(!fs.existsSync(canonical), 'the canonical hook file must be deleted (agrees with registration removal)')
-  ok('uninstall_legacy_relative_nested_project — legacy relative reg removed + file deleted agree under nested --project (F3)')
+  ok('uninstall_legacy_relative_registration — legacy relative reg removed + file deleted agree at the literal --project (F3)')
 })
 
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`)


### PR DESCRIPTION
## #490 + #491 — activation install/uninstall/registry bind to the literal `--project`

The advisory-activation adapter installed its hooks + registrations at `resolveRepoRoot(--project)` while the `installs.json` row key used the literal `--project` (`projectAbs`). That split (a) mistargeted the `activation_installed` flag and **duplicated the row** for a nested/worktree `--project` (#490), and (b) wired a **linked-worktree `--project` into the MAIN checkout**, so activation never fired when Claude Code ran from the worktree (#491).

### Fix
Align activation to the literal `--project` (`projectAbs = path.resolve`), exactly like enforcement + `em-sync-install` — registration, hook files, uninstall, and the registry heal all bind `projectAbs`; store **identity** (`manifest.project_identity.root`) stays `resolveRepoRoot` so a worktree still shares main's episodic store (the one surface that resolves up).

- `runInstallActivation`: registration paths + `report.root` → `registrationRoot`; `authorityRoot` kept for slug + manifest identity.
- `runUninstallActivation`: registration paths **and** the F3 legacy-relative resolve base → `registrationRoot` (root-symmetric with install; no worktree/nested orphan on uninstall).
- registry heal: `activationRoot` `resolveRepoRoot(projectAbs)` → `projectAbs`, so key == artifacts == heal. Both adapters key `projectAbs` → one row carries both flags.
- `--help` + comments retargeted to the literal `<project>/.claude/`.

**Why `projectAbs` and not the git working-tree root:** codex proved keying the row at a resolved root would break `em-sync-install` (which matches `projectAbs`); aligning activation to `projectAbs` avoids that and dissolves the two-row split.

### Review
- **Plan:** `negative-scenario-planner` (2 blockers, runtime-probed) + `codex` (2 new blockers) → design pivoted from the git-working-tree-root approach to `projectAbs`.
- **Diff:** `negative-scenario-reviewer` → **ACCEPT**, 0 blockers/0 major, 6 invariants runtime-probed against the real `install.mjs` on isolated mock HOMEs (worktree + nested + symlink); one MINOR (stale help text) fixed inline.

### Verification
`tests/test-uninstall-activation.mjs` → **26/26**: `worktree_local_registration` + `nested_local_registration` (rewrote the two `authority_root_*` tests that asserted the old walk-up/converge behavior), `single_row_per_project` (#490), `one_row_both_adapters`, `em_sync_recognizes_registered` (codex-B1 guard), `worktree_roundtrip` (B1), F3 test retargeted. Adjacent suites green: install-activation 6, registered-stores 7, install-manifest 57, install-drift-notice 26. `docs/plans/rfc-009-p2.md` §7.1 rows 113/114 updated + S6 open-note resolved.

Closes #490
Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
