### PR TITLE
#496: activation-sessionstart test portability (tracked hook source)

### DIFF
--- a/tests/test-activation-sessionstart.mjs
+++ b/tests/test-activation-sessionstart.mjs
@@ -564,8 +564,10 @@ function rebuildFreshGlobal(home, proj) {
 
 // ===========================================================================
 // 14. handoff_consumes_blend (REQ-26) — the SEPARATE session-handoff hook
-//     (.claude/hooks/session-handoff-prompt.sh), not the activation adapter.
-//     Drives the REAL committed hook file end-to-end against an isolated
+//     (plugins/claude-code/hooks/session-handoff-prompt.sh), not the activation
+//     adapter. Drives the TRACKED canonical hook source (NOT the untracked,
+//     install-generated REPO_ROOT/.claude/hooks/ runtime copy, whose freshness
+//     is per-machine install state — issue #496) end-to-end against an isolated
 //     git-initialized fixture project + a scratch HOME, and proves the
 //     mechanical em-search command it emits has switched to the
 //     `session_start` static blend (no `--no-score` recency-only load) by
@@ -601,7 +603,7 @@ function rebuildFreshGlobal(home, proj) {
   if (storeResult.status !== 0) throw new Error(`handoff_consumes_blend: em-store failed: ${storeResult.stdout}\n${storeResult.stderr}`);
   const ep = JSON.parse(storeResult.stdout.trim().split("\n").pop());
 
-  const hookPath = path.join(REPO_ROOT, ".claude/hooks/session-handoff-prompt.sh");
+  const hookPath = path.join(REPO_ROOT, "plugins/claude-code/hooks/session-handoff-prompt.sh");
   const r = spawnSync("bash", [hookPath], {
     cwd: proj,
     env,


### PR DESCRIPTION
## #496 — activation-sessionstart test: drive the tracked hook source (deterministic)

Closes #496.

### Root cause
`handoff_consumes_blend` drove `REPO_ROOT/.claude/hooks/session-handoff-prompt.sh` — an **untracked, install-generated** runtime artifact — so pass/fail depended on local install freshness (failed on a stale/absent install copy, passed only when it happened to match the fresh source). The test is also not wired into any CI workflow, so "passes in CI" meant the fresh-install gauntlet.

### Change
- `tests/test-activation-sessionstart.mjs`: repointed the hook invocation to the **tracked** canonical source `plugins/claude-code/hooks/session-handoff-prompt.sh`. The hook resolves `REPO_ROOT` from `stdin.cwd` (not its own file location), so behavior is byte-identical — only the install-freshness dependence is removed. All assertions preserved.

### Verification
- `node tests/test-activation-sessionstart.mjs` → **49 passed, 0 failed**.
- Determinism proof: with a deliberately broken stale hook planted at the old `.claude/hooks/` path, the suite still passes 49/49 and the stale hook never executes.

### Follow-up (not in this PR)
This test file is not run by any GitHub workflow; recommend wiring `tests/test-activation-sessionstart.mjs` (and sibling activation tests) into CI so this regression class is actually caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
