### PR TITLE
RFC-009 P4 plan: record PR-A merge + section 19.9 hotfix review

### DIFF
--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -1,16 +1,18 @@
 <!--
-PLAN STATUS: DRAFT (2026-07-12). Round-1 plan review DONE (2 lenses: negative-scenario-planner +
-design/contract, both HOLD, both CONFIRMED F-STRIP; §19). Findings F1-F6 + P3s folded (apply write
-path = Narrow + direct-write, user-locked). A.7 S2-S7 authoring + round-2 review PENDING.
-Not yet approved. Do NOT implement until A.7 authored, round-2 clear, and human-approved.
+PLAN STATUS: PR-A (S1-S3) MERGED (2026-07-13): PR #523, squash c2abbe8, CI 4/4, #505 closed;
+includes the CI-robustness hotfix (clerkHighDfTags per-run memo + runClerk signal/errorCode, §19.9,
+GLM-5.2 ACCEPT 0 must-fix). PR-B (S4-S7) NOT started: S4 requires FOCUSED REVIEW BEFORE BUILD (A.7)
+and human approval; #522 cosmetics fold in-slice (S4). History: round-1 review DONE (2 lenses, both
+HOLD, CONFIRMED F-STRIP; §19), F1-F6 + P3s folded; per-slice build reviews in §19.4-19.9.
 -->
 
 # RFC-009-P4 — Consolidation clerk (R9b/c/d) + activation telemetry & conversion (R6) Plan
 
 ## §1 Status
 
-`Planning only.` Do not implement until this plan, the plan review, and the adversarial
-review are accepted (Rule 18). Current stage: **draft**.
+Current stage: **PR-A shipped, PR-B gated**. S1-S3 implemented, reviewed (§19.4-19.9),
+merged 2026-07-13 (PR #523 `c2abbe8`, closes #505). S4-S7 remain implement-gated: S4 takes a
+focused review BEFORE build (§A.7) plus human approval (Rule 18) before any code is written.
 
 | Field | Value |
 |---|---|
@@ -332,6 +334,8 @@ AGGREGATION PLANE (on-demand, clerk):
 
 One slice = one concern = one PR-shaped unit. **PR-A = S1–S3** (additive, no store mutation);
 **PR-B = S4–S7** (mutating apply + measurement).
+**PR-A MERGED 2026-07-13**: PR #523, squash `c2abbe8`, CI 4/4 green, closes #505; carried the
+§19.9 CI-robustness hotfix. PR-B not started; S4 review-gated (§A.7).
 
 | Slice | Objective | Primary files | Key deliverables | Tests | Hard stops |
 |---|---|---|---|---|---|
@@ -649,7 +653,8 @@ Fill the right column with the ACTUAL output at build time (order rule: artifact
 - [ ] `node tools/deploy-audit.mjs` clean (hook touched).
 - [ ] Clerk prompt conformance gauntlet green (REQ-15).
 - [ ] Every deferred finding has an issue/comment/violation artifact (D-H, #456, #457, D3, D4) — Rule 18 step 9.
-- [ ] PR-A (S1–S3) and PR-B (S4–S7) each reviewed per §19.
+- [x] PR-A (S1–S3) reviewed per §19 (19.4–19.9) and merged (PR #523 `c2abbe8`, 2026-07-13).
+- [ ] PR-B (S4–S7) reviewed per §19.
 
 ## §19 Review Consensus (Rule 18)
 
@@ -772,6 +777,29 @@ Confirmations (no finding): single drained emit site (REQ-4); boundary semantics
 All seven round-1 findings CLOSED, each verified by code reading + reviewer-run simulation: F1 carve-out wording judged honest and complete; F2 binding verified across local/global/subdir/git-walk/cwd-fallback (reviewer's own global-scope + local-subdir sims); F3/F4 both caps fire with discriminating asserts; F5 clustered state-B pair now reports `dropped_high_df_tags=['common']` (reviewer repro); F6 §12 carries `advisory?: string`; F7 manifest excludes exactly `trigger-index.json`, both stores empirically checked ([] → [trigger-index.json] only), `--break-report-write` still red. N1 raw-compare and N2 dead-param removal confirmed. Silent-skip guards judged acceptable (cap regressions caught in green; drain has its dedicated red control).
 
 Five NEW findings, all P3, none blocking: NEW-1 §12 field name (folded — `members_truncated` named), NEW-2 doc counts 14→15 (folded — §14/DELTA-8/step 3.4), NEW-5 step 3.2 stale signature (folded), NEW-3 no test pins the F5 dropped-list fix (reverting F5 reds zero tests; DEFERRED to issue — add a state-B dropped-list assertion), NEW-4 silent-skip transparency (DEFERRED with NEW-3; optional skip counter). Full transcript: session scratchpad `glm-s3-round2-full.txt`.
+
+### 19.9 PR-A CI hotfix review (GLM-5.2 cross-vendor, 2026-07-13) — VERDICT ACCEPT, 0 must-fix
+
+PR #523's first CI run failed one validate job: `report::envelopeCapPlusNMore` clerk child killed
+(`status null`, job 86696138807) while 15/15 green locally. Root cause (MiniMax diagnostic scout +
+orchestrator confirmation): `clerkSignals` recomputed `clerkHighDfTags(_clerkActiveRows)` for EVERY
+pair — 719,400 pairs x 1,200-row rescans (~1.7B tag visits) on the cap fixture — 50.66s on an M5
+Max against the suite's own 120s spawnSync child timeout (`runClerk`), exceeded on slow ubuntu
+runners. Fix (branch `e56e088`, folded into squash `c2abbe8`): per-run WeakMap memo keyed on the
+immutable `_clerkActiveRows` reference, declared with the pre-branch module state (a first
+placement below the top-level clerk branch hit the file's documented TDZ hazard — clerk exited 1,
+caught by the mandated timed verify, relocated); `runClerk` additionally returns
+`signal`/`errorCode` so a killed child is distinguishable from a nonzero exit. Cap test 50.66s →
+14.58s (residual is fixture I/O). Verification: suite 15/15; all three `--break-*` red controls
+exit 1 single-red; `node --check` clean; telemetry 7/7; em-consolidate neighbor 8/8; CI 4/4 after
+push. Review on the frozen diff probed six equivalence classes (staleness via in-place mutation,
+cross-run leakage, `|| []` fallback, `--break-highdf`/cache interplay, TDZ eval order, `runClerk`
+contract for the other 14 tests) — all structural non-bugs, corroborated by an isolated-store
+probe (sha256-identical fresh runs; cached path drops `common`, red run merges all 12). P3
+cosmetics DEFERRED to #522 comments, fold in S4: `r.error && r.error.code || null` →
+`r.error?.code ?? null`; cache comment gains "in-memory only; store untouched"; CI step name at
+`plan-marker-validate.yml:342` drops REQ-13 (belongs to S4). Transcript: session scratchpad
+`glm-hotfix-review-full.txt`.
 
 ## §20 Lessons Encoded (traceability — do not re-learn)
 
@@ -972,6 +1000,12 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 | 3.5 | — | — | Commit `P4-S3: R9b clerk report mode (REQ-1,2,3,4,5,21,23)` + trailer. | `git log -1 --oneline` shows `P4-S3` |
 
 ### `P4-S4` — R9b clerk **apply** (merge/dedupe) + run-records (REQ-6,7,8,9,10,11,12,13) — **focused review before build** (mutating apply, high blast radius)
+
+**In-slice folds from #522 (§19.9 hotfix P3 cosmetics, zero-behavior):** `runClerk` errorCode →
+`r.error?.code ?? null` (`tests/test-rfc-009-p4-report.mjs`); `_highDfCache` comment gains
+"in-memory only; store untouched" (`scripts/em-consolidate.mjs`); CI step name at
+`.github/workflows/plan-marker-validate.yml:342` drops REQ-13 (belongs to S4, not S3) — fold that
+1-line name fix into the same workflow edit that registers `tests/test-rfc-009-p4-apply.mjs`.
 
 **Files this slice may touch (one per step):** `scripts/lib/lock.mjs` (new — DELTA-2 lock extraction, user-approved), `scripts/em-lock.mjs` (behavior-preserving EDIT), `scripts/em-consolidate.mjs`, `scripts/em-rebuild-index.mjs` (round-2 N2, user-approved fold — whitelist EDIT), `tests/test-rfc-009-p4-apply.mjs` (new). **Read-only:** `scripts/lib/categories.mjs:63` (`validateCategory`), `scripts/lib/activation.mjs:37-67` (`illegalValueChar`/`illegalScalarChar`), `scripts/em-store.mjs:139-167` (the validation ORCHESTRATION `clerkWrite` mirrors — NOT `:59`, which is stale), the JSONL member-flip pattern at `em-consolidate.mjs:622-637` (index-flip exemplar — NOT `updateInverted`, round-2 N1).
 


### PR DESCRIPTION
Docs-only bookkeeping on docs/plans/rfc-009-p4.md after PR #523 merged. Status blocks flipped to PR-A-shipped/PR-B-gated (PR #523 c2abbe8, closes #505 recorded); section 18 done-criteria checklist split (PR-A checked, PR-B open); new section 19.9 records the envelopeCapPlusNMore CI kill, the clerkHighDfTags per-run memo fix, and the GLM-5.2 ACCEPT review round; the S4 heading gains the #522 in-slice fold list (errorCode precedence, cache comment, REQ-13 CI step name). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)