### PR TITLE
Add Codex advisory activation installer

### DIFF
--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Run codex install/uninstall E2E (RFC-008 P6 S4, REQ-11)
         run: node tests/test-install-codex-enforcement.mjs
 
+      - name: Run Codex advisory activation install/uninstall + hook E2E (RFC-009 R3/R4)
+        run: node tests/test-codex-activation-install.mjs
+
       - name: Run pi-agent install/uninstall E2E (RFC-008 P7 S5, P12 closure)
         run: node tests/test-install-pi-enforcement.mjs
 

--- a/docs/install/codex.md
+++ b/docs/install/codex.md
@@ -8,8 +8,7 @@ Self-contained guide. Everything you need is here.
 ## WHEN NOT TO USE
 - You are installing for Claude Code, Cursor, OpenCode, Pi Agent, or Windsurf. Use
   that harness's file in this directory.
-- Do NOT pass `--install-hooks`, `--install-enforcement`, or
-  `--install-second-opinion`. Those are Claude Code only.
+- Do not pass `--install-hooks`; it is a legacy Claude Code flag.
 
 ## Prerequisites
 - git and Node.js (standard library only; zero npm dependencies, no build step).
@@ -29,6 +28,17 @@ does not target the clone itself.
 ```
 node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool codex --project <ABSOLUTE_PATH_TO_TARGET_PROJECT>
 ```
+
+To install advisory lesson activation at prompt, tool, and session-start events:
+
+```
+node <ABSOLUTE_PATH_TO_CLONE>/install.mjs --tool codex --project <ABSOLUTE_PATH_TO_TARGET_PROJECT> --install-activation
+```
+
+This adds context only. It never blocks and is independent of enforcement.
+After installation, start Codex in the project, run `/hooks`, review the three
+episodic-memory activation definitions, and trust them. Codex skips new or
+changed project hooks until their exact definitions are trusted.
 
 Expected output (abbreviated; `<HOME>` is your resolved home, `<PROJ>` your project):
 
@@ -58,8 +68,10 @@ Done! Episodic memory is ready.
 | `<project>/.agents/skills/episodic-memory/SKILL.md` | the Codex skill (points at the guide) |
 | `<project>/.episodic-memory/` | local episode store |
 | `<project>/.gitignore` | created/appended with `.episodic-memory/` + run.key pattern |
+| `<project>/.codex/episodic-memory-activation/` | optional Codex advisory activation runtime and manifest |
+| `<project>/.codex/hooks.json` | optional merged activation registrations |
 
-The Codex project tree after install is just:
+Without optional activation, the Codex project tree after install is just:
 
 ```
 <PROJ>/.agents/skills/episodic-memory/SKILL.md
@@ -92,13 +104,18 @@ node ~/.episodic-memory/scripts/em-search.mjs --project <name> --no-track --no-s
   `.agents/skills/episodic-memory/SKILL.md`. If you also install Pi Agent (or run
   `--tool all`), the second install reports "already current" for that file. That is
   expected, not a conflict.
-- Do NOT add the Claude Code hook / enforcement flags.
+- `--install-activation` is Codex-specific when paired with `--tool codex`; it
+  writes only under the target project `.codex/` directory.
+- Installation and uninstallation never remove local episode files under
+  `<project>/.episodic-memory/episodes/`.
 
 ## Uninstall / reinstall
 
 - Reinstall is idempotent: re-run the same command after `git pull`. Re-runs print
   "already current" and "All 11 behavioral patterns already seeded"; these are
   normal.
+- Remove only Codex advisory activation while preserving the skill and episodes:
+  `node <clone>/install.mjs --tool codex --project <project> --uninstall-activation`.
 - To uninstall, remove `<project>/.agents/skills/episodic-memory/SKILL.md` (note this
   is shared with Pi Agent; remove only if neither tool needs it).
 

--- a/install.mjs
+++ b/install.mjs
@@ -93,6 +93,8 @@ const REPO_SECOND_OPINION = path.join(REPO_SCRIPTS, 'second-opinion')
 const REPO_PLUGIN_OPENCODE = path.join(REPO_DIR, 'plugins', 'opencode')
 // RFC-008 P6 S4: Codex enforcement plugin source (adapter + manifest + runbooks).
 const REPO_PLUGIN_CODEX = path.join(REPO_DIR, 'plugins', 'codex')
+// RFC-009 Codex advisory activation adapter source.
+const REPO_PLUGIN_CODEX_ACTIVATION = path.join(REPO_DIR, 'plugins', 'codex-activation')
 // RFC-008 P7 S5: Pi enforcement extension source (adapter + manifest + runbooks).
 const REPO_PLUGIN_PI = path.join(REPO_DIR, 'plugins', 'pi-agent')
 
@@ -240,17 +242,18 @@ Hook flags (claude-code / RFC-008 P4d — enforcement is PER-PROJECT, never glob
                           switch <project>/.episodic-memory/enforce-config.json
                           (explicit destructive opt-in; default leaves it).
 
-Activation flags (claude-code / RFC-009 P2 — advisory, PER-PROJECT, never global):
+Activation flags (claude-code and codex / RFC-009 — advisory, PER-PROJECT, never global):
   --install-activation    Install the PER-PROJECT advisory activation adapter
-                          under the literal <project>/.claude/ (the resolved
-                          --project, same root as enforcement; NEVER ~/.claude):
+                          under the harness-specific project config directory
+                          (.claude/ or .codex/; NEVER the user-global config):
                           the 3 thin hooks (activation-prompt UserPromptSubmit,
                           activation-tool PreToolUse, activation-sessionstart
-                          SessionStart) + the shared activation-hook-run.mjs
-                          runner + a co-located manifest.json carrying the
+                          SessionStart) + the activation runtime closure + a
+                          co-located manifest.json carrying the
                           project scope identity (slug + RESOLVED store root,
                           which for a worktree stays the main checkout), and
-                          register them in <project>/.claude/settings.json.
+                          register them in <project>/.claude/settings.json or
+                          <project>/.codex/hooks.json for the selected harness.
                           Advisory-ONLY: the hooks emit additionalContext and
                           always exit 0 — no gate, no block. Independent of
                           --install-enforcement. Skips divergent local hook
@@ -2333,6 +2336,165 @@ function uninstallCodexEnforcement(projectDir) {
   return report
 }
 
+// RFC-009 Codex advisory activation. This is deliberately separate from the
+// Codex enforcement plugin: it only injects bounded memory context and every
+// runtime path exits zero without a decision field.
+function codexActivationPaths(projectDir) {
+  let registrationRoot
+  try { registrationRoot = fs.realpathSync(projectDir) } catch { registrationRoot = path.resolve(projectDir) }
+  const authorityRoot = resolveRepoRoot(projectDir)
+  const codexDir = path.join(registrationRoot, '.codex')
+  const pluginDir = path.join(codexDir, 'episodic-memory-activation')
+  return {
+    registrationRoot,
+    authorityRoot,
+    codexDir,
+    pluginDir,
+    hooksDir: path.join(pluginDir, 'hooks'),
+    manifestPath: path.join(pluginDir, 'manifest.json'),
+    hooksJsonPath: path.join(codexDir, 'hooks.json'),
+  }
+}
+
+function codexActivationSourceManifest() {
+  return JSON.parse(fs.readFileSync(path.join(REPO_PLUGIN_CODEX_ACTIVATION, 'manifest.json'), 'utf8'))
+}
+
+function codexActivationCommand(hookPath) {
+  return `bash ${shellQuote(hookPath)}`
+}
+
+function installCodexActivation(projectDir) {
+  const report = { root: null, installedFiles: [], registrations: [], manifest: null, withheld: [], warnings: [], runnerReady: false }
+  const P = codexActivationPaths(projectDir)
+  report.root = P.registrationRoot
+
+  // Parse and validate the destination shape before writing any file.
+  let config = {}
+  if (fs.existsSync(P.hooksJsonPath)) {
+    try { config = JSON.parse(fs.readFileSync(P.hooksJsonPath, 'utf8')) }
+    catch (e) { report.warnings.push(`.codex/hooks.json is not valid JSON (${e.message}); aborted — nothing changed`); return report }
+    if (!isPlainObject(config) || (config.hooks !== undefined && !isPlainObject(config.hooks))) {
+      report.warnings.push('.codex/hooks.json must be an object with hooks absent or an object; aborted — nothing changed')
+      return report
+    }
+  }
+
+  const sourceManifest = codexActivationSourceManifest()
+  const owned = [
+    ...sourceManifest.registrations.map((r) => r.file),
+    ...(sourceManifest.support_files || []).map((r) => r.file),
+  ]
+  const results = new Map()
+  for (const file of owned) {
+    const src = path.join(REPO_PLUGIN_CODEX_ACTIVATION, 'hooks', file)
+    const dst = path.join(P.hooksDir, file)
+    const result = installHookFile(src, dst, installHooksForce)
+    results.set(file, result)
+    if (result === 'skipped-divergent' || result === 'missing-source') report.withheld.push(dst)
+    else report.installedFiles.push(dst)
+  }
+
+  const ready = owned.every((file) => ['copied', 'unchanged', 'forced'].includes(results.get(file)))
+  if (!ready) {
+    report.warnings.push('Codex activation registration withheld because one or more owned files are missing or locally modified; use --install-hooks-force to accept replacement')
+    return report
+  }
+
+  const deployedManifest = {
+    ...sourceManifest,
+    project_identity: { slug: path.basename(P.authorityRoot), root: P.authorityRoot },
+  }
+  writeJSONAtomic(P.manifestPath, deployedManifest)
+  report.installedFiles.push(P.manifestPath)
+  report.manifest = P.manifestPath
+
+  if (!config.hooks) config.hooks = {}
+  for (const reg of sourceManifest.registrations) {
+    if (!Array.isArray(config.hooks[reg.event])) config.hooks[reg.event] = []
+    const command = codexActivationCommand(path.join(P.hooksDir, reg.file))
+    const exists = config.hooks[reg.event].some((group) =>
+      Array.isArray(group && group.hooks) && group.hooks.some((hook) => hook && hook.command === command))
+    if (!exists) {
+      config.hooks[reg.event].push({
+        hooks: [{ type: 'command', command, statusMessage: 'episodic-memory activation', timeout: reg.timeout }],
+      })
+    }
+    report.registrations.push(`${reg.event} → ${reg.file}`)
+  }
+  writeJSONAtomic(P.hooksJsonPath, config)
+  report.installedFiles.push(P.hooksJsonPath)
+  report.runnerReady = true
+  console.log(`[codex activation] deployed under ${P.pluginDir}. Run "/hooks" inside Codex (cwd ${P.registrationRoot}) and trust the three episodic-memory activation hooks.`)
+  return report
+}
+
+function uninstallCodexActivation(projectDir) {
+  const report = { removedRegistrations: [], removedFiles: [], preserved: [], warnings: [] }
+  const P = codexActivationPaths(projectDir)
+  let config = {}
+  let configPresent = false
+  if (fs.existsSync(P.hooksJsonPath)) {
+    configPresent = true
+    try { config = JSON.parse(fs.readFileSync(P.hooksJsonPath, 'utf8')) }
+    catch (e) { report.warnings.push(`.codex/hooks.json is not valid JSON (${e.message}); aborted — nothing changed`); return report }
+    if (!isPlainObject(config) || (config.hooks !== undefined && !isPlainObject(config.hooks))) {
+      report.warnings.push('.codex/hooks.json has an unsupported shape; aborted — nothing changed')
+      return report
+    }
+  }
+
+  let manifest
+  try { manifest = JSON.parse(fs.readFileSync(P.manifestPath, 'utf8')) }
+  catch (e) { report.warnings.push(`Codex activation manifest unavailable (${e.message}); preserving files and registrations`); return report }
+
+  let changed = false
+  if (config.hooks) {
+    for (const reg of manifest.registrations || []) {
+      const command = codexActivationCommand(path.join(P.hooksDir, reg.file))
+      const removed = removeHookCommandFromEvent(config.hooks, reg.event, command)
+      if (removed > 0) {
+        changed = true
+        report.removedRegistrations.push(`${reg.event} → ${reg.file}`)
+      }
+      if (Array.isArray(config.hooks[reg.event]) && config.hooks[reg.event].length === 0) delete config.hooks[reg.event]
+    }
+    if (Object.keys(config.hooks).length === 0) delete config.hooks
+  }
+  if (configPresent && changed) writeJSONAtomic(P.hooksJsonPath, config)
+
+  const declared = [...(manifest.registrations || []), ...(manifest.support_files || [])]
+  let preservedOwnedFile = false
+  for (const item of declared) {
+    const target = path.join(P.hooksDir, item.file)
+    if (!fs.existsSync(target)) continue
+    const actual = `sha256:${sha256File(target)}`
+    if (actual !== item.checksum) {
+      preservedOwnedFile = true
+      report.preserved.push(target)
+      report.warnings.push(`preserved locally modified ${target}: expected ${item.checksum}, got ${actual}`)
+      continue
+    }
+    assertContained(target, P.pluginDir)
+    fs.rmSync(target, { force: true })
+    report.removedFiles.push(target)
+  }
+  // Keep the ownership record beside any locally modified owned file so a
+  // later uninstall can still verify and clean it after the operator reverts
+  // or explicitly replaces it.
+  if (fs.existsSync(P.manifestPath) && !preservedOwnedFile) {
+    assertContained(P.manifestPath, P.pluginDir)
+    fs.rmSync(P.manifestPath, { force: true })
+    report.removedFiles.push(P.manifestPath)
+  } else if (fs.existsSync(P.manifestPath)) {
+    report.preserved.push(P.manifestPath)
+  }
+  for (const dir of [P.hooksDir, P.pluginDir]) {
+    try { if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) { fs.rmdirSync(dir); report.removedFiles.push(dir) } } catch {}
+  }
+  return report
+}
+
 // ---------------------------------------------------------------------------
 // RFC-008 P7 S5 — Pi enforcement extension install/uninstall (per-project .pi/).
 // Mirrors installCodexEnforcement but deploys under
@@ -2470,7 +2632,10 @@ if (uninstallEnforcement) {
   console.log(JSON.stringify(rep, null, 2))
 }
 
-if (uninstallActivation && (tool === 'claude-code' || tool === 'all')) {
+if (uninstallActivation && tool === 'codex') {
+  const rep = uninstallCodexActivation(projectDir)
+  console.log(JSON.stringify(rep, null, 2))
+} else if (uninstallActivation && (tool === 'claude-code' || tool === 'all')) {
   // RFC-009 P2-S6: reverse the per-project advisory activation adapter. Never
   // touches ~/.claude or ~/.episodic-memory (the global-side Layer-1 writes
   // below are gated off for this run). Advisory-only, claude-code-only.
@@ -2478,7 +2643,11 @@ if (uninstallActivation && (tool === 'claude-code' || tool === 'all')) {
   console.log(JSON.stringify(rep, null, 2))
 }
 
-if (installActivation && (tool === 'claude-code' || tool === 'all')) {
+if (installActivation && tool === 'codex') {
+  const rep = installCodexActivation(projectDir)
+  lastActivationInstallReport = rep
+  console.log(JSON.stringify(rep, null, 2))
+} else if (installActivation && (tool === 'claude-code' || tool === 'all')) {
   // RFC-009 P2-S6: deploy the per-project advisory activation adapter under the
   // literal <project>/.claude/. Independent of --install-enforcement.
   const rep = runInstallActivation(projectDir)
@@ -3368,7 +3537,7 @@ try {
         enforcementInstalled = false // healed: a prior --uninstall-enforcement removed the engine
       }
       if (t === enforcementTool && installEnforcement) enforcementInstalled = true
-      // RFC-009 P2-S6: activation is claude-code-only + per-project. Same
+      // RFC-009 activation is harness-specific + per-project. Same
       // heal-from-disk-truth posture as enforcement (an --uninstall-activation
       // run cannot touch the registry, so the flag heals here on the next
       // regular install: runner gone on disk ⇒ false).
@@ -3376,6 +3545,10 @@ try {
       if (t === 'claude-code' && activationInstalled &&
           !fs.existsSync(path.join(activationRoot, '.claude', 'hooks', 'activation-hook-run.mjs'))) {
         activationInstalled = false // healed: a prior --uninstall-activation removed the runner
+      }
+      if (t === 'codex' && activationInstalled &&
+          !fs.existsSync(path.join(activationRoot, '.codex', 'episodic-memory-activation', 'hooks', 'activation-hook-run.mjs'))) {
+        activationInstalled = false
       }
       // Finding A: gate the flag on the runner actually landing on disk. A
       // malformed-settings abort in runInstallActivation returns without writing
@@ -3391,6 +3564,11 @@ try {
       if (t === 'claude-code' && installActivation &&
           lastActivationInstallReport && lastActivationInstallReport.runnerReady === true &&
           fs.existsSync(path.join(activationRoot, '.claude', 'hooks', 'activation-hook-run.mjs'))) {
+        activationInstalled = true
+      }
+      if (t === 'codex' && installActivation &&
+          lastActivationInstallReport && lastActivationInstallReport.runnerReady === true &&
+          fs.existsSync(path.join(activationRoot, '.codex', 'episodic-memory-activation', 'hooks', 'activation-hook-run.mjs'))) {
         activationInstalled = true
       }
       return {

--- a/plugins/_index.json
+++ b/plugins/_index.json
@@ -66,6 +66,20 @@
       },
       "manifest": "plugins/claude-code-activation/manifest.json",
       "status": "active"
+    },
+    {
+      "type": "activation",
+      "id": "codex",
+      "harness": "codex",
+      "directory": "plugins/codex-activation",
+      "blocking": false,
+      "capabilities": {
+        "user_prompt_submit": "MEDIUM",
+        "pre_tool_use": "MEDIUM",
+        "session_start": "MEDIUM"
+      },
+      "manifest": "plugins/codex-activation/manifest.json",
+      "status": "active"
     }
   ]
 }

--- a/plugins/codex-activation/hooks/activation-hook-run.mjs
+++ b/plugins/codex-activation/hooks/activation-hook-run.mjs
@@ -1,0 +1,578 @@
+#!/usr/bin/env node
+// activation-hook-run.mjs — RFC-009 Codex advisory activation runner for
+// UserPromptSubmit, PreToolUse, and SessionStart. The three thin registered
+// .sh entry points invoke it with the event name as argv[2] and pipe the hook's
+// raw stdin JSON. ONE shared runner (not three near-duplicate ones) is a
+// deliberate §8.2 SYMMETRY choice: identity/freshness/suppress/matcher/render
+// logic lives in exactly one place, closing the P1b asymmetric-validation
+// class (`…3c55`) where a lenient sibling branch drifts from its twin.
+//
+// ADVISORY INVARIANT (holds on EVERY path — parse failure, missing manifest,
+// missing/corrupt index, stale-rebuild-subprocess failure, matcher throw):
+// this script prints EITHER nothing OR exactly
+//   { hookSpecificOutput: { hookEventName, additionalContext } }
+// and the calling .sh ALWAYS exits 0 regardless of this process's exit code.
+// Never a decision/block/permissionDecision field.
+//
+// READ BOUNDARY (REQ-19): the FRESH path reads ONLY the persisted per-store
+// trigger-index.json files (stat-only freshness check against index.jsonl,
+// never its content) plus lesson-suppress.json (REQ-13) and its schema
+// (REQ-14) — never index.jsonl content, tags.json, activation-classes.json,
+// or process.env. The STALE/CORRUPT path's rebuild is an explicit CARVE-OUT:
+// it shells out to the standalone `em-trigger-index` CLI as a SUBPROCESS
+// (never imports the writer module directly), so the index.jsonl read that
+// powers a rebuild happens inside that tool's own process boundary, not this
+// event-plane process. Output flows only through the rebuilt trigger-index.json
+// artifact this process then reads back.
+//
+// IDENTITY (§7.1, §8.3, REQ-4): resolved EXCLUSIVELY from the co-located
+// manifest.json's `project_identity: {slug, root}` (+ `harness` as tool_id).
+// stdin `.cwd` is NEVER read by this script — not even for confirmation — the
+// simplest defensible posture given the plan explicitly forbids cwd/env as an
+// identity SOURCE (P2-S2 REQ-4, §7.1 "adapter scope identity" row). A missing
+// manifest, an unparseable manifest, or a manifest without project_identity
+// all degrade to "no injection" (§12 "manifest absent -> no injection", R2-M1).
+//
+// MANIFEST RESOLUTION: candidate order is (1) HOOK_DIR/manifest.json for a
+// flat installed layout; (2) HOOK_DIR/../manifest.json for the source and
+// deployed Codex plugin layout. No global fallback: project
+// identity has no meaningful global default (P12) and a manifest lacking
+// project_identity must degrade to no-injection, not to some other project's
+// identity.
+//
+// SCRIPT/LIB RESOLUTION: em-trigger-index.mjs (subprocess) and
+// scripts/lib/activation-match.mjs (imported) resolve co-located first, then
+// from the in-repo scripts tree, then from the deployed global copy under
+// ~/.episodic-memory/scripts/. The Codex installer co-deploys the two imported
+// libraries so the event path does not depend on a prior global install.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const EVENT_NAME = process.argv[2] // UserPromptSubmit | PreToolUse | SessionStart
+
+const HOOK_DIR = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT_GUESS = path.join(HOOK_DIR, '..', '..', '..')
+const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
+
+const CANDIDATE_ROOTS = [HOOK_DIR, REPO_ROOT_GUESS, GLOBAL_DIR]
+
+function resolveAsset(relForms) {
+  for (const root of CANDIDATE_ROOTS) {
+    for (const rel of relForms) {
+      const candidate = path.join(root, rel)
+      try {
+        if (fs.existsSync(candidate)) return candidate
+      } catch {
+        /* keep trying */
+      }
+    }
+  }
+  return null
+}
+
+const TRIGGER_INDEX_SCRIPT = resolveAsset(['em-trigger-index.mjs', 'scripts/em-trigger-index.mjs'])
+const MATCH_LIB_PATH = resolveAsset(['activation-match.mjs', 'lib/activation-match.mjs', 'scripts/lib/activation-match.mjs'])
+const VALIDATE_LIB_PATH = resolveAsset(['json-instance-validate.mjs', 'lib/json-instance-validate.mjs', 'scripts/lib/json-instance-validate.mjs'])
+const SUPPRESS_SCHEMA_PATH = resolveAsset(['lesson-suppress.schema.json', 'schemas/lesson-suppress.schema.json'])
+
+function firstExisting(candidates) {
+  for (const p of candidates) {
+    try {
+      if (p && fs.existsSync(p)) return p
+    } catch {
+      /* keep trying */
+    }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Identity (manifest-only, never stdin cwd / env)
+// ---------------------------------------------------------------------------
+function resolveIdentity() {
+  const manifestPath = firstExisting([
+    path.join(HOOK_DIR, 'manifest.json'),
+    path.join(HOOK_DIR, '..', 'manifest.json'),
+  ])
+  if (!manifestPath) return null
+
+  let manifest
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  } catch {
+    return null // corrupt manifest -> no injection
+  }
+  const pi = manifest && typeof manifest === 'object' ? manifest.project_identity : null
+  if (!pi || typeof pi.slug !== 'string' || !pi.slug || typeof pi.root !== 'string' || !pi.root) {
+    return null // absent/malformed project_identity -> no injection (repo template / pre-install)
+  }
+  const toolId = typeof manifest.harness === 'string' && manifest.harness ? manifest.harness : ''
+  return { slug: pi.slug, root: pi.root, tool_id: toolId }
+}
+
+// ---------------------------------------------------------------------------
+// Event construction (REQ-16/17/21)
+// ---------------------------------------------------------------------------
+function buildEvent(payload) {
+  if (EVENT_NAME === 'UserPromptSubmit') {
+    const prompt = typeof payload.prompt === 'string' ? payload.prompt : ''
+    return { kind: 'prompt', prompt }
+  }
+  if (EVENT_NAME === 'SessionStart') {
+    // R4/S5: no phrase/tool/target on the event -- the two-tier blend is
+    // read from merged.session_start, not matched against a prompt/target.
+    return { kind: 'session_start' }
+  }
+  if (EVENT_NAME === 'PreToolUse') {
+    const toolName = typeof payload.tool_name === 'string' ? payload.tool_name : ''
+    const ti = payload.tool_input && typeof payload.tool_input === 'object' && !Array.isArray(payload.tool_input)
+      ? payload.tool_input
+      : {}
+    let target = ''
+    if (toolName === 'Bash' || toolName === 'apply_patch') {
+      target = typeof ti.command === 'string' ? ti.command : ''
+    } else if (toolName === 'Edit' || toolName === 'Write' || toolName === 'MultiEdit' || toolName === 'NotebookEdit') {
+      target = typeof ti.file_path === 'string'
+        ? ti.file_path
+        : (typeof ti.notebook_path === 'string' ? ti.notebook_path : '')
+    } else {
+      target = '' // EC9: unknown tool -> empty target; `tool:<Name>:*` still name-matches
+    }
+    return { kind: 'tool', tool: toolName, target }
+  }
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Store read (REQ-19): stat-only freshness; STALE/CORRUPT -> subprocess
+// carve-out rebuild, then a single re-read. A wholly MISSING trigger-index.json
+// is a "not participating yet" store (skip; no build attempt) -- distinct from
+// a CORRUPT one (existed, now broken -> rebuild once, else skip + stderr,
+// EC10). A subprocess/rebuild failure of any kind still degrades to "skip (or
+// best-effort stale data)", never a thrown error (EC12).
+// ---------------------------------------------------------------------------
+function loadStoreIndex({ scope, root }) {
+  const storeDir = scope === 'global' ? GLOBAL_DIR : path.join(root, '.episodic-memory')
+  const triggerIndexPath = path.join(storeDir, 'trigger-index.json')
+
+  let raw
+  try {
+    raw = fs.readFileSync(triggerIndexPath, 'utf8')
+  } catch {
+    return null // missing -> skip this store, no build attempt
+  }
+
+  let cached
+  try {
+    cached = JSON.parse(raw)
+  } catch {
+    cached = undefined // corrupt (unparseable)
+  }
+
+  if (cached === undefined) {
+    return rebuildStore({ scope, root, storeDir }) // corrupt -> rebuild once, else skip+stderr
+  }
+
+  // Freshness (RFC-011 R2.5 / REQ-6, S3): compare MTIME+SIZE ONLY at event
+  // time (never sha256 — the build-side cache probe owns the sha; the strict
+  // read boundary governs CONTENT reads, and stat fingerprints are the
+  // sanctioned freshness mechanism). Compares three legs:
+  //   - index_* ALWAYS (the LOCAL store's index.jsonl — the existing R2.5 check).
+  //   - playbooks_* UNCONDITIONALLY (v3 builds record the local playbooks.json
+  //     fingerprint on every build — zero-state {0,0} when the file is absent,
+  //     so CREATE/edit/DELETE all invalidate). A cached v2 index (no playbooks_*)
+  //     mismatches `undefined !== 0` and rebuilds (T12).
+  //   - global_index_* IFF THE CACHED SOURCE CARRIES IT (fix-round Item 1,
+  //     3-way convergent: agent F2 + codex S3-F1 + kimi F1). The build records
+  //     the GLOBAL store's index.jsonl fingerprint on a LOCAL index IFF a valid
+  //     preference file couples this store to the global (R2.5: "config-free
+  //     projects pay no cross-store coupling"). The PRIOR either-side rule also
+  //     compared when an on-disk global index.jsonl existed — so EVERY config-
+  //     free project with any global store spawned a rebuild subprocess on EVERY
+  //     event forever (probe: 3 events = 3 spawns). Now: compare the global leg
+  //     ONLY when the cached source carries `global_index_mtime_ms` (i.e., the
+  //     build that produced this cache ran with a valid preference file). This
+  //     mirrors the build's own sourceMatches conditional at
+  //     em-trigger-index.mjs:547 (the "fresh" side only carries global_index_*
+  //     when validPref). Pref CREATE is still caught by the unconditional
+  //     playbooks_* leg (mtime+size move off zero-state); a global revision with
+  //     a valid pref is caught here. Missed-invalidation: a same-mtime+size
+  //     rewrite of playbooks.json (e.g. valid → malformed) evades until any other
+  //     leg moves — the identical PRE-EXISTING residual the index.jsonl stat
+  //     carries, stated per P5 (kimi F analysis: no NEW missed-invalidation
+  //     beyond that accepted residual). For a GLOBAL-store cache no
+  //     global_index_* is ever emitted (R2/F4) → this leg is a no-op there.
+  const jsonlPath = path.join(storeDir, 'index.jsonl')
+  const expectIndex = (() => {
+    try { const s = fs.statSync(jsonlPath); return { mtimeMs: s.mtimeMs, size: s.size } }
+    catch { return { mtimeMs: 0, size: 0 } }
+  })()
+  const expectPlaybooks = (() => {
+    try { const s = fs.statSync(path.join(storeDir, 'playbooks.json')); return { mtimeMs: s.mtimeMs, size: s.size } }
+    catch { return { mtimeMs: 0, size: 0 } } // zero-state when absent (clean uninstall)
+  })()
+  const src = cached && cached.source
+  let fresh = !!src
+    && src.index_mtime_ms === expectIndex.mtimeMs && src.index_size === expectIndex.size
+    && src.playbooks_mtime_ms === expectPlaybooks.mtimeMs && src.playbooks_size === expectPlaybooks.size
+  if (fresh && scope === 'local' && src.global_index_mtime_ms !== undefined) {
+    // Cached source carries the global coupling fingerprint → compare it against
+    // the on-disk global index.jsonl stat (computed ONLY here, lazily, iff the
+    // cached source says the build recorded one — NOT unconditionally).
+    let expectGM = 0, expectGS = 0
+    try { const s = fs.statSync(path.join(GLOBAL_DIR, 'index.jsonl')); expectGM = s.mtimeMs; expectGS = s.size } catch { /* absent global index.jsonl -> zero-state */ }
+    fresh = src.global_index_mtime_ms === expectGM && src.global_index_size === expectGS
+  }
+  if (fresh) return cached
+
+  const rebuilt = rebuildStore({ scope, root, storeDir })
+  return rebuilt || cached // best-effort: a failed stale rebuild still has the stale-but-parseable copy to fall back on
+}
+
+function rebuildStore({ scope, root, storeDir }) {
+  if (!TRIGGER_INDEX_SCRIPT) {
+    process.stderr.write(`activation-hook: em-trigger-index.mjs not found; skipping ${scope} store\n`)
+    return null
+  }
+  const args = [TRIGGER_INDEX_SCRIPT, '--scope', scope]
+  if (scope === 'local' && root) args.push('--project', root)
+  try {
+    spawnSync(process.execPath, args, { stdio: ['ignore', 'ignore', 'pipe'], timeout: 4000 })
+  } catch {
+    // subprocess failed to even spawn (EC12) -- fall through to a best-effort read
+  }
+  const triggerIndexPath = path.join(storeDir, 'trigger-index.json')
+  try {
+    return JSON.parse(fs.readFileSync(triggerIndexPath, 'utf8'))
+  } catch (e) {
+    process.stderr.write(`activation-hook: ${scope} trigger-index.json unreadable after rebuild attempt (${e.message}); skipping store\n`)
+    return null
+  }
+}
+
+// RFC-011 R2.9(a) + REQ-6b: dedup key is now (episode_id, trigger_kind, value),
+// NOT episode_id alone. The prior per-episode first-row-wins collapse silently
+// dropped every trigger after the first for ANY multi-trigger episode (probe-
+// confirmed at activation-hook-run.mjs:240-241, the latent RFC-009 defect the
+// S3 slice repairs). Tuple-key dedup preserves every trigger row across stores
+// while still keeping LOCAL precedence for the SAME tuple (local iterates
+// first). The CLI merged leg (loadMergedTriggerIndex) already keeps all rows
+// via its delayed seen-set; the two merge sites now CONVERGE on the same shape.
+//
+// R2.9(b) playbook-wins: for the SAME episode_id + trigger tuple, when BOTH a
+// lesson row and a playbook row exist, the PLAYBOOK form wins (it carries the
+// `read_command`). Implemented by REPLACING a queued lesson entry with a later
+// playbook entry of the same tuple — so an inherited playbook (episode's own
+// triggers, no override) collapses its matching lesson row into the playbook
+// row at MERGE time (zero new matching semantics on the matcher side, per R4).
+//
+// REQ-6b override-drop leg (mirrors loadMergedTriggerIndex semantics): a local
+// playbook row carrying `triggers_overridden:true` marks an episode whose own
+// (superseded) phrase/tool trigger set has been REPLACED within this project.
+// The hook DROPS the episode's own NON-playbook lesson rows for those ids in
+// BOTH local AND global streams (the matcher then never fires the old triggers —
+// T6 E2E "the episode's original phrase no longer fires"). Playbook row
+// presence is by-construction LOCAL-only (R2: persisted in the LOCAL store),
+// so LOCAL precedence is automatic; the override-drop covers BOTH origins.
+function mergeIndexes(local, global) {
+  const overriddenIds = new Set()
+  if (local && Array.isArray(local.entries)) {
+    for (const e of local.entries) {
+      if (e && e.entry_class === 'playbook' && e.triggers_overridden === true) overriddenIds.add(e.episode_id)
+    }
+  }
+  const mapped = new Map() // tuple key -> entry (playbook-replaces-lesson for the same tuple)
+  for (const idx of [local, global]) {
+    if (!idx || !Array.isArray(idx.entries)) continue
+    for (const e of idx.entries) {
+      if (!e || typeof e.episode_id !== 'string' || !e.episode_id) continue
+      if (e.entry_class !== 'playbook' && overriddenIds.has(e.episode_id)) continue
+      const tk = typeof e.trigger_kind === 'string' ? e.trigger_kind : ''
+      const v = typeof e.value === 'string' ? e.value : ''
+      const key = `${e.episode_id}\u0000${tk}\u0000${v}`
+      const existing = mapped.get(key)
+      if (!existing) { mapped.set(key, e); continue }
+      // R2.9(b): a playbook row replaces a lesson row for the same tuple ("the
+      // PLAYBOOK form wins" — it carries the read_command). Forged/malformed
+      // rows of either kind pass without replacement if entry_class is absent.
+      if (e.entry_class === 'playbook' && existing.entry_class !== 'playbook') mapped.set(key, e)
+    }
+  }
+  const entries = [...mapped.values()]
+  const activityPhrases =
+    local && local.activity_phrases && typeof local.activity_phrases === 'object' && !Array.isArray(local.activity_phrases)
+      ? local.activity_phrases
+      : (global && global.activity_phrases && typeof global.activity_phrases === 'object' && !Array.isArray(global.activity_phrases)
+        ? global.activity_phrases
+        : {})
+  return { entries, activity_phrases: activityPhrases }
+}
+
+// ---------------------------------------------------------------------------
+// REQ-19/21 (R4/S5 SessionStart only -- never computed for the R3 hooks, so
+// their behavior/timing is byte-identical to before this slice): merge each
+// store's `session_start` section, dedup by episode_id with LOCAL precedence
+// (same rule as mergeIndexes' `entries`), and classify each store's section
+// as present-and-ok / present-but-malformed / absent so main() can emit the
+// single REQ-21 stderr note when a LOADED trigger-index.json lacks a usable
+// session_start (never when the store itself is simply absent -- that is the
+// separate, already-tested "missing index" path).
+// ---------------------------------------------------------------------------
+function sessionStartStatus(idx) {
+  if (!idx) return { present: false, ok: true, value: null } // store not built/absent -- not an error
+  const raw = idx.session_start
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { present: true, ok: false, value: null }
+  return { present: true, ok: true, value: raw }
+}
+
+function dedupByEpisodeId(lists) {
+  const out = []
+  const seen = new Set()
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue
+    for (const e of list) {
+      if (!e || typeof e.episode_id !== 'string' || !e.episode_id || seen.has(e.episode_id)) continue
+      seen.add(e.episode_id)
+      out.push(e)
+    }
+  }
+  return out
+}
+
+// F3 (review-confirmed): merged tier-2 must be re-sorted by static_score DESC
+// (tie-break episode_id asc for determinism) after the local-precedence dedup.
+// dedupByEpisodeId preserves local-list-then-global ORDER, but the pure
+// renderer documents its precondition as "entriesRaw is already pre-sorted by
+// static_score desc" and preserves whatever order it receives. Without this
+// re-sort a high-static_score GLOBAL lesson renders after / is token-budgeted
+// out behind low-score LOCAL ones, diverging from the union-top-N-by-score that
+// `entries` represents (and that `em-trigger-index --merged` produces for the
+// handoff path). This reads static_score only (NOT effective_priority), so the
+// REQ-18 plain-only tier-2 invariant is unaffected. Non-numeric static_score
+// sorts last (treated as -Infinity) rather than throwing.
+function sortEntriesByStaticScore(entries) {
+  const scoreOf = (e) => (Number.isFinite(e.static_score) ? e.static_score : -Infinity)
+  return [...entries].sort((a, b) => {
+    const sa = scoreOf(a)
+    const sb = scoreOf(b)
+    if (sb !== sa) return sb - sa
+    return a.episode_id < b.episode_id ? -1 : a.episode_id > b.episode_id ? 1 : 0
+  })
+}
+
+// F2 (review-confirmed): merge the preflight per task-type key across BOTH
+// stores — union of task keys; for each, union of pattern_ids; SUM the numeric
+// counts. The prior `local || global || {}` took local wholesale and dropped
+// global counts entirely (or a local {} shadowed a populated global). Summing
+// matches what `em-trigger-index --merged` (loadMergedTriggerIndex over the
+// union of both stores' rows) produces, so the R4 hook and the REQ-26 handoff
+// path stay consistent. Non-finite counts are skipped; a pattern surviving
+// with a >0 summed count is kept.
+function mergePreflight(localVal, globalVal) {
+  const validMap = (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : null)
+  const merged = {}
+  for (const val of [localVal, globalVal]) {
+    const pf = val && validMap(val.preflight)
+    if (!pf) continue
+    for (const [taskType, counts] of Object.entries(pf)) {
+      if (!counts || typeof counts !== 'object' || Array.isArray(counts)) continue
+      if (!Object.hasOwn(merged, taskType)) merged[taskType] = {}
+      const bucket = merged[taskType]
+      for (const [patternId, n] of Object.entries(counts)) {
+        if (!Number.isFinite(n)) continue
+        bucket[patternId] = (Object.hasOwn(bucket, patternId) ? bucket[patternId] : 0) + n
+      }
+    }
+  }
+  return merged
+}
+
+function mergeSessionStart(localStatus, globalStatus) {
+  const localVal = localStatus.ok ? localStatus.value : null
+  const globalVal = globalStatus.ok ? globalStatus.value : null
+  const critical_entries = dedupByEpisodeId([
+    localVal ? localVal.critical_entries : null,
+    globalVal ? globalVal.critical_entries : null,
+  ])
+  const entries = sortEntriesByStaticScore(dedupByEpisodeId([
+    localVal ? localVal.entries : null,
+    globalVal ? globalVal.entries : null,
+  ]))
+  const preflight = mergePreflight(localVal, globalVal)
+  // RFC-011 R2.7 / REQ-8: thread the LOCAL persisted playbooks trio UNCHANGED
+  // (global never produces one; neither merge site recomputes any of the
+  // three — the build pre-caps/pre-computes them). Present iff a valid LOCAL
+  // preference file was processed (the build only attaches the trio then).
+  const out = { critical_entries, entries, preflight }
+  if (localVal && Object.prototype.hasOwnProperty.call(localVal, 'playbooks')) {
+    out.playbooks = localVal.playbooks
+    out.playbooks_capped = localVal.playbooks_capped
+    out.playbooks_capped_first = localVal.playbooks_capped_first
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Suppress (REQ-13/14): whole-file, whole-document fail-open. Missing OR
+// syntax-malformed OR shape-malformed (schema-invalid) -> empty Set + ONE
+// stderr note, injection proceeds. Schema validation is attempted via the
+// real schema (REQ-14, a SHOULD) when resolvable; otherwise an equivalent
+// manual structural check (same required/type constraints) degrades safely
+// -- schemas/ is not yet part of the deployed global tree (see RETURN item 7).
+// ---------------------------------------------------------------------------
+let _schemaValidatorPromise = null
+function getSchemaValidator() {
+  if (_schemaValidatorPromise) return _schemaValidatorPromise
+  _schemaValidatorPromise = (async () => {
+    if (!VALIDATE_LIB_PATH || !SUPPRESS_SCHEMA_PATH) return null
+    try {
+      const mod = await import(pathToFileURL(VALIDATE_LIB_PATH).href)
+      const schema = JSON.parse(fs.readFileSync(SUPPRESS_SCHEMA_PATH, 'utf8'))
+      if (typeof mod.validateInstance !== 'function') return null
+      return { validateInstance: mod.validateInstance, schema }
+    } catch {
+      return null
+    }
+  })()
+  return _schemaValidatorPromise
+}
+
+function manualSuppressShapeOk(doc) {
+  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) return false
+  if (doc.schema_version !== 1) return false
+  if (!Array.isArray(doc.suppress)) return false
+  for (const item of doc.suppress) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return false
+    if (typeof item.episode_id !== 'string' || !item.episode_id) return false
+  }
+  return true
+}
+
+async function loadSuppressSet(root) {
+  const p = path.join(root, '.episodic-memory', 'lesson-suppress.json')
+
+  // ENOENT (file simply absent — the common case for a project that has never
+  // authored a mute list) is SILENT: empty Set, NO stderr note (codex F2a — a
+  // note on every event was noise that masked the spec-required note). Read the
+  // bytes first and treat ONLY a genuine "does not exist" as the silent path;
+  // any other read error (permissions, is-a-directory, ...) counts as
+  // "exists-but-unusable" and DOES earn the single note, since the operator
+  // authored something the hook cannot honor.
+  let raw
+  try {
+    raw = fs.readFileSync(p, 'utf8')
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return new Set() // absent -> silent, no note
+    process.stderr.write(`activation-hook: lesson-suppress.json unreadable (${e && e.message}); proceeding with no suppression\n`)
+    return new Set()
+  }
+
+  // The file EXISTS: any parse / shape / schema failure fails OPEN with exactly
+  // ONE observable stderr note (REQ-13 / EC6), injection proceeds.
+  try {
+    const doc = JSON.parse(raw)
+    const validator = await getSchemaValidator()
+    let ok
+    if (validator) {
+      try {
+        ok = validator.validateInstance(doc, validator.schema).valid
+      } catch {
+        ok = manualSuppressShapeOk(doc)
+      }
+    } else {
+      ok = manualSuppressShapeOk(doc)
+    }
+    if (!ok) throw new Error('shape-malformed')
+    const set = new Set()
+    for (const item of doc.suppress) set.add(item.episode_id)
+    return set
+  } catch (e) {
+    process.stderr.write(`activation-hook: lesson-suppress.json unusable (${e && e.message}); proceeding with no suppression\n`)
+    return new Set()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  let raw = ''
+  try {
+    raw = fs.readFileSync(0, 'utf8')
+  } catch {
+    raw = ''
+  }
+
+  let payload
+  try {
+    payload = JSON.parse(raw)
+  } catch {
+    payload = null
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return // EC1: empty/non-object stdin -> exit 0, no output
+  }
+
+  const identity = resolveIdentity()
+  if (!identity) return // manifest absent/malformed/no project_identity -> no injection
+
+  const event = buildEvent(payload)
+  if (!event) return
+
+  const local = loadStoreIndex({ scope: 'local', root: identity.root })
+  const global = loadStoreIndex({ scope: 'global', root: identity.root })
+  const merged = mergeIndexes(local, global)
+
+  if (EVENT_NAME === 'SessionStart') {
+    // Computed ONLY on this branch -- the R3 hooks' merged shape/timing is
+    // byte-identical to before this slice (§8.2 SYMMETRY: no cross-hook
+    // side effect from adding R4).
+    const localSS = sessionStartStatus(local)
+    const globalSS = sessionStartStatus(global)
+    if ((localSS.present && !localSS.ok) || (globalSS.present && !globalSS.ok)) {
+      // REQ-21: missing/malformed session_start -> exactly one stderr note.
+      process.stderr.write('activation-hook: session_start section missing or malformed in a trigger-index.json; rendering from available data\n')
+    }
+    merged.session_start = mergeSessionStart(localSS, globalSS)
+  }
+
+  const suppress = await loadSuppressSet(identity.root)
+
+  let matchActivation
+  try {
+    if (!MATCH_LIB_PATH) return
+    const mod = await import(pathToFileURL(MATCH_LIB_PATH).href)
+    matchActivation = mod.matchActivation
+    if (typeof matchActivation !== 'function') return
+  } catch {
+    return
+  }
+
+  let result
+  try {
+    result = matchActivation(merged, event, identity, suppress, { max_matches: 3, max_tokens: 500 })
+  } catch {
+    result = { lines: [], overflowNote: null }
+  }
+
+  const lines = result && Array.isArray(result.lines) ? result.lines : []
+  if (lines.length === 0) return // nothing to inject -> exit 0, no output
+
+  let text = lines.join('\n')
+  if (result.overflowNote) text += `\n${result.overflowNote}`
+
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: EVENT_NAME,
+      additionalContext: text,
+    },
+  }) + '\n')
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(() => process.exit(0)) // advisory invariant: never a non-zero exit, never a decision field

--- a/plugins/codex-activation/hooks/activation-match.mjs
+++ b/plugins/codex-activation/hooks/activation-match.mjs
@@ -1,0 +1,635 @@
+// activation-match.mjs — RFC-009 P2-S3 (R3). The pure matcher core.
+//
+// matchActivation(index, event, identity, suppress, bounds) -> MatchResult
+//   MatchResult = { lines: string[], overflowNote: string|null }
+//
+// ZERO I/O. No fs, no process.env, no network, no Date.now(). Takes
+// already-loaded data (the persisted per-store/merged trigger-index.json
+// shape, or a hook-assembled equivalent) and returns a bounded, rendered
+// result. The hooks (P2-S4/S5) do all I/O — read the index files, build the
+// suppress Set, resolve identity from the adapter manifest — and call this.
+//
+// ADVISORY INVARIANT (the one thing that must never break): the return value
+// NEVER carries a `decision`/`block`/`permissionDecision` field, and this
+// function THROWS NOTHING. Any internal error (malformed index, malformed
+// event, a regex that would otherwise throw) fails OPEN to
+// `{ lines: [], overflowNote: null }` — the deliberate inverse of a gate
+// (RFC-008 R1): a fail-closed advisory that ever blocked a tool call would be
+// the bug, not a suppressed lesson pointer.
+//
+// STEP 0 (behavior-simulated, not guessed): the REAL trigger-index.json entry
+// shape was probed against an isolated fixture store (em-store + em-trigger-
+// index, explicit cwd, --scope local) before writing this file. The plan's
+// approximate `applies_to` field name does NOT exist on disk — the real
+// entry carries TWO separate arrays, `applies_to_projects` and
+// `applies_to_tools` (see scripts/em-trigger-index.mjs TRIGGER_ENTRY_FIELDS).
+// This matcher's REQ-15 scope predicate gates BOTH axes: `applies_to_projects`
+// against `identity.slug` AND `applies_to_tools` against `identity.tool_id`
+// (the S4 hook supplies tool_id = the activation manifest's `harness`, a
+// constant "claude-code"). An empty EITHER array never fires (RFC-009 R1:54,
+// R2:71; plan REQ-15). See the scopeOk() rationale for the full grounding.
+//
+// Real observed entry (fixture probe, trimmed):
+//   {
+//     "trigger_kind": "phrase",              // "phrase" | "tool" | "activity"
+//     "value": "test phrase",
+//     "episode_id": "20260709-003019-fixture-lesson-for-s3-probe-a334",
+//     "summary": "fixture lesson for S3 probe",
+//     "effective_priority": 5,                // DERIVED 1-9 (earned band)
+//     "applies_to_projects": ["acme"],
+//     "applies_to_tools": ["claude-code"]
+//     // review_by?: "YYYY-MM-DD" (present only when the lesson set one)
+//   }
+// Activity phrase sets are baked ONCE at the INDEX top level (REQ-9), not
+// duplicated per entry:
+//   index.activity_phrases = { "plan": ["plan", "planning", ...], ... }
+// so an `activity:<class>` entry's firing phrases are looked up via
+// `index.activity_phrases[class]`, never re-read from activation-classes.json.
+
+// ---------------------------------------------------------------------------
+// Small pure helpers
+// ---------------------------------------------------------------------------
+
+function escapeRegex(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// REQ-6: case-fold, word-boundary via negative lookaround on [\w-] (NOT the
+// classic \b, which does not treat '-' as a word char and would let
+// "plan-approval" false-match on "plan"/"approval" independently). The
+// phrase is regex-escaped before the RegExp is built, so metacharacters in a
+// phrase (e.g. "C++", "a.b") are matched LITERALLY and never throw / ReDoS.
+function matchesPhrase(text, phrase) {
+  if (typeof text !== "string" || !text) return false;
+  if (typeof phrase !== "string" || !phrase) return false;
+  let re;
+  try {
+    re = new RegExp(`(?<![\\w-])${escapeRegex(phrase)}(?![\\w-])`, "i");
+  } catch {
+    return false;
+  }
+  try {
+    return re.test(text);
+  } catch {
+    return false;
+  }
+}
+
+// REQ-7: parse `tool:<ToolName>:<glob>`. `\` escapes a literal `:` or `*`
+// (only those two characters carry escape meaning). Returns null when the
+// value is not tool-shaped or has no name/glob separator (malformed —
+// caller treats as "does not match", never throws).
+function parseToolTrigger(rawValue) {
+  if (typeof rawValue !== "string" || !rawValue.startsWith("tool:")) return null;
+  const rest = rawValue.slice("tool:".length);
+  let i = 0;
+  let toolNameRaw = "";
+  for (; i < rest.length; i++) {
+    const c = rest[i];
+    if (c === "\\" && i + 1 < rest.length && (rest[i + 1] === ":" || rest[i + 1] === "*")) {
+      toolNameRaw += rest[i] + rest[i + 1];
+      i++;
+      continue;
+    }
+    if (c === ":") break;
+    toolNameRaw += c;
+  }
+  if (i >= rest.length) return null; // no unescaped ':' separator found
+  const globRaw = rest.slice(i + 1);
+  if (!toolNameRaw) return null;
+  return { toolName: unescapeToolField(toolNameRaw), globRaw };
+}
+
+function unescapeToolField(s) {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\\" && (s[i + 1] === ":" || s[i + 1] === "*")) {
+      out += s[i + 1];
+      i++;
+      continue;
+    }
+    out += s[i];
+  }
+  return out;
+}
+
+// `*` is the ONLY glob metachar (matches zero-or-more of anything); an
+// escaped `\*` is a literal asterisk. Every other character (after
+// unescaping `\:`) is matched literally.
+function globToRegexSource(globRaw) {
+  let pattern = "";
+  for (let i = 0; i < globRaw.length; i++) {
+    const c = globRaw[i];
+    if (c === "\\" && (globRaw[i + 1] === ":" || globRaw[i + 1] === "*")) {
+      pattern += escapeRegex(globRaw[i + 1]);
+      i++;
+      continue;
+    }
+    if (c === "*") {
+      pattern += ".*";
+      continue;
+    }
+    pattern += escapeRegex(c);
+  }
+  return pattern;
+}
+
+// REQ-7: tool name match + primary-target glob match. `tool:<Name>:*`
+// matches on NAME ALONE (target may be '' for an unknown tool — EC9); a
+// non-'*' glob requires the target to match the (escaped) glob pattern.
+function matchesToolTrigger(entryValue, eventTool, eventTarget) {
+  const parsed = parseToolTrigger(entryValue);
+  if (!parsed) return false;
+  const toolName = typeof eventTool === "string" ? eventTool : "";
+  if (parsed.toolName !== toolName) return false;
+  if (parsed.globRaw === "*") return true; // name-alone match, target ignored
+  const target = typeof eventTarget === "string" ? eventTarget : "";
+  try {
+    const re = new RegExp(`^${globToRegexSource(parsed.globRaw)}$`);
+    return re.test(target);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// REQ-15 scope predicate — BOTH axes gate (codex F1, ACCEPTED).
+//
+// The RFC scopes on project AND tool identity, both drawn from the adapter
+// manifest: RFC-009 R1:54 defines `applies_to_projects` AND `applies_to_tools`;
+// R2:71 filters an entry against the hook's project AND tool identity; plan
+// REQ-15 (:63) makes the empty-never-fires rule apply to BOTH arrays. An
+// earlier draft of this matcher gated projects only and treated
+// `applies_to_tools` as a P3-reserved axis — that was the leak codex found: a
+// lesson tagged for another tool (`applies_to_tools: ['codex']`, or an empty
+// `[]`) still fired under a claude-code identity. Both predicates now gate.
+//
+// `identity.tool_id` is supplied by the S4 hook from the activation manifest's
+// `harness` field — a constant "claude-code" for the STRONG-tier adapter P2
+// ships (no S2 manifest change needed; the matcher just consumes it). Both
+// axes honor the `'*'` wildcard. An empty EITHER array -> false -> NEVER fires
+// (state F / EC7); an empty/absent `slug` OR `tool_id` must not accidentally
+// match a `['*']` entry (EC5) — the predicate requires a non-empty value on
+// every branch.
+// ---------------------------------------------------------------------------
+function scopeOk(entry, identity) {
+  const slug = identity && typeof identity.slug === "string" ? identity.slug : "";
+  const toolId = identity && typeof identity.tool_id === "string" ? identity.tool_id : "";
+  const projects = Array.isArray(entry.applies_to_projects) ? entry.applies_to_projects : [];
+  const tools = Array.isArray(entry.applies_to_tools) ? entry.applies_to_tools : [];
+  if (slug === "" || toolId === "") return false;
+  if (projects.length === 0 || tools.length === 0) return false;
+  const projectOk = projects.includes(slug) || projects.includes("*");
+  const toolOk = tools.includes(toolId) || tools.includes("*");
+  return projectOk && toolOk;
+}
+
+// ---------------------------------------------------------------------------
+// REQ-11 render. No decision/block/permissionDecision field in any form.
+//
+// RFC-011 R4 (S3): an entry with `entry_class: "playbook"` renders the R3
+// playbook form (provenance prefix + READ + precomputed read_command) instead
+// of the lesson forms, regardless of the pinned effective_priority 0. The
+// matchers (sanitizeEntries/candidatesForEvent/scopeOk/selectAndBound) UNITE
+// playbook + lesson rows under the SAME matching semantics — only the render
+// branches on entry_class. read_command is precomputed at build (R2.4); a
+// malformed row without one degrades to a non-empty fallback line rather than
+// throwing (advisory fail-open, REQ-12).
+// ---------------------------------------------------------------------------
+function renderPlaybookLine(entry) {
+  const id = entry && typeof entry.episode_id === "string" ? entry.episode_id : "";
+  const summary = String((entry && entry.summary) ?? "");
+  const rc = entry && typeof entry.read_command === "string" && entry.read_command
+    ? entry.read_command
+    : `node <scripts>/em-search.mjs --read ${id}`;
+  // RFC-011 R3 / §8.2 verbatim — provenance prefix names the source file, so
+  // declared injection is auditable (R1 threat model). No body content, ever
+  // (R2.8 sentinel): only episode_id + summary + read_command appear.
+  return `playbook (playbooks.json): READ ${id} before proceeding (${rc}): ${summary}`;
+}
+
+function renderLine(entry) {
+  // R4 (S3): playbook rows render the playbook form regardless of priority.
+  if (entry && entry.entry_class === "playbook") return renderPlaybookLine(entry);
+  const id = entry.episode_id;
+  const summary = String(entry.summary ?? "");
+  if (Number(entry.effective_priority) >= 8) {
+    return `READ ${id} before proceeding (em-search --history ${id} --full): ${summary}`;
+  }
+  return `lesson ${id}: ${summary}`;
+}
+
+// Rough, dependency-free token estimate (~4 chars/token, the standard
+// order-of-magnitude heuristic) — the bound is advisory (~500), not an exact
+// tokenizer contract, so a proportional proxy is sufficient and stays zero-I/O.
+function estimateTokens(s) {
+  return Math.ceil(String(s).length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// State J: malformed entries (missing value/id, or a non-integer priority)
+// are skipped silently — never thrown, never counted toward overflow.
+// ---------------------------------------------------------------------------
+function sanitizeEntries(index) {
+  const entries = index && Array.isArray(index.entries) ? index.entries : [];
+  const out = [];
+  for (const e of entries) {
+    if (!e || typeof e !== "object") continue;
+    if (typeof e.episode_id !== "string" || !e.episode_id) continue;
+    if (typeof e.value !== "string" || !e.value) continue;
+    if (!Number.isInteger(e.effective_priority)) continue;
+    out.push(e);
+  }
+  return out;
+}
+
+function activityPhrasesMap(index) {
+  const m = index && index.activity_phrases;
+  return m && typeof m === "object" && !Array.isArray(m) ? m : {};
+}
+
+// REQ-8: activity match. Class lookup uses Object.hasOwn — NEVER
+// `obj[key]`-as-membership (proto-key lesson `…3c55`). `activity:__proto__`
+// / `activity:hasOwnProperty` etc. are never OWN keys of a JSON-built map
+// (state K) -> Object.hasOwn returns false -> no match, no throw.
+function activityFires(prompt, className, index) {
+  const map = activityPhrasesMap(index);
+  if (!Object.hasOwn(map, className)) return false;
+  const phrases = map[className];
+  if (!Array.isArray(phrases)) return false;
+  return phrases.some((p) => typeof p === "string" && matchesPhrase(prompt, p));
+}
+
+// ---------------------------------------------------------------------------
+// Kind-dispatched candidate gathering (fires-for-event AND scope-ok).
+// ---------------------------------------------------------------------------
+function candidatesForEvent(entries, event, index, identity) {
+  const kind = event && event.kind;
+  const out = [];
+  for (const entry of entries) {
+    let fires = false;
+    if (kind === "prompt") {
+      const prompt = typeof event.prompt === "string" ? event.prompt : "";
+      if (entry.trigger_kind === "phrase") {
+        fires = matchesPhrase(prompt, entry.value);
+      } else if (entry.trigger_kind === "activity" && entry.value.startsWith("activity:")) {
+        const cls = entry.value.slice("activity:".length);
+        fires = activityFires(prompt, cls, index);
+      }
+    } else if (kind === "tool") {
+      if (entry.trigger_kind === "tool") {
+        fires = matchesToolTrigger(entry.value, event.tool, event.target);
+      }
+    }
+    if (!fires) continue;
+    if (!scopeOk(entry, identity)) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+function filterSuppressed(candidates, suppress) {
+  const s = suppress instanceof Set ? suppress : new Set();
+  return candidates.filter((e) => !s.has(e.episode_id));
+}
+
+// ---------------------------------------------------------------------------
+// RFC-011 R2.9(b) first half (fix-round Item 2, agent F1): event-level render
+// dedup — ONE rendered entry per episode id per event. An episode with 2+
+// triggers that co-match one prompt (e.g. triggers ["alphaword", "betaword"],
+// prompt "alphaword and betaword together") produces N candidate rows → would
+// render N duplicate lines and burn N max_matches slots (probe-confirmed:
+// playbookLineCount=2, lessonLineCount=2). The session-start bands are
+// per-episode by construction (T4d — the session_start.playbooks array carries
+// one entry per episode; tier-1 critical_entries + tier-2 entries dedup by id
+// via tier1CandidateIds) and are NOT routed through this function.
+//
+// R2.9(b) second half (playbook form wins): when BOTH a lesson row AND a
+// playbook row for the SAME episode id match the same event, the PLAYBOOK form
+// wins (it carries the read_command). resolve the form BEFORE dedup — pick the
+// playbook representative when any playbook candidate exists for the group,
+// else keep the FIRST-ENCOUNTERED lesson candidate (local precedence — the
+// hook's mergeIndexes iterates local-then-global and candidatesForEvent
+// preserves entry order; no priority comparison happens here). All lesson rows
+// for one episode carry the SAME effective_priority (the band is derived
+// per-episode via effectivePriority(lessonId, rows), never per-trigger), so
+// which lesson row is the representative does not affect selectAndBound's
+// downstream sort. Forged/malformed rows (no entry_class) are treated as
+// lesson-form here; the schema-side F6a binding rejects forged playbook rows
+// at validation.
+// All playbook rows for one episode render identically (same episode_id /
+// summary / read_command), so the first playbook candidate is the representative.
+// The representative carries its OWN effective_priority into selectAndBound's
+// sort — a playbook row (pinned 0 per R2) sorts below every lesson, preserving
+// the R2 pinning invariant (a declared playbook never displaces an earned
+// lesson inside max_matches).
+// ---------------------------------------------------------------------------
+function dedupByEpisodePreferPlaybook(candidates) {
+  const byEpisode = new Map();
+  for (const e of candidates) {
+    if (!e || typeof e.episode_id !== "string" || !e.episode_id) continue;
+    const existing = byEpisode.get(e.episode_id);
+    if (!existing) { byEpisode.set(e.episode_id, e); continue; }
+    // R2.9(b) playbook-wins: a playbook representative replaces an existing
+    // lesson-form representative. Once a playbook row is the representative, a
+    // later lesson row for the same episode does NOT displace it.
+    if (e.entry_class === "playbook" && existing.entry_class !== "playbook") {
+      byEpisode.set(e.episode_id, e);
+    }
+  }
+  return [...byEpisode.values()];
+}
+
+// ---------------------------------------------------------------------------
+// REQ-10/12 bounds + selection. Unifies states C/D/G/H/I/I' behind one pass:
+//   - top-K by effective_priority desc, then recency (episode_id desc — ids
+//     are date-prefixed, so lexical-desc IS recency-desc) via max_matches
+//   - a single entry whose OWN rendered line exceeds max_tokens is dropped
+//     WHOLE (never truncated) — state I / I'
+//   - the running total must also stay <= max_tokens; once it would not,
+//     remaining candidates are treated as count-overflow (state G/H)
+//   - overflowNote fires iff ANY dropped entry (either reason) is band 8-9;
+//     it names ONE such id (the highest-priority/most-recent dropped
+//     critical) and the total dropped count. A plain-band-only drop (state
+//     G, or state I' oversize-non-critical) never gets a note.
+// ---------------------------------------------------------------------------
+function selectAndBound(candidates, bounds) {
+  // codex F2 (ACCEPTED): accept only POSITIVE integers. A zero/negative
+  // max_matches made `lines.length >= maxMatches` always true, dropping every
+  // entry AND emitting a spurious critical overflow note with empty lines —
+  // the plan §12 fail-OPEN-to-empty contract inverted. Out-of-range bounds
+  // fall back to the defaults.
+  const maxMatches = Number.isInteger(bounds && bounds.max_matches) && bounds.max_matches > 0 ? bounds.max_matches : 3;
+  const maxTokens = Number.isInteger(bounds && bounds.max_tokens) && bounds.max_tokens > 0 ? bounds.max_tokens : 500;
+
+  const sorted = [...candidates].sort((a, b) => {
+    if (b.effective_priority !== a.effective_priority) return b.effective_priority - a.effective_priority;
+    return a.episode_id < b.episode_id ? 1 : a.episode_id > b.episode_id ? -1 : 0;
+  });
+
+  const lines = [];
+  const dropped = [];
+  let totalTokens = 0;
+
+  for (const entry of sorted) {
+    if (lines.length >= maxMatches) {
+      dropped.push(entry);
+      continue;
+    }
+    const line = renderLine(entry);
+    const lineTokens = estimateTokens(line);
+    if (lineTokens > maxTokens) {
+      dropped.push(entry); // state I / I' — oversize, dropped WHOLE
+      continue;
+    }
+    if (totalTokens + lineTokens > maxTokens) {
+      dropped.push(entry); // total-budget overflow — same bucket as count-overflow
+      continue;
+    }
+    lines.push(line);
+    totalTokens += lineTokens;
+  }
+
+  const criticalDropped = dropped.find((e) => Number(e.effective_priority) >= 8);
+  const overflowNote = criticalDropped
+    ? `+${dropped.length} more matches suppressed, incl. critical ${criticalDropped.episode_id}`
+    : null;
+
+  return { lines, overflowNote };
+}
+
+// ---------------------------------------------------------------------------
+// R4 SessionStart (RFC-009 REQ-18) — two-tier blend + preflight advisory,
+// rendered from the caller-merged `index.session_start` (local+global,
+// dedup-by-id LOCAL precedence — done by the S5 hook BEFORE calling this
+// pure function, mirroring how R3's `index.entries` is already merged).
+//
+// Tier 1 = `critical_entries` (band 8/9, TRIGGER-INDEPENDENT): scope+suppress
+// filtered, sorted priority-desc/recency-desc (same tie-break as
+// selectAndBound), bounded by `max_matches`/`max_tokens` with the SAME
+// overflow-note contract as states H/I (every dropped tier-1 entry is by
+// construction band 8-9, so any drop is a critical drop) — REQ-18 test
+// `tier1_band_overflow_noted`.
+//
+// Tier 2 = `entries` (the static blend), rendered PLAIN-ONLY — REQ-18/§8.2
+// pins that tier 2 entries carry NO `effective_priority` and no code may read
+// one even if a malformed/forged input smuggled it in; `renderPlainLine`
+// below never inspects that field. Cross-tier dedup: any id already emitted
+// in tier 1 is excluded from tier 2 (tier 1 wins, REQ-18/EC13). Oversize/
+// over-budget tier-2 entries are dropped silently (never a critical entry by
+// construction, so never an overflow note — mirrors state I').
+//
+// Preflight advisory is derived GENERICALLY (REQ-18): for each task type key
+// in `preflight` (em-recall TASK TYPES — implementation/push/rule — never
+// activity classes), `ids = Object.keys(counts)` and `count = sum(values)`;
+// a task with no positive-count ids contributes no line. `Object.keys`/
+// `Object.entries` only ever return OWN enumerable keys (proto-key safe by
+// construction — no `obj[key]`-as-membership check is used here).
+// ---------------------------------------------------------------------------
+function renderPlainLine(entry) {
+  return `lesson ${entry.episode_id}: ${String(entry.summary ?? "")}`;
+}
+
+function tieBreakDesc(a, b) {
+  if (b.effective_priority !== a.effective_priority) return b.effective_priority - a.effective_priority;
+  return a.episode_id < b.episode_id ? 1 : a.episode_id > b.episode_id ? -1 : 0;
+}
+
+function renderSessionStart(sessionStart, identity, suppress, bounds) {
+  const ss = sessionStart && typeof sessionStart === "object" && !Array.isArray(sessionStart) ? sessionStart : {};
+  const criticalRaw = Array.isArray(ss.critical_entries) ? ss.critical_entries : [];
+  const entriesRaw = Array.isArray(ss.entries) ? ss.entries : [];
+  const preflightRaw = ss.preflight && typeof ss.preflight === "object" && !Array.isArray(ss.preflight) ? ss.preflight : {};
+
+  const s = suppress instanceof Set ? suppress : new Set();
+  const maxMatches = Number.isInteger(bounds && bounds.max_matches) && bounds.max_matches > 0 ? bounds.max_matches : 3;
+  const maxTokens = Number.isInteger(bounds && bounds.max_tokens) && bounds.max_tokens > 0 ? bounds.max_tokens : 500;
+
+  // ---- Tier 1: critical_entries -------------------------------------------
+  const tier1Candidates = criticalRaw.filter((e) =>
+    e && typeof e === "object" &&
+    typeof e.episode_id === "string" && e.episode_id &&
+    Number.isInteger(e.effective_priority) &&
+    scopeOk(e, identity) &&
+    !s.has(e.episode_id));
+
+  const sortedTier1 = [...tier1Candidates].sort(tieBreakDesc);
+
+  // Cross-tier exclusion set (F1, review-confirmed): tier 2 must exclude EVERY
+  // scope+suppress-surviving tier-1 CANDIDATE id — the rendered ones AND the
+  // ones dropped by count- or token-overflow. A dropped band-8/9 critical is
+  // already accounted for by the overflow note ("…incl. critical <id>"); if it
+  // were only the RENDERED ids here, that same dropped critical would resurface
+  // as a PLAIN `lesson <id>:` line in tier 2 — simultaneously "suppressed" per
+  // the note and re-injected demoted, the single most-important overflowed
+  // lesson silently downgraded. The exclusion is by tier-1 CANDIDACY, not by
+  // rendering.
+  const tier1CandidateIds = new Set(tier1Candidates.map((e) => e.episode_id));
+
+  const tier1Lines = [];
+  const droppedTier1 = [];
+  let totalTokens = 0;
+  for (const e of sortedTier1) {
+    if (tier1Lines.length >= maxMatches) { droppedTier1.push(e); continue; }
+    const line = renderLine(e); // tier 1 always carries effective_priority>=8 -> always imperative
+    const t = estimateTokens(line);
+    if (t > maxTokens || totalTokens + t > maxTokens) { droppedTier1.push(e); continue; }
+    tier1Lines.push(line);
+    totalTokens += t;
+  }
+
+  // ---- Playbook band (RFC-011 R3, REQ-9): provenance-prefixed imperative
+  // line, positioned AFTER tier-1 critical_entries and BEFORE the tier-2
+  // static blend. The cap is enforced AT BUILD (R3/REQ-9: the array arrives
+  // pre-capped to bounds.max_playbooks in preference-file order); the renderer
+  // renders what is present. Playbooks consume ONLY the shared max_tokens
+  // budget (NEVER tier-1/tier-2 count caps, R3). Suppression by id BEFORE dedup
+  // (REQ-9). Dedup (R2.9(b)/EC5): a playbook id that is ALSO a tier-1 candidate
+  // renders once in critical form (existing candidacy rule — the playbook band
+  // skips it); playbook ids are then added to the tier-2 exclusion set the same
+  // way tier-1 candidates are (one id, one line, always). The exclusion uses the
+  // pre-budget candidacy set (mirrors the tier-1 F1 rule) so a playbook dropped
+  // by the shared token budget is still excluded from tier 2.
+  const playbooksRaw = Array.isArray(ss.playbooks) ? ss.playbooks : [];
+  const playbookCandidates = playbooksRaw.filter((p) =>
+    p && typeof p === "object" &&
+    typeof p.episode_id === "string" && p.episode_id &&
+    !s.has(p.episode_id) &&
+    !tier1CandidateIds.has(p.episode_id));
+  // Extend the cross-tier exclusion set so tier 2 also skips playbook ids
+  // (mutates tier1CandidateIds in place — the variable is local to this call).
+  for (const p of playbookCandidates) tier1CandidateIds.add(p.episode_id);
+  const playbookLines = [];
+  const droppedPlaybooks = [];
+  for (const p of playbookCandidates) {
+    const line = renderPlaybookLine(p);
+    const t = estimateTokens(line);
+    if (t > maxTokens || totalTokens + t > maxTokens) { droppedPlaybooks.push(p); continue; }
+    playbookLines.push(line);
+    totalTokens += t;
+  }
+
+  // ---- Tier 2: entries (plain-only, cross-tier dedup incl. playbook ids) ----
+  const tier2Candidates = entriesRaw.filter((e) =>
+    e && typeof e === "object" &&
+    typeof e.episode_id === "string" && e.episode_id &&
+    !tier1CandidateIds.has(e.episode_id) &&
+    scopeOk(e, identity) &&
+    !s.has(e.episode_id));
+  // entriesRaw is already pre-sorted by static_score desc (buildSessionStart);
+  // preserve that order rather than re-sorting on a field tier 2 must not read.
+
+  const tier2Lines = [];
+  for (const e of tier2Candidates) {
+    const line = renderPlainLine(e);
+    const t = estimateTokens(line);
+    if (t > maxTokens || totalTokens + t > maxTokens) continue; // state I' — silent, never critical
+    tier2Lines.push(line);
+    totalTokens += t;
+  }
+
+  // ---- Preflight advisory (generic derivation) -----------------------------
+  const preflightLines = [];
+  for (const [taskType, counts] of Object.entries(preflightRaw)) {
+    if (!counts || typeof counts !== "object" || Array.isArray(counts)) continue;
+    const ids = Object.keys(counts);
+    if (ids.length === 0) continue;
+    let total = 0;
+    for (const id of ids) {
+      const v = counts[id];
+      if (Number.isFinite(v)) total += v;
+    }
+    if (total <= 0) continue;
+    preflightLines.push(`preflight: ${total} recent ${taskType} violation(s) (${ids.join(", ")})`);
+  }
+
+  // ---- Overflow notes (RFC-011 R3 / REQ-9) ----
+  // Token-drop note: one named id per note. When BOTH a critical and a playbook
+  // line were dropped by the shared token budget, the critical id takes the
+  // named slot and counts aggregate (round-2 planner N4 note-precedence). When
+  // only a playbook line was dropped (no critical), the playbook form names an
+  // id (R3 §8.2 verbatim `+N more suppressed, incl. playbook <episode_id>`).
+  // Build-cap note (R3/REQ-9): when the build capped declarations at
+  // max_playbooks (playbooks_capped > 0), a SECOND note names the first capped
+  // id from session_start.playbooks_capped_first (both fields arrive inside the
+  // merged session_start — no other data path exists to the renderer).
+  const notes = [];
+  const criticalDropped = droppedTier1.find((e) => Number(e.effective_priority) >= 8);
+  if (criticalDropped) {
+    notes.push(`+${droppedTier1.length + droppedPlaybooks.length} more matches suppressed, incl. critical ${criticalDropped.episode_id}`);
+  } else if (droppedPlaybooks.length > 0) {
+    notes.push(`+${droppedPlaybooks.length} more suppressed, incl. playbook ${droppedPlaybooks[0].episode_id}`);
+  }
+  if (Number.isInteger(ss.playbooks_capped) && ss.playbooks_capped > 0) {
+    const first = typeof ss.playbooks_capped_first === "string" && ss.playbooks_capped_first
+      ? ss.playbooks_capped_first
+      : "";
+    notes.push(`+${ss.playbooks_capped} declared playbooks capped, incl. ${first}`);
+  }
+  const overflowNote = notes.length > 0 ? notes.join("\n") : null;
+
+  return { lines: [...tier1Lines, ...playbookLines, ...tier2Lines, ...preflightLines], overflowNote };
+}
+
+// ---------------------------------------------------------------------------
+// PUBLIC: matchActivation
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} ActivationEvent
+ * @property {'prompt'|'tool'|'session_start'} kind
+ * @property {string} [prompt]
+ * @property {string} [tool]
+ * @property {string} [target]
+ *
+ * @typedef {Object} MatchResult
+ * @property {string[]} lines
+ * @property {string|null} overflowNote
+ */
+
+/**
+ * Pure, zero-I/O matcher core (RFC-009 R3, plan §12). Fails OPEN to
+ * `{lines:[], overflowNote:null}` on any internal error; throws nothing;
+ * never returns a decision/block/permissionDecision field.
+ *
+ * @param {{entries?:Array<object>, activity_phrases?:object}} index
+ * @param {ActivationEvent} event
+ * @param {{slug?:string, root?:string, tool_id?:string}} identity
+ * @param {Set<string>} [suppress]
+ * @param {{max_matches?:number, max_tokens?:number}} [bounds]
+ * @returns {MatchResult}
+ */
+export function matchActivation(index, event, identity, suppress, bounds) {
+  try {
+    const kind = event && event.kind;
+
+    // R4/S5: session_start is a distinct rendering path (two-tier blend +
+    // preflight advisory from index.session_start), not the prompt/tool
+    // trigger-matching path below.
+    if (kind === "session_start") {
+      return renderSessionStart(index && index.session_start, identity, suppress, bounds);
+    }
+
+    const entries = sanitizeEntries(index);
+    if (entries.length === 0) return { lines: [], overflowNote: null };
+
+    if (kind !== "prompt" && kind !== "tool") {
+      // any other/unknown kind: empty, advisory (fail open).
+      return { lines: [], overflowNote: null };
+    }
+
+    const candidates = candidatesForEvent(entries, event, index, identity);
+    const surviving = filterSuppressed(candidates, suppress);
+    const deduped = dedupByEpisodePreferPlaybook(surviving); // RFC-011 R2.9(b) one-per-episode + playbook-wins
+    if (deduped.length === 0) return { lines: [], overflowNote: null };
+
+    return selectAndBound(deduped, bounds);
+  } catch {
+    return { lines: [], overflowNote: null };
+  }
+}
+
+// Exported for the test file's direct unit coverage of the parsing/escape
+// helpers (word-boundary/regex-metachar/tool-glob edge cases) without
+// re-deriving them through full matchActivation fixtures.
+export { matchesPhrase, matchesToolTrigger, parseToolTrigger, scopeOk, renderLine, renderPlainLine, renderPlaybookLine, estimateTokens, renderSessionStart, dedupByEpisodePreferPlaybook };

--- a/plugins/codex-activation/hooks/activation-prompt.sh
+++ b/plugins/codex-activation/hooks/activation-prompt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Codex RFC-009 advisory activation — UserPromptSubmit.
+INPUT="$(cat)"
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+RUNNER="$HOOK_DIR/activation-hook-run.mjs"
+if [ -n "$HOOK_DIR" ] && [ -f "$RUNNER" ]; then
+  printf '%s' "$INPUT" | node "$RUNNER" UserPromptSubmit || true
+fi
+exit 0

--- a/plugins/codex-activation/hooks/activation-sessionstart.sh
+++ b/plugins/codex-activation/hooks/activation-sessionstart.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Codex RFC-009 advisory activation — SessionStart.
+INPUT="$(cat)"
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+RUNNER="$HOOK_DIR/activation-hook-run.mjs"
+if [ -n "$HOOK_DIR" ] && [ -f "$RUNNER" ]; then
+  printf '%s' "$INPUT" | node "$RUNNER" SessionStart || true
+fi
+exit 0

--- a/plugins/codex-activation/hooks/activation-tool.sh
+++ b/plugins/codex-activation/hooks/activation-tool.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Codex RFC-009 advisory activation — PreToolUse. Never blocks.
+INPUT="$(cat)"
+HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+RUNNER="$HOOK_DIR/activation-hook-run.mjs"
+if [ -n "$HOOK_DIR" ] && [ -f "$RUNNER" ]; then
+  printf '%s' "$INPUT" | node "$RUNNER" PreToolUse || true
+fi
+exit 0

--- a/plugins/codex-activation/hooks/json-instance-validate.mjs
+++ b/plugins/codex-activation/hooks/json-instance-validate.mjs
@@ -1,0 +1,520 @@
+// json-instance-validate.mjs — zero-dep closed-subset JSON-Schema 2020-12
+// INSTANCE validator with a fail-CLOSED closure guard (RFC-008 R0c P1b, §2.1).
+//
+// This is NOT a general 2020-12 validator and NOT the schema-DOC linter
+// (scripts/lib/mini-jsonschema.mjs asserts "a schema is a valid schema"; this
+// asserts "an instance satisfies a schema"). It models exactly the keyword
+// subset the P0 plugin/runtime schemas use, and is the FIRST consumer to
+// instance-validate plugins/_index.json + plugins/claude-code/manifest.json
+// (M1/M2). validate-plugin-registry.mjs imports it.
+//
+// Three closure properties make it fail CLOSED, not open (the class the
+// negative-scenario-planner GAP-3 + codex F-c1 review peeled apart):
+//
+//   (a) ALLOWLIST — KEYWORD_SHAPE enumerates every modeled keyword. A keyword
+//       NOT in it (a future 2020-12 applicator like anyOf/patternProperties/
+//       contains/dependentSchemas/unevaluated*) is a HARD ERROR, never a silent
+//       skip — the inverse of "ignore unknown keywords".
+//
+//   (b) VALUE-SHAPE — the ALLOWLIST keys on keyword NAME, but each keyword's
+//       modeled VALUE SHAPE is asserted too. `additionalProperties` and `type`
+//       are both allowlisted, so name-only closure (a) would still fail OPEN on
+//       a schema-VALUED `additionalProperties` ({$ref}, {type:string}) or an
+//       array-VALUED `type` (["string","null"]) the interpreter didn't model
+//       (codex F-c1). An allowlisted keyword in an UNMODELED value-shape is the
+//       SAME hard error as an unmodeled keyword name.
+//
+//   (c) SCAN==INTERPRET — assertSchemaModeled() pre-scans the WHOLE schema doc
+//       (a) + (b) BEFORE any instance is validated, and validateInstance()
+//       refuses to interpret a root schema that has not been asserted-modeled
+//       (memoized by identity). So you cannot instance-validate against a schema
+//       whose keyword/value-shape set the interpreter has not vetted.
+//
+// Modeled subset (the union the interpreted schemas use — the 5 P1b schemas
+// _index, manifest, bypass_known, installed-state, structured-alert, PLUS the
+// P1c consumers schemas/events/event-*.schema.json + runbook-agent-manifest):
+//   applicators : properties additionalProperties(bool|schema) items
+//                 propertyNames allOf oneOf if then else not $ref $defs
+//   validation  : type(scalar|array) enum const(any-JSON deep-equal) pattern
+//                 format(date-time) required minLength minItems maxItems
+//                 minProperties minimum
+//   annotations : $schema $id title description $comment  (explicit no-ops)
+//
+// `minimum` + `maxItems` added in P1c (RFC-008 R0c): the event schemas assert
+// `minimum:0` on turn_index, and runbook-agent-manifest asserts `maxItems:0` on
+// command_shapes (static-rules). `validateInstance` is the first P1c consumer of
+// both schema sets, so without these the closure guard throws SchemaModelingError
+// before validating. Both are fail-closed value-shape-checked like every keyword.
+//
+// Deliberately ABSENT (fail CLOSED if ever introduced): anyOf, contains,
+// patternProperties, dependentSchemas, dependentRequired, prefixItems,
+// unevaluatedItems, unevaluatedProperties, multipleOf, maximum, exclusiveMinimum,
+// exclusiveMaximum, maxLength, uniqueItems, max/minContains, maxProperties,
+// default, deprecated, readOnly, writeOnly, examples, content*, $anchor,
+// $dynamicRef, $dynamicAnchor, $vocabulary.
+
+const VALID_TYPES = new Set([
+  "null", "boolean", "object", "array", "number", "string", "integer",
+]);
+
+// JSON-Schema annotations / core identifiers that assert NOTHING about an
+// instance. The scanner skips them (never fail-on-unmodeled) and the
+// interpreter ignores them — a no-op can never fail OPEN because it constrains
+// nothing (§2.1f). $defs is a definition container (referenced via $ref), so it
+// is also a non-asserting position, but it DOES bear subschemas that must be
+// scanned — handled in SUBSCHEMA_POSITION, not here.
+const ANNOTATION_KEYWORDS = new Set([
+  "$schema", "$id", "title", "description", "$comment",
+]);
+
+// Modeled value-shape per keyword. The single source of truth for closure (a)
+// (membership) AND (b) (value-shape assertion). Shape codes:
+//   "schema"       value IS a schema (object or boolean)         -> recurse
+//   "schemaArray"  value is a non-empty array of schemas         -> recurse each
+//   "schemaMap"    value is an object whose every value is schema -> recurse each
+//   "boolOrSchema" value is a boolean OR a schema (additionalProperties)
+//   "typeValue"    value is a type name or non-empty array of unique type names
+//   "stringArray"  value is an array of strings
+//   "enumArray"    value is a non-empty array (any JSON members)
+//   "any"          value is any JSON (const)
+//   "string"       value is a string
+//   "nonNegInt"    value is a non-negative integer
+//   "number"       value is any finite JSON number (minimum — negative/float OK)
+const KEYWORD_SHAPE = {
+  // applicators (subschema-bearing)
+  properties: "schemaMap",
+  additionalProperties: "boolOrSchema",
+  items: "schema",
+  propertyNames: "schema",
+  allOf: "schemaArray",
+  oneOf: "schemaArray",
+  if: "schema",
+  then: "schema",
+  else: "schema",
+  not: "schema",
+  $defs: "schemaMap",
+  // reference
+  $ref: "string",
+  // validation (non-recursing)
+  type: "typeValue",
+  enum: "enumArray",
+  const: "any",
+  pattern: "string",
+  format: "string",
+  required: "stringArray",
+  minLength: "nonNegInt",
+  minItems: "nonNegInt",
+  maxItems: "nonNegInt",
+  minProperties: "nonNegInt",
+  minimum: "number",
+};
+
+// The recurse-set: which shapes bear subschemas the scanner must descend into.
+const RECURSING_SHAPES = new Set(["schema", "schemaArray", "schemaMap", "boolOrSchema"]);
+
+export class SchemaModelingError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SchemaModelingError";
+  }
+}
+
+function jsonType(v) {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v; // "object" | "string" | "number" | "boolean"
+}
+
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function isSchemaShaped(node) {
+  // A 2020-12 schema is an object OR a boolean.
+  return typeof node === "boolean" || isPlainObject(node);
+}
+
+// ---------------------------------------------------------------------------
+// CLOSURE GUARD — assertSchemaModeled (closures a + b + c-prescan).
+// Walks the whole schema doc; throws SchemaModelingError on the first
+// unmodeled keyword NAME or unmodeled VALUE-SHAPE. Mirrors the doc structure so
+// nested subschemas (under properties / $defs / items / allOf / oneOf / if /
+// then / else / not / additionalProperties / propertyNames) are all vetted.
+// ---------------------------------------------------------------------------
+function assertShape(keyword, value, path) {
+  const shape = KEYWORD_SHAPE[keyword];
+  switch (shape) {
+    case "schema":
+      if (!isSchemaShaped(value)) {
+        throw new SchemaModelingError(
+          `${path}: "${keyword}" must be a schema (object|boolean), got ${jsonType(value)}`,
+        );
+      }
+      return;
+    case "schemaArray":
+      if (!Array.isArray(value) || value.length === 0) {
+        throw new SchemaModelingError(
+          `${path}: "${keyword}" must be a non-empty array of schemas, got ${jsonType(value)}`,
+        );
+      }
+      value.forEach((el, i) => {
+        if (!isSchemaShaped(el)) {
+          throw new SchemaModelingError(
+            `${path}/${i}: "${keyword}" element must be a schema, got ${jsonType(el)}`,
+          );
+        }
+      });
+      return;
+    case "schemaMap":
+      if (!isPlainObject(value)) {
+        throw new SchemaModelingError(
+          `${path}: "${keyword}" must be an object of schemas, got ${jsonType(value)}`,
+        );
+      }
+      for (const [k, sub] of Object.entries(value)) {
+        if (!isSchemaShaped(sub)) {
+          throw new SchemaModelingError(
+            `${path}/${k}: "${keyword}" value must be a schema, got ${jsonType(sub)}`,
+          );
+        }
+      }
+      return;
+    case "boolOrSchema":
+      // The codex F-c1 fail-open: BOTH boolean false AND a schema value are
+      // modeled; anything else (array, number) is an unmodeled value-shape.
+      if (typeof value === "boolean" || isPlainObject(value)) return;
+      throw new SchemaModelingError(
+        `${path}: "${keyword}" must be boolean or schema-object, got ${jsonType(value)}`,
+      );
+    case "typeValue":
+      if (typeof value === "string") {
+        if (!VALID_TYPES.has(value)) {
+          throw new SchemaModelingError(`${path}: "${keyword}" unknown type name ${JSON.stringify(value)}`);
+        }
+        return;
+      }
+      if (Array.isArray(value)) {
+        // array-VALUED type, e.g. ["string","null"] (structured-alert) — codex F-c1.
+        if (value.length === 0) throw new SchemaModelingError(`${path}: "type" array must be non-empty`);
+        if (new Set(value).size !== value.length) throw new SchemaModelingError(`${path}: "type" array must be unique`);
+        for (const t of value) {
+          if (typeof t !== "string" || !VALID_TYPES.has(t)) {
+            throw new SchemaModelingError(`${path}: "type" unknown type name in array ${JSON.stringify(t)}`);
+          }
+        }
+        return;
+      }
+      throw new SchemaModelingError(`${path}: "type" must be a type name or array of type names, got ${jsonType(value)}`);
+    case "enumArray":
+      if (!Array.isArray(value) || value.length === 0) {
+        throw new SchemaModelingError(`${path}: "enum" must be a non-empty array, got ${jsonType(value)}`);
+      }
+      return;
+    case "any":
+      return; // const — any JSON literal (§2.1e)
+    case "string":
+      if (typeof value !== "string") {
+        throw new SchemaModelingError(`${path}: "${keyword}" must be a string, got ${jsonType(value)}`);
+      }
+      if (keyword === "pattern") {
+        try { new RegExp(value); }
+        catch (e) { throw new SchemaModelingError(`${path}: "pattern" is not a compilable regex: ${e.message}`); }
+      }
+      return;
+    case "stringArray":
+      if (!Array.isArray(value) || !value.every((s) => typeof s === "string")) {
+        throw new SchemaModelingError(`${path}: "${keyword}" must be an array of strings`);
+      }
+      return;
+    case "nonNegInt":
+      if (!Number.isInteger(value) || value < 0) {
+        throw new SchemaModelingError(`${path}: "${keyword}" must be a non-negative integer, got ${JSON.stringify(value)}`);
+      }
+      return;
+    case "number":
+      // `minimum` bound — any finite JSON number (negative/float admitted; JSON
+      // has no NaN/Infinity literal, but reject defensively if one is injected).
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw new SchemaModelingError(`${path}: "${keyword}" must be a finite number, got ${jsonType(value)}`);
+      }
+      return;
+    default:
+      // Unreachable: KEYWORD_SHAPE only carries the shapes above.
+      throw new SchemaModelingError(`${path}: internal — unhandled shape "${shape}" for "${keyword}"`);
+  }
+}
+
+function scanNode(node, path) {
+  if (typeof node === "boolean") return; // boolean schema — nothing to model
+  if (!isPlainObject(node)) {
+    throw new SchemaModelingError(`${path}: not a schema (expected object or boolean), got ${jsonType(node)}`);
+  }
+  for (const [keyword, value] of Object.entries(node)) {
+    if (ANNOTATION_KEYWORDS.has(keyword)) continue; // §2.1f explicit no-op
+    if (!(keyword in KEYWORD_SHAPE)) {
+      // closure (a) — fail-on-unmodeled keyword NAME.
+      throw new SchemaModelingError(
+        `${path}: unmodeled keyword "${keyword}" — json-instance-validate models a closed 2020-12 subset; ` +
+        `add it to KEYWORD_SHAPE (and its interpretation) or it fails CLOSED`,
+      );
+    }
+    // closure (b) — assert the modeled value-SHAPE.
+    assertShape(keyword, value, `${path}/${keyword}`);
+    // recurse into subschema-bearing positions.
+    const shape = KEYWORD_SHAPE[keyword];
+    if (!RECURSING_SHAPES.has(shape)) continue;
+    if (shape === "schema") scanNode(value, `${path}/${keyword}`);
+    else if (shape === "boolOrSchema") { if (isPlainObject(value)) scanNode(value, `${path}/${keyword}`); }
+    else if (shape === "schemaArray") value.forEach((el, i) => scanNode(el, `${path}/${keyword}/${i}`));
+    else if (shape === "schemaMap") for (const [k, sub] of Object.entries(value)) scanNode(sub, `${path}/${keyword}/${k}`);
+  }
+}
+
+const _modeledSchemas = new WeakSet();
+
+/**
+ * Assert a parsed schema doc uses ONLY the modeled keyword/value-shape subset.
+ * Throws SchemaModelingError on the first violation. Idempotent + memoized by
+ * object identity (so validateInstance can cheaply guarantee scan==interpret).
+ * @param {object} schema parsed JSON-Schema 2020-12 doc (the root)
+ */
+export function assertSchemaModeled(schema) {
+  if (!isPlainObject(schema)) {
+    throw new SchemaModelingError("#: root schema must be an object");
+  }
+  if (_modeledSchemas.has(schema)) return;
+  scanNode(schema, "#");
+  _modeledSchemas.add(schema);
+}
+
+/**
+ * Assert every schema in a registry {name: parsedSchema} is modeled. Drives the
+ * scan-set from a single registry so it cannot drift from the interpret-set
+ * (claude-subagent F2). Returns the registry for chaining.
+ */
+export function assertAllSchemasModeled(registry) {
+  for (const [name, schema] of Object.entries(registry)) {
+    try {
+      assertSchemaModeled(schema);
+    } catch (e) {
+      throw new SchemaModelingError(`schema "${name}": ${e.message}`);
+    }
+  }
+  return registry;
+}
+
+// ---------------------------------------------------------------------------
+// DEEP EQUALITY — const / enum membership over any JSON value (§2.1e).
+// Order-sensitive for arrays; order-insensitive (key-set + value) for objects.
+// ---------------------------------------------------------------------------
+function deepEqual(a, b) {
+  if (a === b) return true;
+  const ta = jsonType(a), tb = jsonType(b);
+  if (ta !== tb) return false;
+  if (ta === "array") {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (!deepEqual(a[i], b[i])) return false;
+    return true;
+  }
+  if (ta === "object") {
+    const ka = Object.keys(a), kb = Object.keys(b);
+    if (ka.length !== kb.length) return false;
+    for (const k of ka) {
+      if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+      if (!deepEqual(a[k], b[k])) return false;
+    }
+    return true;
+  }
+  return false; // primitives already handled by === (incl. NaN!==NaN, acceptable)
+}
+
+// RFC 3339 / ISO-8601 date-time (the only `format` used by the modeled schemas).
+const DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/;
+
+// ---------------------------------------------------------------------------
+// JSON-pointer $ref resolution. Supports the local "#/a/b/c" form (the schemas
+// only use "#/$defs/NAME"); throws on external/malformed refs (fail closed).
+// ---------------------------------------------------------------------------
+function resolveRef(ref, root) {
+  if (typeof ref !== "string" || !ref.startsWith("#/")) {
+    throw new SchemaModelingError(`unsupported $ref ${JSON.stringify(ref)} (only local "#/..." pointers modeled)`);
+  }
+  const parts = ref.slice(2).split("/").map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let node = root;
+  for (const p of parts) {
+    if (!isPlainObject(node) || !(p in node)) {
+      throw new SchemaModelingError(`$ref ${ref} does not resolve (missing segment ${JSON.stringify(p)})`);
+    }
+    node = node[p];
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// THE INTERPRETER. validateAgainst pushes structured errors; isValid is the
+// branch-selector helper (if/oneOf/allOf/not) that runs it into a scratch sink.
+// Error shape: {path, keyword, detail}.
+// ---------------------------------------------------------------------------
+function err(errors, path, keyword, detail) {
+  errors.push({ path, keyword, detail });
+}
+
+function isValid(instance, schema, root) {
+  const sink = [];
+  validateAgainst(instance, schema, root, "#", sink);
+  return sink.length === 0;
+}
+
+function validateAgainst(instance, schema, root, path, errors) {
+  // boolean schema: true accepts anything, false rejects everything.
+  if (typeof schema === "boolean") {
+    if (!schema) err(errors, path, "false", "boolean false schema rejects all instances");
+    return;
+  }
+  if (!isPlainObject(schema)) {
+    err(errors, path, "$schema", `not a schema node (${jsonType(schema)})`);
+    return;
+  }
+
+  const it = jsonType(instance);
+
+  // $ref — resolve and validate against the referenced subschema (siblings
+  // still apply, 2020-12 semantics).
+  if ("$ref" in schema) {
+    const resolved = resolveRef(schema.$ref, root);
+    validateAgainst(instance, resolved, root, path, errors);
+  }
+
+  if ("type" in schema) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const ok = types.some((t) => t === it || (t === "integer" && it === "number" && Number.isInteger(instance)));
+    if (!ok) err(errors, path, "type", `expected ${JSON.stringify(schema.type)}, got ${it}`);
+  }
+
+  if ("const" in schema) {
+    if (!deepEqual(instance, schema.const)) {
+      err(errors, path, "const", `must equal ${JSON.stringify(schema.const)}`);
+    }
+  }
+
+  if ("enum" in schema) {
+    if (!schema.enum.some((e) => deepEqual(instance, e))) {
+      err(errors, path, "enum", `must be one of ${JSON.stringify(schema.enum)}, got ${JSON.stringify(instance)}`);
+    }
+  }
+
+  // string assertions
+  if (it === "string") {
+    if ("pattern" in schema && !new RegExp(schema.pattern).test(instance)) {
+      err(errors, path, "pattern", `${JSON.stringify(instance)} does not match /${schema.pattern}/`);
+    }
+    if ("minLength" in schema && instance.length < schema.minLength) {
+      err(errors, path, "minLength", `length ${instance.length} < ${schema.minLength}`);
+    }
+    if ("format" in schema && schema.format === "date-time" && !DATE_TIME_RE.test(instance)) {
+      err(errors, path, "format", `${JSON.stringify(instance)} is not a valid date-time`);
+    }
+  }
+
+  // array assertions
+  if (it === "array") {
+    if ("minItems" in schema && instance.length < schema.minItems) {
+      err(errors, path, "minItems", `${instance.length} items < ${schema.minItems}`);
+    }
+    if ("maxItems" in schema && instance.length > schema.maxItems) {
+      err(errors, path, "maxItems", `${instance.length} items > ${schema.maxItems}`);
+    }
+    if ("items" in schema) {
+      instance.forEach((el, i) => validateAgainst(el, schema.items, root, `${path}/${i}`, errors));
+    }
+  }
+
+  // number assertions (integers are jsonType "number" too)
+  if (it === "number") {
+    if ("minimum" in schema && instance < schema.minimum) {
+      err(errors, path, "minimum", `${instance} < ${schema.minimum}`);
+    }
+  }
+
+  // object assertions
+  if (it === "object") {
+    if ("minProperties" in schema && Object.keys(instance).length < schema.minProperties) {
+      err(errors, path, "minProperties", `${Object.keys(instance).length} properties < ${schema.minProperties}`);
+    }
+    if ("required" in schema) {
+      for (const key of schema.required) {
+        if (!Object.prototype.hasOwnProperty.call(instance, key)) {
+          err(errors, path, "required", `missing required property ${JSON.stringify(key)}`);
+        }
+      }
+    }
+    if ("propertyNames" in schema) {
+      // applies the subschema to each KEY (as a string instance) — NOT the value.
+      for (const key of Object.keys(instance)) {
+        const sink = [];
+        validateAgainst(key, schema.propertyNames, root, `${path}/${key}`, sink);
+        if (sink.length) err(errors, `${path}/${key}`, "propertyNames", `key ${JSON.stringify(key)} violates propertyNames`);
+      }
+    }
+    const props = isPlainObject(schema.properties) ? schema.properties : null;
+    if (props) {
+      for (const [key, sub] of Object.entries(props)) {
+        if (Object.prototype.hasOwnProperty.call(instance, key)) {
+          validateAgainst(instance[key], sub, root, `${path}/${key}`, errors);
+        }
+      }
+    }
+    if ("additionalProperties" in schema) {
+      const ap = schema.additionalProperties;
+      for (const key of Object.keys(instance)) {
+        if (props && Object.prototype.hasOwnProperty.call(props, key)) continue; // matched by properties
+        if (ap === false) {
+          err(errors, `${path}/${key}`, "additionalProperties", `unexpected property ${JSON.stringify(key)}`);
+        } else if (isPlainObject(ap) || typeof ap === "boolean") {
+          if (ap !== true && ap !== false) {
+            validateAgainst(instance[key], ap, root, `${path}/${key}`, errors); // schema-valued — RECURSE (codex F-c1)
+          }
+        }
+      }
+    }
+  }
+
+  // applicators
+  if ("allOf" in schema) {
+    schema.allOf.forEach((sub, i) => validateAgainst(instance, sub, root, `${path}/allOf/${i}`, errors));
+  }
+  if ("oneOf" in schema) {
+    const matches = schema.oneOf.filter((sub) => isValid(instance, sub, root)).length;
+    if (matches !== 1) {
+      err(errors, path, "oneOf", `must match exactly one branch, matched ${matches}`);
+    }
+  }
+  if ("not" in schema) {
+    if (isValid(instance, schema.not, root)) {
+      err(errors, path, "not", "must NOT match the `not` subschema");
+    }
+  }
+  if ("if" in schema) {
+    if (isValid(instance, schema.if, root)) {
+      if ("then" in schema) validateAgainst(instance, schema.then, root, `${path}/then`, errors);
+    } else if ("else" in schema) {
+      validateAgainst(instance, schema.else, root, `${path}/else`, errors);
+    }
+  }
+}
+
+/**
+ * Validate a parsed instance against a parsed root schema (closed 2020-12
+ * subset). $ref resolves against `schema`. The root schema is asserted-modeled
+ * first (closure c — scan ⊇ interpret), so an unmodeled keyword/value-shape
+ * throws SchemaModelingError rather than silently passing.
+ * @returns {{valid: boolean, errors: Array<{path,keyword,detail}>}}
+ */
+export function validateInstance(instance, schema) {
+  assertSchemaModeled(schema); // closure (c): cannot interpret an un-vetted schema
+  const errors = [];
+  validateAgainst(instance, schema, schema, "#", errors);
+  return { valid: errors.length === 0, errors };
+}
+
+export { KEYWORD_SHAPE, ANNOTATION_KEYWORDS, deepEqual };

--- a/plugins/codex-activation/manifest.json
+++ b/plugins/codex-activation/manifest.json
@@ -1,0 +1,28 @@
+{
+  "type": "activation",
+  "schema_version": "1.0.0",
+  "id": "codex",
+  "harness": "codex",
+  "version": "1.0.0",
+  "blocking": false,
+  "capabilities": {
+    "user_prompt_submit": "MEDIUM",
+    "pre_tool_use": "MEDIUM",
+    "session_start": "MEDIUM"
+  },
+  "registrations": [
+    { "id": "rfc-009-codex-activation-user-prompt-submit", "file": "activation-prompt.sh", "event": "UserPromptSubmit", "timeout": 5, "checksum": "sha256:fa0488cea80a3b2c1fc0e8559d04d979b296da95fe8dbac70eb3c0171d4b52fc" },
+    { "id": "rfc-009-codex-activation-pre-tool-use", "file": "activation-tool.sh", "event": "PreToolUse", "timeout": 5, "checksum": "sha256:45b560242c22bcd0ee6b6e438cadb79555b78af26aa9158e48c80ed06e6c37d7" },
+    { "id": "rfc-009-codex-activation-session-start", "file": "activation-sessionstart.sh", "event": "SessionStart", "timeout": 10, "checksum": "sha256:f90557b032279799a3be34639b0c8946bb25015073b63c58e87296c582b01697" }
+  ],
+  "support_files": [
+    { "file": "activation-hook-run.mjs", "checksum": "sha256:ee8959086489e94cc16cd8bc78b86e2ad5cbd18530e84e455734f221bc3789dc" },
+    { "file": "activation-match.mjs", "checksum": "sha256:75dfbed55f1d3a0a7cea5d0d83dd8d5b7ad623d12c5a8e2a49d57b69d636ec0e" },
+    { "file": "json-instance-validate.mjs", "checksum": "sha256:5ccf2b3121e0ec0631e39e583ecc30d98fe625f15c9810cdd9ae1e8675927528" }
+  ],
+  "io_schema": "schemas/runtime/activation-io.schema.json",
+  "runbook": {
+    "full": "plugins/codex-activation/runbooks/activation.md",
+    "quickref": "plugins/codex-activation/runbooks/activation.quickref.md"
+  }
+}

--- a/plugins/codex-activation/runbooks/activation.md
+++ b/plugins/codex-activation/runbooks/activation.md
@@ -1,0 +1,12 @@
+# Codex activation adapter
+
+RFC-009 advisory activation for Codex. It installs project-local command hooks
+for `UserPromptSubmit`, `PreToolUse`, and `SessionStart` under `.codex/`.
+
+The adapter is recall-side and advisory only. Every path exits zero and emits
+no blocking or decision field. It reads the purpose-built trigger indexes and
+injects bounded lesson context through `hookSpecificOutput.additionalContext`.
+
+After installation, run `/hooks` inside Codex from the project and trust the
+three new hook definitions. Codex skips new or changed project hooks until their
+exact definitions are trusted.

--- a/plugins/codex-activation/runbooks/activation.quickref.md
+++ b/plugins/codex-activation/runbooks/activation.quickref.md
@@ -1,0 +1,7 @@
+# Codex activation quick reference
+
+- Install: `node install.mjs --tool codex --project <path> --install-activation`
+- Trust: run `/hooks` in Codex and trust the three activation hooks
+- Uninstall: `node install.mjs --tool codex --project <path> --uninstall-activation`
+- Scope: project-local `.codex/`; local episodes are never removed
+- Behavior: advisory context only; always exits zero; never blocks

--- a/scripts/lib/install-version.mjs
+++ b/scripts/lib/install-version.mjs
@@ -211,6 +211,16 @@ export function perProjectArtifactPairs(repoDir, projectDir) {
   add('plugins/claude-code/hooks/lib/so-timeout-floor.mjs', '.claude/hooks/lib/so-timeout-floor.mjs', 'capability')
   add('plugins/second-opinion/runbooks/harness.md', '.claude/hooks/runbooks/second-opinion-harness.md', 'capability')
 
+  // Codex RFC-009 advisory activation runtime. The generated deployed manifest
+  // is intentionally excluded because it carries project_identity; the owned
+  // hook/runtime bytes are stable and checksum-refreshable.
+  for (const file of [
+    'activation-prompt.sh', 'activation-tool.sh', 'activation-sessionstart.sh',
+    'activation-hook-run.mjs', 'activation-match.mjs', 'json-instance-validate.mjs',
+  ]) {
+    add(`plugins/codex-activation/hooks/${file}`, `.codex/episodic-memory-activation/hooks/${file}`, 'capability')
+  }
+
   return pairs
 }
 

--- a/tests/test-codex-activation-install.mjs
+++ b/tests/test-codex-activation-install.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const INSTALL = path.join(REPO, 'install.mjs')
+const tmpRoots = []
+process.on('exit', () => {
+  if (process.env.EM_KEEP_TMP === '1') return
+  for (const root of tmpRoots) fs.rmSync(root, { recursive: true, force: true })
+})
+
+function fixture(label) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `em-codex-act-${label}-`)))
+  tmpRoots.push(base)
+  const home = path.join(base, 'home')
+  const project = path.join(base, 'project')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(project, { recursive: true })
+  const init = spawnSync('git', ['init', '--quiet', project], { encoding: 'utf8' })
+  assert.equal(init.status, 0, `fixture git init failed: ${init.stderr}`)
+  fs.mkdirSync(path.join(project, '.episodic-memory', 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(project, '.episodic-memory', 'episodes', 'keep.md'), 'must survive\n')
+  return { base, home, project }
+}
+
+function install(F, ...flags) {
+  return installAt(F, F.project, ...flags)
+}
+
+function installAt(F, project, ...flags) {
+  return spawnSync(process.execPath, [INSTALL, '--tool', 'codex', '--project', project, ...flags], {
+    cwd: project,
+    env: { ...process.env, HOME: F.home },
+    encoding: 'utf8',
+    timeout: 120000,
+  })
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
+function commands(settings, event) {
+  return ((settings.hooks && settings.hooks[event]) || []).flatMap((group) =>
+    (group.hooks || []).map((hook) => hook.command).filter(Boolean))
+}
+
+function treeHash(dir) {
+  const hash = crypto.createHash('sha256')
+  const walk = (current, rel = '') => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const nextRel = rel ? `${rel}/${entry.name}` : entry.name
+      const abs = path.join(current, entry.name)
+      hash.update(nextRel)
+      if (entry.isDirectory()) walk(abs, nextRel)
+      else hash.update(fs.readFileSync(abs))
+    }
+  }
+  walk(dir)
+  return hash.digest('hex')
+}
+
+function testInstallAndUninstall() {
+  const F = fixture('cycle')
+  const episodes = path.join(F.project, '.episodic-memory', 'episodes')
+  const beforeEpisodes = treeHash(episodes)
+
+  const result = install(F, '--install-activation')
+  assert.equal(result.status, 0, `install failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
+
+  const codexDir = path.join(F.project, '.codex')
+  const pluginDir = path.join(codexDir, 'episodic-memory-activation')
+  const hooks = readJson(path.join(codexDir, 'hooks.json'))
+  const manifest = readJson(path.join(pluginDir, 'manifest.json'))
+  assert.equal(manifest.harness, 'codex')
+  assert.equal(manifest.blocking, false)
+  assert.deepEqual(manifest.project_identity, { slug: 'project', root: F.project })
+  for (const event of ['UserPromptSubmit', 'PreToolUse', 'SessionStart']) {
+    assert.equal(commands(hooks, event).filter((command) => command.includes('episodic-memory-activation')).length, 1,
+      `${event} must have exactly one Codex activation registration`)
+  }
+  for (const file of ['activation-prompt.sh', 'activation-tool.sh', 'activation-sessionstart.sh', 'activation-hook-run.mjs', 'activation-match.mjs', 'json-instance-validate.mjs']) {
+    assert.equal(fs.existsSync(path.join(pluginDir, 'hooks', file)), true, `${file} must be installed`)
+  }
+  assert.match(result.stdout, /Run "\/hooks" inside Codex.*trust/i)
+  assert.equal(treeHash(episodes), beforeEpisodes, 'install must preserve local episodes byte-for-byte')
+
+  const registry = readJson(path.join(F.home, '.episodic-memory', 'installs.json'))
+  const row = registry.entries.find((entry) => entry.tool === 'codex' && entry.project_path === F.project)
+  assert.equal(row && row.activation_installed, true, 'Codex registry row must record activation_installed:true')
+
+  const uninstall = install(F, '--uninstall-activation')
+  assert.equal(uninstall.status, 0, `uninstall failed\nstdout:\n${uninstall.stdout}\nstderr:\n${uninstall.stderr}`)
+  const hooksAfter = readJson(path.join(codexDir, 'hooks.json'))
+  for (const event of ['UserPromptSubmit', 'PreToolUse', 'SessionStart']) {
+    assert.equal(commands(hooksAfter, event).some((command) => command.includes('episodic-memory-activation')), false,
+      `${event} activation registration must be removed`)
+  }
+  assert.equal(fs.existsSync(pluginDir), false, 'Codex activation plugin directory must be removed')
+  assert.equal(treeHash(episodes), beforeEpisodes, 'uninstall must preserve local episodes byte-for-byte')
+}
+
+function testSessionStartOutput() {
+  const F = fixture('session')
+  const result = install(F, '--install-activation')
+  assert.equal(result.status, 0, result.stderr)
+  const hook = path.join(F.project, '.codex', 'episodic-memory-activation', 'hooks', 'activation-sessionstart.sh')
+  const localIndex = path.join(F.project, '.episodic-memory', 'index.jsonl')
+  const indexStat = fs.existsSync(localIndex) ? fs.statSync(localIndex) : { mtimeMs: 0, size: 0 }
+  const trigger = {
+    schema_version: 3,
+    source: { index_mtime_ms: indexStat.mtimeMs, index_size: indexStat.size, playbooks_mtime_ms: 0, playbooks_size: 0 },
+    entries: [
+      {
+        trigger_kind: 'phrase', value: 'codex activation', episode_id: 'lesson-prompt', summary: 'Codex prompt context',
+        effective_priority: 5, applies_to_projects: ['project'], applies_to_tools: ['codex'],
+      },
+      {
+        trigger_kind: 'tool', value: 'tool:apply_patch:*', episode_id: 'lesson-tool', summary: 'Codex tool context',
+        effective_priority: 5, applies_to_projects: ['project'], applies_to_tools: ['codex'],
+      },
+    ],
+    activity_phrases: {},
+    session_start: {
+      critical_entries: [],
+      entries: [{
+        episode_id: 'lesson-1',
+        summary: 'Codex session context',
+        static_score: 10,
+        applies_to_projects: ['project'],
+        applies_to_tools: ['codex'],
+      }],
+      preflight: {},
+    },
+  }
+  fs.writeFileSync(path.join(F.project, '.episodic-memory', 'trigger-index.json'), JSON.stringify(trigger))
+  const hookRun = spawnSync('bash', [hook], {
+    cwd: F.project,
+    env: { ...process.env, HOME: F.home },
+    input: JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', cwd: F.project, session_id: 'test' }),
+    encoding: 'utf8',
+  })
+  assert.equal(hookRun.status, 0, hookRun.stderr)
+  assert.notEqual(hookRun.stdout.trim(), '', `SessionStart hook emitted no context\nstderr:\n${hookRun.stderr}`)
+  const output = JSON.parse(hookRun.stdout)
+  assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart')
+  assert.match(output.hookSpecificOutput.additionalContext, /Codex session context/)
+  assert.equal('decision' in output, false)
+  assert.equal('permissionDecision' in output.hookSpecificOutput, false)
+
+  const runEvent = (file, payload) => spawnSync('bash', [path.join(F.project, '.codex', 'episodic-memory-activation', 'hooks', file)], {
+    cwd: F.project,
+    env: { ...process.env, HOME: F.home },
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  })
+  const promptRun = runEvent('activation-prompt.sh', { hook_event_name: 'UserPromptSubmit', prompt: 'please use codex activation' })
+  assert.equal(promptRun.status, 0, promptRun.stderr)
+  assert.match(JSON.parse(promptRun.stdout).hookSpecificOutput.additionalContext, /Codex prompt context/)
+  const toolRun = runEvent('activation-tool.sh', {
+    hook_event_name: 'PreToolUse', tool_name: 'apply_patch', tool_input: { command: '*** Begin Patch' },
+  })
+  assert.equal(toolRun.status, 0, toolRun.stderr)
+  const toolOutput = JSON.parse(toolRun.stdout)
+  assert.match(toolOutput.hookSpecificOutput.additionalContext, /Codex tool context/)
+  assert.equal('permissionDecision' in toolOutput.hookSpecificOutput, false)
+}
+
+function testFailurePaths() {
+  const malformed = fixture('malformed')
+  fs.mkdirSync(path.join(malformed.project, '.codex'), { recursive: true })
+  fs.writeFileSync(path.join(malformed.project, '.codex', 'hooks.json'), '{bad')
+  const beforeEpisodes = treeHash(path.join(malformed.project, '.episodic-memory', 'episodes'))
+  const rejected = install(malformed, '--install-activation')
+  assert.equal(rejected.status, 0)
+  assert.match(rejected.stdout, /aborted — nothing changed/)
+  assert.equal(fs.existsSync(path.join(malformed.project, '.codex', 'episodic-memory-activation')), false)
+  assert.equal(treeHash(path.join(malformed.project, '.episodic-memory', 'episodes')), beforeEpisodes)
+
+  const idempotent = fixture('idempotent')
+  fs.mkdirSync(path.join(idempotent.project, '.codex'), { recursive: true })
+  fs.writeFileSync(path.join(idempotent.project, '.codex', 'hooks.json'), JSON.stringify({
+    hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'echo keep-me', timeout: 1 }] }] },
+  }))
+  assert.equal(install(idempotent, '--install-activation').status, 0)
+  assert.equal(install(idempotent, '--install-activation').status, 0)
+  const hooks = readJson(path.join(idempotent.project, '.codex', 'hooks.json'))
+  for (const event of ['UserPromptSubmit', 'PreToolUse', 'SessionStart']) {
+    assert.equal(commands(hooks, event).filter((command) => command.includes('episodic-memory-activation')).length, 1)
+  }
+
+  const modified = path.join(idempotent.project, '.codex', 'episodic-memory-activation', 'hooks', 'activation-hook-run.mjs')
+  fs.appendFileSync(modified, '\n// operator modification\n')
+  const removed = install(idempotent, '--uninstall-activation')
+  assert.equal(removed.status, 0)
+  assert.equal(fs.existsSync(modified), true, 'modified Codex activation file must survive uninstall')
+  assert.equal(fs.existsSync(path.join(idempotent.project, '.codex', 'episodic-memory-activation', 'manifest.json')), true,
+    'ownership manifest must remain beside a preserved modified file')
+  assert.match(fs.readFileSync(modified, 'utf8'), /operator modification/)
+  assert.equal(commands(readJson(path.join(idempotent.project, '.codex', 'hooks.json')), 'SessionStart').includes('echo keep-me'), true,
+    'unrelated Codex hooks must survive activation install and uninstall')
+
+  const nestedFixture = fixture('nested')
+  const nested = path.join(nestedFixture.project, 'packages', 'app')
+  fs.mkdirSync(nested, { recursive: true })
+  const nestedInstall = installAt(nestedFixture, nested, '--install-activation')
+  assert.equal(nestedInstall.status, 0, nestedInstall.stderr)
+  const nestedManifest = readJson(path.join(nested, '.codex', 'episodic-memory-activation', 'manifest.json'))
+  assert.deepEqual(nestedManifest.project_identity, { slug: 'project', root: nestedFixture.project },
+    'nested registration must read the canonical repository episode store')
+  assert.equal(fs.existsSync(path.join(nestedFixture.project, '.codex', 'episodic-memory-activation')), false,
+    'registration must remain at the literal nested target')
+}
+
+testInstallAndUninstall()
+testSessionStartOutput()
+testFailurePaths()
+console.log('test-codex-activation-install: 3 passed')

--- a/tests/test-plugin-registry.mjs
+++ b/tests/test-plugin-registry.mjs
@@ -444,6 +444,16 @@ function buildLiveProject() {
     "plugins/claude-code-activation/hooks/activation-tool.sh",
     "plugins/claude-code-activation/hooks/activation-sessionstart.sh",
     "plugins/claude-code-activation/hooks/activation-hook-run.mjs",
+    // RFC-009 Codex activation entry and its checksum-governed runtime closure.
+    "plugins/codex-activation/manifest.json",
+    "plugins/codex-activation/runbooks/activation.md",
+    "plugins/codex-activation/runbooks/activation.quickref.md",
+    "plugins/codex-activation/hooks/activation-prompt.sh",
+    "plugins/codex-activation/hooks/activation-tool.sh",
+    "plugins/codex-activation/hooks/activation-sessionstart.sh",
+    "plugins/codex-activation/hooks/activation-hook-run.mjs",
+    "plugins/codex-activation/hooks/activation-match.mjs",
+    "plugins/codex-activation/hooks/json-instance-validate.mjs",
     // A-io-schema reads the manifest's io_schema off disk.
     "schemas/runtime/activation-io.schema.json",
     "scripts/scaffold-plugin/templates/common-rows.md",


### PR DESCRIPTION
## What changed

- add a project-local Codex advisory activation adapter for `SessionStart`, `UserPromptSubmit`, and `PreToolUse`
- make `--tool codex --install-activation` merge definitions into `.codex/hooks.json`
- add checksum-aware, idempotent uninstall that preserves modified files and local episodes
- document Codex hook trust and add installer/runtime/registry CI coverage

## Why

The installer accepted `--tool codex --install-activation` but activation dispatch was gated to Claude Code, so it exited successfully without installing Codex hooks. Recall activation is advisory and independent of enforcement.

## Validation

- `node tests/test-codex-activation-install.mjs`
- `node tests/test-plugin-registry.mjs` (204 pass, 1 environment skip)
- `node tests/test-codex-adapter-conformance.mjs` (67/67)
- `node --test tests/test-install-codex-skill.mjs`
- `node tests/test-install-codex-enforcement.mjs` (45/45)
- `node tests/test-activation-manifest.mjs` (35/35)
- `node scripts/validate-schemas.mjs --project . --json`
- `node tests/test-install-manifest.mjs` (57/57)
- `node tests/test-uninstall-activation.mjs` (26/26)

The Codex second-opinion provider was attempted through `scripts/second-opinion.mjs` but hung without producing a reply; the alternate Gemini provider was unavailable because its CLI is not installed.
