### PR TITLE
#504 + #377: wire remaining suites; class-closing CI suite-registration lint

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -321,6 +321,31 @@ jobs:
       - name: Run install activation-classes deploy E2E (RFC-009 P1b S9)
         run: node tests/test-install-activation.mjs
 
+      # #504 remainder: the activation suites that predate RFC-011 S5's REQ-19
+      # wiring, listed explicitly per convention 8 (CI runs explicitly listed
+      # test files — unlisted suites silently never run).
+      - name: Run activation sessionstart adapter suite (#504)
+        run: node tests/test-activation-sessionstart.mjs
+
+      - name: Run activation hook E2E suite (#504)
+        run: node tests/test-activation-hook-e2e.mjs
+
+      - name: Run activation-manifest conformance suite (#504)
+        run: node tests/test-activation-manifest.mjs
+
+      - name: Run activation-match core conformance suite (#504)
+        run: node tests/test-activation-match.mjs
+
+      - name: Run uninstall-activation round-trip suite (#504)
+        run: node tests/test-uninstall-activation.mjs
+
+      # #504 class closure: every top-level tests/test-*.{mjs,sh} must be
+      # referenced by a workflow, run by the P12 meta-runner, or listed in the
+      # shrink-only KNOWN_UNWIRED baseline inside the lint. A new suite that is
+      # not wired anywhere fails this step instead of silently never running.
+      - name: Lint CI suite registration (#504 — class-closing, shrink-only baseline)
+        run: node tests/test-ci-suite-registration.mjs
+
   p12-invariant-gate:
     # RFC-008 P4d S8 (REQ-10 / REQ-11): the three Principle-12 invariants as ONE
     # separately-named REQUIRED check. Membership is defined in code

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -7,11 +7,9 @@ name: Plugin + schema validation
 # while a hand-curated per-file filter silently stops running when a new
 # scripts/lib helper joins the import graph.
 #
-# Issue #377 tracks the REMAINING plugin-family suites — still pending here:
-# test-json-instance-validate.mjs, test-plugin-json.mjs,
-# test-field-bindings.mjs, test-plugin-gauntlet.mjs,
-# test-plugin-harness-binding.mjs. Add them as steps per #377; this comment is
-# the marker that their absence is a tracked gap, not full coverage.
+# #377 (closed by #504's class sweep): the full plugin-family set now runs
+# here. tests/test-ci-suite-registration.mjs is the class gate — a suite
+# missing from every workflow fails CI instead of hiding behind a comment.
 
 on:
   pull_request:
@@ -60,6 +58,20 @@ jobs:
 
       - name: Run claude-code plugin gauntlet (REQ-1 regression lock)
         run: node tests/test-plugin-gauntlet.mjs
+
+      # #377 remainder (surfaced by the #504 registration lint): the plugin
+      # suites that were tracked in a comment here instead of running.
+      - name: Run closed-subset instance-validator suite (#377)
+        run: node tests/test-json-instance-validate.mjs
+
+      - name: Run plugin.json manifest conformance suite (#377)
+        run: node tests/test-plugin-json.mjs
+
+      - name: Run field_bindings interpreter suite (#377 — key-axis closure incl. __proto__)
+        run: node tests/test-field-bindings.mjs
+
+      - name: Run plugin harness-binding suite (#377 — F31/F36/F61 project-root→store-root axes)
+        run: node tests/test-plugin-harness-binding.mjs
 
       - name: Run opencode plugin gauntlet (RFC-008 P5, REQ-1/REQ-12)
         run: node scripts/test-plugin.mjs --project "$GITHUB_WORKSPACE" --harness opencode

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -5,27 +5,37 @@
  * The class lesson behind #504 (and PLAN-session-auto-capture convention 8):
  * CI runs explicitly listed test files, so an unlisted suite silently never
  * runs. Instance fixes (wiring suites one by one) leave the class open — this
- * lint closes it: every top-level tests/test-*.{mjs,sh} must be
+ * lint closes it: every test-*.{mjs,sh} at any depth under tests/ must be
  *
- *   (a) referenced by a .github/workflows/*.yml run step (comment lines are
- *       stripped first, so a commented-out step does not count as wired), OR
- *   (b) a member of the P12 invariant meta-runner (glob test-p12-*.mjs plus
- *       its EXPLICIT set — membership-in-code, Rule 14), OR
+ *   (a) INVOKED by a .github/workflows/*.{yml,yaml} `run:` command — the
+ *       reference must be an interpreter invocation (`node|bash|sh tests/<f>`)
+ *       at command position inside an extracted run value. Step names, `if:`
+ *       conditions, YAML comments, shell comment lines, quoted strings, and
+ *       longer tokens that merely contain the filename do NOT count; OR
+ *   (b) a member of the P12 invariant meta-runner — re-derived the way the
+ *       runner derives it: glob(test-p12-*.mjs) minus meta-runners, plus the
+ *       runner's actual `const EXPLICIT = [...]` array (parsed from that
+ *       block only, comments stripped — a name quoted elsewhere in the runner
+ *       source does not count); OR
  *   (c) listed in the KNOWN_UNWIRED baseline below.
  *
  * The baseline is SHRINK-ONLY (a ratchet): it enumerates the suites that were
  * already unwired when this lint landed (2026-07-11, #504 audit). A baseline
- * entry that becomes wired must be deleted from the baseline (t_baseline_not_wired),
- * and an entry whose file is deleted must be deleted too (t_baseline_exists).
- * Adding a NEW suite to the baseline is a conscious reviewed edit of this
- * file, never the path of least resistance: a brand-new unwired suite fails
- * t_all_suites_registered by default.
+ * entry that becomes wired must be deleted (t_baseline_not_wired), and an
+ * entry whose file is deleted must be deleted too (t_baseline_exists). A
+ * brand-new unwired suite fails t_all_suites_registered by default; adding it
+ * to the baseline is a conscious reviewed edit of this file.
+ *
+ * Known out-of-contract files (tracked, not lint members): tests/e2e/
+ * console.e2e.mjs and tests/integration/codex-tmux-e2e.mjs do not follow the
+ * test-* naming contract (browser/tmux-bound; structurally CI-unsuitable).
  *
  * Zero deps. Node stdlib only.
  */
 
 import assert from 'node:assert'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -36,9 +46,10 @@ const repoRoot = path.dirname(testsDir)
 const workflowsDir = path.join(repoRoot, '.github', 'workflows')
 
 // Suites known to be unwired when this lint landed (#504 audit, 2026-07-11).
-// SHRINK-ONLY: entries may be removed (when wired or deleted), never added
-// without review. Many are structurally CI-unsuitable (live seats, external
-// codex/opencode binaries, network); wiring decisions stay per-suite.
+// Paths are relative to tests/. SHRINK-ONLY: entries may be removed (when
+// wired or deleted), never added without review. Many are structurally
+// CI-unsuitable (live seats, external codex/opencode binaries, network);
+// wiring decisions stay per-suite.
 const KNOWN_UNWIRED = [
   'test-bp1-approval-check-hook.mjs',
   'test-bp1-atomic.mjs',
@@ -125,54 +136,112 @@ const KNOWN_UNWIRED = [
   'test-worktree-marker-write.sh',
 ]
 
-// --- derivation (kept as small pure helpers so the negative control can run
-// --- the same predicate against synthetic input) --------------------------
+// --- derivation (small pure helpers so mutation fixtures can drive the SAME
+// --- code paths CI drives) --------------------------------------------------
 
-function listSuites(dir) {
-  return fs
-    .readdirSync(dir)
-    .filter((f) => /^test-.*\.(mjs|sh)$/.test(f))
-    .sort()
+// Recursive discovery: every test-*.{mjs,sh} at ANY depth under tests/,
+// returned as paths relative to tests/ (top level: 'test-x.mjs'; nested:
+// 'e2e/test-x.mjs'). Codex F3: a suite landing in tests/e2e etc. must not
+// escape the gate.
+function listSuites(dir, prefix = '') {
+  const out = []
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (ent.isDirectory()) out.push(...listSuites(path.join(dir, ent.name), `${prefix}${ent.name}/`))
+    else if (/^test-.*\.(mjs|sh)$/.test(ent.name)) out.push(`${prefix}${ent.name}`)
+  }
+  return out
 }
 
-// All workflow YAML with full-line comments stripped: a commented-out step
-// must not count as wired.
-function readWorkflowsText(dir) {
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
-    .map((f) =>
-      fs
-        .readFileSync(path.join(dir, f), 'utf8')
-        .split('\n')
-        .filter((line) => !/^\s*#/.test(line))
-        .join('\n'),
-    )
-    .join('\n')
+// Extract the VALUE TEXT of every `run:` key in a workflow YAML, without a
+// YAML dependency. Single-line values get their trailing YAML comment
+// stripped; block scalars (| or >, with chomping/indent modifiers) collect
+// the following deeper-indented lines verbatim. Everything outside run:
+// values (step names, if: conditions, YAML comments) is dropped, so a suite
+// name there can never count as wired (codex F1).
+function extractRunCommands(yamlText) {
+  const lines = yamlText.split('\n')
+  const commands = []
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)(?:-\s+)?run:\s*(.*)$/)
+    if (!m) continue
+    const keyIndent = m[1].length
+    const value = m[2]
+    if (/^[|>]/.test(value)) {
+      const block = []
+      for (let j = i + 1; j < lines.length; j++) {
+        const line = lines[j]
+        if (line.trim() === '') { block.push(''); continue }
+        const indent = line.match(/^(\s*)/)[1].length
+        if (indent <= keyIndent) break
+        block.push(line)
+        i = j
+      }
+      commands.push(block.join('\n'))
+    } else {
+      commands.push(value.replace(/\s#.*$/, ''))
+    }
+  }
+  return commands
 }
 
-// P12 meta-runner membership, re-derived the way the runner derives it
-// (glob test-p12-*.mjs minus meta-runners) plus a textual match against its
-// source for the EXPLICIT set (the names appear literally there).
-const P12_RUNNER = 'test-p12-invariant-suite.mjs'
-const p12Source = fs.readFileSync(path.join(testsDir, P12_RUNNER), 'utf8')
-
-function isWired(basename, wfText) {
-  if (wfText.includes(basename)) return true
-  if (/^test-p12-.*\.mjs$/.test(basename) && !basename.includes('invariant-suite')) return true
-  if (p12Source.includes(`'${basename}'`)) return true
+// A suite counts as workflow-wired ONLY if some run-command line invokes it:
+// `node|bash|sh [./]tests/<relpath>` at command position (line start or after
+// ;, &&, ||, |, ( or $( ). Shell comment segments are stripped first, so
+// `# node tests/x.mjs` and `echo done # node tests/x.mjs` never count; a
+// quoted occurrence (`echo 'node tests/x.mjs'`) fails the command-position
+// anchor (codex F1 axes).
+function invokedByRunCommands(relPath, runCommands) {
+  const esc = relPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`(?:^|[;&|(]|\\$\\()\\s*(?:node|bash|sh)\\s+(?:\\./)?tests/${esc}(?=$|[\\s;&|)'"])`)
+  for (const cmd of runCommands) {
+    for (const rawLine of cmd.split('\n')) {
+      const line = rawLine.replace(/(^|\s)#.*$/, '$1')
+      if (re.test(line)) return true
+    }
+  }
   return false
 }
 
-function computeUnregistered(suites, wfText, baseline) {
+function readWorkflowRunCommands(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .flatMap((f) => extractRunCommands(fs.readFileSync(path.join(dir, f), 'utf8')))
+}
+
+// P12 meta-runner membership, re-derived the way the runner derives it
+// (test-p12-invariant-suite.mjs deriveMembers()): glob(test-p12-*.mjs) minus
+// meta-runners, plus its actual `const EXPLICIT = [...]` array. The EXPLICIT
+// set is parsed from THAT BLOCK ONLY, with // comments stripped first — a
+// filename quoted in a comment, assertion message, or anywhere else in the
+// runner source does not confer membership (codex F2).
+const P12_RUNNER = 'test-p12-invariant-suite.mjs'
+
+function parseP12Explicit(runnerSource) {
+  const block = runnerSource.match(/const EXPLICIT = \[([\s\S]*?)\n\]/)
+  assert.ok(block, `cannot locate "const EXPLICIT = [" block in ${P12_RUNNER} — update this lint's parser`)
+  const noComments = block[1].replace(/\/\/.*$/gm, '')
+  return [...noComments.matchAll(/'([^']+)'/g)].map((m) => m[1])
+}
+
+function p12Members(runnerSource, suiteBasenames) {
+  const globbed = suiteBasenames.filter((f) => /^test-p12-.*\.mjs$/.test(f) && !f.includes('invariant-suite'))
+  return new Set([...globbed, ...parseP12Explicit(runnerSource)])
+}
+
+function computeUnregistered(suites, runCommands, p12Set, baseline) {
   const base = new Set(baseline)
-  return suites.filter((f) => !isWired(f, wfText) && !base.has(f))
+  return suites.filter(
+    (f) => !invokedByRunCommands(f, runCommands) && !p12Set.has(f) && !base.has(f),
+  )
 }
 
 const SUITES = listSuites(testsDir)
-const WF_TEXT = readWorkflowsText(workflowsDir)
+const RUN_COMMANDS = readWorkflowRunCommands(workflowsDir)
+const P12_SOURCE = fs.readFileSync(path.join(testsDir, P12_RUNNER), 'utf8')
+const P12_SET = p12Members(P12_SOURCE, SUITES)
 
-// --- test harness ----------------------------------------------------------
+// --- test harness ------------------------------------------------------------
 
 let passed = 0
 let failed = 0
@@ -190,11 +259,11 @@ function test(name, fn) {
   }
 }
 
-console.log('# test-ci-suite-registration (#504 - every suite wired or baselined)')
-console.log(`# suites: ${SUITES.length}, baseline: ${KNOWN_UNWIRED.length}`)
+console.log('# test-ci-suite-registration (#504 - every suite invoked by CI or baselined)')
+console.log(`# suites: ${SUITES.length}, baseline: ${KNOWN_UNWIRED.length}, run commands: ${RUN_COMMANDS.length}`)
 
-test('t_all_suites_registered: every tests/test-*.{mjs,sh} is wired in a workflow, run by the P12 meta-runner, or baselined', () => {
-  const unregistered = computeUnregistered(SUITES, WF_TEXT, KNOWN_UNWIRED)
+test('t_all_suites_registered: every tests/ test-*.{mjs,sh} (any depth) is invoked by a workflow run command, a P12 member, or baselined', () => {
+  const unregistered = computeUnregistered(SUITES, RUN_COMMANDS, P12_SET, KNOWN_UNWIRED)
   assert.deepStrictEqual(
     unregistered,
     [],
@@ -202,8 +271,10 @@ test('t_all_suites_registered: every tests/test-*.{mjs,sh} is wired in a workflo
   )
 })
 
-test('t_baseline_not_wired: no baseline entry is wired (shrink-only ratchet — delete wired entries from KNOWN_UNWIRED)', () => {
-  const wiredButBaselined = KNOWN_UNWIRED.filter((f) => isWired(f, WF_TEXT))
+test('t_baseline_not_wired: no baseline entry is invoked or a P12 member (shrink-only ratchet — delete wired entries)', () => {
+  const wiredButBaselined = KNOWN_UNWIRED.filter(
+    (f) => invokedByRunCommands(f, RUN_COMMANDS) || P12_SET.has(f),
+  )
   assert.deepStrictEqual(
     wiredButBaselined,
     [],
@@ -220,20 +291,76 @@ test('t_baseline_sorted_unique: baseline is sorted and duplicate-free (reviewabl
   assert.deepStrictEqual(KNOWN_UNWIRED, [...new Set(KNOWN_UNWIRED)].sort())
 })
 
-test('t_detection_sanity: a known-wired suite reads wired; this lint itself is wired; positive workflow signal exists', () => {
-  // Guards the comment-stripper / reader against silently matching nothing.
-  assert.ok(isWired('test-plan-marker.mjs', WF_TEXT), 'test-plan-marker.mjs must read as wired')
-  // The P12 glob path must still short-circuit meta-runner members.
-  assert.ok(isWired('test-p12-global-clean.mjs', WF_TEXT), 'P12 glob member must read as wired')
-  // Rename drift: if this file is renamed without updating the workflow step,
-  // fail here on the next local run.
-  assert.ok(WF_TEXT.includes(SELF_BASENAME), `${SELF_BASENAME} must itself be wired in a workflow`)
+test('t_detection_sanity: known-wired suites detected via each acceptance branch; this lint itself is wired', () => {
+  assert.ok(invokedByRunCommands('test-plan-marker.mjs', RUN_COMMANDS), 'node-invoked suite must read as wired')
+  assert.ok(invokedByRunCommands('test-plan-gate.sh', RUN_COMMANDS), 'bash-invoked suite must read as wired')
+  assert.ok(P12_SET.has('test-p12-global-clean.mjs'), 'P12 glob member must read as wired')
+  assert.ok(P12_SET.has('test-uninstall-enforcement.mjs'), 'P12 EXPLICIT member must read as wired')
+  assert.ok(invokedByRunCommands(SELF_BASENAME, RUN_COMMANDS), `${SELF_BASENAME} must itself be invoked by a workflow`)
 })
 
-test('t_negative_control: a synthetic unwired suite is reported unregistered (red path proves the predicate bites)', () => {
+// Codex F1 mutation axes: every non-invocation reference class must read as
+// NOT wired, driven through the same extractRunCommands + invokedByRunCommands
+// paths the real check uses.
+test('t_mutation_workflow_axes: step-name / if: / YAML comment / shell comment / quoted / longer-token references never count', () => {
+  const target = 'test-mut-probe.mjs'
+  const wired = (yaml) => invokedByRunCommands(target, extractRunCommands(yaml))
+  // Positive controls: plain and block-scalar invocations DO count.
+  assert.ok(wired('      - name: x\n        run: node tests/test-mut-probe.mjs\n'), 'plain run invocation')
+  assert.ok(wired('      - run: |\n          echo start\n          node tests/test-mut-probe.mjs\n'), 'block-scalar invocation')
+  assert.ok(wired('      - run: node tests/a.mjs && node tests/test-mut-probe.mjs\n'), 'command position after &&')
+  // Attack axes: each must NOT count.
+  assert.ok(!wired('      - name: run node tests/test-mut-probe.mjs\n        run: echo hi\n'), 'step-name-only reference')
+  assert.ok(!wired("      - if: contains(github.event.head_commit.message, 'tests/test-mut-probe.mjs')\n        run: echo hi\n"), 'if-condition-only reference')
+  assert.ok(!wired('      # node tests/test-mut-probe.mjs\n      - run: echo hi\n'), 'YAML comment-only reference')
+  assert.ok(!wired('      - run: node tests/other.mjs # node tests/test-mut-probe.mjs\n'), 'inline trailing YAML comment')
+  assert.ok(!wired('      - run: |\n          # node tests/test-mut-probe.mjs\n          echo hi\n'), 'shell comment line in block scalar')
+  assert.ok(!wired('      - run: |\n          echo done # node tests/test-mut-probe.mjs\n'), 'trailing shell comment in block scalar')
+  assert.ok(!wired("      - run: |\n          echo 'node tests/test-mut-probe.mjs'\n"), 'quoted inert text in block scalar')
+  assert.ok(!wired('      - run: node tests/test-mut-probe.mjs.backup\n'), 'filename embedded in longer token')
+  assert.ok(!wired('      - run: node tests/prefix-test-mut-probe.mjs\n'), 'filename as suffix of longer token')
+  assert.ok(!wired('      - run: echo node tests/test-mut-probe.mjs\n'), 'echoed (non-command-position) reference')
+})
+
+// Codex F2 mutation axes: P12 membership binds to the ACTUAL EXPLICIT array.
+test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments and stray literals elsewhere do not', () => {
+  const src = [
+    '// intro comment mentioning \'test-ghost-a.mjs\'',
+    'const EXPLICIT = [',
+    "  // rationale comment naming 'test-ghost-b.mjs'",
+    "  'test-real-member.mjs',",
+    ']',
+    "assert.deepStrictEqual([...EXPLICIT].sort(), ['test-ghost-c.mjs'])",
+  ].join('\n')
+  const set = p12Members(src, ['test-p12-extra.mjs', 'test-p12-invariant-suite.mjs'])
+  assert.ok(set.has('test-real-member.mjs'), 'actual EXPLICIT entry is a member')
+  assert.ok(set.has('test-p12-extra.mjs'), 'glob member joins')
+  assert.ok(!set.has('test-p12-invariant-suite.mjs'), 'meta-runner excluded from glob')
+  assert.ok(!set.has('test-ghost-a.mjs'), 'literal outside the array does not confer membership')
+  assert.ok(!set.has('test-ghost-b.mjs'), 'comment inside the array does not confer membership')
+  assert.ok(!set.has('test-ghost-c.mjs'), 'literal after the array (assertion pin) does not confer membership')
+})
+
+// Codex F3 mutation axis: nested suites are discovered and gated.
+test('t_mutation_nested_discovery: a suite under tests/e2e/ is discovered and reported unregistered', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-suite-reg-'))
+  try {
+    fs.mkdirSync(path.join(tmp, 'e2e'), { recursive: true })
+    fs.writeFileSync(path.join(tmp, 'test-top.mjs'), '')
+    fs.writeFileSync(path.join(tmp, 'e2e', 'test-nested.mjs'), '')
+    fs.writeFileSync(path.join(tmp, 'e2e', 'helper.mjs'), '')
+    const found = listSuites(tmp)
+    assert.deepStrictEqual(found, ['e2e/test-nested.mjs', 'test-top.mjs'])
+    const out = computeUnregistered(found, [' node tests/test-top.mjs'.trim()], new Set(), [])
+    assert.deepStrictEqual(out, ['e2e/test-nested.mjs'])
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('t_negative_control: a synthetic unwired suite is reported unregistered against the REAL repo state', () => {
   const synthetic = 'test-synthetic-never-wired-504.mjs'
-  assert.ok(!isWired(synthetic, WF_TEXT), 'synthetic name must not read as wired')
-  const out = computeUnregistered([...SUITES, synthetic], WF_TEXT, KNOWN_UNWIRED)
+  const out = computeUnregistered([...SUITES, synthetic], RUN_COMMANDS, P12_SET, KNOWN_UNWIRED)
   assert.deepStrictEqual(out, [synthetic])
 })
 

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -7,16 +7,25 @@
  * runs. Instance fixes (wiring suites one by one) leave the class open — this
  * lint closes it: every test-*.{mjs,sh} at any depth under tests/ must be
  *
- *   (a) INVOKED by a .github/workflows/*.{yml,yaml} `run:` command — the
- *       reference must be an interpreter invocation (`node|bash|sh tests/<f>`)
- *       at command position inside an extracted run value. Step names, `if:`
- *       conditions, YAML comments, shell comment lines, quoted strings, and
- *       longer tokens that merely contain the filename do NOT count; OR
+ *   (a) STEP-WIRED in .github/workflows/*.{yml,yaml}: some line, OUTSIDE any
+ *       YAML block scalar, in a workflow whose `on:` declares a pull_request
+ *       or push trigger, trims to exactly
+ *           [- ]run: node|bash|sh tests/<suite>
+ *       This is a structural line-grammar contract, not shell parsing (codex
+ *       rounds 1-3 killed every textual predicate: substrings, comments,
+ *       step names, and four heredoc spellings). Heredocs can only exist
+ *       inside block scalars, so skipping block-scalar content closes the
+ *       entire heredoc class; the trigger check closes the
+ *       disabled-workflow class. STRICT by design: an invocation with
+ *       arguments, inside a block scalar, or with a trailing comment does
+ *       NOT count — a legitimate future wiring in one of those forms fails
+ *       CI loudly and this contract gets extended consciously (false
+ *       negatives are loud; only silent false positives are dangerous); OR
  *   (b) a member of the P12 invariant meta-runner — re-derived the way the
  *       runner derives it: glob(test-p12-*.mjs) minus meta-runners, plus the
- *       runner's actual `const EXPLICIT = [...]` array (parsed from that
- *       block only, comments stripped — a name quoted elsewhere in the runner
- *       source does not count); OR
+ *       runner's actual `const EXPLICIT = [...]` array (block comments
+ *       stripped before locating the declaration, exactly one declaration
+ *       required, line comments stripped inside it); OR
  *   (c) listed in the KNOWN_UNWIRED baseline below.
  *
  * The baseline is SHRINK-ONLY (a ratchet): it enumerates the suites that were
@@ -27,8 +36,16 @@
  * to the baseline is a conscious reviewed edit of this file.
  *
  * Known out-of-contract files (tracked, not lint members): tests/e2e/
- * console.e2e.mjs and tests/integration/codex-tmux-e2e.mjs do not follow the
- * test-* naming contract (browser/tmux-bound; structurally CI-unsuitable).
+ * console.e2e.mjs (opt-in, Playwright) and tests/integration/
+ * codex-tmux-e2e.mjs (live codex + tmux) do not follow the test-* naming
+ * contract and are documented exemptions.
+ *
+ * Accepted residual (documented, review-guarded): a workflow author who
+ * deliberately forges a byte-exact `run: node tests/<f>` line as heredoc-free
+ * block-scalar-free DATA cannot exist — outside a block scalar such a line IS
+ * a step key — so the residual reduces to adversarial YAML that GitHub would
+ * reject or execute. The lint targets accidental drift, not a hostile author
+ * with commit rights.
  *
  * Zero deps. Node stdlib only.
  */
@@ -141,8 +158,7 @@ const KNOWN_UNWIRED = [
 
 // Recursive discovery: every test-*.{mjs,sh} at ANY depth under tests/,
 // returned as paths relative to tests/ (top level: 'test-x.mjs'; nested:
-// 'e2e/test-x.mjs'). Codex F3: a suite landing in tests/e2e etc. must not
-// escape the gate.
+// 'e2e/test-x.mjs').
 function listSuites(dir, prefix = '') {
   const out = []
   for (const ent of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
@@ -152,99 +168,64 @@ function listSuites(dir, prefix = '') {
   return out
 }
 
-// Extract the VALUE TEXT of every `run:` key in a workflow YAML, without a
-// YAML dependency. Single-line values get their trailing YAML comment
-// stripped; block scalars (| or >, with chomping/indent modifiers) collect
-// the following deeper-indented lines verbatim. Everything outside run:
-// values (step names, if: conditions, YAML comments) is dropped, so a suite
-// name there can never count as wired (codex F1).
-function extractRunCommands(yamlText) {
-  const lines = yamlText.split('\n')
-  const commands = []
-  for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(/^(\s*)(?:-\s+)?run:\s*(.*)$/)
-    if (!m) continue
-    const keyIndent = m[1].length
-    const value = m[2]
-    if (/^[|>]/.test(value)) {
-      const block = []
-      for (let j = i + 1; j < lines.length; j++) {
-        const line = lines[j]
-        if (line.trim() === '') { block.push(''); continue }
-        const indent = line.match(/^(\s*)/)[1].length
-        if (indent <= keyIndent) break
-        block.push(line)
-        i = j
-      }
-      // De-indent the way YAML hands the scalar to the shell: strip the
-      // common block indentation so heredoc delimiters compare the text the
-      // shell actually sees.
-      const baseIndent = Math.min(
-        ...block.filter((l) => l.trim() !== '').map((l) => l.match(/^( *)/)[1].length),
-      )
-      commands.push(block.map((l) => (l.trim() === '' ? l : l.slice(baseIndent))).join('\n'))
-    } else {
-      commands.push(value.replace(/\s#.*$/, ''))
-    }
-  }
-  return commands
-}
+// A `key: |` / `key: >` line (with optional chomp/indent modifiers) opens a
+// YAML block scalar; its content is every following line indented deeper than
+// the key. Heredocs, echoed text, and any other data can only live inside
+// such content, so step scanning skips it entirely.
+const BLOCK_SCALAR_KEY = /^(\s*)(?:-\s+)?[\w-]+:\s*[|>][+-]?\d*\s*(?:#.*)?$/
 
-// Drop shell heredoc BODIES from a command's lines: text between
-// `<<[-]['"]WORD['"]` and the closing WORD line is data fed to a program, not
-// executable commands (codex round-2 F1: `cat <<'INERT' ... INERT` carrying an
-// invocation-shaped line must not count as wired).
-function stripHeredocBodies(lines) {
+// The one shape that counts as a wiring step (trimmed, exact):
+//   [- ]run: node|bash|sh tests/<relpath>
+const STEP_INVOCATION = /^(?:-\s+)?run:\s*(?:node|bash|sh)\s+tests\/(\S+)$/
+
+// Collect the suite relpaths step-wired by one workflow's text: scan lines,
+// skip block-scalar content, exact-match the remainder against
+// STEP_INVOCATION.
+function collectStepInvocations(yamlText) {
+  const lines = yamlText.split('\n')
   const out = []
-  let delimiter = null
-  let dashed = false
-  for (const line of lines) {
-    if (delimiter !== null) {
-      const closing = dashed ? line.replace(/^\t+/, '') : line
-      if (closing === delimiter) delimiter = null
+  for (let i = 0; i < lines.length; i++) {
+    const scalar = lines[i].match(BLOCK_SCALAR_KEY)
+    if (scalar) {
+      const keyIndent = scalar[1].length
+      while (i + 1 < lines.length) {
+        const next = lines[i + 1]
+        if (next.trim() !== '' && next.match(/^(\s*)/)[1].length <= keyIndent) break
+        i++
+      }
       continue
     }
-    out.push(line)
-    const m = line.replace(/(^|\s)#.*$/, '$1').match(/<<(-?)\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][A-Za-z0-9_]*))/)
-    if (m) {
-      dashed = m[1] === '-'
-      delimiter = m[2] ?? m[3] ?? m[4]
-    }
+    const m = lines[i].trim().match(STEP_INVOCATION)
+    if (m) out.push(m[1])
   }
   return out
 }
 
-// A suite counts as workflow-wired ONLY if some run-command line invokes it:
-// `node|bash|sh [./]tests/<relpath>` at command position (line start or after
-// ;, &&, ||, |, ( or $( ). Heredoc bodies are dropped and shell comment
-// segments stripped first, so `cat <<'X' ... X`, `# node tests/x.mjs`, and
-// `echo done # node tests/x.mjs` never count; a quoted occurrence
-// (`echo 'node tests/x.mjs'`) fails the command-position anchor (codex F1 axes).
-function invokedByRunCommands(relPath, runCommands) {
-  const esc = relPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const re = new RegExp(`(?:^|[;&|(]|\\$\\()\\s*(?:node|bash|sh)\\s+(?:\\./)?tests/${esc}(?=$|[\\s;&|)'"])`)
-  for (const cmd of runCommands) {
-    for (const rawLine of stripHeredocBodies(cmd.split('\n'))) {
-      const line = rawLine.replace(/(^|\s)#.*$/, '$1')
-      if (re.test(line)) return true
-    }
-  }
-  return false
+// A workflow only executes on PRs/pushes if its `on:` declares those
+// triggers; a workflow_dispatch- or schedule-only file wires nothing (a
+// suite invoked only there never gates a merge).
+function workflowHasActiveTrigger(yamlText) {
+  const noComments = yamlText
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n')
+  return /^\s*(?:pull_request|push)\s*:/m.test(noComments) || /^on:\s*\[[^\]]*(?:pull_request|push)[^\]]*\]/m.test(noComments)
 }
 
-function readWorkflowRunCommands(dir) {
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
-    .flatMap((f) => extractRunCommands(fs.readFileSync(path.join(dir, f), 'utf8')))
+// The set of suites step-wired across all trigger-active workflows.
+function collectWiredSet(dir) {
+  const wired = new Set()
+  for (const f of fs.readdirSync(dir).filter((n) => n.endsWith('.yml') || n.endsWith('.yaml'))) {
+    const text = fs.readFileSync(path.join(dir, f), 'utf8')
+    if (!workflowHasActiveTrigger(text)) continue
+    for (const suite of collectStepInvocations(text)) wired.add(suite)
+  }
+  return wired
 }
 
 // P12 meta-runner membership, re-derived the way the runner derives it
 // (test-p12-invariant-suite.mjs deriveMembers()): glob(test-p12-*.mjs) minus
-// meta-runners, plus its actual `const EXPLICIT = [...]` array. The EXPLICIT
-// set is parsed from THAT BLOCK ONLY, with // comments stripped first — a
-// filename quoted in a comment, assertion message, or anywhere else in the
-// runner source does not confer membership (codex F2).
+// meta-runners, plus its actual `const EXPLICIT = [...]` array.
 const P12_RUNNER = 'test-p12-invariant-suite.mjs'
 
 function parseP12Explicit(runnerSource) {
@@ -269,15 +250,13 @@ function p12Members(runnerSource, suiteBasenames) {
   return new Set([...globbed, ...parseP12Explicit(runnerSource)])
 }
 
-function computeUnregistered(suites, runCommands, p12Set, baseline) {
+function computeUnregistered(suites, wiredSet, p12Set, baseline) {
   const base = new Set(baseline)
-  return suites.filter(
-    (f) => !invokedByRunCommands(f, runCommands) && !p12Set.has(f) && !base.has(f),
-  )
+  return suites.filter((f) => !wiredSet.has(f) && !p12Set.has(f) && !base.has(f))
 }
 
 const SUITES = listSuites(testsDir)
-const RUN_COMMANDS = readWorkflowRunCommands(workflowsDir)
+const WIRED = collectWiredSet(workflowsDir)
 const P12_SOURCE = fs.readFileSync(path.join(testsDir, P12_RUNNER), 'utf8')
 const P12_SET = p12Members(P12_SOURCE, SUITES)
 
@@ -299,22 +278,20 @@ function test(name, fn) {
   }
 }
 
-console.log('# test-ci-suite-registration (#504 - every suite invoked by CI or baselined)')
-console.log(`# suites: ${SUITES.length}, baseline: ${KNOWN_UNWIRED.length}, run commands: ${RUN_COMMANDS.length}`)
+console.log('# test-ci-suite-registration (#504 - every suite step-wired, P12-run, or baselined)')
+console.log(`# suites: ${SUITES.length}, baseline: ${KNOWN_UNWIRED.length}, step-wired: ${WIRED.size}`)
 
-test('t_all_suites_registered: every tests/ test-*.{mjs,sh} (any depth) is invoked by a workflow run command, a P12 member, or baselined', () => {
-  const unregistered = computeUnregistered(SUITES, RUN_COMMANDS, P12_SET, KNOWN_UNWIRED)
+test('t_all_suites_registered: every tests/ test-*.{mjs,sh} (any depth) is step-wired, a P12 member, or baselined', () => {
+  const unregistered = computeUnregistered(SUITES, WIRED, P12_SET, KNOWN_UNWIRED)
   assert.deepStrictEqual(
     unregistered,
     [],
-    `unregistered suites (wire them into a workflow, or — with review — baseline them):\n  ${unregistered.join('\n  ')}`,
+    `unregistered suites (wire them as a bare "run: node|bash tests/<f>" step, or — with review — baseline them):\n  ${unregistered.join('\n  ')}`,
   )
 })
 
-test('t_baseline_not_wired: no baseline entry is invoked or a P12 member (shrink-only ratchet — delete wired entries)', () => {
-  const wiredButBaselined = KNOWN_UNWIRED.filter(
-    (f) => invokedByRunCommands(f, RUN_COMMANDS) || P12_SET.has(f),
-  )
+test('t_baseline_not_wired: no baseline entry is step-wired or a P12 member (shrink-only ratchet — delete wired entries)', () => {
+  const wiredButBaselined = KNOWN_UNWIRED.filter((f) => WIRED.has(f) || P12_SET.has(f))
   assert.deepStrictEqual(
     wiredButBaselined,
     [],
@@ -332,43 +309,51 @@ test('t_baseline_sorted_unique: baseline is sorted and duplicate-free (reviewabl
 })
 
 test('t_detection_sanity: known-wired suites detected via each acceptance branch; this lint itself is wired', () => {
-  assert.ok(invokedByRunCommands('test-plan-marker.mjs', RUN_COMMANDS), 'node-invoked suite must read as wired')
-  assert.ok(invokedByRunCommands('test-plan-gate.sh', RUN_COMMANDS), 'bash-invoked suite must read as wired')
+  assert.ok(WIRED.has('test-plan-marker.mjs'), 'node-invoked suite must read as wired')
+  assert.ok(WIRED.has('test-plan-gate.sh'), 'bash-invoked suite must read as wired')
   assert.ok(P12_SET.has('test-p12-global-clean.mjs'), 'P12 glob member must read as wired')
   assert.ok(P12_SET.has('test-uninstall-enforcement.mjs'), 'P12 EXPLICIT member must read as wired')
-  assert.ok(invokedByRunCommands(SELF_BASENAME, RUN_COMMANDS), `${SELF_BASENAME} must itself be invoked by a workflow`)
+  assert.ok(WIRED.has(SELF_BASENAME), `${SELF_BASENAME} must itself be step-wired`)
 })
 
-// Codex F1 mutation axes: every non-invocation reference class must read as
-// NOT wired, driven through the same extractRunCommands + invokedByRunCommands
-// paths the real check uses.
-test('t_mutation_workflow_axes: step-name / if: / YAML comment / shell comment / quoted / longer-token references never count', () => {
+// Codex rounds 1-3 workflow axes, driven through the SAME helpers CI uses.
+// Every non-step reference class must read as NOT wired.
+test('t_mutation_workflow_axes: only bare step lines outside block scalars in trigger-active workflows count', () => {
   const target = 'test-mut-probe.mjs'
-  const wired = (yaml) => invokedByRunCommands(target, extractRunCommands(yaml))
-  // Positive controls: plain and block-scalar invocations DO count.
-  assert.ok(wired('      - name: x\n        run: node tests/test-mut-probe.mjs\n'), 'plain run invocation')
-  assert.ok(wired('      - run: |\n          echo start\n          node tests/test-mut-probe.mjs\n'), 'block-scalar invocation')
-  assert.ok(wired('      - run: node tests/a.mjs && node tests/test-mut-probe.mjs\n'), 'command position after &&')
-  // Attack axes: each must NOT count.
-  assert.ok(!wired('      - name: run node tests/test-mut-probe.mjs\n        run: echo hi\n'), 'step-name-only reference')
-  assert.ok(!wired("      - if: contains(github.event.head_commit.message, 'tests/test-mut-probe.mjs')\n        run: echo hi\n"), 'if-condition-only reference')
-  assert.ok(!wired('      # node tests/test-mut-probe.mjs\n      - run: echo hi\n'), 'YAML comment-only reference')
-  assert.ok(!wired('      - run: node tests/other.mjs # node tests/test-mut-probe.mjs\n'), 'inline trailing YAML comment')
-  assert.ok(!wired('      - run: |\n          # node tests/test-mut-probe.mjs\n          echo hi\n'), 'shell comment line in block scalar')
-  assert.ok(!wired('      - run: |\n          echo done # node tests/test-mut-probe.mjs\n'), 'trailing shell comment in block scalar')
-  assert.ok(!wired("      - run: |\n          echo 'node tests/test-mut-probe.mjs'\n"), 'quoted inert text in block scalar')
-  assert.ok(!wired('      - run: node tests/test-mut-probe.mjs.backup\n'), 'filename embedded in longer token')
-  assert.ok(!wired('      - run: node tests/prefix-test-mut-probe.mjs\n'), 'filename as suffix of longer token')
-  assert.ok(!wired('      - run: echo node tests/test-mut-probe.mjs\n'), 'echoed (non-command-position) reference')
-  // Codex round-2 F1: heredoc bodies are data, not commands.
-  assert.ok(!wired("      - run: |\n          cat <<'INERT'\n          node tests/test-mut-probe.mjs\n          INERT\n"), 'quoted-delimiter heredoc body')
-  assert.ok(!wired('      - run: |\n          cat <<INERT\n          node tests/test-mut-probe.mjs\n          INERT\n'), 'unquoted-delimiter heredoc body')
-  assert.ok(!wired('      - run: |\n          cat <<-INERT\n\t\t\tnode tests/test-mut-probe.mjs\n\tINERT\n'), 'dash-heredoc body with tab-indented close')
-  assert.ok(wired("      - run: |\n          cat <<'INERT'\n          inert text\n          INERT\n          node tests/test-mut-probe.mjs\n"), 'real invocation AFTER a closed heredoc still counts')
+  const ACTIVE = 'on:\n  pull_request:\n'
+  const wires = (yaml) => {
+    const text = ACTIVE + yaml
+    return workflowHasActiveTrigger(text) && collectStepInvocations(text).includes(target)
+  }
+  // Positive controls.
+  assert.ok(wires('      - name: x\n        run: node tests/test-mut-probe.mjs\n'), 'plain step line')
+  assert.ok(wires('      - run: bash tests/test-mut-probe.mjs\n'), 'inline "- run:" step form (bash)')
+  // Round-1 axes.
+  assert.ok(!wires('      - name: run node tests/test-mut-probe.mjs\n        run: echo hi\n'), 'step-name-only reference')
+  assert.ok(!wires("      - if: contains(x, 'tests/test-mut-probe.mjs')\n        run: echo hi\n"), 'if-condition-only reference')
+  assert.ok(!wires('      # run: node tests/test-mut-probe.mjs\n      - run: echo hi\n'), 'YAML comment-only reference')
+  assert.ok(!wires('      - run: node tests/test-mut-probe.mjs # note\n'), 'trailing comment breaks exactness (strict false negative)')
+  assert.ok(!wires('      - run: node tests/test-mut-probe.mjs.backup\n'), 'filename embedded in longer token')
+  assert.ok(!wires('      - run: node tests/prefix-test-mut-probe.mjs\n'), 'filename as suffix of longer token')
+  assert.ok(!wires('      - run: echo node tests/test-mut-probe.mjs\n'), 'echoed reference is not a step line')
+  // Rounds 2-3 heredoc class: heredocs only exist inside block scalars, and
+  // ALL block-scalar content is skipped — quoted, unquoted, backslash-quoted,
+  // and stacked delimiters die identically.
+  assert.ok(!wires("      - run: |\n          cat <<'INERT'\n          node tests/test-mut-probe.mjs\n          INERT\n"), 'quoted-delimiter heredoc body')
+  assert.ok(!wires('      - run: |\n          cat <<\\INERT\n          node tests/test-mut-probe.mjs\n          INERT\n'), 'backslash-quoted heredoc body (round-3)')
+  assert.ok(!wires('      - run: |\n          cat <<FIRST <<SECOND\n          inert\n          FIRST\n          node tests/test-mut-probe.mjs\n          SECOND\n'), 'stacked heredocs (round-3)')
+  assert.ok(!wires('      - run: |\n          cat <<X\n          run: node tests/test-mut-probe.mjs\n          X\n'), 'forged step line inside block scalar')
+  assert.ok(!wires('      - run: |\n          node tests/test-mut-probe.mjs\n'), 'block-scalar invocation does not count (strict false negative, loud in CI)')
+  // Trigger axis (round-1 subagent finding): a workflow without pull_request/
+  // push wires nothing.
+  const inert = 'on:\n  workflow_dispatch:\n'
+  assert.ok(!workflowHasActiveTrigger(inert + 'jobs: {}\n'), 'dispatch-only workflow is not trigger-active')
+  assert.ok(!workflowHasActiveTrigger('# pull_request: in a comment\non:\n  schedule:\n    - cron: "0 0 * * *"\n'), 'schedule-only workflow with a comment mention is not trigger-active')
+  assert.ok(workflowHasActiveTrigger('on: [push]\n'), 'flow-style trigger list is recognized')
 })
 
-// Codex F2 mutation axes: P12 membership binds to the ACTUAL EXPLICIT array.
-test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments and stray literals elsewhere do not', () => {
+// Codex round-2/3 P12 axes: membership binds to the ACTUAL EXPLICIT array.
+test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments, stray literals, and shadow declarations do not', () => {
   const src = [
     '// intro comment mentioning \'test-ghost-a.mjs\'',
     'const EXPLICIT = [',
@@ -384,8 +369,6 @@ test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments a
   assert.ok(!set.has('test-ghost-a.mjs'), 'literal outside the array does not confer membership')
   assert.ok(!set.has('test-ghost-b.mjs'), 'comment inside the array does not confer membership')
   assert.ok(!set.has('test-ghost-c.mjs'), 'literal after the array (assertion pin) does not confer membership')
-  // Codex round-2 F2: a block-commented fake declaration must not shadow the
-  // real one, and an ambiguous parse must fail closed rather than guess.
   const shadowed = [
     '/* const EXPLICIT = [',
     "  'test-ghost-d.mjs',",
@@ -402,7 +385,7 @@ test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments a
   assert.throws(() => p12Members(ambiguous, []), /exactly one/, 'two surviving declarations fail closed')
 })
 
-// Codex F3 mutation axis: nested suites are discovered and gated.
+// Nested placement cannot escape the gate.
 test('t_mutation_nested_discovery: a suite under tests/e2e/ is discovered and reported unregistered', () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-suite-reg-'))
   try {
@@ -412,8 +395,11 @@ test('t_mutation_nested_discovery: a suite under tests/e2e/ is discovered and re
     fs.writeFileSync(path.join(tmp, 'e2e', 'helper.mjs'), '')
     const found = listSuites(tmp)
     assert.deepStrictEqual(found, ['e2e/test-nested.mjs', 'test-top.mjs'])
-    const out = computeUnregistered(found, [' node tests/test-top.mjs'.trim()], new Set(), [])
+    const out = computeUnregistered(found, new Set(['test-top.mjs']), new Set(), [])
     assert.deepStrictEqual(out, ['e2e/test-nested.mjs'])
+    // A nested suite wired with its relative path registers.
+    const wiredNested = collectStepInvocations('      - run: node tests/e2e/test-nested.mjs\n')
+    assert.deepStrictEqual(wiredNested, ['e2e/test-nested.mjs'])
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
@@ -421,7 +407,7 @@ test('t_mutation_nested_discovery: a suite under tests/e2e/ is discovered and re
 
 test('t_negative_control: a synthetic unwired suite is reported unregistered against the REAL repo state', () => {
   const synthetic = 'test-synthetic-never-wired-504.mjs'
-  const out = computeUnregistered([...SUITES, synthetic], RUN_COMMANDS, P12_SET, KNOWN_UNWIRED)
+  const out = computeUnregistered([...SUITES, synthetic], WIRED, P12_SET, KNOWN_UNWIRED)
   assert.deepStrictEqual(out, [synthetic])
 })
 

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * test-ci-suite-registration.mjs - #504 class closure.
+ *
+ * The class lesson behind #504 (and PLAN-session-auto-capture convention 8):
+ * CI runs explicitly listed test files, so an unlisted suite silently never
+ * runs. Instance fixes (wiring suites one by one) leave the class open — this
+ * lint closes it: every top-level tests/test-*.{mjs,sh} must be
+ *
+ *   (a) referenced by a .github/workflows/*.yml run step (comment lines are
+ *       stripped first, so a commented-out step does not count as wired), OR
+ *   (b) a member of the P12 invariant meta-runner (glob test-p12-*.mjs plus
+ *       its EXPLICIT set — membership-in-code, Rule 14), OR
+ *   (c) listed in the KNOWN_UNWIRED baseline below.
+ *
+ * The baseline is SHRINK-ONLY (a ratchet): it enumerates the suites that were
+ * already unwired when this lint landed (2026-07-11, #504 audit). A baseline
+ * entry that becomes wired must be deleted from the baseline (t_baseline_not_wired),
+ * and an entry whose file is deleted must be deleted too (t_baseline_exists).
+ * Adding a NEW suite to the baseline is a conscious reviewed edit of this
+ * file, never the path of least resistance: a brand-new unwired suite fails
+ * t_all_suites_registered by default.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SELF = fileURLToPath(import.meta.url)
+const SELF_BASENAME = path.basename(SELF)
+const testsDir = path.dirname(SELF)
+const repoRoot = path.dirname(testsDir)
+const workflowsDir = path.join(repoRoot, '.github', 'workflows')
+
+// Suites known to be unwired when this lint landed (#504 audit, 2026-07-11).
+// SHRINK-ONLY: entries may be removed (when wired or deleted), never added
+// without review. Many are structurally CI-unsuitable (live seats, external
+// codex/opencode binaries, network); wiring decisions stay per-suite.
+const KNOWN_UNWIRED = [
+  'test-bp1-approval-check-hook.mjs',
+  'test-bp1-atomic.mjs',
+  'test-bp1-check-deadlines.mjs',
+  'test-bp1-crash-classify.mjs',
+  'test-bp1-deadlines-lib.mjs',
+  'test-bp1-emit-marker-invalid-evidence.mjs',
+  'test-bp1-finalize-run.mjs',
+  'test-bp1-flag-flip.mjs',
+  'test-bp1-frontmatter.mjs',
+  'test-bp1-hmac-manifest.mjs',
+  'test-bp1-manifest-collect.mjs',
+  'test-bp1-marker-validate.mjs',
+  'test-bp1-marker.mjs',
+  'test-bp1-orchestrator-286-race-and-crash.mjs',
+  'test-bp1-orchestrator-287-rollback.mjs',
+  'test-bp1-orchestrator-288-resume.mjs',
+  'test-bp1-orchestrator-confirm-approval.mjs',
+  'test-bp1-orchestrator-parseargs.mjs',
+  'test-bp1-orchestrator-record-awaiting-approval.mjs',
+  'test-bp1-orchestrator-sweep-naked-entries.mjs',
+  'test-bp1-request-claim.mjs',
+  'test-bp1-rfc-scan.mjs',
+  'test-bp1-run-state-trylock.mjs',
+  'test-bp1-state-lock.mjs',
+  'test-bp1-sweep-loader.mjs',
+  'test-canonicalize-path-tolerant.mjs',
+  'test-checkpoint-marker.mjs',
+  'test-classify-correction.mjs',
+  'test-claude-subagent-env-propagation.mjs',
+  'test-em-audit-compliance.mjs',
+  'test-em-body-file.mjs',
+  'test-em-help-flags.mjs',
+  'test-em-local-dir-worktree.mjs',
+  'test-em-mine-transcripts.mjs',
+  'test-em-restore.mjs',
+  'test-em-revise-scope-inherit.mjs',
+  'test-em-sort-missing-datetime.mjs',
+  'test-em-store-tag-flags.mjs',
+  'test-em-watch-codex.mjs',
+  'test-install-codex-skill.mjs',
+  'test-install-opencode-pi-agent.mjs',
+  'test-install-scripts-guide.mjs',
+  'test-install-worktree-grant.mjs',
+  'test-marker-paths.mjs',
+  'test-marker-paths.sh',
+  'test-marker-write-helper.mjs',
+  'test-migration-sweep.mjs',
+  'test-namespaced-marker-helpers.mjs',
+  'test-namespaced-marker-helpers.sh',
+  'test-opencode-enforcement-live-e2e.mjs',
+  'test-p3-fixes.mjs',
+  'test-phase2.mjs',
+  'test-phase3.mjs',
+  'test-preflight-gate-sid-parser.sh',
+  'test-preflight-non-worsening.sh',
+  'test-preflight-prompt-canon.mjs',
+  'test-rfc002-phase1.mjs',
+  'test-rfc002-phase2.mjs',
+  'test-rfc002-phase3.mjs',
+  'test-runbook-marker-checkpoint-gate.sh',
+  'test-runbook-marker-classifier.sh',
+  'test-script-identity-key.mjs',
+  'test-second-opinion-audit-drift.mjs',
+  'test-second-opinion-consensus-e2e.mjs',
+  'test-second-opinion-consensus.mjs',
+  'test-second-opinion-dispatch.mjs',
+  'test-second-opinion-gate-runbook.mjs',
+  'test-second-opinion-gate.mjs',
+  'test-second-opinion-i22-algorithm-parity.mjs',
+  'test-second-opinion-install-snapshot.mjs',
+  'test-second-opinion-preamble.mjs',
+  'test-second-opinion-providers.mjs',
+  'test-second-opinion-storage.mjs',
+  'test-seed-patterns.mjs',
+  'test-session-end-quartet-cleanup.mjs',
+  'test-session-handoff-cwd-matrix.sh',
+  'test-so-gate-timeout-floor-integration.mjs',
+  'test-so-gate-timeout-floor.mjs',
+  'test-tier0-overrides.mjs',
+  'test-transcript-walker.mjs',
+  'test-validate-discipline-load-bundles.mjs',
+  'test-workflow-validate.mjs',
+  'test-worktree-marker-write.sh',
+]
+
+// --- derivation (kept as small pure helpers so the negative control can run
+// --- the same predicate against synthetic input) --------------------------
+
+function listSuites(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => /^test-.*\.(mjs|sh)$/.test(f))
+    .sort()
+}
+
+// All workflow YAML with full-line comments stripped: a commented-out step
+// must not count as wired.
+function readWorkflowsText(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f) =>
+      fs
+        .readFileSync(path.join(dir, f), 'utf8')
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n'),
+    )
+    .join('\n')
+}
+
+// P12 meta-runner membership, re-derived the way the runner derives it
+// (glob test-p12-*.mjs minus meta-runners) plus a textual match against its
+// source for the EXPLICIT set (the names appear literally there).
+const P12_RUNNER = 'test-p12-invariant-suite.mjs'
+const p12Source = fs.readFileSync(path.join(testsDir, P12_RUNNER), 'utf8')
+
+function isWired(basename, wfText) {
+  if (wfText.includes(basename)) return true
+  if (/^test-p12-.*\.mjs$/.test(basename) && !basename.includes('invariant-suite')) return true
+  if (p12Source.includes(`'${basename}'`)) return true
+  return false
+}
+
+function computeUnregistered(suites, wfText, baseline) {
+  const base = new Set(baseline)
+  return suites.filter((f) => !isWired(f, wfText) && !base.has(f))
+}
+
+const SUITES = listSuites(testsDir)
+const WF_TEXT = readWorkflowsText(workflowsDir)
+
+// --- test harness ----------------------------------------------------------
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  + ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  x ${name}: ${e.message}`)
+  }
+}
+
+console.log('# test-ci-suite-registration (#504 - every suite wired or baselined)')
+console.log(`# suites: ${SUITES.length}, baseline: ${KNOWN_UNWIRED.length}`)
+
+test('t_all_suites_registered: every tests/test-*.{mjs,sh} is wired in a workflow, run by the P12 meta-runner, or baselined', () => {
+  const unregistered = computeUnregistered(SUITES, WF_TEXT, KNOWN_UNWIRED)
+  assert.deepStrictEqual(
+    unregistered,
+    [],
+    `unregistered suites (wire them into a workflow, or — with review — baseline them):\n  ${unregistered.join('\n  ')}`,
+  )
+})
+
+test('t_baseline_not_wired: no baseline entry is wired (shrink-only ratchet — delete wired entries from KNOWN_UNWIRED)', () => {
+  const wiredButBaselined = KNOWN_UNWIRED.filter((f) => isWired(f, WF_TEXT))
+  assert.deepStrictEqual(
+    wiredButBaselined,
+    [],
+    `now wired — remove from KNOWN_UNWIRED: ${wiredButBaselined.join(', ')}`,
+  )
+})
+
+test('t_baseline_exists: every baseline entry exists on disk (delete stale entries)', () => {
+  const missing = KNOWN_UNWIRED.filter((f) => !fs.existsSync(path.join(testsDir, f)))
+  assert.deepStrictEqual(missing, [], `baseline entries with no file — remove: ${missing.join(', ')}`)
+})
+
+test('t_baseline_sorted_unique: baseline is sorted and duplicate-free (reviewable shrink diffs)', () => {
+  assert.deepStrictEqual(KNOWN_UNWIRED, [...new Set(KNOWN_UNWIRED)].sort())
+})
+
+test('t_detection_sanity: a known-wired suite reads wired; this lint itself is wired; positive workflow signal exists', () => {
+  // Guards the comment-stripper / reader against silently matching nothing.
+  assert.ok(isWired('test-plan-marker.mjs', WF_TEXT), 'test-plan-marker.mjs must read as wired')
+  // The P12 glob path must still short-circuit meta-runner members.
+  assert.ok(isWired('test-p12-global-clean.mjs', WF_TEXT), 'P12 glob member must read as wired')
+  // Rename drift: if this file is renamed without updating the workflow step,
+  // fail here on the next local run.
+  assert.ok(WF_TEXT.includes(SELF_BASENAME), `${SELF_BASENAME} must itself be wired in a workflow`)
+})
+
+test('t_negative_control: a synthetic unwired suite is reported unregistered (red path proves the predicate bites)', () => {
+  const synthetic = 'test-synthetic-never-wired-504.mjs'
+  assert.ok(!isWired(synthetic, WF_TEXT), 'synthetic name must not read as wired')
+  const out = computeUnregistered([...SUITES, synthetic], WF_TEXT, KNOWN_UNWIRED)
+  assert.deepStrictEqual(out, [synthetic])
+})
+
+console.log(`\n# ${passed} passed, ${failed} failed`)
+if (failures.length > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}
+console.log('test-ci-suite-registration: PASS')

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -7,20 +7,22 @@
  * runs. Instance fixes (wiring suites one by one) leave the class open — this
  * lint closes it: every test-*.{mjs,sh} at any depth under tests/ must be
  *
- *   (a) STEP-WIRED in .github/workflows/*.{yml,yaml}: some line, OUTSIDE any
- *       YAML block scalar, in a workflow whose `on:` declares a pull_request
- *       or push trigger, trims to exactly
- *           [- ]run: node|bash|sh tests/<suite>
- *       This is a structural line-grammar contract, not shell parsing (codex
- *       rounds 1-3 killed every textual predicate: substrings, comments,
- *       step names, and four heredoc spellings). Heredocs can only exist
+ *   (a) STEP-WIRED in .github/workflows/*.{yml,yaml}: a `run:` line whose
+ *       value is exactly `node|bash|sh tests/<suite>`, located (by an
+ *       indent-stack walk that skips block scalars) at the YAML path
+ *       jobs.<job>.steps, in a workflow whose TOP-LEVEL `on:` declares a
+ *       pull_request or push trigger. This is a structural contract, not
+ *       shell parsing (codex rounds 1-4 killed every looser predicate:
+ *       substrings, comments, step names, four heredoc spellings, and
+ *       hierarchy-unbound exact lines under `env:`). Heredocs can only exist
  *       inside block scalars, so skipping block-scalar content closes the
- *       entire heredoc class; the trigger check closes the
- *       disabled-workflow class. STRICT by design: an invocation with
- *       arguments, inside a block scalar, or with a trailing comment does
- *       NOT count — a legitimate future wiring in one of those forms fails
- *       CI loudly and this contract gets extended consciously (false
- *       negatives are loud; only silent false positives are dangerous); OR
+ *       entire heredoc class; hierarchy binding closes the forged-placement
+ *       class; the trigger check closes the disabled-workflow class. STRICT
+ *       by design: an invocation with arguments, inside a block scalar, or
+ *       with a trailing comment does NOT count — a legitimate future wiring
+ *       in one of those forms fails CI loudly and this contract gets
+ *       extended consciously (false negatives are loud; only silent false
+ *       positives are dangerous); OR
  *   (b) a member of the P12 invariant meta-runner — re-derived the way the
  *       runner derives it: glob(test-p12-*.mjs) minus meta-runners, plus the
  *       runner's actual `const EXPLICIT = [...]` array (block comments
@@ -171,21 +173,31 @@ function listSuites(dir, prefix = '') {
 // A `key: |` / `key: >` line (with optional chomp/indent modifiers) opens a
 // YAML block scalar; its content is every following line indented deeper than
 // the key. Heredocs, echoed text, and any other data can only live inside
-// such content, so step scanning skips it entirely.
+// such content, so the scanner skips it entirely.
 const BLOCK_SCALAR_KEY = /^(\s*)(?:-\s+)?[\w-]+:\s*[|>][+-]?\d*\s*(?:#.*)?$/
 
-// The one shape that counts as a wiring step (trimmed, exact):
-//   [- ]run: node|bash|sh tests/<relpath>
-const STEP_INVOCATION = /^(?:-\s+)?run:\s*(?:node|bash|sh)\s+tests\/(\S+)$/
+// The one value shape that counts as a wiring step (exact to end of line):
+//   run: node|bash|sh tests/<relpath>
+const STEP_INVOCATION = /^run:\s*(?:node|bash|sh)\s+tests\/(\S+)$/
 
-// Collect the suite relpaths step-wired by one workflow's text: scan lines,
-// skip block-scalar content, exact-match the remainder against
-// STEP_INVOCATION.
-function collectStepInvocations(yamlText) {
+// One structural pass over a workflow's YAML (codex round-4 P1: matches must
+// bind to hierarchy, not just line shape). An indent stack of mapping keys is
+// maintained (sequence-item `- ` prefixes fold into effective indent), block
+// scalars are skipped wholesale, and:
+//   - a STEP_INVOCATION line counts ONLY under the exact path
+//     jobs(col 0) -> <job> -> steps, so a byte-identical line under `env:` or
+//     anywhere else confers nothing;
+//   - trigger keys count ONLY as direct children of top-level `on:` (or its
+//     flow/scalar value), so `env: { pull_request: x }` activates nothing.
+function parseWorkflow(yamlText) {
   const lines = yamlText.split('\n')
-  const out = []
+  const stack = [] // { indent, key }
+  const triggers = new Set()
+  const stepSuites = []
   for (let i = 0; i < lines.length; i++) {
-    const scalar = lines[i].match(BLOCK_SCALAR_KEY)
+    const raw = lines[i]
+    if (raw.trim() === '' || /^\s*#/.test(raw)) continue
+    const scalar = raw.match(BLOCK_SCALAR_KEY)
     if (scalar) {
       const keyIndent = scalar[1].length
       while (i + 1 < lines.length) {
@@ -195,30 +207,57 @@ function collectStepInvocations(yamlText) {
       }
       continue
     }
-    const m = lines[i].trim().match(STEP_INVOCATION)
-    if (m) out.push(m[1])
+    const indent = raw.match(/^( *)/)[1].length
+    let content = raw.slice(indent)
+    let seqOffset = 0
+    while (content.startsWith('- ')) {
+      content = content.slice(2)
+      seqOffset += 2
+    }
+    const effIndent = indent + seqOffset
+    while (stack.length && stack[stack.length - 1].indent >= effIndent) stack.pop()
+
+    const step = content.match(STEP_INVOCATION)
+    if (step) {
+      const n = stack.length
+      if (
+        n >= 3 &&
+        stack[n - 1].key === 'steps' &&
+        stack[n - 3].key === 'jobs' &&
+        stack[n - 3].indent === 0
+      ) {
+        stepSuites.push(step[1])
+      }
+      continue
+    }
+
+    const key = content.match(/^([\w_-]+):\s*(.*?)\s*(?:#.*)?$/)
+    if (!key) continue
+    if (key[1] === 'on' && effIndent === 0 && key[2] !== '') {
+      // Flow (`on: [push, pull_request]`) or scalar (`on: push`) trigger value.
+      for (const t of key[2].replace(/[[\]]/g, '').split(',')) triggers.add(t.trim())
+    } else if (stack.length === 1 && stack[0].key === 'on' && stack[0].indent === 0) {
+      triggers.add(key[1])
+    }
+    stack.push({ indent: effIndent, key: key[1] })
   }
-  return out
+  return { triggers, stepSuites }
 }
 
-// A workflow only executes on PRs/pushes if its `on:` declares those
-// triggers; a workflow_dispatch- or schedule-only file wires nothing (a
+// A workflow only executes on PRs/pushes if its top-level `on:` declares
+// those triggers; a workflow_dispatch- or schedule-only file wires nothing (a
 // suite invoked only there never gates a merge).
-function workflowHasActiveTrigger(yamlText) {
-  const noComments = yamlText
-    .split('\n')
-    .filter((line) => !/^\s*#/.test(line))
-    .join('\n')
-  return /^\s*(?:pull_request|push)\s*:/m.test(noComments) || /^on:\s*\[[^\]]*(?:pull_request|push)[^\]]*\]/m.test(noComments)
+function isTriggerActive(triggers) {
+  return triggers.has('pull_request') || triggers.has('push')
 }
 
 // The set of suites step-wired across all trigger-active workflows.
 function collectWiredSet(dir) {
   const wired = new Set()
   for (const f of fs.readdirSync(dir).filter((n) => n.endsWith('.yml') || n.endsWith('.yaml'))) {
-    const text = fs.readFileSync(path.join(dir, f), 'utf8')
-    if (!workflowHasActiveTrigger(text)) continue
-    for (const suite of collectStepInvocations(text)) wired.add(suite)
+    const { triggers, stepSuites } = parseWorkflow(fs.readFileSync(path.join(dir, f), 'utf8'))
+    if (!isTriggerActive(triggers)) continue
+    for (const suite of stepSuites) wired.add(suite)
   }
   return wired
 }
@@ -316,14 +355,14 @@ test('t_detection_sanity: known-wired suites detected via each acceptance branch
   assert.ok(WIRED.has(SELF_BASENAME), `${SELF_BASENAME} must itself be step-wired`)
 })
 
-// Codex rounds 1-3 workflow axes, driven through the SAME helpers CI uses.
+// Codex rounds 1-4 workflow axes, driven through the SAME parser CI uses.
 // Every non-step reference class must read as NOT wired.
-test('t_mutation_workflow_axes: only bare step lines outside block scalars in trigger-active workflows count', () => {
+test('t_mutation_workflow_axes: only jobs.*.steps run lines outside block scalars in on:-triggered workflows count', () => {
   const target = 'test-mut-probe.mjs'
-  const ACTIVE = 'on:\n  pull_request:\n'
-  const wires = (yaml) => {
-    const text = ACTIVE + yaml
-    return workflowHasActiveTrigger(text) && collectStepInvocations(text).includes(target)
+  const SKELETON = 'on:\n  pull_request:\njobs:\n  validate:\n    runs-on: ubuntu-latest\n    steps:\n'
+  const wires = (steps, prefix = SKELETON) => {
+    const { triggers, stepSuites } = parseWorkflow(prefix + steps)
+    return isTriggerActive(triggers) && stepSuites.includes(target)
   }
   // Positive controls.
   assert.ok(wires('      - name: x\n        run: node tests/test-mut-probe.mjs\n'), 'plain step line')
@@ -344,12 +383,20 @@ test('t_mutation_workflow_axes: only bare step lines outside block scalars in tr
   assert.ok(!wires('      - run: |\n          cat <<FIRST <<SECOND\n          inert\n          FIRST\n          node tests/test-mut-probe.mjs\n          SECOND\n'), 'stacked heredocs (round-3)')
   assert.ok(!wires('      - run: |\n          cat <<X\n          run: node tests/test-mut-probe.mjs\n          X\n'), 'forged step line inside block scalar')
   assert.ok(!wires('      - run: |\n          node tests/test-mut-probe.mjs\n'), 'block-scalar invocation does not count (strict false negative, loud in CI)')
-  // Trigger axis (round-1 subagent finding): a workflow without pull_request/
-  // push wires nothing.
-  const inert = 'on:\n  workflow_dispatch:\n'
-  assert.ok(!workflowHasActiveTrigger(inert + 'jobs: {}\n'), 'dispatch-only workflow is not trigger-active')
-  assert.ok(!workflowHasActiveTrigger('# pull_request: in a comment\non:\n  schedule:\n    - cron: "0 0 * * *"\n'), 'schedule-only workflow with a comment mention is not trigger-active')
-  assert.ok(workflowHasActiveTrigger('on: [push]\n'), 'flow-style trigger list is recognized')
+  // Round-4 hierarchy axes: a byte-exact run line bound to the wrong YAML
+  // path confers nothing.
+  assert.ok(!wires('', 'on:\n  pull_request:\nenv:\n  run: node tests/test-mut-probe.mjs\njobs:\n  validate:\n    steps:\n'), 'top-level env.run placement (round-4)')
+  assert.ok(!wires('', 'on:\n  pull_request:\njobs:\n  validate:\n    env:\n      run: node tests/test-mut-probe.mjs\n    steps:\n'), 'job-level env.run placement (round-4)')
+  // Trigger axes (round-1 subagent + round-4): only top-level on: children
+  // (or its flow/scalar value) activate a workflow.
+  const dispatchOnly = 'on:\n  workflow_dispatch:\njobs:\n  v:\n    steps:\n      - run: node tests/test-mut-probe.mjs\n'
+  assert.ok(!wires('', dispatchOnly), 'dispatch-only workflow wires nothing')
+  const envTrigger = 'on:\n  workflow_dispatch:\nenv:\n  pull_request: inert-non-trigger-key\njobs:\n  v:\n    steps:\n      - run: node tests/test-mut-probe.mjs\n'
+  assert.ok(!wires('', envTrigger), 'pull_request under env: is not a trigger (round-4)')
+  assert.ok(!isTriggerActive(parseWorkflow('# pull_request: in a comment\non:\n  schedule:\n    - cron: "0 0 * * *"\n').triggers), 'schedule-only workflow with a comment mention is not trigger-active')
+  assert.ok(isTriggerActive(parseWorkflow('on: [push]\n').triggers), 'flow-style trigger list is recognized')
+  assert.ok(isTriggerActive(parseWorkflow('on: push\n').triggers), 'scalar trigger value is recognized')
+  assert.ok(wires('      - run: node tests/test-mut-probe.mjs\n', 'on:\n  push:\n    branches: [main]\njobs:\n  v:\n    steps:\n'), 'push-with-branches trigger activates (nested keys do not leak)')
 })
 
 // Codex round-2/3 P12 axes: membership binds to the ACTUAL EXPLICIT array.
@@ -398,7 +445,9 @@ test('t_mutation_nested_discovery: a suite under tests/e2e/ is discovered and re
     const out = computeUnregistered(found, new Set(['test-top.mjs']), new Set(), [])
     assert.deepStrictEqual(out, ['e2e/test-nested.mjs'])
     // A nested suite wired with its relative path registers.
-    const wiredNested = collectStepInvocations('      - run: node tests/e2e/test-nested.mjs\n')
+    const wiredNested = parseWorkflow(
+      'on:\n  pull_request:\njobs:\n  v:\n    steps:\n      - run: node tests/e2e/test-nested.mjs\n',
+    ).stepSuites
     assert.deepStrictEqual(wiredNested, ['e2e/test-nested.mjs'])
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -176,7 +176,13 @@ function extractRunCommands(yamlText) {
         block.push(line)
         i = j
       }
-      commands.push(block.join('\n'))
+      // De-indent the way YAML hands the scalar to the shell: strip the
+      // common block indentation so heredoc delimiters compare the text the
+      // shell actually sees.
+      const baseIndent = Math.min(
+        ...block.filter((l) => l.trim() !== '').map((l) => l.match(/^( *)/)[1].length),
+      )
+      commands.push(block.map((l) => (l.trim() === '' ? l : l.slice(baseIndent))).join('\n'))
     } else {
       commands.push(value.replace(/\s#.*$/, ''))
     }
@@ -184,17 +190,41 @@ function extractRunCommands(yamlText) {
   return commands
 }
 
+// Drop shell heredoc BODIES from a command's lines: text between
+// `<<[-]['"]WORD['"]` and the closing WORD line is data fed to a program, not
+// executable commands (codex round-2 F1: `cat <<'INERT' ... INERT` carrying an
+// invocation-shaped line must not count as wired).
+function stripHeredocBodies(lines) {
+  const out = []
+  let delimiter = null
+  let dashed = false
+  for (const line of lines) {
+    if (delimiter !== null) {
+      const closing = dashed ? line.replace(/^\t+/, '') : line
+      if (closing === delimiter) delimiter = null
+      continue
+    }
+    out.push(line)
+    const m = line.replace(/(^|\s)#.*$/, '$1').match(/<<(-?)\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][A-Za-z0-9_]*))/)
+    if (m) {
+      dashed = m[1] === '-'
+      delimiter = m[2] ?? m[3] ?? m[4]
+    }
+  }
+  return out
+}
+
 // A suite counts as workflow-wired ONLY if some run-command line invokes it:
 // `node|bash|sh [./]tests/<relpath>` at command position (line start or after
-// ;, &&, ||, |, ( or $( ). Shell comment segments are stripped first, so
-// `# node tests/x.mjs` and `echo done # node tests/x.mjs` never count; a
-// quoted occurrence (`echo 'node tests/x.mjs'`) fails the command-position
-// anchor (codex F1 axes).
+// ;, &&, ||, |, ( or $( ). Heredoc bodies are dropped and shell comment
+// segments stripped first, so `cat <<'X' ... X`, `# node tests/x.mjs`, and
+// `echo done # node tests/x.mjs` never count; a quoted occurrence
+// (`echo 'node tests/x.mjs'`) fails the command-position anchor (codex F1 axes).
 function invokedByRunCommands(relPath, runCommands) {
   const esc = relPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   const re = new RegExp(`(?:^|[;&|(]|\\$\\()\\s*(?:node|bash|sh)\\s+(?:\\./)?tests/${esc}(?=$|[\\s;&|)'"])`)
   for (const cmd of runCommands) {
-    for (const rawLine of cmd.split('\n')) {
+    for (const rawLine of stripHeredocBodies(cmd.split('\n'))) {
       const line = rawLine.replace(/(^|\s)#.*$/, '$1')
       if (re.test(line)) return true
     }
@@ -218,9 +248,19 @@ function readWorkflowRunCommands(dir) {
 const P12_RUNNER = 'test-p12-invariant-suite.mjs'
 
 function parseP12Explicit(runnerSource) {
-  const block = runnerSource.match(/const EXPLICIT = \[([\s\S]*?)\n\]/)
-  assert.ok(block, `cannot locate "const EXPLICIT = [" block in ${P12_RUNNER} — update this lint's parser`)
-  const noComments = block[1].replace(/\/\/.*$/gm, '')
+  // Strip /* */ block comments BEFORE locating the declaration: a
+  // block-commented fake `const EXPLICIT = [...]` preceding the real one must
+  // not shadow it (codex round-2 F2). Then require the declaration to be
+  // unique — two surviving declarations means this parser's assumptions broke,
+  // so fail closed instead of guessing.
+  const noBlockComments = runnerSource.replace(/\/\*[\s\S]*?\*\//g, '')
+  const decls = [...noBlockComments.matchAll(/const EXPLICIT = \[([\s\S]*?)\n\]/g)]
+  assert.strictEqual(
+    decls.length,
+    1,
+    `expected exactly one "const EXPLICIT = [" declaration in ${P12_RUNNER}, found ${decls.length} — update this lint's parser`,
+  )
+  const noComments = decls[0][1].replace(/\/\/.*$/gm, '')
   return [...noComments.matchAll(/'([^']+)'/g)].map((m) => m[1])
 }
 
@@ -320,6 +360,11 @@ test('t_mutation_workflow_axes: step-name / if: / YAML comment / shell comment /
   assert.ok(!wired('      - run: node tests/test-mut-probe.mjs.backup\n'), 'filename embedded in longer token')
   assert.ok(!wired('      - run: node tests/prefix-test-mut-probe.mjs\n'), 'filename as suffix of longer token')
   assert.ok(!wired('      - run: echo node tests/test-mut-probe.mjs\n'), 'echoed (non-command-position) reference')
+  // Codex round-2 F1: heredoc bodies are data, not commands.
+  assert.ok(!wired("      - run: |\n          cat <<'INERT'\n          node tests/test-mut-probe.mjs\n          INERT\n"), 'quoted-delimiter heredoc body')
+  assert.ok(!wired('      - run: |\n          cat <<INERT\n          node tests/test-mut-probe.mjs\n          INERT\n'), 'unquoted-delimiter heredoc body')
+  assert.ok(!wired('      - run: |\n          cat <<-INERT\n\t\t\tnode tests/test-mut-probe.mjs\n\tINERT\n'), 'dash-heredoc body with tab-indented close')
+  assert.ok(wired("      - run: |\n          cat <<'INERT'\n          inert text\n          INERT\n          node tests/test-mut-probe.mjs\n"), 'real invocation AFTER a closed heredoc still counts')
 })
 
 // Codex F2 mutation axes: P12 membership binds to the ACTUAL EXPLICIT array.
@@ -339,6 +384,22 @@ test('t_mutation_p12_axes: EXPLICIT-array literals confer membership; comments a
   assert.ok(!set.has('test-ghost-a.mjs'), 'literal outside the array does not confer membership')
   assert.ok(!set.has('test-ghost-b.mjs'), 'comment inside the array does not confer membership')
   assert.ok(!set.has('test-ghost-c.mjs'), 'literal after the array (assertion pin) does not confer membership')
+  // Codex round-2 F2: a block-commented fake declaration must not shadow the
+  // real one, and an ambiguous parse must fail closed rather than guess.
+  const shadowed = [
+    '/* const EXPLICIT = [',
+    "  'test-ghost-d.mjs',",
+    ']',
+    '*/',
+    'const EXPLICIT = [',
+    "  'test-real-member.mjs',",
+    ']',
+  ].join('\n')
+  const shadowSet = p12Members(shadowed, [])
+  assert.ok(shadowSet.has('test-real-member.mjs'), 'real declaration read past a block-commented fake')
+  assert.ok(!shadowSet.has('test-ghost-d.mjs'), 'block-commented fake declaration confers nothing')
+  const ambiguous = "const EXPLICIT = [\n  'a.mjs',\n]\nconst EXPLICIT = [\n  'b.mjs',\n]"
+  assert.throws(() => p12Members(ambiguous, []), /exactly one/, 'two surviving declarations fail closed')
 })
 
 // Codex F3 mutation axis: nested suites are discovered and gated.


### PR DESCRIPTION
Closes #504. Closes #377.

## What

- **plan-marker-validate.yml**: wires the 5 activation suites that predate RFC-011 S5's REQ-19 pass — test-activation-{sessionstart,hook-e2e,manifest,match}.mjs + test-uninstall-activation.mjs. (The audit's 6th, test-install-activation.mjs, was already wired at S5 line 322; the #504 audit comment's grep pattern could not match that filename.)
- **plugin-validate.yml**: wires the 4 plugin-family suites #377 tracked only as a placeholder comment — test-json-instance-validate, test-plugin-json, test-field-bindings, test-plugin-harness-binding — and replaces the stale comment (it also listed test-plugin-gauntlet, wired since P2a).
- **tests/test-ci-suite-registration.mjs** (new): closes the class. Every test-*.{mjs,sh} at any depth under tests/ must be (a) step-wired — a run: line whose value is exactly `node|bash|sh tests/<f>`, bound by an indent-stack walk to the YAML path jobs.<job>.steps, block scalars skipped, in a workflow whose top-level on: declares pull_request/push; (b) a P12 meta-runner member (glob + the runner's actual EXPLICIT array, block-comment-proof, fail-closed on ambiguity); or (c) in an 83-entry shrink-only KNOWN_UNWIRED baseline (t_baseline_not_wired forces deletion once wired; t_baseline_exists on file deletion).

## Review

Adversarial panel per the multi-agent playbook, 5 rounds to convergence:

- negative-scenario-reviewer round 1 (reply episode 20260710-230809-…-1a9f): HOLD — textual-inclusion class (runtime-proven), nested-scope gap, baseline grow-gaming (dispositioned accepted-documented). Final re-verdict on e09be50 pending as merge gate.
- codex rounds 1-5 via second-opinion harness (.review-store replies …-87bea6e6a9d0 REJECT, …-dad1d9df86a6 REJECT, …-8eae82f89e45 REJECT + convergence signal, …-e22d2b06f09f **ACCEPT**). Every REJECT was mutation-proven and every fix carries the mutation as a permanent fixture: substring/step-name/if:/comment axes, four heredoc spellings, EXPLICIT-array shadowing, hierarchy-unbound placements, trigger forgery under env:.
- Round-3 dispatches surfaced a harness defect (10-min dispatch ceiling kills long reviews with an opaque error) — filed as #512.

## Verification

- Lint at HEAD: 9/9 (237 suites, 83 baseline, 152 step-wired — the step-wired count matches the reviewer's independent runtime sweep).
- All 9 newly wired suites pass as CI invokes them: 49+48+35+84+26 activation + 36+6+32+21 plugin checks, zero failures (run locally and re-verified by codex).
- Known out-of-contract files documented: tests/e2e/console.e2e.mjs (Playwright, opt-in), tests/integration/codex-tmux-e2e.mjs (live codex+tmux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)