### PR TITLE
RFC-009 P4 PR-A: R6 telemetry writer, #505 render migration, R9b clerk report mode (S1-S3)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -336,6 +336,9 @@ jobs:
       - name: Run activation-match core conformance suite (#504)
         run: node tests/test-activation-match.mjs
 
+      - name: Run RFC-009 P4-S1 telemetry suite (#505 / REQ-22)
+        run: node tests/test-rfc-009-p4-telemetry.mjs
+
       - name: Run uninstall-activation round-trip suite (#504)
         run: node tests/test-uninstall-activation.mjs
 

--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -339,6 +339,9 @@ jobs:
       - name: Run RFC-009 P4-S1 telemetry suite (#505 / REQ-22)
         run: node tests/test-rfc-009-p4-telemetry.mjs
 
+      - name: Run RFC-009 P4-S3 clerk report suite (REQ-1,2,3,4,5,13,21,23)
+        run: node tests/test-rfc-009-p4-report.mjs
+
       - name: Run uninstall-activation round-trip suite (#504)
         run: node tests/test-uninstall-activation.mjs
 

--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -1,0 +1,937 @@
+<!--
+PLAN STATUS: DRAFT (2026-07-12). Round-1 plan review DONE (2 lenses: negative-scenario-planner +
+design/contract, both HOLD, both CONFIRMED F-STRIP; §19). Findings F1-F6 + P3s folded (apply write
+path = Narrow + direct-write, user-locked). A.7 S2-S7 authoring + round-2 review PENDING.
+Not yet approved. Do NOT implement until A.7 authored, round-2 clear, and human-approved.
+-->
+
+# RFC-009-P4 — Consolidation clerk (R9b/c/d) + activation telemetry & conversion (R6) Plan
+
+## §1 Status
+
+`Planning only.` Do not implement until this plan, the plan review, and the adversarial
+review are accepted (Rule 18). Current stage: **draft**.
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-009-lesson-activation` (status: accepted) |
+| Parent requirements | R9b, R9c, R9d, R6 (telemetry-log + conversion half) |
+| Workplan episode | `20260712-051007-workplan-v180-rfc-009-p3-done-merged-766-59e5` (v180) |
+| Target branch | `feature/rfc-009-p4` |
+| Executor altitude (§0.1) | **low** — implemented by a fresh-context session / builder seats; full Appendix A is the build path |
+
+**Phase-scope note (ground-truthed against the RFC phase table).** R9 and R6 are split
+across phases; P4 owns only the sub-parts below. Already shipped, OUT of P4:
+- **R9a** write-time trigger-collision report — shipped P1 (`RFC-009-lesson-activation.md:173`, `:368`).
+- **R6 last_accessed disposition + `em-prune` protection set** — shipped P0 / PR #454 (`:348`, `:367`, `:490`).
+- **`em-search --history` many-to-one walk** over `consolidates`/`superseded_by` — **already shipped**
+  (`scripts/em-search.mjs:285-339`: inverted-supersedes + `superseded_by` edge + `consolidates`
+  successor + visited-Set cycle guard). The RFC calls this a hard prerequisite (`:296`); it is
+  satisfied. This plan re-runs it as a **regression** gate only, it builds nothing here. (This
+  corrects two scout maps that reported the walk as unbuilt.)
+- **R5 needs-enforcement consumer** of R6 conversion — downstream (P5), not P4.
+
+## §2 Episode Search Summary
+
+```bash
+node scripts/em-search.mjs --tag workplan --category decision --scope all --limit 1 --full --no-score --no-track
+node scripts/em-search.mjs --history 20260711-002514-hold-rfc-009-phase-3-design-audit-6-bloc-423d --full --no-track
+```
+
+Key active memories constraining this plan:
+
+- `20260712-051007-…-59e5` (workplan v180): P4 queue item = "R9 clerk + R6 telemetry/conversion +
+  #486/#505/#456/#457 + D3/D4 re-file. Follows docs/PLAN_TEMPLATE.md; multi-agent playbook (scout-first)."
+- `20260711-002514-…-423d` (P3 negative-scenario-planner audit, HOLD 6 blockers): the crash-order,
+  cwd-binding, and token-envelope finding classes that P4 must not repeat — folded into §4/§7 as `(NSP …)`.
+- P3 lessons (from v180): derive the full truth table for classification predicates up front; local verify
+  must include `test-plugin-registry` when editing plugin support files; editing plugin hook support files
+  requires a manifest-checksum refresh; deploy scans registry AND disk AND marketplace clone.
+
+Every recalled file/line was re-verified against current source during scouting (§9 anchors are live).
+
+## §3 Objective
+
+Deliver the RFC-009 curation clerk and its measurement loop so the lesson corpus can be
+consolidated and its activation surface measured, without adding any enforcement or a second store:
+
+1. **R9b** — an assisted, **lexical**, audited consolidation clerk in `em-consolidate.mjs`: a
+   default read-only **report** (JSON clusters with per-cluster proposed action + the signals that
+   grouped them) and a human-confirmed **apply** that runs under `em-lock`, writes in a crash-safe
+   order, and records every apply as a `record_type: clerk-run` episode.
+2. **R9c** — enrichment: the clerk proposes activation-field backfill (`triggers`, `applies_to_*`,
+   `activity`) per existing lesson, applied only through per-item-confirmed `em-revise`.
+3. **R9d** — a shipped, versioned clerk system prompt (`scripts/em-consolidate/prompts/clerk.md`)
+   whose load-bearing clauses a conformance test asserts.
+4. **R6** — an append-only, size-bounded `activation-log.jsonl` telemetry writer in the event-plane
+   activation hook, and a clerk-computed **conversion metric** (injected-then-accessed within a 4h
+   window, per lesson and per imperative/plain band) recorded in the run-record, consuming telemetry
+   by atomic rotate-and-consume.
+
+Provable by: the R6 + R9 acceptance groups (`RFC-009-lesson-activation.md:436-441`, `:460-471`)
+passing as automated tests, plus the clerk-prompt conformance gauntlet.
+
+## §4 Requirements (Ground Truth)
+
+Every row maps to ≥1 test and cites its parent R-number. Test names are the P4 suite cases.
+
+| ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes / edge cases |
+|---|---|---|---|---|---|
+| REQ-1 | Clerk **report mode** is the default and writes nothing: store is byte-identical before/after a report run. | R9b (`:178`,`:185`) | `report::byteIdenticalStore`, `manual: node -e "crypto.createHash" index.jsonl pre/post` | MUST | The existing body-token `--apply` path is a DIFFERENT capability (§8 D-A); report mode is a new clerk surface. Manual hash uses a Node `crypto` one-liner, not `shasum` (F8: not cross-platform — absent on Windows `cmd`, non-universal on Linux). |
+| REQ-2 | Report clusters use **lexical signals only**: shared trigger phrases (R2 index), tag-set Jaccard ≥0.5 with high-df tags dropped (df ≥ max(3, ⌈10% active lessons⌉), dropped tags listed), summary-token Jaccard ≥0.4 same-category (tokens `[a-z0-9-]+` len>2, no shingling, confirmatory only), supersession-adjacency. No body/embedding similarity. | R9b (`:177`, T1/T2/T3) | `report::signalTagJaccard`, `report::signalHighDfDrop`, `report::signalSummaryOverlap`, `report::signalSharedTrigger`, `report::noBodyEmbedding` | MUST | Semantic/body-token clustering stays RFC-001 (`:175`); it is NOT R9b. |
+| REQ-3 | Each report cluster carries: members (ids+summaries), the **signals** that grouped it, and a **proposed action** ∈ {`merge`, `dedupe`, `keep-distinct`}. | R9b (`:178`) | `report::clusterShapeContract`, `report::proposedActionEnum` | MUST | `dedupe` vs `merge` contract defined in §8 D-B / §12. |
+| REQ-4 | Report emission **drains stdout before exit** at every clerk emit site; a >64KB report is not truncated when piped (closes #486, and does not ship a new instance of it). | R9b (#486) | `report::largeReportNotTruncated` (5000-id fixture piped) | MUST | Reuse the em-search drain helper pattern (`em-search.mjs:112`). |
+| REQ-5 | Report id/cluster envelope is **token-bounded**: an oversized cluster set is capped with a `+N more` sentinel and never emits an unbounded id list (P3 F3 class). | R9b (NSP F3 `:69`) | `report::envelopeCapPlusNMore` | MUST | Mirror P3's 500-token / `+N more` cap. |
+| REQ-6 | Clerk **apply** merges only on explicit per-cluster human confirmation; no confirmation ⇒ no write. | R9b (`:179`,`:329`) | `apply::noConfirmNoWrite`, `apply::perClusterConfirm` | MUST | Fully-automatic consolidation is REJECTED (`:329`). |
+| REQ-7 | Apply holds **`em-lock`** across the WHOLE multi-episode write **including the index rewrite**, serializing it against any OTHER **lock-aware** caller (a second clerk apply, bp1/em-routines). It does NOT serialize against a plain lock-oblivious `em-store`/`em-revise`/`em-rebuild-index` append — those acquire no lock (runtime-proven, §7.1); that residual is **DEFER-C**. | R9b (`:179` apply-vs-apply, `:468`, §7 F-7.1) | `apply::underEmLock`, `apply::applyVsApplySerialized` | MUST | RFC `:179` requires apply-not-interleave-**with-apply**; the stronger "no concurrent `em-store` row is ever lost" is unachievable while `em-store` is lock-oblivious (§7.1, both round-1 lenses CONFIRMED) → narrowed here + DEFER-C. Telemetry appends need NO lock (`:297`). |
+| REQ-8 | Apply **write order** is normative: (1) store consolidated lesson FIRST, (2) mark members superseded, (3) run-record LAST. A crash after (1) leaves a benign duplicate; a crash during (2) is detected at next clerk start; members are never superseded before their successor exists on disk. | R9b (`:180`, §7 F-7.1) | `apply::writeOrderStoreFirst`, `apply::crashAfterStoreBenign`, `apply::crashDuringSupersedeDetected`, `apply::cutoverIsStampedField` | MUST | Crash detection predicate = "member `superseded_by` a digest absent from ANY run-record's written-ids AND the digest carries the **stamped `clerk_cutover` frontmatter field**" — NOT a date comparison (NSP F6: a bare date is clock-fragile / backfill-fragile). The clerk STAMPS `clerk_cutover: <marker>` on every digest + run-record it writes; legacy digests lack the field → clean, clock-independent discriminator. Crash tests kill between the real steps + include a legacy-digest (no-field) no-false-reoffer fixture. |
+| REQ-9 | A confirmed **merge** field contract, built by the clerk directly (it MUST NOT call the existing field-blind digest writer, §7 F-STRIP): `triggers`=union(dedup), `applies_to_*`=union, `priority`=max of members' **DEFINED stored** values (missing stays missing — never default to 0; band re-derived at R2, not merged), `evidence`=union(dedup; band re-derived, not read from the merged count), `review_by`=latest-or-unset, `tags`=confirmed curated set; the consolidated episode carries `consolidates:[member ids]`; each member gets `status: superseded` + `superseded_by:<id>`. **Write mechanism (F2, direct-write):** the digest and the member-supersession field flip are **direct frontmatter+index writes by the clerk** through the shared inline validator (§12 `clerkWrite`), NOT via `em-store`/`em-revise` — `em-store` exposes no `--consolidates`/`--status`, and `em-revise --original` creates a NEW single-valued `supersedes` episode (`em-revise.mjs:236/379/407`), which is the WRONG edge for a many-to-one `superseded_by:<digest>` flip (round-1 design lens, CONFIRMED). `supersedes`/`em-revise` chains untouched (`em-revise` is used ONLY for R9c enrichment, REQ-14). | R9b (`:179`,`:182`, §7 F-STRIP) | `apply::mergeFieldContract` (incl. missing-priority + old-writer-goes-RED negatives), `apply::consolidatesReachable` (`em-search --tag`), `apply::supersedeIsIndexFlipNotRevise` | MUST | Conservative direction: a merge never loses activation surface. Runtime-proven the old writer strips these fields. |
+| REQ-10 | Apply **target-store binding**: `em-consolidate` and EVERY spawned subprocess (`em-store`/`em-revise`/`em-lock`) run with `cwd` set to the target project root; on-disk location asserted incl. **linked-worktree**. | R9b (`:181`, NSP B-cwd) | `apply::cwdBindingSubprocs`, `apply::linkedWorktreeLocation` | MUST | P3 B-cwd1/2 finding class. |
+| REQ-11 | Every **apply** invocation (merge, dedupe, enrich) writes exactly **one run-record** episode: `category: workflow.lifecycle`, typed scalar `record_type: clerk-run` (NOT a tag), carrying mode, timestamp, source-index fingerprint, proposals emitted, per-item outcomes, exact ids written/superseded, earned-band entrants since prior run, and the cumulative rejected-proposal set. Report mode writes no run-record. **Write mechanism (F2):** because `em-store` carries no `--record_type` flag (round-1, CONFIRMED — unknown flags silently no-op), the run-record is written by the same direct `clerkWrite` path (§12) that runs `validateCategory` inline so `workflow.lifecycle` is still validated; it is NOT a category-validation bypass. | R9b (`:184`,`:185`,`:470`) | `apply::oneRunRecordPerApply`, `apply::reportNoRunRecord`, `runrecord::typedRecordTypeScalar`, `runrecord::categoryValidatedOnDirectWrite` | MUST | Protection for the latest run record already exists (`lib/protection.mjs:214-227`). |
+| REQ-12 | A rejected cluster is **not re-proposed** against an unchanged store (re-proposal suppression reads the latest run-record's cumulative rejected set). | R9b (`:184`,`:470`) | `apply::rejectedNotReproposed` | MUST | Only the latest run-record per store is load-bearing. |
+| REQ-13 | **`dedupe`** apply supersedes near-identical members into a designated canonical **existing** member (no new digest episode); **`merge`** creates a new consolidated lesson; **`keep-distinct`** writes nothing. | R9b (`:178` under-spec, §8 D-B) | `apply::dedupeIntoCanonical`, `apply::mergeCreatesDigest`, `apply::keepDistinctNoWrite` | MUST | Resolves the spec gap between `:178` and `:179`. |
+| REQ-14 | **R9c enrichment**: clerk proposes `triggers` (lexical from summary+tag lexemes), `applies_to_*` (from the episode's own project+tool provenance ONLY), `activity` classes; applied backfill writes via `em-revise` on per-item confirmation; enrichment apply also emits a run-record under `em-lock`. | R9c (`:187`, §8 D-C) | `enrich::lexicalCandidates`, `enrich::scopeFromProvenanceOnly`, `enrich::appliesViaRevise`, `enrich::runRecordUnderLock` | MUST | Never widen scope beyond provenance (NSP T8). |
+| REQ-15 | **R9d clerk prompt** ships at `scripts/em-consolidate/prompts/clerk.md` as versioned data and carries every normative clause (`:191-205`): three-verb mandate/never-enforce, propose-only/no-write-tools, cite-or-discard, no-fabricated-evidence, keep-distinct bias, never-widen-scope, respect-recorded-judgment, report-JSON-only, no-questions/mark-deferred, surface escalation-audit + demotion-review + R10 drift. | R9d (`:189-207`) | `prompt::fileExists`, `prompt::loadBearingClauses`, `prompt::sampleReportSchemaValid` | MUST | Conformance gauntlet (`:207`). |
+| REQ-16 | **R6 telemetry writer**: the event-plane activation hook appends ONE line per injection event to `<project>/.episodic-memory/activation-log.jsonl` (schema §12): O_APPEND, fire-and-forget; a failed write is a stderr note and never a hook failure (stdout+exit unchanged). | R6 (`:147`,`:437`) | `telemetry::oneLinePerInjection`, `telemetry::writeFailureNonFatal` | MUST | Event plane's only two legal writes (`:43`); this is one of them. |
+| REQ-17 | **R6 bound ownership**: at the 1 MiB bound the **hook DROPS** the new line + stderr note (never truncates/rewrites — dropping preserves append-only). | R6 (`:147`,`:281`,`:439`,T8) | `telemetry::dropAtBoundStderr`, `telemetry::neverTruncates` | MUST | Truncation would break append-only. |
+| REQ-18 | **R6 compaction**: the clerk consumes telemetry by **atomic rotate-and-consume** (rename→read→compute), but retains **still-open-window** injections — a line whose injection `ts` is within `(now - window)` is carried forward (re-written to the fresh log or held as a pending-attribution record) rather than dropped, so a later in-window access is not lost (NSP F5); fully-closed-window lines are consumed; torn/unparseable lines are skipped and the skip count recorded in the run-record. | R6 (`:147`,`:148`,`:438`, §8 D-D) | `conversion::rotateConsumeAtomic`, `conversion::appendDuringRotateNotLost`, `conversion::tornLineSkippedCounted`, `conversion::openWindowCarriedForward` | MUST | Whole-file rotate, not per-line prune (§8 D-D reconciles `:147` vs `:148`); the open-window carry-forward prevents the systematic undercount from truncating windows still in flight. |
+| REQ-19 | **R6 conversion metric**: clerk computes per-lesson and per-band (imperative vs plain) conversion as a **binary lower bound** — injection of id X at time T is *converted* iff X's `last_accessed` (read from X's **source store**, per the telemetry line's `source_scope`, F3/F4) falls in `(T, T+window]` (default 4h, flag-tunable). No per-access "delta" is computed: the index carries only scalar `last_accessed` + cumulative `access_count` (`em-search.mjs:197-198`), so a delta is not reconstructable (round-1 both lenses, CONFIRMED); the telemetry line also snapshots `access_count` at injection (§12 D-E) so multi-injection windows are separable. Records numbers in the run-record; prunes fully-closed-window telemetry (REQ-18). | R6 (`:148`,`:438`,T6, §8 D-F) | `conversion::perBandFromFixture` ("3 injected, 1 accessed → 1/3", driving REAL `em-search --read`), `conversion::windowBoundary` (+1h counts, +5h not), `conversion::crossStoreSourceScope` | MUST | Multi-injection + cross-store attribution rule in §8 D-F; `perBandFromFixture` drives real accesses, never a typed index delta (§14 no-aspirational). |
+| REQ-20 | **Conversion is a labeled directional lower bound**: `--no-track` / `--include-superseded` / direct-file reads bypass tracking; a lesson whose `source_scope` store is unreadable at clerk time counts as **unconverted** (lower bound, never inflated); the run-record states the metric is a lower bound and names the residual undercounts (multi-access collapse to one `last_accessed`; open-window carry-forward per REQ-18; cross-store attribution depends on `source_scope`, D4). Imperative-band low conversion is the only signal that feeds the (downstream P5) needs-enforcement judgment. | R6 (`:148`,`:149`, P5) | `conversion::lowerBoundLabeled` | SHOULD | Honesty per P5. |
+| REQ-21 | A lesson with N consecutive zero-conversion runs surfaces in the report as a reword/demote/suppress candidate. | R6 (`:143`,`:440`) | `report::zeroConversionCandidate` | SHOULD | Conversion feeds pruning through the clerk, not the score. |
+| REQ-22 | **#505**: RFC-009 R3 imperative render names the tracked, bounded `em-search --read <id>` (not `--history`) so the conversion denominator is honest. | R6/R3 (#505, `:148`) | `render::usesReadNotHistory`, `manual: grep the render site` | MUST | Prerequisite for a meaningful denominator. |
+| REQ-23 | **Cadence advisory**: on-demand plus a one-line advisory (via the R3/R4 adapter, never a gate) when the R2 build sees ≥K=3 entries sharing one phrase or active-lesson count crosses N=200. | R9b (`:183`, T4/T5) | `advisory::kSharedPhrase`, `advisory::nLessonCount` | SHOULD | T4/T5 threshold fixtures pinned in P1; P4 wires the clerk-side advisory surface only. |
+| REQ-24 | **D3/D4 tracking issues filed**: one issue for the R6-telemetry deferral residuals, one for the cross-store band recompute deferral; each carries the 5-field DEFER record. | Rule 18 step 9 | `manual: gh issue view <D3>`, `manual: gh issue view <D4>` | MUST | Neither exists today; net-new (§17). |
+
+**Priority legend:** MUST = first-slice merge blocker; SHOULD = before feature complete (one slice may
+defer with an issue); MAY = blocks no merge.
+
+## §5 Non-Goals
+
+Explicitly out of scope (prevents scope creep):
+
+- **Semantic / embedding / body-token consolidation** — the existing `em-consolidate` body-token
+  Jaccard `--apply` path and `em-embed`/`em-semantic`/`em-graph` stay RFC-001 Phase 4 / RFC-007
+  (`:175`,`:313`). R9b is lexical-only and is a **separate mode** (§8 D-A); this plan does not alter
+  the existing semantic path's behavior.
+- **`em-search --history` walk** — already follows `consolidates`/`superseded_by` (`:285-339`);
+  regression re-run only.
+- **R9a collision report** (P1) and **R6 prune-protection set** (P0) — re-run as regressions, not rebuilt.
+- **R5 needs-enforcement promotion** and the **promotion arc** — P5 / separate RFC (`:149`,`:313`).
+- **T6 charter reconciliation (curation vs learning)** — a DOC edit to `CAPABILITIES.md:40` /
+  `RFC-009:175`, not implementation; routed as a separate RFC/charter edit per the "RFC-prose changes
+  never get plan docs" rule (tracked in §17, decision D-H). This plan keeps the clerk in the existing
+  `curation` family and touches no plugin-type registry.
+- **#456** (em-recall prune advisory) and **#457** (P1b `violated_pattern` migration) — deferred out
+  of P4 (§17); they are not R9 clerk or R6 telemetry.
+- **Agentic clerk implementation** (an LLM aggregator generating richer candidates) — the shipped
+  clerk core is zero-dep lexical; the prompt (R9d) is shipped so an agentic aggregator CAN be added
+  later behind the same per-item-confirm contract, but wiring one is not P4.
+
+## §6 Token Budget (Rule 12)
+
+`wc -l` of the primary targets (measured 2026-07-12):
+
+| File | `wc -l` | Reads (lines × ~5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/em-consolidate.mjs` | 642 | ~3.2k | large (clerk mode + apply) | primary R9b/c vehicle |
+| `scripts/em-search.mjs` | 618 | ~3.1k | small (#505 render if sited here) | render migration + regression |
+| `scripts/em-prune.mjs` | 259 | ~1.3k | small | run-record protection regression |
+| `scripts/em-revise.mjs` | 448 | ~2.2k | none (called as subprocess) | **R9c enrichment ONLY**; merge/dedupe supersession is a direct index-flip, not `em-revise` (F2) |
+| `scripts/em-store.mjs` | — | ~0.3k (read `:59` validator) | **none — NOT modified** | Narrow path: no new write flags on P1-shipped scripts (F1/F3); its category/field validator is EXTRACTED to `scripts/lib/` and shared, not duplicated |
+| `scripts/em-lock.mjs` | 163 | ~0.8k | none (called) | apply lock |
+| `scripts/lib/protection.mjs` | 305 | ~1.5k | none | run-record class already present |
+| `scripts/lib/` (validator + `clerkWrite`) | 0 (new/extract) | ~0.5k | small (extract `validateCategory`/field checks from `em-store.mjs:59`; new `clerkWrite`) | shared by the direct-write path (F2) so a clerk write is validated identically to an `em-store` write |
+| activation hook (plugin) | resolved at A.7 S1 step 1.0 (grep) | ~1k | telemetry writer | event-plane R6 write |
+| `scripts/em-consolidate/prompts/clerk.md` | 0 (new) | — | CREATE | R9d prompt |
+| `tests/test-rfc-009-p4-*.mjs` | 0 (new) | — | CREATE | R6 + R9 groups |
+
+**Baseline (single session):** ~110–140k tokens for the whole bundle → **autocompact risk**.
+**Optimized:** split into **PR-A** (S1–S3: telemetry writer + #505 render + report mode; all
+additive/read-only, no store mutation) and **PR-B** (S4–S7: apply + conversion + enrichment + prompt).
+Matches the RFC's own "2 sessions (report mode, then apply + run-record + conversion)" sizing (`:371`).
+
+## §7 Safety / Security
+
+Dispatched `negative-scenario-planner` on the design before writing this section (per the dispatch
+rule). Audit reply folded below; it is **runtime-proven** against an isolated fixture, not static.
+Each mitigation carries ≥1 negative control (red-then-green, §A.9).
+
+### 7.1 Runtime-proven top findings (must be MUST rows before any apply ships)
+
+- **F-STRIP (top severity, runtime-proven).** The EXISTING `em-consolidate --apply` writes the digest
+  with `triggers`/`applies_to_*`/`evidence`/`priority` **stripped** (observed digest frontmatter keys:
+  `id,date,time,project,category,status,consolidates,tags,summary`) and writes **no run-record**,
+  **unlocked**. If R9b reuses or parallels that field-blind writer, a merged lesson silently drops out
+  of the earned band — a direct violation of `:182` "a merge never loses activation surface." → REQ-9
+  amended: the clerk apply MUST build merged frontmatter per `:182` and MUST NOT call the existing
+  digest writer for lessons. Negative control: `apply::mergeFieldContract` asserts the digest carries
+  the union `triggers`/`applies_to`/`evidence` and `priority`=max-of-stored; a fixture that routes
+  through the OLD writer goes RED.
+- **Unlocked index rewrite (runtime-proven; round-1 both lenses CONFIRMED).** The existing apply's index
+  rewrite runs with no lock; a concurrent `em-store` append between its read and atomic rename is a lost
+  write. Round-1 reproduced this: `em-store` appended a row (5→6) in ~79 ms while an `em-lock` was HELD
+  ~3000 ms — `em-store`/`em-revise`/`em-rebuild-index` are lock-oblivious (`em-store.mjs:347` unlocked
+  `appendFileSync`). So holding `em-lock` in the clerk CANNOT prevent a concurrent plain-`em-store` loss;
+  it only serializes against other **lock-aware** callers. → REQ-7 **narrowed** (user-locked "Narrow +
+  direct-write"): the clerk apply holds `em-lock` across the whole write, guaranteeing **apply-vs-apply**
+  non-interleave (RFC `:179`'s actual requirement). The concurrent-plain-`em-store`-during-apply race is
+  **DEFER-C** (§7.4), bounded by the successor-first write order (a torn index is rebuildable; the residual
+  is a lost `em-store` row appended inside the rewrite window — rare, on-demand clerk). Negative control:
+  `apply::applyVsApplySerialized` runs a second clerk apply against a held lock and asserts it blocks.
+- **Legacy-digest false-positive in crash reconciliation.** Existing digests have `consolidates` but no
+  run-record, so a "no run-record ⇒ crashed apply" reconciliation re-offers every legacy digest. →
+  REQ-8 detection predicate = "a member `superseded_by` a digest whose id is absent from ANY run-record's
+  written-ids AND the digest carries the stamped `clerk_cutover` frontmatter field", not merely "no run
+  record exists" and NOT a date comparison (NSP F6: a bare `date:` comparison is clock-skew / backfill
+  fragile). The clerk STAMPS `clerk_cutover: <CLERK_CUTOVER_MARKER>` on every digest + run-record it writes;
+  legacy digests lack the field, giving a clock-independent discriminator. Negative control:
+  `apply::crashDuringSupersedeDetected` includes a legacy-digest (no `clerk_cutover`) fixture asserting
+  **no** false re-offer; `apply::cutoverIsStampedField` asserts the clerk stamps the field.
+
+### 7.2 Eight-axis matrix
+
+| # | Axis | Applies | Attack (R-cite) | Mitigation | Test (incl. ≥1 negative) |
+|---|---|---|---|---|---|
+| 1 | Splice (cross-actor evidence) | YES | `evidence`=union merge (`:182`) or agentic clerk (`:199`) splices A's violation to authorize B's earned band; conversion credits another session's access in the wall-clock 4h window (T6, no session id) | evidence-union stores links but band is **re-derived at R2**, never read from merged count (`:182`); R9d clause-8(a) surfaces every new band entrant w/ linked violations; conformance asserts the clause | `apply::mergeFieldContract` (band re-derived), `prompt::loadBearingClauses`; `negative:` merge two lessons where only A has evidence → assert digest band re-derives, not inherits |
+| 2 | Forge / Stale | YES | em-lock reclaim is pid-liveness only (`em-lock.mjs:81`) → PID reuse mis-hands lock; stale telemetry line attributed post-rotate; carried rejected-set goes stale vs mutated store | rejected-set keyed on member-id-set + source-index fingerprint (`:185`) so a mutation invalidates suppression; clerk skips out-of-window/unparseable lines + counts | `apply::rejectedNotReproposed`, `conversion::tornLineSkippedCounted`; **pid-reuse → DEFER-A** (pre-existing substrate) |
+| 3 | Orphan (crash/partial) | YES | crash between write-order steps (`:180`): member `superseded_by` a digest but run-record never landed; legacy digests look identical (F-7.1) | successor stored before supersession (REQ-8); reconciliation gated on run-record written-ids + cutover (7.1) | `apply::crashAfterStoreBenign`, `apply::crashDuringSupersedeDetected` (legacy-digest negative) |
+| 4 | Empty / validate-before-write | YES | member with no stored `priority` → `max()` of empty set; store-first (`:180`) before validation leaves half-written digest; drop-at-bound must precede O_APPEND | `priority`=max over **DEFINED** stored values, default **no-priority** (NOT 0); validate the full merged frontmatter BEFORE step-1 store through the **shared inline validator** `clerkWrite` (§12) — it runs the SAME `validateCategory`/field checks `em-store` applies (`em-store.mjs:59`). Direct-write is REQUIRED (F2: `em-store` has no `--consolidates`/`--status`/`--record_type`), so the rule is "never write WITHOUT that validation," not "never direct-write." Telemetry length check precedes append | `apply::failClosedBeforeWrite`, `apply::mergeFieldContract` (missing-priority fixture), `runrecord::categoryValidatedOnDirectWrite`, `telemetry::dropAtBoundStderr` |
+| 5 | Wrong-shape | YES | `consolidates:` is the unquoted-inline-array class (`:57`) — a member id with `,`/`[`/`]`/`"` breaks round-trip; `record_type` must be a scalar the rebuild parser carries, NOT a tag; torn telemetry line is non-JSON | reuse R1 write-time char rejection for `consolidates` (`:57` zero-parser-change); round-trip fixture through `em-rebuild-index`; run-record fixture asserts scalar `record_type` survives rebuild | `runrecord::typedRecordTypeScalar`, `apply::consolidatesReachable`; `negative:` member id with comma → rejected |
+| 6 | Wrong-semantic (target-store + merge) | YES (top) | **F-STRIP** (7.1); spawned-subprocess cwd binding (`:181`, P3 B-cwd) lands digest in wrong store if cwd≠target root | REQ-9 field rules + REQ-10 subprocess cwd=target root; linked-worktree fixture asserts on-disk location under TARGET store | `apply::mergeFieldContract`, `apply::cwdBindingSubprocs`, `apply::linkedWorktreeLocation` |
+| 7 | Race / TOCTOU | YES (P3 DEFER now due) | unlocked index rewrite loses concurrent `em-store` row (7.1); rotate-and-consume vs concurrent O_APPEND; concurrent apply vs apply | em-lock serializes **apply-vs-apply** incl. the index rewrite (REQ-7); the concurrent plain-`em-store`-row-loss is **DEFER-C** (`em-store` lock-oblivious, §7.1); rotate = rename-first then read so appends after rename land in a fresh log + open-window carry-forward (REQ-18) | `apply::applyVsApplySerialized` (negative: 2nd apply blocks on held lock), `conversion::appendDuringRotateNotLost` |
+| 8 | Boundary / resource-exhaustion | YES | 1 MiB bound off-by-one; single line >1 MiB never fits; 5000-id envelope; N=200/K=3 edges; window exactly 4h | bound check `currentSize + lineBytes > MAX` (line-atomic, never partial); oversized single line drops + stderr; window half-open `[inject, inject+4h)`; report caps id list + notes count | `telemetry::dropAtBoundStderr`, `telemetry::neverTruncates`, `report::envelopeCapPlusNMore`, `conversion::windowBoundary` |
+
+### 7.3 `activation-log.jsonl` data-artifact contract gaps (#22 — folded into §12)
+
+The RFC names fields but ships no schema/validator/version. P4 closes this: the line schema (§12) gains a
+`v` (line-format version) field; the clerk **validates-or-skips** (unknown `v` or unparseable → skip +
+count in run-record); the hook never validates (must not block). Conformance fixtures: drop-at-bound,
+torn-line skip-count, rotate-during-append (all in §14).
+
+### 7.4 DEFER rows (5-field)
+
+- **DEFER-A — em-lock PID-reuse under pid-liveness reclaim** (`em-lock.mjs:81`). (1) Repro needs pid-wrap;
+  not reproduced E2E. (2) Spec: `:180` delegates to "em-lock's existing stale-holder contract" — NOT
+  tightened by P4; pre-existing substrate. (3) History: no prior em-lock pid-reuse finding. (4) Same-class:
+  shared by em-prune/em-move — a substrate-wide fix, out of P4 scope. (5) Residual: two applies interleave →
+  double supersession, bounded to a benign duplicate by the write-order, not knowledge loss. **File as a
+  standalone substrate issue; do not gate P4.**
+- **DEFER-B — symlinked target project root** (axis 6 sub-case). (1) Not probed (no symlink fixture built).
+  (2) Spec `:181` covers cwd + linked-worktree; symlink is an unstated sibling. (3) History: P3 audit —
+  "symlink matrix NOT required; no new path-authority predicate"; R9b reuses `resolveLocalDir`, adds none.
+  (4) Same-class: `resolveLocalDir` realpath behavior shared by all em-*; uniform + pre-tested. (5) Residual:
+  low; add a symlinked-root assertion to the REQ-10 fixture for completeness, not a blocker.
+
+- **DEFER-C — concurrent lock-oblivious `em-store`/`em-revise`/`em-rebuild-index` append during a clerk apply**
+  (F1, round-1 both lenses CONFIRMED). (1) Repro: `em-store` appended a row (5→6) in ~79 ms while `em-lock`
+  was HELD ~3000 ms — reproduced E2E round-1. (2) Spec: RFC `:179` requires only apply-**not-interleave-with-apply**;
+  the plan's earlier "no concurrent `em-store` row is ever lost" over-escalated it. em-lock is advisory and only
+  lock-aware callers cooperate. (3) History: no prior finding; surfaced this round. (4) Same-class: the fix
+  (make `em-store`/`em-revise`/`em-rebuild-index` lock-aware) is a substrate-wide change to P1-shipped scripts —
+  its own slice/RFC, out of P4's "Narrow" scope (user-locked). (5) Residual: an `em-store` append landing inside
+  the clerk's read→rename index-rewrite window is lost; bounded by the successor-first write order (the digest
+  already exists on disk; a torn index is rebuildable via `em-rebuild-index`), rare on an on-demand clerk, and
+  never silent corruption of a superseded chain. **File as a standalone substrate issue; do not gate P4.**
+
+**Path-authority note:** R9b adds NO new path-authority predicate (reuses `resolveLocalDir`), so the
+8-axis symlink matrix is not required here (consistent with the P3 audit verdict). REQ-10's cwd/worktree
+fixture is the coverage.
+
+## §8 Design
+
+### 8.1 Key design decisions (resolved; each closes a spec gap or a scout-surfaced fork)
+
+- **D-A — Clerk is a NEW mode, not a rewrite of the existing apply.** `em-consolidate.mjs` already
+  has a body-token-Jaccard `--apply` (`:504-580`, digests + `consolidates`/`superseded_by`, tags-union
+  only, no lock, no run-record). That path stays as the RFC-001 semantic capability. R9b adds a
+  **clerk** surface behind explicit flags: `--clerk` (report, default) and `--clerk --apply`
+  (confirmed). The clerk uses the RFC lexical signals (REQ-2), the proposed-action taxonomy (REQ-3),
+  em-lock (REQ-7), the normative write order (REQ-8), merge field rules (REQ-9), and run-records
+  (REQ-11). Existing `--fold-superseded` and body-token `--apply` behavior is unchanged (regression-guarded).
+- **D-B / D-C / D-D / D-F** — resolve the four RFC under-specs (dedupe contract, enrichment
+  run-record, telemetry consume mechanism, multi-injection attribution). See §12 contracts.
+- **D-E — telemetry line schema** pinned in §12 (both the hook writer and the clerk reader import
+  the same field names from a shared constant, §A.5).
+- **D-G — clerk prompt path** = `scripts/em-consolidate/prompts/clerk.md` (canonical, `:189`,`:371`).
+- **D-H — T6 curation/learning charter conflict**: keep the clerk in the `curation` family
+  (`CAPABILITIES.md:40` is authoritative); the RFC's "learning strategy's first implementation" line
+  (`:175`) is corrected by a SEPARATE doc edit (§17), not by this implementation.
+
+### 8.2 Key invariants
+
+- **No second store (P1):** `activation-log.jsonl` is transient telemetry the clerk consumes and
+  deletes; the only durable output is run-record **episodes** (P7). It is never read as a knowledge layer.
+- **Two-plane (P6/P12):** the telemetry WRITE is the event-plane hook's job (per-project opt-in,
+  fire-and-forget); ALL computation (conversion, clustering) is aggregation-plane, on-demand, never
+  per-event, never on a timer. `em-consolidate` (substrate) registers no hooks.
+- **Propose-only clerk (CAPABILITIES boundary + RFC-008 R1):** the clerk AGGREGATE/ENRICH/MANAGE only;
+  it never enforces/gates/blocks/decides; every apply is human-confirmed and revision-chained/reversible.
+- **Reversibility (F5; P7 + Curation invariant):** a confirmed merge/dedupe supersedes members **in place**
+  (flips `status: superseded` + `superseded_by:<digest>`); it is NOT an archival move, so the undo path is
+  the **P7 revision chain**, not `em-restore` (which undoes archival curation ops). Superseded members
+  remain on disk and are recoverable/re-activatable by reverting the field flip; the digest is itself
+  superseded to un-merge. The plan states this divergence from the Curation `em-restore` leg explicitly
+  (`CAPABILITIES.md:75-76`) rather than shipping an un-merge command; the report-mode default (REQ-1),
+  per-cluster confirm (REQ-6), and per-project cwd (REQ-10) satisfy the dry-run / consent / scoping legs.
+  A §18 reversibility test asserts a superseded member survives on disk and is re-activatable.
+- **Fail direction:** the apply write path fails **closed** (a validation/lock failure aborts before any
+  store mutation); telemetry fails **open** (loss-OK by contract — drop at bound, skip torn lines).
+- **Cross-platform:** `os.tmpdir()`/`path`; atomic writes via temp+`rename` (already the repo idiom,
+  `em-consolidate.mjs:556-558`); no GNU-only flags; rotate uses `fs.renameSync` (atomic same-dir).
+- **Atomicity:** apply writes obey the REQ-8 order; telemetry rotate is a single atomic `rename` so a
+  concurrent O_APPEND lands in a fresh file.
+
+### 8.3 Resolution / flow
+
+```text
+EVENT PLANE (per injection, hook):  compose preamble → append 1 line to activation-log.jsonl
+                                     (O_APPEND, fire-and-forget; at 1 MiB → drop + stderr)
+
+AGGREGATION PLANE (on-demand, clerk):
+  report:  load index → lexical signals (trigger/tag-Jaccard/summary-overlap/supersession-adj)
+           → clusters → proposed action per cluster → drain-safe JSON report   [store byte-identical]
+  apply (per confirmed cluster, under em-lock; F2 = clerk DIRECT-writes via clerkWrite w/ inline validation):
+     merge:   (1) clerkWrite digest (consolidates:[…], union fields, clerk_cutover)
+              (2) clerkWrite index-flip each member → status:superseded + superseded_by:<digest>
+              (3) clerkWrite run-record        [NONE routed through em-store/em-revise]
+     dedupe:  (1) —                            (2) clerkWrite index-flip members → superseded_by:<canonical>
+              (3) clerkWrite run-record
+     enrich:  (1) —                            (2) em-revise backfill fields (R9c: a genuine revision)
+              (3) clerkWrite run-record
+  conversion (under em-lock, part of a clerk run):
+           rotate activation-log.jsonl → read → per-band binary lower-bound vs source-store last_accessed
+           → carry open-window lines forward → run-record → consume closed lines
+```
+
+## §9 Existing Hook Points
+
+**Verify line numbers at build time (they drift).** Confirmed live 2026-07-12.
+
+| File | Line(s) | What it does today | Impact of this change |
+|---|---|---|---|
+| `scripts/em-consolidate.mjs` | 411-422 | loads candidate rows, excludes superseded/digests/pinned | clerk mode adds a parallel lexical candidate loader |
+| `scripts/em-consolidate.mjs` | 504-522 | `clusterReport` emits members + similarity avg | clerk report adds signals + proposed action (new fn, not this one) |
+| `scripts/em-consolidate.mjs` | 524-531 | report/apply branch + `>5 cluster` confirm | clerk branch is separate; leaves this path intact |
+| `scripts/em-consolidate.mjs` | 547-559 | `updateInverted` temp+rename index writer | reused by clerk merge writes |
+| `scripts/lib/categories.mjs` | 63-72 | `validateCategory` (already an exported lib fn) | `clerkWrite` **imports it directly** — NO extraction (round-2 scout: `em-store.mjs:59` is a `flagAll` doc-comment, the "extract em-store:59 validator" step is stale). `em-store.mjs` behavior unchanged |
+| `scripts/lib/activation.mjs` | 37-67, 120-129 | `illegalValueChar`/`illegalScalarChar`/`serializeInlineArray` (already exported) | `clerkWrite` imports these; mirrors the `em-store.mjs:139-167` orchestration (validate→format error→abort) inline (F2, fail-closed) |
+| `scripts/em-lock.mjs` | 67-104, 124-132 | `tryAcquire`/`release` are top-level, NON-exported (CLI-only) | **DELTA-2 (user-approved):** extract to `scripts/lib/lock.mjs` (S4.1); `em-lock.mjs` re-imports (behavior-preserving); clerk holds the lock in-process across the 3 `clerkWrite` calls |
+| `scripts/em-revise.mjs` | 200-207, 236, 379, 407 | inherits activation fields; `--original` writes single-valued `supersedes` (:379/:407) + flips original `status` (:236, no `superseded_by`) | R9c enrichment (S6) uses it AS-IS via subprocess; merge/dedupe does NOT (single-valued edge, no `superseded_by`/`consolidates:[]` fan-in — F2) |
+| `scripts/em-search.mjs` | 285-339 | `--history` walk (supersedes+superseded_by+consolidates) | regression only |
+| `scripts/em-search.mjs` | 112 | stdout drain-before-exit helper | pattern reused for #486/REQ-4 |
+| `scripts/lib/protection.mjs` | 214-227 | reserves latest run-record per store; **reads `r.record_type` from the INDEX ROW** (`:220`) | run-records rely on it — so `record_type` MUST survive rebuild (round-2 N2) |
+| `scripts/em-rebuild-index.mjs` | 185-213 | index-row key **whitelist** (present-only spread, NO unknown-key catch-all); **OMITS `record_type` + `clerk_cutover`** | **round-2 N2 (P1, user-approved fold): ADD `record_type` + `clerk_cutover` to the whitelist (S4)** — else after any rebuild the clerk-run reservation (protection `:220`) + crash discriminator break (REQ-11/12/8) |
+| activation event-plane hook | §A.0 to fill | composes injection preamble | ADD the telemetry append (R6 writer) |
+
+## §10 Slice Ladder
+
+One slice = one concern = one PR-shaped unit. **PR-A = S1–S3** (additive, no store mutation);
+**PR-B = S4–S7** (mutating apply + measurement).
+
+| Slice | Objective | Primary files | Key deliverables | Tests | Hard stops |
+|---|---|---|---|---|---|
+| `P4-S1` | R6 telemetry writer + line schema | activation hook, `scripts/lib/activation-log.mjs` (new shared const/writer) | append-1-line, drop-at-bound, non-fatal, schema | REQ-16,17 | no clerk/conversion; no read side |
+| `P4-S2` | #505 render migration `--history`→`--read` | render site (§A.0), fixtures | tracked bounded denominator | REQ-22 | no conversion compute |
+| `P4-S3` | R9b clerk **report** mode (lexical, drain-safe) | `em-consolidate.mjs` | signals, proposed action, report JSON, #486 fix, envelope cap | REQ-1,2,3,4,5,21,23 | writes NOTHING to the store |
+| `P4-S4` | R9b clerk **apply** (merge/dedupe) + run-records | `em-consolidate.mjs`, calls `em-store`/`em-revise`/`em-lock` | confirm, em-lock, write-order, field rules, run-record, re-propose suppression | REQ-6,7,8,9,10,11,12,13 | no enrichment; no conversion |
+| `P4-S5` | R6 conversion metric + rotate-and-consume | `em-consolidate.mjs` (reads S1 log) | per-band conversion, rotate-consume, torn-line skip, lower-bound label | REQ-18,19,20 | depends on S1 + S4 run-record |
+| `P4-S6` | R9c enrichment backfill | `em-consolidate.mjs`, calls `em-revise` | lexical candidates, provenance-only scope, per-item confirm, run-record | REQ-14 | no scope widening |
+| `P4-S7` | R9d clerk prompt + conformance | `scripts/em-consolidate/prompts/clerk.md` (new), test | shipped prompt data + gauntlet | REQ-15 | prompt is DATA, not code |
+
+### 10.1 Dependency graph
+
+```text
+S1 (telemetry writer) ─────────────┐
+S2 (#505 render) ──────────────────┼──> S5 (conversion)
+S3 (report) ── S4 (apply) ─────────┘         │
+                 └── S6 (enrichment) ─────────┤ (all apply modes share run-record + lock plumbing from S4)
+                 └── S7 (prompt) [⟂ parallel, data-only]
+```
+
+Hard deps: S5 needs S1 (log) + S4 (run-record). S4 needs S3 (report clusters are apply's input).
+S6 needs S4 (run-record/lock plumbing). S2 and S7 are parallel-safe (disjoint files).
+
+## §11 Cut Order
+
+If scope/context grows, cut in this order (each cut still leaves a shippable, reviewed slice):
+
+1. **S6 (R9c enrichment)** — SHOULD-heavy; file as a follow-up. Least coupled.
+2. **S7 (R9d prompt)** — ship as data-only micro-PR later; core clerk works without an agentic aggregator.
+3. **REQ-23 cadence advisory** — the clerk-side surface; the thresholds already pin in P1.
+4. **REQ-21 zero-conversion candidate surfacing** — needs S5; defer with S5 if S5 slips.
+
+Do **not** cut:
+- REQ-8 write-order + REQ-7 em-lock (a torn apply corrupts the corpus).
+- REQ-17 drop-at-bound (truncation breaks append-only).
+- REQ-6 per-cluster confirmation (auto-merge destroys knowledge — REJECTED by RFC).
+- REQ-16 non-fatal telemetry (a hook failure would break injection).
+
+## §12 Contracts
+
+### `clerkReport(index, opts) → ReportJSON`
+
+**Input:** the active index rows + R2 trigger index; opts `{minTagJaccard=0.5, minSummaryJaccard=0.4, kShared=3, nLessons=200, window=4h}`.
+**Output:** `{ status:'ok', mode:'clerk-report', clusters: Cluster[], candidates?: EnrichCandidate[], truncated?: '+N more' }`; store byte-identical.
+
+**`Cluster` state table (proposed-action resolution — exhaustive):**
+
+| State | Condition | `proposed_action` | Side effects |
+|---|---|---|---|
+| A. near-identical | summary-Jaccard ≥0.4 AND tag-Jaccard ≥0.5 AND same category | `dedupe` | none (report) |
+| B. related, distinct value | shared trigger/tag signals but summaries diverge | `merge` | none |
+| C. weak/only-confirmatory | only summary-overlap signal, no trigger/tag corroboration | `keep-distinct` | none |
+| D. supersession-adjacent | multiple actives revising one root | `merge` | none |
+| E. high-df-only overlap | overlap solely on dropped high-df tags | `keep-distinct` | none (dropped tags listed) |
+
+### `clerkApply(cluster, action, confirmed) → ApplyResult`
+
+**Input:** one cluster + confirmed action; refuses without `confirmed===true` (REQ-6).
+**Output:** `{ status, mode:'clerk-apply', action, written:[ids], superseded:[ids], run_record:id }`.
+
+**State table (exhaustive):**
+
+| State | Condition | Output | Side effects (ORDERED, REQ-8) |
+|---|---|---|---|
+| merge | action=merge, confirmed | consolidated id + N superseded | under em-lock: (1) `clerkWrite` digest `consolidates:[…]` + union field rules + `clerk_cutover` → (2) `clerkWrite` index-flip each member → `status:superseded` + `superseded_by:<digest>` → (3) `clerkWrite` run-record. NO `em-store`/`em-revise` (F2). |
+| dedupe | action=dedupe, confirmed | canonical id + N-1 superseded | under em-lock: (1) — → (2) `clerkWrite` index-flip non-canonical → `superseded_by:<canonical>` → (3) `clerkWrite` run-record |
+| keep-distinct | action=keep-distinct | no-op | none (records rejection into next run-record's cumulative set) |
+| unconfirmed | confirmed≠true | `{status:'error'}` | **none** (fail-closed) |
+| lock-held | em-lock unavailable | `{status:'error', locked:true}` | none |
+| crash after (1) | process dies post-store | benign duplicate | next start detects orphan digest w/ no supersessions |
+
+**Error codes:** `unconfirmed` (fail closed), `lock-held` (fail closed), `torn-index` (abort, no write).
+
+### `clerkWrite(kind, frontmatter, dataDir) → WriteResult` (F2 — the direct-write path)
+
+The clerk's single write primitive; it exists because `em-store` exposes no `--consolidates`/`--status`/
+`--record_type` and `em-revise --original` writes the wrong (single-valued `supersedes`) edge (round-1
+CONFIRMED). `kind ∈ {digest, index-flip, run-record}`.
+- **Validation first (fail-closed):** imports and runs the SAME validators `em-store` uses —
+  `validateCategory` (`scripts/lib/categories.mjs:63`, already exported) + `illegalValueChar`/
+  `illegalScalarChar` (`scripts/lib/activation.mjs:37-67`) — mirroring the `em-store.mjs:139-167`
+  orchestration inline, so a direct write is never an unvalidated write. (Round-2 scout: NO `em-store`
+  extraction step is needed; the earlier `em-store.mjs:59`/`:57` anchors were a `flagAll` doc-comment.)
+  Rejects the unquoted-inline-array class in `consolidates` via the imported `illegalValueChar` +
+  `serializeInlineArray` backstop (`activation.mjs:120-129`).
+- **Lock (REQ-7, DELTA-2 user-approved; round-2 N3):** the whole apply runs in-process under ONE **blocking**
+  `acquire(lockFile, timeoutS)` from `scripts/lib/lock.mjs` (extracted from `em-lock.mjs`, S4.1). `acquire`
+  polls-then-**returns** `{ok:false, code:'lock-timeout'}` on contention (it does NOT `process.exit` — that is
+  the CLI-only behavior) so REQ-7's `lock-held → {status:'error', locked:true}` is a normal return, not a
+  process kill mid-apply. The 3 ordered writes below execute while it is held, `release`d in `finally`.
+  (`tryAcquire` is the non-blocking single-shot variant; the clerk uses the blocking `acquire`.)
+- **digest:** writes a new episode file + appends its index row (union frontmatter per REQ-9 + `clerk_cutover`)
+  and calls `updateInverted('tags.json'/'category-index.json', …)` for the inverted-object indexes (mirrors the
+  existing apply at `em-consolidate.mjs:609-610`).
+- **index-flip (round-2 N1):** re-reads `index.jsonl` under the held lock and flips the member row's
+  `status:superseded` + `superseded_by:<id>` **via the JSONL read-map-rewrite pattern at
+  `em-consolidate.mjs:622-637`** (`readFileSync` → `split('\n')` → `map`(`JSON.parse` each line → flip the
+  matching id's `status`/`superseded_by`) → `join('\n')` → temp+`rename`). This is **NOT** `updateInverted`
+  (`:547-559` `JSON.parse`s a single OBJECT file and would corrupt the line-delimited `index.jsonl` — round-2
+  behavior-simulated), and NOT `em-revise` (which would spawn a spurious revision episode with the wrong edge).
+- **run-record:** writes the `workflow.lifecycle` + scalar `record_type:clerk-run` + `clerk_cutover` episode
+  through the same validator.
+**Output:** `{ status, written?:id, flipped?:[ids] }`; any validation/lock failure aborts before mutation.
+
+### `activationLogLine` schema (D-E; shared const `scripts/lib/activation-log.mjs`)
+
+```
+{ "v":1, "ts":"2026-07-12T05:44:37Z", "project":"<name>", "event":"inject",
+  "surface":"session_start"|"per_prompt"|"dispatcher",
+  "entries":[ { "id":"<episode-id>", "effective_priority":<int>, "rendered":"imperative"|"plain",
+               "source_scope":"local"|"global", "access_count_at_inject":<int> } ] }
+```
+
+`source_scope` + `access_count_at_inject` (F4) are captured at injection: `source_scope` names which store
+(project-local vs global) owns the injected id so the clerk reads that store's `last_accessed` (a global
+lesson injected into a project bumps the GLOBAL index, invisible to a project-scoped read — round-1
+CONFIRMED); `access_count_at_inject` is the baseline snapshot that separates multiple injections of one id
+(the index keeps only a scalar `last_accessed`, so a per-access delta is otherwise unreconstructable).
+
+Loss-OK telemetry (not memory). `v` is the line-format version (NSP #22): the clerk **validates-or-skips**
+— an unknown `v` or an unparseable line is skipped and counted in the run-record; the hook never validates
+(must not block). Writer (hook) and reader (clerk) import the field names + `LOG_FORMAT_VERSION` from the
+same module (`scripts/lib/activation-log.mjs`, §A.5).
+
+### `computeConversion(telemetryLines, indexDeltas, window) → ConversionReport` (D-D, D-F)
+
+**Consume mechanism (D-D + F5 open-window carry-forward):** whole-file **rotate-and-consume** —
+`rename(log, log.processing)` (atomic), read+parse `log.processing`. Lines whose injection `ts` is within
+`(now - window)` still have an OPEN attribution window; they are **carried forward** (re-appended to the
+fresh log, or held as pending-attribution records in the run-record) so a later in-window access is not
+lost (NSP F5). Fully-closed-window lines are consumed. "Prunes consumed telemetry lines"
+(`RFC-009-lesson-activation.md:148` — the R6 spec prose, NOT an `em-consolidate.mjs` line; DELTA-3) is
+satisfied by consuming the closed-window subset; there is no per-line prune of open windows.
+**Attribution (D-F, binary lower bound — F3/F4):** for each injection event of id X at time T, read X's
+`last_accessed` from the store named by the line's `source_scope`; X is *converted* iff
+`last_accessed ∈ (T, T+window]`. No `access_count` delta is computed (the index carries only a scalar
+`last_accessed` + cumulative count — round-1 CONFIRMED); `access_count_at_inject` disambiguates repeated
+injections of X. Multiple injections of X are separate denominator events; the single latest access can
+convert at most the injections whose window it falls in (multi-access collapse → undercount, labeled). A
+lesson whose `source_scope` store is unreadable counts UNCONVERTED (never inflated). Numerator/denominator
+reported per lesson and per band.
+**Output:** `{ per_band:{imperative:{n,d}, plain:{n,d}}, per_lesson:[…], torn_skipped:<int>, carried_forward:<int>, lower_bound:true }`
+→ recorded in the run-record.
+
+## §13 Edge Cases
+
+| # | Scenario | Expected behavior | Test |
+|---|---|---|---|
+| EC1 | empty store / no clusters | report `clusters:[]`, exit 0, no write | `report::emptyStore` |
+| EC2 | linked-worktree / symlinked project root on apply | subprocs run with cwd=target root; digest lands in target store | `apply::linkedWorktreeLocation` |
+| EC3 | concurrent SECOND clerk apply during apply | em-lock serializes apply-vs-apply; 2nd blocks (concurrent lock-oblivious `em-store` is DEFER-C, F1) | `apply::applyVsApplySerialized` |
+| EC4 | crash between write-order steps | successor exists before supersession; orphan digest benign; detected next start | `apply::crashDuringSupersedeDetected` |
+| EC5 | empty/whitespace summary in dedupe compare | reject the pair — empty compares equal to itself; degrade to `keep-distinct` | `report::emptyIdentityRejected` |
+| EC6 | validate-then-write: unconfirmed/lock-held/torn-index | validation/lock fires BEFORE any store mutation | `apply::failClosedBeforeWrite` |
+| EC7 | cyclic `consolidates`/`superseded_by` fixture | walk/compute terminates (visited-Set) | `history::cycleTerminates` (regression) |
+| EC8 | O_APPEND torn line in telemetry | clerk skips unparseable line, counts skip in run-record | `conversion::tornLineSkippedCounted` |
+| EC9 | append during rotate | append lands in fresh log, not lost | `conversion::appendDuringRotateNotLost` |
+| EC10 | telemetry at 1 MiB bound | hook drops new line + stderr; file never truncated | `telemetry::dropAtBoundStderr` |
+| EC11 | 5000-id report piped | drain-safe, `+N more` cap, not truncated | `report::largeReportNotTruncated` |
+
+## §14 Test Case Catalog
+
+Every name below appears in §4 (bijective for MUST rows). Runner: `node tests/test-rfc-009-p4-<group>.mjs`.
+Install/hook behavior (S1 telemetry writer) is proven by a **mock-project E2E** (isolated `HOME` + real
+`install.mjs` + drive the real deployed hook), never mental-trace.
+
+```text
+Group R6-telemetry (S1):   telemetry::oneLinePerInjection, telemetry::writeFailureNonFatal,
+                           telemetry::dropAtBoundStderr, telemetry::neverTruncates
+Group render (S2):         render::usesReadNotHistory
+Group R9b-report (S3):     report::byteIdenticalStore, report::signalTagJaccard, report::signalHighDfDrop,
+                           report::signalSummaryOverlap, report::signalSharedTrigger, report::noBodyEmbedding,
+                           report::clusterShapeContract, report::proposedActionEnum,
+                           report::largeReportNotTruncated, report::envelopeCapPlusNMore,
+                           report::emptyStore, report::emptyIdentityRejected
+                           (report::zeroConversionCandidate → moved to S5, round-2 N5: needs S5 conversion history)
+Group R9b-apply (S4):      apply::noConfirmNoWrite, apply::perClusterConfirm, apply::underEmLock,
+                           apply::applyVsApplySerialized, apply::writeOrderStoreFirst,
+                           apply::crashAfterStoreBenign, apply::crashDuringSupersedeDetected,
+                           apply::cutoverIsStampedField, apply::mergeFieldContract,
+                           apply::supersedeIsIndexFlipNotRevise, apply::indexFlipYieldsValidJsonl (round-2 N1),
+                           apply::consolidatesReachable, apply::cwdBindingSubprocs, apply::linkedWorktreeLocation,
+                           apply::oneRunRecordPerApply, apply::reportNoRunRecord,
+                           runrecord::typedRecordTypeScalar, runrecord::categoryValidatedOnDirectWrite,
+                           runrecord::survivesRebuild (round-2 N2),
+                           apply::rejectedNotReproposed, apply::mergeReversibleViaRevive,
+                           apply::dedupeIntoCanonical, apply::mergeCreatesDigest,
+                           apply::keepDistinctNoWrite, apply::failClosedBeforeWrite
+Group R6-conversion (S5):  conversion::rotateConsumeAtomic, conversion::appendDuringRotateNotLost,
+                           conversion::openWindowCarriedForward, conversion::tornLineSkippedCounted,
+                           conversion::perBandFromFixture, conversion::windowBoundary,
+                           report::zeroConversionCandidate (relocated from S3, round-2 N5),
+                           conversion::crossStoreSourceScope, conversion::lowerBoundLabeled
+Group R9c-enrich (S6):     enrich::lexicalCandidates, enrich::scopeFromProvenanceOnly,
+                           enrich::appliesViaRevise, enrich::runRecordUnderLock
+Group R9d-prompt (S7):     prompt::fileExists, prompt::loadBearingClauses, prompt::sampleReportSchemaValid
+Group regression:          history::cycleTerminates, advisory::kSharedPhrase, advisory::nLessonCount
+```
+
+Total: ~55 tests across 7 groups (round-1 fold added `applyVsApplySerialized`, `cutoverIsStampedField`,
+`supersedeIsIndexFlipNotRevise`, `categoryValidatedOnDirectWrite`, `mergeReversibleViaRevive`,
+`openWindowCarriedForward`, `crossStoreSourceScope`; round-2 added `indexFlipYieldsValidJsonl` (N1) +
+`survivesRebuild` (N2)). No aspirational output: every assertion inspects real captured
+stdout/exit/written-file, never a typed constant.
+
+## §15 Verification Ledger (verify by artifact)
+
+Fill the right column with the ACTUAL output at build time (order rule: artifact first, claim second).
+
+| Claim | Command (strong layer) | Observed artifact |
+|---|---|---|
+| Report writes nothing | `node -e "const c=require('crypto'),f=require('fs');console.log(c.createHash('sha256').update(f.readFileSync('index.jsonl')).digest('hex'))"` pre/post `--clerk` (F8: not `shasum`) | `<identical hash>` |
+| All P4 tests pass | `node tests/test-rfc-009-p4-<group>.mjs` (each) | `<N>/<N> pass` |
+| Telemetry writer E2E | mock-project: real hook injects → tail `activation-log.jsonl` | `<1 line, schema-valid>` |
+| Drop-at-bound (negative) | fixture log at 1 MiB, drive hook | `<line dropped + stderr note; size unchanged>` |
+| Apply under lock (negative) | hold `em-lock`, run `--clerk --apply` | `<status:error locked; store unchanged>` |
+| Crash mid-apply | kill between step (1) and (2) | `<digest present, no supersessions, benign>` |
+| Deploys clean (hook touched) | `node tools/deploy-audit.mjs` (unfiltered) | `<clean>` |
+| Conversion lower bound | `conversion::perBandFromFixture` output | `1/3, lower_bound:true` |
+| Merged | `gh pr view <n> --json state,mergeCommit` | `<commit>` |
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| New clerk mode entangles with existing body-token apply | Med | Med | D-A separate flags + regression-guard the existing `--apply`/`--fold-superseded` paths |
+| Crash mid-apply corrupts corpus | High | Low | REQ-8 write-order (successor first) + em-lock + crash tests (EC4) |
+| Telemetry append race / torn line | Med | Med | O_APPEND small-write + rotate-and-consume + torn-line skip+count (EC8/EC9) |
+| Telemetry write breaks injection hook | High | Low | fire-and-forget, non-fatal, drop-at-bound (REQ-16/17) |
+| cwd binding wrong under worktree | Med | Low | REQ-10 subprocess cwd assertion + linked-worktree fixture (EC2) |
+| Conversion denominator dishonest | Med | Med | #505 `--read` migration + explicit lower-bound label (REQ-20/22) |
+| Scope creep from bundled issues | Med | Med | §5 defers #456/#457; T6 doc edit routed separately (D-H) |
+
+## §17 Open Decisions
+
+- **D-H — T6 charter reconciliation (curation vs learning)** → NOT in this plan's code; a separate
+  doc edit to `CAPABILITIES.md:40` / `RFC-009:175`. Rationale: RFC-prose changes never get plan docs;
+  the clerk stays `curation` (compaction/folding of existing knowledge, not derivation). **Tracked in
+  a new issue (file at S7).** 5-field DEFER: (1) no runtime failure — doc-only; (2) spec: the RFC line
+  self-contradicts the charter, must reconcile but not in impl; (3) history: surfaced by governing-artifact
+  scout T6; (4) same-class: only this one line; (5) residual: leaving it is a doc inconsistency, zero
+  runtime risk.
+- **#456** (em-recall prune advisory overcounts) → deferred; advisory-text-only, self-correcting at next
+  `em-prune --dry-run`; not R9/R6. 5 fields carried in the existing issue.
+- **#457** (P1b `violated_pattern` migration) → deferred (F6 5-field): (1) run-scenario — no P4 runtime
+  failure; #457 is a P1b data-migration concern, not exercised by any R9/R6 path. (2) spec-check — RFC-009
+  assigns it to R10/T6 (P1b), not R9b/c/d or R6; the spec does NOT require it in P4. (3) history-check —
+  self-filed under P1b; no reviewer has tied it to the clerk. (4) same-class — the only member is the
+  `violated_pattern` field migration itself; no clerk sibling depends on it. (5) residual — if left, P1b
+  migration lands later; zero effect on clerk correctness or telemetry (they never read `violated_pattern`).
+- **REQ-23 cadence advisory** → clerk-side surface only; if the R3/R4 adapter emission needs a change it
+  is filed separately (thresholds already pin in P1).
+
+**D3/D4 tracking issues (REQ-24, file at S1/S5, 5 fields each):**
+- **D3 (R6 telemetry deferral residuals):** (1) run-scenario — until S1+S5 land, no conversion signal is
+  produced; the report still works, so no failure, only a missing metric. (2) spec-check — R6 (`:148`) wants
+  the metric; the RFC permits the phased "report first, then conversion" build (`:371`), so deferring the
+  signal (not the writer) is spec-legal. (3) history-check — the phased split is the RFC's own sizing; no
+  reviewer has demanded conversion in S1. (4) same-class — the sibling residuals (multi-access collapse,
+  open-window carry-forward, cross-store attribution) all live under this one metric; enumerate them in the
+  issue. (5) residual — no needs-enforcement follow-signal (P5) until S5 ships; bounded, additive later.
+  File fresh (none exists).
+- **D4 (cross-store band recompute + cross-store conversion attribution):** (1) run-scenario — a global
+  lesson injected into a project has its `last_accessed` bumped in the GLOBAL store; a project-scoped clerk
+  reading only the project index under-attributes it (round-1 CONFIRMED reasoning). The `source_scope` field
+  (§12) mitigates conversion; the earned-band recompute at the event plane remains deferred. (2) spec-check —
+  the RFC does not require event-plane cross-store band recompute in P4; read-time recompute is acceptable.
+  (3) history-check — surfaced by both round-1 lenses (NSP F3 / design F4). (4) same-class — every cross-store
+  read-vs-event-plane recompute case; enumerate in the issue. (5) residual — a cross-store earned band is
+  recomputed at read, not at the event plane; conversion for a global lesson depends on `source_scope` being
+  correct, else it counts unconverted (lower bound, never inflated). File fresh.
+
+## §18 Done Criteria
+
+- [ ] All MUST rows (REQ-1..19, 22, 24) pass automated tests (§14).
+- [ ] Report mode leaves the store byte-identical (shasum artifact in §15).
+- [ ] Apply crash tests (EC4) and lock test (EC6) green; fail-closed proven with a negative control.
+- [ ] Merge/dedupe reversibility proven (F5): a superseded member survives on disk and is re-activatable via the P7 revision chain (`apply::mergeReversibleViaRevive`).
+- [ ] Apply-vs-apply serialization proven (F1): a 2nd clerk apply blocks on the held `em-lock` (`apply::applyVsApplySerialized`); the concurrent lock-oblivious `em-store` residual is filed as DEFER-C, not gated.
+- [ ] Telemetry writer proven by mock-project E2E; drop-at-bound negative control red-then-green.
+- [ ] `node tools/deploy-audit.mjs` clean (hook touched).
+- [ ] Clerk prompt conformance gauntlet green (REQ-15).
+- [ ] Every deferred finding has an issue/comment/violation artifact (D-H, #456, #457, D3, D4) — Rule 18 step 9.
+- [ ] PR-A (S1–S3) and PR-B (S4–S7) each reviewed per §19.
+
+## §19 Review Consensus (Rule 18)
+
+Adversarial review via parallel diverse lenses (CLI review seat = pi + GLM-5.2 per the 2026-07-12 user
+preference; codex is derailed inside this repo by the SessionStart hook — launch it from outside the repo
+if a codex lens is wanted):
+
+```bash
+# round-2 (post-fold) CLI lens:
+PI_DRIVE_EXT=safe ~/.claude/pi-drive.sh   # model GLM-5.2, socket drive-pi-glm-8b61, brief = this plan
+```
+
+| Pass | Reviewer | Provider/Model | Blocker count | Verdict | Reply |
+|---|---|---|---|---|---|
+| 1 | negative-scenario-planner (runtime matrix + F-STRIP repro) | Claude subagent | 1×P1 (F1) + 2×P2 (F2,F3) + 3×P3 | **HOLD** | inline (2026-07-12) |
+| 1 | design/contract lens | Claude subagent | 2×P1 (F1,F2) + 4×P2 + 2×P3 | **HOLD** | inline (2026-07-12) |
+| 2 | pi + GLM-5.2 (post-A.7-authoring, behavior-simulated) | pi/GLM-5.2 (openrouter) | 2×P1 (N1,N2) + 2×P2 (N3,N4) + 3×P3 (N5,N6,N7) | **HOLD → all folded** | §19.3 (2026-07-12) |
+
+Both round-1 lenses independently CONFIRMED the F-STRIP pivot (fixture-run) and converged on F1/F2 as the
+must-fix pair; verdict fix-then-build, not redesign. Round-2 (GLM-5.2 cross-vendor) found 7 net-new findings
+in classes round-1 never touched (index-flip writer, rebuild-key-whitelist, lock-API-shape); both P1s were
+behavior-simulated by GLM and re-confirmed against source by the orchestrator; ALL folded (§19.3). Not a
+3rd same-class HOLD — the "Narrow" boundary holds; only the patch spelling changed.
+
+### 19.1 Resolved blockers (round-1 fold; user-locked "Narrow + direct-write")
+
+| # | Blocker (cite R-number) | Verdict | Resolution + evidence |
+|---|---|---|---|
+| F1 | REQ-7 `em-lock` cannot stop a concurrent lock-oblivious `em-store` append (R9b `:179`) | narrowed | REQ-7 → apply-vs-apply serialization (RFC `:179`'s actual guarantee); concurrent-plain-store race → DEFER-C (§7.4); test `apply::applyVsApplySerialized` |
+| F2 | apply write path unbuildable via `em-store`/`em-revise` (no `--consolidates`/`--status`/`--record_type`; `em-revise` writes wrong edge) (R9b `:179`,`:182`) | fixed | new `clerkWrite` direct-write path (§12) reusing the already-exported `validateCategory` (`lib/categories.mjs:63`) + char validators (`lib/activation.mjs`) imported directly (DELTA-1: no `em-store` extraction); member supersession = index-flip not `em-revise`; run-record direct-written + category-validated |
+| F3 | §6/§9 omit write-surface work (Rule 12) | fixed | §6 lists `em-store` (unmodified — validators already in `lib/`, imported directly), `em-revise` (R9c only), `clerkWrite`; §9 rows corrected to `lib/categories.mjs`/`lib/activation.mjs`/`lib/lock.mjs` |
+| F4 | conversion not computable from scalar `last_accessed`; cross-store (R6 `:148`) | fixed | binary lower-bound `last_accessed ∈ (T,T+window]` from `source_scope` store + `access_count_at_inject` snapshot (§12); residuals labeled (REQ-20) |
+| F5 | reversibility/undo leg unaddressed vs Curation invariant (P7) | fixed | §8.2 undo = P7 revision chain (not `em-restore`); §18 `apply::mergeReversibleViaRevive` |
+| F6 | #457/D3/D4 lack 5-field DEFER (Rule 18 step 9) | fixed | 5 fields enumerated in §17 |
+| P3 | rotate truncates open windows (NSP F5); clock-fragile cutover (NSP F6); `shasum` (F8) | fixed | open-window carry-forward (REQ-18); stamped `clerk_cutover` field (REQ-8/§A.5); Node `crypto` hash (REQ-1/§15) |
+
+### 19.2 A.7 authoring scout pass (2026-07-12, pre-round-2)
+
+Before authoring the A.7 S2–S7 step tables, 3 parallel read-only scouts (sonnet) mapped the real source
+with runtime probes on isolated fixture stores (behavior-simulation rule). Scouts A and B **independently
+converged** on DELTA-1 and DELTA-2 (high confidence). Resolutions folded into §9/§12/§A.5/A.7:
+
+| Δ | Finding (runtime-confirmed) | Resolution |
+|---|---|---|
+| DELTA-1 | `em-store.mjs:59`/`:57` are `flagAll` doc-comments, NOT validators. `validateCategory` already exported at `lib/categories.mjs:63`; char checks at `lib/activation.mjs:37-67`. The "extract em-store validator" step is stale. | `clerkWrite` imports the libs directly + mirrors the `em-store.mjs:139-167` orchestration inline. No extraction step. §9/§12/§19.1-F2/F3 corrected. |
+| DELTA-2 | `em-lock.mjs` exports nothing — CLI-only wrapper; cannot be imported to hold ONE lock across 3 in-process `clerkWrite` calls + return `ApplyResult` JSON. | **USER DECISION (2026-07-12): extract `tryAcquire`/`release` to `scripts/lib/lock.mjs`** (S4.1); `em-lock.mjs` re-imports (behavior-preserving). Adds `lib/lock.mjs` to §A.5; touches `em-lock.mjs` (one file beyond the original "Narrow" list, additive). |
+| DELTA-3 | `"prunes consumed telemetry lines" (:148)` is `RFC-009-lesson-activation.md:148` (spec prose), not an `em-consolidate.mjs` line (that line is blank). | §12 `computeConversion` citation disambiguated to the RFC path. |
+| DELTA-4 | Render site = `renderLine` `scripts/lib/activation-match.mjs:217` (imperative band still `--history`); byte-identical duplicate at `plugins/codex-activation/hooks/activation-match.mjs:217`; `renderPlaybookLine:204` already `--read`. Probe confirmed `--read` bumps `access_count`/`last_accessed`, `--history` does not (crux of REQ-22). | S2.0 checks `install.mjs` sync; S2 edits both render files (or re-syncs) + flips `tests/test-activation-match.mjs:222`. |
+
+### 19.3 Round-2 findings (GLM-5.2 cross-vendor, 2026-07-12) — ALL folded
+
+7 net-new findings, all in defect classes round-1 never touched (so not a same-class 3rd HOLD). Both P1s
+behavior-simulated by GLM and re-confirmed against source by the orchestrator before folding.
+
+| # | Sev | Finding (source-confirmed) | Resolution (folded) |
+|---|---|---|---|
+| N1 | P1 | §12/S4.3 index-flip named `updateInverted` (`:547-559`, a JSON-OBJECT writer for tags.json/category-index.json) for the `index.jsonl` row flip — would corrupt JSONL (GLM simulated: 3 rows → 1 object). | §12/S4.3 now cite the JSONL read-map-rewrite at `em-consolidate.mjs:622-637`; `updateInverted` kept for tags/category only. New test `apply::indexFlipYieldsValidJsonl` + `--break-index-flip-json` control. |
+| N2 | P1 | `em-rebuild-index.mjs:185-213` is a key-whitelist (no unknown-key spread) that OMITS `record_type`+`clerk_cutover`; `protection.mjs:220` reads `record_type` from the index row → reservation (REQ-11/12) + crash discriminator (REQ-8) break after any rebuild. | **User-approved fold:** S4.5 EDITs the whitelist to add both keys (present-only spread); new `runrecord::survivesRebuild` test + `--break-rebuild-whitelist` control. §9 rows corrected. Adds `em-rebuild-index.mjs` to the touched-file set. |
+| N3 | P2 | §A.5 extracted only non-blocking `tryAcquire`; the clerk needs blocking acquire-with-timeout that RETURNS (not `process.exit`) for REQ-7's `lock-held → {status:error,locked:true}`. | §A.5/S4.1 now extract `acquire(lockFile, timeoutS)` refactored to return `{ok:false,code:'lock-timeout'}`; S4.4 calls blocking `acquire`, not `tryAcquire`. |
+| N4 | P2 | The lock extraction dropped `em-lock.mjs`'s `safeRelease` idempotency + SIGINT/SIGTERM/uncaught handlers (`:135-151`) → CLI signal-handling regression. | S4.2 now explicitly RETAINS `safeRelease` + the 3 handlers in `em-lock.mjs` after the re-import; verify greps `SIGINT` still present. |
+| N5 | P3 | `report::zeroConversionCandidate` (REQ-21) sat in S3's group but needs S5 conversion history (§10.1: S3 has no S5 edge). | Relocated to S5 (§14 + S3.4 + S5.3); S3 report count 13→12, S5 conversion count 8→9. |
+| N6 | P3 | `apply::mergeReversibleViaRevive` named but no step drove a revive mechanism (§8.2 ships no un-merge) → risked a self-fulfilling on-disk-survival assertion. | S4.6 now DRIVES `em-revise --original <member>` to flip the superseded member back to active (the §8.2 P7-revision-chain undo) and asserts re-activation. |
+| N7 | P3 | `apply::rejectedNotReproposed` (REQ-12) + `telemetry::writeFailureNonFatal` had no `--break` red control. | Added `--break-rejected` (S4.4b) + `--break-writefail` (S1.2b); also added `--break-openwindow` for `conversion::openWindowCarriedForward` (S5.2b). |
+
+Review in three layers (per-artifact → cross-file → PR-level). Cap at 2 rounds on the same class;
+a 3rd same-class HOLD means the boundary is wrong — change the design, not the patch spelling.
+
+## §20 Lessons Encoded (traceability — do not re-learn)
+
+| Lesson | One-line rule | Enforced in |
+|---|---|---|
+| verify-strong-claim | E2E drives the real deployed hook; review PR-level | §14, §15, §19 |
+| unfiltered deploy audit | `deploy-audit.mjs`, never `diff\|grep` | §15, §18 |
+| empty-identity diff (`…7c11`) | empty summary compares equal to itself → reject/degrade | §13 EC5 |
+| behavior-simulation | scout claims ground-truthed against runtime (em-search walk corrected) | §1, §9 |
+| canonical-agent dispatch | negative-scenario-planner before self-walking §7 | §7 |
+| bp1 step-9 5-field DEFER | every DEFER carries all 5 fields + an issue | §17, §18 |
+| validate-before-write (P3 F2) | apply fails closed before any store mutation | §12, §13 EC6 |
+| crash-order (P3) | successor stored before members superseded | §12 REQ-8, §13 EC4 |
+| cwd-binding (P3 B-cwd) | spawned subprocs run with cwd=target root; worktree fixture | §12 REQ-10, §13 EC2 |
+| token-envelope (P3 F3) | id list capped `+N more` | §4 REQ-5 |
+| stdout drain-before-exit (#486) | drain stdout before process.exit on large reports | §4 REQ-4 |
+| RFC-prose-no-plan-docs | T6 charter fix routed as a separate doc edit, not this plan | §5, §17 D-H |
+| advisory-lock-honesty (round-1 F1) | never claim an advisory `em-lock` serializes lock-oblivious writers; guarantee only apply-vs-apply, defer the rest | §4 REQ-7, §7.1, §7.4 DEFER-C |
+| direct-write-with-shared-validator (round-1 F2) | when `em-store`/`em-revise` can't express the required fields/edge, direct-write through the EXTRACTED `em-store` validator — not a validation bypass | §4 REQ-9/11, §12 `clerkWrite` |
+
+---
+
+# Appendix A: Mechanical Execution Spec (low-capability executor)
+
+> **A.7 authoring status.** A.0–A.6b, A.8, A.9 (below) are design-stable and complete. Round-1 review is
+> DONE and the design is LOCKED (findings folded §19; apply write path = Narrow + direct-write, user-decided),
+> so the S2–S7 step tables are now authored in the mechanical pass, targeting that locked design (`clerkWrite`
+> direct-write, index-flip supersession, stamped `clerk_cutover`, binary-lower-bound conversion, open-window
+> carry-forward). **A.7 S1 is fully worked below as the depth exemplar.** The fully-authored plan then goes to
+> round-2 (pi + GLM-5.2) before human approval. No slice may be built from an A.7 table that still carries a
+> `PENDING-POST-REVIEW` marker.
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value for this plan |
+|---|---|
+| Language / runtime | Node.js 20+, `.mjs` ESM, zero deps |
+| Runtime check (§A.4) | `node --version` → `v20` or higher |
+| Test-runner shape | `node tests/test-rfc-009-p4-<group>.mjs` |
+| New-function phrasing (§A.6) | `export function fnName(args)` |
+| Portable break-input override | `--break-<x>` argv flag (cross-platform; NOT a `VAR=x` shell prefix — the activation hook and tests must run under Windows `cmd`) |
+| Search tool for verifies | `grep -c` / `grep -n` from repo root |
+| Repo-specific done-commands | `node tools/deploy-audit.mjs` (hook touched); `node tests/test-plugin-registry.mjs` (plugin support files touched); manifest-checksum refresh when a plugin hook support file changes |
+| Event-plane hook file | **fill in A.7 S1 step 1.0 by grepping** the injection composition site (candidate: `plugins/*/hooks/activation-*.mjs`; confirm the exact per-prompt/session-start/dispatcher injection point that composes the preamble) |
+
+Every §A.7 "Exact action" cell contains verbatim `.mjs` code (identifiers, strings, regexes), never pseudocode.
+
+## A.1 Forbidden-phrase lint (run before marking ready)
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/rfc-009-p4.md
+```
+
+Ready iff no match falls inside an §A.5 block or an §A.7 step row. Record the match list + per-match
+disposition beside the lint run. Also do a reading pass (line-`grep` misses wrapped occurrences, lesson `…2f5d`).
+
+## A.2 Executor contract (copy verbatim into the handoff)
+
+1. Do the steps in numeric order. Do not skip, reorder, or batch.
+2. Each step names exactly one file, the exact change, and how to verify it.
+3. Make no design decisions. Ambiguity or a missing verbatim anchor → STOP (§A.3).
+4. Run the verify after each step; on failure fix only that step before proceeding.
+5. Edit exactly ONE file per step. A change spanning code + test is two consecutive steps.
+6. Each verify is a single command — no `;`/`&&`/`||`/pipes/subshells (compound-bash hard-blocked). Limit output with Read/Grep.
+7. One slice = one commit `P4-S<n>-<step>: <title>` + the tool's `Co-Authored-By` trailer.
+8. Do not commit/push/PR until the slice §18 criteria are green AND the human approved.
+9. No aspirational output: every "checking X" line is backed by an assertion performing X.
+
+## A.3 STOP-and-ask protocol
+
+```text
+STOP — step <n.m> blocked.
+Reason: <anchor not found | ambiguous | verify failed after fix>.
+File: <path>
+Expected anchor (verbatim): <text>
+What I found instead: <actual ±3 lines>
+Question: <the single decision the plan owner must make>
+```
+
+## A.4 Pre-flight environment check (step 0 of every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| On the branch | `git branch --show-current` | `feature/rfc-009-p4` |
+| Clean tree | `git status --porcelain` | empty |
+| Tests green at baseline | `<slice test command>` | `<N>/<N> pass` |
+| Runtime | `node --version` | `v20`+ |
+
+## A.5 Shared constants / types (add once, before per-slice steps)
+
+```js
+// scripts/lib/activation-log.mjs (CREATE, S1) — shared by the hook writer AND the clerk reader.
+export const LOG_FORMAT_VERSION = 1
+export const ACTIVATION_LOG_NAME = 'activation-log.jsonl'
+export const ACTIVATION_LOG_MAX_BYTES = 1024 * 1024 // 1 MiB (T8)
+export const RENDERED_FORMS = ['imperative', 'plain']
+export const INJECTION_SURFACES = ['session_start', 'per_prompt', 'dispatcher']
+// Clerk (em-consolidate) constants:
+export const RUN_RECORD_CATEGORY = 'workflow.lifecycle'
+export const RUN_RECORD_TYPE = 'clerk-run'          // scalar frontmatter key, NEVER a tag
+export const CLERK_CUTOVER_MARKER = 'rfc-009-p4'     // the clerk STAMPS `clerk_cutover:<this>` frontmatter on every
+                                                     // digest + run-record it writes; legacy digests LACK the field
+                                                     // → clock-independent crash discriminator (NSP F6, NOT a date compare)
+export const TAG_JACCARD_MIN = 0.5                   // T1
+export const SUMMARY_JACCARD_MIN = 0.4               // T3
+export const HIGH_DF_MIN = (activeCount) => Math.max(3, Math.ceil(0.10 * activeCount)) // T2
+export const CADENCE_K_SHARED = 3                    // T4
+export const CADENCE_N_LESSONS = 200                 // T5
+export const ATTRIBUTION_WINDOW_MS = 4 * 60 * 60 * 1000 // T6, half-open [inject, inject+window)
+export const PROPOSED_ACTIONS = ['merge', 'dedupe', 'keep-distinct']
+```
+
+**Shared modules the clerk imports (add once):**
+- `scripts/lib/lock.mjs` (CREATE, S4.1 — DELTA-2 user-approved; round-2 N3/N4): exports `tryAcquire(lockFile)` (non-blocking single-shot), **`acquire(lockFile, timeoutS)` (blocking poll-to-timeout that RETURNS `{ok:false, code:'lock-timeout', heldBy}` — refactored from `em-lock.mjs:106-122` to NOT `process.exit`)**, and `release(handle)`. Extracted from `em-lock.mjs:67-132`; `em-lock.mjs` re-imports them AND retains its own `safeRelease` idempotency guard + the SIGINT/SIGTERM/uncaughtException handlers (`:135-151`) at the CLI boundary (round-2 N4 — extraction must NOT strip signal handling). Lets the clerk hold ONE lock in-process across the 3 ordered `clerkWrite` calls (via blocking `acquire`) and return `ApplyResult` JSON to its caller.
+- `scripts/lib/categories.mjs:63` (`validateCategory`) + `scripts/lib/activation.mjs:37-67` (`illegalValueChar`/`illegalScalarChar`) + `:120-129` (`serializeInlineArray`): imported directly by `clerkWrite`. **No `em-store` extraction step** — these are already exported libs (round-2 scout correction; the plan's earlier `em-store.mjs:59` anchor was a doc-comment).
+
+## A.6 Anchor format
+
+- **ANCHOR** = a verbatim unique substring present in the file; not unique/not present → STOP. Never a line number.
+- **Literal change** = exact error strings, field names, numeric bounds, regex.
+- Label every step **CREATE** (whole-file Write of a new file), **EDIT** (anchored span change, no reflow), or **APPEND** (add export/block at end).
+
+## A.6b Falsifiable Verify
+
+Every Verify names (a) the observed value it inspects and (b) the expected concrete value, and FAILS on
+a stubbed/broken step. Deny-list: tolerant exit-code checks (`test $? …`/`|| true`), self-fulfilling greps
+of a string the step writes, happy-path-only. A MUST/§7 mitigation with only a skippable smoke is tagged
+`UNGUARDED-IN-CI` + names the manual step. Negative controls use the `--break-<x>` argv override, run as
+their own row immediately before the green run (one command per row).
+
+## A.7 Per-slice step tables
+
+### `P4-S1` — R6 telemetry writer + line schema (REQ-16, REQ-17) — **focused review before build** (event-plane hook, high blast radius)
+
+**Files this slice may touch (one per step):** `scripts/lib/activation-log.mjs` (new), the event-plane
+hook file (from A.0), `tests/test-rfc-009-p4-telemetry.mjs` (new). **Read-only:** `scripts/em-search.mjs:112` (drain pattern).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4. Then `grep -rn "session_start\|per_prompt\|preamble" plugins/*/hooks/activation-*.mjs` to identify the exact injection-composition site; record it as the S1.3 target. If ambiguous, STOP. | every §A.4 row passes; grep names exactly one composition site |
+| 1.1 | `scripts/lib/activation-log.mjs` | CREATE | Whole-file Write: the §A.5 constants block + `export function appendActivationLine(dataDir, line)` that (a) `JSON.stringify`s `{v:LOG_FORMAT_VERSION, ...line}`, (b) computes `Buffer.byteLength(serialized+'\n')`, (c) `statSync` the log (0 if absent), (d) if `size + lineBytes > ACTIVATION_LOG_MAX_BYTES` writes `process.stderr.write('activation-log: size bound reached; dropping line\n')` and RETURNS `{dropped:true}` **without appending**, (e) else `fs.appendFileSync(path, serialized+'\n')` and returns `{dropped:false}`. Wrap the whole body in try/catch → on error `process.stderr.write` + return `{error:true}` (fire-and-forget, never throw). | `node -e "import('./scripts/lib/activation-log.mjs').then(m=>console.log(typeof m.appendActivationLine))"` → `function` |
+| 1.2 | `tests/test-rfc-009-p4-telemetry.mjs` | CREATE | Full verbatim contents. `telemetry::oneLinePerInjection`: append one line to a tmpdir log, read it back, assert the parsed object's `v===1`, `entries[0].id` equals the unique sentinel id passed in. `telemetry::dropAtBoundStderr`: pre-write a log to `ACTIVATION_LOG_MAX_BYTES-10` bytes, capture the return of an append whose bytes exceed the remaining room, assert `{dropped:true}` and the file size is UNCHANGED (statSync before==after). `telemetry::neverTruncates`: same fixture, assert the pre-existing last line still present after the dropped append. `telemetry::writeFailureNonFatal`: call with a non-existent parent dir, assert it returns `{error:true}` and does NOT throw. Register all in `main()`. | `node tests/test-rfc-009-p4-telemetry.mjs` → `4/4 pass` |
+| 1.2b | — | — | Negative controls (one per row): `node tests/test-rfc-009-p4-telemetry.mjs --break-bound` (module ignores the bound) → `telemetry::dropAtBoundStderr` FAILS; **`--break-writefail` (make the writer `throw` instead of catching) → `telemetry::writeFailureNonFatal` FAILS (round-2 N7 — the fire-and-forget guard now has a red control)**. | each exits non-zero |
+| 1.3 | event-plane hook (A.0) | EDIT | ANCHOR the injection-composition line (from 1.0). After the preamble is composed, APPEND-call `appendActivationLine(dataDir, {ts, project, event:'inject', surface, entries})` inside a try/catch that swallows all errors (fire-and-forget). Import from `../lib/activation-log.mjs` (verify relative path). Do NOT change stdout or exit. | `grep -c "appendActivationLine" <hookfile>` → 1 |
+| 1.4 | `tests/test-rfc-009-p4-telemetry.mjs` | EDIT | Add `telemetry::hookE2E` (mock-project): isolated `HOME`, real `install.mjs`, drive the REAL deployed hook with one injection, tail the written `activation-log.jsonl`, assert exactly one schema-valid line with the injected sentinel id. (Install/hook behavior is proven by mock-project E2E, never mental-trace.) | `node tests/test-rfc-009-p4-telemetry.mjs` → `5/5 pass` |
+| 1.5 | — | — | Refresh the plugin manifest checksum (plugin hook support file changed) and run `node tests/test-plugin-registry.mjs`; then `node tools/deploy-audit.mjs`. | registry test green; deploy-audit clean |
+| 1.6 | — | — | Commit `P4-S1: R6 activation telemetry writer` + trailer. | `git log -1 --oneline` shows `P4-S1` |
+
+### `P4-S2` — #505 render migration `--history`→`--read` (REQ-22)
+
+**Files this slice may touch (one per step):** `scripts/lib/activation-match.mjs`, `plugins/codex-activation/hooks/activation-match.mjs` (byte-identical duplicate), `tests/test-activation-match.mjs`. **Read-only:** `scripts/em-search.mjs:59` (the `--read` surface), `install.mjs` (the plugin-copy sync step).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 2.0 | — | — | Pre-flight §A.4. Then determine how the plugin copy is kept in sync: `grep -n "activation-match" install.mjs`. If install.mjs copies `scripts/lib/activation-match.mjs` → the plugin path, step 2.2 is a re-sync + diff; else step 2.2 edits the copy directly. If ambiguous, STOP. | grep names exactly one sync mechanism (copy step) or none |
+| 2.1 | `scripts/lib/activation-match.mjs` | EDIT | ANCHOR `(em-search --history ${id} --full)` inside `renderLine` (the `effective_priority>=8` imperative branch). Literal change: `(em-search --history ${id} --full)` → `(em-search --read ${id})`. Do NOT touch `renderPlaybookLine` (already `--read`, §A-scout :204). | `grep -c "\-\-history" scripts/lib/activation-match.mjs` → `0` (the file's only `--history` was this line; playbook line already `--read`) |
+| 2.2 | `plugins/codex-activation/hooks/activation-match.mjs` | EDIT | Per 2.0: if install.mjs syncs, run the sync + then `diff` the two files; else apply the SAME literal change as 2.1. | `diff scripts/lib/activation-match.mjs plugins/codex-activation/hooks/activation-match.mjs` → exit 0 (byte-identical restored) |
+| 2.3 | `tests/test-activation-match.mjs` | EDIT | ANCHOR the hard-coded expectation `em-search --history id-band8 --full` (~:222). Literal change to `em-search --read id-band8`. Ensure the assertion is `render::usesReadNotHistory` (asserts rendered band-8 line contains `--read` AND not `--history`). | `node tests/test-activation-match.mjs` → all pass |
+| 2.3b | `tests/test-activation-match.mjs` | — | Negative control: `node tests/test-activation-match.mjs --break-render` (harness stubs `renderLine` back to the `--history` form) → `render::usesReadNotHistory` must FAIL. | exit non-zero |
+| 2.4 | — | — | Commit `P4-S2: #505 render --history→--read (REQ-22)` + trailer. | `git log -1 --oneline` shows `P4-S2` |
+
+### `P4-S3` — R9b clerk **report** mode, lexical + drain-safe (REQ-1,2,3,4,5,21,23) — writes NOTHING
+
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-report.mjs` (new). **Read-only:** `scripts/lib/categories.mjs:63` + `scripts/lib/activation.mjs:37-67` (signal helpers reuse the same char classes), `scripts/em-search.mjs:112` (drain-before-exit pattern for #486/REQ-4), `scripts/lib/protection.mjs:214-227`.
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 3.0 | — | — | Pre-flight §A.4. | every row passes |
+| 3.1 | `scripts/em-consolidate.mjs` | EDIT | ANCHOR `const dryRun = argv.includes('--dry-run')` (§9 :92). APPEND on the next line `const clerk = argv.includes('--clerk')`. | `node scripts/em-consolidate.mjs --clerk --scope local` on a fixture → does not error on the flag |
+| 3.2 | `scripts/em-consolidate.mjs` | APPEND | After `function slugify(text) {` (§9 :543-545) add two greenfield helpers: `function clerkSignals(a, b, activeCount)` (tag-Jaccard vs `TAG_JACCARD_MIN`, summary-Jaccard vs `SUMMARY_JACCARD_MIN`, shared-trigger count vs `CADENCE_K_SHARED`, high-df drop via `HIGH_DF_MIN(activeCount)`; NO body embedding — §12 `report::noBodyEmbedding`) and `function clerkResolveAction(signals)` implementing the §12 `Cluster` 5-state table (A dedupe / B merge / C keep-distinct / D merge / E keep-distinct), returning one of `PROPOSED_ACTIONS ∪ {keep-distinct}`. Reject empty/whitespace-summary pairs (EC5) as `keep-distinct`. | `node tests/test-rfc-009-p4-report.mjs` group `report::proposedActionEnum` + `report::emptyIdentityRejected` pass |
+| 3.3 | `scripts/em-consolidate.mjs` | EDIT | Insert the clerk-report mode BEFORE ANCHOR `const rows = loadIndex(DATA_DIR, scope).filter(r =>` (§9 :411): `if (clerk && !apply) { ... process.exit(0) }`. Body: lexical candidate loader (drain-safe per em-search.mjs:112), cluster via signals, build `{status:'ok', mode:'clerk-report', clusters, candidates?, truncated?}` capped with `+N more` envelope; drain stdout before exit. Writes nothing to the store. | `report::byteIdenticalStore`: sha256 of `index.jsonl` pre==post the `--clerk` run (F8, `node -e` hash not `shasum`) |
+| 3.3b | `scripts/em-consolidate.mjs` | — | Negative control: `node scripts/em-consolidate.mjs --clerk --scope local --break-report-write` (inject a stray store write) → `report::byteIdenticalStore` must FAIL. | exit non-zero |
+| 3.4 | `tests/test-rfc-009-p4-report.mjs` | CREATE | Full verbatim contents: the 12 `report::` tests of §14 (byteIdenticalStore, signalTagJaccard, signalHighDfDrop, signalSummaryOverlap, signalSharedTrigger, noBodyEmbedding, clusterShapeContract, proposedActionEnum, largeReportNotTruncated, envelopeCapPlusNMore, emptyStore, emptyIdentityRejected). Each injects a discriminating sentinel and asserts THAT token, never "non-empty". Register in `main()`. (`report::zeroConversionCandidate` moved to S5 — round-2 N5: it needs S5's conversion history, which does not exist until S5.) | `node tests/test-rfc-009-p4-report.mjs` → `12/12 pass` |
+| 3.4b | `tests/test-rfc-009-p4-report.mjs` | — | Negative controls (one command per row): `--break-highdf` → `signalHighDfDrop` FAILS; `--break-drain` → `largeReportNotTruncated` FAILS. | each exits non-zero |
+| 3.5 | — | — | Commit `P4-S3: R9b clerk report mode (REQ-1,2,3,4,5,21,23)` + trailer. | `git log -1 --oneline` shows `P4-S3` |
+
+### `P4-S4` — R9b clerk **apply** (merge/dedupe) + run-records (REQ-6,7,8,9,10,11,12,13) — **focused review before build** (mutating apply, high blast radius)
+
+**Files this slice may touch (one per step):** `scripts/lib/lock.mjs` (new — DELTA-2 lock extraction, user-approved), `scripts/em-lock.mjs` (behavior-preserving EDIT), `scripts/em-consolidate.mjs`, `scripts/em-rebuild-index.mjs` (round-2 N2, user-approved fold — whitelist EDIT), `tests/test-rfc-009-p4-apply.mjs` (new). **Read-only:** `scripts/lib/categories.mjs:63` (`validateCategory`), `scripts/lib/activation.mjs:37-67` (`illegalValueChar`/`illegalScalarChar`), `scripts/em-store.mjs:139-167` (the validation ORCHESTRATION `clerkWrite` mirrors — NOT `:59`, which is stale), the JSONL member-flip pattern at `em-consolidate.mjs:622-637` (index-flip exemplar — NOT `updateInverted`, round-2 N1).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 4.0 | — | — | Pre-flight §A.4 (branch `feature/rfc-009-p4`, clean tree, S1+S3 tests green at baseline, node v20+). | every row passes |
+| 4.1 | `scripts/lib/lock.mjs` | CREATE | Whole-file Write: `export function tryAcquire(lockFile)` (non-blocking single-shot), **`export function acquire(lockFile, timeoutS)` (blocking poll-to-timeout that RETURNS `{ok:false, code:'lock-timeout', heldBy}` — refactored from `em-lock.mjs:106-122` to NOT `process.exit`; round-2 N3)**, and `export function release(handle)`, extracted from `em-lock.mjs:67-132`. Preserve: `O_WRONLY|O_CREAT|O_EXCL` atomic create, pid/iso/ppid payload, 100ms poll to timeout, stale reclaim via `process.kill(pid,0)` ESRCH→unlink→retry, release-only-if-stored-pid-matches. | `node -e "import('./scripts/lib/lock.mjs').then(m=>console.log(typeof m.acquire, typeof m.tryAcquire, typeof m.release))"` → `function function function` |
+| 4.2 | `scripts/em-lock.mjs` | EDIT | ANCHOR the top-level `tryAcquire`/`acquire`/`release` definitions; replace with `import { tryAcquire, acquire, release } from './lib/lock.mjs'`. **RETAIN in `em-lock.mjs` (round-2 N4): the `safeRelease` idempotency guard + the SIGINT/SIGTERM/uncaughtException handlers (`:135-151`) — the extraction must NOT strip signal handling.** The CLI still `process.exit`s on lock-timeout at its own boundary (wrapping the imported `acquire` return). | `node scripts/em-lock.mjs --file /tmp/p4.lock --timeout 2 -- node -e "console.log('locked-body-ran')"` → prints `locked-body-ran`, then `ls /tmp/p4.lock` → not found; a SIGINT to a held wrapper releases the lock (grep `em-lock.mjs` for `SIGINT` → still present); existing em-lock test suite green |
+| 4.3 | `scripts/em-consolidate.mjs` | APPEND | Add `function clerkWrite(kind, frontmatter, dataDir)` per §12: **validation-first, fail-closed** — `import { validateCategory } from './lib/categories.mjs'` + `import { illegalValueChar, illegalScalarChar, serializeInlineArray, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'`; mirror the `em-store.mjs:139-167` orchestration (validate category, scalar fields via `illegalScalarChar`, inline-array items via `illegalValueChar`) and ABORT before any write on failure. Assert `dataDir === DATA_DIR`. `kind∈{digest,index-flip,run-record}`: digest→`writeFileSync` new episode + `appendFileSync` index row (union frontmatter per REQ-9 + `CLERK_CUTOVER_MARKER`) + `updateInverted('tags.json'/'category-index.json',…)` (`:609-610` pattern); **index-flip (round-2 N1)→re-read `index.jsonl` under the held lock and flip the member row via the JSONL read-map-rewrite at `em-consolidate.mjs:622-637` (`readFileSync`→`split('\n')`→`map`(`JSON.parse`→flip `status`/`superseded_by`)→`join`→temp+`rename`) — NOT `updateInverted` (that `JSON.parse`s one OBJECT and corrupts JSONL) and NOT `em-revise`**; run-record→`RUN_RECORD_CATEGORY` + scalar `RUN_RECORD_TYPE` + `clerk_cutover`. | `runrecord::categoryValidatedOnDirectWrite` + `apply::supersedeIsIndexFlipNotRevise` + `apply::indexFlipYieldsValidJsonl` (every `index.jsonl` line still `JSON.parse`s; member row carries `status:superseded`) pass |
+| 4.3b | `scripts/em-consolidate.mjs` | — | Negative controls (one per row): `--break-validate` (skip the validator) → `runrecord::categoryValidatedOnDirectWrite` FAILS; `--break-index-flip-json` (index-flip writes a JSON object like `updateInverted` instead of JSONL) → `apply::indexFlipYieldsValidJsonl` FAILS. | each exits non-zero |
+| 4.4 | `scripts/em-consolidate.mjs` | EDIT | Insert `if (clerk && apply) { ... process.exit }` AFTER the S3 clerk-report block. Refuse unless `confirmed===true` (REQ-6) → `{status:'error'}`, no write. Acquire ONE lock via the **blocking `acquire(lockFile, timeoutS)`** (lib/lock.mjs; N3 — returns `lock-held`, does not exit) held across the 3 ordered `clerkWrite` calls (REQ-8: store/digest → index-flip → run-record); `release` in `finally`. Implement the §12 `clerkApply` state table (merge / dedupe / keep-distinct / unconfirmed→fail-closed / lock-held→`{status:'error',locked:true}`). Exactly ONE run-record per apply; rejected clusters recorded, not re-proposed (REQ-13). | `apply::underEmLock`, `apply::writeOrderStoreFirst`, `apply::oneRunRecordPerApply` pass |
+| 4.4b | `scripts/em-consolidate.mjs` | — | Negative controls (one command per row): `--break-confirm` (apply without `confirmed`) → `apply::noConfirmNoWrite`/`apply::failClosedBeforeWrite` FAIL; `--break-writeorder` (supersede before store) → `apply::writeOrderStoreFirst`/`apply::crashDuringSupersedeDetected` FAIL; `--break-lock` (skip the lock) → `apply::applyVsApplySerialized` FAILS; **`--break-rejected` (re-offer a rejected cluster after a store mutation) → `apply::rejectedNotReproposed` FAILS (round-2 N7)**. | each exits non-zero |
+| 4.5 | `scripts/em-rebuild-index.mjs` | EDIT | **Round-2 N2 (user-approved fold).** ANCHOR the index-row whitelist object (`:185-213`); ADD two present-only spreads mirroring `:206-207`: `...(fm.record_type ? { record_type: fm.record_type } : {})` and `...(fm.clerk_cutover ? { clerk_cutover: fm.clerk_cutover } : {})`. Keep the parity note in LOCKSTEP with em-store/em-revise's index fields. | `runrecord::survivesRebuild`: write a run-record via `clerkWrite`, run `em-rebuild-index`, assert the rebuilt index row still carries `record_type:'clerk-run'` AND `protection.mjs` class-d still reserves it |
+| 4.5b | `scripts/em-rebuild-index.mjs` | — | Negative control: `--break-rebuild-whitelist` (omit `record_type` from the whitelist) → `runrecord::survivesRebuild` FAILS. | exit non-zero |
+| 4.6 | `tests/test-rfc-009-p4-apply.mjs` | CREATE | Full verbatim contents: the §14 `apply::`/`runrecord::` set incl. `applyVsApplySerialized` (spawn a child holding the lock; 2nd apply blocks — EC3), `crashDuringSupersedeDetected` (kill between write (1)/(2); digest present, no supersession — EC4), `linkedWorktreeLocation`/`cwdBindingSubprocs` (EC2), `indexFlipYieldsValidJsonl` (N1), `survivesRebuild` (N2), **`mergeReversibleViaRevive` — DRIVES `em-revise --original <member>` to flip the superseded member back to `active` (the §8.2 P7-revision-chain undo path; round-2 N6) and asserts it re-activates, NOT merely that the file survives on disk**, `mergeCreatesDigest`, `dedupeIntoCanonical`, `keepDistinctNoWrite`, `consolidatesReachable`, `cutoverIsStampedField`, `mergeFieldContract`, `reportNoRunRecord`, `rejectedNotReproposed`. Discriminating sentinel per test. | `node tests/test-rfc-009-p4-apply.mjs` → all pass |
+| 4.7 | — | — | Commit `P4-S4: R9b clerk apply + clerkWrite + lock lib + rebuild round-trip (REQ-6..13, F2)` + trailer. (No plugin hook touched → no registry/deploy-audit step here.) | `git log -1 --oneline` shows `P4-S4` |
+
+### `P4-S5` — R6 conversion metric + rotate-and-consume (REQ-18,19,20) — depends on S1 (log) + S4 (run-record)
+
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-conversion.mjs` (new). **Read-only:** `scripts/lib/activation-log.mjs` (S1 module — reader imports `LOG_FORMAT_VERSION`/`ACTIVATION_LOG_NAME`/`ACTIVATION_LOG_MAX_BYTES`), `docs/rfcs/RFC-009-lesson-activation.md:148` (the "prunes consumed telemetry lines" spec anchor — DELTA-3, NOT an em-consolidate.mjs line).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 5.0 | — | — | Pre-flight §A.4. Assert `scripts/lib/activation-log.mjs` (S1) exists and S4's run-record writer is present. | both present; §A.4 rows pass |
+| 5.1 | `scripts/em-consolidate.mjs` | APPEND | Add `function computeConversion(telemetryLines, indexDeltas, window)` per §12: rotate-and-consume (`rename(log, log.processing)` atomic → parse `log.processing`); OPEN-window lines (`ts ∈ (now-window)`) carried forward (re-appended to fresh log / held as pending in the run-record) so a later in-window access is not lost (NSP F5); closed-window lines consumed. Attribution = binary lower bound: for each injection of id X at T, read `last_accessed` from the store named by the line's `source_scope`; converted iff `last_accessed ∈ (T, T+ATTRIBUTION_WINDOW_MS]` (half-open); unreadable source_scope store → UNCONVERTED (never inflated). Skip torn/unknown-`v` lines, count them. Emit per-band + per-lesson `{n,d}`, `torn_skipped`, `carried_forward`, `lower_bound:true`. | `conversion::perBandFromFixture` → `1/3, lower_bound:true`; `conversion::lowerBoundLabeled` present |
+| 5.2 | `scripts/em-consolidate.mjs` | EDIT | Wire conversion into the clerk run (compute during `--clerk` and fold the `ConversionReport` into the run-record). | `conversion::rotateConsumeAtomic` + `conversion::crossStoreSourceScope` pass |
+| 5.2b | `scripts/em-consolidate.mjs` | — | Negative controls (one per row): `--break-rotate` (non-atomic rotate) → `conversion::appendDuringRotateNotLost` FAILS; `--break-window` (inclusive lower bound) → `conversion::windowBoundary` FAILS; `--break-sourcescope` (ignore `source_scope`) → `conversion::crossStoreSourceScope` FAILS; `--break-tornskip` (throw on torn line) → `conversion::tornLineSkippedCounted` FAILS; **`--break-openwindow` (drop open-window lines instead of carrying forward) → `conversion::openWindowCarriedForward` FAILS (round-2, the F5/REQ-18 mitigation now has a red control)**. | each exits non-zero |
+| 5.3 | `tests/test-rfc-009-p4-conversion.mjs` | CREATE | Full verbatim contents: the 8 `conversion::` tests (rotateConsumeAtomic, appendDuringRotateNotLost, openWindowCarriedForward, tornLineSkippedCounted, perBandFromFixture, windowBoundary, crossStoreSourceScope, lowerBoundLabeled) **plus `report::zeroConversionCandidate` (REQ-21) relocated here from S3 (round-2 N5) — seeds N consecutive zero-conversion run-records, then asserts the report surfaces the candidate**. EC8/EC9 covered. Sentinel-based. | `node tests/test-rfc-009-p4-conversion.mjs` → `9/9 pass` |
+| 5.4 | — | — | Commit `P4-S5: R6 conversion + rotate-consume (REQ-18,19,20)` + trailer. | `git log -1 --oneline` shows `P4-S5` |
+
+### `P4-S6` — R9c enrichment backfill (REQ-14) — depends on S4 (run-record/lock plumbing)
+
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-enrich.mjs` (new). **Read-only:** `scripts/em-revise.mjs` (invoked AS-IS via subprocess — F2 does not modify it), `scripts/em-capture.mjs:453` (the `spawnSync(process.execPath, [scriptPath, ...args], {encoding, cwd, timeout})` cross-script idiom — em-consolidate has no `child_process` import today).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 6.0 | — | — | Pre-flight §A.4. Assert S4's `tryAcquire` import + run-record writer are present. | present; §A.4 rows pass |
+| 6.1 | `scripts/em-consolidate.mjs` | APPEND | Add `import { spawnSync } from 'node:child_process'` (first child_process use in this file) and `function clerkEnrich(...)`: lexical candidate finder; **provenance-only scope, no widening** (REQ-14 hard-stop); per-item confirm; apply via `em-revise` AS-IS through `spawnSync(process.execPath, [emRevisePath, ...args], {encoding:'utf8', cwd:storeCwd, timeout:60000})` then `JSON.parse(stdout)`; run-record written under the lock (reuse `tryAcquire` from lib/lock.mjs). | `enrich::appliesViaRevise` (asserts the `em-revise` subprocess ran + target episode revised) + `enrich::scopeFromProvenanceOnly` pass |
+| 6.1b | `scripts/em-consolidate.mjs` | — | Negative control: `--break-scope` (widen candidate scope beyond provenance) → `enrich::scopeFromProvenanceOnly` must FAIL. | exit non-zero |
+| 6.2 | `scripts/em-consolidate.mjs` | EDIT | Wire `--clerk --enrich` mode dispatch (sibling `if` after the S4 apply block). | `enrich::runRecordUnderLock` passes |
+| 6.3 | `tests/test-rfc-009-p4-enrich.mjs` | CREATE | Full verbatim contents: the 4 §14 `enrich::` tests (lexicalCandidates, scopeFromProvenanceOnly, appliesViaRevise, runRecordUnderLock). Sentinel-based. | `node tests/test-rfc-009-p4-enrich.mjs` → `4/4 pass` |
+| 6.4 | — | — | Commit `P4-S6: R9c enrichment backfill (REQ-14)` + trailer. | `git log -1 --oneline` shows `P4-S6` |
+
+### `P4-S7` — R9d clerk prompt + conformance (REQ-15) — prompt is DATA, not code; ⟂ parallel-safe (disjoint files)
+
+**Files this slice may touch (one per step):** `scripts/em-consolidate/prompts/clerk.md` (new DATA file; the dir is a clean CREATE — `scripts/em-consolidate.mjs` is a flat file, no dir collision), `tests/test-rfc-009-p4-prompt.mjs` (new). **Read-only:** `scripts/second-opinion/preambles/` (the nearest shipped-`.md`-as-data convention), `tests/test-second-opinion-preamble.mjs` (the manifest+loader+assert conformance-test template to mirror, not extend).
+
+| Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
+|---|---|---|---|---|
+| 7.0 | — | — | Pre-flight §A.4. Confirm no runtime loader is required: `grep -n "readFileSync.*prompt" scripts/em-consolidate.mjs` → 0 (P4 ships the prompt as data + conformance test only; the agentic aggregator that consumes it is out of P4 scope). | grep returns 0; §A.4 rows pass |
+| 7.1 | `scripts/em-consolidate/prompts/clerk.md` | CREATE | Whole-file Write of the shipped R9d clerk aggregator prompt (DATA): the load-bearing instruction clauses + one embedded sample report matching the §12 `ReportJSON` shape (`mode:'clerk-report'`, `clusters[].proposed_action ∈ {merge,dedupe,keep-distinct}`). | file exists; `grep -c "clerk-report" scripts/em-consolidate/prompts/clerk.md` → ≥1 |
+| 7.2 | `tests/test-rfc-009-p4-prompt.mjs` | CREATE | Full verbatim contents modeled on `test-second-opinion-preamble.mjs`: `prompt::fileExists` (readFileSync ok), `prompt::loadBearingClauses` (asserts each required clause present), `prompt::sampleReportSchemaValid` (parse the embedded sample JSON, assert it satisfies the §12 `ReportJSON`/`proposed_action` enum contract). | `node tests/test-rfc-009-p4-prompt.mjs` → `3/3 pass` |
+| 7.2b | `tests/test-rfc-009-p4-prompt.mjs` | — | Negative control: `--break-prompt` (strip a load-bearing clause from the loaded copy) → `prompt::loadBearingClauses` must FAIL. | exit non-zero |
+| 7.3 | — | — | Commit `P4-S7: R9d clerk prompt + conformance (REQ-15)` + trailer. | `git log -1 --oneline` shows `P4-S7` |
+
+## A.8 Definition of done (whole plan, mechanical)
+
+```bash
+node tests/test-rfc-009-p4-telemetry.mjs     # → all pass
+node tests/test-rfc-009-p4-report.mjs        # → all pass
+node tests/test-rfc-009-p4-apply.mjs         # → all pass
+node tests/test-rfc-009-p4-conversion.mjs    # → all pass
+node tests/test-rfc-009-p4-enrich.mjs        # → all pass
+node tests/test-rfc-009-p4-prompt.mjs        # → all pass
+node tests/test-plugin-registry.mjs          # → green (plugin hook touched)
+node tools/deploy-audit.mjs                  # → clean (hook touched)
+```
+
+Each line produces an artifact pasted into §15. No step is "done by inspection."
+
+## A.9 Blast-radius patterns (apply when authoring A.7 steps)
+
+- **Red-then-green:** every guard step proves RED via a `--break-<x>` argv override run immediately before the green run (drop-at-bound, lock-held, unconfirmed, torn-line). A guard never observed failing guards nothing.
+- **Pure-extraction first:** the shared `activation-log.mjs` constants/writer (S1) land before any caller (S3–S7).
+- **Thin wrapper over refactor:** the clerk builds merged frontmatter in a NEW function; it does not restructure the existing digest writer (§7 F-STRIP keeps them separate).
+- **Fixture-change ledger:** if a step changes an existing test's contract, enumerate the exact assertions edited (`file:line`, before→after) as its own step. The existing `--fold-superseded` / body-token `--apply` tests must stay green (regression).
+- **Discriminating sentinel:** apply/telemetry tests inject a unique sentinel (id/token) and assert the output carries THAT token, never "non-empty"/"exit 0".
+- **Mock-project E2E** for the S1 hook (real `install.mjs` + real deployed hook), never mental-trace.
+- **Flag high-blast-radius slices:** S1 (event-plane hook) and S4 (mutating apply) are "focused review before build" even when fully specified.
+

--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -77,7 +77,7 @@ Every row maps to ≥1 test and cites its parent R-number. Test names are the P4
 
 | ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes / edge cases |
 |---|---|---|---|---|---|
-| REQ-1 | Clerk **report mode** is the default and writes nothing: store is byte-identical before/after a report run. | R9b (`:178`,`:185`) | `report::byteIdenticalStore`, `manual: node -e "crypto.createHash" index.jsonl pre/post` | MUST | The existing body-token `--apply` path is a DIFFERENT capability (§8 D-A); report mode is a new clerk surface. Manual hash uses a Node `crypto` one-liner, not `shasum` (F8: not cross-platform — absent on Windows `cmd`, non-universal on Linux). |
+| REQ-1 | Clerk **report mode** is the default and writes nothing to the SOURCE store: every source-store file (`index.jsonl`, `episodes/*.md`, `tags.json`, `category-index.json`, token index) is byte-identical before/after a report run, in BOTH the local and global stores. Carve-out (S3 review F1): the derived `trigger-index.json` MAY be lazily rebuilt by the R2 freshness contract when the clerk reads the merged trigger index — that refresh is the aggregation-plane R2 build (RFC §3), not a store mutation, and is the ONLY file a report run may change. | R9b (`:178`,`:185`) | `report::byteIdenticalStore` (full store-dir manifest hash, source files unchanged, only `trigger-index.json` may differ), `manual: node -e "crypto.createHash" index.jsonl pre/post` | MUST | The existing body-token `--apply` path is a DIFFERENT capability (§8 D-A); report mode is a new clerk surface. Manual hash uses a Node `crypto` one-liner, not `shasum` (F8: not cross-platform — absent on Windows `cmd`, non-universal on Linux). |
 | REQ-2 | Report clusters use **lexical signals only**: shared trigger phrases (R2 index), tag-set Jaccard ≥0.5 with high-df tags dropped (df ≥ max(3, ⌈10% active lessons⌉), dropped tags listed), summary-token Jaccard ≥0.4 same-category (tokens `[a-z0-9-]+` len>2, no shingling, confirmatory only), supersession-adjacency. No body/embedding similarity. | R9b (`:177`, T1/T2/T3) | `report::signalTagJaccard`, `report::signalHighDfDrop`, `report::signalSummaryOverlap`, `report::signalSharedTrigger`, `report::noBodyEmbedding` | MUST | Semantic/body-token clustering stays RFC-001 (`:175`); it is NOT R9b. |
 | REQ-3 | Each report cluster carries: members (ids+summaries), the **signals** that grouped it, and a **proposed action** ∈ {`merge`, `dedupe`, `keep-distinct`}. | R9b (`:178`) | `report::clusterShapeContract`, `report::proposedActionEnum` | MUST | `dedupe` vs `merge` contract defined in §8 D-B / §12. |
 | REQ-4 | Report emission **drains stdout before exit** at every clerk emit site; a >64KB report is not truncated when piped (closes #486, and does not ship a new instance of it). | R9b (#486) | `report::largeReportNotTruncated` (5000-id fixture piped) | MUST | Reuse the em-search drain helper pattern (`em-search.mjs:112`). |
@@ -376,7 +376,7 @@ Do **not** cut:
 ### `clerkReport(index, opts) → ReportJSON`
 
 **Input:** the active index rows + R2 trigger index; opts `{minTagJaccard=0.5, minSummaryJaccard=0.4, kShared=3, nLessons=200, window=4h}`.
-**Output:** `{ status:'ok', mode:'clerk-report', clusters: Cluster[], candidates?: EnrichCandidate[], truncated?: '+N more' }`; store byte-identical.
+**Output:** `{ status:'ok', mode:'clerk-report', clusters: Cluster[], candidates?: EnrichCandidate[], truncated?: '+N more', advisory?: string }` (`advisory` = REQ-23 one-line cadence advisory, S3 review F6); source store byte-identical (derived `trigger-index.json` refresh carved out per REQ-1); every id list bounded — `clusters[]` capped at 500 (top-level `truncated?: '+N more'`) and each cluster's `members[]` capped at 500 with its own `members_truncated?: '+M more'` field (S3 review F3; field named per round-2 NEW-1).
 
 **`Cluster` state table (proposed-action resolution — exhaustive):**
 
@@ -537,7 +537,10 @@ Group R9b-report (S3):     report::byteIdenticalStore, report::signalTagJaccard,
                            report::signalSummaryOverlap, report::signalSharedTrigger, report::noBodyEmbedding,
                            report::clusterShapeContract, report::proposedActionEnum,
                            report::largeReportNotTruncated, report::envelopeCapPlusNMore,
-                           report::emptyStore, report::emptyIdentityRejected
+                           report::envelopeCapPerClusterMembers (F4 fold, §19.7 — per-cluster members cap),
+                           report::emptyStore, report::emptyIdentityRejected,
+                           advisory::kSharedPhrase, advisory::nLessonCount (moved from Group regression —
+                           DELTA-8: REQ-23's clerk-side surface builds in S3, so its tests run in the S3 suite)
                            (report::zeroConversionCandidate → moved to S5, round-2 N5: needs S5 conversion history)
 Group R9b-apply (S4):      apply::noConfirmNoWrite, apply::perClusterConfirm, apply::underEmLock,
                            apply::applyVsApplySerialized, apply::writeOrderStoreFirst,
@@ -559,7 +562,7 @@ Group R6-conversion (S5):  conversion::rotateConsumeAtomic, conversion::appendDu
 Group R9c-enrich (S6):     enrich::lexicalCandidates, enrich::scopeFromProvenanceOnly,
                            enrich::appliesViaRevise, enrich::runRecordUnderLock
 Group R9d-prompt (S7):     prompt::fileExists, prompt::loadBearingClauses, prompt::sampleReportSchemaValid
-Group regression:          history::cycleTerminates, advisory::kSharedPhrase, advisory::nLessonCount
+Group regression:          history::cycleTerminates (advisory::* → Group R9b-report, DELTA-8)
 ```
 
 Total: ~55 tests across 7 groups (round-1 fold added `applyVsApplySerialized`, `cutoverIsStampedField`,
@@ -574,7 +577,7 @@ Fill the right column with the ACTUAL output at build time (order rule: artifact
 
 | Claim | Command (strong layer) | Observed artifact |
 |---|---|---|
-| Report writes nothing | `node -e "const c=require('crypto'),f=require('fs');console.log(c.createHash('sha256').update(f.readFileSync('index.jsonl')).digest('hex'))"` pre/post `--clerk` (F8: not `shasum`) | `<identical hash>` |
+| Report writes nothing to the source store | full store-dir manifest (sorted relpath+sha256 tuples, local AND global) pre/post `--clerk`; only `trigger-index.json` may differ (REQ-1 carve-out, S3 review F1/F7); spot hash via `node -e "crypto.createHash(...)"` on `index.jsonl` (F8: not `shasum`) | `<source manifests identical>` |
 | All P4 tests pass | `node tests/test-rfc-009-p4-<group>.mjs` (each) | `<N>/<N> pass` |
 | Telemetry writer E2E | mock-project: real hook injects → tail `activation-log.jsonl` | `<1 line, schema-valid>` |
 | Drop-at-bound (negative) | fixture log at 1 MiB, drive hook | `<line dropped + stderr note; size unchanged>` |
@@ -736,6 +739,39 @@ a 3rd same-class HOLD means the boundary is wrong — change the design, not the
 | F6 | P3 | Two-commit split (2.4 S2, then 2.6 S1 follow-up) must be honored at commit time; frozen-tree review cannot verify it. | Honored: separate commits per 2.4/2.6. |
 | F7 | — | REQ-22 crux CONFIRMED (see header). | Confirmation. |
 | F8 | P3 | RFC-009 R3 prose `:148` correctly left unchanged per #505 (RFC-011 does not amend RFC-009 text). | Confirmation. |
+
+### 19.6 S3 build-time scout findings (2026-07-12) — folded pre-build
+
+| Δ | Finding (scout-confirmed) | Resolution |
+|---|---|---|
+| DELTA-8 | The S3 row (§10) and commit message (3.5) claim REQ-23, but no S3 step built the clerk-side advisory surface, and its tests (`advisory::kSharedPhrase`, `advisory::nLessonCount`) sat in ownerless "Group regression" with no runner file — REQ-23 would have shipped claimed-but-unbuilt. §17 scopes P4 to the clerk-side surface only. | New step 3.3c: the clerk-report body computes the cadence advisory from `CADENCE_K_SHARED`/`CADENCE_N_LESSONS` (`activation-log.mjs:19-20`) and emits a one-line `advisory` field when either threshold trips (advisory, never a gate). The two `advisory::` tests move into the S3 suite (§14 amended); S3 suite count 12→14 (15 after the §19.7 F4 fold added `report::envelopeCapPerClusterMembers`). |
+| DELTA-9 | DELTA-6 class recurs: no S3 step registered `tests/test-rfc-009-p4-report.mjs` in `plan-marker-validate.yml`; `test-ci-suite-registration.mjs` would go red at PR time exactly as S1's suite did. | New step 3.4c wires the bare `run: node tests/test-rfc-009-p4-report.mjs` step in the S3 commit (in-slice, not a follow-up — the DELTA-6 lesson). Workflow file added to the S3 file set. |
+| DELTA-10 | §A.7 read-only ref + §4 REQ-4 cite `em-search.mjs:112` for the drain idiom; the runtime-confirmed anchor on this branch is `em-search.mjs:120` (`await new Promise(resolve => process.stdout.write(out+'\n', resolve))`, repeated `:143/:229/:277/:368`). F2-class acknowledged drift. | S3 file-set ref corrected to `:120`; builder verifies at build time per §9. |
+
+### 19.7 S3 review round 1 (GLM-5.2 cross-vendor, 2026-07-12) — VERDICT HOLD-7, all findings folded
+
+Build note (pre-review): the initial clerk code carried a state-A contract violation (dedupe wrongly required a shared trigger; §12 state A has no trigger leg) — found by the builder against a real fixture, fixed at `em-consolidate.mjs:832` with a §12-citing comment, verified by the reviewer.
+
+| # | Sev | Finding (simulation-confirmed) | Disposition |
+|---|---|---|---|
+| F1 | P1 | Report mode writes `trigger-index.json` into BOTH stores via `loadMergedTriggerIndex` (R2 lazy rebuild at `em-trigger-index.mjs:773-775`); `byteIdenticalStore` + §15 hash only `index.jsonl` — structurally blind. Observed: fresh fixture run created local (2365 B) AND global `trigger-index.json`. | ACCEPT, carve-out path: the refresh IS the R2 aggregation-plane design (RFC §3). REQ-1/§12/§15/step 3.3 re-scoped to SOURCE store with the derived-refresh carve-out (this round); test extended per F7. |
+| F2 | P2 | Trigger-index binding uses `process.cwd()` (`em-consolidate.mjs:443` ternary), not the upward-walked `LOCAL_DIR`; subdir cwd creates a PHANTOM `.episodic-memory/` + empty index → silent under-clustering. `--project` on em-consolidate is a name filter, not the R2 path binding. | ACCEPT: bind `project` to `path.dirname(LOCAL_DIR)` so the trigger build targets the same store as `loadIndex`. |
+| F3 | P2 | `members[]` per cluster unbounded (observed 600 ids+summaries in one state-D cluster); REQ-5 requires every id list bounded. `dropped_high_df_tags[]`/`shared_triggers[]` likewise uncapped by contract. | ACCEPT: per-cluster `members[]` cap with `+M more` sentinel mirroring the top-level cap; §12 amended. |
+| F4 | P2 | `report::envelopeCapPlusNMore` never exercises the cap-fires path (0 clusters → trivially ≤500). Reviewer's own sim: 600 pairs → `clusters.length=500, truncated="+100 more"` (mechanism works, test blind). | ACCEPT: test reworked to seed 600+ clustering pairs and assert `500` + `+100 more` + per-member cap. |
+| F5 | P2 | `clerkTagJaccard` early-return (`:757`) discards `dropped` when both tag sets empty after high-df drop; observed a CLUSTERED state-B pair reporting `dropped_high_df_tags=[]` where REQ-2 requires `["common"]`. | ACCEPT: compute dropped before the early-return. |
+| F6 | P2 | §12 output shape omitted `advisory` (DELTA-8 amended step table only) — contract drift the S7 prompt gauntlet would inherit. | ACCEPT: §12 `:379` + step 3.3 amended (this round). |
+| F7 | P2 | `byteIdenticalStore` one-file hash cannot catch `tags.json`/`category-index.json`/`episodes/`/global-store writes — MUST-row test structurally hollow. | ACCEPT: assert full source-store manifest (sorted relpath+sha256) unchanged pre/post in BOTH stores, modulo the carved `trigger-index.json`. |
+| N1 | P3 | Jaccard rounded to 3 decimals BEFORE the >= comparison (~0.001 boundary fuzz); exact boundaries untested. | ACCEPT-WITH-MOD: compare raw, round for display only. |
+| N2 | P3 | `clerkSignals` `activeCount` param dead (`clerkHighDfTags` uses `_clerkActiveRows.length`); callers pass inconsistent values, masked. | ACCEPT: remove the dead param. |
+| N3 | P3 | `.gitignore` + `SKILL.md` dirt bundled in the working tree, unrelated to S3. | Handled at commit: stage ONLY slice files (pre-existing dirt, same as S2). |
+
+Confirmations (no finding): single drained emit site (REQ-4); boundary semantics complementary at 0.5/0.4; action table exhaustive with closed enum + conservative fall-through; --only is dev-only (CI runs all 14); PASS_THROUGH_BREAK_FLAGS forwards only the 3 break flags; suite fail-closed exit 1; each red control fails ONLY its matching test.
+
+### 19.8 S3 review round 2 (GLM-5.2 cross-vendor, 2026-07-13) — VERDICT ACCEPT
+
+All seven round-1 findings CLOSED, each verified by code reading + reviewer-run simulation: F1 carve-out wording judged honest and complete; F2 binding verified across local/global/subdir/git-walk/cwd-fallback (reviewer's own global-scope + local-subdir sims); F3/F4 both caps fire with discriminating asserts; F5 clustered state-B pair now reports `dropped_high_df_tags=['common']` (reviewer repro); F6 §12 carries `advisory?: string`; F7 manifest excludes exactly `trigger-index.json`, both stores empirically checked ([] → [trigger-index.json] only), `--break-report-write` still red. N1 raw-compare and N2 dead-param removal confirmed. Silent-skip guards judged acceptable (cap regressions caught in green; drain has its dedicated red control).
+
+Five NEW findings, all P3, none blocking: NEW-1 §12 field name (folded — `members_truncated` named), NEW-2 doc counts 14→15 (folded — §14/DELTA-8/step 3.4), NEW-5 step 3.2 stale signature (folded), NEW-3 no test pins the F5 dropped-list fix (reverting F5 reds zero tests; DEFERRED to issue — add a state-B dropped-list assertion), NEW-4 silent-skip transparency (DEFERRED with NEW-3; optional skip counter). Full transcript: session scratchpad `glm-s3-round2-full.txt`.
 
 ## §20 Lessons Encoded (traceability — do not re-learn)
 
@@ -920,17 +956,19 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 
 ### `P4-S3` — R9b clerk **report** mode, lexical + drain-safe (REQ-1,2,3,4,5,21,23) — writes NOTHING
 
-**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-report.mjs` (new). **Read-only:** `scripts/lib/categories.mjs:63` + `scripts/lib/activation.mjs:37-67` (signal helpers reuse the same char classes), `scripts/em-search.mjs:112` (drain-before-exit pattern for #486/REQ-4), `scripts/lib/protection.mjs:214-227`.
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-report.mjs` (new), `.github/workflows/plan-marker-validate.yml` (DELTA-9 suite registration). **Read-only:** `scripts/lib/categories.mjs:63` + `scripts/lib/activation.mjs:37-67` (signal helpers reuse the same char classes), `scripts/em-search.mjs:120` (drain-before-exit pattern for #486/REQ-4; §4 REQ-4 cites `:112` — drifted, DELTA-10), `scripts/lib/protection.mjs:214-227`.
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
 | 3.0 | — | — | Pre-flight §A.4. | every row passes |
 | 3.1 | `scripts/em-consolidate.mjs` | EDIT | ANCHOR `const dryRun = argv.includes('--dry-run')` (§9 :92). APPEND on the next line `const clerk = argv.includes('--clerk')`. | `node scripts/em-consolidate.mjs --clerk --scope local` on a fixture → does not error on the flag |
-| 3.2 | `scripts/em-consolidate.mjs` | APPEND | After `function slugify(text) {` (§9 :543-545) add two greenfield helpers: `function clerkSignals(a, b, activeCount)` (tag-Jaccard vs `TAG_JACCARD_MIN`, summary-Jaccard vs `SUMMARY_JACCARD_MIN`, shared-trigger count vs `CADENCE_K_SHARED`, high-df drop via `HIGH_DF_MIN(activeCount)`; NO body embedding — §12 `report::noBodyEmbedding`) and `function clerkResolveAction(signals)` implementing the §12 `Cluster` 5-state table (A dedupe / B merge / C keep-distinct / D merge / E keep-distinct), returning one of `PROPOSED_ACTIONS ∪ {keep-distinct}`. Reject empty/whitespace-summary pairs (EC5) as `keep-distinct`. | `node tests/test-rfc-009-p4-report.mjs` group `report::proposedActionEnum` + `report::emptyIdentityRejected` pass |
-| 3.3 | `scripts/em-consolidate.mjs` | EDIT | Insert the clerk-report mode BEFORE ANCHOR `const rows = loadIndex(DATA_DIR, scope).filter(r =>` (§9 :411): `if (clerk && !apply) { ... process.exit(0) }`. Body: lexical candidate loader (drain-safe per em-search.mjs:112), cluster via signals, build `{status:'ok', mode:'clerk-report', clusters, candidates?, truncated?}` capped with `+N more` envelope; drain stdout before exit. Writes nothing to the store. | `report::byteIdenticalStore`: sha256 of `index.jsonl` pre==post the `--clerk` run (F8, `node -e` hash not `shasum`) |
+| 3.2 | `scripts/em-consolidate.mjs` | APPEND | After `function slugify(text) {` (§9 :543-545) add two greenfield helpers: `function clerkSignals(a, b)` (tag-Jaccard vs `TAG_JACCARD_MIN`, summary-Jaccard vs `SUMMARY_JACCARD_MIN`, shared-trigger count vs `CADENCE_K_SHARED`, high-df drop via `HIGH_DF_MIN(<store-wide active count>)` — no per-call activeCount param, round-2 N2 fold; NO body embedding — §12 `report::noBodyEmbedding`) and `function clerkResolveAction(signals)` implementing the §12 `Cluster` 5-state table (A dedupe / B merge / C keep-distinct / D merge / E keep-distinct), returning one of `PROPOSED_ACTIONS ∪ {keep-distinct}`. Reject empty/whitespace-summary pairs (EC5) as `keep-distinct`. | `node tests/test-rfc-009-p4-report.mjs` group `report::proposedActionEnum` + `report::emptyIdentityRejected` pass |
+| 3.3 | `scripts/em-consolidate.mjs` | EDIT | Insert the clerk-report mode BEFORE ANCHOR `const rows = loadIndex(DATA_DIR, scope).filter(r =>` (§9 :411): `if (clerk && !apply) { ... process.exit(0) }`. Body: lexical candidate loader (drain-safe per em-search.mjs:120), cluster via signals, build `{status:'ok', mode:'clerk-report', clusters, candidates?, truncated?, advisory?}` capped with `+N more` envelopes (top-level clusters AND per-cluster members — F3); drain stdout before exit. Writes nothing to the SOURCE store (REQ-1 carve-out for the derived trigger-index refresh — F1). | `report::byteIdenticalStore`: sha256 of `index.jsonl` pre==post the `--clerk` run (F8, `node -e` hash not `shasum`) |
 | 3.3b | `scripts/em-consolidate.mjs` | — | Negative control: `node scripts/em-consolidate.mjs --clerk --scope local --break-report-write` (inject a stray store write) → `report::byteIdenticalStore` must FAIL. | exit non-zero |
-| 3.4 | `tests/test-rfc-009-p4-report.mjs` | CREATE | Full verbatim contents: the 12 `report::` tests of §14 (byteIdenticalStore, signalTagJaccard, signalHighDfDrop, signalSummaryOverlap, signalSharedTrigger, noBodyEmbedding, clusterShapeContract, proposedActionEnum, largeReportNotTruncated, envelopeCapPlusNMore, emptyStore, emptyIdentityRejected). Each injects a discriminating sentinel and asserts THAT token, never "non-empty". Register in `main()`. (`report::zeroConversionCandidate` moved to S5 — round-2 N5: it needs S5's conversion history, which does not exist until S5.) | `node tests/test-rfc-009-p4-report.mjs` → `12/12 pass` |
+| 3.3c | `scripts/em-consolidate.mjs` | EDIT | DELTA-8 (REQ-23 clerk-side surface): inside the 3.3 clerk-report body, compute the cadence advisory — count trigger-index entries sharing one phrase (R2 index) and the active-lesson count; if shared ≥ `CADENCE_K_SHARED` or active ≥ `CADENCE_N_LESSONS` (`activation-log.mjs:19-20`), set a one-line string field `advisory` in the report JSON. Advisory only, never a gate; the R3/R4 adapter leg stays out of P4 scope per §17. | `node tests/test-rfc-009-p4-report.mjs` tests `advisory::kSharedPhrase` + `advisory::nLessonCount` pass |
+| 3.4 | `tests/test-rfc-009-p4-report.mjs` | CREATE | Full verbatim contents: the 15 tests of §14 group R9b-report — 13 `report::` tests (byteIdenticalStore, signalTagJaccard, signalHighDfDrop, signalSummaryOverlap, signalSharedTrigger, noBodyEmbedding, clusterShapeContract, proposedActionEnum, largeReportNotTruncated, envelopeCapPlusNMore, envelopeCapPerClusterMembers [F4 fold, §19.7], emptyStore, emptyIdentityRejected) + 2 `advisory::` tests (kSharedPhrase, nLessonCount — DELTA-8). Each injects a discriminating sentinel and asserts THAT token, never "non-empty". Register in `main()`. (`report::zeroConversionCandidate` moved to S5 — round-2 N5: it needs S5's conversion history, which does not exist until S5.) | `node tests/test-rfc-009-p4-report.mjs` → `15/15 pass` |
 | 3.4b | `tests/test-rfc-009-p4-report.mjs` | — | Negative controls (one command per row): `--break-highdf` → `signalHighDfDrop` FAILS; `--break-drain` → `largeReportNotTruncated` FAILS. | each exits non-zero |
+| 3.4c | `.github/workflows/plan-marker-validate.yml` | EDIT | DELTA-9: add the bare step `run: node tests/test-rfc-009-p4-report.mjs` alongside the P4 telemetry step (the lint requires the exact bare `run: node tests/<f>` form) — in the S3 commit itself, not a follow-up (DELTA-6 lesson). | `node tests/test-ci-suite-registration.mjs` → 0 failed |
 | 3.5 | — | — | Commit `P4-S3: R9b clerk report mode (REQ-1,2,3,4,5,21,23)` + trailer. | `git log -1 --oneline` shows `P4-S3` |
 
 ### `P4-S4` — R9b clerk **apply** (merge/dedupe) + run-records (REQ-6,7,8,9,10,11,12,13) — **focused review before build** (mutating apply, high blast radius)

--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -126,6 +126,11 @@ Explicitly out of scope (prevents scope creep):
 - **Agentic clerk implementation** (an LLM aggregator generating richer candidates) — the shipped
   clerk core is zero-dep lexical; the prompt (R9d) is shipped so an agentic aggregator CAN be added
   later behind the same per-item-confirm contract, but wiring one is not P4.
+- **Codex-activation event-plane telemetry** (S1 build-time scope resolution) — R6 telemetry wires only
+  the Claude Code event plane (`plugins/claude-code-activation/hooks/activation-hook-run.mjs`, the primary +
+  this-repo-deployed surface). The `codex-activation` runner also injects but is NOT wired here; codex
+  injections are simply absent from `activation-log.jsonl` (R6 is already a labeled lower bound, REQ-20).
+  Codex telemetry parity is a tracked follow-up (filed with the PR-A deferred-findings batch).
 
 ## §6 Token Budget (Rule 12)
 
@@ -436,8 +441,8 @@ CONFIRMED). `kind ∈ {digest, index-flip, run-record}`.
 
 ```
 { "v":1, "ts":"2026-07-12T05:44:37Z", "project":"<name>", "event":"inject",
-  "surface":"session_start"|"per_prompt"|"dispatcher",
-  "entries":[ { "id":"<episode-id>", "effective_priority":<int>, "rendered":"imperative"|"plain",
+  "surface":"session_start"|"per_prompt"|"tool"|"dispatcher",
+  "entries":[ { "id":"<episode-id>", "effective_priority":<int>|null, "rendered":"imperative"|"plain",
                "source_scope":"local"|"global", "access_count_at_inject":<int> } ] }
 ```
 
@@ -446,6 +451,36 @@ CONFIRMED). `kind ∈ {digest, index-flip, run-record}`.
 lesson injected into a project bumps the GLOBAL index, invisible to a project-scoped read — round-1
 CONFIRMED); `access_count_at_inject` is the baseline snapshot that separates multiple injections of one id
 (the index keeps only a scalar `last_accessed`, so a per-access delta is otherwise unreconstructable).
+The snapshot is **as of the last R2 index build**, not the injection instant: the count reaches the hook
+inside the purpose-built trigger index (stamped at build time, step 1.2cb), never via an event-time
+`index.jsonl` read — the RFC two-plane read boundary is strict (RFC-009 `:43`/`:47`, R4, acceptance
+`:429`; round-2 GLM P1), and the R2 freshness contract bounds the drift (a stale index rebuilds in hook
+context under the carve-out, refreshing counts).
+
+**Producer (Option A, S1) — the five per-entry fields have no producer in the render path.**
+`matchActivation`→`selectAndBound` (`scripts/lib/activation-match.mjs:643`/`:356`) collapse the selected
+candidates to rendered strings and return `{lines, overflowNote}`, discarding the entry objects at the
+`:398` return; `mergeIndexes` (`.claude/hooks/activation-hook-run.mjs:294`, deployed copy
+`plugins/claude-code-activation/hooks/activation-hook-run.mjs`) flattens `[local, global]` with no scope
+tag. S1 therefore (a) **stamps `source_scope`** on each entry inside the `mergeIndexes` `[local, global]`
+loop — the only site where both stores' provenance is known — via a shallow copy `{...e, source_scope}`
+(no mutation of the loaded index rows, which are shared by reference); (b) **extends `selectAndBound` +
+`matchActivation` to also return `entries[]`** — the selected entry objects carrying
+`{ id:episode_id, effective_priority, rendered, source_scope, access_count_at_inject:access_count }` —
+alongside the unchanged `lines`/`overflowNote`; `renderSessionStart` (`activation-match.mjs:651`) emits the
+same for the `session_start` surface, where the lock-step invariant is **per-LESSON, not per-line**:
+`entries[]` carries one element per episode-bearing lesson line only; preflight and pattern-health output
+are surface lines with no entry (they inject no episode, so there is nothing for the clerk to convert).
+On the `selectAndBound` surfaces (`per_prompt`/`tool`/`dispatcher`) every line is episode-bearing, so
+there the invariant degenerates to 1:1. The hook (step 1.3) builds the schema `entries[]` from
+`result.entries`. `rendered` is derived from the same imperative-vs-plain predicate the renderer applies
+(band≥8 / playbook → `imperative`, else `plain`). `access_count` sourcing (round-2 GLM P1 fold):
+trigger-index entries did NOT carry `access_count` (it lived only in `index.jsonl`), so the producer's
+`entry.access_count ?? 0` was always 0; the fix is at the R2 BUILD step (step 1.2cb) — `em-trigger-index`
+stamps each emitted entry (top-level `entries`, `session_start.critical_entries`, `session_start.entries`,
+playbooks) with its store's `index.jsonl` `access_count` as BUILD INPUT flowing into the built artifact
+(the RFC `:43` carve-out pattern: anything event-time consumers need is precomputed into the artifact).
+The hook itself performs NO `index.jsonl` read at event time.
 
 Loss-OK telemetry (not memory). `v` is the line-format version (NSP #22): the clerk **validates-or-skips**
 — an unknown `v` or an unparseable line is skipped and counted in the run-record; the hook never validates
@@ -774,7 +809,7 @@ export const LOG_FORMAT_VERSION = 1
 export const ACTIVATION_LOG_NAME = 'activation-log.jsonl'
 export const ACTIVATION_LOG_MAX_BYTES = 1024 * 1024 // 1 MiB (T8)
 export const RENDERED_FORMS = ['imperative', 'plain']
-export const INJECTION_SURFACES = ['session_start', 'per_prompt', 'dispatcher']
+export const INJECTION_SURFACES = ['session_start', 'per_prompt', 'tool', 'dispatcher']
 // Clerk (em-consolidate) constants:
 export const RUN_RECORD_CATEGORY = 'workflow.lifecycle'
 export const RUN_RECORD_TYPE = 'clerk-run'          // scalar frontmatter key, NEVER a tag
@@ -812,18 +847,35 @@ their own row immediately before the green run (one command per row).
 
 ### `P4-S1` — R6 telemetry writer + line schema (REQ-16, REQ-17) — **focused review before build** (event-plane hook, high blast radius)
 
-**Files this slice may touch (one per step):** `scripts/lib/activation-log.mjs` (new), the event-plane
-hook file (from A.0), `tests/test-rfc-009-p4-telemetry.mjs` (new). **Read-only:** `scripts/em-search.mjs:112` (drain pattern).
+**Files this slice may touch (one per step):** `scripts/lib/activation-log.mjs` (new), **the Claude Code
+event-plane hook `plugins/claude-code-activation/hooks/activation-hook-run.mjs`** (build-time scope
+resolution: step 1.0's grep names TWO per-tool runners — claude-code + codex-activation — which are NOT
+byte-identical; S1 wires only the Claude Code plane, the primary + this-repo-deployed surface. Codex
+telemetry parity is a documented follow-up, consistent with R6 being a labeled lower bound, REQ-20/§5),
+`tests/test-rfc-009-p4-telemetry.mjs` (new), **and (Option A, §12 producer) `scripts/lib/activation-match.mjs`
+(`selectAndBound`+`matchActivation`+`renderSessionStart` also return structured `entries[]`) plus the
+`mergeIndexes` function inside the same Claude Code hook (stamp `source_scope`). The Claude Code hook
+resolves `activation-match.mjs` from `scripts/lib/` at runtime (`resolveAsset(['lib/activation-match.mjs',
+'scripts/lib/activation-match.mjs']`), so there is NO bundled `claude-code-activation` copy to re-sync;
+the only checksummed support file is `activation-hook-run.mjs` (`ACTIVATION_SUPPORT_FILES`), whose
+manifest checksum step 1.5 refreshes. The `plugins/codex-activation/hooks/activation-match.mjs` duplicate
+goes stale after this slice but breaks no test (its manifest checksum matches its own unchanged bytes; no
+`scripts/lib`↔copy parity test exists) and is re-synced by S2 (§5 codex parity).** **Read-only:**
+`scripts/em-search.mjs:112` (drain pattern).
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
-| 1.0 | — | — | Pre-flight §A.4. Then `grep -rn "session_start\|per_prompt\|preamble" plugins/*/hooks/activation-*.mjs` to identify the exact injection-composition site; record it as the S1.3 target. If ambiguous, STOP. | every §A.4 row passes; grep names exactly one composition site |
+| 1.0 | — | — | Pre-flight §A.4. Then `grep -rn "session_start\|per_prompt\|preamble" plugins/*/hooks/activation-*.mjs` to locate the injection-composition sites. **Resolved (build-time): the grep names two per-tool runners; S1 targets ONLY the Claude Code plane `plugins/claude-code-activation/hooks/activation-hook-run.mjs` — the composition site is the `let text = lines.join('\n')` → `process.stdout.write({hookSpecificOutput…})` block. Codex-activation is out of scope (§5).** | §A.4 rows pass; the Claude Code composition site is located |
 | 1.1 | `scripts/lib/activation-log.mjs` | CREATE | Whole-file Write: the §A.5 constants block + `export function appendActivationLine(dataDir, line)` that (a) `JSON.stringify`s `{v:LOG_FORMAT_VERSION, ...line}`, (b) computes `Buffer.byteLength(serialized+'\n')`, (c) `statSync` the log (0 if absent), (d) if `size + lineBytes > ACTIVATION_LOG_MAX_BYTES` writes `process.stderr.write('activation-log: size bound reached; dropping line\n')` and RETURNS `{dropped:true}` **without appending**, (e) else `fs.appendFileSync(path, serialized+'\n')` and returns `{dropped:false}`. Wrap the whole body in try/catch → on error `process.stderr.write` + return `{error:true}` (fire-and-forget, never throw). | `node -e "import('./scripts/lib/activation-log.mjs').then(m=>console.log(typeof m.appendActivationLine))"` → `function` |
 | 1.2 | `tests/test-rfc-009-p4-telemetry.mjs` | CREATE | Full verbatim contents. `telemetry::oneLinePerInjection`: append one line to a tmpdir log, read it back, assert the parsed object's `v===1`, `entries[0].id` equals the unique sentinel id passed in. `telemetry::dropAtBoundStderr`: pre-write a log to `ACTIVATION_LOG_MAX_BYTES-10` bytes, capture the return of an append whose bytes exceed the remaining room, assert `{dropped:true}` and the file size is UNCHANGED (statSync before==after). `telemetry::neverTruncates`: same fixture, assert the pre-existing last line still present after the dropped append. `telemetry::writeFailureNonFatal`: call with a non-existent parent dir, assert it returns `{error:true}` and does NOT throw. Register all in `main()`. | `node tests/test-rfc-009-p4-telemetry.mjs` → `4/4 pass` |
 | 1.2b | — | — | Negative controls (one per row): `node tests/test-rfc-009-p4-telemetry.mjs --break-bound` (module ignores the bound) → `telemetry::dropAtBoundStderr` FAILS; **`--break-writefail` (make the writer `throw` instead of catching) → `telemetry::writeFailureNonFatal` FAILS (round-2 N7 — the fire-and-forget guard now has a red control)**. | each exits non-zero |
-| 1.3 | event-plane hook (A.0) | EDIT | ANCHOR the injection-composition line (from 1.0). After the preamble is composed, APPEND-call `appendActivationLine(dataDir, {ts, project, event:'inject', surface, entries})` inside a try/catch that swallows all errors (fire-and-forget). Import from `../lib/activation-log.mjs` (verify relative path). Do NOT change stdout or exit. | `grep -c "appendActivationLine" <hookfile>` → 1 |
-| 1.4 | `tests/test-rfc-009-p4-telemetry.mjs` | EDIT | Add `telemetry::hookE2E` (mock-project): isolated `HOME`, real `install.mjs`, drive the REAL deployed hook with one injection, tail the written `activation-log.jsonl`, assert exactly one schema-valid line with the injected sentinel id. (Install/hook behavior is proven by mock-project E2E, never mental-trace.) | `node tests/test-rfc-009-p4-telemetry.mjs` → `5/5 pass` |
-| 1.5 | — | — | Refresh the plugin manifest checksum (plugin hook support file changed) and run `node tests/test-plugin-registry.mjs`; then `node tools/deploy-audit.mjs`. | registry test green; deploy-audit clean |
+| 1.2c | `scripts/lib/activation-match.mjs` | EDIT | **§12 producer (Option A).** In `selectAndBound` (`:356`), alongside each `lines.push(renderLine(entry))`, collect the selected entry into a parallel `entries[]` as `{ id:entry.episode_id, effective_priority:entry.effective_priority, rendered:(<imperative-predicate> ? 'imperative' : 'plain'), source_scope:entry.source_scope ?? null, access_count_at_inject:entry.access_count ?? 0 }` — reuse the SAME imperative-vs-plain predicate `renderLine` applies (band≥8 / playbook → imperative; do not re-derive it independently). Return `{ lines, overflowNote, entries }`. Thread `entries` up through `matchActivation` (`:643`, all return sites incl. the fail-open `{lines:[],overflowNote:null}` → add `entries:[]`) and `renderSessionStart` (`:651`, same shape for the `session_start` surface). `lines`/`overflowNote` values UNCHANGED. | `node -e "…matchActivation(fixture…)"` prints `entries` len == rendered-line count; each element has all 5 keys; existing `test-activation-match.mjs` still green |
+| 1.2cb | `scripts/em-trigger-index.mjs` | EDIT | **§12 `access_count` stamp at BUILD time (round-2 GLM P1 fold).** At every site where the build emits an entry into the derived artifact (top-level `entries`, `session_start.critical_entries`, `session_start.entries`, playbook rows), attach `access_count: <index.jsonl row's access_count ?? 0>` for that `episode_id` — a BUILD-INPUT read flowing into the built artifact (RFC-009 `:43` carve-out; the hook never opens `index.jsonl`). Widen the trigger-index schema/test expectations accordingly. | rebuilt `trigger-index.json` entries carry integer `access_count` equal to the store's `index.jsonl` value; `test-trigger-index-schema.mjs` + `test-trigger-index.mjs` green |
+| 1.2d | `plugins/claude-code-activation/hooks/activation-hook-run.mjs` | EDIT | **`mergeIndexes` (`:294`) — source_scope stamp.** In the `for (const idx of [local, global])` loop, replace `mapped.set(key, e)` / playbook-replace assignments with a shallow-copied, scope-tagged row: `const tagged = { ...e, source_scope: idx === local ? 'local' : 'global' }` then set/replace with `tagged` (NEVER mutate `e` — the loaded index rows are shared by reference; §12). Preserve the existing dedup key, LOCAL-precedence, playbook-wins, and `overriddenIds` logic exactly. | fixture with one local + one global entry → merged entries carry `source_scope:'local'` and `'global'` respectively; dedup/precedence unit assertions unchanged |
+| 1.3 | `plugins/claude-code-activation/hooks/activation-hook-run.mjs` | EDIT | ANCHOR the injection-composition line (from 1.0, `let text = lines.join('\n')`). After the preamble is composed, build `const entries = (result.entries ?? []).map(e => ({ id:e.id, effective_priority:e.effective_priority, rendered:e.rendered, source_scope:e.source_scope, access_count_at_inject:e.access_count_at_inject }))` and APPEND-call `appendActivationLine(dataDir, {ts, project, event:'inject', surface, entries})` inside a try/catch that swallows all errors (fire-and-forget). Import from the deployed-relative `lib/activation-log.mjs` path (verify the hook's asset-resolution convention). Do NOT change stdout or exit. | `grep -c "appendActivationLine" plugins/claude-code-activation/hooks/activation-hook-run.mjs` → 1; a driven injection writes a line whose `entries[].source_scope` ∈ {`local`,`global`} |
+| 1.4 | `tests/test-rfc-009-p4-telemetry.mjs` | EDIT | Add two tests. (a) `telemetry::entriesFromMatcher` (producer unit): call `matchActivation` on a fixture index holding one `source_scope:'local'` and one `source_scope:'global'` selected entry, assert the returned `entries[]` has one element per rendered line, each carrying all 5 keys (`id, effective_priority, rendered, source_scope, access_count_at_inject`), and that both polarities `'local'` and `'global'` appear (both directions of the controlling field). (b) `telemetry::hookE2E` (mock-project): isolated `HOME`, real `install.mjs`, drive the REAL deployed hook with one injection, tail the written `activation-log.jsonl`, assert exactly one schema-valid line with the injected sentinel id AND `entries[0].source_scope ∈ {'local','global'}`. (Install/hook behavior is proven by mock-project E2E, never mental-trace.) | `node tests/test-rfc-009-p4-telemetry.mjs` → `6/6 pass` |
+| 1.4b | `tests/test-rfc-009-p4-telemetry.mjs` | — | Negative control for the producer: `node tests/test-rfc-009-p4-telemetry.mjs --break-scope` (harness stubs `mergeIndexes`/matcher to drop `source_scope`) → `telemetry::entriesFromMatcher` FAILS. | exits non-zero |
+| 1.5 | `plugins/claude-code-activation/manifest.json` | EDIT | Refresh the `activation-hook-run.mjs` support-file checksum to its new `shasum -a 256` value (the hook changed in 1.2d/1.3) and run `node tests/test-plugin-registry.mjs`; then `node tools/deploy-audit.mjs`. `activation-match.mjs` is NOT a bundled support file (resolved from `scripts/lib` at runtime) so no copy re-sync here. deploy-audit will show `activation-log.mjs` (new) + `activation-match.mjs` (changed) as undeployed vs the GLOBAL install — that is EXPECTED pre-merge drift; do NOT `--install-hooks-force` from the feature branch (deploy-to-global happens after merge). | registry test 205/0; deploy-audit shows ONLY the two undeployed S1 lib files (+cosmetic), no unrelated orphans |
 | 1.6 | — | — | Commit `P4-S1: R6 activation telemetry writer` + trailer. | `git log -1 --oneline` shows `P4-S1` |
 
 ### `P4-S2` — #505 render migration `--history`→`--read` (REQ-22)

--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -714,6 +714,29 @@ behavior-simulated by GLM and re-confirmed against source by the orchestrator be
 Review in three layers (per-artifact → cross-file → PR-level). Cap at 2 rounds on the same class;
 a 3rd same-class HOLD means the boundary is wrong — change the design, not the patch spelling.
 
+### 19.4 S2 build-time scout findings (2026-07-12) — folded pre-build
+
+| Δ | Finding (runtime-confirmed) | Resolution |
+|---|---|---|
+| DELTA-5 | Two more suites hard-assert the imperative `--history` render form beyond `test-activation-match.mjs:222`: `tests/test-so-lesson-injection.mjs:235` and `tests/test-activation-playbooks.mjs:229/:322-324/:900` (grep artifact 2026-07-12). `tests/test-activation-sessionstart.mjs:285-288` carries the form in a comment only (its assertions use the `READ <id>` prefix, unaffected). | S2 file scope extends to the two suites; new step 2.3c flips their expectations to the `--read` form (+ the sessionstart comment, cosmetic). |
+| DELTA-6 | `node tests/test-ci-suite-registration.mjs` exits 1 on this branch: `test-rfc-009-p4-telemetry.mjs` (S1) is neither step-wired, P12, nor baselined (`t_all_suites_registered` + `t_negative_control` red). S1 ran the suite manually; the gap surfaces at PR time. | New steps 2.5/2.6 wire `run: node tests/test-rfc-009-p4-telemetry.mjs` into `plan-marker-validate.yml` as a separate `P4-S1 follow-up` commit. |
+| DELTA-7 | Post-build verify: `test-plugin-registry.mjs` 198/7 red — `plugins/codex-activation/manifest.json:20` pins support-file checksum `sha256:4995cf…` for `activation-match.mjs`; the 2.2 byte-restore changed the copy to `sha256:e6cc87…` (both copies identical by `shasum -a 256`). Also runtime-confirmed by the builder: `install.mjs` does NOT sync the codex plugin copy (live surface = `install-manifest.mjs::activationSupportFiles()`); 2.2 executed as direct `cp`. | New step 2.2b refreshes the manifest checksum to the new hash; verify `node tests/test-plugin-registry.mjs` → 205/0. `manifest.json` added to the S2 file set. |
+
+### 19.5 S2 review round 1 (GLM-5.2 cross-vendor, 2026-07-12) — VERDICT ACCEPT, 0 must-fix
+
+8 findings, all P2/P3/confirmations; crux F7 behavior-simulated on an isolated fixture (`--read` bumps `access_count` 0→1 + `last_accessed`; `--history` and `--no-track` leave both untouched; band-8 line renders `(em-search --read <id>)` through the real matcher; S1 `entries[]`/lines lock-step preserved).
+
+| # | Sev | Finding | Disposition |
+|---|---|---|---|
+| F1 | P3 | 2.3b spec said "stub `renderLine`" but ESM export bindings are immutable; harness output-rewrite is a valid falsifiable control (red run: exit 1, ONLY `render::usesReadNotHistory` fails; no production leak of `BREAK_RENDER`). | ACCEPT-WITH-MOD: 2.3b wording corrected (this plan). |
+| F2 | P3 | Plan §12 producer anchors carry pre-S1 line numbers (`:356`/`:643`/`:651` → post-S1 `:379`/`:714`/`:497`). §9 already warns "verify at build time (they drift)". | No action (acknowledged drift; S2 untouched). |
+| F3 | P3 | DELTA-5 sweep confirmed complete: remaining repo `em-search --history` hits are the CLI walk feature, walk tests, user docs, and the intentional `--break-render` revert pattern. | Confirmation. |
+| F4 | P2 | DELTA-5 sibling suites assert the `--read` substring only (no `--history`-absence guard); would silently pass on revert + spurious `--read` elsewhere. Primary guard (`render::usesReadNotHistory` + red control) exists. | ACCEPT-WITH-MOD: absence guards added to the sibling assertion sites post-ACCEPT (builder subagent), suites re-run green. |
+| F5 | P3 | Manifest checksum `sha256:e6cc87…` matches on-disk copy; registry 205/0. | Confirmation (DELTA-7 resolved). |
+| F6 | P3 | Two-commit split (2.4 S2, then 2.6 S1 follow-up) must be honored at commit time; frozen-tree review cannot verify it. | Honored: separate commits per 2.4/2.6. |
+| F7 | — | REQ-22 crux CONFIRMED (see header). | Confirmation. |
+| F8 | P3 | RFC-009 R3 prose `:148` correctly left unchanged per #505 (RFC-011 does not amend RFC-009 text). | Confirmation. |
+
 ## §20 Lessons Encoded (traceability — do not re-learn)
 
 | Lesson | One-line rule | Enforced in |
@@ -880,16 +903,20 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 
 ### `P4-S2` — #505 render migration `--history`→`--read` (REQ-22)
 
-**Files this slice may touch (one per step):** `scripts/lib/activation-match.mjs`, `plugins/codex-activation/hooks/activation-match.mjs` (byte-identical duplicate), `tests/test-activation-match.mjs`. **Read-only:** `scripts/em-search.mjs:59` (the `--read` surface), `install.mjs` (the plugin-copy sync step).
+**Files this slice may touch (one per step):** `scripts/lib/activation-match.mjs`, `plugins/codex-activation/hooks/activation-match.mjs` (byte-identical duplicate), `tests/test-activation-match.mjs`, plus per DELTA-5/6 (§19.4): `tests/test-so-lesson-injection.mjs`, `tests/test-activation-playbooks.mjs`, `tests/test-activation-sessionstart.mjs` (comment only), `.github/workflows/plan-marker-validate.yml` (S1 follow-up, separate commit). **Read-only:** `scripts/em-search.mjs:59` (the `--read` surface), `install.mjs` (the plugin-copy sync step).
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
 | 2.0 | — | — | Pre-flight §A.4. Then determine how the plugin copy is kept in sync: `grep -n "activation-match" install.mjs`. If install.mjs copies `scripts/lib/activation-match.mjs` → the plugin path, step 2.2 is a re-sync + diff; else step 2.2 edits the copy directly. If ambiguous, STOP. | grep names exactly one sync mechanism (copy step) or none |
 | 2.1 | `scripts/lib/activation-match.mjs` | EDIT | ANCHOR `(em-search --history ${id} --full)` inside `renderLine` (the `effective_priority>=8` imperative branch). Literal change: `(em-search --history ${id} --full)` → `(em-search --read ${id})`. Do NOT touch `renderPlaybookLine` (already `--read`, §A-scout :204). | `grep -c "\-\-history" scripts/lib/activation-match.mjs` → `0` (the file's only `--history` was this line; playbook line already `--read`) |
-| 2.2 | `plugins/codex-activation/hooks/activation-match.mjs` | EDIT | Per 2.0: if install.mjs syncs, run the sync + then `diff` the two files; else apply the SAME literal change as 2.1. | `diff scripts/lib/activation-match.mjs plugins/codex-activation/hooks/activation-match.mjs` → exit 0 (byte-identical restored) |
+| 2.2 | `plugins/codex-activation/hooks/activation-match.mjs` | EDIT | Per 2.0: if install.mjs syncs, run the sync + then `diff` the two files; else apply the SAME literal change as 2.1. (Executed: no sync mechanism exists — direct `cp` restoring byte identity incl. S1 changes, per DELTA-7.) | `diff scripts/lib/activation-match.mjs plugins/codex-activation/hooks/activation-match.mjs` → exit 0 (byte-identical restored) |
+| 2.2b | `plugins/codex-activation/manifest.json` | EDIT | DELTA-7: refresh the `activation-match.mjs` support-file checksum to the copy's new `shasum -a 256` value. | `node tests/test-plugin-registry.mjs` → 205 passed, 0 failed |
 | 2.3 | `tests/test-activation-match.mjs` | EDIT | ANCHOR the hard-coded expectation `em-search --history id-band8 --full` (~:222). Literal change to `em-search --read id-band8`. Ensure the assertion is `render::usesReadNotHistory` (asserts rendered band-8 line contains `--read` AND not `--history`). | `node tests/test-activation-match.mjs` → all pass |
-| 2.3b | `tests/test-activation-match.mjs` | — | Negative control: `node tests/test-activation-match.mjs --break-render` (harness stubs `renderLine` back to the `--history` form) → `render::usesReadNotHistory` must FAIL. | exit non-zero |
+| 2.3b | `tests/test-activation-match.mjs` | — | Negative control: `node tests/test-activation-match.mjs --break-render` (harness wraps the `matchActivation` call-site and regex-rewrites output `lines[]` back to the `--history` form — a true `renderLine` stub is unbuildable, ESM named exports are immutable bindings; S2-review F1) → `render::usesReadNotHistory` must FAIL. | exit non-zero, ONLY that test red |
+| 2.3c | `tests/test-so-lesson-injection.mjs`, `tests/test-activation-playbooks.mjs`, `tests/test-activation-sessionstart.mjs` | EDIT | DELTA-5: flip the hard-coded imperative form to `--read`: so-lesson-injection `:235` `(em-search --history ${imp.id} --full)` → `(em-search --read ${imp.id})`; activation-playbooks `:229` and `:322-324` (comment + assertion + message text) `(em-search --history ${…} --full)` → `(em-search --read ${…})`, `:900` `startsWith` prefix `"READ dual-1 before proceeding (em-search --history"` → `"…(em-search --read"`; sessionstart `:285-288` comment text only. | `node tests/test-so-lesson-injection.mjs` pass; `node tests/test-activation-playbooks.mjs` pass; `grep -c` of `em-search --history` across the three suites → 0 |
 | 2.4 | — | — | Commit `P4-S2: #505 render --history→--read (REQ-22)` + trailer. | `git log -1 --oneline` shows `P4-S2` |
+| 2.5 | `.github/workflows/plan-marker-validate.yml` | EDIT | DELTA-6: add a bare step `run: node tests/test-rfc-009-p4-telemetry.mjs` alongside the other RFC-009 activation suites (the lint requires the exact bare `run: node tests/<f>` form). | `node tests/test-ci-suite-registration.mjs` → 16 passed, 0 failed |
+| 2.6 | — | — | Commit `P4-S1 follow-up: register telemetry suite in CI` + trailer. | `git log -1 --oneline` shows the follow-up commit |
 
 ### `P4-S3` — R9b clerk **report** mode, lexical + drain-safe (REQ-1,2,3,4,5,21,23) — writes NOTHING
 

--- a/plugins/claude-code-activation/hooks/activation-hook-run.mjs
+++ b/plugins/claude-code-activation/hooks/activation-hook-run.mjs
@@ -89,6 +89,7 @@ function resolveAsset(relForms) {
 
 const TRIGGER_INDEX_SCRIPT = resolveAsset(['em-trigger-index.mjs', 'scripts/em-trigger-index.mjs'])
 const MATCH_LIB_PATH = resolveAsset(['lib/activation-match.mjs', 'scripts/lib/activation-match.mjs'])
+const ACTIVATION_LOG_LIB_PATH = resolveAsset(['lib/activation-log.mjs', 'scripts/lib/activation-log.mjs'])
 const VALIDATE_LIB_PATH = resolveAsset(['lib/json-instance-validate.mjs', 'scripts/lib/json-instance-validate.mjs'])
 const SUPPRESS_SCHEMA_PATH = resolveAsset(['lesson-suppress.schema.json', 'schemas/lesson-suppress.schema.json'])
 
@@ -308,11 +309,15 @@ function mergeIndexes(local, global) {
       const v = typeof e.value === 'string' ? e.value : ''
       const key = `${e.episode_id}\u0000${tk}\u0000${v}`
       const existing = mapped.get(key)
-      if (!existing) { mapped.set(key, e); continue }
+      // RFC-009 P4-S1 (1.2d): tag each row with its origin store via a shallow
+      // copy — the entry object itself is NEVER mutated (e stays pristine for
+      // any other consumer holding a reference to the same object).
+      const tagged = { ...e, source_scope: idx === local ? 'local' : 'global' }
+      if (!existing) { mapped.set(key, tagged); continue }
       // R2.9(b): a playbook row replaces a lesson row for the same tuple ("the
       // PLAYBOOK form wins" — it carries the read_command). Forged/malformed
       // rows of either kind pass without replacement if entry_class is absent.
-      if (e.entry_class === 'playbook' && existing.entry_class !== 'playbook') mapped.set(key, e)
+      if (e.entry_class === 'playbook' && existing.entry_class !== 'playbook') mapped.set(key, tagged)
     }
   }
   const entries = [...mapped.values()]
@@ -407,13 +412,20 @@ function mergePreflight(localVal, globalVal) {
 function mergeSessionStart(localStatus, globalStatus) {
   const localVal = localStatus.ok ? localStatus.value : null
   const globalVal = globalStatus.ok ? globalStatus.value : null
+  // F4 (review-confirmed): stamp source_scope on each session_start entry during
+  // the merge — the persisted sections carry no origin tag, so without this
+  // stamp the entries[] producer in activation-match.mjs sees source_scope=null
+  // and the F4 access-count join (per-scope index lookup below) can't bind the
+  // row to its index.jsonl. Mirrors mergeIndexes' shallow-copy tag (same
+  // non-mutation invariant: original entries stay pristine).
+  const tagScope = (list, scope) => Array.isArray(list) ? list.map((e) => (e && typeof e === 'object' ? { ...e, source_scope: scope } : e)) : []
   const critical_entries = dedupByEpisodeId([
-    localVal ? localVal.critical_entries : null,
-    globalVal ? globalVal.critical_entries : null,
+    localVal ? tagScope(localVal.critical_entries, 'local') : null,
+    globalVal ? tagScope(globalVal.critical_entries, 'global') : null,
   ])
   const entries = sortEntriesByStaticScore(dedupByEpisodeId([
-    localVal ? localVal.entries : null,
-    globalVal ? globalVal.entries : null,
+    localVal ? tagScope(localVal.entries, 'local') : null,
+    globalVal ? tagScope(globalVal.entries, 'global') : null,
   ]))
   const preflight = mergePreflight(localVal, globalVal)
   // RFC-011 R2.7 / REQ-8: thread the LOCAL persisted playbooks trio UNCHANGED
@@ -582,6 +594,32 @@ async function main() {
 
   let text = lines.join('\n')
   if (result.overflowNote) text += `\n${result.overflowNote}`
+
+  // RFC-009 P4-S1 (R6, REQ-16): event-plane telemetry — one append per
+  // injection, fire-and-forget. Never allowed to affect stdout/exit (the
+  // advisory invariant governs this whole file); the try/catch here is a
+  // SECOND belt-and-suspenders layer on top of appendActivationLine's own
+  // internal try/catch, covering the resolveAsset/import/dataDir plumbing
+  // itself, not just the write.
+  try {
+    if (ACTIVATION_LOG_LIB_PATH) {
+      const logMod = await import(pathToFileURL(ACTIVATION_LOG_LIB_PATH).href)
+      const entries = (result.entries ?? []).map((e) => ({
+        id: e.id,
+        effective_priority: e.effective_priority,
+        rendered: e.rendered,
+        source_scope: e.source_scope,
+        access_count_at_inject: e.access_count_at_inject,
+      }))
+      const ts = new Date().toISOString()
+      const project = identity.slug
+      const surface = EVENT_NAME === 'PreToolUse' ? 'tool' : EVENT_NAME === 'SessionStart' ? 'session_start' : 'per_prompt'
+      const dataDir = path.join(identity.root, '.episodic-memory')
+      logMod.appendActivationLine(dataDir, { ts, project, event: 'inject', surface, entries })
+    }
+  } catch {
+    // fire-and-forget (REQ-16): never let telemetry affect stdout/exit.
+  }
 
   process.stdout.write(JSON.stringify({
     hookSpecificOutput: {

--- a/plugins/claude-code-activation/manifest.json
+++ b/plugins/claude-code-activation/manifest.json
@@ -16,7 +16,7 @@
     { "id": "rfc-009-activation-session-start", "file": "activation-sessionstart.sh", "event": "SessionStart", "timeout": 10, "checksum": "sha256:b3db3db55f11dbeeed04fc0314e286d6cd37de27af260ef23909b58129a32667" }
   ],
   "support_files": [
-    { "file": "activation-hook-run.mjs", "checksum": "sha256:637540da08f00f717e1d02e610e7f081b5e9e95233489c70d7f3f7e58ca3d94d" }
+    { "file": "activation-hook-run.mjs", "checksum": "sha256:60c88ad441401e1bd28050261e075bff8b04cfd7cc5c6e68d46f771f7c63f8a0" }
   ],
   "io_schema": "schemas/runtime/activation-io.schema.json",
   "runbook": {

--- a/plugins/codex-activation/hooks/activation-match.mjs
+++ b/plugins/codex-activation/hooks/activation-match.mjs
@@ -208,13 +208,24 @@ function renderPlaybookLine(entry) {
   return `playbook (playbooks.json): READ ${id} before proceeding (${rc}): ${summary}`;
 }
 
+// isImperative(entry) — single source of truth for the imperative-vs-plain
+// predicate. R4 (S3) playbook rows are ALWAYS imperative (read_command-bearing
+// provenance prefix); lesson rows are imperative iff their effective_priority
+// is in the critical band (>=8). Exported so the RFC-009 P4-S1 telemetry
+// schema entries[] cannot diverge from the rendered lines[] (REQ-16/RFC-009
+// R6 telemetry producer — S1).
+function isImperative(entry) {
+  if (entry && entry.entry_class === "playbook") return true;
+  return Number(entry && entry.effective_priority) >= 8;
+}
+
 function renderLine(entry) {
   // R4 (S3): playbook rows render the playbook form regardless of priority.
   if (entry && entry.entry_class === "playbook") return renderPlaybookLine(entry);
   const id = entry.episode_id;
   const summary = String(entry.summary ?? "");
-  if (Number(entry.effective_priority) >= 8) {
-    return `READ ${id} before proceeding (em-search --history ${id} --full): ${summary}`;
+  if (isImperative(entry)) {
+    return `READ ${id} before proceeding (em-search --read ${id}): ${summary}`;
   }
   return `lesson ${id}: ${summary}`;
 }
@@ -368,6 +379,11 @@ function selectAndBound(candidates, bounds) {
   });
 
   const lines = [];
+  const entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to lines[], one
+                      // entry per INJECTED lesson, carrying the schema fields
+                      // {id, effective_priority, rendered, source_scope,
+                      // access_count_at_inject}. Populated in lock-step with
+                      // lines.push so result.entries.length === result.lines.length.
   const dropped = [];
   let totalTokens = 0;
 
@@ -387,6 +403,19 @@ function selectAndBound(candidates, bounds) {
       continue;
     }
     lines.push(line);
+    // trigger-index entries carry effective_priority AND access_count (RFC-009
+    // P4-S1 R6 / plan step 1.2cb: em-trigger-index.mjs stamps access_count from
+    // the in-hand index.jsonl rows at build time, so the hook never reads
+    // index.jsonl at event time). access_count defaults to 0 for any row whose
+    // index.jsonl record did not carry an integer value. source_scope is
+    // stamped by mergeIndexes in the hook.
+    entries.push({
+      id: entry.episode_id,
+      effective_priority: entry.effective_priority,
+      rendered: isImperative(entry) ? "imperative" : "plain",
+      source_scope: entry.source_scope ?? null,
+      access_count_at_inject: entry.access_count ?? 0,
+    });
     totalTokens += lineTokens;
   }
 
@@ -395,7 +424,7 @@ function selectAndBound(candidates, bounds) {
     ? `+${dropped.length} more matches suppressed, incl. critical ${criticalDropped.episode_id}`
     : null;
 
-  return { lines, overflowNote };
+  return { lines, overflowNote, entries };
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +497,7 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   const tier1CandidateIds = new Set(tier1Candidates.map((e) => e.episode_id));
 
   const tier1Lines = [];
+  const tier1Entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to tier1Lines.
   const droppedTier1 = [];
   let totalTokens = 0;
   for (const e of sortedTier1) {
@@ -476,6 +506,16 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) { droppedTier1.push(e); continue; }
     tier1Lines.push(line);
+    // entries[] carries one entry per episode-bearing LESSON only.
+    // preflight and pattern-health output are surface lines only and
+    // never carry entries — they are spread into lines below, not entries.
+    tier1Entries.push({
+      id: e.episode_id,
+      effective_priority: e.effective_priority,
+      rendered: isImperative(e) ? "imperative" : "plain",
+      source_scope: e.source_scope ?? null,
+      access_count_at_inject: e.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -502,11 +542,19 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   for (const p of playbookCandidates) tier1CandidateIds.add(p.episode_id);
   const playbookLines = [];
   const droppedPlaybooks = [];
+  const playbookEntries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to playbookLines.
   for (const p of playbookCandidates) {
     const line = renderPlaybookLine(p);
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) { droppedPlaybooks.push(p); continue; }
     playbookLines.push(line);
+    playbookEntries.push({
+      id: p.episode_id,
+      effective_priority: p.effective_priority ?? 0, // playbooks pinned 0 (R2)
+      rendered: "imperative", // playbooks always imperative (R4 S3)
+      source_scope: p.source_scope ?? null,
+      access_count_at_inject: p.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -521,11 +569,21 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   // preserve that order rather than re-sorting on a field tier 2 must not read.
 
   const tier2Lines = [];
+  const tier2Entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to tier2Lines.
   for (const e of tier2Candidates) {
     const line = renderPlainLine(e);
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) continue; // state I' — silent, never critical
     tier2Lines.push(line);
+    // tier-2 entries carry NO effective_priority by REQ-18/§8.2 — the schema
+    // pin is plain-only, so the rendered form is unconditionally 'plain'.
+    tier2Entries.push({
+      id: e.episode_id,
+      effective_priority: null,
+      rendered: "plain",
+      source_scope: e.source_scope ?? null,
+      access_count_at_inject: e.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -609,7 +667,11 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
     }
   }
 
-  return { lines: [...tier1Lines, ...playbookLines, ...tier2Lines, ...preflightLines, ...patternHealthLines], overflowNote };
+  return {
+    lines: [...tier1Lines, ...playbookLines, ...tier2Lines, ...preflightLines, ...patternHealthLines],
+    overflowNote,
+    entries: [...tier1Entries, ...playbookEntries, ...tier2Entries], // RFC-009 P4-S1 (R6) telemetry
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -652,25 +714,25 @@ export function matchActivation(index, event, identity, suppress, bounds) {
     }
 
     const entries = sanitizeEntries(index);
-    if (entries.length === 0) return { lines: [], overflowNote: null };
+    if (entries.length === 0) return { lines: [], overflowNote: null, entries: [] };
 
     if (kind !== "prompt" && kind !== "tool") {
       // any other/unknown kind: empty, advisory (fail open).
-      return { lines: [], overflowNote: null };
+      return { lines: [], overflowNote: null, entries: [] };
     }
 
     const candidates = candidatesForEvent(entries, event, index, identity);
     const surviving = filterSuppressed(candidates, suppress);
     const deduped = dedupByEpisodePreferPlaybook(surviving); // RFC-011 R2.9(b) one-per-episode + playbook-wins
-    if (deduped.length === 0) return { lines: [], overflowNote: null };
+    if (deduped.length === 0) return { lines: [], overflowNote: null, entries: [] };
 
     return selectAndBound(deduped, bounds);
   } catch {
-    return { lines: [], overflowNote: null };
+    return { lines: [], overflowNote: null, entries: [] };
   }
 }
 
 // Exported for the test file's direct unit coverage of the parsing/escape
 // helpers (word-boundary/regex-metachar/tool-glob edge cases) without
 // re-deriving them through full matchActivation fixtures.
-export { matchesPhrase, matchesToolTrigger, parseToolTrigger, scopeOk, renderLine, renderPlainLine, renderPlaybookLine, estimateTokens, renderSessionStart, dedupByEpisodePreferPlaybook };
+export { matchesPhrase, matchesToolTrigger, parseToolTrigger, scopeOk, isImperative, renderLine, renderPlainLine, renderPlaybookLine, estimateTokens, renderSessionStart, dedupByEpisodePreferPlaybook };

--- a/plugins/codex-activation/manifest.json
+++ b/plugins/codex-activation/manifest.json
@@ -17,7 +17,7 @@
   ],
   "support_files": [
     { "file": "activation-hook-run.mjs", "checksum": "sha256:4bc2605eda864e38fe6894b53690aafa20f64e18114788f661886a37aa53e844" },
-    { "file": "activation-match.mjs", "checksum": "sha256:4995cfe35554c6b61f06eff20ed1deaab9c99f4f5f8513cd3281d50e658e52f2" },
+    { "file": "activation-match.mjs", "checksum": "sha256:e6cc87b0787b425c5a8d86a9e8847cc1a7d11b438e432d83e01624ed6f2d37af" },
     { "file": "json-instance-validate.mjs", "checksum": "sha256:5ccf2b3121e0ec0631e39e583ecc30d98fe625f15c9810cdd9ae1e8675927528" }
   ],
   "io_schema": "schemas/runtime/activation-io.schema.json",

--- a/schemas/trigger-index.schema.json
+++ b/schemas/trigger-index.schema.json
@@ -78,7 +78,8 @@
         "review_by": { "type": "string" },
         "entry_class": { "enum": ["playbook"] },
         "read_command": { "type": "string" },
-        "triggers_overridden": { "type": "boolean" }
+        "triggers_overridden": { "type": "boolean" },
+        "access_count": { "type": "integer" }
       },
       "allOf": [
         {
@@ -113,7 +114,8 @@
       "properties": {
         "episode_id": { "type": "string", "minLength": 1 },
         "summary": { "type": "string" },
-        "read_command": { "type": "string" }
+        "read_command": { "type": "string" },
+        "access_count": { "type": "integer" }
       }
     },
     "playbooksReport": {

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -419,6 +419,11 @@ if (foldSuperseded) {
 // TDZ on const/let below the if-block would otherwise break the loader path).
 const _clerkTriggerPhrasesByEpisodeId = new Map()
 let _clerkActiveRows = []
+// Per-run memo for clerkHighDfTags: keyed on activeRows ref identity (stable
+// within a run because _clerkActiveRows is assigned once). Declared at module
+// scope so it's initialized BEFORE clerkSignals first runs (function decls are
+// hoisted; const is not — keeping it here avoids TDZ).
+const _highDfCache = new WeakMap()
 // --break-highdf disables the high-df tag drop in clerkSignals (negative control
 // for report::signalHighDfDrop; production runs never carry this flag).
 const _BREAK_HIGHDF = process.argv.includes('--break-highdf')
@@ -760,11 +765,15 @@ function clerkTagsFor(row) {
 // _BREAK_HIGHDF declared above the clerk-report branch to avoid TDZ.
 function clerkHighDfTags(activeRows) {
   if (_BREAK_HIGHDF) return new Set()
+  const rows = activeRows || []
+  const cached = _highDfCache.get(rows)
+  if (cached) return cached
   const df = new Map()
-  for (const r of activeRows) for (const t of clerkTagsFor(r)) df.set(t, (df.get(t) || 0) + 1)
-  const cutoff = HIGH_DF_MIN(activeRows.length)
+  for (const r of rows) for (const t of clerkTagsFor(r)) df.set(t, (df.get(t) || 0) + 1)
+  const cutoff = HIGH_DF_MIN(rows.length)
   const high = new Set()
   for (const [tag, n] of df) if (n >= cutoff) high.add(tag)
+  _highDfCache.set(rows, high)
   return high
 }
 function clerkTagJaccard(aTags, bTags, highDf) {

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -63,6 +63,8 @@ import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensInd
 import { loadCategories, canonicalCategory, machineConsumedCategories } from './lib/categories.mjs'
 import { loadProtectionRows, computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
 import { resolveRegisteredStores, resolveRegisteredStoresWithStatus, realpathSafe } from './lib/registered-stores.mjs'
+import { TAG_JACCARD_MIN, SUMMARY_JACCARD_MIN, HIGH_DF_MIN, CADENCE_K_SHARED, CADENCE_N_LESSONS, PROPOSED_ACTIONS } from './lib/activation-log.mjs'
+import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -90,6 +92,7 @@ const apply = argv.includes('--apply')
 const confirm = argv.includes('--confirm')
 const foldSuperseded = argv.includes('--fold-superseded')
 const dryRun = argv.includes('--dry-run')
+const clerk = argv.includes('--clerk')
 // Default chain length before folding kicks in. 10 keeps short, still-warm
 // revision chains intact while catching the pathological ones (the live
 // store's worst chain measured ~145 members).
@@ -406,6 +409,193 @@ if (foldSuperseded) {
 }
 
 // ---------------------------------------------------------------------------
+// Clerk report mode (--clerk, default). RFC-009 P4-S3, R9b, REQ-1..5/13/21/23.
+// Pure-read: writes NOTHING to the store — byte-identical index.jsonl before/after.
+// --break-report-write injects a stray appendFileSync inside the clerk branch
+// (negative control for report::byteIdenticalStore; guarded so it ONLY fires
+// with the flag).
+// ---------------------------------------------------------------------------
+// Module-level state for clerkSignals (must be declared before this block runs;
+// TDZ on const/let below the if-block would otherwise break the loader path).
+const _clerkTriggerPhrasesByEpisodeId = new Map()
+let _clerkActiveRows = []
+// --break-highdf disables the high-df tag drop in clerkSignals (negative control
+// for report::signalHighDfDrop; production runs never carry this flag).
+const _BREAK_HIGHDF = process.argv.includes('--break-highdf')
+if (clerk && !apply) {
+  const _clerkBreakReportWrite = process.argv.includes('--break-report-write')
+  const _clerkBreakDrain = process.argv.includes('--break-drain')
+  const _clerkActiveRaw = loadIndex(DATA_DIR, scope).filter(r =>
+    r.status !== 'superseded' &&
+    typeof r.id === 'string' &&
+    typeof r.summary === 'string' &&
+    !EXCLUDED_CATEGORIES.has(canonicalCategory(r.category)) &&
+    (includePinned || r.pinned !== true) &&
+    (!categoryFilter || canonicalCategory(r.category) === canonicalCategory(categoryFilter)) &&
+    (!projectFilter || r.project === projectFilter) &&
+    !Array.isArray(r.consolidates)
+  )
+  _clerkActiveRows = _clerkActiveRaw
+
+  // Load the R2 trigger index (merged across local+global) for shared-trigger detection.
+  // FIX-1 (S3 review F2): bind `project` to path.dirname(LOCAL_DIR) so the
+  // trigger-index build targets the SAME store loadIndex walks up to
+  // (LOCAL_DIR = <repo-root>/.episodic-memory → path.dirname = repo-root).
+  // The prior ternary (process.cwd()) created a PHANTOM .episodic-memory in
+  // any subdir cwd, silently under-clustering. NOTE em-consolidate's own
+  // --project flag is a NAME filter over row.project and is intentionally
+  // NOT forwarded here; em-trigger-index's project arg is a PATH binding.
+  let _clerkTriggerIndex = { entries: [] }
+  try {
+    _clerkTriggerIndex = loadMergedTriggerIndex({ project: LOCAL_DIR === DATA_DIR ? path.dirname(LOCAL_DIR) : undefined })
+  } catch {}
+  clerkRegisterTriggers(_clerkTriggerIndex)
+
+  // REQ-23 cadence advisory inputs: phrase-sharing count + active-lesson count.
+  const phraseSharingCount = (() => {
+    const map = new Map()
+    for (const e of (_clerkTriggerIndex.entries || [])) {
+      if (!e || e.trigger_kind !== 'phrase' || typeof e.value !== 'string') continue
+      map.set(e.value, (map.get(e.value) || 0) + 1)
+    }
+    let max = 0
+    for (const n of map.values()) if (n > max) max = n
+    return max
+  })()
+  const activeCount = _clerkActiveRaw.length
+
+  // Group by (project, category) — identical to existing consolidation grouping.
+  const _groups = new Map()
+  for (const r of _clerkActiveRaw) {
+    const key = `${r.project}\u0000${canonicalCategory(r.category)}`
+    if (!_groups.has(key)) _groups.set(key, [])
+    _groups.get(key).push(r)
+  }
+
+  // Union-find pair clustering over clerkSignals/clerkResolveAction.
+  const _parent = new Map()
+  const _find = (x) => { while (_parent.get(x) !== x) { _parent.set(x, _parent.get(_parent.get(x))); x = _parent.get(x) } return x }
+  const _union = (a, b) => { const ra = _find(a), rb = _find(b); if (ra !== rb) _parent.set(ra, rb) }
+  for (const r of _clerkActiveRaw) _parent.set(r.id, r.id)
+
+  // Per-row supersession-adjacency (state D): an active that points at the SAME
+  // root (r.supersedes) as another active in the group → mark both roots.
+  const _supersessionRoots = new Map() // root -> [ids]
+  for (const r of _clerkActiveRaw) {
+    if (typeof r.supersedes === 'string' && r.supersedes) {
+      if (!_supersessionRoots.has(r.supersedes)) _supersessionRoots.set(r.supersedes, [])
+      _supersessionRoots.get(r.supersedes).push(r.id)
+    }
+  }
+  const _supersessionAdjacent = new Set()
+  for (const ids of _supersessionRoots.values()) {
+    if (ids.length >= 2) for (const id of ids) _supersessionAdjacent.add(id)
+  }
+
+  // Pairwise signals → cluster when resolveAction returns merge or dedupe.
+  for (const members of _groups.values()) {
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const a = members[i], b = members[j]
+        const sig = clerkSignals(a, b)
+        // EC5 — empty/whitespace summaries always keep-distinct (handled inside).
+        // State D — supersession-adjacency → merge regardless of pair signal.
+        let action
+        if (_supersessionAdjacent.has(a.id) && _supersessionAdjacent.has(b.id) && a.supersedes === b.supersedes) {
+          action = 'merge'
+        } else {
+          action = clerkResolveAction(sig)
+        }
+        if (action === 'merge' || action === 'dedupe') _union(a.id, b.id)
+      }
+    }
+  }
+
+  const _byRoot = new Map()
+  for (const r of _clerkActiveRaw) {
+    const root = _find(r.id)
+    if (!_byRoot.has(root)) _byRoot.set(root, [])
+    _byRoot.get(root).push(r)
+  }
+  const _clusters = [..._byRoot.entries()]
+    .filter(([, members]) => members.length >= minCluster)
+    .map(([, members]) => members.sort((a, b) => String(a.date).localeCompare(String(b.date)) || a.id.localeCompare(b.id)))
+
+  // Cluster envelope contract: members (id+summary), signals, proposed_action.
+  // proposed_action for the WHOLE cluster = the most-actionable action seen
+  // across its pairs (dedupe > merge > keep-distinct).
+  const ACTION_RANK = { 'dedupe': 3, 'merge': 2, 'keep-distinct': 1 }
+  const _clusterReports = _clusters.map((members) => {
+    const ids = members.map(m => m.id)
+    let bestAction = 'keep-distinct'
+    let bestSig = null
+    for (let i = 0; i < members.length && bestAction !== 'dedupe'; i++) {
+      for (let j = i + 1; j < members.length && bestAction !== 'dedupe'; j++) {
+        const a = members[i], b = members[j]
+        const sig = clerkSignals(a, b)
+        const action = (_supersessionAdjacent.has(a.id) && _supersessionAdjacent.has(b.id) && a.supersedes === b.supersedes)
+          ? 'merge'
+          : clerkResolveAction(sig)
+        if (ACTION_RANK[action] > ACTION_RANK[bestAction]) { bestAction = action; bestSig = sig }
+      }
+    }
+    // FIX-3 (S3 review F3): cap each cluster's members[] at CLUSTER_MEMBER_CAP
+    // with a per-cluster members_truncated '+M more' sentinel, mirroring the
+    // top-level clusters cap (REQ-5: every id list bounded).
+    const CLUSTER_MEMBER_CAP = 500
+    const memberObjs = members.map(m => ({ id: m.id, summary: m.summary }))
+    const cluster = {
+      members: memberObjs.slice(0, CLUSTER_MEMBER_CAP),
+      signals: bestSig || { tag_jaccard: 0, summary_jaccard: 0, shared_triggers: [], dropped_high_df_tags: [], same_category: true },
+      proposed_action: bestAction,
+    }
+    if (memberObjs.length > CLUSTER_MEMBER_CAP) {
+      cluster.members_truncated = `+${memberObjs.length - CLUSTER_MEMBER_CAP} more`
+    }
+    return cluster
+  })
+
+  // Token-bounded envelope (REQ-5): never an unbounded id list. Cap at 500 ids.
+  const CLERK_ID_CAP = 500
+  let truncatedSentinel
+  if (_clusterReports.length > CLERK_ID_CAP) {
+    truncatedSentinel = `+${_clusterReports.length - CLERK_ID_CAP} more`
+    _clusterReports.length = CLERK_ID_CAP
+  }
+
+  // REQ-23 cadence advisory (one-line string field; advisory ONLY, never a gate).
+  let advisory
+  if (phraseSharingCount >= CADENCE_K_SHARED) {
+    advisory = `cadence: ${phraseSharingCount} trigger-index entries share a phrase (>= ${CADENCE_K_SHARED}); consider a clerk run`
+  } else if (activeCount >= CADENCE_N_LESSONS) {
+    advisory = `cadence: ${activeCount} active lessons (>= ${CADENCE_N_LESSONS}); consider a clerk run`
+  }
+
+  // Negative control: --break-report-write injects a stray write INSIDE the clerk
+  // branch so report::byteIdenticalStore has teeth (red when the flag is set).
+  if (_clerkBreakReportWrite) {
+    try { fs.appendFileSync(path.join(DATA_DIR, 'index.jsonl'), '{"id":"__break-report-write-sentinel__"}\n') } catch {}
+  }
+
+  const _report = {
+    status: 'ok',
+    mode: 'clerk-report',
+    clusters: _clusterReports,
+    ...(truncatedSentinel ? { truncated: truncatedSentinel } : {}),
+    ...(advisory ? { advisory } : {}),
+  }
+
+  // Drain-before-exit (#486, REQ-4): em-search.mjs:120 idiom.
+  const _drain = () => new Promise(resolve => process.stdout.write(JSON.stringify(_report) + '\n', resolve))
+  if (_clerkBreakDrain) {
+    process.stdout.write(JSON.stringify(_report) + '\n')
+    process.exit(0)
+  }
+  await _drain()
+  process.exit(0)
+}
+
+// ---------------------------------------------------------------------------
 // Load candidates
 // ---------------------------------------------------------------------------
 const rows = loadIndex(DATA_DIR, scope).filter(r =>
@@ -542,6 +732,141 @@ function nowParts() {
 
 function slugify(text) {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
+}
+
+// ---------------------------------------------------------------------------
+// Clerk lexical signals + action resolution (RFC-009 P4-S3, R9b, REQ-2/3/13/21)
+// ---------------------------------------------------------------------------
+// Module-level trigger-phrase index populated by the clerk-report loader: id ->
+// Set<phrase> (the trigger VALUES whose R2 trigger-index entry points at the id).
+// Pure lexical (no body/embedding); same-category + summary-tokens are case-folded,
+// /[a-z0-9-]+/, length>2, no shingling, confirmatory only.
+// (state holders declared above the clerk-report branch to avoid TDZ on hoisted refs)
+function clerkRegisterTriggers(triggerIndex) {
+  _clerkTriggerPhrasesByEpisodeId.clear()
+  if (!triggerIndex || !Array.isArray(triggerIndex.entries)) return
+  for (const e of triggerIndex.entries) {
+    if (!e || typeof e.episode_id !== 'string') continue
+    if (e.trigger_kind !== 'phrase' || typeof e.value !== 'string') continue
+    if (!_clerkTriggerPhrasesByEpisodeId.has(e.episode_id)) _clerkTriggerPhrasesByEpisodeId.set(e.episode_id, new Set())
+    _clerkTriggerPhrasesByEpisodeId.get(e.episode_id).add(e.value)
+  }
+}
+function clerkTagsFor(row) {
+  return Array.isArray(row && row.tags) ? row.tags.filter(t => typeof t === 'string') : []
+}
+// High-df drop: a tag whose document frequency across the ACTIVE lessons meets
+// HIGH_DF_MIN(activeCount) is dropped from the tag-Jaccard comparison (T2).
+// _BREAK_HIGHDF declared above the clerk-report branch to avoid TDZ.
+function clerkHighDfTags(activeRows) {
+  if (_BREAK_HIGHDF) return new Set()
+  const df = new Map()
+  for (const r of activeRows) for (const t of clerkTagsFor(r)) df.set(t, (df.get(t) || 0) + 1)
+  const cutoff = HIGH_DF_MIN(activeRows.length)
+  const high = new Set()
+  for (const [tag, n] of df) if (n >= cutoff) high.add(tag)
+  return high
+}
+function clerkTagJaccard(aTags, bTags, highDf) {
+  // FIX-2 (S3 review F5): compute `dropped` BEFORE the both-empty-after-drop
+  // early-return. The prior implementation discarded `dropped` on the empty
+  // path — observed a CLUSTERED state-B pair reporting dropped_high_df_tags=[]
+  // where REQ-2 requires ["common"].
+  const dropped = [...new Set([...aTags, ...bTags].filter(t => highDf.has(t)))].sort()
+  const a = new Set(aTags.filter(t => !highDf.has(t)))
+  const b = new Set(bTags.filter(t => !highDf.has(t)))
+  if (a.size === 0 && b.size === 0) return { j: 0, dropped }
+  let inter = 0
+  const small = a.size <= b.size ? a : b
+  const large = small === a ? b : a
+  for (const t of small) if (large.has(t)) inter++
+  const union = a.size + b.size - inter
+  return { j: union === 0 ? 0 : inter / union, dropped }
+}
+function clerkSummaryTokens(s) {
+  if (typeof s !== 'string') return new Set()
+  const out = new Set()
+  const lc = s.toLowerCase()
+  const re = /[a-z0-9-]+/g
+  let m
+  while ((m = re.exec(lc)) !== null) {
+    if (m[0].length > 2) out.add(m[0])
+  }
+  return out
+}
+function clerkSummaryJaccard(aSummary, bSummary) {
+  const a = clerkSummaryTokens(aSummary)
+  const b = clerkSummaryTokens(bSummary)
+  if (a.size === 0 && b.size === 0) return 0
+  let inter = 0
+  const small = a.size <= b.size ? a : b
+  const large = small === a ? b : a
+  for (const t of small) if (large.has(t)) inter++
+  const union = a.size + b.size - inter
+  return union === 0 ? 0 : inter / union
+}
+function clerkSharedTriggers(idA, idB) {
+  const a = _clerkTriggerPhrasesByEpisodeId.get(idA)
+  const b = _clerkTriggerPhrasesByEpisodeId.get(idB)
+  if (!a || !b) return []
+  const out = []
+  for (const t of a) if (b.has(t)) out.push(t)
+  return out.sort()
+}
+// clerkSignals(a, b) — returns the LEXICAL signal object for a pair; caller
+// adds the supersession-adjacency flag separately because it needs the broader
+// cluster context. NO body/embedding similarity anywhere.
+// FIX-2 (S3 review N2): the activeCount parameter was dead — clerkHighDfTags
+// reads _clerkActiveRows.length directly. Removed; callers no longer pass it.
+// FIX-2 (S3 review N1): compare RAW jaccard values against the thresholds in
+// clerkResolveAction. Round to 3 decimals ONLY for the reported signal fields
+// (display). Prior code rounded BEFORE comparison, fuzzing the 0.5/0.4 boundary.
+function clerkSignals(a, b) {
+  const highDf = clerkHighDfTags(_clerkActiveRows || [])
+  const tagJ = clerkTagJaccard(clerkTagsFor(a), clerkTagsFor(b), highDf)
+  const sumJ = clerkSummaryJaccard(a && a.summary, b && b.summary)
+  const triggers = clerkSharedTriggers(a && a.id, b && b.id)
+  const sameCategory = !!a && !!b && canonicalCategory(a.category) === canonicalCategory(b.category)
+  return {
+    tag_jaccard: Math.round(tagJ.j * 1000) / 1000,
+    tag_jaccard_raw: tagJ.j,
+    tag_jaccard_min: TAG_JACCARD_MIN,
+    dropped_high_df_tags: tagJ.dropped,
+    summary_jaccard: Math.round(sumJ * 1000) / 1000,
+    summary_jaccard_raw: sumJ,
+    summary_jaccard_min: SUMMARY_JACCARD_MIN,
+    same_category: sameCategory,
+    shared_triggers: triggers,
+    summary_empty_or_whitespace: !(typeof (a && a.summary) === 'string' && a.summary.trim()) ||
+                                !(typeof (b && b.summary) === 'string' && b.summary.trim()),
+  }
+}
+// clerkResolveAction(signals) — §12 5-state table. EC5 empty/whitespace summaries
+// always degrade to keep-distinct (empty compares equal to itself).
+// FIX-2 (S3 review N1): compare RAW jaccard values via the *_raw fields, not
+// the rounded display fields. Round only for reporting.
+function clerkResolveAction(signals) {
+  if (!signals || signals.summary_empty_or_whitespace) return 'keep-distinct'
+  const tagJ = typeof signals.tag_jaccard_raw === 'number' ? signals.tag_jaccard_raw : signals.tag_jaccard
+  const sumJ = typeof signals.summary_jaccard_raw === 'number' ? signals.summary_jaccard_raw : signals.summary_jaccard
+  // E: high-df-only overlap → keep-distinct (dropped tags listed in signals)
+  if (tagJ === 0 && signals.shared_triggers.length === 0 && signals.dropped_high_df_tags.length > 0) {
+    return 'keep-distinct'
+  }
+  const tagStrong = tagJ >= TAG_JACCARD_MIN
+  const sumStrong = sumJ >= SUMMARY_JACCARD_MIN
+  const triggerShared = signals.shared_triggers.length > 0
+  // A: near-identical — summary-J + tag-J + same category → dedupe
+  // §12 state A: "summary-Jaccard ≥0.4 AND tag-Jaccard ≥0.5 AND same category"
+  // (trigger-shared is NOT a state A precondition — it makes B fire earlier
+  // via the shared-trigger leg below; state A is the lexical-near-identical case).
+  if (tagStrong && sumStrong && signals.same_category) return 'dedupe'
+  // B: related distinct — shared trigger or strong tag-J, summaries diverge
+  if ((triggerShared || tagStrong) && sumJ < SUMMARY_JACCARD_MIN) return 'merge'
+  // C: only confirmatory summary overlap, no trigger/tag corroboration
+  if (sumStrong && !triggerShared && !tagStrong) return 'keep-distinct'
+  // D caller-side flag (supersession-adjacent): handled in caller, NOT here.
+  return 'keep-distinct'
 }
 
 function updateInverted(fileName, id, keys, pretty) {

--- a/scripts/em-trigger-index.mjs
+++ b/scripts/em-trigger-index.mjs
@@ -129,6 +129,21 @@ function parseRows(raw) {
   return rows
 }
 
+// Build an id -> access_count lookup from an in-hand rows array. The build
+// already loads index.jsonl as input, so this is data it has in hand at
+// emit time — never a new read path. Plan step 1.2cb: stamp access_count
+// into the trigger-index entry so the matcher picks it up as
+// entry.access_count ?? 0, leaving the event plane (hook) read-free.
+function accessCountById(rows) {
+  const m = new Map()
+  for (const r of rows) {
+    if (r && typeof r.id === 'string' && r.id) {
+      m.set(r.id, Number.isInteger(r.access_count) ? r.access_count : 0)
+    }
+  }
+  return m
+}
+
 // ---------------------------------------------------------------------------
 // Chain resolution + the earned band (REQ-13)
 // ---------------------------------------------------------------------------
@@ -421,6 +436,7 @@ function buildPlaybookSection({ config, localRows, globalRaw, storeDir, scriptsR
   const globalRows = globalRaw ? parseRows(globalRaw) : []
   const merged = mergeIndexRowsForChain(localRows, globalRows)
   const { byId, successorOf } = buildChainMaps(merged) // reused verbatim (R2.1)
+  const acMap = accessCountById(merged) // plan 1.2cb: stamp access_count at build time
   const todayStr = now.toISOString().slice(0, 10)
   const maxPlaybooks = (config.bounds && Number.isInteger(config.bounds.max_playbooks))
     ? config.bounds.max_playbooks : 2
@@ -482,6 +498,7 @@ function buildPlaybookSection({ config, localRows, globalRaw, storeDir, scriptsR
     episode_id: r.terminalId,
     summary: r.terminal.summary,
     read_command: `node ${scriptsRoot}/em-search.mjs --read ${r.terminalId}`,
+    access_count: acMap.get(r.terminalId) ?? 0,
   }))
 
   // Phase 6: on_demand entry rows — the FULL verbatim shape (R2), pinned to 0.
@@ -504,6 +521,7 @@ function buildPlaybookSection({ config, localRows, globalRaw, storeDir, scriptsR
         applies_to_tools: ['*'],
         entry_class: 'playbook',
         read_command: `node ${scriptsRoot}/em-search.mjs --read ${r.terminalId}`,
+        access_count: acMap.get(r.terminalId) ?? 0,
         ...(r.overridden ? { triggers_overridden: true } : {}),
       })
     }
@@ -657,6 +675,7 @@ export function buildTriggerIndex({ project, scope = 'local', now = new Date(), 
   }
 
   const excludedActivity = Object.create(null)
+  const acMap = accessCountById(rows)
   const entries = []
   for (const row of rows) {
     if (!row || row.category !== 'lesson') continue
@@ -682,6 +701,7 @@ export function buildTriggerIndex({ project, scope = 'local', now = new Date(), 
         effective_priority: ep, // DERIVED 1-9; never the stored `priority`
         applies_to_projects: Array.isArray(row.applies_to_projects) ? row.applies_to_projects : [],
         applies_to_tools: Array.isArray(row.applies_to_tools) ? row.applies_to_tools : [],
+        access_count: acMap.get(row.id) ?? 0,
         ...(typeof row.review_by === 'string' ? { review_by: row.review_by } : {}),
       })
     }
@@ -789,6 +809,7 @@ export function buildSessionStart(rows, now = new Date()) {
 
   // critical_entries — EVERY active band-8/9 lesson, TRIGGER-INDEPENDENT (EC14:
   // R8 always-tier content carries no trigger; the band scan covers ALL lessons).
+  const acMap = accessCountById(rows)
   const critical_entries = activeLessons
     .filter(r => ep(r.id) >= 8)
     .map(r => ({
@@ -798,6 +819,7 @@ export function buildSessionStart(rows, now = new Date()) {
       effective_priority: ep(r.id),
       applies_to_projects: Array.isArray(r.applies_to_projects) ? r.applies_to_projects : [],
       applies_to_tools: Array.isArray(r.applies_to_tools) ? r.applies_to_tools : [],
+      access_count: acMap.get(r.id) ?? 0,
     }))
     .sort((a, b) => b.effective_priority - a.effective_priority || (a.episode_id < b.episode_id ? -1 : 1))
 
@@ -832,6 +854,7 @@ export function buildSessionStart(rows, now = new Date()) {
     static_score: Number(static_score.toFixed(6)),
     applies_to_projects: Array.isArray(r.applies_to_projects) ? r.applies_to_projects : [],
     applies_to_tools: Array.isArray(r.applies_to_tools) ? r.applies_to_tools : [],
+    access_count: acMap.get(r.id) ?? 0,
   }))
 
   // preflight — per-task-type recent-violation counts keyed by the TYPED

--- a/scripts/lib/activation-log.mjs
+++ b/scripts/lib/activation-log.mjs
@@ -1,0 +1,58 @@
+// scripts/lib/activation-log.mjs (CREATE, S1) — shared by the hook writer AND the clerk reader.
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const LOG_FORMAT_VERSION = 1
+export const ACTIVATION_LOG_NAME = 'activation-log.jsonl'
+export const ACTIVATION_LOG_MAX_BYTES = 1024 * 1024 // 1 MiB (T8)
+export const RENDERED_FORMS = ['imperative', 'plain']
+export const INJECTION_SURFACES = ['session_start', 'per_prompt', 'tool', 'dispatcher']
+// Clerk (em-consolidate) constants:
+export const RUN_RECORD_CATEGORY = 'workflow.lifecycle'
+export const RUN_RECORD_TYPE = 'clerk-run'          // scalar frontmatter key, NEVER a tag
+export const CLERK_CUTOVER_MARKER = 'rfc-009-p4'     // the clerk STAMPS `clerk_cutover:<this>` frontmatter on every
+                                                     // digest + run-record it writes; legacy digests LACK the field
+                                                     // → clock-independent crash discriminator (NSP F6, NOT a date compare)
+export const TAG_JACCARD_MIN = 0.5                   // T1
+export const SUMMARY_JACCARD_MIN = 0.4               // T3
+export const HIGH_DF_MIN = (activeCount) => Math.max(3, Math.ceil(0.10 * activeCount)) // T2
+export const CADENCE_K_SHARED = 3                    // T4
+export const CADENCE_N_LESSONS = 200                 // T5
+export const ATTRIBUTION_WINDOW_MS = 4 * 60 * 60 * 1000 // T6, half-open [inject, inject+window)
+export const PROPOSED_ACTIONS = ['merge', 'dedupe', 'keep-distinct']
+
+// Portable negative-control break overrides (§A.0/A.9): cross-platform `--break-<x>`
+// argv flags, NOT env vars — the activation hook + tests must run under Windows `cmd`.
+// Production invocations never carry these; the S1 tests pass them to prove the
+// drop-at-bound / non-fatal guards are not vacuous.
+const BREAK_BOUND = process.argv.includes('--break-bound')
+const BREAK_WRITEFAIL = process.argv.includes('--break-writefail')
+
+// appendActivationLine(dataDir, line) — the R6 event-plane telemetry writer.
+// Append-only, size-bounded, fire-and-forget: at the 1 MiB bound the new line is
+// DROPPED (never truncates/rewrites — dropping preserves append-only, REQ-17); a
+// failed write is a stderr note, never a throw (REQ-16, hook stays non-fatal).
+export function appendActivationLine(dataDir, line) {
+  try {
+    const serialized = JSON.stringify({ v: LOG_FORMAT_VERSION, ...line })
+    const withNewline = serialized + '\n'
+    const lineBytes = Buffer.byteLength(withNewline)
+    const logPath = path.join(dataDir, ACTIVATION_LOG_NAME)
+    let size = 0
+    try {
+      size = fs.statSync(logPath).size
+    } catch {
+      size = 0 // log absent → 0
+    }
+    if (!BREAK_BOUND && size + lineBytes > ACTIVATION_LOG_MAX_BYTES) {
+      process.stderr.write('activation-log: size bound reached; dropping line\n')
+      return { dropped: true } // REQ-17: drop, do NOT append (never truncate)
+    }
+    fs.appendFileSync(logPath, withNewline)
+    return { dropped: false }
+  } catch (e) {
+    if (BREAK_WRITEFAIL) throw e // negative control only: prove the guard has teeth
+    process.stderr.write(`activation-log: write failed (${e && e.message}); dropping line\n`)
+    return { error: true } // REQ-16: fire-and-forget, never a hook failure
+  }
+}

--- a/scripts/lib/activation-match.mjs
+++ b/scripts/lib/activation-match.mjs
@@ -225,7 +225,7 @@ function renderLine(entry) {
   const id = entry.episode_id;
   const summary = String(entry.summary ?? "");
   if (isImperative(entry)) {
-    return `READ ${id} before proceeding (em-search --history ${id} --full): ${summary}`;
+    return `READ ${id} before proceeding (em-search --read ${id}): ${summary}`;
   }
   return `lesson ${id}: ${summary}`;
 }

--- a/scripts/lib/activation-match.mjs
+++ b/scripts/lib/activation-match.mjs
@@ -208,12 +208,23 @@ function renderPlaybookLine(entry) {
   return `playbook (playbooks.json): READ ${id} before proceeding (${rc}): ${summary}`;
 }
 
+// isImperative(entry) — single source of truth for the imperative-vs-plain
+// predicate. R4 (S3) playbook rows are ALWAYS imperative (read_command-bearing
+// provenance prefix); lesson rows are imperative iff their effective_priority
+// is in the critical band (>=8). Exported so the RFC-009 P4-S1 telemetry
+// schema entries[] cannot diverge from the rendered lines[] (REQ-16/RFC-009
+// R6 telemetry producer — S1).
+function isImperative(entry) {
+  if (entry && entry.entry_class === "playbook") return true;
+  return Number(entry && entry.effective_priority) >= 8;
+}
+
 function renderLine(entry) {
   // R4 (S3): playbook rows render the playbook form regardless of priority.
   if (entry && entry.entry_class === "playbook") return renderPlaybookLine(entry);
   const id = entry.episode_id;
   const summary = String(entry.summary ?? "");
-  if (Number(entry.effective_priority) >= 8) {
+  if (isImperative(entry)) {
     return `READ ${id} before proceeding (em-search --history ${id} --full): ${summary}`;
   }
   return `lesson ${id}: ${summary}`;
@@ -368,6 +379,11 @@ function selectAndBound(candidates, bounds) {
   });
 
   const lines = [];
+  const entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to lines[], one
+                      // entry per INJECTED lesson, carrying the schema fields
+                      // {id, effective_priority, rendered, source_scope,
+                      // access_count_at_inject}. Populated in lock-step with
+                      // lines.push so result.entries.length === result.lines.length.
   const dropped = [];
   let totalTokens = 0;
 
@@ -387,6 +403,19 @@ function selectAndBound(candidates, bounds) {
       continue;
     }
     lines.push(line);
+    // trigger-index entries carry effective_priority AND access_count (RFC-009
+    // P4-S1 R6 / plan step 1.2cb: em-trigger-index.mjs stamps access_count from
+    // the in-hand index.jsonl rows at build time, so the hook never reads
+    // index.jsonl at event time). access_count defaults to 0 for any row whose
+    // index.jsonl record did not carry an integer value. source_scope is
+    // stamped by mergeIndexes in the hook.
+    entries.push({
+      id: entry.episode_id,
+      effective_priority: entry.effective_priority,
+      rendered: isImperative(entry) ? "imperative" : "plain",
+      source_scope: entry.source_scope ?? null,
+      access_count_at_inject: entry.access_count ?? 0,
+    });
     totalTokens += lineTokens;
   }
 
@@ -395,7 +424,7 @@ function selectAndBound(candidates, bounds) {
     ? `+${dropped.length} more matches suppressed, incl. critical ${criticalDropped.episode_id}`
     : null;
 
-  return { lines, overflowNote };
+  return { lines, overflowNote, entries };
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +497,7 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   const tier1CandidateIds = new Set(tier1Candidates.map((e) => e.episode_id));
 
   const tier1Lines = [];
+  const tier1Entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to tier1Lines.
   const droppedTier1 = [];
   let totalTokens = 0;
   for (const e of sortedTier1) {
@@ -476,6 +506,16 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) { droppedTier1.push(e); continue; }
     tier1Lines.push(line);
+    // entries[] carries one entry per episode-bearing LESSON only.
+    // preflight and pattern-health output are surface lines only and
+    // never carry entries — they are spread into lines below, not entries.
+    tier1Entries.push({
+      id: e.episode_id,
+      effective_priority: e.effective_priority,
+      rendered: isImperative(e) ? "imperative" : "plain",
+      source_scope: e.source_scope ?? null,
+      access_count_at_inject: e.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -502,11 +542,19 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   for (const p of playbookCandidates) tier1CandidateIds.add(p.episode_id);
   const playbookLines = [];
   const droppedPlaybooks = [];
+  const playbookEntries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to playbookLines.
   for (const p of playbookCandidates) {
     const line = renderPlaybookLine(p);
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) { droppedPlaybooks.push(p); continue; }
     playbookLines.push(line);
+    playbookEntries.push({
+      id: p.episode_id,
+      effective_priority: p.effective_priority ?? 0, // playbooks pinned 0 (R2)
+      rendered: "imperative", // playbooks always imperative (R4 S3)
+      source_scope: p.source_scope ?? null,
+      access_count_at_inject: p.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -521,11 +569,21 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
   // preserve that order rather than re-sorting on a field tier 2 must not read.
 
   const tier2Lines = [];
+  const tier2Entries = []; // RFC-009 P4-S1 (R6) telemetry: parallel to tier2Lines.
   for (const e of tier2Candidates) {
     const line = renderPlainLine(e);
     const t = estimateTokens(line);
     if (t > maxTokens || totalTokens + t > maxTokens) continue; // state I' — silent, never critical
     tier2Lines.push(line);
+    // tier-2 entries carry NO effective_priority by REQ-18/§8.2 — the schema
+    // pin is plain-only, so the rendered form is unconditionally 'plain'.
+    tier2Entries.push({
+      id: e.episode_id,
+      effective_priority: null,
+      rendered: "plain",
+      source_scope: e.source_scope ?? null,
+      access_count_at_inject: e.access_count ?? 0,
+    });
     totalTokens += t;
   }
 
@@ -609,7 +667,11 @@ function renderSessionStart(sessionStart, identity, suppress, bounds) {
     }
   }
 
-  return { lines: [...tier1Lines, ...playbookLines, ...tier2Lines, ...preflightLines, ...patternHealthLines], overflowNote };
+  return {
+    lines: [...tier1Lines, ...playbookLines, ...tier2Lines, ...preflightLines, ...patternHealthLines],
+    overflowNote,
+    entries: [...tier1Entries, ...playbookEntries, ...tier2Entries], // RFC-009 P4-S1 (R6) telemetry
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -652,25 +714,25 @@ export function matchActivation(index, event, identity, suppress, bounds) {
     }
 
     const entries = sanitizeEntries(index);
-    if (entries.length === 0) return { lines: [], overflowNote: null };
+    if (entries.length === 0) return { lines: [], overflowNote: null, entries: [] };
 
     if (kind !== "prompt" && kind !== "tool") {
       // any other/unknown kind: empty, advisory (fail open).
-      return { lines: [], overflowNote: null };
+      return { lines: [], overflowNote: null, entries: [] };
     }
 
     const candidates = candidatesForEvent(entries, event, index, identity);
     const surviving = filterSuppressed(candidates, suppress);
     const deduped = dedupByEpisodePreferPlaybook(surviving); // RFC-011 R2.9(b) one-per-episode + playbook-wins
-    if (deduped.length === 0) return { lines: [], overflowNote: null };
+    if (deduped.length === 0) return { lines: [], overflowNote: null, entries: [] };
 
     return selectAndBound(deduped, bounds);
   } catch {
-    return { lines: [], overflowNote: null };
+    return { lines: [], overflowNote: null, entries: [] };
   }
 }
 
 // Exported for the test file's direct unit coverage of the parsing/escape
 // helpers (word-boundary/regex-metachar/tool-glob edge cases) without
 // re-deriving them through full matchActivation fixtures.
-export { matchesPhrase, matchesToolTrigger, parseToolTrigger, scopeOk, renderLine, renderPlainLine, renderPlaybookLine, estimateTokens, renderSessionStart, dedupByEpisodePreferPlaybook };
+export { matchesPhrase, matchesToolTrigger, parseToolTrigger, scopeOk, isImperative, renderLine, renderPlainLine, renderPlaybookLine, estimateTokens, renderSessionStart, dedupByEpisodePreferPlaybook };

--- a/tests/test-activation-match.mjs
+++ b/tests/test-activation-match.mjs
@@ -19,8 +19,27 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { matchActivation } from "../scripts/lib/activation-match.mjs";
+import { matchActivation as _matchActivationRaw } from "../scripts/lib/activation-match.mjs";
 import { validateInstance } from "../scripts/lib/json-instance-validate.mjs";
+
+// --break-* negative control (matches test-rfc-009-p4-telemetry.mjs's
+// argv-flag convention): --break-render post-processes rendered lines back to
+// the pre-P4-S2 --history form so render::usesReadNotHistory fails loud when
+// the migration is reverted. Render is closed-over inside matchActivation
+// (ESM named exports are immutable bindings), so the harness wraps the
+// call-site and rewrites the output instead of stubbing renderLine in place.
+const BREAK_RENDER = process.argv.includes("--break-render");
+const matchActivation = BREAK_RENDER
+  ? (...args) => {
+      const r = _matchActivationRaw(...args);
+      return {
+        ...r,
+        lines: r.lines.map((l) =>
+          l.replace(/\(em-search --read (\S+)\)/g, "(em-search --history $1 --full)"),
+        ),
+      };
+    }
+  : _matchActivationRaw;
 
 const REPO = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), ".."));
 
@@ -217,11 +236,12 @@ for (const cls of LAUNCH_CLASSES) {
 {
   const index = idx([entry({ value: "criticalthing", episode_id: "id-band8", effective_priority: 8, summary: "do the thing" })]);
   const r = matchActivation(index, promptEvent("criticalthing happened"), IDENTITY, undefined, BOUNDS);
-  assert(r.lines.length === 1, "render_imperative_band8: one line rendered", JSON.stringify(r));
+  const line = r.lines[0] || "";
+  assert(r.lines.length === 1, "render::usesReadNotHistory: exactly one line rendered for a band-8 trigger", JSON.stringify(r));
   assert(
-    r.lines[0] === "READ id-band8 before proceeding (em-search --history id-band8 --full): do the thing",
-    "render_imperative_band8: exact imperative form naming the tracked read command",
-    r.lines[0],
+    line.includes("--read") && !line.includes("--history"),
+    "render::usesReadNotHistory: rendered band-8 imperative line names the tracked --read command and never --history",
+    line,
   );
 }
 {

--- a/tests/test-activation-match.mjs
+++ b/tests/test-activation-match.mjs
@@ -251,13 +251,13 @@ for (const cls of LAUNCH_CLASSES) {
   const dirty = [];
   for (const [i, s] of samples.entries()) {
     const keys = Object.keys(s).sort();
-    const shapeOk = keys.length === 2 && keys[0] === "lines" && keys[1] === "overflowNote";
+    const shapeOk = keys.length === 3 && keys[0] === "entries" && keys[1] === "lines" && keys[2] === "overflowNote";
     const noDecision = !Object.hasOwn(s, "decision") && !Object.hasOwn(s, "block") && !Object.hasOwn(s, "permissionDecision");
     const serialized = JSON.stringify(s);
     const noDecisionInJson = !/"decision"|"block"|"permissionDecision"/.test(serialized);
     if (!shapeOk || !noDecision || !noDecisionInJson) { allClean = false; dirty.push({ i, s }); }
   }
-  assert(allClean, "render_no_decision_field: MatchResult carries only {lines, overflowNote} across every sampled state, never decision/block/permissionDecision", JSON.stringify(dirty));
+  assert(allClean, "render_no_decision_field: MatchResult carries only {entries, lines, overflowNote} across every sampled state, never decision/block/permissionDecision", JSON.stringify(dirty));
 }
 
 // ===========================================================================

--- a/tests/test-activation-playbooks.mjs
+++ b/tests/test-activation-playbooks.mjs
@@ -226,7 +226,7 @@ function writeBand9Violations(dir, crit) {
   assert(ctx.includes(`node ${path.join(FAKE_ROOT, "scripts", "em-search.mjs")} --read ${ss}`), "T4a_session_start_playbook_renders: read_command names the verbatim tracked em-search --read command (precomputed at build)", ctx);
   assert(ctx.includes("ss playbook summary"), "T4a_session_start_playbook_renders: summary carried", ctx);
   // Positioning: critical (band-9 imperative form) -> playbook band -> tier-2 plain.
-  const critIdx = ctx.indexOf(`READ ${crit} before proceeding (em-search --history ${crit} --full)`);
+  const critIdx = ctx.indexOf(`READ ${crit} before proceeding (em-search --read ${crit})`);
   const pbIdx = ctx.indexOf(`playbook (playbooks.json): READ ${ss}`);
   const plainIdx = ctx.indexOf(`lesson ${plain}:`);
   assert(critIdx !== -1 && pbIdx !== -1 && plainIdx !== -1 && critIdx < pbIdx && pbIdx < plainIdx,
@@ -319,9 +319,11 @@ function writeBand9Violations(dir, crit) {
   const r = runSessionStart({ home, stdin: { hook_event_name: "SessionStart" } });
   const out = parseHookOut(r.stdout);
   const ctx = out && out.hookSpecificOutput ? out.hookSpecificOutput.additionalContext : "";
-  // Critical form verbatim: `READ ${ss} before proceeding (em-search --history ${ss} --full): ...`
-  assert(ctx.includes(`READ ${ss} before proceeding (em-search --history ${ss} --full)`),
-    "T4d_critical_wins: the dual id renders in CRITICAL form (em-search --history)", ctx);
+  // Critical form verbatim: `READ ${ss} before proceeding (em-search --read ${ss}): ...`
+  assert(ctx.includes(`READ ${ss} before proceeding (em-search --read ${ss})`),
+    "T4d_critical_wins: the dual id renders in CRITICAL form (em-search --read)", ctx);
+  assert(!ctx.includes("(em-search --history"),
+    "T4d_critical_wins: critical render never names --history (REQ-22 guard)", ctx);
   const pbMatchCount = (ctx.match(/playbook \(playbooks\.json\): READ /g) || []).length;
   assert(pbMatchCount === 0, "T4d_critical_wins: the playbook line for the dual id never renders (one id, one line, critical form wins; R2.9(c))", `pbMatchCount=${pbMatchCount}`);
   removeManifest();
@@ -897,7 +899,7 @@ function normalizeMtime(p) {
     const r = matchActivation(idx, promptEvent("alphaword and betaword together"), IDENTITY, undefined, BOUNDS);
     const lines = r.lines;
     const pbForm = lines.filter((l) => l.includes("playbook (playbooks.json):"));
-    const lsForm = lines.filter((l) => l.startsWith("lesson dual-1:") || l.startsWith("READ dual-1 before proceeding (em-search --history"));
+    const lsForm = lines.filter((l) => l.startsWith("lesson dual-1:") || l.startsWith("READ dual-1 before proceeding (em-search --read"));
     assert(lines.length === 1, "T6g_playbook_wins_one_line: exactly ONE line for the episode (R2.9(b) one-per-episode)", JSON.stringify(lines));
     assert(pbForm.length === 1 && lsForm.length === 0, "T6g_playbook_wins: the one line is the PLAYBOOK form, NOT the lesson imperative/plain form (R2.9(b) playbook-wins; the seen-set did not let the band-9 lesson row block the playbook row)", JSON.stringify(lines));
   }

--- a/tests/test-activation-sessionstart.mjs
+++ b/tests/test-activation-sessionstart.mjs
@@ -283,7 +283,7 @@ function rebuildFreshGlobal(home, proj) {
   assert(ctx.includes(`READ ${crit.id}`), "tier2_static_order_plain_only: the critical lesson renders imperative (tier 1)", ctx);
   assert(ctx.includes(`lesson ${plain.id}:`), "tier2_static_order_plain_only: the plain lesson renders plain (tier 2)", ctx);
   // renderLine's imperative form legitimately repeats the id twice within its
-  // OWN line (`READ <id> ... --history <id> --full`) -- the dedup assertion
+  // OWN line (`READ <id> ... --read <id>`) -- the dedup assertion
   // is that the PLAIN tier-2 rendering of the critical id never appears, not
   // a raw substring count.
   assert(!ctx.includes(`lesson ${crit.id}:`),

--- a/tests/test-rfc-009-p4-report.mjs
+++ b/tests/test-rfc-009-p4-report.mjs
@@ -173,7 +173,14 @@ function runClerk({ root, extraArgs = [], home }) {
     timeout: 120000,
     env,
   })
-  return { status: r.status, stdout: r.stdout, stderr: r.stderr, json: parseLastJson(r.stdout) }
+  return {
+    status: r.status,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    json: parseLastJson(r.stdout),
+    signal: r.signal,
+    errorCode: r.error && r.error.code || null,
+  }
 }
 function parseLastJson(stdout) {
   if (!stdout) return null

--- a/tests/test-rfc-009-p4-report.mjs
+++ b/tests/test-rfc-009-p4-report.mjs
@@ -1,0 +1,665 @@
+#!/usr/bin/env node
+/**
+ * test-rfc-009-p4-report.mjs — RFC-009 P4-S3 (R9b clerk report mode, REQ-1..5/13/21/23).
+ *
+ * Proves the clerk report mode of scripts/em-consolidate.mjs:
+ *   - writes NOTHING to the store (byte-identical index.jsonl before/after);
+ *   - uses lexical signals ONLY (no body/embedding similarity);
+ *   - emits clusters with the canonical shape (members + signals + proposed_action);
+ *   - caps oversized cluster sets with a '+N more' sentinel;
+ *   - drains stdout before exit on >64KB reports;
+ *   - emits the REQ-23 cadence advisory when trigger-phrase sharing or active-lesson
+ *     count crosses the pinned threshold.
+ *
+ * Every assertion inspects real captured runtime state (parsed JSON, hash, file size,
+ * spawn stdout/stderr) — never a constant. The clerk is spawned via the REAL
+ * scripts/em-consolidate.mjs with explicit cwd into isolated fixture dirs.
+ *
+ * Negative controls (§A.9, portable --break-* argv flags):
+ *   --break-report-write → injects a stray appendFileSync inside the clerk branch
+ *                          → report::byteIdenticalStore FAILS
+ *   --break-highdf       → disables the high-df drop in clerkSignals
+ *                          → report::signalHighDfDrop FAILS (and the green run
+ *                            against the same fixture must pass)
+ *   --break-drain        → bypasses drain-before-exit at the large-report emit
+ *                          → report::largeReportNotTruncated FAILS
+ *
+ * Suite pass-through: this runner forwards --break-* / --break-report-write /
+ * --break-highdf / --break-drain flags from its own argv to every spawned
+ * em-consolidate.mjs so the negative-control assertions run against the same
+ * fixture as the green runs.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'em-consolidate.mjs')
+
+// Suite-level --break-* passthrough: a test runner argv flag MUST NOT propagate
+// blindly (otherwise --break-X from the suite runner shadows other suites). Forward
+// ONLY the four S3-documented break flags.
+const PASS_THROUGH_BREAK_FLAGS = new Set()
+for (const flag of ['--break-report-write', '--break-highdf', '--break-drain']) {
+  if (process.argv.includes(flag)) PASS_THROUGH_BREAK_FLAGS.add(flag)
+}
+
+let pass = 0, fail = 0
+const failures = []
+const ONLY_FLAG = (() => { const i = process.argv.indexOf('--only'); return i >= 0 ? process.argv[i + 1] : null })()
+function t(name, fn) {
+  if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
+  try { fn(); pass++ }
+  catch (e) { fail++; failures.push(`${name} - ${e && e.message}`) }
+}
+function eq(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`)
+}
+function ok(cond, label) { if (!cond) throw new Error(label) }
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+for (const sig of ['SIGINT', 'SIGTERM']) process.on(sig, () => process.exit(130))
+function mkTmp(label) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `p4s3-${label}-`)))
+  _tmpDirs.push(base)
+  return base
+}
+
+// Build a minimal but valid local store under <root>/.episodic-memory/ + an
+// episodes/ dir. Returns { root, dataDir, episodesDir }.
+function mkStore(label) {
+  const root = mkTmp(`store-${label}`)
+  const dataDir = path.join(root, '.episodic-memory')
+  const episodesDir = path.join(dataDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  // categories.json is required for em-consolidate's loadCategories() guard
+  // (otherwise the script fails closed at startup). Copy the real one.
+  const realCats = path.join(REPO_ROOT, 'scripts', 'categories.json')
+  if (fs.existsSync(realCats)) {
+    fs.copyFileSync(realCats, path.join(dataDir, 'categories.json'))
+  }
+  return { root, dataDir, episodesDir }
+}
+
+// Seed one lesson: writes <id>.md into episodesDir AND appends a row to index.jsonl.
+// `sentinel` is a per-test discriminating token (the assertion token, never
+// "non-empty"); every fixture row embeds it so the test can locate its fixture.
+function seedLesson({ dataDir, episodesDir, id, date, project, category, tags, summary, body, triggers = [], appliesToProjects = [], appliesToTools = [], priority, supersedes, pinned, sourceScope }) {
+  const fmLines = [
+    '---',
+    `id: ${id}`,
+    `date: ${date}`,
+    `time: "00:00"`,
+    `project: ${project}`,
+    `category: ${category}`,
+    'status: active',
+    ...(supersedes ? [`supersedes: ${supersedes}`] : []),
+    ...(pinned ? ['pinned: true'] : []),
+    `tags: [${(tags || []).join(', ')}]`,
+    ...(typeof priority === 'number' ? [`priority: ${priority}`] : []),
+    `summary: ${summary}`,
+    ...(triggers.length ? [`triggers: [${triggers.map(t => `"${t}"`).join(', ')}]`] : []),
+    ...(appliesToProjects.length ? [`applies_to_projects: [${appliesToProjects.map(t => `"${t}"`).join(', ')}]`] : []),
+    ...(appliesToTools.length ? [`applies_to_tools: [${appliesToTools.map(t => `"${t}"`).join(', ')}]`] : []),
+    '---',
+  ]
+  const content = `${fmLines.join('\n')}\n\n# ${summary}\n\n${body || ''}\n`
+  fs.writeFileSync(path.join(episodesDir, `${id}.md`), content, 'utf8')
+  const row = {
+    id, date, time: '00:00', project, category,
+    status: 'active', supersedes: supersedes || null, consolidates: null,
+    tags: tags || [], summary,
+    ...(triggers.length ? { triggers: triggers.slice() } : {}),
+    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects.slice() } : {}),
+    ...(appliesToTools.length ? { applies_to_tools: appliesToTools.slice() } : {}),
+    ...(typeof priority === 'number' ? { priority } : {}),
+    ...(pinned ? { pinned: true } : {}),
+    ...(sourceScope ? { source_scope: sourceScope } : {}),
+  }
+  fs.appendFileSync(path.join(dataDir, 'index.jsonl'), JSON.stringify(row) + '\n', 'utf8')
+}
+
+// Seed the trigger-index.json directly (the simplest controllable shape for
+// shared-trigger tests; em-trigger-index --scope local rebuilds from index.jsonl
+// so we could shell out, but the schema is small and stable). Schema: { entries:
+// [{ trigger_kind, value, episode_id, ... }], session_start, schema_version }.
+//
+// Kept as a fallback for tests that need a controlled trigger-index shape
+// without going through seedLesson's `triggers:` field — the actual clerk runs
+// REBUILD the index from index.jsonl, so the preferred path is to seedLesson
+// with triggers and then call `buildFixtureTriggerIndex(root)`.
+function seedTriggerIndex({ dataDir, entries }) {
+  const idx = {
+    schema_version: 3,
+    generated_at: new Date().toISOString(),
+    source: { index_size: 0, index_sha256: '', playbooks_size: 0, playbooks_sha256: '' },
+    entries,
+    session_start: { entries: [], critical_entries: [], playbooks: [], playbooks_capped: false, playbooks_capped_first: '' },
+  }
+  fs.writeFileSync(path.join(dataDir, 'trigger-index.json'), JSON.stringify(idx), 'utf8')
+}
+
+// Build the trigger-index.json for a fixture root by shelling out to the real
+// em-trigger-index.mjs. The clerk reads `loadMergedTriggerIndex` which CALLS
+// `buildTriggerIndex` — the loader rebuilds the index from index.jsonl on a
+// fingerprint mismatch, so a stale `trigger-index.json` is overwritten anyway.
+// Running the build BEFORE the clerk call is the only way to guarantee the
+// fixture sees its test-specific trigger entries (the prior session proved
+// seeded-only `trigger-index.json` files never reach the clerk; the loader
+// re-reads index.jsonl, which had no `triggers:` field).
+const SCRIPT_TRIGGER_INDEX = path.join(REPO_ROOT, 'scripts', 'em-trigger-index.mjs')
+function buildFixtureTriggerIndex(root) {
+  const r = spawnSync('node', [SCRIPT_TRIGGER_INDEX, '--project', root, '--scope', 'local'], {
+    cwd: root, encoding: 'utf8', timeout: 60000,
+  })
+  if (r.status !== 0) throw new Error(`em-trigger-index build failed (exit ${r.status}, stderr=${(r.stderr || '').slice(0, 200)})`)
+  const idxPath = path.join(root, '.episodic-memory', 'trigger-index.json')
+  if (!fs.existsSync(idxPath)) throw new Error(`trigger-index.json not produced at ${idxPath} (stdout=${(r.stdout || '').slice(0, 200)})`)
+}
+
+// Spawn the real em-consolidate.mjs with --clerk into the given fixture root.
+// Returns { status, stdout, stderr, json }.
+function runClerk({ root, extraArgs = [], home }) {
+  const args = [SCRIPT, '--clerk', '--scope', 'local', ...extraArgs, ...PASS_THROUGH_BREAK_FLAGS]
+  const env = { ...process.env }
+  if (home) env.HOME = home
+  const r = spawnSync('node', args, {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: 120000,
+    env,
+  })
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, json: parseLastJson(r.stdout) }
+}
+function parseLastJson(stdout) {
+  if (!stdout) return null
+  const lines = stdout.trim().split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim()
+    if (!line.startsWith('{')) continue
+    try { return JSON.parse(line) } catch {}
+  }
+  return null
+}
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')
+}
+// FIX-4 (S3 review F7): full source-store manifest as sorted (relpath, sha256)
+// tuples for every file under a store dir, EXCEPT trigger-index.json — the
+// REQ-1 carve-out (R2 lazy rebuild may produce or change it; the rest of the
+// store MUST be byte-identical). Returned as a sorted array of arrays so deep
+// equality is unambiguous; missing dir → empty array.
+function manifestExcludingTriggerIndex(dataDir) {
+  const out = []
+  if (!fs.existsSync(dataDir)) return out
+  function walk(dir, relBase) {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const rel = relBase ? `${relBase}/${ent.name}` : ent.name
+      if (rel === 'trigger-index.json') continue
+      const full = path.join(dir, ent.name)
+      if (ent.isDirectory()) walk(full, rel)
+      else if (ent.isFile()) out.push([rel, sha256(full)])
+    }
+  }
+  walk(dataDir, '')
+  out.sort((a, b) => a[0].localeCompare(b[0]))
+  return out
+}
+
+function main() {
+  // 1. report::byteIdenticalStore — FULL source-store manifest unchanged across
+  //    a --clerk run, in BOTH local AND global stores (FIX-4 / S3 review F7).
+  //    The one-file sha256(index.jsonl) check is structurally blind to
+  //    tags.json / category-index.json / episodes/ / global-store writes; the
+  //    manifest walk closes the class. trigger-index.json is EXCLUDED from
+  //    both manifests — the REQ-1 carve-out (R2 lazy rebuild MAY produce or
+  //    change it). HOME is isolated to a fixture-scoped dir so the GLOBAL
+  //    store is contained; the post-manifest in the isolated global must be
+  //    empty (or trigger-index.json only, which the exclusion removes).
+  //    The --break-report-write red control writes to DATA_DIR (local) via
+  //    appendFileSync(index.jsonl), so the LOCAL manifest WILL differ and
+  //    this assertion still fails when the flag is passed.
+  t('report::byteIdenticalStore', () => {
+    const S = mkStore('byteidentical')
+    const fixtureHome = mkTmp('byteidentical-home')
+    const globalDir = path.join(fixtureHome, '.episodic-memory')
+    fs.mkdirSync(globalDir, { recursive: true })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-byteident-aaaa', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['t-byteidentical'], summary: 'byteidentical baseline lesson', body: 'body' })
+    const localPre = manifestExcludingTriggerIndex(S.dataDir)
+    const globalPre = manifestExcludingTriggerIndex(globalDir)
+    const r = runClerk({ root: S.root, home: fixtureHome })
+    eq(r.status, 0, 'clerk exits 0')
+    eq(r.json && r.json.status, 'ok', 'status:ok')
+    const localPost = manifestExcludingTriggerIndex(S.dataDir)
+    const globalPost = manifestExcludingTriggerIndex(globalDir)
+    eq(JSON.stringify(localPost), JSON.stringify(localPre), `local manifest unchanged pre/post (pre=${JSON.stringify(localPre)} post=${JSON.stringify(localPost)})`)
+    eq(JSON.stringify(globalPost), JSON.stringify(globalPre), `isolated-global manifest unchanged pre/post (pre=${JSON.stringify(globalPre)} post=${JSON.stringify(globalPost)})`)
+  })
+
+  // 2. report::signalTagJaccard — pair with tag-Jaccard >= 0.5 + same category +
+  //    DIVERGENT summaries clusters as `merge` (state B); below threshold does NOT.
+  //    Note: tag-Jaccard alone is NOT a cluster signal (state B requires tag-J
+  //    AND summary divergence per the §12 5-state table).
+  t('report::signalTagJaccard', () => {
+    const S = mkStore('tagjaccard')
+    // pair A: tag-Jaccard >= 0.5 (3/4 shared = 0.75), DIVERGENT summaries (summary-J ~0)
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-tagjac-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['alpha', 'beta', 'gamma', 'delta'], summary: 'tagjaccard-strong zebra apple mango', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-tagjac-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['alpha', 'beta', 'gamma', 'epsilon'], summary: 'tagjaccard-strong yakkity plover quince', body: 'body' })
+    // pair B: tag-Jaccard < 0.5 (1/4 shared = 0.25), divergent summaries
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-tagjac-3333', date: '2026-01-03', project: 'acme', category: 'lesson', tags: ['one', 'two', 'three', 'four'], summary: 'tagjaccard-weak delta epsilon zeta', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-tagjac-4444', date: '2026-01-04', project: 'acme', category: 'lesson', tags: ['five', 'six', 'seven', 'eight'], summary: 'tagjaccard-weak eta theta iota', body: 'body' })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    const clusters = r.json.clusters || []
+    const strongPair = ['20260101-000000-tagjac-1111', '20260101-000000-tagjac-2222'].sort()
+    const weakPair = ['20260101-000000-tagjac-3333', '20260101-000000-tagjac-4444'].sort()
+    const strongCluster = clusters.find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === strongPair[0] && ids[1] === strongPair[1]
+    })
+    ok(!!strongCluster, `tag-Jaccard>=0.5 + divergent summaries clusters (got ${clusters.length} clusters)`)
+    const weakCluster = clusters.find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === weakPair[0] && ids[1] === weakPair[1]
+    })
+    ok(!weakCluster, 'tag-Jaccard<0.5 pair does NOT cluster')
+  })
+
+  // 3. report::signalHighDfDrop — a tag whose df >= HIGH_DF_MIN(activeCount) is
+  //    dropped from the tag-Jaccard comparison and listed in `dropped_high_df_tags`.
+  //    Disable the drop via --break-highdf to prove the drop is the discriminator
+  //    (paired negative control: a green run asserts dropped tags listed; the
+  //    --break-highdf run asserts the same pair STILL clusters because the high-df
+  //    tag is the only shared one and it was the only thing keeping them apart).
+  t('report::signalHighDfDrop', () => {
+    const S = mkStore('highdf')
+    // 10 lessons total; HIGH_DF_MIN(10) = max(3, ceil(0.10*10)) = 3; 'common'
+    // has df=10 >= 3 → high-df. The pair shares ONLY 'common' (the high-df tag);
+    // summaries are TOTALLY DISJOINT so summary-J=0. Without the drop (red):
+    // tag-J=[common] vs [common] = 1.0 → tagStrong → state B (merge) → cluster.
+    // With the drop (green): 'common' dropped, tag-J=0/0=0 → state E (keep-distinct) → no cluster.
+    for (let i = 0; i < 8; i++) {
+      const id = `20260101-000000-highdf-c${String(i).padStart(4, '0')}`
+      // Each filler has a UNIQUE summary token set so they don't cluster among
+      // themselves once 'common' is dropped (they only share 'common'). Each
+      // filler carries TWO unique tags (`lesson-N` + `unique-filler-N`) so the
+      // pair (pA, pB) — which only shares the high-df `common` tag with fillers —
+      // tag-Jaccards to <0.5 with any filler in EITHER mode. Without the extra
+      // unique tag, `lesson-N` alone gives filler↔pair tag-Jaccard 0.5 (just
+      // touching TAG_JACCARD_MIN) and the fillers would absorb the pair into
+      // one giant cluster under --break-highdf (F8 fixture-isolation bug).
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id, date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['common', `lesson-${i}`, `unique-filler-${i}`], summary: `filler${i} zebraword appleword mangoword`, body: 'body' })
+    }
+    const pairA = '20260101-000000-highdf-p0001'
+    const pairB = '20260101-000000-highdf-p0002'
+    // Pair shares ONLY 'common' (a high-df tag); summaries are disjoint (no shared
+    // tokens length>2) so summary-J=0 → state B (merge) fires under no-drop.
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: pairA, date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['common'], summary: 'pairmemberA yakkityword quinceword rhubarbword', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: pairB, date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['common'], summary: 'pairmemberB ploverword gannetword basilword', body: 'body' })
+    // GREEN: 'common' has df=10 >= HIGH_DF_MIN(10)=3 → dropped; pair tags=[]. J=0 → no cluster.
+    const r1 = runClerk({ root: S.root })
+    eq(r1.status, 0, 'green clerk exits 0')
+    const pairIds = [pairA, pairB].sort()
+    const greenCluster = (r1.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!greenCluster, `green: high-df tag dropped → pair does NOT cluster (got ${r1.json.clusters.length} clusters)`)
+    // RED: --break-highdf disables the drop → 'common' counts → tag-J=1.0 → clusters.
+    const r2 = runClerk({ root: S.root, extraArgs: ['--break-highdf'] })
+    eq(r2.status, 0, 'red clerk exits 0')
+    const redCluster = (r2.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!!redCluster, `red: --break-highdf disables drop → pair DOES cluster (got ${r2.json.clusters.length} clusters)`)
+  })
+
+  // 4. report::signalSummaryOverlap — summary-token Jaccard >= 0.4, same category
+  //    is a confirmatory signal (groups with corroborating tag/trigger).
+  t('report::signalSummaryOverlap', () => {
+    const S = mkStore('summaryoverlap')
+    // Tokenize summaries; with /[a-z0-9-]+/ length>2, case-folded:
+    //   "summary overlap confirmatory alphaword betaword gammaword deltaword one"  → {summary, overlap, confirmatory, alphaword, betaword, gammaword, deltaword, one}
+    //   "summary overlap confirmatory alphaword betaword gammaword deltaword two"  → shares 6 of 9 = 0.667
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-sumovr-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'summary overlap confirmatory alphaword betaword gammaword deltaword one', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-sumovr-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'summary overlap confirmatory alphaword betaword gammaword deltaword two', body: 'body' })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    const pairIds = ['20260101-000000-sumovr-1111', '20260101-000000-sumovr-2222'].sort()
+    const cluster = (r.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!!cluster, 'summary-Jaccard>=0.4 + tag corroboration clusters')
+  })
+
+  // 5. report::signalSharedTrigger — a shared trigger phrase (R2 trigger index)
+  //    groups a pair into a cluster. Seed triggers via the lesson frontmatter /
+  //    index row (the clerk's loadMergedTriggerIndex rebuilds the index from
+  //    index.jsonl, so a directly-seeded trigger-index.json is overwritten) then
+  //    buildFixtureTriggerIndex to materialize the derived artifact before the clerk run.
+  t('report::signalSharedTrigger', () => {
+    const S = mkStore('sharedtrigger')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-strig-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: [], summary: 'shared trigger one summary content distinct enough', body: 'body', triggers: ['sharedtrigrphrase'] })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-strig-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: [], summary: 'shared trigger two summary content different terms here', body: 'body', triggers: ['sharedtrigrphrase'] })
+    buildFixtureTriggerIndex(S.root)
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    const pairIds = ['20260101-000000-strig-1111', '20260101-000000-strig-2222'].sort()
+    const cluster = (r.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!!cluster, 'shared trigger phrase groups a pair into a cluster')
+  })
+
+  // 6. report::noBodyEmbedding — two episodes with near-identical BODIES but
+  //    disjoint tags/summaries/triggers do NOT cluster (lexical signals only;
+  //    body/embedding similarity is NEVER used).
+  t('report::noBodyEmbedding', () => {
+    const S = mkStore('nobody')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-nobody-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['alpha'], summary: 'nobody summary one terms zebra', body: 'BODY-SENTINEL-prjx9qw7 identical content across both lessons for the body overlap check', triggers: ['nobodytrigonephrase'] })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-nobody-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['beta'], summary: 'nobody summary two terms yakkity', body: 'BODY-SENTINEL-prjx9qw7 identical content across both lessons for the body overlap check', triggers: ['nobodytrigtwophrasex'] })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    const pairIds = ['20260101-000000-nobody-1111', '20260101-000000-nobody-2222'].sort()
+    const cluster = (r.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!cluster, 'near-identical bodies but disjoint tags/summaries/triggers do NOT cluster (no body/embedding similarity)')
+  })
+
+  // 7. report::clusterShapeContract — every cluster carries members (each with
+  //    id+summary), signals, and proposed_action.
+  t('report::clusterShapeContract', () => {
+    const S = mkStore('shape')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-shape-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'shape contract one summary overlap test alphaword betaword', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-shape-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'shape contract two summary overlap test alphaword gammaword', body: 'body' })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    ok((r.json.clusters || []).length >= 1, `at least one cluster (got ${(r.json.clusters || []).length})`)
+    for (const c of r.json.clusters) {
+      ok(Array.isArray(c.members) && c.members.length >= 2, 'cluster.members is an array with >=2 entries')
+      for (const m of c.members) {
+        ok(typeof m.id === 'string' && typeof m.summary === 'string', `member has id+summary (got ${JSON.stringify(m)})`)
+      }
+      ok(c.signals && typeof c.signals === 'object', 'cluster.signals is an object')
+      ok(typeof c.proposed_action === 'string', `cluster.proposed_action is a string (got ${JSON.stringify(c.proposed_action)})`)
+    }
+  })
+
+  // 8. report::proposedActionEnum — every proposed_action ∈ {merge, dedupe, keep-distinct}.
+  t('report::proposedActionEnum', () => {
+    const S = mkStore('enum')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-enum-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'enum test one summary overlap alphaword betaword', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-enum-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB'], summary: 'enum test two summary overlap alphaword betaword', body: 'body' })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    const VALID = new Set(['merge', 'dedupe', 'keep-distinct'])
+    for (const c of (r.json.clusters || [])) {
+      ok(VALID.has(c.proposed_action), `proposed_action ∈ enum (got ${JSON.stringify(c.proposed_action)})`)
+    }
+  })
+
+  // 9. report::largeReportNotTruncated — a >64KB report piped to a consumer
+  //    arrives complete (byte length matches the producer's stdout).
+  t('report::largeReportNotTruncated', () => {
+    const S = mkStore('large')
+    // Seed enough lesson pairs that the cluster count drives the JSON above 64KB.
+    // Tags are PER-PAIR (`sharedA-${i}`, `sharedB-${i}`) so each pair's shared tags
+    // have df=2 (well below HIGH_DF_MIN(800)=80). A globally-shared tag like
+    // `sharedA` across all 800 lessons triggers the high-df drop → state E fires
+    // everywhere → 0 clusters → report = 52 bytes. Per-pair tags keep tag-J=1.0
+    // within a pair (state A → dedupe) and tag-J=0 across pairs (state C keep-distinct
+    // because summary-J is high but no corroboration) so we get 400 distinct 2-member
+    // clusters × ~250 bytes ≈ 100KB JSON.
+    for (let i = 0; i < 400; i++) {
+      const idA = `20260101-${String(i).padStart(6, '0')}-large-aaaa`
+      const idB = `20260101-${String(i).padStart(6, '0')}-large-bbbb`
+      const base = `large report fixture pair ${i} alphaword betaword summary`
+      const tags = [`sharedA-${i}`, `sharedB-${i}`]
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: idA, date: '2026-01-01', project: 'acme', category: 'lesson', tags, summary: `${base} one`, body: 'body' })
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: idB, date: '2026-01-02', project: 'acme', category: 'lesson', tags, summary: `${base} two`, body: 'body' })
+    }
+    const args = [SCRIPT, '--clerk', '--scope', 'local', ...PASS_THROUGH_BREAK_FLAGS]
+    // Pipe stdout to `wc -c` and capture BOTH the direct stdout AND the piped byte count.
+    const direct = spawnSync('node', args, { cwd: S.root, encoding: 'utf8', env: { ...process.env } })
+    ok(direct.status === 0, `direct spawn exits 0 (got ${direct.status}, stderr=${direct.stderr})`)
+    const piped = spawnSync('bash', ['-c', `node ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')} | wc -c`], { cwd: S.root, encoding: 'utf8' })
+    const pipedBytes = parseInt((piped.stdout || '0').trim(), 10)
+    ok(pipedBytes >= 65536, `piped stdout is >= 64KB (got ${pipedBytes} bytes)`)
+    const directBytes = Buffer.byteLength(direct.stdout || '', 'utf8')
+    ok(Math.abs(directBytes - pipedBytes) < 100, `direct byte count ~ piped byte count (direct=${directBytes} piped=${pipedBytes})`)
+    // Ensure the JSON parses as a complete clerk-report (no truncation). The piped
+    // JSON is captured via `| cat > file` (not `> file` redirect) so the pipe
+    // buffer — not a plain-file redirect — carries the data; without
+    // drain-before-exit (--break-drain) the pipe drops everything past the HWM
+    // and the captured file is truncated, so this parse fails (negative control
+    // for the drain idiom).
+    const pipedJsonPath = path.join(S.root, 'piped.json')
+    const pipedJson = spawnSync('bash', ['-c', `node ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')} | cat > '${pipedJsonPath}'`], { cwd: S.root, encoding: 'utf8' })
+    eq(pipedJson.status, 0, 'piped-redirection exit 0')
+    const pipedStdout = fs.readFileSync(pipedJsonPath, 'utf8')
+    const pipedJsonLen = Buffer.byteLength(pipedStdout, 'utf8')
+    ok(pipedJsonLen >= 65536, `piped-to-file stdout is >= 64KB (got ${pipedJsonLen} bytes)`)
+    const json = parseLastJson(pipedStdout)
+    ok(json && json.status === 'ok' && json.mode === 'clerk-report', `piped JSON is well-formed clerk-report (got status=${json && json.status} mode=${json && json.mode})`)
+    ok(Array.isArray(json.clusters), 'piped JSON clusters[] is an array')
+    ok(json.clusters.length > 0, `piped JSON has clusters (got ${json.clusters && json.clusters.length})`)
+  })
+
+  // 10. report::envelopeCapPlusNMore — the top-level cluster cap actually fires
+  //     (FIX-5 / S3 review F4). Seed 600 clustering 2-member pairs:
+  //     per-pair unique tags (df=2, no high-df) → tag-J=1.0 within pair;
+//     identical per-pair summaries → summary-J=1.0 within pair; different
+  //     summary across pairs → cross-pair signals zero. 600 clusters form
+  //     via state A (dedupe). The cap slices clusters[] at 500 with the
+  //     '+100 more' top-level sentinel. The prior test used 1200 disjoint
+  //     non-clustering lessons → clusters=[] (the cap path was never exercised).
+  t('report::envelopeCapPlusNMore', () => {
+    const S = mkStore('cap-clusters')
+    for (let i = 0; i < 600; i++) {
+      const tags = [`cap-pairA-${i}`, `cap-pairB-${i}`]
+      // Same summary text per pair (within-pair summary-J = 1.0); UNIQUE
+      // summary text across pairs (cross-pair summary-J ≈ 0). The summary
+      // body carries one PAIR-DISCRIMINATING token so cross-pair token
+      // overlap stays low; the shared cluster-summary base anchors the
+      // within-pair Jaccard.
+      const summary = `cap pair ${i} capclustermarker wordone wordtwo wordthree wordfour wordfive wordsix wordseven wodeight`
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: `20260101-${String(i).padStart(6, '0')}-cap-Aaaa`, date: '2026-01-01', project: 'acme', category: 'lesson', tags, summary, body: 'body' })
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: `20260101-${String(i).padStart(6, '0')}-cap-Bbbb`, date: '2026-01-01', project: 'acme', category: 'lesson', tags, summary, body: 'body' })
+    }
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    // FIX-4/-5: drain-tolerant — under --break-drain the large (~150KB) JSON
+    // exceeds the spawnSync pipe buffer (64KB on macOS) so stdout is truncated
+    // and r.json is null. Skip the structural assertions silently; the SOLE
+    // red control for drain is report::largeReportNotTruncated.
+    if (r.json === null) return
+    eq(r.json.status, 'ok', 'status:ok')
+    ok(Array.isArray(r.json.clusters), 'clusters[] present')
+    eq(r.json.clusters.length, 500, `clusters[] is capped at 500 (got ${r.json.clusters.length})`)
+    eq(r.json.truncated, '+100 more', `top-level '+100 more' sentinel present (got ${JSON.stringify(r.json.truncated)})`)
+    for (const c of r.json.clusters) {
+      ok(Array.isArray(c.members) && c.members.length === 2, `each cluster is 2 members (got ${c.members && c.members.length})`)
+    }
+  })
+
+  // 10b. report::envelopeCapPerClusterMembers — the per-cluster members[] cap
+  //      actually fires (FIX-3 / S3 review F3). Seed a chained giant cluster
+  //      of 600 lessons: lesson i shares 2 unique tags with lesson i+1 AND
+  //      all 600 carry IDENTICAL summaries. Adjacent-pair tag-Jaccard = 2/4 = 0.5
+  //      (lesson i = [tag_i, tag_{i+1}, unique_i, pad_i]; lesson i+1 = [tag_{i+1},
+  //      tag_{i+2}, unique_{i+1}, pad_{i+1}] sharing [tag_{i+1}] + ... ). Use a
+  //      2-tag shared window pattern: lesson i has [shared-i, shared-(i+1)] so
+  //      adjacent pair shares both tags → tag-J=1.0 (within the pair's 2-tag
+  //      footprint) and union is 3 → tag-J=2/3 ≈ 0.667; identical summaries
+  //      give summary-J=1.0; same category → state A → dedupe. Union-find
+  //      transitively connects all 600. Per-cluster members[] is capped at 500
+  //      with members_truncated='+100 more'.
+  t('report::envelopeCapPerClusterMembers', () => {
+    const S = mkStore('cap-members')
+    const sharedSummary = 'capmembers giant cluster summary anchor wordone wordtwo wordthree wordfour wordfive wordsix'
+    // Pattern: lesson i has [tag-i, tag-(i+1)] — tag-(i+1) is shared with
+    // lesson i+1. Adjacent pair shares exactly 1 tag → tag-J=1/3=0.333 (BELOW
+    // 0.5). To make every adjacent pair satisfy state A (tag-J ≥ 0.5), use the
+    // chain-of-overlap pattern: lesson i = [chain-i, chain-(i+1), uniq-i],
+    // chain-(i+1) shared with i AND i+2. Adjacent pair shares [chain-(i+1)]
+    // over union [chain-i, chain-(i+1), uniq-i, chain-(i+1), chain-(i+2),
+    // uniq-(i+1)] = 5 distinct → tag-J = 1/5 = 0.2 (BELOW). Need more shared.
+    //
+    // Final pattern: every lesson has [shared-anchor-A, shared-anchor-B, uniq-i].
+    // shared-anchor-{A,B} appear in EVERY lesson → df=600 ≥ HIGH_DF_MIN(600)=60
+    // → high-df drop → tag-J=0/0 → state E → no cluster. That's the wrong path.
+    //
+    // Correct path: use a CHAIN where each adjacent pair shares 2 unique tags.
+    // Lesson i = [c-i-a, c-i-b, c-(i+1)-a, c-(i+1)-b] (4 tags; the c-(i+1)-*
+    // set is shared with lesson i+1 which has [c-i-a, c-i-b, c-(i+1)-a,
+    // c-(i+1)-b, c-(i+2)-a, c-(i+2)-b]). The 2 shared tags with adjacent pair
+    // over 6 distinct union = 2/6 = 0.333. Below 0.5.
+    //
+    // The simplest way to make all 600 transitively cluster with state A:
+    // 2-tag overlap = 2 unique shared between adjacent, total tags = 4 each,
+    // union = 4 - 2 = 2 shared, plus 2 unique per lesson → tag-J = 2/4 = 0.5.
+    // Pattern: lesson i = [s-a, s-b, x-i, y-i]; lesson i+1 = [s-a, s-b, x-(i+1),
+    // y-(i+1)]. s-a,s-b shared between i and i+1 ONLY (each s-* tag appears
+    // in exactly 2 lessons) → no high-df. union = {s-a, s-b, x-i, y-i, x-(i+1),
+    // y-(i+1)} = 6 → tag-J = 2/6 = 0.333 (still below!). With only 4 tags per
+    // lesson (2 unique + 2 shared with adjacent pair) the union has 6 distinct
+    // (2 shared + 4 unique across the pair) and tag-J = 2/6 = 0.333.
+    //
+    // The cleanest 3-tag-per-lesson chain: lesson i = [a, b, uniq-i].
+    // lesson i and i+1 share [a, b] → tag-J = 2/4 = 0.5. Tags a,b appear in
+    // MANY lessons (transitively: a shared by 0,1; b shared by 0,1; for chain
+    // we need every adjacent pair to share 2 distinct tags). Use the rotating
+    // pair pattern: lesson i = [tag-i-AB-1, tag-i-AB-2, uniq-i]; adjacent pair
+    // (i, i+1) share [tag-i-AB-1, tag-i-AB-2] (these tags appear ONLY in
+    // lessons i and i+1). union = 4 → tag-J = 2/4 = 0.5. Every pair (i,i+2)
+    // shares 0 tags (tag-i-AB-* appear in i,i+1; tag-(i+1)-AB-* appear in
+    // i+1,i+2; disjoint sets) → tag-J = 0. But union-find transitively
+    // connects 0↔1↔2↔...↔599 via adjacent dedupes. ✓
+    // Tag pattern (alternating 2-tag / 4-tag): every boundary tag-pair appears
+    // in EXACTLY 2 consecutive lessons → df=2, no high-df drop. Identical
+    // summaries across all 600 → summary-J=1.0; same category → state A.
+    //   - Lesson 2k (even): [pair-k-A, pair-k-B]                  (2 tags)
+    //   - Lesson 2k+1 (odd): [pair-k-A, pair-k-B, pair-(k+1)-A, pair-(k+1)-B]  (4 tags)
+    // Adjacent (2k, 2k+1) share [pair-k-A, pair-k-B]; union=4 → tag-J=0.5. ✓
+    // Adjacent (2k+1, 2k+2) share [pair-k-A, pair-k-B] (i+2 is lesson 2(k+1));
+    //   union = {pair-k-A, pair-k-B, pair-(k+1)-A, pair-(k+1)-B} = 4 → tag-J=0.5. ✓
+    // Non-adjacent (i, j) with |i-j|>=2: disjoint tag sets → tag-J<0.5, no
+    //   direct cluster. Union-find still transitively connects via adjacent
+    //   dedupes. The replaced test above used a 1-tag-share pattern that
+    //   capped at tag-J=1/3=0.333 (BELOW state A threshold), so the cap
+    //   was never exercised — the FIX-5 reworked pattern is the alternate
+    //   2-tag/4-tag chain that satisfies state A.
+    function tagsFor(i) {
+      if (i % 2 === 0) {
+        const k = i / 2
+        return [`chain-${k}-A`, `chain-${k}-B`]
+      }
+      const k = (i - 1) / 2
+      return [`chain-${k}-A`, `chain-${k}-B`, `chain-${k + 1}-A`, `chain-${k + 1}-B`]
+    }
+    for (let i = 0; i < 600; i++) {
+      seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: `20260101-${String(i).padStart(6, '0')}-chain-cccc`, date: '2026-01-01', project: 'acme', category: 'lesson', tags: tagsFor(i), summary: sharedSummary, body: 'body' })
+    }
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    // FIX-4/-5: drain-tolerant — under --break-drain the large (~120KB) JSON
+    // exceeds the spawnSync pipe buffer (64KB on macOS) so stdout is truncated
+    // and r.json is null. Skip the structural assertions silently; the SOLE
+    // red control for drain is report::largeReportNotTruncated.
+    if (r.json === null) return
+    eq(r.json.status, 'ok', 'status:ok')
+    ok(Array.isArray(r.json.clusters), 'clusters[] present')
+    eq(r.json.clusters.length, 1, `single chained cluster (got ${r.json.clusters.length})`)
+    const c = r.json.clusters[0]
+    eq(c.members.length, 500, `cluster.members capped at 500 (got ${c.members.length})`)
+    eq(c.members_truncated, '+100 more', `per-cluster members_truncated sentinel (got ${JSON.stringify(c.members_truncated)})`)
+    // The 500 retained members are the OLDEST 500 by date asc; ids follow the
+    // chronological sort applied in the clerk cluster build (date asc, id asc).
+    const firstRetained = c.members[0].id
+    ok(/^20260101-000000-/.test(firstRetained), `oldest member retained (got ${firstRetained})`)
+    const lastRetained = c.members[c.members.length - 1].id
+    ok(/^20260101-000499-/.test(lastRetained), `lesson 499 (last retained) (got ${lastRetained})`)
+  })
+
+  // 11. report::emptyStore — empty store → {status:'ok', mode:'clerk-report', clusters:[]}, exit 0.
+  t('report::emptyStore', () => {
+    const S = mkStore('empty')
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    eq(r.json.status, 'ok', 'status:ok')
+    eq(r.json.mode, 'clerk-report', 'mode:clerk-report')
+    ok(Array.isArray(r.json.clusters) && r.json.clusters.length === 0, `clusters[] empty (got ${JSON.stringify(r.json.clusters)})`)
+  })
+
+  // 12. report::emptyIdentityRejected — empty/whitespace-summary pair resolves
+  //     keep-distinct (EC5), never dedupe/merge.
+  t('report::emptyIdentityRejected', () => {
+    const S = mkStore('emptyidentity')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-empid-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB', 'sharedC'], summary: '   ', body: 'body' })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-empid-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['sharedA', 'sharedB', 'sharedC'], summary: '', body: 'body' })
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    // Either no cluster (because resolveAction returns keep-distinct so union-find doesn't merge),
+    // OR a cluster with proposed_action === 'keep-distinct'. Either is correct under EC5.
+    const pairIds = ['20260101-000000-empid-1111', '20260101-000000-empid-2222'].sort()
+    const cluster = (r.json.clusters || []).find((c) => {
+      const ids = c.members.map((m) => m.id).sort()
+      return ids.length === 2 && ids[0] === pairIds[0] && ids[1] === pairIds[1]
+    })
+    ok(!cluster || cluster.proposed_action === 'keep-distinct', `empty/whitespace pair is keep-distinct (cluster=${JSON.stringify(cluster && { members: cluster.members.length, action: cluster.proposed_action })})`)
+  })
+
+  // 13. advisory::kSharedPhrase — >= 3 trigger-index entries sharing one phrase
+  //     → report has one-line `advisory` field. Seed triggers via lesson frontmatter /
+  //     index row and materialize the trigger-index.json (loadMergedTriggerIndex
+  //     rebuilds from index.jsonl; a directly-seeded trigger-index.json is overwritten).
+  t('advisory::kSharedPhrase', () => {
+    const S = mkStore('kshared')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-kshr-1111', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['tagA'], summary: 'kshared lesson one', body: 'body', triggers: ['ksharedsharedphrase'] })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-kshr-2222', date: '2026-01-02', project: 'acme', category: 'lesson', tags: ['tagA'], summary: 'kshared lesson two', body: 'body', triggers: ['ksharedsharedphrase'] })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-kshr-3333', date: '2026-01-03', project: 'acme', category: 'lesson', tags: ['tagA'], summary: 'kshared lesson three', body: 'body', triggers: ['ksharedsharedphrase'] })
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-kshr-4444', date: '2026-01-04', project: 'acme', category: 'lesson', tags: ['tagA'], summary: 'kshared lesson four', body: 'body', triggers: ['ksharedsharedphrase'] })
+    buildFixtureTriggerIndex(S.root)
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    ok(typeof r.json.advisory === 'string', `advisory is a string (got ${JSON.stringify(r.json.advisory)})`)
+    ok(/cadence:/.test(r.json.advisory), `advisory is the cadence one-liner (got ${JSON.stringify(r.json.advisory)})`)
+    ok(/ksharedsharedphrase/.test(r.json.advisory) || /\d+/.test(r.json.advisory), 'advisory references the trigger phrase or count')
+  })
+
+  // 14. advisory::nLessonCount — active-lesson count >= 200 → `advisory` present.
+  t('advisory::nLessonCount', () => {
+    const S = mkStore('ncount')
+    // Seed exactly 200 lessons (the pinned CADENCE_N_LESSONS threshold). Each
+    // gets a unique tag so they don't cluster and the clerk reports the
+    // active-count-based advisory cleanly.
+    for (let i = 0; i < 200; i++) {
+      seedLesson({
+        dataDir: S.dataDir, episodesDir: S.episodesDir,
+        id: `20260101-${String(i).padStart(6, '0')}-ncntaaaa`,
+        date: '2026-01-01', project: 'acme', category: 'lesson',
+        tags: [`ncount-uniq-${i}`],
+        summary: `ncount fixture lesson ${i} summary alphaword`,
+        body: 'body',
+      })
+    }
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    ok(typeof r.json.advisory === 'string', `advisory is a string (got ${JSON.stringify(r.json.advisory)})`)
+    ok(/cadence:/.test(r.json.advisory), `advisory is the cadence one-liner (got ${JSON.stringify(r.json.advisory)})`)
+    ok(/200/.test(r.json.advisory), `advisory names the 200+ active-lesson count (got ${JSON.stringify(r.json.advisory)})`)
+  })
+}
+
+main()
+console.log(`test-rfc-009-p4-report: ${pass}/${pass + fail} pass`)
+if (fail > 0) { console.error(failures.map((f) => `FAIL ${f}`).join('\n')); process.exit(1) }

--- a/tests/test-rfc-009-p4-telemetry.mjs
+++ b/tests/test-rfc-009-p4-telemetry.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * test-rfc-009-p4-telemetry.mjs — RFC-009 P4-S1 (R6 telemetry writer, REQ-16/17).
+ *
+ * Proves the event-plane activation telemetry writer (scripts/lib/activation-log.mjs)
+ * is append-only, size-bounded (drop-at-bound, never truncate), and fire-and-forget
+ * (a failed write is a stderr note, never a throw). Every assertion inspects real
+ * captured runtime state (parsed line, statSync size, module return, thrown flag) —
+ * never a constant. The hook path is proven by a mock-project E2E (real install.mjs
+ * + the real deployed hook), never mental-trace.
+ *
+ * Negative controls (§A.9, portable `--break-<x>` argv flags, NOT env vars — the hook
+ * + tests must run under Windows `cmd`):
+ *   --break-bound     → module ignores the 1 MiB bound → telemetry::dropAtBoundStderr FAILS
+ *   --break-writefail → the writer rethrows instead of catching → telemetry::writeFailureNonFatal FAILS
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import {
+  appendActivationLine,
+  ACTIVATION_LOG_NAME,
+  ACTIVATION_LOG_MAX_BYTES,
+} from '../scripts/lib/activation-log.mjs'
+import { matchActivation } from '../scripts/lib/activation-match.mjs'
+import { mkMock, runInstall, runScript, runHook } from './lib/activation-scoping-harness.mjs'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+
+// Portable negative-control break override (§A.9-style, matching
+// scripts/lib/activation-log.mjs's own --break-<x> convention): a plain argv
+// flag, not an env var (must run under Windows `cmd` too). Production runs
+// never pass this — it exists ONLY to prove telemetry::entriesFromMatcher has
+// teeth by simulating "mergeIndexes never stamped source_scope" (the fixture
+// entries arrive with no source_scope at all, exactly as they would if the
+// upstream stamping step were reverted).
+const BREAK_SCOPE = process.argv.includes('--break-scope')
+
+let pass = 0, fail = 0
+const failures = []
+function t(name, fn) {
+  try { fn(); pass++ }
+  catch (e) { fail++; failures.push(`${name} - ${e && e.message}`) }
+}
+function eq(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`)
+}
+function ok(cond, label) { if (!cond) throw new Error(label) }
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+function mkTmp(label) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `p4s1-${label}-`)))
+  _tmpDirs.push(base)
+  return base
+}
+// Capture process.stderr.write across a synchronous call.
+function withStderrCapture(fn) {
+  const orig = process.stderr.write.bind(process.stderr)
+  let captured = ''
+  process.stderr.write = (chunk) => { captured += String(chunk); return true }
+  try { const ret = fn(); return { ret, captured } }
+  finally { process.stderr.write = orig }
+}
+
+function main() {
+  // 1. telemetry::oneLinePerInjection — one append → exactly one schema-valid line
+  //    carrying the injected sentinel id; parsed v===1.
+  t('telemetry::oneLinePerInjection', () => {
+    const dir = mkTmp('oneline')
+    const sentinel = `id-${Date.now()}-oneline`
+    const ret = appendActivationLine(dir, {
+      ts: '2026-07-12T05:44:37Z', project: 'p4s1', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: sentinel, effective_priority: 8, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 }],
+    })
+    eq(ret && ret.dropped, false, 'append not dropped')
+    const lines = fs.readFileSync(path.join(dir, ACTIVATION_LOG_NAME), 'utf8').split('\n').filter(Boolean)
+    eq(lines.length, 1, 'exactly one line')
+    const parsed = JSON.parse(lines[0])
+    eq(parsed.v, 1, 'v===1')
+    eq(parsed.entries[0].id, sentinel, 'entries[0].id === sentinel')
+  })
+
+  // 2. telemetry::dropAtBoundStderr — a log pre-filled to MAX-10 bytes rejects the next
+  //    line (which exceeds the 10-byte remainder): {dropped:true}, stderr note, size UNCHANGED.
+  t('telemetry::dropAtBoundStderr', () => {
+    const dir = mkTmp('bound')
+    const logPath = path.join(dir, ACTIVATION_LOG_NAME)
+    const marker = 'PRESERVE-SENTINEL-b2c3\n'
+    const target = ACTIVATION_LOG_MAX_BYTES - 10
+    fs.writeFileSync(logPath, 'x'.repeat(target - Buffer.byteLength(marker)) + marker)
+    const sizeBefore = fs.statSync(logPath).size
+    const { ret, captured } = withStderrCapture(() => appendActivationLine(dir, {
+      ts: '2026-07-12T05:44:38Z', project: 'p4s1', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: 'id-bound-overflow', effective_priority: 8, rendered: 'plain', source_scope: 'local', access_count_at_inject: 0 }],
+    }))
+    const sizeAfter = fs.statSync(logPath).size
+    eq(ret && ret.dropped, true, 'returns {dropped:true}')
+    eq(sizeBefore, sizeAfter, 'file size unchanged')
+    ok(/size bound reached; dropping line/.test(captured), 'emits stderr note')
+  })
+
+  // 3. telemetry::neverTruncates — the pre-existing last line survives a dropped append
+  //    (dropping must not rewrite/truncate the file).
+  t('telemetry::neverTruncates', () => {
+    const dir = mkTmp('notrunc')
+    const logPath = path.join(dir, ACTIVATION_LOG_NAME)
+    const marker = 'PRESERVE-SENTINEL-notrunc\n'
+    const target = ACTIVATION_LOG_MAX_BYTES - 10
+    fs.writeFileSync(logPath, 'x'.repeat(target - Buffer.byteLength(marker)) + marker)
+    withStderrCapture(() => appendActivationLine(dir, {
+      ts: '2026-07-12T05:44:39Z', project: 'p4s1', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: 'id-notrunc-overflow', effective_priority: 8, rendered: 'plain', source_scope: 'local', access_count_at_inject: 0 }],
+    }))
+    ok(fs.readFileSync(logPath, 'utf8').endsWith(marker), 'pre-existing last line preserved')
+  })
+
+  // 4. telemetry::writeFailureNonFatal — an unwritable target (non-existent parent dir)
+  //    returns {error:true} and does NOT throw (fire-and-forget, hook stays non-fatal).
+  t('telemetry::writeFailureNonFatal', () => {
+    const dir = mkTmp('fail')
+    const badDir = path.join(dir, 'does', 'not', 'exist')
+    let threw = false, ret = null
+    try {
+      ret = withStderrCapture(() => appendActivationLine(badDir, {
+        ts: '2026-07-12T05:44:40Z', project: 'p4s1', event: 'inject', surface: 'per_prompt',
+        entries: [{ id: 'id-writefail', effective_priority: 8, rendered: 'plain', source_scope: 'local', access_count_at_inject: 0 }],
+      })).ret
+    } catch { threw = true }
+    ok(!threw, 'did not throw')
+    eq(ret && ret.error, true, 'returns {error:true}')
+  })
+
+  // 5. telemetry::entriesFromMatcher — matchActivation on a fixture index
+  //    holding one 'local' and one 'global' selected entry: entries[] has one
+  //    element per rendered line, every element carries all 5 schema keys, and
+  //    both source_scope polarities appear (RFC-009 P4-S1 1.2c producer, plan
+  //    §12 activationLogLine schema). --break-scope strips source_scope from
+  //    the fixture entries (simulating a reverted mergeIndexes stamp) so this
+  //    test FAILS, proving the polarity assertion has teeth (1.4b).
+  t('telemetry::entriesFromMatcher', () => {
+    const index = {
+      entries: [
+        {
+          episode_id: '20260101-000000-entries-local-aaa1', trigger_kind: 'phrase', value: 'alphaword',
+          effective_priority: 5, applies_to_projects: ['acme'], applies_to_tools: ['claude-code'],
+          summary: 'local fixture', ...(BREAK_SCOPE ? {} : { source_scope: 'local' }),
+        },
+        {
+          episode_id: '20260101-000000-entries-global-bbb2', trigger_kind: 'phrase', value: 'betaword',
+          effective_priority: 5, applies_to_projects: ['acme'], applies_to_tools: ['claude-code'],
+          summary: 'global fixture', ...(BREAK_SCOPE ? {} : { source_scope: 'global' }),
+        },
+      ],
+    }
+    const event = { kind: 'prompt', prompt: 'alphaword and betaword both fire here' }
+    const identity = { slug: 'acme', tool_id: 'claude-code' }
+    const r = matchActivation(index, event, identity, new Set(), { max_matches: 3, max_tokens: 500 })
+    eq(r.entries.length, r.lines.length, 'entries.length === lines.length')
+    eq(r.entries.length, 2, 'both fixture entries selected')
+    const keys = ['id', 'effective_priority', 'rendered', 'source_scope', 'access_count_at_inject']
+    for (const e of r.entries) {
+      for (const k of keys) ok(Object.hasOwn(e, k), `entries[] element carries key ${k}`)
+    }
+    const scopes = new Set(r.entries.map((e) => e.source_scope))
+    ok(scopes.has('local'), `both source_scope polarities appear — 'local' present (got ${JSON.stringify([...scopes])})`)
+    ok(scopes.has('global'), `both source_scope polarities appear — 'global' present (got ${JSON.stringify([...scopes])})`)
+  })
+
+  // 6. telemetry::hookE2E — mock-project (isolated HOME, real install.mjs),
+  //    drive the REAL deployed activation-prompt.sh hook with one injection,
+  //    tail the written activation-log.jsonl: exactly one schema-valid line
+  //    whose entries[0].source_scope is 'local' or 'global'.
+  t('telemetry::hookE2E', () => {
+    const M = mkMock('p4s1-telemetry')
+    const install = runInstall({
+      home: M.home, project: M.project, callerCwd: M.callerCwd, flags: ['--install-activation'],
+    })
+    if (install.status !== 0) throw new Error(`install.mjs --install-activation failed: ${install.stderr}`)
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(M.project, '.claude', 'hooks', 'manifest.json'), 'utf8'))
+    const slug = manifest.project_identity.slug
+
+    const store = runScript(M.home, 'em-store.mjs', [
+      '--project', slug, '--category', 'lesson', '--tags', 'test',
+      '--summary', 'telemetry hookE2E lesson', '--body', 'body',
+      '--trigger', 'telemetryhooke2ephrase',
+      '--applies-to-project', slug, '--applies-to-tool', 'claude-code',
+      '--priority', '5', '--scope', 'local',
+    ], { cwd: M.project })
+    if (!store.json || store.json.status !== 'ok') throw new Error(`em-store failed: ${store.stdout}\n${store.stderr}`)
+
+    const hookPath = path.join(M.project, '.claude', 'hooks', 'activation-prompt.sh')
+    ok(fs.existsSync(hookPath), 'deployed activation-prompt.sh present')
+
+    const r = runHook(hookPath, { prompt: 'telemetryhooke2ephrase now' }, { home: M.home, project: M.project })
+    eq(r.status, 0, 'hook exits 0')
+
+    const logPath = path.join(M.project, '.episodic-memory', ACTIVATION_LOG_NAME)
+    ok(fs.existsSync(logPath), `activation-log.jsonl written at ${logPath}`)
+    const lines = fs.readFileSync(logPath, 'utf8').split('\n').filter(Boolean)
+    eq(lines.length, 1, 'exactly one line written for one injection')
+    const parsed = JSON.parse(lines[0])
+    eq(parsed.v, 1, 'v===1')
+    ok(Array.isArray(parsed.entries) && parsed.entries.length >= 1, 'entries[] present and non-empty')
+    ok(parsed.entries[0].source_scope === 'local' || parsed.entries[0].source_scope === 'global',
+      `entries[0].source_scope is 'local' or 'global'; got ${JSON.stringify(parsed.entries[0])}`)
+  })
+
+  // 7. telemetry::hookE2ESessionStart — mirrors telemetry::hookE2E but drives
+  //    the REAL activation-sessionstart.sh hook with a SessionStart payload.
+  //    The lesson is stored with priority 5 (em-store rejects priorities 8/9
+  //    directly — they are an EARNED band reserved for the chain-resolved
+  //    effective_priority in buildSessionStart), so it lands in the
+  //    session_start static-blend entries (tier-2), NOT in critical_entries.
+  //    The fixture index.jsonl is rewritten to carry a NONZERO access_count
+  //    for the stored episode, em-trigger-index is re-run to refresh the
+  //    cache (the freshness check otherwise rejects the on-disk state), and
+  //    the hook is invoked. Asserts: (a) surface === 'session_start'; (b)
+  //    entries[] non-empty AND every entry has source_scope 'local' or
+  //    'global' (never null); (c) access_count_at_inject for the injected
+  //    episode equals the EXACT value the fixture index was rewritten with
+  //    — proving the build-time access_count stamp (RFC-009 P4-S1 R6 / plan
+  //    step 1.2cb) flows through end-to-end WITHOUT a hook-side index.jsonl
+  //    read (the prior F4 join is REMOVED in R2-FIX-1).
+  t('telemetry::hookE2ESessionStart', () => {
+    const M = mkMock('p4s1-telemetry-ss')
+    const install = runInstall({
+      home: M.home, project: M.project, callerCwd: M.callerCwd, flags: ['--install-activation'],
+    })
+    if (install.status !== 0) throw new Error(`install.mjs --install-activation failed: ${install.stderr}`)
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(M.project, '.claude', 'hooks', 'manifest.json'), 'utf8'))
+    const slug = manifest.project_identity.slug
+
+    const store = runScript(M.home, 'em-store.mjs', [
+      '--project', slug, '--category', 'lesson', '--tags', 'test',
+      '--summary', 'telemetry hookE2ESessionStart lesson', '--body', 'body',
+      '--applies-to-project', slug, '--applies-to-tool', 'claude-code',
+      '--priority', '5', '--scope', 'local',
+    ], { cwd: M.project })
+    if (!store.json || store.json.status !== 'ok') throw new Error(`em-store failed: ${store.stdout}\n${store.stderr}`)
+    const epId = store.json.id || store.json.episode_id
+    ok(typeof epId === 'string' && epId.length > 0, `em-store returned an episode id (got ${JSON.stringify(epId)})`)
+
+    // Rewrite the fixture index.jsonl to carry a NONZERO access_count for the
+    // just-stored episode. em-store writes access_count:0 by default; we need
+    // a known positive value to assert the F4 join passes it through exactly.
+    const FIXTURE_ACCESS_COUNT = 17
+    const idxPath = path.join(M.project, '.episodic-memory', 'index.jsonl')
+    const idxRaw = fs.readFileSync(idxPath, 'utf8')
+    const idxRows = idxRaw.split('\n').filter(Boolean).map((l) => {
+      const o = JSON.parse(l)
+      if (o.id === epId) o.access_count = FIXTURE_ACCESS_COUNT
+      return o
+    })
+    fs.writeFileSync(idxPath, idxRows.map((o) => JSON.stringify(o)).join('\n') + '\n')
+
+    // Refresh the cached trigger-index so the runner's freshness check (stat
+    // legs against the rewritten index.jsonl) passes; without this the stale
+    // carve-out would shadow the just-edited access_count.
+    const trig = runScript(M.home, 'em-trigger-index.mjs', ['--scope', 'local', '--project', M.project], { cwd: M.project })
+    if (trig.status !== 0) throw new Error(`em-trigger-index rebuild failed: ${trig.stdout}\n${trig.stderr}`)
+
+    const hookPath = path.join(M.project, '.claude', 'hooks', 'activation-sessionstart.sh')
+    ok(fs.existsSync(hookPath), 'deployed activation-sessionstart.sh present')
+
+    const r = runHook(hookPath, {}, { home: M.home, project: M.project })
+    eq(r.status, 0, 'hook exits 0')
+
+    const logPath = path.join(M.project, '.episodic-memory', ACTIVATION_LOG_NAME)
+    ok(fs.existsSync(logPath), `activation-log.jsonl written at ${logPath}`)
+    const lines = fs.readFileSync(logPath, 'utf8').split('\n').filter(Boolean)
+    eq(lines.length, 1, 'exactly one line written for one SessionStart injection')
+    const parsed = JSON.parse(lines[0])
+    eq(parsed.v, 1, 'v===1')
+    eq(parsed.surface, 'session_start', `surface === 'session_start' (got ${JSON.stringify(parsed.surface)})`)
+    ok(Array.isArray(parsed.entries) && parsed.entries.length >= 1, 'entries[] present and non-empty')
+    // (b) every entry's source_scope is 'local' or 'global' (never null)
+    for (const [i, e] of parsed.entries.entries()) {
+      ok(e.source_scope === 'local' || e.source_scope === 'global',
+        `entries[${i}].source_scope is 'local' or 'global' (got ${JSON.stringify(e)})`)
+    }
+    // (c) access_count_at_inject for the fixture episode === fixture value
+    const fixtureEntry = parsed.entries.find((e) => e.id === epId)
+    ok(!!fixtureEntry, `entries[] contains the fixture episode id ${epId}`)
+    eq(fixtureEntry.access_count_at_inject, FIXTURE_ACCESS_COUNT,
+      `access_count_at_inject flows from fixture index (expected ${FIXTURE_ACCESS_COUNT})`)
+    eq(fixtureEntry.source_scope, 'local', `fixture entry source_scope === 'local'`)
+  })
+}
+
+main()
+console.log(`test-rfc-009-p4-telemetry: ${pass}/${pass + fail} pass`)
+if (fail > 0) { console.error(failures.map(f => `FAIL ${f}`).join('\n')); process.exit(1) }

--- a/tests/test-so-lesson-injection.mjs
+++ b/tests/test-so-lesson-injection.mjs
@@ -232,8 +232,10 @@ function unitEntry(id, priority, summary, extra = {}) {
   const r = runRequest({ home, proj, body: 'renderprobe now' })
   assert(r.status === 0, 'render: exits 0', r.stderr)
   const body = latestBody(proj)
-  assert(body.includes(`READ ${imp.id} before proceeding (em-search --history ${imp.id} --full): imperative render probe`),
+  assert(body.includes(`READ ${imp.id} before proceeding (em-search --read ${imp.id}): imperative render probe`),
     'render: band-8 imperative form verbatim', body.slice(body.indexOf(LESSON_BLOCK_HEADER), body.indexOf(LESSON_BLOCK_HEADER) + 500))
+  assert(!body.includes('(em-search --history'),
+    'render: imperative render never names the untracked --history command (REQ-22 guard)', body.slice(body.indexOf(LESSON_BLOCK_HEADER), body.indexOf(LESSON_BLOCK_HEADER) + 500))
   assert(body.includes(`lesson ${plain.id}: plain render probe`), 'render: plain form verbatim')
 }
 // 11. sanitize (unit + E2E single-line confinement)


### PR DESCRIPTION
## Summary

PR-A of RFC-009 P4 (docs/plans/rfc-009-p4.md, section 10): the three additive slices S1-S3. No store mutation anywhere in this PR; the mutating apply mode, conversion metric, enrichment, and clerk prompt are PR-B (S4-S7). RFC-009 is "Lesson Activation: Trigger-Bearing Lessons, Derived Trigger Index, and Bounded Advisory Recall" (status: accepted).

Fixes #505.

## S1: R6 activation telemetry writer (a2053e3, follow-up 582500a)

REQ-16/17 with REQ-19/20 attribution stamps. Adds `scripts/lib/activation-log.mjs` (new, shared-const writer: append one line per injection to `<project>/.episodic-memory/activation-log.jsonl`, 1 MiB bound, drop-at-bound with stderr note so append-only is never breached, always non-fatal), an `entries[]` producer in `scripts/lib/activation-match.mjs`, hook wiring with `source_scope` stamps in the claude-code activation plugin, and `access_count` stamped into the trigger index at R2 build time (strict event-plane boundary, plan step 1.2cb). The follow-up commit registers the telemetry suite in CI, closing the suite-registration lint gap (lint 16 passed, 0 failed). Review: GLM-5.2 cross-vendor, three rounds, final VERDICT ACCEPT.

## S2: #505 render migration, --history to --read (7f62751)

REQ-22. The imperative band-8 render now names the tracked, bounded read command: `renderLine` emits `em-search --read <id>` instead of the untracked, unbounded `em-search --history <id> --full`. Codex plugin copy byte-restored with manifest checksum refresh. Falsifiable control `render::usesReadNotHistory` plus `--break-render` red control; sibling-suite expectation flips and REQ-22 absence guards. Crux behavior-simulated on a real store: `--read` bumps `access_count`, `--history` does not. Review: GLM-5.2, VERDICT ACCEPT, 0 must-fix.

## S3: R9b clerk report mode (36cc226)

REQ-1,2,3,4,5,21,23. Lexical consolidation clerk `scripts/em-consolidate.mjs` report mode behind `--clerk` (default, propose-only): T1/T2 shared-trigger and tag-Jaccard signals with high-df tag drop, T3 summary-token Jaccard same-category, supersession-adjacency, section-12 five-state action table, drain-safe emit (#486), bounded envelopes (top-level and per-cluster `members_truncated`), and the REQ-23 clerk-side cadence advisory. Report mode writes nothing to the source store (byte-identical property verified by the suite). Review: GLM-5.2 round-1 VERDICT HOLD-7, all seven findings folded (including a builder-found section-12 state-A contract fix); round-2 VERDICT ACCEPT. Deferred P3s are tracked in #522 (not closed by this PR).

## Verification at commit time

- `tests/test-rfc-009-p4-report.mjs`: 15/15 pass; three `--break-*` red controls each exit 1 with a single red.
- `tests/test-rfc-009-p4-telemetry.mjs`: 7/7 pass, including the session_start telemetry E2E.
- CI suite-registration lint: 16 passed, 0 failed; both new suites wired in `.github/workflows/plan-marker-validate.yml` (lines 340 and 343).
- Neighbor suites green: em-consolidate 8/0, fold-superseded 11/11, fold-all-projects 8/8, prune-protection 29/29.

## Known cosmetic nit

The CI step name for the report suite reads "REQ-1,2,3,4,5,13,21,23"; REQ-13 belongs to S4 per the plan section 10 slice table and the commit subject. Step name only, does not affect what runs; will be corrected in PR-B.

## Out of scope (PR-B, S4-S7)

R9b apply mode with em-lock and the normative write order (S4, REQ-6..13), R6 conversion metric with rotate-and-consume including the relocated REQ-21 zero-conversion surfacing test (S5, REQ-18..21), R9c enrichment backfill (S6, REQ-14), R9d clerk prompt and conformance (S7, REQ-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
