### PR TITLE
docs: refresh README, user manual, and scripts guide to current reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,16 @@ The installer:
 3. Creates `.episodic-memory/` in the target project for local episodes
 4. Copies the appropriate instruction file for your tool
 5. Copies `docs/EM_SCRIPTS_GUIDE.md` to `~/.episodic-memory/EM_SCRIPTS_GUIDE.md` (all tools)
-6. With `--install-hooks`: copies `plugins/claude-code/hooks/*.sh` into `~/.claude/hooks/` and `plugins/claude-code/hooks/lib/*.sh` into `~/.claude/hooks/lib/`, then registers PreToolUse (checkpoint-gate + plan-gate + stop-gate, from `~/.claude/hooks/`), SessionStart (em-recall-sessionstart + BP-1 fallback sweep, from `~/.claude/hooks/`), and SessionEnd (em-session-end-prompt, run directly from `~/.episodic-memory/scripts/`) hooks in `~/.claude/settings.json` (Claude Code only, opt-in). Re-running the installer warns when an installed hook has drifted from the source-of-truth copy ([#201](https://github.com/lantisprime/episodic-memory/pull/201)). Use `--install-hooks-force` to overwrite locally edited hook files.
+6. With Claude Code hook flags (all registrations are per-project):
+
+   > **Per-project layer — the headline.** Hooks, enforcement, and activation are three INDEPENDENT per-project opt-ins. Each one is scoped to the project you pass via `--project <path>`. A project with only `--install-hooks` has no gates; a project without `--install-enforcement` has no gates. None of these three layers ever writes to `~/.claude`, and removing or changing a layer in project A never touches project B or your global Claude Code setup. The one separate global write is `install.mjs --install-second-opinion`, which installs the second-opinion provider snapshot at `~/.claude/hooks/second-opinion-providers.json`; that flag is its own capability and is not part of the per-project layers above.
+
+   - `--install-hooks` installs only the non-enforcement hooks under `<project>/.claude/`: `em-recall` and `session-handoff` at SessionStart, plus `em-session-end-prompt` at SessionEnd. It registers them in `<project>/.claude/settings.json`; it does not install gates or write to `~/.claude`.
+   - `--install-enforcement` is the only flag that arms enforcement. It installs the four gates (`checkpoint-gate`, `plan-gate`, `preflight-gate`, `stop-gate`), their `hooks/lib` closure, and the enforce-contract config set under `<project>/.claude/`; registers them in `<project>/.claude/settings.json`; and seeds `<project>/.episodic-memory/enforce-config.json` if absent. Use `--uninstall-enforcement` to remove that project's enforcement files and registrations; add `--purge-config` to remove the operator-owned config too. Re-running either install warns about drift; `--install-hooks-force` accepts the repository copies.
+   - `--install-activation` is the third independent per-project opt-in: it installs the advisory activation adapter (UserPromptSubmit + PreToolUse + SessionStart hooks) under `<project>/.claude/` and registers them in `<project>/.claude/settings.json`. It never writes to `~/.claude` and never blocks; reverse with `--uninstall-activation`.
 7. Records what it installed (Layer 1 update distribution): a **version manifest** at each target root — `~/.episodic-memory/install-manifest.json` for the global set, `<project>/.episodic-memory-install.json` per project — with the source version (git SHA of the repo the installer ran from; content hash when git is unavailable), timestamp, tool, and per-file sha256 checksums; a **consumer registry** entry in `~/.episodic-memory/installs.json` (`{project_path, tool, version, enforcement_installed, last_install_ts}`, deduped per project+tool); and a **dist cache** of the current artifact payloads at `~/.episodic-memory/dist/<version>/` (copy source only — nothing is registered or executed from there).
+
+For a fresh Claude Code session, `--bootstrap-last-prompt` writes a 60-second per-project sentinel from `CLAUDE_SESSION_ID`, giving the preflight gate first-prompt ground truth before UserPromptSubmit has fired.
 
 **Keeping consuming projects up to date.** Copies used to fall behind silently on every repo update; now:
 
@@ -159,9 +167,9 @@ The per-project SessionStart hook (Claude Code, installed with `--install-enforc
 
 **Per-harness agent guides.** If you are an AI coding agent installing this for yourself, read the self-contained guide for your harness in [docs/install/](docs/install/) (one file each for Claude Code, Cursor, Codex, OpenCode, Pi Agent, Windsurf): exact commands, real expected output, artifact tables, and troubleshooting. The agent-facing per-script command reference is [docs/EM_SCRIPTS_GUIDE.md](docs/EM_SCRIPTS_GUIDE.md), also deployed to `~/.episodic-memory/EM_SCRIPTS_GUIDE.md` on every install.
 
-**Per-project enforcement config (optional, RFC-008 P4).** With `--install-enforcement`, the installer **seeds** a default `<project>/.episodic-memory/enforce-config.json` = `{"active": true}` (create-if-absent, never overwriting your edits — a deliberate `{"active": false}` survives reinstalls, even with `--install-hooks-force`). Tune enforcement **per project** by editing it — no need to touch global hooks:
+**Per-project enforcement config (optional, RFC-008 P4).** With `--install-enforcement`, the installer **seeds** a default `<project>/.episodic-memory/enforce-config.json` = `{"active": true}` (create-if-absent, never overwriting your edits — a deliberate `{"active": false}` survives reinstalls, even with `--install-hooks-force`). Tune enforcement **per project** by editing it — no need to change the project's hook registrations:
 
-- `{"active": false}` — layer-wide **kill switch**: silences *all* episodic-memory gates (checkpoint, plan, stop, preflight, second-opinion) for that project only; your other repos keep their hooks (R5).
+- `{"active": false}` — layer-wide **kill switch**: silences *all* episodic-memory gates (checkpoint, plan, stop, preflight, second-opinion) for that project only; other repos keep their own project-local hooks (R5).
 - `{"bp-001": {"plan_approval": "MEDIUM"}}` — relax an individual gate (clamps tier DOWN only; never raises).
 - `{"auto_update": true}` — opt-in **session-start auto-update** (Layer 1): on version drift the SessionStart hook refreshes this project's unmodified installed artifacts from `~/.episodic-memory/dist/<version>/` instead of only printing the drift notice (locally modified files are always left untouched and reported). Never enabled automatically. Set it only after this project's deployed `enforce-config.schema.json` is current (an older deployed schema rejects the key, and validation failure fails closed to `{active: true}` — which would override a deliberate `"active": false`).
 
@@ -244,6 +252,7 @@ script through `scripts/lib/categories.mjs`. Filter by category with `em-search 
 ├── tags.json                 # Inverted tag index
 ├── category-index.json       # Category -> episode-ids index
 ├── trigger-index.json        # Derived lesson-activation index (RFC-009 R2, lazy-built)
+├── activation-log.jsonl      # Append-only, 1 MiB-bounded injected-pointer telemetry (RFC-009 R6)
 └── lesson-suppress.json      # Optional, hand-authored: mute lessons by id (RFC-009 R3, fail-open)
 
 patterns/                     # Behavioral patterns (shipped with repo)
@@ -304,7 +313,7 @@ Behavioral patterns are documentation by default — but the most-violated patte
 - **Violation tracking** (`em-violation.mjs`) — structured storage with pattern linkage, searchable by `--category violation` and `--tag violated:<pattern_id>`
 - **Session-end prompt** (`em-session-end-prompt.mjs`) — SessionEnd hook that asks about violations
 - **Proactive recall** (`em-recall.mjs`) — surfaces past violations at session start as pre-flight warnings
-- **Checkpoint enforcement gate** (RFC-002 Phase 3b, shipped + activated 2026-05-02 via [#78](https://github.com/lantisprime/episodic-memory/pull/78) and [#84](https://github.com/lantisprime/episodic-memory/pull/84)) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done. Opt-in via `node install.mjs --tool claude-code --install-hooks --project <path>`; registers SessionStart + PreToolUse + SessionEnd hooks in `~/.claude/settings.json`.
+- **Checkpoint enforcement gate** (RFC-002 Phase 3b, shipped + activated 2026-05-02 via [#78](https://github.com/lantisprime/episodic-memory/pull/78) and [#84](https://github.com/lantisprime/episodic-memory/pull/84)) — PreToolUse hook that blocks code edits until the implementation checkpoint is printed, and blocks pushes until E2E + bug logging are done. Opt in per project via `node install.mjs --tool claude-code --install-enforcement --project <path>`; the four enforcement gates are registered only in `<project>/.claude/settings.json`.
 - **LLM intent classifier for the checkpoint gate** (Tier 2/3 shipped 2026-05-22 via [#326](https://github.com/lantisprime/episodic-memory/pull/326); replaced by agent-self-classify marker 2026-05-23 via [#331](https://github.com/lantisprime/episodic-memory/pull/331)) — when the Tier 1 heuristic table doesn't recognize a `Bash` command, the gate consults a per-session marker (`scripts/classifier-marker.mjs`) populated by the active agent's own reasoning, then falls through to the Tier 1 safe-default if no marker exists. Configuration loaded by `scripts/classifier-config-loader.mjs` from `<project>/.episodic-memory/classifier-config.json` (or the global file under `~/.episodic-memory/`); set `enabled: false` to disable LLM dispatch entirely and run on the Tier 1 heuristic alone. False-positives (read-only inspectors blocked as `shared_write`) are corrected via the `classify-correction` skill — see [Skills](#skills) below.
 - **BP-1 Auto-Pilot** (RFC-004, M0 + M1 + M2 shipped 2026-05-06..23 via [#181](https://github.com/lantisprime/episodic-memory/pull/181), [#186](https://github.com/lantisprime/episodic-memory/pull/186), [#188](https://github.com/lantisprime/episodic-memory/pull/188), [#200](https://github.com/lantisprime/episodic-memory/pull/200), [#206](https://github.com/lantisprime/episodic-memory/pull/206), [#305](https://github.com/lantisprime/episodic-memory/pull/305), [#309](https://github.com/lantisprime/episodic-memory/pull/309), [#313](https://github.com/lantisprime/episodic-memory/pull/313), [#322](https://github.com/lantisprime/episodic-memory/pull/322)) — activation gate, deadline sweep, finalize-replay state machine, HMAC-signed run manifests, per-session preflight markers, and the M2 finish-line `bp1-flag-flip` cutover that mechanically enforce bp-001 (implementation workflow). Replaces documentation-only enforcement for the workflow lifecycle.
 
@@ -324,7 +333,12 @@ Episodic-memory and user-preferences are fully independent — install either or
 | [RFC-003](docs/rfcs/RFC-003-pluggable-tool-adapters.md) | Pluggable Tool Adapters: Per-Platform Enforcement and Cross-Tool Messaging | Accepted (Phase 1 not yet started) |
 | [RFC-004](docs/rfcs/RFC-004-bp1-auto-pilot.md) | BP-1 Auto-Pilot: Automated Rule-18 Implementation Workflow | Accepted (M0 + M1 + M2 shipped) |
 | [RFC-005](docs/rfcs/RFC-005-em-move.md) | em-move — atomic episode relocation between scopes | Accepted |
-| [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Accepted (harness shipped PR #222) |
+| [RFC-006](docs/rfcs/RFC-006-codex-review-adapter.md) | Codex Review Adapter: Typed-Request Consumer with Failure Classification and Local Fallback | Withdrawn (the review harness shipped separately) |
+| [RFC-007](docs/rfcs/RFC-007-graph-projection.md) | Graph Projection — first-class traversal over latent episode/rule edges | Draft |
+| [RFC-008](docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md) | Decoupling the Enforcement Layer from the Memory Substrate | Accepted |
+| [RFC-009](docs/rfcs/RFC-009-lesson-activation.md) | Lesson Activation: Trigger-Bearing Lessons, Derived Trigger Index, and Bounded Advisory Recall | Accepted |
+| [RFC-010](docs/rfcs/RFC-010-versioned-central-engine.md) | Version-pinned central enforcement engine with per-project shims | Draft |
+| [RFC-011](docs/rfcs/RFC-011-playbook-activation-preferences.md) | Playbook Activation Preferences: Per-Project Session-Start and On-Demand Playbook Loading | Accepted |
 
 ## Scripts Reference
 
@@ -344,6 +358,7 @@ Health check + repair for stores and installation: index parse/drift, tags + cat
 node ~/.episodic-memory/scripts/em-doctor.mjs            # report (exit 1 on errors)
 node ~/.episodic-memory/scripts/em-doctor.mjs --fix      # rebuild indexes, clear litter
 node ~/.episodic-memory/scripts/em-doctor.mjs --strict   # CI mode: warns also fail
+node ~/.episodic-memory/scripts/em-doctor.mjs --verbose  # include affected ids/files in findings
 node ~/.episodic-memory/scripts/em-doctor.mjs --all-projects        # + every registered project store
 node ~/.episodic-memory/scripts/em-doctor.mjs --all-projects --fix  # repair each store in place
 ```
@@ -399,6 +414,9 @@ node ~/.episodic-memory/scripts/em-store.mjs ... --pin                # pin at c
 # Feedback: retrieval says an episode was SEEN; feedback says it HELPED.
 # ±5% per point in ranking (clamped −30%/+50%), survives rebuilds.
 node ~/.episodic-memory/scripts/em-feedback.mjs --id <episode-id> --useful   # or --noise
+# Infer useful feedback from episode ids cited in a file; preview before writing.
+node ~/.episodic-memory/scripts/em-feedback.mjs --scan-text <file> --dry-run
+node ~/.episodic-memory/scripts/em-feedback.mjs --scan-text <file>
 ```
 
 ### Move (scope relocation, RFC-005)
@@ -465,6 +483,17 @@ A failing/unavailable reranker falls back to vector order with a warning;
 node ~/.episodic-memory/scripts/em-consolidate.mjs --scope local            # preview
 node ~/.episodic-memory/scripts/em-consolidate.mjs --scope local --apply    # fold
 
+# Clerk mode uses lesson-specific lexical signals (high-df-filtered tag Jaccard,
+# summary Jaccard, shared triggers) to propose merge/dedupe/keep-distinct clusters.
+node ~/.episodic-memory/scripts/em-consolidate.mjs --clerk --scope local
+node ~/.episodic-memory/scripts/em-consolidate.mjs --clerk --apply --confirm --scope local
+```
+
+`--clerk` without `--apply` emits a read-only `clerk-report`: it writes no episodes or store indexes, although it may lazily build the derived `trigger-index.json`. Apply mode fails closed without `--confirm`; holds one blocking `.episodic-memory/clerk-apply.lock` for the entire apply (`--lock-timeout <s>`, default 30); and, for merges, writes the digest before flipping members to `superseded` (the members remain reversible via `em-revise`). Every apply writes exactly one `category: workflow.lifecycle`, `record_type: clerk-run` episode with a `clerk_cutover` stamp and reports crash orphans as benign or dangerous.
+
+Human rejection is part of apply: `--reject-all` rejects every proposal, while repeatable `--reject-member <id>` rejects any cluster containing that member. Rejections are stored by fingerprint in the run record and are not proposed again while the store is unchanged.
+
+```bash
 # Archive long supersedes-chains (reversible move; terminal untouched), and
 # the registry-wide form: every registered project store in one pass. A real
 # multi-store run requires --confirm; unsafe store layouts are skipped.
@@ -547,6 +576,7 @@ node ~/.episodic-memory/scripts/em-search.mjs --tag auth --category decision --s
 node ~/.episodic-memory/scripts/em-search.mjs --history <id> --full
 node ~/.episodic-memory/scripts/em-search.mjs --read <id>            # RFC-011 R7: tracked, bounded, single-episode read the playbook pointers name
 node ~/.episodic-memory/scripts/em-search.mjs --include-superseded
+node ~/.episodic-memory/scripts/em-search.mjs --warn-time-ms <n> --warn-count <n>  # tune performance-warning thresholds
 ```
 
 `--read <id>` (RFC-011 R7) fetches exactly one episode by exact id (resolving
@@ -591,6 +621,7 @@ node ~/.episodic-memory/scripts/em-seed-patterns.mjs
 node ~/.episodic-memory/scripts/em-recall.mjs
 node ~/.episodic-memory/scripts/em-recall.mjs --project my-project --limit 5
 node ~/.episodic-memory/scripts/em-recall.mjs --days 14 --no-track
+node ~/.episodic-memory/scripts/em-recall.mjs --warn-time-ms <n> --warn-count <n>  # tune performance-warning thresholds
 ```
 
 ### Prune (Archive Stale Episodes)
@@ -601,10 +632,13 @@ node ~/.episodic-memory/scripts/em-prune.mjs --check  # exit 1 if prunable episo
 # RFC-009 R6: evidence-linked violations, trigger-bearing lessons, consolidates
 # members, and the latest clerk run record are never archived — see the
 # protected / protected_episodes output fields in --dry-run.
+# Clerk run records are produced by em-consolidate --clerk --apply.
 # RFC-011 R5(b): playbook-referenced chains (declared in playbooks.json) are also
 # protected (reason playbook-referenced / chain-member); a present-but-unparseable
 # playbooks.json aborts archival exit 1 and archives nothing (fail-closed).
 ```
+
+`--check` is the read-only CI gate: it exits 1 when prunable episodes exist and 0 when the store passes, without archiving anything.
 
 ### Backup (Mirror to Private Repo with Redaction)
 ```bash
@@ -823,7 +857,10 @@ bands; a missing or malformed file fails open (injection proceeds). An optional 
 declared playbook pointers — one imperative line per playbook (`playbook (playbooks.json):
 READ <id> before proceeding (...)`) pointing at a tracked bounded `em-search --read <id>`,
 never a body; the `playbook (playbooks.json):` provenance prefix keeps declared injection
-visible. Reverse with `--uninstall-activation`. Enforcement is a separate, independently installed layer
+visible. Each activation hook appends injected lesson-pointer telemetry to the per-project
+`activation-log.jsonl`; the event-plane log is append-only and capped at 1 MiB. It is the
+raw input for the planned R6 conversion metric; the shipped clerk's cadence advisory is
+computed from the trigger index, not this log. Reverse with `--uninstall-activation`. Enforcement is a separate, independently installed layer
 (`--install-enforcement`).
 
 ### BP-1 Auto-Pilot (RFC-004)
@@ -843,22 +880,26 @@ node ~/.episodic-memory/scripts/bp1-canonicalize.mjs --episode <path> [--pretty]
 # Path A + Path B fallback executor (auto-wired as SessionStart H2 hook)
 node ~/.episodic-memory/scripts/bp1-deadline-sweep.mjs --once [--project <root>]
 
-# Orchestrator subcommands: init-run, finalize-run, finalize-recover (M1)
-node ~/.episodic-memory/scripts/bp1-orchestrator.mjs init-run --project <root>
-node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-run --run-id <id>
-node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-recover --run-id <id>
+# Orchestrator subcommands (M1)
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs init-run --project <root> --rfc-id <rfcId>
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-run --project <root> --run-id <id>
+node ~/.episodic-memory/scripts/bp1-orchestrator.mjs finalize-recover --project <root> --run-id <id>
+# Further subcommands: detect-rfcs, record-classifier-dispatch-pre,
+# record-classification, record-awaiting-approval, confirm-approval,
+# check-deadlines, sweep-naked-entries.
 
-# Marker validation — verify a checkpoint marker's HMAC + shape (slice 2d-W, #305)
-node ~/.episodic-memory/scripts/bp1-marker-validate.mjs --marker <path>
+# Marker validation — verify a run's checkpoint marker HMAC + shape (slice 2d-W, #305)
+node ~/.episodic-memory/scripts/bp1-marker-validate.mjs --project <path> --run-id <id> [--skip-mtime-check]
 
 # Crash-class classification for SessionStart resumption (slice 2e, #313)
-node ~/.episodic-memory/scripts/bp1-crash-classify.mjs --run-id <id>
+node ~/.episodic-memory/scripts/bp1-crash-classify.mjs --project <root> --run-id <id> [--now <iso>]
 
 # Emit a marker-invalid evidence episode (used by the deadline-firing path, #313)
-node ~/.episodic-memory/scripts/bp1-emit-marker-invalid-evidence.mjs --run-id <id> --reason <code>
+node ~/.episodic-memory/scripts/bp1-emit-marker-invalid-evidence.mjs --project <path> --run-id <id> --reason <enum> --marker-path <path>
 
-# M2 finish-line: flip the BP-1 activation flag (slice 2f, #322)
-node ~/.episodic-memory/scripts/bp1-flag-flip.mjs --enable    # or --disable
+# M2 finish-line: only --disable is functional.
+node ~/.episodic-memory/scripts/bp1-flag-flip.mjs --disable <projectRoot>
+# --enable, --dry-run-on, and --dry-run-off are M5 stubs that exit 2.
 ```
 
 The orchestrator also auto-stubs a missing run on first interaction via `scripts/bp1-auto-stub.mjs` — not normally invoked directly.
@@ -878,7 +919,9 @@ node ~/.episodic-memory/scripts/em-mine-transcripts.mjs \
   [--since <ISO>] [--slug <substr>] [--output <path>] [--dry-run]
 ```
 
-### Scheduled Routines (launchd, macOS)
+### Scheduled Routines — Legacy macOS launchd Bootstrap (maintainer-machine only)
+
+> **Legacy, macOS-only, maintainer-machine claude-skill jobs.** This section is kept for the small set of `claude -p`-driven SKILL jobs that the maintainer machine still runs directly; it is NOT the general path. For normal scheduled maintenance (doctor repair, embed refresh, backup sync, hygiene reports) use **`em-routines.mjs`** — definitions live in `~/.episodic-memory/routines.json` and adapt to launchd on macOS, systemd user timers on Linux, or managed cron as the fallback. Install via the wizard, `install.mjs --install-routines`, or `node ~/.episodic-memory/scripts/em-routines.mjs sync`. See [USER_MANUAL Scenario 8c](docs/USER_MANUAL.md#scenario-8c-running-routines-on-a-schedule-cross-platform) for the full reference.
 
 Bootstrap (`install-launchd-routines.sh`) installs four LaunchAgent plists so the recurring chores run without manual invocation:
 

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -21,6 +21,8 @@ This guide is deployed to `~/.episodic-memory/EM_SCRIPTS_GUIDE.md` on every inst
 Human-facing walkthroughs live in `docs/USER_MANUAL.md`. Installation per harness is
 in `docs/install/`.
 
+> **Per-project model.** `install.mjs` hook and enforcement flags (`--install-hooks`, `--install-enforcement`, `--install-activation` and their uninstall counterparts) are independent per-project opt-ins, each scoped to the `--project <path>` you pass; enforcement is per-project and never global, none of these three layers ever writes to `~/.claude`, and a project without `--install-enforcement` has no gates.
+
 All outputs shown below are trimmed from real runs (Node v26, isolated sandbox).
 
 ---
@@ -245,11 +247,11 @@ Create a new episode.
 ```
 node ~/.episodic-memory/scripts/em-store.mjs \
   --project <name> \
-  --category <decision|discovery|milestone|context|research|lesson|violation|workflow.lifecycle> \
+  --category <decision|discovery|milestone|context|research|lesson|violation|workflow.lifecycle|workplan|temporary> \
   --tags "<t1,t2>" \
   --summary "<one line>" \
   --body "<detail>" \
-  [--body-file <path>] [--scope local|global] [--url <source-url>]
+  [--body-file <path|->] [--scope local|global] [--url <source-url>]
 ```
 
 Output on success:
@@ -261,15 +263,13 @@ Output on success:
 Output when required args are missing:
 
 ```json
-{"status":"error","message":"Missing required args. Usage: --project <name> --category <decision|discovery|milestone|context|research|lesson|violation|workflow.lifecycle> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path>) [--scope local|global]"}
+{"status":"error","message":"Missing required args. Usage: --project <name> --category <decision|discovery|milestone|context|research|lesson|violation|workflow.lifecycle|workplan|temporary> (--tags <t1,t2> | --tag <t> [--tag <t> ...]) --summary <text> (--body <text> | --body-file <path|->) [--scope local|global]"}
 ```
 
 Flags that matter:
 - `--scope` defaults to `global`. Pass `--scope local` for episodes that should stay
   inside this repo.
-- `--body-file <path>` reads the body from a file. Use it for long bodies (plan
-  documents) so a huge inline `--body "$(cat ...)"` does not trip a shell or a
-  permission gate. Mutually exclusive with `--body`.
+- `--body-file <path|->` reads the body from a file; `-` reads stdin. It is recommended for bodies containing backticks, `$()`, or `$VAR`, which an inline shell argument may expand before the script sees it. Also use it for long bodies (plan documents), so a huge inline `--body` does not trip a shell or permission gate. Mutually exclusive with `--body`.
 - Tags accept `--tags a,b`, repeated `--tag a --tag b`, or a mix. They are merged,
   deduplicated, lowercased, and sorted.
 - Lesson-only activation flags (`--trigger`, `--applies-to-project`, `--applies-to-tool`,
@@ -328,7 +328,8 @@ Search episodes with local plus global fallback.
 node ~/.episodic-memory/scripts/em-search.mjs \
   [--project <name>] [--query <text>] [--tag <t>] [--category <cat>] \
   [--since <YYYY-MM-DD>] [--limit <n>] [--scope local|global|all] \
-  [--full] [--include-superseded] [--read <id>] [--history <id>] [--no-score] [--no-track]
+  [--full] [--include-superseded] [--read <id>] [--history <id>] [--no-score] [--no-track] \
+  [--warn-time-ms <n>] [--warn-count <n>]
 ```
 
 Output:
@@ -388,6 +389,7 @@ Flags that matter (from the script's own `Usage:` header):
 - `--category <cat>` is index-backed via `category-index.json` (same degrade-to-linear-scan
   fallback as `--tag`). A deprecated category name canonicalizes to its successor; an unknown
   category still filters (tolerant read).
+- `--warn-time-ms <n>` and `--warn-count <n>` tune the elapsed-time and total-episode thresholds for performance warnings (defaults 500 ms and 5000 episodes).
 
 `--history` output (chain, oldest first):
 
@@ -450,7 +452,7 @@ recent cross-project) plus behavioral-pattern pre-flight warnings.
 - WHEN NOT TO USE: for a specific topic lookup (use `em-search`).
 
 ```
-node ~/.episodic-memory/scripts/em-recall.mjs [--project <name>] [--task-type <implementation|push|rule|general>] [--scope local|global|all] [--limit <n>] [--days <n>] [--no-track]
+node ~/.episodic-memory/scripts/em-recall.mjs [--project <name>] [--task-type <implementation|push|rule|general>] [--scope local|global|all] [--limit <n>] [--days <n>] [--no-track] [--warn-time-ms <n>] [--warn-count <n>]
 ```
 
 Output shape:
@@ -460,7 +462,8 @@ Output shape:
 ```
 
 Flags that matter: `--task-type implementation` adds the violation pre-flight;
-`--no-track` avoids bumping access counts if you are recalling repeatedly.
+`--no-track` avoids bumping access counts if you are recalling repeatedly;
+`--warn-time-ms <n>` and `--warn-count <n>` tune performance-warning thresholds.
 
 Common mistakes: skipping recall and re-deriving context that a past session already
 recorded.
@@ -553,13 +556,22 @@ semantic-consolidation capability). Dry-run by DEFAULT — `--apply` writes.
 node ~/.episodic-memory/scripts/em-consolidate.mjs [--scope local|global] \
   [--min-sim <0..1>] [--min-cluster <n>] [--category <cat>] [--project <name>] \
   [--include-pinned] [--apply] [--confirm]
+node ~/.episodic-memory/scripts/em-consolidate.mjs --clerk [--scope local|global]
+node ~/.episodic-memory/scripts/em-consolidate.mjs --clerk --apply --confirm \
+  [--scope local|global] [--reject-all] [--reject-member <id>]... [--lock-timeout <s>]
 node ~/.episodic-memory/scripts/em-consolidate.mjs --fold-superseded \
   [--min-chain <n>] [--dry-run] [--scope local|global]
 node ~/.episodic-memory/scripts/em-consolidate.mjs --fold-superseded \
   --all-projects [--min-chain <n>] [--dry-run] [--confirm]
 ```
 
-Clustering is body-token Jaccard within (project, category) groups; the
+Clerk report mode (`--clerk` without `--apply`) is READ-ONLY over episode and source-index state. It proposes `merge`, `dedupe`, or `keep-distinct` clusters from lexical signals: tag Jaccard after high-document-frequency tags are dropped, summary Jaccard, and shared triggers. It emits `mode: "clerk-report"` and writes nothing except a derived `trigger-index.json` that may be lazily built while loading shared triggers.
+
+Clerk apply mode (`--clerk --apply --confirm`) fails closed without `--confirm`. It holds one blocking target-store `clerk-apply.lock` (`.episodic-memory/clerk-apply.lock` for a local store) for the whole apply; `--lock-timeout <s>` controls acquisition and defaults to 30 seconds. For a merge, writes are ordered digest first, then member `status: superseded` / `superseded_by` index flips; the original knowledge remains reachable and can be reactivated through `em-revise`. Apply finishes with exactly one run-record episode per invocation: `category: workflow.lifecycle`, scalar `record_type: clerk-run`, with a `clerk_cutover` stamp. Each apply invocation detects incomplete prior applies and reports their orphans as benign (digest written, members active) or dangerous (members already superseded).
+
+Human rejections are explicit apply inputs: `--reject-all`, or repeatable `--reject-member <id>` for any cluster containing that member. The run record carries rejected cluster fingerprints, and a rejected cluster is not re-proposed against an unchanged store. `--scope local|global` chooses the store for both report and apply.
+
+Standard (non-clerk) clustering is body-token Jaccard within (project, category) groups; the
 0.35 default separates genuine near-duplicates (~0.35–0.5) from unrelated
 episodes (~0.0). On `--apply`, each cluster gets one digest episode carrying
 `consolidates: [ids...]`, union tags, full member bodies, and inherited
@@ -719,7 +731,8 @@ file storage, built fresh per query — no sidecar DB.
 
 ```
 node ~/.episodic-memory/scripts/em-graph.mjs --from <id> [--depth <n>] [--limit <n>] \
-  [--edges supersedes,consolidates,evidence,cites,tags|all] [--scope local|global|all]
+  [--edges supersedes,consolidates,evidence,cites,tags|all] [--scope local|global|all] \
+  [--include-superseded]
 node ~/.episodic-memory/scripts/em-graph.mjs --orphans     # no non-tag edges at all
 node ~/.episodic-memory/scripts/em-graph.mjs --hubs [--top <n>]
 ```
@@ -1039,7 +1052,8 @@ no writes.
 evidence-linked to a valid lesson (either direction: the lesson's `evidence` array
 or the violation's `lessons` array); valid lessons carrying `triggers`; episodes
 named in a valid episode's `consolidates` array; supersession-chain members of any
-of those; and the latest `record_type: clerk-run` episode per store. "Valid" means
+of those; and the latest `record_type: clerk-run` episode per store. Clerk run records
+are produced by `em-consolidate --clerk --apply`. "Valid" means
 not superseded and `review_by` absent or unexpired — protection lapses when the
 referencing episode is superseded or expires. Retained entries are counted in the
 `protected` output field; `--dry-run` lists them in `protected_episodes` as
@@ -1137,8 +1151,13 @@ Interactive day-2 maintenance wizard: status (doctor + stats), hygiene
 (rebuild-index, fold-superseded, prune, doctor --fix — dry-run first, apply only
 on explicit confirm), backup, capture drafts, routines, and an em-console
 launcher. Prose menus for humans; every underlying operation is a spawned `em-*`
-script. Scriptable via piped stdin (EOF takes defaults). Agent rule: human
-surface — suggest it to users; agents call the underlying scripts directly.
+script. Scriptable via piped stdin (EOF takes defaults).
+
+```
+node ~/.episodic-memory/scripts/em-manage.mjs
+```
+
+Agent rule: human surface — suggest it to users; agents call the underlying scripts directly.
 
 ### em-pattern-health
 
@@ -1153,6 +1172,7 @@ which patterns need enforcement.
 node ~/.episodic-memory/scripts/em-pattern-health.mjs            # full report
 node ~/.episodic-memory/scripts/em-pattern-health.mjs --summary  # one line
 node ~/.episodic-memory/scripts/em-pattern-health.mjs --check    # exit 1 if attention needed
+node ~/.episodic-memory/scripts/em-pattern-health.mjs --pattern <id> --window-days <N> --min-violations <N> --json
 ```
 
 `needs-enforcement` means violated repeatedly with no hook found. `needs-attention`
@@ -1235,6 +1255,11 @@ without a config; it refuses rather than ship raw personal memory. Deep docs:
 `docs/em-backup.md` and README.md "Backup" section. Agent rule: do not touch unless
 the user asks to back up.
 
+```
+node ~/.episodic-memory/scripts/em-backup.mjs --self-test    # built-in redaction tests
+node ~/.episodic-memory/scripts/em-backup.mjs --show-config  # resolved config, secrets/PII masked
+```
+
 ### em-restore
 
 Selectively restore from a cloned backup repo (filter by tag / date / category /
@@ -1277,9 +1302,13 @@ recall.
 
 ### em-lock
 
-Zero-dependency atomic file lock (a `flock` replacement for macOS) used by the
-auto-promote and backup-sync paths. Deep docs: header comment in the script. Agent
-rule: infrastructure primitive; do not invoke directly.
+Zero-dependency atomic lock CLI around `scripts/lib/lock.mjs`:
+
+```
+node ~/.episodic-memory/scripts/em-lock.mjs --file <path> --timeout <s> -- <cmd> [args...]
+```
+
+It releases the lock when the child exits and on `SIGINT` / `SIGTERM`. Clerk apply uses the same lock primitive internally through `scripts/lib/lock.mjs` for its whole-apply lock. Agent rule: infrastructure primitive; do not invoke directly.
 
 ### em-watch-codex
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -16,9 +16,10 @@ A persistent memory system for AI coding assistants. It remembers your decisions
 - [Scenario 7: Recording Project Context](#scenario-7-recording-project-context)
 - [Scenario 8: Switching Between Tools](#scenario-8-switching-between-tools)
 - [Scenario 8b: Running a Second-Opinion Review on a Plan or Diff](#scenario-8b-running-a-second-opinion-review-on-a-plan-or-diff)
-- [Scenario 8c: Running Routines on a Schedule (macOS)](#scenario-8c-running-routines-on-a-schedule-macos)
+- [Scenario 8c: Running Routines on a Schedule (Cross-Platform)](#scenario-8c-running-routines-on-a-schedule-cross-platform)
 - [Scenario 8d: One View Across Every Project](#scenario-8d-one-view-across-every-project)
 - [Scenario 8e: Looking at Your Memory Instead of Querying It](#scenario-8e-looking-at-your-memory-instead-of-querying-it)
+- [Scenario 8f: Tending the Memory Store by Hand](#scenario-8f-tending-the-memory-store-by-hand)
 - [Scenario 9: Explicitly Asking to Remember](#scenario-9-explicitly-asking-to-remember)
 - [Scenario 10: Preventing Repeated Mistakes](#scenario-10-preventing-repeated-mistakes)
 - [Scenario 11: Tracking Rule Violations](#scenario-11-tracking-rule-violations)
@@ -40,8 +41,8 @@ node ~/episodic-memory/install.mjs --tool cursor --project /path/to/my-project
 # For Claude Code
 node ~/episodic-memory/install.mjs --tool claude-code --project /path/to/my-project
 
-# For Claude Code with checkpoint enforcement hooks (opt-in, recommended)
-node ~/episodic-memory/install.mjs --tool claude-code --install-hooks --project /path/to/my-project
+# For Claude Code with the four per-project enforcement gates (opt-in)
+node ~/episodic-memory/install.mjs --tool claude-code --install-enforcement --project /path/to/my-project
 
 # For Codex
 node ~/episodic-memory/install.mjs --tool codex --project /path/to/my-project
@@ -61,19 +62,24 @@ node ~/episodic-memory/install.mjs --tool all --project /path/to/my-project
 
 That's the only manual step. After this, your AI assistant reads the instruction file automatically and manages everything.
 
+> **Everything here is per-project.** Installing gates in project A changes nothing in project B, and your global Claude Code setup is never touched. `--install-hooks`, `--install-enforcement`, and `--install-activation` are three independent per-project opt-ins, each scoped to the `--project <path>` you pass; a project without `--install-enforcement` has no gates, and removing the layer touches only that project. None of these three layers ever writes to `~/.claude`.
+
+If you do want the command line, the installer places a shim at `~/.episodic-memory/bin/em`. `em <command>` is shorthand for `node ~/.episodic-memory/scripts/em-<command>.mjs`; `em help` lists the available commands, and unknown commands include did-you-mean suggestions.
+
 ### What the installer does
 
 1. Copies scripts to `~/.episodic-memory/scripts/` (shared across all projects)
 2. Creates `.episodic-memory/` in your project for local memories
 3. Adds the right instruction file for your tool
 4. Updates `.gitignore` to exclude memory data
-5. With `--install-hooks` (Claude Code only): registers PreToolUse (checkpoint-gate, plan-gate, stop-gate), SessionStart (recall + BP-1 fallback sweep), and SessionEnd hooks. Re-running the installer warns when any installed hook has drifted from the source-of-truth copy.
+5. With `--install-hooks` (Claude Code only): installs the non-enforcement SessionStart hooks (`em-recall`, `session-handoff`) and SessionEnd prompt under `<project>/.claude/`, registered in `<project>/.claude/settings.json`.
+6. With `--install-enforcement` (Claude Code only): installs the four per-project gates (checkpoint, plan, preflight, stop), their library closure, and enforce-contract config under `<project>/.claude/`; registers them in the project's settings; and seeds `<project>/.episodic-memory/enforce-config.json` if absent. This is the only flag that arms enforcement, and neither flag writes to `~/.claude`.
 
 ### Turn enforcement on or off per project (optional)
 
-The checkpoint / plan / stop / preflight / second-opinion gates are opt-in via `--install-hooks`. Once installed, you can tune them **per project** with `<project>/.episodic-memory/enforce-config.json` (RFC-008 P4) — without disabling them everywhere:
+The checkpoint / plan / preflight / stop gates are opt-in per project via `--install-enforcement`. Once installed, you can tune them with `<project>/.episodic-memory/enforce-config.json` (RFC-008 P4) — without disabling enforcement in other projects:
 
-- **Turn it all off for this project** — `{"active": false}`. Silences *every* episodic-memory gate for this repo only; your other projects keep their hooks (R5). Cleaner than removing the global hook entry, which would disable enforcement across all repos.
+- **Turn it all off for this project** — `{"active": false}`. Silences every episodic-memory enforcement gate in this repo only; your other projects keep their settings. To remove the layer instead, run `--uninstall-enforcement` for this project (add `--purge-config` only if you also want to delete the operator-owned config).
 - **Relax a single gate** — `{"bp-001": {"plan_approval": "MEDIUM"}}`. Lowers one gate's tier (clamps DOWN only; never raises).
 
 Fail-closed by design: a missing, empty, or malformed file leaves enforcement fully ON. (`enforce-config.json` is operator-owned — `--install-enforcement` **seeds** a default `{"active": true}`, create-if-absent, and never overwrites your edits; a deliberate `{"active": false}` survives reinstalls, even with `--install-hooks-force`.)
@@ -391,30 +397,33 @@ The `--rebuttal-cb` is a script that takes the reviewer's verdict and decides wh
 
 ---
 
-## Scenario 8c: Running Routines on a Schedule (macOS)
+## Scenario 8c: Running Routines on a Schedule (Cross-Platform)
 
-**What happens:** Some episodic-memory chores benefit from running on a recurring schedule rather than waiting for your next session — nightly transcript mining (so today's lessons don't pile up), Sunday digest, weekly hygiene check, and daily backup sync. macOS `launchd` can drive these for you so you never have to remember.
+**What happens:** Doctor repair, embedding refresh, backup sync, and hygiene reports benefit from a recurring schedule instead of waiting for your next session. `em-routines.mjs` keeps the definitions in `~/.episodic-memory/routines.json` and adapts them to launchd on macOS, systemd user timers on Linux, or managed cron as the fallback.
 
-This is the one corner of the project where you run a script yourself: a one-shot install. After that, the routines fire on their own and write logs you can read later.
+Start with a preview, then sync the defaults to the detected scheduler:
 
 ```bash
-# From the project root
-bash install-launchd-routines.sh --dry-run     # preview, no writes
-bash install-launchd-routines.sh               # install
-bash install-launchd-routines.sh --smoke       # install + kickstart daily-mining for a smoke test
-bash install-launchd-routines.sh --uninstall   # remove everything (logs preserved)
+node ~/.episodic-memory/scripts/em-routines.mjs sync --dry-run
+node ~/.episodic-memory/scripts/em-routines.mjs sync
+node ~/.episodic-memory/scripts/em-routines.mjs list
 ```
 
-After install:
+You can manage or inspect each routine through the same surface:
 
-- **Daily 19:30** — mines the day's transcripts into a staging file you'll review next session.
-- **Sunday 09:00** — writes the weekly digest episode (so Monday you wake up to a summary).
-- **Sunday 11:00** — runs the instruction-hygiene audit against your behavioral rules.
-- **Daily 23:00** — pushes your em-backup repo to remote.
+```bash
+node ~/.episodic-memory/scripts/em-routines.mjs run doctor
+node ~/.episodic-memory/scripts/em-routines.mjs enable doctor
+node ~/.episodic-memory/scripts/em-routines.mjs disable doctor
+node ~/.episodic-memory/scripts/em-routines.mjs add --name my-job --cron "0 4 * * *" --cmd "..."
+node ~/.episodic-memory/scripts/em-routines.mjs remove my-job
+node ~/.episodic-memory/scripts/em-routines.mjs logs doctor --lines 50
+node ~/.episodic-memory/scripts/em-routines.mjs uninstall
+```
 
-Logs live at `~/Library/Logs/episodic-memory/`. If something looks off (digest didn't run, mining looks empty), `tail ~/Library/Logs/episodic-memory/em-daily-mining.log` is the first stop; `launchctl print gui/$(id -u)/com.charltonho.em-daily-mining` shows whether the job is loaded and when it last ran.
+Use `--scheduler launchd|systemd|cron` to select a scheduler explicitly; otherwise the script chooses the platform adapter. `list` reports platform, last run, and staleness, so a silently dead schedule is visible.
 
-**When you don't want this:** if you're on Linux/Windows or just prefer manual control, skip the install — the mining job has a direct CLI equivalent (`node scripts/em-mine-transcripts.mjs`), and the digest / hygiene jobs run their SKILLs, so you can trigger those by asking your AI assistant to run the weekly-digest / instruction-hygiene routine when you want one.
+The old `install-launchd-routines.sh` remains only as a legacy, macOS-specific path for maintainer-machine Claude-skill jobs; use `em-routines.mjs` for normal scheduled maintenance.
 
 ---
 
@@ -441,6 +450,8 @@ a glance which store is bloated, which has index drift, and which has a 40-revis
 folding. A real multi-store fold additionally requires `--confirm`, and stores whose layout the
 substrate can't safely write (a registered subfolder of a bigger repo, a linked worktree) are
 reported and skipped rather than touched.
+
+**Consolidating near-duplicate lessons.** Ask the assistant for a clerk report when the store starts repeating itself. `em-consolidate --clerk` only proposes merge / dedupe / keep-distinct groups (apart from a possible derived trigger-index refresh); it does not change episodes. If the report looks right, the assistant can run `--clerk --apply --confirm`, applying approved groups while recording any `--reject-all` or `--reject-member <id>` decisions so unchanged clusters are not suggested again.
 
 **Promoting lessons that keep recurring.** When the same lesson shows up independently in two or
 more projects ("always quote hook command paths" learned in project A, then learned again in
@@ -489,14 +500,29 @@ Prefer the terminal? The same day-2 chores come as a guided menu:
 node ~/.episodic-memory/scripts/em-manage.mjs
 ```
 
-Pick `status` for health + analytics, `hygiene` for rebuild-index / fold / prune
-(you always see the dry-run before anything is applied and confirm explicitly),
+Pick `status` for health + analytics, `hygiene` for rebuild-index / fold / prune,
 `backup`, `capture` for pending drafts, `routines`, or `console` to launch the web
-page from the menu.
+page from the menu. Fold and prune always show a dry-run before offering apply.
 
 **When you don't want this:** neither surface is for agents — they keep using the
 JSON CLI. And nothing here runs unattended: both exist only while you're looking
 at them.
+
+---
+
+## Scenario 8f: Tending the Memory Store by Hand
+
+**What happens:** You want to inspect and maintain memory yourself without memorizing individual flags. `em-manage` is the one command to run when you want to tend the memory store by hand.
+
+```bash
+node ~/.episodic-memory/scripts/em-manage.mjs
+```
+
+The terminal menu offers `status` (doctor + stats), `hygiene` (rebuild-index, fold superseded chains, prune, doctor fix), `backup` (show config or sync), `capture` (review pending drafts), `routines` (list or sync schedules), and `console` (launch the local web console).
+
+Nothing is applied merely by opening the wizard: you choose each action. Fold and prune run a dry-run first and ask again before apply; backup sync, routines sync, and console write access also ask for confirmation. The manager then shows the underlying `em-*` JSON result. For automation, the same menu is scriptable through piped stdin; EOF takes safe defaults instead of hanging.
+
+**What you did:** Ran one guided, dry-run-first maintenance surface and confirmed only the work you wanted.
 
 ---
 
@@ -593,7 +619,9 @@ AI:   ⚠️ Pre-flight warning: bp-001 (implementation workflow) was
 
 ## Scenario 12: The Checkpoint Gate Stopped the AI
 
-**What happens:** You installed Claude Code with `--install-hooks`. The AI tries to edit a file or run a command and is blocked with a message about a "checkpoint required."
+> **Per-project model (restated).** These gates belong to one project, not your whole machine. A project with no `--install-enforcement` has no gates; opting in for project A leaves project B's behaviour (and your global Claude Code setup) unchanged. To remove the layer for THIS project only, run `--uninstall-enforcement` for that project.
+
+**What happens:** You installed Claude Code with `--install-enforcement`. The AI tries to edit a file or run a command and is blocked with a message about a "checkpoint required."
 
 ```
 AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
@@ -608,10 +636,11 @@ AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
 
 **Why this exists:** The checkpoint enforcement gates (RFC-002 Phase 3b + RFC-004 BP-1 Auto-Pilot) are PreToolUse hooks that prevent the AI from skipping the plan → review → approval → testing steps of the implementation workflow (bp-001). It's the mechanical version of the rules described in Scenario 11 — instead of relying on the AI to remember, the hooks physically block edits until each checkpoint is recorded.
 
-**Three gates:**
-- **Pre-checkpoint** — blocks `Edit`/`Write`/`Bash` until the AI has printed its plan and you've approved it.
-- **Stop-gate (post-checkpoint)** — blocks turn-end until E2E testing has run and any bugs found are logged ([#144](https://github.com/lantisprime/episodic-memory/pull/144)).
-- **Push-gate** — blocks `git push` until all wrap-up steps are complete.
+**Four installed gates:**
+- **Checkpoint-gate** — blocks repository-source writes until the pre-implementation checkpoint is complete, and blocks push / PR creation until the post-checkpoint is complete.
+- **Plan-gate** — blocks write tools while plan approval is pending; read-only tools remain available.
+- **Preflight-gate** — requires a structured memory pre-flight before review handoffs and rule-bearing edits.
+- **Stop-gate** — blocks turn-end while required post-implementation wrap-up remains incomplete.
 
 **To clear a gate:** Approve the AI's plan in chat. The AI writes the checkpoint marker on your behalf — you don't run any commands manually. (Marker location is an internal implementation detail; PR #207 relocated it from `<repo>/.claude/.X` to `<repo>/.checkpoints/.X` to escape Claude Code's built-in sensitive-file prompt — readers honor both during burn-in.)
 
@@ -628,11 +657,11 @@ AI:   I tried to edit auth.ts but the checkpoint gate blocked me:
    ```
    Labels: `read_only`, `shared_write`, `marker_write`, `push_or_pr_create`, `unsafe_complex`. Overrides are per-project (cache key includes the project root + the script's sha256 digest — they don't bleed across repos and re-trigger if the script content changes). See `skills/classify-correction/SKILL.md` for the full reference, including the `--allow-non-git` mode for non-git projects (PR #327).
 2. **Disable LLM dispatch entirely** by setting `enabled: false` in `<project-root>/.episodic-memory/classifier-config.json` (or globally at `~/.episodic-memory/classifier-config.json`). The Tier 1 heuristic table + safe `shared_write` default then apply — useful if you're offline, don't have an API key, or want to minimize cost.
-3. **Remove the hook entry** from `~/.claude/settings.json` to opt out of the gate entirely.
+3. **Uninstall this project's enforcement layer** with `node ~/episodic-memory/install.mjs --tool claude-code --uninstall-enforcement --project <path>`. This removes only the project's enforcement files and registrations; it never changes another project or `~/.claude`.
 
-**Behind the scenes — BP-1 Auto-Pilot (RFC-004).** These three gates are part of a run-lifecycle system that signs each implementation run with HMAC, tracks state across crashes, and replays unfinished work via a finalize-recovery state machine. You don't interact with it directly — the gates above are its user-facing edges.
+**Behind the scenes — BP-1 Auto-Pilot (RFC-004).** These four gates are part of a run-lifecycle system that signs each implementation run with HMAC, tracks state across crashes, and replays unfinished work via a finalize-recovery state machine. You don't interact with it directly — the gates above are its user-facing edges.
 
-**To opt out entirely:** Don't pass `--install-hooks` during install, or remove the hook entries from `~/.claude/settings.json`.
+**To opt out entirely:** Don't pass `--install-enforcement`, or reverse it for this project with `--uninstall-enforcement`.
 
 ---
 
@@ -844,6 +873,12 @@ node ~/.episodic-memory/scripts/em-backup.mjs --init
 
 # Daily run: rsync sources, redact, commit, push
 node ~/.episodic-memory/scripts/em-backup.mjs --sync
+
+# Run built-in redaction tests
+node ~/.episodic-memory/scripts/em-backup.mjs --self-test
+
+# Inspect the resolved config with secrets / PII masked
+node ~/.episodic-memory/scripts/em-backup.mjs --show-config
 ```
 
 Config lives at `~/.config/em-backup/config.json`; see `examples/em-backup.config.example.json`. Refuses `--init` / `--sync` without a config to prevent shipping raw personal memory.


### PR DESCRIPTION
## Summary
Scouted staleness audit of README.md, docs/USER_MANUAL.md, and docs/EM_SCRIPTS_GUIDE.md against main @ ea69b95 (the accumulation of all shipped PRs), then a spec-driven rewrite. Corrections and additions:

- **Per-project enforcement story fixed everywhere** (was pre-RFC-008-P4d): `--install-hooks` = non-enforcement hooks only; `--install-enforcement` = the four gates (checkpoint, plan, preflight, stop), per project, never `~/.claude`. Prominent per-project callouts added in all three docs (user-requested emphasis), scoped precisely (the second-opinion registry snapshot is documented as the one separate global write).
- **Clerk consolidation documented** (was entirely absent): `--clerk` read-only report mode and `--clerk --apply --confirm` with `--reject-all` / `--reject-member` / `--lock-timeout`, run-records, crash-orphan detection; the em-prune "latest clerk run record" dangling reference now resolves.
- **New USER_MANUAL Scenario 8f** for `em-manage` (user-requested) and Scenario 8c rewritten around cross-platform `em-routines` (launchd/systemd/cron); README's launchd section reframed as legacy.
- **RFC table extended through RFC-011** with RFC-006 corrected to Withdrawn; bp1 script examples fixed to real flag spellings (incl. `bp1-flag-flip --enable` marked as an M5 stub); `activation-log.jsonl` telemetry documented truthfully (writer shipped; the conversion reader is labeled planned); `em` CLI shim added to the manual; category enum completed (10 members, stdin `--body-file -`); flag gaps closed across em-search/em-recall/em-graph/em-pattern-health/em-backup/em-doctor/em-feedback; `em-lock` entry rewritten.

Every claim was verified against live `--help` surfaces by the builder, then adversarially re-verified by a GLM-5.2 documentation review (round 1 HOLD-2: one factual error + one class leftover, both folded; round 2 ACCEPT).

## Test plan
- `node tests/test-ci-suite-registration.mjs` -> 16 passed, 0 failed (docs changes cannot break suite wiring)
- Reviewer-verified: no doc claims `--install-hooks` installs gates; no doc claims the clerk reads the activation log; TOC anchors match; code fences balanced; all flag spellings match observed usage output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ej86wDjv9493szKinjRYKd