### PR TITLE
RFC-009 P4 S5-S7 (PR-B remainder): R6 conversion + rotate-consume, R9c enrichment, R9d clerk prompt

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -345,6 +345,15 @@ jobs:
       - name: Run RFC-009 P4-S4 clerk apply suite (REQ-6..13)
         run: node tests/test-rfc-009-p4-apply.mjs
 
+      - name: Run RFC-009 P4-S5 conversion suite (REQ-18,19,20,21)
+        run: node tests/test-rfc-009-p4-conversion.mjs
+
+      - name: Run RFC-009 P4-S6 enrichment suite (REQ-14)
+        run: node tests/test-rfc-009-p4-enrich.mjs
+
+      - name: Run RFC-009 P4-S7 clerk prompt conformance (REQ-15)
+        run: node tests/test-rfc-009-p4-prompt.mjs
+
       - name: Run uninstall-activation round-trip suite (#504)
         run: node tests/test-uninstall-activation.mjs
 

--- a/docs/plans/rfc-009-p4.md
+++ b/docs/plans/rfc-009-p4.md
@@ -1,25 +1,28 @@
 <!--
 PLAN STATUS: PR-A (S1-S3) MERGED (2026-07-13): PR #523, squash c2abbe8, CI 4/4, #505 closed;
 includes the CI-robustness hotfix (clerkHighDfTags per-run memo + runClerk signal/errorCode, §19.9,
-GLM-5.2 ACCEPT 0 must-fix). PR-B (S4-S7) NOT started: S4 requires FOCUSED REVIEW BEFORE BUILD (A.7)
-and human approval; #522 cosmetics fold in-slice (S4). History: round-1 review DONE (2 lenses, both
-HOLD, CONFIRMED F-STRIP; §19), F1-F6 + P3s folded; per-slice build reviews in §19.4-19.9.
+GLM-5.2 ACCEPT 0 must-fix). S4 MERGED (2026-07-13) as its own PR: #525, squash ea69b95 (clerk apply
++ clerkWrite + scripts/lib/lock.mjs + rebuild round-trip, REQ-6..13; review arc §19.10-19.11,
+HOLD-3 -> HOLD-1 -> ACCEPT; #522 cosmetics folded in-slice). REMAINDER OF PR-B = S5+S6+S7, built
+together on feat/rfc-009-p4-s5-s7; pre-build scout deltas in §19.12. History: round-1 review DONE
+(2 lenses, both HOLD, CONFIRMED F-STRIP; §19), F1-F6 + P3s folded; per-slice reviews §19.4-19.11.
 -->
 
 # RFC-009-P4 — Consolidation clerk (R9b/c/d) + activation telemetry & conversion (R6) Plan
 
 ## §1 Status
 
-Current stage: **PR-A shipped, PR-B gated**. S1-S3 implemented, reviewed (§19.4-19.9),
-merged 2026-07-13 (PR #523 `c2abbe8`, closes #505). S4-S7 remain implement-gated: S4 takes a
-focused review BEFORE build (§A.7) plus human approval (Rule 18) before any code is written.
+Current stage: **S1-S4 shipped; S5-S7 in build (the PR-B remainder)**. S1-S3 merged
+2026-07-13 (PR #523 `c2abbe8`, closes #505). S4 merged 2026-07-13 as its own PR (#525
+`ea69b95`; focused pre-build review §19.10, post-build rounds §19.11). S5-S7 ship together on
+`feat/rfc-009-p4-s5-s7`; pre-build deltas recorded in §19.12 before any build step ran.
 
 | Field | Value |
 |---|---|
 | RFC | `RFC-009-lesson-activation` (status: accepted) |
 | Parent requirements | R9b, R9c, R9d, R6 (telemetry-log + conversion half) |
-| Workplan episode | `20260712-051007-workplan-v180-rfc-009-p3-done-merged-766-59e5` (v180) |
-| Target branch | `feature/rfc-009-p4` |
+| Workplan episode | `20260713-094635-workplan-v190-docs-refresh-shipped-pr-52-6ccc` (v190) |
+| Target branch | `feat/rfc-009-p4-s5-s7` (S5-S7; S1-S3 shipped via #523, S4 via #525) |
 | Executor altitude (§0.1) | **low** — implemented by a fresh-context session / builder seats; full Appendix A is the build path |
 
 **Phase-scope note (ground-truthed against the RFC phase table).** R9 and R6 are split
@@ -335,7 +338,8 @@ AGGREGATION PLANE (on-demand, clerk):
 One slice = one concern = one PR-shaped unit. **PR-A = S1–S3** (additive, no store mutation);
 **PR-B = S4–S7** (mutating apply + measurement).
 **PR-A MERGED 2026-07-13**: PR #523, squash `c2abbe8`, CI 4/4 green, closes #505; carried the
-§19.9 CI-robustness hotfix. PR-B not started; S4 review-gated (§A.7).
+§19.9 CI-robustness hotfix. **S4 MERGED 2026-07-13 as its own PR** (#525 `ea69b95`, review arc
+§19.10-19.11); the PR-B remainder = S5-S7, built together (pre-build deltas §19.12).
 
 | Slice | Objective | Primary files | Key deliverables | Tests | Hard stops |
 |---|---|---|---|---|---|
@@ -380,7 +384,7 @@ Do **not** cut:
 ### `clerkReport(index, opts) → ReportJSON`
 
 **Input:** the active index rows + R2 trigger index; opts `{minTagJaccard=0.5, minSummaryJaccard=0.4, kShared=3, nLessons=200, window=4h}`.
-**Output:** `{ status:'ok', mode:'clerk-report', clusters: Cluster[], candidates?: EnrichCandidate[], truncated?: '+N more', advisory?: string }` (`advisory` = REQ-23 one-line cadence advisory, S3 review F6); source store byte-identical (derived `trigger-index.json` refresh carved out per REQ-1); every id list bounded — `clusters[]` capped at 500 (top-level `truncated?: '+N more'`) and each cluster's `members[]` capped at 500 with its own `members_truncated?: '+M more'` field (S3 review F3; field named per round-2 NEW-1).
+**Output:** `{ status:'ok', mode:'clerk-report', clusters: Cluster[], candidates?: EnrichCandidate[], truncated?: '+N more', advisory?: string, conversion: ConversionReport, zero_conversion_candidates?: ZeroConversionCandidate[] }` (`advisory` = REQ-23 one-line cadence advisory, S3 review F6; `conversion` + conditional `zero_conversion_candidates` added by S5 REQ-19/REQ-21 — envelope updated per PR-B review round 1 P3-3, the ConversionReport shape is the `computeConversion` output below); source store byte-identical (derived `trigger-index.json` refresh carved out per REQ-1); every id list bounded — `clusters[]` capped at 500 (top-level `truncated?: '+N more'`) and each cluster's `members[]` capped at 500 with its own `members_truncated?: '+M more'` field (S3 review F3; field named per round-2 NEW-1).
 
 **`Cluster` state table (proposed-action resolution — exhaustive):**
 
@@ -654,7 +658,8 @@ Fill the right column with the ACTUAL output at build time (order rule: artifact
 - [ ] Clerk prompt conformance gauntlet green (REQ-15).
 - [ ] Every deferred finding has an issue/comment/violation artifact (D-H, #456, #457, D3, D4) — Rule 18 step 9.
 - [x] PR-A (S1–S3) reviewed per §19 (19.4–19.9) and merged (PR #523 `c2abbe8`, 2026-07-13).
-- [ ] PR-B (S4–S7) reviewed per §19.
+- [x] S4 reviewed per §19 (19.10–19.11, HOLD-3 → HOLD-1 → ACCEPT) and merged (PR #525 `ea69b95`, 2026-07-13).
+- [ ] PR-B remainder (S5–S7) reviewed per §19.
 
 ## §19 Review Consensus (Rule 18)
 
@@ -862,6 +867,27 @@ guarded under the lock (`clerkReadIndexRows` fresh canonical-superseded read at 
 run-record shape verified faithful (canonical-id sort picks it); `--break-lock` interaction ruled
 test-only-acceptable; sleep-1.5s choreography measured ~1425ms headroom and can only false-FAIL,
 never false-green. Seat costs: builder ~$1.70 total, reviewer ~$1.86 across rounds 2-3.
+
+### 19.12 PR-B remainder (S5-S7) pre-build scout pass (2026-07-13) — deltas folded before build
+
+Three parallel scout maps (spec/plan, implementation surface, test+CI), ground-truthed against
+main `7bc580c` (S1-S4 all merged). Governing-artifact consult re-run for this arc: conversion
+metric stays on the R6 aggregation plane (CAPABILITIES `activation` advisory contract, criterion-4
+enforcement-free; P6 — rotate-consume is lifecycle-gated inside a clerk run, no polling; P7 — the
+run-record is an episode, `activation-log.jsonl` stays transient per §5, no second store).
+Disposition sweep: CHANGED = `em-consolidate.mjs` (+ new `prompts/clerk.md`, workflow yml);
+INTERACTS = `lib/activation-log.mjs` (read-only constants), `lib/lock.mjs` (reuse),
+`em-revise.mjs` (subprocess AS-IS), `em-rebuild-index.mjs` (round-trip regression),
+`em-search.mjs` (read surface, unmodified); UNCHANGED = all other em-*.
+
+| # | Delta | Fold |
+|---|---|---|
+| D-PRB1 | Plan status surfaces (header comment, §1, §10, §18) still described S4 as review-gated/unbuilt; S4 merged as PR #525 `ea69b95` | Corrected in this edit; PR boundary restated: PR-B remainder = S5+S6+S7 on `feat/rfc-009-p4-s5-s7` |
+| D-PRB2 | S5/S6/S7 step tables lacked the CI suite-registration step (the DELTA-6/DELTA-9/4.6c class — recurred at S1, S3, and S4) | NEW steps 5.3c / 6.3c / 7.2c wire each new test file into `.github/workflows/plan-marker-validate.yml`; verify = `node tests/test-ci-suite-registration.mjs` → 0 failed |
+| D-PRB3 | §17 D3/D4 tracking issues (REQ-24, "file at S1/S5") were never filed — `gh issue list --state open --limit 50` 2026-07-13 shows no matching title | File both at S5 wrap with the 5 DEFER fields, before the PR-B review round |
+| D-PRB4 | Anchor drift: `scripts/em-consolidate.mjs` grew 642 → 1550 lines through S3/S4; §9/§12 anchors are stale | Builder re-greps every ANCHOR at build time (§A.6 verbatim-anchor rule stands; line numbers are hints, never targets) |
+| D-PRB5 | `em-consolidate --help` usage string omits ALL clerk modes (#527); S5/S6 add flags to that same surface | S5/S6 extend the usage string for the flags they ADD, in-slice; the pre-existing `--clerk` gap stays #527, not widened here |
+| D-PRB6 | REQ-21 (SHOULD) test relocated into `tests/test-rfc-009-p4-conversion.mjs` (round-2 N5) creates a hard S5 coupling | Confirmed intended: REQ-21 rides with S5, cut only together (§11 item 4); S5 commit message now cites REQ-21 |
 
 ## §20 Lessons Encoded (traceability — do not re-learn)
 
@@ -1089,7 +1115,7 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 
 ### `P4-S5` — R6 conversion metric + rotate-and-consume (REQ-18,19,20) — depends on S1 (log) + S4 (run-record)
 
-**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-conversion.mjs` (new). **Read-only:** `scripts/lib/activation-log.mjs` (S1 module — reader imports `LOG_FORMAT_VERSION`/`ACTIVATION_LOG_NAME`/`ACTIVATION_LOG_MAX_BYTES`), `docs/rfcs/RFC-009-lesson-activation.md:148` (the "prunes consumed telemetry lines" spec anchor — DELTA-3, NOT an em-consolidate.mjs line).
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-conversion.mjs` (new), `.github/workflows/plan-marker-validate.yml` (step 5.3c only). **Read-only:** `scripts/lib/activation-log.mjs` (S1 module — reader imports `LOG_FORMAT_VERSION`/`ACTIVATION_LOG_NAME`/`ACTIVATION_LOG_MAX_BYTES`), `docs/rfcs/RFC-009-lesson-activation.md:148` (the "prunes consumed telemetry lines" spec anchor — DELTA-3, NOT an em-consolidate.mjs line).
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
@@ -1098,11 +1124,12 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 | 5.2 | `scripts/em-consolidate.mjs` | EDIT | Wire conversion into the clerk run (compute during `--clerk` and fold the `ConversionReport` into the run-record). | `conversion::rotateConsumeAtomic` + `conversion::crossStoreSourceScope` pass |
 | 5.2b | `scripts/em-consolidate.mjs` | — | Negative controls (one per row): `--break-rotate` (non-atomic rotate) → `conversion::appendDuringRotateNotLost` FAILS; `--break-window` (inclusive lower bound) → `conversion::windowBoundary` FAILS; `--break-sourcescope` (ignore `source_scope`) → `conversion::crossStoreSourceScope` FAILS; `--break-tornskip` (throw on torn line) → `conversion::tornLineSkippedCounted` FAILS; **`--break-openwindow` (drop open-window lines instead of carrying forward) → `conversion::openWindowCarriedForward` FAILS (round-2, the F5/REQ-18 mitigation now has a red control)**. | each exits non-zero |
 | 5.3 | `tests/test-rfc-009-p4-conversion.mjs` | CREATE | Full verbatim contents: the 8 `conversion::` tests (rotateConsumeAtomic, appendDuringRotateNotLost, openWindowCarriedForward, tornLineSkippedCounted, perBandFromFixture, windowBoundary, crossStoreSourceScope, lowerBoundLabeled) **plus `report::zeroConversionCandidate` (REQ-21) relocated here from S3 (round-2 N5) — seeds N consecutive zero-conversion run-records, then asserts the report surfaces the candidate**. EC8/EC9 covered. Sentinel-based. | `node tests/test-rfc-009-p4-conversion.mjs` → `9/9 pass` |
-| 5.4 | — | — | Commit `P4-S5: R6 conversion + rotate-consume (REQ-18,19,20)` + trailer. | `git log -1 --oneline` shows `P4-S5` |
+| 5.3c | `.github/workflows/plan-marker-validate.yml` | EDIT | **CI suite registration (the DELTA-6/DELTA-9/4.6c class — §19.12 D-PRB2).** ANCHOR the S4 step (`run: node tests/test-rfc-009-p4-apply.mjs`); APPEND after it a new step `name: Run RFC-009 P4-S5 conversion suite (REQ-18,19,20,21)` with the bare line `run: node tests/test-rfc-009-p4-conversion.mjs` (the registration lint requires the exact bare form at `jobs.<job>.steps`). | `node tests/test-ci-suite-registration.mjs` → 0 failed |
+| 5.4 | — | — | Commit `P4-S5: R6 conversion + rotate-consume (REQ-18,19,20,21)` + trailer. | `git log -1 --oneline` shows `P4-S5` |
 
 ### `P4-S6` — R9c enrichment backfill (REQ-14) — depends on S4 (run-record/lock plumbing)
 
-**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-enrich.mjs` (new). **Read-only:** `scripts/em-revise.mjs` (invoked AS-IS via subprocess — F2 does not modify it), `scripts/em-capture.mjs:453` (the `spawnSync(process.execPath, [scriptPath, ...args], {encoding, cwd, timeout})` cross-script idiom — em-consolidate has no `child_process` import today).
+**Files this slice may touch (one per step):** `scripts/em-consolidate.mjs`, `tests/test-rfc-009-p4-enrich.mjs` (new), `.github/workflows/plan-marker-validate.yml` (step 6.3c only). **Read-only:** `scripts/em-revise.mjs` (invoked AS-IS via subprocess — F2 does not modify it), `scripts/em-capture.mjs:453` (the `spawnSync(process.execPath, [scriptPath, ...args], {encoding, cwd, timeout})` cross-script idiom — em-consolidate has no `child_process` import today).
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
@@ -1111,11 +1138,12 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 | 6.1b | `scripts/em-consolidate.mjs` | — | Negative control: `--break-scope` (widen candidate scope beyond provenance) → `enrich::scopeFromProvenanceOnly` must FAIL. | exit non-zero |
 | 6.2 | `scripts/em-consolidate.mjs` | EDIT | Wire `--clerk --enrich` mode dispatch (sibling `if` after the S4 apply block). | `enrich::runRecordUnderLock` passes |
 | 6.3 | `tests/test-rfc-009-p4-enrich.mjs` | CREATE | Full verbatim contents: the 4 §14 `enrich::` tests (lexicalCandidates, scopeFromProvenanceOnly, appliesViaRevise, runRecordUnderLock). Sentinel-based. | `node tests/test-rfc-009-p4-enrich.mjs` → `4/4 pass` |
+| 6.3c | `.github/workflows/plan-marker-validate.yml` | EDIT | **CI suite registration (§19.12 D-PRB2).** ANCHOR the S5 step added at 5.3c (`run: node tests/test-rfc-009-p4-conversion.mjs`); APPEND after it `name: Run RFC-009 P4-S6 enrichment suite (REQ-14)` with the bare line `run: node tests/test-rfc-009-p4-enrich.mjs`. | `node tests/test-ci-suite-registration.mjs` → 0 failed |
 | 6.4 | — | — | Commit `P4-S6: R9c enrichment backfill (REQ-14)` + trailer. | `git log -1 --oneline` shows `P4-S6` |
 
 ### `P4-S7` — R9d clerk prompt + conformance (REQ-15) — prompt is DATA, not code; ⟂ parallel-safe (disjoint files)
 
-**Files this slice may touch (one per step):** `scripts/em-consolidate/prompts/clerk.md` (new DATA file; the dir is a clean CREATE — `scripts/em-consolidate.mjs` is a flat file, no dir collision), `tests/test-rfc-009-p4-prompt.mjs` (new). **Read-only:** `scripts/second-opinion/preambles/` (the nearest shipped-`.md`-as-data convention), `tests/test-second-opinion-preamble.mjs` (the manifest+loader+assert conformance-test template to mirror, not extend).
+**Files this slice may touch (one per step):** `scripts/em-consolidate/prompts/clerk.md` (new DATA file; the dir is a clean CREATE — `scripts/em-consolidate.mjs` is a flat file, no dir collision), `tests/test-rfc-009-p4-prompt.mjs` (new), `.github/workflows/plan-marker-validate.yml` (step 7.2c only). **Read-only:** `scripts/second-opinion/preambles/` (the nearest shipped-`.md`-as-data convention), `tests/test-second-opinion-preamble.mjs` (the manifest+loader+assert conformance-test template to mirror, not extend).
 
 | Step | File | Kind | Exact action | Verify (observed → expected; falsifiable) |
 |---|---|---|---|---|
@@ -1123,6 +1151,7 @@ goes stale after this slice but breaks no test (its manifest checksum matches it
 | 7.1 | `scripts/em-consolidate/prompts/clerk.md` | CREATE | Whole-file Write of the shipped R9d clerk aggregator prompt (DATA): the load-bearing instruction clauses + one embedded sample report matching the §12 `ReportJSON` shape (`mode:'clerk-report'`, `clusters[].proposed_action ∈ {merge,dedupe,keep-distinct}`). | file exists; `grep -c "clerk-report" scripts/em-consolidate/prompts/clerk.md` → ≥1 |
 | 7.2 | `tests/test-rfc-009-p4-prompt.mjs` | CREATE | Full verbatim contents modeled on `test-second-opinion-preamble.mjs`: `prompt::fileExists` (readFileSync ok), `prompt::loadBearingClauses` (asserts each required clause present), `prompt::sampleReportSchemaValid` (parse the embedded sample JSON, assert it satisfies the §12 `ReportJSON`/`proposed_action` enum contract). | `node tests/test-rfc-009-p4-prompt.mjs` → `3/3 pass` |
 | 7.2b | `tests/test-rfc-009-p4-prompt.mjs` | — | Negative control: `--break-prompt` (strip a load-bearing clause from the loaded copy) → `prompt::loadBearingClauses` must FAIL. | exit non-zero |
+| 7.2c | `.github/workflows/plan-marker-validate.yml` | EDIT | **CI suite registration (§19.12 D-PRB2).** ANCHOR the S6 step added at 6.3c (`run: node tests/test-rfc-009-p4-enrich.mjs`); APPEND after it `name: Run RFC-009 P4-S7 clerk prompt conformance (REQ-15)` with the bare line `run: node tests/test-rfc-009-p4-prompt.mjs`. | `node tests/test-ci-suite-registration.mjs` → 0 failed |
 | 7.3 | — | — | Commit `P4-S7: R9d clerk prompt + conformance (REQ-15)` + trailer. | `git log -1 --oneline` shows `P4-S7` |
 
 ## A.8 Definition of done (whole plan, mechanical)

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -58,15 +58,17 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
+import { fileURLToPath } from 'node:url'
 import { resolveLocalDir } from './lib/local-dir.mjs'
-import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
+import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensIndex, tokenizeQuery } from './lib/relevance.mjs'
 import { loadCategories, canonicalCategory, machineConsumedCategories, validateCategory } from './lib/categories.mjs'
 import { loadProtectionRows, computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
 import { resolveRegisteredStores, resolveRegisteredStoresWithStatus, realpathSafe } from './lib/registered-stores.mjs'
-import { TAG_JACCARD_MIN, SUMMARY_JACCARD_MIN, HIGH_DF_MIN, CADENCE_K_SHARED, CADENCE_N_LESSONS, PROPOSED_ACTIONS, RUN_RECORD_CATEGORY, RUN_RECORD_TYPE, CLERK_CUTOVER_MARKER } from './lib/activation-log.mjs'
+import { TAG_JACCARD_MIN, SUMMARY_JACCARD_MIN, HIGH_DF_MIN, CADENCE_K_SHARED, CADENCE_N_LESSONS, PROPOSED_ACTIONS, RUN_RECORD_CATEGORY, RUN_RECORD_TYPE, CLERK_CUTOVER_MARKER, ATTRIBUTION_WINDOW_MS, ACTIVATION_LOG_NAME, ACTIVATION_LOG_MAX_BYTES, LOG_FORMAT_VERSION } from './lib/activation-log.mjs'
 import { illegalValueChar, illegalScalarChar, serializeInlineArray, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
 import { acquire, release } from './lib/lock.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
+import { spawnSync } from 'node:child_process'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -74,7 +76,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-consolidate.mjs', usage: 'node em-consolidate.mjs [--scope local|global] [--min-sim <0..1>] [--min-cluster <n>] [--category <cat>] [--project <name>] [--include-pinned] [--apply] [--confirm] — fold near-duplicate episodes into digest episodes (dry-run by default) | --fold-superseded [--min-chain <n>] [--dry-run] [--all-projects] — archive non-terminal members of long supersedes-chains (reversible; terminal untouched; history walk still resolves the chain). --all-projects (fold mode only, mutually exclusive with --scope) folds every consumer-registry store; a real multi-store run requires --confirm; per-store R6 protection unions cwd-local + global + all registered stores' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-consolidate.mjs', usage: 'node em-consolidate.mjs [--scope local|global] [--min-sim <0..1>] [--min-cluster <n>] [--category <cat>] [--project <name>] [--include-pinned] [--apply] [--confirm] — fold near-duplicate episodes into digest episodes (dry-run by default) | --fold-superseded [--min-chain <n>] [--dry-run] [--all-projects] — archive non-terminal members of long supersedes-chains (reversible; terminal untouched; history walk still resolves the chain). --all-projects (fold mode only, mutually exclusive with --scope) folds every consumer-registry store; a real multi-store run requires --confirm; per-store R6 protection unions cwd-local + global + all registered stores | --clerk [--apply] [--confirm] [--window-ms <ms>] [--zero-conversion-runs <n>] — R9b lexical clerk (report by default, apply with --apply; consumes activation-log.jsonl via rotate-and-consume; the R6 conversion metric is a binary lower bound folded into the run-record; the report surfaces lessons with >= --zero-conversion-runs (default 3) consecutive zero-conversion runs as reword/demote/suppress candidates) | --clerk --enrich [--apply] [--confirm] [--reject-member <id>]... — R9c lexical enrichment backfill (proposes triggers/applies_to_project/applies_to_tool from the episode\'s OWN project and tool provenance fields ONLY, never widened; per-item confirm; apply writes via em-revise AS-IS and a run-record under the same lock)' }))
   process.exit(0)
 }
 
@@ -95,6 +97,7 @@ const confirm = argv.includes('--confirm')
 const foldSuperseded = argv.includes('--fold-superseded')
 const dryRun = argv.includes('--dry-run')
 const clerk = argv.includes('--clerk')
+const enrich = argv.includes('--enrich')
 // Default chain length before folding kicks in. 10 keeps short, still-warm
 // revision chains intact while catching the pathological ones (the live
 // store's worst chain measured ~145 members).
@@ -438,7 +441,7 @@ const CLERK_LOCK_FILE = path.join(DATA_DIR, 'clerk-apply.lock')
 // clerk branch) because clerkWrite is called from the top-level apply branch
 // during module evaluation; a `const` below the branch is in the TDZ then.
 const CLERK_SCALAR_FM_FIELDS = ['id', 'date', 'project', 'category', 'status', 'summary', 'record_type', 'clerk_cutover', 'superseded_by', 'supersedes', 'review_by']
-if (clerk && !apply) {
+if (clerk && !apply && !enrich) {
   const _clerkBreakReportWrite = process.argv.includes('--break-report-write')
   const _clerkBreakDrain = process.argv.includes('--break-drain')
   const _clerkActiveRaw = loadIndex(DATA_DIR, scope).filter(r =>
@@ -587,6 +590,56 @@ if (clerk && !apply) {
     advisory = `cadence: ${activeCount} active lessons (>= ${CADENCE_N_LESSONS}); consider a clerk run`
   }
 
+  // S5 REQ-18/19/20: compute the R6 conversion metric under the SAME
+  // CLERK_LOCK_FILE lock the apply mode holds (one lock, one writer). The
+  // conversion rotate-and-consume mutates the activation log; the lock
+  // serializes the rotate against concurrent appends AND a concurrent apply.
+  // The report's envelope carries the conversion summary so a reword/demote/
+  // suppress candidate surface is available to the human reviewer.
+  const _zeroRuns = (() => { const v = flag('--zero-conversion-runs'); const n = v !== undefined ? parseInt(v, 10) : 3; return Number.isFinite(n) && n >= 1 ? n : 3 })()
+  const _windowMs = (() => { const v = flag('--window-ms'); const n = v !== undefined ? parseInt(v, 10) : ATTRIBUTION_WINDOW_MS; return Number.isFinite(n) && n > 0 ? n : ATTRIBUTION_WINDOW_MS })()
+  const _clerkReportLockHandle = await acquire(CLERK_LOCK_FILE, 30)
+  let _conversion = { per_band: { imperative: { n: 0, d: 0 }, plain: { n: 0, d: 0 } }, per_lesson: [], torn_skipped: 0, carried_forward: 0, lower_bound: true }
+  if (_clerkReportLockHandle && _clerkReportLockHandle.ok) {
+    try {
+      _conversion = clerkComputeConversion(DATA_DIR, GLOBAL_DIR, Date.now(), _windowMs)
+    } finally {
+      release(_clerkReportLockHandle.handle)
+    }
+  }
+  // REQ-21: read the last N run-records; surface lessons with N consecutive
+  // zero-conversion runs as reword/demote/suppress candidates. (S5 stays
+  // ADVISORY — it never blocks an apply; the run-record body carries the same
+  // conversion report so a later P5 needs-enforcement reader can act on it.)
+  const _zeroCandidates = (() => {
+    const candidates = []
+    const lessonHits = new Map() // id -> [{ts,n}, ...] most-recent first
+    try {
+      const allRows = loadIndex(DATA_DIR, scope)
+      const rrRows = allRows
+        .filter(r => r.record_type === RUN_RECORD_TYPE && r.category === RUN_RECORD_CATEGORY)
+        .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')) || String(b.id || '').localeCompare(String(a.id || '')))
+      for (const rr of rrRows) {
+        let payload = null
+        try { payload = JSON.parse((fs.readFileSync(path.join(EPISODES_DIR, `${rr.id}.md`), 'utf8').split('\n\n').slice(1).join('\n\n') || '{}').replace(/^[^{]*/, '').match(/\{[\s\S]*\}/)?.[0] || 'null') } catch {}
+        if (!payload || !payload.conversion || !Array.isArray(payload.conversion.per_lesson)) continue
+        for (const le of payload.conversion.per_lesson) {
+          if (!le || typeof le.id !== 'string') continue
+          if (!lessonHits.has(le.id)) lessonHits.set(le.id, [])
+          lessonHits.get(le.id).push({ ts: rr.date || '', n: le.n || 0, d: le.d || 0 })
+        }
+      }
+    } catch {}
+    for (const [id, hits] of lessonHits) {
+      if (hits.length < _zeroRuns) continue
+      const recent = hits.slice(0, _zeroRuns)
+      if (recent.every(h => (h.n || 0) === 0 && (h.d || 0) > 0)) {
+        candidates.push({ id, consecutive_zero_runs: recent.length, suggestion: 'reword' })
+      }
+    }
+    return candidates
+  })()
+
   // Negative control: --break-report-write injects a stray write INSIDE the clerk
   // branch so report::byteIdenticalStore has teeth (red when the flag is set).
   if (_clerkBreakReportWrite) {
@@ -599,6 +652,8 @@ if (clerk && !apply) {
     clusters: _clusterReports,
     ...(truncatedSentinel ? { truncated: truncatedSentinel } : {}),
     ...(advisory ? { advisory } : {}),
+    conversion: _conversion,
+    ...(_zeroCandidates.length ? { zero_conversion_candidates: _zeroCandidates } : {}),
   }
 
   // Drain-before-exit (#486, REQ-4): em-search.mjs:120 idiom.
@@ -619,8 +674,22 @@ if (clerk && !apply) {
 // at end of file, hoisted) so this branch stays small and the TDZ-sensitive
 // module state stays in the pre-branch block above.
 // ---------------------------------------------------------------------------
-if (clerk && apply) {
+if (clerk && apply && !enrich) {
   await clerkApplyMain()
+}
+
+// ---------------------------------------------------------------------------
+// Clerk ENRICH mode (--clerk --enrich). RFC-009 P4-S6, R9c, REQ-14.
+// Lexical enrichment backfill: proposes triggers/applies_to_project/
+// applies_to_tool from the episode's OWN project and tool provenance
+// fields ONLY (never widened). REPORT mode (no --apply) prints proposals;
+// APPLY mode (--apply --confirm) calls em-revise AS-IS per confirmed
+// item and writes ONE run-record under the SAME CLERK_LOCK_FILE the
+// apply path uses (one lock, one writer — reuse, never a second lock).
+// Delegated to clerkEnrichMain (defined at end of file, hoisted).
+// ---------------------------------------------------------------------------
+if (clerk && enrich) {
+  await clerkEnrichMain()
 }
 
 // ---------------------------------------------------------------------------
@@ -1351,7 +1420,10 @@ function clerkLegacyDigestWrite(members, digest) {
 // REQ-11 run-record: category workflow.lifecycle + scalar record_type:clerk-run +
 // clerk_cutover; payload (JSON body) carries the source-index fingerprint, proposals,
 // per-item outcomes, written/superseded ids, and the cumulative rejected set.
-function clerkBuildRunRecord({ writtenIds, supersededIds, proposals, applied, rejected, skippedGuard, rejectedSet, storeFp, orphans, badCategory }) {
+// S5: payload also carries the conversion report (REQ-18/19/20) so a later
+// report::zeroConversionCandidate scan can read prior run-records and surface
+// lessons with N consecutive zero-conversion runs (REQ-21).
+function clerkBuildRunRecord({ writtenIds, supersededIds, proposals, applied, rejected, skippedGuard, rejectedSet, storeFp, orphans, badCategory, conversion }) {
   const { dateStr, timeStr, idStamp } = nowParts()
   const id = `${idStamp}-clerk-run-${crypto.randomBytes(2).toString('hex')}`
   const payload = {
@@ -1360,6 +1432,7 @@ function clerkBuildRunRecord({ writtenIds, supersededIds, proposals, applied, re
     written_ids: writtenIds, superseded_ids: supersededIds,
     proposals, applied, rejected, skipped_guard: skippedGuard,
     rejected_cumulative: rejectedSet, orphans,
+    ...(conversion ? { conversion } : {}),
   }
   return {
     id, date: dateStr, time: timeStr, project: 'clerk',
@@ -1373,6 +1446,247 @@ function clerkBuildRunRecord({ writtenIds, supersededIds, proposals, applied, re
     // rejected fingerprints stored top-level too so clerkLoadLatestRunRecord can
     // read them without the full payload parse (belt-and-braces).
     body: `Clerk run record (RFC-009 R9b P4-S4).\n\n${JSON.stringify({ ...payload, rejected: rejectedSet })}`,
+  }
+}
+
+// ===========================================================================
+// clerkComputeConversion(localDataDir, globalDataDir, now, windowMs)
+//   — RFC-009 P4-S5 (R6 conversion metric, REQ-18/19/20).
+//
+// Rotate-and-consume the activation-log: atomic rename of activation-log.jsonl
+// to a .processing name, parse the .processing file. OPEN-window lines
+// (ts ∈ (now-window, now]) are carried forward (re-appended to a fresh log) so
+// a later in-window access is not lost (NSP F5 / REQ-18). CLOSED-window lines
+// are consumed: for each entry, read last_accessed from the store named by
+// the line's source_scope; converted iff last_accessed ∈ (ts, ts+windowMs]
+// (half-open, REQ-19). An unreadable source_scope store counts UNCONVERTED
+// (lower bound, never inflated, REQ-20). Torn/unknown-v lines are skipped +
+// counted (EC8). Multi-injection disambiguation: a (ts, access_count_at_inject)
+// tuple is the attribution unit; the binary lower bound operates per-tuple
+// (a per-access delta is unreconstructable from the scalar last_accessed index,
+// see §7.1 F-7.1 / D-F).
+//
+// Crash recovery (REQ-18, fold round 2026-07-13): a leftover
+// activation-log.jsonl.processing from a PRIOR crashed rotation is consumed
+// FIRST (BEFORE the current log's rename) so its lines are folded into the
+// same report — the next rotate would otherwise rename ON TOP of the leftover
+// and silently lose those lines. The broken --break-rotate path
+// (read+unlink) never touches a leftover .processing, so the red control
+// proves the recovery is wired by leaving the leftover intact. Fail-open on
+// any recovery error (crash recovery is best-effort, telemetry never raises).
+//
+// Fail direction (REQ-16/17 + §8.2): telemetry handling fails OPEN (drop at
+// bound, skip torn lines, skip leftover on read error); the run-record write
+// fails CLOSED (clerkWrite). This function returns an EMPTY lower_bound:true
+// report on any read/rotate failure rather than throwing — the caller folds
+// the (possibly empty) report into the run-record or the report envelope,
+// never raising.
+//
+// Negative-control argv flags (portable — no env vars):
+//   --break-rotate       : non-atomic rotate (read-then-truncate-in-place) AND skip leftover consumption — proves EC9 + crash recovery wiring
+//   --break-window       : inclusive lower bound (last_accessed >= ts) — proves the half-open boundary
+//   --break-sourcescope  : ignore line.source_scope, always read local — proves cross-store attribution
+//   --break-tornskip     : throw on torn line instead of skipping+counting — proves EC8
+//   --break-openwindow   : drop open-window lines instead of carrying forward — proves REQ-18 carry-forward
+// ===========================================================================
+
+// _parseLogForConversion(filePath, now, windowMs, opts) — pure line parser
+// shared by the leftover-recovery and the rotated-log paths. Reads the file
+// at filePath, partitions lines by ts vs the open-window boundary, and
+// returns { perBand, perLessonMap, tornSkipped, openWindowLines }. The
+// caller merges the returned state into its accumulator.
+function _parseLogForConversion(filePath, now, windowMs, opts) {
+  const perBand = { imperative: { n: 0, d: 0 }, plain: { n: 0, d: 0 } }
+  const perLessonMap = new Map()
+  let tornSkipped = 0
+  const openWindowLines = []
+  let raw
+  try { raw = fs.readFileSync(filePath, 'utf8') } catch { return { perBand, perLessonMap, tornSkipped, openWindowLines } }
+  const openWindowStart = now - windowMs
+  for (const lineRaw of raw.split('\n')) {
+    if (!lineRaw.trim()) continue
+    let parsed
+    try { parsed = JSON.parse(lineRaw) } catch {
+      if (opts.breakTornSkip) throw new Error('torn line (--break-tornskip)')
+      tornSkipped++
+      continue
+    }
+    if (!parsed || parsed.v !== opts.logFormatVersion) {
+      if (opts.breakTornSkip) throw new Error('unknown v (--break-tornskip)')
+      tornSkipped++
+      continue
+    }
+    const tsMs = Date.parse(parsed.ts)
+    if (!Number.isFinite(tsMs)) { tornSkipped++; continue }
+    if (tsMs > openWindowStart) {
+      if (!opts.breakOpenWindow) openWindowLines.push({ serialized: lineRaw, ts: parsed.ts })
+      continue
+    }
+    const lineEntries = Array.isArray(parsed.entries) ? parsed.entries : []
+    for (const entry of lineEntries) {
+      if (!entry || typeof entry.id !== 'string') continue
+      // F3 (GLM review round 1): an entry with a missing or unknown
+      // source_scope is treated as UNCONVERTED for that entry — counts toward
+      // d, never n (REQ-20 lower bound, never inflated). The previous
+      // implementation silently coerced unknown/missing to 'local' and could
+      // count CONVERTED. --break-sourcescope still forces ALL scopes to
+      // local (the red control semantics).
+      const isKnownScope = entry.source_scope === 'local' || entry.source_scope === 'global'
+      const entrySourceScope = isKnownScope ? entry.source_scope : 'local'
+      const sourceDataDir = (opts.breakSourceScope || entrySourceScope === 'local') ? opts.localDataDir : opts.globalDataDir
+      let lastAccessedRow = null
+      if (isKnownScope) {
+        // F4 (GLM review round 1): scan ALL rows matching the id and take the
+        // MINIMUM last_accessed (conservative, provably lower-bound — the
+        // earliest access that could have converted). Row-order independent.
+        try {
+          const indexFile = path.join(sourceDataDir, 'index.jsonl')
+          if (fs.existsSync(indexFile)) {
+            let minLa = null
+            for (const ln of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+              if (!ln.trim()) continue
+              try {
+                const row = JSON.parse(ln)
+                if (!row || row.id !== entry.id) continue
+                const la = row.last_accessed ? Date.parse(row.last_accessed) : null
+                if (la === null || Number.isNaN(la)) continue
+                if (minLa === null || la < minLa) {
+                  minLa = la
+                  lastAccessedRow = row
+                }
+              } catch {}
+            }
+          }
+        } catch {}
+      }
+      const lastAccessedMs = lastAccessedRow && lastAccessedRow.last_accessed ? Date.parse(lastAccessedRow.last_accessed) : null
+      let converted = false
+      if (lastAccessedMs !== null) {
+        const upper = tsMs + windowMs
+        if (opts.breakWindow) converted = (lastAccessedMs >= tsMs && lastAccessedMs <= upper) // RED: inclusive lower bound
+        else converted = (lastAccessedMs > tsMs && lastAccessedMs <= upper) // GREEN: half-open
+      }
+      const band = entry.rendered === 'imperative' ? 'imperative' : 'plain'
+      perBand[band].d++
+      if (converted) perBand[band].n++
+      const lessonKey = entry.id
+      if (!perLessonMap.has(lessonKey)) perLessonMap.set(lessonKey, { n: 0, d: 0, last_ts: null, last_access_count: 0, band })
+      const agg = perLessonMap.get(lessonKey)
+      agg.d++
+      if (converted) agg.n++
+      agg.last_ts = parsed.ts
+      agg.last_access_count = entry.access_count_at_inject || 0
+    }
+  }
+  return { perBand, perLessonMap, tornSkipped, openWindowLines }
+}
+
+// _mergeParseResult(into, from) — fold one _parseLogForConversion result
+// into the running accumulator. All accumulators are object properties so
+// mutations are visible to the caller (primitives would NOT be visible
+// across a function call).
+function _mergeParseResult(into, from) {
+  into.perBand.imperative.n += from.perBand.imperative.n
+  into.perBand.imperative.d += from.perBand.imperative.d
+  into.perBand.plain.n += from.perBand.plain.n
+  into.perBand.plain.d += from.perBand.plain.d
+  into.tornSkipped += from.tornSkipped
+  for (const l of from.openWindowLines) into.openWindowLines.push(l)
+  for (const [id, v] of from.perLessonMap) {
+    const existing = into.perLessonMap.get(id)
+    if (existing) {
+      existing.n += v.n
+      existing.d += v.d
+      if (v.last_ts && (!existing.last_ts || v.last_ts > existing.last_ts)) {
+        existing.last_ts = v.last_ts
+        existing.last_access_count = v.last_access_count
+      }
+    } else {
+      into.perLessonMap.set(id, { n: v.n, d: v.d, last_ts: v.last_ts, last_access_count: v.last_access_count, band: v.band })
+    }
+  }
+}
+
+function clerkComputeConversion(localDataDir, globalDataDir, now, windowMs) {
+  const _breakRotate = process.argv.includes('--break-rotate')
+  const _breakWindow = process.argv.includes('--break-window')
+  const _breakSourceScope = process.argv.includes('--break-sourcescope')
+  const _breakTornSkip = process.argv.includes('--break-tornskip')
+  const _breakOpenWindow = process.argv.includes('--break-openwindow')
+  const logPath = path.join(localDataDir, ACTIVATION_LOG_NAME)
+  const processingPath = logPath + '.processing'
+  const freshLogPath = logPath // re-append open-window lines here
+  // Single state object — all accumulators live as object properties so
+  // _mergeParseResult mutations are visible to the caller (a primitive
+  // local would NOT be visible across a function call).
+  const state = {
+    perBand: { imperative: { n: 0, d: 0 }, plain: { n: 0, d: 0 } },
+    perLessonMap: new Map(),
+    tornSkipped: 0,
+    openWindowLines: [],
+  }
+  const opts = { breakTornSkip: _breakTornSkip, breakOpenWindow: _breakOpenWindow, breakSourceScope: _breakSourceScope, breakWindow: _breakWindow, localDataDir, globalDataDir, logFormatVersion: LOG_FORMAT_VERSION }
+  // REQ-18 crash recovery: a leftover .processing from a prior CRASHED
+  // rotation is consumed FIRST so its lines are folded into the same report.
+  // The next atomic rename would otherwise overwrite the leftover, silently
+  // losing those telemetry lines. The broken --break-rotate path does not
+  // touch a leftover .processing, so a red run leaves the leftover intact
+  // (proves the recovery is wired). Fail-open on any read/parse error.
+  if (!_breakRotate && fs.existsSync(processingPath)) {
+    try { _mergeParseResult(state, _parseLogForConversion(processingPath, now, windowMs, opts)) } catch {}
+  }
+  // FAIL OPEN: no log AND no leftover → empty lower-bound report, no throw.
+  if (!fs.existsSync(logPath)) {
+    if (state.openWindowLines.length) {
+      try { fs.appendFileSync(freshLogPath, state.openWindowLines.map(l => l.serialized).join('\n') + '\n', 'utf8') } catch {}
+      try { fs.unlinkSync(processingPath) } catch {}
+    } else if (fs.existsSync(processingPath)) {
+      // no log, no open-window lines: the leftover was fully consumed; clean up.
+      try { fs.unlinkSync(processingPath) } catch {}
+    }
+    return { per_band: state.perBand, per_lesson: [...state.perLessonMap.entries()].map(([id, v]) => ({ id, n: v.n, d: v.d, last_ts: v.last_ts, last_access_count_at_inject: v.last_access_count, band: v.band })), torn_skipped: state.tornSkipped, carried_forward: state.openWindowLines.length, lower_bound: true }
+  }
+  // Rotate: atomic rename (.processing) or, under --break-rotate, copy-then-truncate.
+  if (_breakRotate) {
+    // RED (--break-rotate): non-atomic — a concurrent O_APPEND after readSync
+    // but before unlink would be lost. EC9 counterexample. Also skips the
+    // leftover-recovery step above (proves recovery is wired) AND refuses to
+    // touch a leftover .processing (would overwrite it). The red run leaves
+    // both the leftover and the current log intact, with the leftover's
+    // sentinel id absent from per_lesson.
+    if (fs.existsSync(processingPath)) {
+      // A leftover exists; the broken path does not recover it. Leave both
+      // files intact and return the (still-empty) accumulating state. The
+      // leftover is preserved on disk for a later atomic run to recover.
+      return { per_band: state.perBand, per_lesson: [...state.perLessonMap.entries()].map(([id, v]) => ({ id, n: v.n, d: v.d, last_ts: v.last_ts, last_access_count_at_inject: v.last_access_count, band: v.band })), torn_skipped: state.tornSkipped, carried_forward: 0, lower_bound: true }
+    }
+    try {
+      const raw = fs.readFileSync(logPath, 'utf8')
+      fs.writeFileSync(processingPath, raw, 'utf8')
+      fs.unlinkSync(logPath)
+    } catch { return { per_band: state.perBand, per_lesson: [...state.perLessonMap.entries()].map(([id, v]) => ({ id, n: v.n, d: v.d, last_ts: v.last_ts, last_access_count_at_inject: v.last_access_count, band: v.band })), torn_skipped: state.tornSkipped, carried_forward: 0, lower_bound: true } }
+  } else {
+    try { fs.renameSync(logPath, processingPath) }
+    catch { return { per_band: state.perBand, per_lesson: [...state.perLessonMap.entries()].map(([id, v]) => ({ id, n: v.n, d: v.d, last_ts: v.last_ts, last_access_count_at_inject: v.last_access_count, band: v.band })), torn_skipped: state.tornSkipped, carried_forward: 0, lower_bound: true } }
+  }
+  // Parse the (post-rename / post-write) .processing file and fold into state.
+  // No try/catch here: a throw from --break-tornskip propagates to the caller
+  // (clerk report / apply) which fails-closed on the run-record write.
+  _mergeParseResult(state, _parseLogForConversion(processingPath, now, windowMs, opts))
+  // Re-append open-window lines to a fresh log + unlink the .processing file.
+  try {
+    if (state.openWindowLines.length) {
+      const fresh = state.openWindowLines.map(l => l.serialized).join('\n') + '\n'
+      fs.appendFileSync(freshLogPath, fresh, 'utf8')
+    }
+    fs.unlinkSync(processingPath)
+  } catch {}
+  return {
+    per_band: state.perBand,
+    per_lesson: [...state.perLessonMap.entries()].map(([id, v]) => ({ id, n: v.n, d: v.d, last_ts: v.last_ts, last_access_count_at_inject: v.last_access_count, band: v.band })),
+    torn_skipped: state.tornSkipped,
+    carried_forward: state.openWindowLines.length,
+    lower_bound: true,
   }
 }
 
@@ -1480,8 +1794,20 @@ async function clerkApplyMain() {
   if (!_breakLockedReread) priorRejected = markSuppression()
   const newRejectedSet = new Set(priorRejected)
 
+  // S5 REQ-18/19/20: compute the R6 conversion metric INSIDE the same locked
+  // block the apply holds (one lock, one writer). The rotate-and-consume is
+  // bounded by _windowMs (defaults to ATTRIBUTION_WINDOW_MS, 4h); the result
+  // is folded into the run-record body so report::zeroConversionCandidate
+  // (REQ-21) can read it later. Moved INSIDE the try block below so a throw
+  // from the conversion still releases the held lock.
+  const _applyWindowMs = (() => { const v = flag('--window-ms'); const n = v !== undefined ? parseInt(v, 10) : ATTRIBUTION_WINDOW_MS; return Number.isFinite(n) && n > 0 ? n : ATTRIBUTION_WINDOW_MS })()
+  let _applyConversion = { per_band: { imperative: { n: 0, d: 0 }, plain: { n: 0, d: 0 } }, per_lesson: [], torn_skipped: 0, carried_forward: 0, lower_bound: true }
+
   let runRecordId = null
   try {
+    // R6 conversion rotate-and-consume INSIDE the held lock; a throw from
+    // --break-tornskip propagates to the finally (releases the lock + exits).
+    _applyConversion = clerkComputeConversion(DATA_DIR, GLOBAL_DIR, Date.now(), _applyWindowMs)
     for (const p of proposals) {
       if (p.suppressed) continue
       const humanRejected = _rejectAll || p.memberIds.some(id => _rejectMembers.has(id))
@@ -1526,6 +1852,7 @@ async function clerkApplyMain() {
       proposals: proposals.map(p => ({ members: p.memberIds, action: p.action, fingerprint: p.fingerprint, suppressed: p.suppressed })),
       applied, rejected: rejectedThisRun, skippedGuard,
       rejectedSet: [...newRejectedSet], storeFp, orphans, badCategory: _simBadRunRecordCat,
+      conversion: _applyConversion,
     })
     const rrRes = clerkWrite('run-record', rr, DATA_DIR)
     if (rrRes.status === 'ok') runRecordId = rr.id
@@ -1544,7 +1871,186 @@ async function clerkApplyMain() {
     proposals: proposals.filter(p => !p.suppressed).map(p => ({ members: p.memberIds, action: p.action, fingerprint: p.fingerprint })),
     rejected: rejectedThisRun, skipped_guard: skippedGuard,
     run_record: runRecordId, orphans,
+    conversion: _applyConversion,
   }
   await new Promise(resolve => process.stdout.write(JSON.stringify(out) + '\n', resolve))
   process.exit(0)
 }
+
+// ===========================================================================
+// clerkEnrichCandidates(row, opts) — R9c lexical candidate finder (REQ-14).
+// For a given active lesson row, proposes:
+//   - triggers: lexemes extracted from the row's summary + tags (tokenizeQuery)
+//   - applies_to_project: [row.project] — the episode's OWN project; NEVER
+//     widened beyond provenance (REQ-14 hard stop, NSP T8)
+//   - applies_to_tool: row.applies_to_tools — the episode's OWN tool
+//     provenance; NEVER widened
+//   - activity: [] (no automatic activity-class inference; humans or a
+//     downstream R10 classifier would fill this in)
+//
+// --break-scope widens the candidate scope beyond provenance (RED control
+// for enrich::scopeFromProvenanceOnly).
+// ===========================================================================
+function clerkEnrichCandidates(row, opts) {
+  const triggers = new Set()
+  for (const t of tokenizeQuery(row.summary || '')) triggers.add(t)
+  for (const tag of (Array.isArray(row.tags) ? row.tags : [])) {
+    for (const t of tokenizeQuery(tag)) triggers.add(t)
+  }
+  const appliesToProject = [row.project].filter(Boolean)
+  const appliesToTool = Array.isArray(row.applies_to_tools) ? row.applies_to_tools.slice() : []
+  if (opts && opts._breakScope) {
+    // RED: widen beyond provenance (violates REQ-14). The red control proves
+    // the green test discriminates the scope-narrow invariant.
+    appliesToProject.push('unrelated-widened-project-1', 'unrelated-widened-project-2')
+    appliesToTool.push('unrelated-widened-tool-1')
+  }
+  return {
+    id: row.id,
+    triggers: [...triggers].slice(0, 20),
+    applies_to_project: appliesToProject,
+    applies_to_tool: appliesToTool,
+    activity: [],
+  }
+}
+
+// ===========================================================================
+// clerkEnrichMain() — the --clerk --enrich flow (REQ-14, R9c lexical
+// enrichment). REPORT mode: prints per-lesson candidates. APPLY mode: per
+// confirmed item, calls em-revise AS-IS via spawnSync (the
+// scripts/em-capture.mjs:453 idiom), then writes ONE run-record under
+// the SAME CLERK_LOCK_FILE lock the apply path uses — reuse, never a second
+// writer or second lock. em-revise is NEVER modified; the clerk drives
+// its existing --original --project --summary --body --trigger
+// --applies-to-project --applies-to-tool surface. Fail direction split is
+// preserved: the per-item em-revise subprocess failures fail CLOSED
+// (the apply halts and the run-record is NOT written); a successful apply
+// drains a single JSON envelope to stdout then exits 0.
+// ===========================================================================
+async function clerkEnrichMain() {
+  const _breakScope = process.argv.includes('--break-scope')
+  // --break-confirm bypasses the fail-closed confirm gate (GLM review F2 red
+  // control for enrich::noConfirmNoWrite, mirroring S4's --break-confirm).
+  const _breakConfirm = process.argv.includes('--break-confirm')
+  // Per-item rejection (mirrors S4's --reject-member).
+  const _rejectMembers = new Set()
+  for (let i = 0; i < process.argv.length; i++) if (process.argv[i] === '--reject-member' && process.argv[i + 1]) _rejectMembers.add(process.argv[i + 1])
+  const _lockTimeoutS = (() => { const v = flag('--lock-timeout'); const n = v !== undefined ? parseInt(v, 10) : 30; return Number.isFinite(n) && n >= 0 ? n : 30 })()
+  const _enrichHome = process.env.HOME || os.homedir()
+  const _revisePath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'em-revise.mjs')
+
+  const activeRaw = loadIndex(DATA_DIR, scope).filter(r =>
+    r.status !== 'superseded' &&
+    typeof r.id === 'string' &&
+    typeof r.summary === 'string' &&
+    !EXCLUDED_CATEGORIES.has(canonicalCategory(r.category)) &&
+    (includePinned || r.pinned !== true) &&
+    (!categoryFilter || canonicalCategory(r.category) === canonicalCategory(categoryFilter)) &&
+    (!projectFilter || r.project === projectFilter) &&
+    !Array.isArray(r.consolidates)
+  )
+
+  // Compute candidates for each active row.
+  const proposals = activeRaw.map(row => ({
+    id: row.id,
+    project: row.project,
+    candidates: clerkEnrichCandidates(row, { _breakScope }),
+  }))
+
+  // REPORT mode (default): print proposals, no writes.
+  if (!apply) {
+    const out = {
+      status: 'ok',
+      mode: 'clerk-enrich',
+      proposals,
+    }
+    await new Promise(resolve => process.stdout.write(JSON.stringify(out) + '\n', resolve))
+    process.exit(0)
+  }
+
+  // APPLY mode: per-item confirmation gating (REQ-6 mirror). --break-confirm
+  // bypasses the gate (red control for enrich::noConfirmNoWrite).
+  if (!confirm && !_breakConfirm) {
+    process.stdout.write(JSON.stringify({ status: 'error', mode: 'clerk-enrich', code: 'unconfirmed', message: 'clerk enrich apply requires --confirm (REQ-14)', proposals }) + '\n')
+    process.exit(1)
+  }
+
+  // Acquire the SAME CLERK_LOCK_FILE the apply path uses (one lock, one
+  // writer — reuse, never a second lock).
+  const acq = await acquire(CLERK_LOCK_FILE, _lockTimeoutS)
+  if (!acq.ok) {
+    process.stdout.write(JSON.stringify({ status: 'error', mode: 'clerk-enrich', locked: true, code: 'lock-held', proposals }) + '\n')
+    process.exit(1)
+  }
+  const lockHandle = acq.handle
+
+  const applied = []
+  const rejectedThisRun = []
+  try {
+    for (const p of proposals) {
+      if (_rejectMembers.has(p.id)) { rejectedThisRun.push(p.id); continue }
+      const c = p.candidates
+      // Skip if no candidates to apply (no triggers, no applies, no tools).
+      if (c.triggers.length === 0 && c.applies_to_project.length === 0 && c.applies_to_tool.length === 0) continue
+      const row = activeRaw.find(r => r.id === p.id)
+      if (!row) continue
+      // Read the original body from the episode file.
+      let body = ''
+      try { body = bodyOf(fs.readFileSync(path.join(EPISODES_DIR, `${p.id}.md`), 'utf8')) } catch {}
+      // Build em-revise args (REQ-14: provenance-only triggers/applies).
+      const args = [
+        _revisePath,
+        '--original', p.id,
+        '--project', row.project,
+        '--summary', row.summary,
+        '--body', body,
+      ]
+      for (const t of c.triggers) args.push('--trigger', t)
+      for (const ap of c.applies_to_project) args.push('--applies-to-project', ap)
+      for (const at of c.applies_to_tool) args.push('--applies-to-tool', at)
+      // scripts/em-capture.mjs:453 idiom (cwd = TARGET project root,
+      // encoding utf8, timeout 60000). HOME inherited from the test
+      // fixture override.
+      const r = spawnSync(process.execPath, args, { encoding: 'utf8', cwd: process.cwd(), timeout: 60000, env: { ...process.env, HOME: _enrichHome } })
+      let json = null
+      try { json = JSON.parse(r.stdout.trim()) } catch {}
+      if (r.status !== 0 || !json || json.status !== 'ok') {
+        release(lockHandle)
+        process.stdout.write(JSON.stringify({ status: 'error', mode: 'clerk-enrich', code: 'revise-failed', id: p.id, status: r.status, stderr: r.stderr, applied, rejected: rejectedThisRun }) + '\n')
+        process.exit(1)
+      }
+      applied.push({ id: p.id, revised_id: json.id })
+    }
+    // Build run-record (clerkBuildRunRecord, same writer as S4) under the lock.
+    const writtenIds = applied.map(a => a.revised_id).filter(Boolean)
+    const supersededIds = applied.map(a => a.id)
+    const rr = clerkBuildRunRecord({
+      writtenIds, supersededIds,
+      proposals: proposals.map(p => ({ id: p.id, candidates: p.candidates })),
+      applied, rejected: rejectedThisRun, skippedGuard: [],
+      rejectedSet: rejectedThisRun.slice(), storeFp: 'enrich', orphans: [], badCategory: false,
+    })
+    // Override the summary to reflect the enrich action.
+    rr.summary = `Clerk enrich run: ${writtenIds.length} enriched, ${supersededIds.length} superseded, ${rejectedThisRun.length} rejected`
+    const rrRes = clerkWrite('run-record', rr, DATA_DIR)
+    let runRecordId = null
+    if (rrRes.status === 'ok') runRecordId = rr.id
+    else {
+      release(lockHandle)
+      process.stdout.write(JSON.stringify({ status: 'error', mode: 'clerk-enrich', code: 'run-record-write-failed', message: rrRes.message, applied }) + '\n')
+      process.exit(1)
+    }
+    const out = {
+      status: 'ok', mode: 'clerk-enrich',
+      applied, rejected: rejectedThisRun,
+      run_record: runRecordId, proposals,
+    }
+    release(lockHandle)
+    await new Promise(resolve => process.stdout.write(JSON.stringify(out) + '\n', resolve))
+    process.exit(0)
+  } catch (e) {
+    release(lockHandle)
+    throw e
+  }
+}
+

--- a/scripts/em-consolidate/prompts/clerk.md
+++ b/scripts/em-consolidate/prompts/clerk.md
@@ -1,0 +1,193 @@
+# Clerk aggregator system prompt (RFC-009 R9d, P4-S7)
+
+> You are the memory clerk for the episodic-memory substrate. You work on
+> the AGGREGATION plane. Your mandate is exactly three verbs: AGGREGATE,
+> ENRICH, and MANAGE memory episodes. You never enforce, gate, block, or
+> decide workflow — those belong to a different layer that you do not touch.
+>
+> You PROPOSE; a human confirms. Nothing you output is applied without
+> per-item confirmation. You have no write tools; your report is your only
+> output, and writes happen in the assisted apply step outside you.
+>
+> Inputs: the store's `index.jsonl` rows (episode bodies on request), the
+> derived trigger index, prior clerk run-record episodes, and the activation
+> telemetry summary.
+
+## Rules
+
+1. **Ground every proposal in cited artifacts** — episode ids, index
+   fields, telemetry counts. A proposal without citations is invalid and
+   will be discarded. Cite every cluster member, every evidence link, and
+   every backfill input by its concrete episode id (or row id, or telemetry
+   line id) — never "the lessons about X" or "the recent cluster".
+
+2. **Never fabricate or stretch evidence links.** An `--evidence` linkage
+   may reference only a violation episode that exists AND describes the
+   same failure the lesson addresses. When unsure, omit the link. A
+   fabricated link is worse than a missing link: a missing one just means
+   the lesson has no audit trail, a fabricated one writes a false claim
+   into the corpus that propagates forward forever.
+
+3. **Prefer `keep-distinct` over `merge` when intent might differ**: a
+   wrong merge destroys knowledge, a kept duplicate only costs tokens. Give
+   a one-or-two-line rationale per cluster either way, naming the signal
+   that drove the decision (tag-Jaccard, shared trigger, supersession-
+   adjacency, or a combination).
+
+4. **Never widen scope**: proposed `applies_to_*` values come ONLY from
+   the episode's own project and tool provenance, never from your judgment
+   of where the lesson "should" apply. A lesson's own frontmatter is the
+   sole source of its `applies_to_projects` and `applies_to_tools`
+   candidates; do not propose `applies_to_projects: ["global"]` for a
+   project-local lesson, do not propose tool matches you inferred from the
+   summary text.
+
+5. **Respect recorded human judgment**: consult prior clerk run-record
+   episodes (their `rejected_cumulative` field carries the fingerprint set)
+   and do not re-propose a cluster or backfill that was rejected against
+   an unchanged store. The operator's rejection persists as memory —
+   re-offering a rejected cluster against an unchanged source-index
+   fingerprint is a violation of the per-item confirmation contract.
+
+6. **Output ONLY the report JSON** (the §12 R9 report schema). No prose
+   outside it. Every item carries: proposal, action, citations, rationale,
+   confidence. If you would explain something in English, encode it as a
+   `rationale` field in the JSON instead.
+
+7. **Do not ask the operator questions.** Propose with defaults and mark
+   low-confidence items `deferred` — the only cognitive load the operator
+   carries is confirm/reject (Principle 4). A `deferred` marker is a JSON
+   field on the cluster, not a question in the prose.
+
+8. **Surface, in every report**:
+   (a) each lesson that ENTERED the earned critical band since the prior
+   run record, with its linked violations — the **escalation audit**;
+   (b) each band member whose linked violations are all superseded or
+   stale — a **demotion-review candidate**;
+   (c) each episode whose stored category is unknown or deprecated in the
+   current vocabulary, with a recategorization proposal — the **R10 drift
+   queue**.
+
+## Output schema (per §12 R9 report)
+
+```json
+{
+  "status": "ok",
+  "mode": "clerk-report",
+  "clusters": [
+    {
+      "members": [{ "id": "<episode-id>", "summary": "<summary>" }],
+      "signals": {
+        "tag_jaccard": 0.6,
+        "summary_jaccard": 0.0,
+        "shared_triggers": ["<trigger-phrase>"],
+        "dropped_high_df_tags": ["<tag>"],
+        "same_category": true,
+        "supersession_adjacent": false
+      },
+      "proposed_action": "merge",
+      "citations": ["<episode-id-1>", "<episode-id-2>"],
+      "rationale": "<one-or-two-line>",
+      "confidence": "high|medium|low"
+    }
+  ],
+  "deferred": [{ "id": "<episode-id>", "reason": "<low-confidence rationale>" }],
+  "escalation_audit": [{ "lesson_id": "<id>", "linked_violations": ["<vid>"] }],
+  "demotion_review_candidates": [{ "lesson_id": "<id>", "stale_violation_count": 2 }],
+  "r10_drift_queue": [{ "episode_id": "<id>", "stored_category": "<cat>", "proposed_category": "<new-cat>" }]
+}
+```
+
+## Sample report (citation-bearing + deferred)
+
+```json
+{
+  "status": "ok",
+  "mode": "clerk-report",
+  "clusters": [
+    {
+      "members": [
+        { "id": "20260101-000000-mergefixture-aaaa", "summary": "merge cluster fixture first member trigger phrase" },
+        { "id": "20260101-000000-mergefixture-bbbb", "summary": "merge cluster fixture second member trigger phrase" }
+      ],
+      "signals": {
+        "tag_jaccard": 0.6,
+        "summary_jaccard": 0.0,
+        "shared_triggers": ["mergeclustrigshared"],
+        "dropped_high_df_tags": [],
+        "same_category": true,
+        "supersession_adjacent": false
+      },
+      "proposed_action": "merge",
+      "citations": ["20260101-000000-mergefixture-aaaa", "20260101-000000-mergefixture-bbbb"],
+      "rationale": "Tag-Jaccard 0.6 with shared trigger phrase; same category; merged digest preserves both bodies.",
+      "confidence": "high"
+    },
+    {
+      "members": [
+        { "id": "20260101-000000-dedupefixture-cccc", "summary": "dedupe canonical shared near-identical" },
+        { "id": "20260101-000000-dedupefixture-dddd", "summary": "dedupe canonical shared near-identical" }
+      ],
+      "signals": {
+        "tag_jaccard": 1.0,
+        "summary_jaccard": 0.92,
+        "shared_triggers": [],
+        "dropped_high_df_tags": [],
+        "same_category": true,
+        "supersession_adjacent": false
+      },
+      "proposed_action": "dedupe",
+      "citations": ["20260101-000000-dedupefixture-cccc", "20260101-000000-dedupefixture-dddd"],
+      "rationale": "Near-identical summaries + perfect tag overlap; canonical keeps the older id, the duplicate is superseded.",
+      "confidence": "high"
+    },
+    {
+      "members": [
+        { "id": "20260101-000000-keepdistinct-eeee", "summary": "keep distinct fixture summary overlap one" },
+        { "id": "20260101-000000-keepdistinct-ffff", "summary": "keep distinct fixture summary overlap two" }
+      ],
+      "signals": {
+        "tag_jaccard": 0.0,
+        "summary_jaccard": 0.5,
+        "shared_triggers": [],
+        "dropped_high_df_tags": [],
+        "same_category": true,
+        "supersession_adjacent": false
+      },
+      "proposed_action": "keep-distinct",
+      "citations": ["20260101-000000-keepdistinct-eeee", "20260101-000000-keepdistinct-ffff"],
+      "rationale": "Summary overlap alone (no tag or trigger corroboration) — keep-distinct per rule 3 (prefer keep-distinct when intent might differ).",
+      "confidence": "medium"
+    }
+  ],
+  "deferred": [
+    {
+      "id": "20260101-000000-deferreddeferred-gggg",
+      "reason": "Low-confidence backfill: applies_to_project field is empty on the source episode and provenance-only scope yields no candidates (rule 4)."
+    }
+  ],
+  "escalation_audit": [
+    { "lesson_id": "20260101-000000-escalationentrant-hhhh", "linked_violations": ["20260101-000000-violation-iiii"] }
+  ],
+  "demotion_review_candidates": [
+    { "lesson_id": "20260101-000000-stalebandmember-jjjj", "stale_violation_count": 2 }
+  ],
+  "r10_drift_queue": [
+    { "episode_id": "20260101-000000-driftunknowncat-kkkk", "stored_category": "obsoletecat", "proposed_category": "lesson" }
+  ],
+  "conversion": {
+    "per_band": {
+      "imperative": { "n": 1, "d": 3 },
+      "plain": { "n": 0, "d": 0 }
+    },
+    "per_lesson": [
+      { "id": "20260101-000000-mergefixture-aaaa", "n": 1, "d": 1, "last_ts": "2026-07-12T10:00:00Z", "last_access_count_at_inject": 0, "band": "imperative" },
+      { "id": "20260101-000000-mergefixture-bbbb", "n": 0, "d": 1, "last_ts": "2026-07-12T10:00:00Z", "last_access_count_at_inject": 0, "band": "imperative" },
+      { "id": "20260101-000000-dedupefixture-cccc", "n": 0, "d": 0, "last_ts": null, "last_access_count_at_inject": 0, "band": "imperative" }
+    ],
+    "torn_skipped": 0,
+    "carried_forward": 0,
+    "lower_bound": true
+  }
+}
+```

--- a/tests/test-rfc-009-p4-apply.mjs
+++ b/tests/test-rfc-009-p4-apply.mjs
@@ -646,6 +646,52 @@ function main() {
     ok(rowById(SR, rrId2).record_type === undefined, 'RED: broken whitelist drops record_type on rebuild')
   })
 
+  // ---- GLM review F5: run-record body carries the conversion report ----
+  // apply::runRecordBodyConversionFold — a real --clerk --apply --confirm
+  // run with a seeded closed-window activation log writes a run-record
+  // whose .md body embeds the conversion report (the way the report scan
+  // reads it for report::zeroConversionCandidate). The test parses the
+  // payload the same way the report scan does and asserts
+  // payload.conversion.per_band + per_lesson + lower_bound:true are
+  // present. (Additive — no existing assertions touched.)
+  t('apply::runRecordBodyConversionFold', () => {
+    const S = mkStore('rrbodyconv')
+    seedMergePair(S, 'rrbc')
+    // Seed a closed-window activation log line (in the past, well before NOW)
+    // so the conversion rotate-consume is exercised and per_band + per_lesson
+    // are populated.
+    const SENTINEL_ID = '20260101-000000-rrbc-logline-aaaa'
+    const injectTs = '2026-07-12T10:00:00Z'
+    fs.appendFileSync(path.join(S.dataDir, 'activation-log.jsonl'), JSON.stringify({
+      v: 1, ts: injectTs, project: 'rrbc', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: SENTINEL_ID, effective_priority: 8, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 }],
+    }) + '\n')
+    // Real --clerk --apply --confirm run.
+    const r = runClerk(S, { confirm: true })
+    eq(r.status, 0, `run-record-body F5: clerk apply exit 0 (stderr=${r.stderr})`)
+    const rrRows = runRecordRows(S)
+    eq(rrRows.length, 1, 'run-record-body F5: exactly 1 run-record written')
+    const rrId = rrRows[0].id
+    // Read the run-record .md body and extract the JSON payload the same
+    // way the report scan does (drop the frontmatter, regex out the
+    // first JSON object — mirrors the em-consolidate.mjs zeroConversionCandidate
+    // scan at the read site, so the two stay in lock-step).
+    const rrPath = path.join(S.episodesDir, `${rrId}.md`)
+    const rrBody = fs.readFileSync(rrPath, 'utf8')
+    const afterFrontmatter = rrBody.split('\n\n').slice(1).join('\n\n') || '{}'
+    const jsonMatch = afterFrontmatter.replace(/^[^{]*/, '').match(/\{[\s\S]*\}/)
+    ok(jsonMatch && jsonMatch[0], 'run-record-body F5: a JSON object is embedded in the run-record body')
+    let payload = null
+    try { payload = JSON.parse(jsonMatch[0]) } catch (e) { throw new Error(`run-record-body F5: payload JSON parse failed: ${e.message} (raw=${jsonMatch[0].slice(0, 100)})`) }
+    ok(payload && payload.conversion, 'run-record-body F5: payload.conversion is present')
+    ok(payload.conversion.per_band && typeof payload.conversion.per_band === 'object', 'run-record-body F5: payload.conversion.per_band is present')
+    ok(Array.isArray(payload.conversion.per_lesson), 'run-record-body F5: payload.conversion.per_lesson is an array')
+    eq(payload.conversion.lower_bound, true, 'run-record-body F5: payload.conversion.lower_bound === true')
+    // The seeded closed-window line is consumed (denominator ≥ 1).
+    const totalD = (payload.conversion.per_band.imperative?.d || 0) + (payload.conversion.per_band.plain?.d || 0)
+    ok(totalD >= 1, `run-record-body F5: per_band denominator is ≥ 1 (got ${totalD})`)
+  })
+
   // ---- FOLD ROUND F1: rejected-set read is UNDER the lock (REQ-12/REQ-6 TOCTOU) ----
   // apply::rejectedVisibleUnderLock — a rejection run-record that lands WHILE a
   // concurrent apply B is blocked on the lock is visible to B once it acquires

--- a/tests/test-rfc-009-p4-conversion.mjs
+++ b/tests/test-rfc-009-p4-conversion.mjs
@@ -1,0 +1,609 @@
+#!/usr/bin/env node
+/**
+ * test-rfc-009-p4-conversion.mjs — RFC-009 P4-S5 (R6 conversion metric,
+ * REQ-18/19/20 + REQ-21 zero-conversion candidate surfacing).
+ *
+ * Proves the conversion half of the clerk (scripts/em-consolidate.mjs):
+ *   - rotate-and-consume: the activation log is renamed to a .processing name
+ *     atomically, then parsed (REQ-18, never read-then-truncate-in-place);
+ *   - REQ-18 crash recovery: a leftover activation-log.jsonl.processing
+ *     from a prior CRASHED rotation is consumed FIRST (folded into the same
+ *     report) so the next atomic rename does not silently overwrite it;
+ *   - open-window lines (ts within now-window) are carried forward (re-appended
+ *     to a fresh log) so a later in-window access is not lost (REQ-18);
+ *   - torn / unknown-v lines are skipped and counted in the run-record
+ *     (EC8, REQ-18);
+ *   - per-band + per-lesson conversion is a binary lower bound: an injection of
+ *     id X at time T is converted iff X's last_accessed (read from the store
+ *     named by the line's source_scope) falls in (T, T+window] (half-open,
+ *     REQ-19);
+ *   - an unreadable source_scope store counts as UNCONVERTED (lower bound,
+ *     never inflated, REQ-20);
+ *   - the conversion report carries lower_bound:true;
+ *   - a lesson with N consecutive zero-conversion runs surfaces in the report
+ *     as a reword/demote/suppress candidate (REQ-21).
+ *
+ * Every assertion inspects real captured runtime state (parsed JSON,
+ * statSync sizes, on-disk log content, spawn stdout/exit) with a discriminating
+ * sentinel — never a typed constant. The clerk is spawned via the REAL
+ * scripts/em-consolidate.mjs with cwd into isolated fixture stores under /tmp
+ * and an isolated HOME (so the GLOBAL store is contained).
+ *
+ * Negative controls (§A.9, portable --break-* argv flags, NOT env vars — the
+ * activation hook and tests must run under Windows `cmd`):
+ *   --break-rotate       → broken read+unlink rotate + SKIP leftover recovery
+ *                           → conversion::appendDuringRotateNotLost FAILS
+ *                             (leftover .processing is NOT consumed → sentinel
+ *                              absent from per_lesson + .processing still on
+ *                              disk with the sentinel inside; deterministic,
+ *                              race-free, sequential assertion proves recovery
+ *                              is wired and the broken path is provably
+ *                              non-discriminating)
+ *   --break-window       → inclusive lower bound (last_accessed >= ts)
+ *                           → conversion::windowBoundary FAILS
+ *   --break-sourcescope  → ignore line.source_scope, always read local
+ *                           → conversion::crossStoreSourceScope FAILS
+ *   --break-tornskip     → throw on torn line instead of skipping+counting
+ *                           → conversion::tornLineSkippedCounted FAILS
+ *   --break-openwindow   → drop open-window lines instead of carrying forward
+ *                           → conversion::openWindowCarriedForward FAILS
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'em-consolidate.mjs')
+const SEARCH = path.join(REPO_ROOT, 'scripts', 'em-search.mjs')
+
+// Suite-level --break-* passthrough: a test runner argv flag MUST NOT propagate
+// blindly (otherwise --break-X from the suite runner shadows other suites). Forward
+// ONLY the five S5-documented break flags (mirrors tests/test-rfc-009-p4-report.mjs
+// lines 45-48).
+const PASS_THROUGH_BREAK_FLAGS = new Set()
+for (const flag of ['--break-rotate', '--break-window', '--break-sourcescope', '--break-tornskip', '--break-openwindow']) {
+  if (process.argv.includes(flag)) PASS_THROUGH_BREAK_FLAGS.add(flag)
+}
+
+let pass = 0, fail = 0
+const failures = []
+const ONLY_FLAG = (() => { const i = process.argv.indexOf('--only'); return i >= 0 ? process.argv[i + 1] : null })()
+function t(name, fn) {
+  if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
+  try { fn(); pass++ }
+  catch (e) { fail++; failures.push(`${name} - ${e && e.message}`) }
+}
+function eq(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`)
+}
+function ok(cond, label) { if (!cond) throw new Error(label) }
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+for (const sig of ['SIGINT', 'SIGTERM']) process.on(sig, () => process.exit(130))
+function mkTmp(label) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `p4s5-${label}-`)))
+  _tmpDirs.push(base)
+  return base
+}
+
+// Build a minimal but valid local store under <root>/.episodic-memory/ + an
+// isolated fixture HOME so the GLOBAL store is contained. em-consolidate's
+// loadCategories() guard fails closed at startup without a reachable
+// categories.json — copy the real one into the fixture data dir (per the
+// report-test pattern).
+function mkStore(label) {
+  const root = mkTmp(`store-${label}`)
+  const dataDir = path.join(root, '.episodic-memory')
+  const episodesDir = path.join(dataDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  const fixtureHome = mkTmp(`home-${label}`)
+  fs.mkdirSync(path.join(fixtureHome, '.episodic-memory'), { recursive: true })
+  const realCats = path.join(REPO_ROOT, 'scripts', 'categories.json')
+  if (fs.existsSync(realCats)) {
+    fs.copyFileSync(realCats, path.join(dataDir, 'categories.json'))
+  }
+  return { root, dataDir, episodesDir, home: fixtureHome }
+}
+
+// Seed one lesson: writes <id>.md AND appends a JSON row to index.jsonl.
+// `sentinel` is a per-test discriminating token.
+function seedLesson(S, o) {
+  const {
+    id, date = '2026-01-01', time = '00:00', project = 'acme', category = 'lesson',
+    status = 'active', tags = [], summary, body = 'body text', triggers = [],
+    appliesToProjects = [], appliesToTools = [], priority, reviewBy,
+    lastAccessed, accessCount = 0,
+  } = o
+  const fm = ['---', `id: ${id}`, `date: ${date}`, `time: "${time}"`, `project: ${project}`, `category: ${category}`, `status: ${status}`]
+  fm.push(`tags: [${tags.join(', ')}]`)
+  if (typeof priority === 'number') fm.push(`priority: ${priority}`)
+  if (triggers.length) fm.push(`triggers: [${triggers.map(x => `"${x}"`).join(', ')}]`)
+  if (appliesToProjects.length) fm.push(`applies_to_projects: [${appliesToProjects.map(x => `"${x}"`).join(', ')}]`)
+  if (appliesToTools.length) fm.push(`applies_to_tools: [${appliesToTools.map(x => `"${x}"`).join(', ')}]`)
+  if (reviewBy) fm.push(`review_by: ${reviewBy}`)
+  fm.push(`summary: ${summary}`)
+  fm.push('---')
+  fs.writeFileSync(path.join(S.episodesDir, `${id}.md`), `${fm.join('\n')}\n\n# ${summary}\n\n${body}\n`, 'utf8')
+  const row = {
+    id, date, time, project, category, status,
+    supersedes: null, consolidates: null,
+    tags: tags.slice(), summary,
+    ...(triggers.length ? { triggers: triggers.slice() } : {}),
+    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects.slice() } : {}),
+    ...(appliesToTools.length ? { applies_to_tools: appliesToTools.slice() } : {}),
+    ...(typeof priority === 'number' ? { priority } : {}),
+    ...(reviewBy ? { review_by: reviewBy } : {}),
+    ...(lastAccessed ? { last_accessed: lastAccessed } : {}),
+    ...(accessCount ? { access_count: accessCount } : {}),
+  }
+  fs.appendFileSync(path.join(S.dataDir, 'index.jsonl'), JSON.stringify(row) + '\n', 'utf8')
+}
+
+// Write an activation-log line directly to <dataDir>/activation-log.jsonl.
+// Each entry produces ONE line per the S1 schema: { v, ts, project, event,
+// surface, entries: [{ id, effective_priority, rendered, source_scope,
+// access_count_at_inject }] }. The test always writes a single-entry line.
+function seedActivationLine(S, { id, ts, rendered = 'imperative', sourceScope = 'local', accessCountAtInject = 0 }) {
+  const line = JSON.stringify({
+    v: 1, ts, project: 'p4s5', event: 'inject', surface: 'per_prompt',
+    entries: [{ id, effective_priority: 8, rendered, source_scope: sourceScope, access_count_at_inject: accessCountAtInject }],
+  })
+  fs.appendFileSync(path.join(S.dataDir, 'activation-log.jsonl'), line + '\n', 'utf8')
+}
+
+// Spawn the real em-consolidate.mjs --clerk into the fixture root. `mode: 'apply'`
+// adds --apply --confirm. `extraArgs` forwarded to the script.
+function runClerk(S, { mode = 'report', extraArgs = [], home, windowMs } = {}) {
+  const args = [SCRIPT, '--clerk', '--scope', 'local', ...(mode === 'apply' ? ['--apply', '--confirm'] : []), ...(windowMs ? ['--window-ms', String(windowMs)] : []), ...extraArgs, ...PASS_THROUGH_BREAK_FLAGS]
+  const env = { ...process.env, HOME: home || S.home }
+  const r = spawnSync('node', args, { cwd: S.root, encoding: 'utf8', timeout: 120000, env })
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, signal: r.signal, errorCode: r.error?.code ?? null, json: parseLastJson(r.stdout) }
+}
+function parseLastJson(stdout) {
+  if (!stdout) return null
+  const lines = stdout.trim().split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim()
+    if (!line.startsWith('{')) continue
+    try { return JSON.parse(line) } catch {}
+  }
+  return null
+}
+
+// Write a synthetic clerk-run run-record (index row + episode file with the
+// conversion report body) so the report::zeroConversionCandidate scan has
+// historical context. Its id sorts as the LATEST (2099) so the scan picks it
+// as the most-recent run-record. The conversion report's per_lesson names the
+// sentinel lesson with n=0/d>0 (a "zero conversion" hit).
+function seedSyntheticRunRecord(S, { id, conversionPerLesson = [] }) {
+  const payload = {
+    mode: 'clerk-apply', ts: '2099-12-31T23:59:59Z',
+    source_index_fingerprint: '0000000000000000',
+    written_ids: [], superseded_ids: [], proposals: [], applied: [], rejected: [],
+    skipped_guard: [], rejected_cumulative: [], orphans: [],
+    conversion: {
+      per_band: { imperative: { n: 0, d: 0 }, plain: { n: 0, d: 0 } },
+      per_lesson: conversionPerLesson,
+      torn_skipped: 0, carried_forward: 0, lower_bound: true,
+    },
+  }
+  const fm = ['---', `id: ${id}`, 'date: 2099-12-31', 'time: "23:59"', 'project: clerk', 'category: workflow.lifecycle', 'status: active', 'tags: []', 'summary: synthetic clerk run record', 'record_type: clerk-run', 'clerk_cutover: rfc-009-p4', '---']
+  fs.writeFileSync(path.join(S.episodesDir, `${id}.md`), `${fm.join('\n')}\n\n# synthetic clerk run record\n\n${JSON.stringify(payload)}\n`, 'utf8')
+  const row = { id, date: '2099-12-31', time: '23:59', project: 'clerk', category: 'workflow.lifecycle', status: 'active', supersedes: null, tags: [], summary: 'synthetic clerk run record', record_type: 'clerk-run', clerk_cutover: 'rfc-009-p4' }
+  fs.appendFileSync(path.join(S.dataDir, 'index.jsonl'), JSON.stringify(row) + '\n', 'utf8')
+}
+
+function main() {
+  // -- Section 14: R6-conversion test group (S5) --
+
+  // conversion::rotateConsumeAtomic — the activation log is ATOMICALLY renamed
+  // to a .processing name (renameSync). The fresh log after consume either has
+  // the carried-forward lines OR is absent (fully consumed). --break-rotate
+  // uses a read+unlink (non-atomic) and a concurrent O_APPEND during the
+  // window would be lost. The red sub-assertion verifies --break-rotate still
+  // produces a report (the break is a CONTROL, not a fault — the test asserts
+  // the green rename differs from the red non-atomic rotate by also NOT
+  // leaving a .processing file).
+  t('conversion::rotateConsumeAtomic', () => {
+    const S = mkStore('rotateatomic')
+    seedActivationLine(S, { id: '20260101-000000-ra-zzzz', ts: '2026-07-12T10:00:00Z' })
+    const logPath = path.join(S.dataDir, 'activation-log.jsonl')
+    const procPath = logPath + '.processing'
+    const r = runClerk(S)
+    eq(r.status, 0, `green exit 0 (stderr=${r.stderr})`)
+    eq(r.json.status, 'ok', 'green report ok')
+    ok(!fs.existsSync(procPath), 'green: .processing file is gone (consumed) — atomic rotate, no leftover')
+    // RED: --break-rotate (read-then-unlink) — still no .processing leftover
+    // (the break path also unlinks), but the conversion semantics differ.
+    const S2 = mkStore('rotateatomic-red')
+    seedActivationLine(S2, { id: '20260101-000000-ra2-zzzz', ts: '2026-07-12T10:00:00Z' })
+    const r2 = runClerk(S2, { extraArgs: ['--break-rotate'] })
+    eq(r2.status, 0, 'red: --break-rotate still exits 0 (the control is structural, not a fault)')
+    ok(!fs.existsSync(path.join(S2.dataDir, 'activation-log.jsonl.processing')), 'red: --break-rotate path also cleans up .processing')
+    // The MEANINGFUL differ: the green path uses renameSync (atomic); the red
+    // path uses a read+unlink (non-atomic). We can't easily prove atomicity
+    // from outside, so the next test (appendDuringRotateNotLost) proves the
+    // atomic guarantee end-to-end. Here we just assert both paths consume.
+  })
+
+  // conversion::appendDuringRotateNotLost — REQ-18 crash recovery: a
+  // leftover activation-log.jsonl.processing from a prior CRASHED rotation
+  // must be consumed FIRST (folded into the same report); the next atomic
+  // rename would otherwise overwrite the leftover and silently lose those
+  // telemetry lines. The test seeds a leftover .processing containing one
+  // valid closed-window line with a unique sentinel id PLUS a normal log,
+  // and asserts the GREEN behavior (sentinel in per_lesson, .processing
+  // absent). The RED control: with --break-rotate forwarded (or explicitly
+  // passed), the broken path does NOT recover the leftover → the sentinel
+  // is absent from per_lesson AND .processing still exists with the
+  // sentinel inside. The test's green assertions FAIL on the red run,
+  // proving the recovery is wired. The test additionally seeds a second
+  // fixture and asserts the explicit red behavior for documentation.
+  t('conversion::appendDuringRotateNotLost', () => {
+    const S = mkStore('appendnotlost')
+    const SENTINEL_ID = '20260101-000000-anl-sentinel-zzzz'
+    const logPath = path.join(S.dataDir, 'activation-log.jsonl')
+    const procPath = logPath + '.processing'
+    // Seed the leftover .processing FIRST (simulating a prior crashed rotation).
+    // The leftover carries a single closed-window line with a unique sentinel
+    // id (no last_accessed → counts as UNCONVERTED in the lower bound).
+    const leftoverLine = JSON.stringify({
+      v: 1, ts: '2026-07-12T10:00:00Z', project: 'p4s5', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: SENTINEL_ID, effective_priority: 8, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 }],
+    })
+    fs.writeFileSync(procPath, leftoverLine + '\n', 'utf8')
+    // Seed the NORMAL log with a different line (so the rotation also has work).
+    seedActivationLine(S, { id: '20260101-000000-anl-normal-aaaa', ts: '2026-07-12T10:00:00Z' })
+    // GREEN: the atomic-rotate + leftover-recovery path consumes the leftover
+    // BEFORE renaming the current log on top of it. The sentinel id is folded
+    // into per_lesson; the .processing file is gone.
+    const r = runClerk(S)
+    eq(r.status, 0, `green exit 0 (stderr=${r.stderr})`)
+    const sentinelRow = r.json.conversion.per_lesson.find(l => l.id === SENTINEL_ID)
+    ok(sentinelRow, `green: sentinel id from leftover .processing appears in per_lesson (got ${JSON.stringify(r.json.conversion.per_lesson.map(l => l.id))})`)
+    ok(!fs.existsSync(procPath), 'green: leftover .processing is consumed (absent after run)')
+    // RED: --break-rotate (the broken read+unlink path) NEVER touches a
+    // leftover .processing — it leaves both the leftover and the current
+    // log intact. Re-run against a fresh fixture; the explicit red
+    // assertions document the red behavior (sentinel absent from
+    // per_lesson, .processing still on disk with the sentinel inside).
+    // The green assertions in the green run above FAIL when --break-rotate
+    // is forwarded (the broken path doesn't recover the leftover), which
+    // is the test's red control.
+    const S2 = mkStore('appendnotlost-red')
+    const procPath2 = path.join(S2.dataDir, 'activation-log.jsonl.processing')
+    fs.writeFileSync(procPath2, leftoverLine + '\n', 'utf8')
+    seedActivationLine(S2, { id: '20260101-000000-anl-normal-bbbb', ts: '2026-07-12T10:00:00Z' })
+    const r2 = runClerk(S2, { extraArgs: ['--break-rotate'] })
+    eq(r2.status, 0, 'red: --break-rotate exits 0 (the control does not crash)')
+    // Red assertions: sentinel NOT in per_lesson, .processing still on disk.
+    const sentinelRow2 = r2.json.conversion.per_lesson.find(l => l.id === SENTINEL_ID)
+    ok(!sentinelRow2, `red: --break-rotate did NOT consume the leftover → sentinel absent from per_lesson (got ${JSON.stringify(r2.json.conversion.per_lesson.map(l => l.id))})`)
+    ok(fs.existsSync(procPath2), 'red: --break-rotate leaves the leftover .processing intact (still on disk)')
+    const leftoverContents = fs.readFileSync(procPath2, 'utf8')
+    ok(leftoverContents.includes(SENTINEL_ID), 'red: leftover .processing still contains the sentinel id (untouched)')
+  })
+
+  // conversion::openWindowCarriedForward — a line with ts in (now-window, now]
+  // is re-appended to a fresh log (REQ-18, NSP F5). --break-openwindow DROPS
+  // the open-window line instead of carrying it forward → carried_forward=0
+  // and the fresh log is empty / absent.
+  t('conversion::openWindowCarriedForward', () => {
+    const S = mkStore('openwindow')
+    // Inject NOW (open-window) — anything with ts in (now-window, now] is open.
+    // Use ISO 1 minute in the past to guarantee OPEN.
+    const now = new Date()
+    now.setMinutes(now.getMinutes() - 1)
+    seedActivationLine(S, { id: '20260101-000000-ow-zzzz', ts: now.toISOString() })
+    const r = runClerk(S)
+    eq(r.status, 0, `green exit 0 (stderr=${r.stderr})`)
+    const conv = r.json.conversion
+    ok(conv, 'green: conversion present in report')
+    eq(conv.lower_bound, true, 'green: lower_bound:true stamped')
+    eq(conv.carried_forward, 1, 'green: carried_forward=1 (open-window line re-appended)')
+    const logPath = path.join(S.dataDir, 'activation-log.jsonl')
+    ok(fs.existsSync(logPath), 'green: fresh log exists with the carried-forward line')
+    const logContents = fs.readFileSync(logPath, 'utf8')
+    ok(logContents.includes('20260101-000000-ow-zzzz'), 'green: carried-forward line is back in the log')
+    // RED: --break-openwindow drops the open-window line.
+    const S2 = mkStore('openwindow-red')
+    seedActivationLine(S2, { id: '20260101-000000-owr-zzzz', ts: now.toISOString() })
+    const r2 = runClerk(S2, { extraArgs: ['--break-openwindow'] })
+    eq(r2.status, 0, 'red: --break-openwindow still exits 0 (control semantics)')
+    const conv2 = r2.json.conversion
+    eq(conv2.carried_forward, 0, 'red: --break-openwindow drops the line → carried_forward=0')
+  })
+
+  // conversion::tornLineSkippedCounted — a non-JSON / unknown-v line is
+  // skipped AND counted in torn_skipped (EC8). --break-tornskip throws
+  // instead of skipping+counting, exiting non-zero with no valid report.
+  t('conversion::tornLineSkippedCounted', () => {
+    const S = mkStore('tornskip')
+    seedActivationLine(S, { id: '20260101-000000-ts-zzzz', ts: '2026-07-12T10:00:00Z' })
+    // Append a torn line (not valid JSON) + an unknown-v line.
+    fs.appendFileSync(path.join(S.dataDir, 'activation-log.jsonl'), 'this-is-torn-not-json\n')
+    fs.appendFileSync(path.join(S.dataDir, 'activation-log.jsonl'), JSON.stringify({ v: 99, ts: '2026-07-12T10:00:00Z', id: 'x' }) + '\n')
+    const r = runClerk(S)
+    eq(r.status, 0, `green exit 0 (stderr=${r.stderr})`)
+    const conv = r.json.conversion
+    eq(conv.torn_skipped, 2, 'green: 2 torn lines skipped+counted (1 not-JSON + 1 unknown-v)')
+    // RED: --break-tornskip throws → exit 1, no valid report JSON.
+    const S2 = mkStore('tornskip-red')
+    seedActivationLine(S2, { id: '20260101-000000-tsr-zzzz', ts: '2026-07-12T10:00:00Z' })
+    fs.appendFileSync(path.join(S2.dataDir, 'activation-log.jsonl'), 'this-is-torn-not-json\n')
+    const r2 = runClerk(S2, { extraArgs: ['--break-tornskip'] })
+    ok(r2.status !== 0, `red: --break-tornskip throws → exit non-zero (got ${r2.status})`)
+  })
+
+  // conversion::perBandFromFixture — REAL fixture: 3 lessons injected, 1
+  // accessed (pre-bumped in the index — em-search --read bumps access to
+  // NOW, which the 4h window math can't reconcile with a closed-window
+  // injectTs; the test still drives a real access via the index writer, the
+  // REQ-19 access-bump crux is proven by the conversion::crossStoreSourceScope
+  // + windowBoundary + a separate em-search --read E2E in the report suite).
+  // Expected: per_band imperative.n=1, d=3 AND lower_bound:true.
+  t('conversion::perBandFromFixture', () => {
+    const S = mkStore('perband')
+    const aId = '20260101-000000-pb-aaaa'
+    const bId = '20260101-000000-pb-bbbb'
+    const cId = '20260101-000000-pb-cccc'
+    // injectTs = 5 hours ago (in CLOSED window, so the line is consumed);
+    // access at injectTs + 30min (within (T, T+4h] half-open window).
+    const injectTsDate = new Date(Date.now() - 5 * 60 * 60 * 1000)
+    const accessTsDate = new Date(injectTsDate.getTime() + 30 * 60 * 1000)
+    const injectTs = injectTsDate.toISOString()
+    const accessTs = accessTsDate.toISOString()
+    // Seed 3 lessons — aId has a pre-bumped last_accessed in the window;
+    // bId and cId stay un-accessed (no last_accessed → unconverted).
+    seedLesson(S, { id: aId, tags: ['pb', 'alpha', 'beta', 'gamma'], summary: `${aId} perband fixture first`, lastAccessed: accessTs, accessCount: 1 })
+    seedLesson(S, { id: bId, tags: ['pb', 'alpha', 'beta', 'gamma'], summary: `${bId} perband fixture second` })
+    seedLesson(S, { id: cId, tags: ['pb', 'alpha', 'beta', 'gamma'], summary: `${cId} perband fixture third` })
+    // Activation log: 3 entries (one per lesson), all at the same T.
+    seedActivationLine(S, { id: aId, ts: injectTs, rendered: 'imperative' })
+    seedActivationLine(S, { id: bId, ts: injectTs, rendered: 'imperative' })
+    seedActivationLine(S, { id: cId, ts: injectTs, rendered: 'imperative' })
+    // Run the clerk report — reads the activation log, computes conversion.
+    const r = runClerk(S)
+    eq(r.status, 0, `clerk exit 0 (stderr=${r.stderr})`)
+    const conv = r.json.conversion
+    eq(conv.lower_bound, true, 'per-band: lower_bound:true labeled')
+    // 1 of 3 converted: imperative.n=1, d=3.
+    eq(conv.per_band.imperative.n, 1, 'per-band: 1 imperative converted (the accessed one)')
+    eq(conv.per_band.imperative.d, 3, 'per-band: 3 imperative denominator (all 3 injected)')
+    eq(conv.per_band.plain.n, 0, 'per-band: 0 plain converted')
+    eq(conv.per_band.plain.d, 0, 'per-band: 0 plain denominator')
+    // per_lesson: 3 lessons, only aId is converted.
+    const aRow = conv.per_lesson.find(l => l.id === aId)
+    const bRow = conv.per_lesson.find(l => l.id === bId)
+    const cRow = conv.per_lesson.find(l => l.id === cId)
+    ok(aRow, 'per-lesson: aId row present')
+    ok(bRow, 'per-lesson: bId row present')
+    ok(cRow, 'per-lesson: cId row present')
+    eq(aRow.n, 1, 'per-lesson: aId converted (1/1)')
+    eq(bRow.n, 0, 'per-lesson: bId NOT converted (0/1 — accessed never)')
+    eq(cRow.n, 0, 'per-lesson: cId NOT converted (0/1 — accessed never)')
+  })
+
+  // conversion::windowBoundary — boundary: last_accessed == injectTs is NOT
+  // converted (half-open (T, T+window] excludes equality, REQ-19). A clearly-
+  // in-window access (+1h) IS converted; a clearly-past access (+5h) is NOT.
+  // --break-window uses an inclusive lower bound (>= ts) and would convert
+  // the boundary case; the boundary assertion below catches the red control.
+  t('conversion::windowBoundary', () => {
+    const S = mkStore('windowbound')
+    // Three lessons: boundary (last_accessed == ts), inside (+1h), outside (+5h).
+    const boundaryId = '20260101-000000-wb-boundary'
+    const insideId = '20260101-000000-wb-inside'
+    const outsideId = '20260101-000000-wb-outside'
+    const injectTs = '2026-07-12T10:00:00Z'
+    seedLesson(S, { id: boundaryId, tags: ['wb'], summary: `${boundaryId} window boundary exact ts`, lastAccessed: injectTs })
+    seedLesson(S, { id: insideId, tags: ['wb'], summary: `${insideId} window boundary inside`, lastAccessed: '2026-07-12T11:00:00Z' })
+    seedLesson(S, { id: outsideId, tags: ['wb'], summary: `${outsideId} window boundary outside`, lastAccessed: '2026-07-12T15:00:00Z' })
+    seedActivationLine(S, { id: boundaryId, ts: injectTs })
+    seedActivationLine(S, { id: insideId, ts: injectTs })
+    seedActivationLine(S, { id: outsideId, ts: injectTs })
+    const r = runClerk(S)
+    eq(r.status, 0, `clerk exit 0 (stderr=${r.stderr})`)
+    const boundaryRow = r.json.conversion.per_lesson.find(l => l.id === boundaryId)
+    const insideRow = r.json.conversion.per_lesson.find(l => l.id === insideId)
+    const outsideRow = r.json.conversion.per_lesson.find(l => l.id === outsideId)
+    ok(boundaryRow, 'boundary: boundary row present')
+    ok(insideRow, 'boundary: inside row present')
+    ok(outsideRow, 'boundary: outside row present')
+    eq(boundaryRow.n, 0, 'boundary: last_accessed == ts is NOT converted (half-open excludes equality)')
+    eq(insideRow.n, 1, 'boundary: +1h access is CONVERTED (1/1, strictly > ts)')
+    eq(outsideRow.n, 0, 'boundary: +5h access is NOT converted (0/1, past 4h window)')
+    // RED: --break-window (inclusive lower bound) → boundary IS converted.
+    const S2 = mkStore('windowbound-red')
+    seedLesson(S2, { id: boundaryId, tags: ['wb'], summary: `${boundaryId} window boundary exact ts red`, lastAccessed: injectTs })
+    seedActivationLine(S2, { id: boundaryId, ts: injectTs })
+    const r2 = runClerk(S2, { extraArgs: ['--break-window'] })
+    eq(r2.status, 0, 'red: --break-window still exits 0')
+    const boundaryRow2 = r2.json.conversion.per_lesson.find(l => l.id === boundaryId)
+    eq(boundaryRow2.n, 1, 'red: --break-window (inclusive) CONVERTS the boundary case (1/1)')
+  })
+
+  // conversion::crossStoreSourceScope — a line with source_scope:'global' is
+  // read from the GLOBAL store; a line with source_scope:'local' is read from
+  // the LOCAL store. --break-sourcescope forces BOTH to be read from local,
+  // which would mis-attribute a global-injected lesson. We prove cross-store
+  // by seeding last_accessed DIFFERENTLY in each store for the same id, and
+  // asserting the conversion picks the right one per source_scope.
+  t('conversion::crossStoreSourceScope', () => {
+    const S = mkStore('crossscope')
+    const lessonId = '20260101-000000-cs-shared'
+    // Same id in BOTH stores — local last_accessed = "in window" (10:30),
+    // global last_accessed = "past window" (15:00). source_scope:local reads
+    // local → converted; source_scope:global reads global → NOT converted.
+    const injectTs = '2026-07-12T10:00:00Z'
+    seedLesson(S, { id: lessonId, tags: ['cs'], summary: `${lessonId} cross-store shared id`, lastAccessed: '2026-07-12T10:30:00Z' })
+    // The global store: same id, past-window last_accessed.
+    const globalIdx = path.join(S.home, '.episodic-memory', 'index.jsonl')
+    fs.mkdirSync(path.dirname(globalIdx), { recursive: true })
+    fs.writeFileSync(globalIdx, JSON.stringify({
+      id: lessonId, date: '2026-01-01', time: '00:00', project: 'global', category: 'lesson', status: 'active',
+      supersedes: null, tags: ['cs'], summary: 'global cross-store shared', last_accessed: '2026-07-12T15:00:00Z', access_count: 5,
+    }) + '\n', 'utf8')
+    // Two injection lines: one local, one global, same id.
+    seedActivationLine(S, { id: lessonId, ts: injectTs, sourceScope: 'local' })
+    seedActivationLine(S, { id: lessonId, ts: injectTs, sourceScope: 'global' })
+    const r = runClerk(S)
+    eq(r.status, 0, `clerk exit 0 (stderr=${r.stderr})`)
+    // Two entries, same id → 2 denominator events; conversion differs by
+    // source_scope. per_lesson aggregates by id → 1/2 (local converted,
+    // global not).
+    const row = r.json.conversion.per_lesson.find(l => l.id === lessonId)
+    ok(row, 'cross-store: row present')
+    eq(row.d, 2, 'cross-store: 2 denominator events (one per source_scope)')
+    eq(row.n, 1, 'cross-store: 1 converted (local reads local store, +30min in window; global reads global store, +5h past window)')
+    // RED: --break-sourcescope forces both to be read from local → 2/2.
+    const S2 = mkStore('crossscope-red')
+    seedLesson(S2, { id: lessonId, tags: ['cs'], summary: `${lessonId} cross-store shared id`, lastAccessed: '2026-07-12T10:30:00Z' })
+    seedActivationLine(S2, { id: lessonId, ts: injectTs, sourceScope: 'global' })
+    const r2 = runClerk(S2, { extraArgs: ['--break-sourcescope'] })
+    eq(r2.status, 0, 'red: --break-sourcescope still exits 0')
+    const row2 = r2.json.conversion.per_lesson.find(l => l.id === lessonId)
+    eq(row2.d, 1, 'red: 1 denominator (one source_scope line, but ignored)')
+    eq(row2.n, 1, 'red: --break-sourcescope reads from local regardless of source_scope → still converted (same fixture data)')
+    // GLM review F3: a third entry with source_scope:'bogus' (unknown /
+    // missing) is treated as UNCONVERTED for that entry — counts toward d,
+    // never n (REQ-20 lower bound, never inflated). The lesson is
+    // last_accessed = T+30min (in window) so the bogus entry's failure to
+    // convert is attributable to the source_scope guard, not the window.
+    // Use a FRESH fixture because the previous runClerk(S) above consumed
+    // the activation log (rotate-and-consume is destructive).
+    const S3 = mkStore('crossscope-bogus')
+    const lessonId3 = '20260101-000000-cs-bogus'
+    seedLesson(S3, { id: lessonId3, tags: ['cs'], summary: `${lessonId3} cross-store bogus-source_scope fixture`, lastAccessed: '2026-07-12T10:30:00Z' })
+    seedActivationLine(S3, { id: lessonId3, ts: injectTs, sourceScope: 'bogus' })
+    const r3 = runClerk(S3)
+    eq(r3.status, 0, `F3: clerk exit 0 (stderr=${r3.stderr})`)
+    const row3 = r3.json.conversion.per_lesson.find(l => l.id === lessonId3)
+    ok(row3, 'F3: row present after bogus source_scope entry')
+    eq(row3.d, 1, 'F3: bogus source_scope entry contributes 1 denominator event')
+    eq(row3.n, 0, 'F3: bogus source_scope entry is UNCONVERTED (n=0, never inflated; REQ-20)')
+  })
+
+  // conversion::lowerBoundLabeled — the conversion report carries
+  // lower_bound:true (REQ-20 honesty: the metric is a labeled lower bound).
+  t('conversion::lowerBoundLabeled', () => {
+    const S = mkStore('lowerbound')
+    seedActivationLine(S, { id: '20260101-000000-lb-zzzz', ts: '2026-07-12T10:00:00Z' })
+    const r = runClerk(S)
+    eq(r.status, 0, `clerk exit 0 (stderr=${r.stderr})`)
+    const conv = r.json.conversion
+    ok(conv, 'lower-bound: conversion field present')
+    eq(conv.lower_bound, true, 'lower-bound: lower_bound:true labeled (REQ-20)')
+    // Empty fixture: an empty store still produces a labeled lower-bound report.
+    const S2 = mkStore('lowerbound-empty')
+    const r2 = runClerk(S2)
+    eq(r2.status, 0, 'lower-bound: empty store still exits 0')
+    const conv2 = r2.json.conversion
+    ok(conv2, 'lower-bound: empty conversion field present')
+    eq(conv2.lower_bound, true, 'lower-bound: empty report is still labeled lower_bound:true')
+    eq(conv2.torn_skipped, 0, 'lower-bound: empty torn_skipped=0')
+    eq(conv2.carried_forward, 0, 'lower-bound: empty carried_forward=0')
+  })
+
+  // conversion::duplicateIdRowOrderIndependent (GLM review F4) — the
+  // last_accessed lookup now scans ALL rows matching the id and takes the
+  // MINIMUM (conservative, provably lower-bound, row-order independent).
+  // The test seeds 2 rows of the same id: one with last_accessed IN the
+  // half-open window (T+1h) and one with last_accessed BEFORE the injection
+  // (T-1h — out of the half-open window because the strict `> ts` check
+  // fails). In BOTH row orders, the minimum is the out-of-window value
+  // and the verdict is n=0. (If the lookup were FIRST-match / row-order
+  // dependent, the verdict would flip when the rows are reordered.)
+  t('conversion::duplicateIdRowOrderIndependent', () => {
+    const lessonId = '20260101-000000-duprow-aaaa'
+    // Closed-window injection ts: now - 5h. Half-open window: (T, T+4h].
+    const injectTsDate = new Date(Date.now() - 5 * 60 * 60 * 1000)
+    const injectTs = injectTsDate.toISOString()
+    const inWindowTs = new Date(injectTsDate.getTime() + 60 * 60 * 1000).toISOString() // T+1h: in window
+    const outWindowTs = new Date(injectTsDate.getTime() - 60 * 60 * 1000).toISOString() // T-1h: BEFORE injection → fails `> ts` → out of window
+    function fixtureWithRows(rowATs, rowBTs) {
+      const S = mkStore(`duprow-${rowATs.slice(0,4)}-${rowBTs.slice(0,4)}`)
+      // Seed 2 rows of the same id with the given last_accessed values.
+      const rows = [
+        JSON.stringify({ id: lessonId, date: '2026-01-01', time: '00:00', project: 'duprow', category: 'lesson', status: 'active', supersedes: null, tags: ['duprow'], summary: 'duprow fixture', last_accessed: rowATs, access_count: 1 }),
+        JSON.stringify({ id: lessonId, date: '2026-01-01', time: '00:00', project: 'duprow', category: 'lesson', status: 'active', supersedes: null, tags: ['duprow'], summary: 'duprow fixture', last_accessed: rowBTs, access_count: 1 }),
+      ]
+      fs.writeFileSync(path.join(S.dataDir, 'index.jsonl'), rows.join('\n') + '\n', 'utf8')
+      // Closed-window activation log line.
+      seedActivationLine(S, { id: lessonId, ts: injectTs })
+      return S
+    }
+    // Order A: in-window row first, out-of-window row second.
+    const SA = fixtureWithRows(inWindowTs, outWindowTs)
+    const rA = runClerk(SA)
+    eq(rA.status, 0, `duprow A exit 0 (stderr=${rA.stderr})`)
+    const rowA = rA.json.conversion.per_lesson.find(l => l.id === lessonId)
+    ok(rowA, 'duprow A: row present')
+    eq(rowA.n, 0, `duprow A: n=0 (min is out-of-window T-1h; got n=${rowA.n})`)
+    eq(rowA.d, 1, 'duprow A: d=1 (one closed-window entry)')
+    // Order B: out-of-window row first, in-window row second.
+    const SB = fixtureWithRows(outWindowTs, inWindowTs)
+    const rB = runClerk(SB)
+    eq(rB.status, 0, `duprow B exit 0 (stderr=${rB.stderr})`)
+    const rowB = rB.json.conversion.per_lesson.find(l => l.id === lessonId)
+    ok(rowB, 'duprow B: row present')
+    eq(rowB.n, 0, `duprow B: n=0 (min is out-of-window T-1h, regardless of row order; got n=${rowB.n})`)
+    eq(rowB.d, 1, 'duprow B: d=1')
+    // The two verdicts are identical (row-order independent).
+    eq(rowA.n, rowB.n, 'duprow: n is row-order independent (A === B)')
+    eq(rowA.d, rowB.d, 'duprow: d is row-order independent (A === B)')
+  })
+
+  // report::zeroConversionCandidate (REQ-21) — seed N=3 consecutive
+  // zero-conversion run-records naming the sentinel lesson (n=0/d=1 each),
+  // then run a clerk REPORT and assert the report surfaces that lesson as a
+  // reword/demote/suppress candidate. The clerk scans prior run-records
+  // under the held CLERK_LOCK_FILE lock; the candidate is the lesson whose
+  // last N run-records all show n=0.
+  t('report::zeroConversionCandidate', () => {
+    const S = mkStore('zerocand')
+    const sentinel = '20260101-000000-zc-sentinel-zzzz'
+    // The lesson must be present in the active index for the candidate scan
+    // to find a corresponding active lesson to surface.
+    seedLesson(S, { id: sentinel, tags: ['zc'], summary: `${sentinel} zero-conversion sentinel fixture` })
+    // Seed N=3 run-records, each with the sentinel showing n=0/d=1.
+    for (let i = 0; i < 3; i++) {
+      seedSyntheticRunRecord(S, {
+        id: `20991231-23595${i}-clerk-run-synth-zc`,
+        conversionPerLesson: [{ id: sentinel, n: 0, d: 1, last_ts: '2099-12-31T23:59:59Z', last_access_count_at_inject: 0, band: 'imperative' }],
+      })
+    }
+    // Run a clerk REPORT (no --apply); the report scans the seeded
+    // run-records and surfaces the sentinel as a zero-conversion candidate.
+    const r = runClerk(S, { mode: 'report' })
+    eq(r.status, 0, `clerk report exit 0 (stderr=${r.stderr})`)
+    const candidates = r.json.zero_conversion_candidates
+    ok(Array.isArray(candidates), 'zero-cand: zero_conversion_candidates array present')
+    const hit = candidates.find(c => c.id === sentinel)
+    ok(hit, `zero-cand: sentinel surfaced as a candidate (got ${JSON.stringify(candidates)})`)
+    eq(hit.consecutive_zero_runs, 3, 'zero-cand: 3 consecutive zero-conversion runs')
+    ok(hit.suggestion, 'zero-cand: suggestion field (reword/demote/suppress)')
+    // RED: only N=2 run-records → sentinel is NOT a candidate (not enough
+    // consecutive runs).
+    const S2 = mkStore('zerocand-red')
+    seedLesson(S2, { id: sentinel, tags: ['zc'], summary: `${sentinel} zero-conversion sentinel fixture (red)` })
+    for (let i = 0; i < 2; i++) {
+      seedSyntheticRunRecord(S2, {
+        id: `20991231-23595${i}-clerk-run-synth-zcr`,
+        conversionPerLesson: [{ id: sentinel, n: 0, d: 1, last_ts: '2099-12-31T23:59:59Z', last_access_count_at_inject: 0, band: 'imperative' }],
+      })
+    }
+    const r2 = runClerk(S2, { mode: 'report' })
+    eq(r2.status, 0, 'red: clerk report exit 0')
+    const candidates2 = r2.json.zero_conversion_candidates || []
+    ok(!candidates2.find(c => c.id === sentinel), 'red: only 2 runs → not yet a candidate')
+  })
+}
+
+main()
+console.log(`test-rfc-009-p4-conversion: ${pass}/${pass + fail} pass`)
+if (fail > 0) { console.error(failures.map((f) => `FAIL ${f}`).join('\n')); process.exit(1) }

--- a/tests/test-rfc-009-p4-enrich.mjs
+++ b/tests/test-rfc-009-p4-enrich.mjs
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * test-rfc-009-p4-enrich.mjs — RFC-009 P4-S6 (R9c enrichment backfill, REQ-14).
+ *
+ * Proves the clerk enrich mode of scripts/em-consolidate.mjs:
+ *   - lexical candidate finder: proposes triggers (from summary + tag
+ *     lexemes), applies_to_project/applies_to_tool (from the episode's OWN
+ *     project and tool provenance fields ONLY — never widened, REQ-14
+ *     hard stop);
+ *   - per-item confirmation gating: --confirm or --reject-member <id>;
+ *   - APPLY writes via em-revise AS-IS as a subprocess (spawnSync idiom at
+ *     scripts/em-capture.mjs:453) and the target episode is actually
+ *     revised on disk (supersedes chain + activation fields present);
+ *   - run-record written under the SAME CLERK_LOCK_FILE the S4 apply
+ *     path uses (one lock, one writer — reuse, never a second lock).
+ *
+ * Every assertion inspects real captured runtime state (parsed JSON,
+ * on-disk frontmatter, index rows, spawn stdout/exit) with a discriminating
+ * sentinel — never a typed constant. The clerk is spawned via the REAL
+ * scripts/em-consolidate.mjs with cwd into isolated fixture stores under
+ * /tmp and an isolated HOME (so the GLOBAL store is contained).
+ *
+ * Negative control (§A.9, portable --break-* argv flag, NOT env var — the
+ * clerk + tests must run under Windows `cmd`):
+ *   --break-scope        → widen candidate scope beyond provenance
+ *                           → enrich::scopeFromProvenanceOnly FAILS
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { tryAcquire, release } from '../scripts/lib/lock.mjs'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+const SCRIPT = path.join(REPO_ROOT, 'scripts', 'em-consolidate.mjs')
+const REVISE = path.join(REPO_ROOT, 'scripts', 'em-revise.mjs')
+
+// Suite-level --break-* passthrough: forward ONLY the S6-documented break flags
+// (--break-scope for scopeFromProvenanceOnly; --break-confirm for the
+// noConfirmNoWrite red control — mirrors S4's --break-confirm).
+const PASS_THROUGH_BREAK_FLAGS = new Set()
+for (const flag of ['--break-scope', '--break-confirm']) {
+  if (process.argv.includes(flag)) PASS_THROUGH_BREAK_FLAGS.add(flag)
+}
+
+let pass = 0, fail = 0
+const failures = []
+const ONLY_FLAG = (() => { const i = process.argv.indexOf('--only'); return i >= 0 ? process.argv[i + 1] : null })()
+function t(name, fn) {
+  if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
+  try { fn(); pass++ }
+  catch (e) { fail++; failures.push(`${name} - ${e && e.message}`) }
+}
+function eq(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`)
+}
+function ok(cond, label) { if (!cond) throw new Error(label) }
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+for (const sig of ['SIGINT', 'SIGTERM']) process.on(sig, () => process.exit(130))
+function mkTmp(label) {
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `p4s6-${label}-`)))
+  _tmpDirs.push(base)
+  return base
+}
+
+// Build a minimal but valid local store under <root>/.episodic-memory/ + an
+// isolated fixture HOME so the GLOBAL store is contained. em-consolidate's
+// loadCategories() guard fails closed at startup without a reachable
+// categories.json — copy the real one into the fixture data dir.
+function mkStore(label) {
+  const root = mkTmp(`store-${label}`)
+  const dataDir = path.join(root, '.episodic-memory')
+  const episodesDir = path.join(dataDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  const fixtureHome = mkTmp(`home-${label}`)
+  fs.mkdirSync(path.join(fixtureHome, '.episodic-memory'), { recursive: true })
+  const realCats = path.join(REPO_ROOT, 'categories.json')
+  if (fs.existsSync(realCats)) {
+    fs.copyFileSync(realCats, path.join(dataDir, 'categories.json'))
+  }
+  return { root, dataDir, episodesDir, home: fixtureHome }
+}
+
+// Seed one lesson: writes <id>.md AND appends a JSON row to index.jsonl.
+function seedLesson(S, o) {
+  const {
+    id, date = '2026-01-01', time = '00:00', project = 'acme', category = 'lesson',
+    status = 'active', tags = [], summary, body = 'body text', triggers = [],
+    appliesToProjects = [], appliesToTools = [],
+  } = o
+  const fm = ['---', `id: ${id}`, `date: ${date}`, `time: "${time}"`, `project: ${project}`, `category: ${category}`, `status: ${status}`]
+  fm.push(`tags: [${tags.join(', ')}]`)
+  fm.push(`summary: ${summary}`)
+  if (triggers.length) fm.push(`triggers: [${triggers.map(x => `"${x}"`).join(', ')}]`)
+  if (appliesToProjects.length) fm.push(`applies_to_projects: [${appliesToProjects.map(x => `"${x}"`).join(', ')}]`)
+  if (appliesToTools.length) fm.push(`applies_to_tools: [${appliesToTools.map(x => `"${x}"`).join(', ')}]`)
+  fm.push('---')
+  fs.writeFileSync(path.join(S.episodesDir, `${id}.md`), `${fm.join('\n')}\n\n# ${summary}\n\n${body}\n`, 'utf8')
+  const row = {
+    id, date, time, project, category, status,
+    supersedes: null, consolidates: null,
+    tags: tags.slice(), summary,
+    ...(triggers.length ? { triggers: triggers.slice() } : {}),
+    ...(appliesToProjects.length ? { applies_to_projects: appliesToProjects.slice() } : {}),
+    ...(appliesToTools.length ? { applies_to_tools: appliesToTools.slice() } : {}),
+  }
+  fs.appendFileSync(path.join(S.dataDir, 'index.jsonl'), JSON.stringify(row) + '\n', 'utf8')
+}
+
+// Spawn the real em-consolidate.mjs in the fixture. mode: 'apply' adds --apply.
+function runClerk(S, { mode = 'report', extraArgs = [], home, lockTimeout } = {}) {
+  // mode: 'report' | 'apply' (with --confirm) | 'apply-no-confirm' (no --confirm,
+  // used by enrich::noConfirmNoWrite). The 'apply-no-confirm' mode asserts
+  // the fail-closed gate fires before any write.
+  const confirmFlag = mode === 'apply'
+  const applyFlag = mode === 'apply' || mode === 'apply-no-confirm'
+  const args = [SCRIPT, '--clerk', '--enrich', ...(applyFlag ? ['--apply'] : []), ...(confirmFlag ? ['--confirm'] : []), '--scope', 'local', ...(lockTimeout ? ['--lock-timeout', String(lockTimeout)] : []), ...extraArgs, ...PASS_THROUGH_BREAK_FLAGS]
+  const env = { ...process.env, HOME: home || S.home }
+  const r = spawnSync('node', args, { cwd: S.root, encoding: 'utf8', timeout: 120000, env })
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr, signal: r.signal, errorCode: r.error?.code ?? null, json: parseLastJson(r.stdout) }
+}
+function parseLastJson(stdout) {
+  if (!stdout) return null
+  const lines = stdout.trim().split('\n')
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim()
+    if (!line.startsWith('{')) continue
+    try { return JSON.parse(line) } catch {}
+  }
+  return null
+}
+function indexRows(S) {
+  const p = path.join(S.dataDir, 'index.jsonl')
+  if (!fs.existsSync(p)) return []
+  return fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean).map(l => { try { return JSON.parse(l) } catch { return { __unparsed: l } } })
+}
+function runRecordRows(S) { return indexRows(S).filter(r => r.record_type === 'clerk-run') }
+
+// Read the frontmatter of an episode file as a plain object. Handles
+// quoted strings, unquoted inline arrays (YAML style: [foo, bar] without
+// quotes), plain scalars, and JSON-quoted inline arrays.
+function readEpisodeFm(S, id) {
+  const content = fs.readFileSync(path.join(S.episodesDir, `${id}.md`), 'utf8')
+  const parts = content.split('---')
+  if (parts.length < 3) return {}
+  const fm = {}
+  for (const line of parts[1].split('\n')) {
+    const m = line.match(/^([a-z_]+):\s*(.*)$/)
+    if (!m) continue
+    const key = m[1]
+    const raw = m[2].trim()
+    if (raw.startsWith('[') && raw.endsWith(']')) {
+      // Try JSON first; fall back to unquoted YAML inline-array.
+      try { fm[key] = JSON.parse(raw) } catch { fm[key] = raw.slice(1, -1).split(',').map(s => s.trim()) }
+    } else if (raw.startsWith('"') && raw.endsWith('"')) {
+      fm[key] = raw.slice(1, -1)
+    } else {
+      const n = Number(raw)
+      fm[key] = Number.isFinite(n) && String(n) === raw ? n : raw
+    }
+  }
+  return fm
+}
+
+function main() {
+  // -- Section 14: R9c-enrich test group (S6) --
+
+  // enrich::lexicalCandidates — the lexical candidate finder proposes
+  // triggers extracted from the lesson's summary + tag lexemes. The test
+  // seeds a lesson with a unique summary token + tags, runs --clerk --enrich
+  // (no --apply, report mode), and asserts the proposal carries the
+  // expected lexical triggers.
+  t('enrich::lexicalCandidates', () => {
+    const S = mkStore('lexcand')
+    const SENTINEL = 'lexcandsentinelxyz'
+    seedLesson(S, {
+      id: '20260101-000000-lc-aaaa',
+      project: 'acme',
+      summary: `${SENTINEL} lexical candidate fixture summary tokens`,
+      tags: ['alpha', 'beta', 'gamma'],
+    })
+    const r = runClerk(S, { mode: 'report' })
+    eq(r.status, 0, `clerk enrich exit 0 (stderr=${r.stderr})`)
+    eq(r.json.status, 'ok', 'clerk enrich report ok')
+    eq(r.json.mode, 'clerk-enrich', 'mode = clerk-enrich')
+    const proposal = r.json.proposals.find(p => p.id === '20260101-000000-lc-aaaa')
+    ok(proposal, `proposal present for the seeded lesson (got ${JSON.stringify(r.json.proposals.map(p => p.id))})`)
+    const triggers = proposal.candidates.triggers
+    ok(triggers.includes(SENTINEL), `sentinel token from summary is a trigger (got ${JSON.stringify(triggers)})`)
+    ok(triggers.includes('alpha') && triggers.includes('beta') && triggers.includes('gamma'), `tag lexemes are triggers (got ${JSON.stringify(triggers)})`)
+  })
+
+  // enrich::scopeFromProvenanceOnly — applies_to_project carries ONLY the
+  // episode's OWN project (NEVER widened, REQ-14). --break-scope widens the
+  // scope → the green assertion below fails (the red control).
+  t('enrich::scopeFromProvenanceOnly', () => {
+    const S = mkStore('scopeonly')
+    seedLesson(S, {
+      id: '20260101-000000-scope-aaaa',
+      project: 'scopeprovenanceonly',
+      summary: 'scope provenance only fixture',
+      tags: ['scope'],
+    })
+    const r = runClerk(S, { mode: 'report' })
+    eq(r.status, 0, `clerk enrich exit 0 (stderr=${r.stderr})`)
+    const proposal = r.json.proposals.find(p => p.id === '20260101-000000-scope-aaaa')
+    ok(proposal, 'proposal present')
+    const apps = proposal.candidates.applies_to_project
+    eq(apps.length, 1, `applies_to_project has exactly 1 entry (the episode's own project; got ${JSON.stringify(apps)})`)
+    eq(apps[0], 'scopeprovenanceonly', 'applies_to_project[0] = episode own project')
+    const tools = proposal.candidates.applies_to_tool
+    eq(tools.length, 0, `applies_to_tool is empty (no tool provenance on the episode; got ${JSON.stringify(tools)})`)
+    // RED: --break-scope widens → applies_to_project has more than 1 entry.
+    const Sr = runClerk(S, { mode: 'report', extraArgs: ['--break-scope'] })
+    eq(Sr.status, 0, 'red: --break-scope still exits 0')
+    const proposalR = Sr.json.proposals.find(p => p.id === '20260101-000000-scope-aaaa')
+    ok(proposalR.candidates.applies_to_project.length > 1, `red: --break-scope widened scope (applies_to_project has >1 entry, got ${JSON.stringify(proposalR.candidates.applies_to_project)})`)
+  })
+
+  // enrich::appliesViaRevise — the em-revise subprocess actually runs and
+  // the target episode is revised on disk: a NEW episode with
+  // supersedes:<original_id> + the candidate triggers + applies_to_*
+  // fields. The original is flipped to status:superseded (em-revise
+  // behavior). Discriminating sentinel in the summary makes the
+  // revision's provenance verifiable.
+  t('enrich::appliesViaRevise', () => {
+    const S = mkStore('applyviarevise')
+    const ORIGINAL_ID = '20260101-000000-avr-original-aaaa'
+    const SENTINEL_TOKEN = 'avrdiscriminatingsentinelxyz'
+    seedLesson(S, {
+      id: ORIGINAL_ID,
+      project: 'avrproject',
+      summary: `${SENTINEL_TOKEN} applies via revise fixture summary tokens`,
+      tags: ['avr', 'delta', 'epsilon'],
+    })
+    const r = runClerk(S, { mode: 'apply' })
+    eq(r.status, 0, `clerk enrich apply exit 0 (stderr=${r.stderr})`)
+    eq(r.json.status, 'ok', 'apply ok')
+    eq(r.json.applied.length, 1, `1 lesson enriched (got ${r.json.applied.length})`)
+    const revisedId = r.json.applied[0].revised_id
+    ok(revisedId && revisedId !== ORIGINAL_ID, `a new revision episode id was created (got ${revisedId})`)
+    // The original is now superseded (em-revise behavior).
+    const origRow = indexRows(S).find(r => r.id === ORIGINAL_ID)
+    ok(origRow, 'original index row still present')
+    eq(origRow.status, 'superseded', `original flipped to superseded (em-revise; got ${JSON.stringify(origRow)})`)
+    // The revision is on disk with the candidate fields.
+    const revisedFm = readEpisodeFm(S, revisedId)
+    eq(revisedFm.supersedes, ORIGINAL_ID, 'new revision carries supersedes:<original_id>')
+    ok(Array.isArray(revisedFm.triggers) && revisedFm.triggers.includes(SENTINEL_TOKEN), `revision carries the sentinel token as a trigger (got ${JSON.stringify(revisedFm.triggers)})`)
+    ok(Array.isArray(revisedFm.triggers) && revisedFm.triggers.includes('avr') && revisedFm.triggers.includes('delta') && revisedFm.triggers.includes('epsilon'), 'revision carries tag lexemes as triggers')
+    ok(Array.isArray(revisedFm.applies_to_projects) && revisedFm.applies_to_projects.includes('avrproject'), `revision carries applies_to_projects=[avrproject] (got ${JSON.stringify(revisedFm.applies_to_projects)})`)
+    // The revision is also in index.jsonl.
+    const revisedRow = indexRows(S).find(r => r.id === revisedId)
+    ok(revisedRow, 'revision index row present')
+    eq(revisedRow.supersedes, ORIGINAL_ID, 'revision index row carries supersedes')
+  })
+
+  // enrich::runRecordUnderLock — the SAME CLERK_LOCK_FILE the S4 apply
+  // path uses serializes the enrich apply (one lock, one writer — reuse,
+  // never a second lock). The test holds the lock via tryAcquire
+  // (imported from scripts/lib/lock.mjs, same as the S4 apply test) and
+  // asserts the enrich apply either blocks (returns locked:true) or the
+  // run-record is written under the held lock (succeeds after release).
+  t('enrich::runRecordUnderLock', () => {
+    const S = mkStore('underlock')
+    seedLesson(S, {
+      id: '20260101-000000-ul-aaaa',
+      project: 'ulproject',
+      summary: 'run record under lock fixture',
+      tags: ['ul'],
+    })
+    const lockFile = path.join(S.dataDir, 'clerk-apply.lock')
+    const h = tryAcquire(lockFile) // this test process (alive) holds it
+    ok(h.ok, 'test acquired the clerk lock')
+    try {
+      // GREEN: enrich apply is blocked by the held lock → returns locked:true.
+      const r = runClerk(S, { mode: 'apply', lockTimeout: 1 })
+      eq(r.json.locked, true, 'enrich apply reports locked:true under a held lock')
+      eq(r.json.code, 'lock-held', 'lock-held error code')
+      eq(runRecordRows(S).length, 0, 'no run-record written while lock held')
+      // GREEN: after release, the next run succeeds AND writes the run-record.
+      release(h.handle)
+      const r2 = runClerk(S, { mode: 'apply' })
+      eq(r2.status, 0, `green after release: exit 0 (stderr=${r2.stderr})`)
+      eq(r2.json.applied.length, 1, 'after release: 1 lesson enriched')
+      const rrRows = runRecordRows(S)
+      ok(rrRows.length >= 1, `after release: 1 run-record written (got ${rrRows.length})`)
+      ok(rrRows[0].record_type === 'clerk-run', 'run-record has record_type:clerk-run')
+    } finally {
+      // Make sure the lock is released even if the assertions above throw.
+      try { release(h.handle) } catch {}
+    }
+  })
+
+  // enrich::noConfirmNoWrite (GLM review F2) — the enrich apply
+  // !confirm fail-closed gate fires BEFORE any write. Mirrors
+  // apply::noConfirmNoWrite. --break-confirm bypasses the gate (red
+  // control for parity with S4).
+  t('enrich::noConfirmNoWrite', () => {
+    const SENTINEL_ID = '20260101-000000-encw-aaaa'
+    function sha256FileLocal(p) { return fs.existsSync(p) ? crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex') : 'ABSENT' }
+    const S = mkStore('noconfirm-enrich')
+    seedLesson(S, {
+      id: SENTINEL_ID,
+      project: 'encwproject',
+      summary: 'enrich no-confirm sentinel fixture',
+      tags: ['encw'],
+    })
+    const indexPre = sha256FileLocal(path.join(S.dataDir, 'index.jsonl'))
+    const epCountPre = fs.readdirSync(S.episodesDir).length
+    // GREEN: --clerk --enrich --apply WITHOUT --confirm → fail-closed
+    // (exit nonzero, code:'unconfirmed', store manifest unchanged).
+    const r = runClerk(S, { mode: 'apply-no-confirm' })
+    ok(r.status !== 0, `green: enrich apply without --confirm exits non-zero (got ${r.status})`)
+    eq(r.json.code, 'unconfirmed', 'green: code === unconfirmed')
+    eq(r.json.mode, 'clerk-enrich', 'green: mode === clerk-enrich')
+    eq(sha256FileLocal(path.join(S.dataDir, 'index.jsonl')), indexPre, 'green: index.jsonl byte-unchanged (fail-closed before write)')
+    eq(fs.readdirSync(S.episodesDir).length, epCountPre, 'green: episodes/ count unchanged (no new revision episode)')
+    eq(runRecordRows(S).length, 0, 'green: no run-record written')
+    // RED: --break-confirm bypasses the gate → the run proceeds and writes.
+    const S2 = mkStore('noconfirm-enrich-red')
+    seedLesson(S2, {
+      id: SENTINEL_ID,
+      project: 'encwproject',
+      summary: 'enrich no-confirm sentinel fixture red',
+      tags: ['encw'],
+    })
+    const rRed = runClerk(S2, { mode: 'apply-no-confirm', extraArgs: ['--break-confirm'] })
+    eq(rRed.status, 0, 'red: --break-confirm bypasses the gate → exit 0')
+    ok(fs.readdirSync(S2.episodesDir).length > epCountPre, 'red: --break-confirm wrote a revision episode')
+    ok(runRecordRows(S2).length >= 1, 'red: --break-confirm wrote a run-record')
+  })
+}
+
+main()
+console.log(`test-rfc-009-p4-enrich: ${pass}/${pass + fail} pass`)
+if (fail > 0) { console.error(failures.map((f) => `FAIL ${f}`).join('\n')); process.exit(1) }

--- a/tests/test-rfc-009-p4-prompt.mjs
+++ b/tests/test-rfc-009-p4-prompt.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/**
+ * test-rfc-009-p4-prompt.mjs — RFC-009 P4-S7 (R9d clerk prompt + conformance,
+ * REQ-15). The prompt is DATA (P2) shipped at
+ * `scripts/em-consolidate/prompts/clerk.md` and must carry every
+ * normative clause from docs/rfcs/RFC-009-lesson-activation.md:189-207.
+ *
+ * Coverage:
+ *   - prompt::fileExists — the shipped prompt file exists, is non-trivially
+ *     sized, and the directory structure is intact.
+ *   - prompt::loadBearingClauses — every load-bearing clause from the RFC
+ *     is present in the shipped prompt, asserted by a discriminating
+ *     substring. --break-prompt strips a load-bearing clause from the
+ *     LOADED COPY (no file mutation) and the assertion must FAIL.
+ *   - prompt::sampleReportSchemaValid — the embedded fenced-json sample
+ *     parses, has mode==='clerk-report', every clusters[].proposed_action
+ *     is in {merge,dedupe,keep-distinct}, every cluster has
+ *     members[].id+summary, and the sample includes at least one
+ *     citation-bearing cluster and one deferred item.
+ *
+ * Modeled on tests/test-second-opinion-preamble.mjs (read independently,
+ * do not couple). Zero deps. Node assert + fs.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+const PROMPT_PATH = path.join(REPO_ROOT, 'scripts', 'em-consolidate', 'prompts', 'clerk.md')
+
+let passed = 0, failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+// Extract the FIRST fenced ```json ... ``` block from the prompt body.
+// The prompt is shipped as data with two embedded json blocks: the
+// output SCHEMA (a small example with placeholders like <id>) and the
+// SAMPLE report (a fully-populated example with sentinel ids). The first
+// block is the schema; the last is the sample. Downstream consumers
+// pattern-match the sample, so the sample is what we verify here.
+function extractFencedJson(text) {
+  const m = text.match(/```json\s*([\s\S]*?)```/)
+  if (!m) throw new Error('no fenced ```json``` block found in prompt')
+  return m[1]
+}
+
+// Extract the LAST fenced ```json ... ``` block (the SAMPLE report, after
+// the output SCHEMA). The sample carries the full report shape including
+// per_lesson, deferred, escalation_audit, demotion_review_candidates,
+// r10_drift_queue, and (F6) the conversion block.
+function extractSampleReport(text) {
+  const matches = [...text.matchAll(/```json\s*([\s\S]*?)```/g)]
+  if (matches.length < 1) throw new Error('no fenced ```json``` block found in prompt')
+  return matches[matches.length - 1][1]
+}
+
+// Load the prompt into memory; --break-prompt strips a load-bearing clause
+// from the IN-MEMORY copy (no file mutation, no on-disk side-effect).
+const BREAK_PROMPT = process.argv.includes('--break-prompt')
+function loadPrompt() {
+  let body = fs.readFileSync(PROMPT_PATH, 'utf8')
+  if (BREAK_PROMPT) {
+    // RED: strip a single load-bearing clause marker from the loaded copy.
+    // The "keep-distinct bias" rule (rule 3) is the most-testable single
+    // substring; stripping it breaks exactly one of the 13 load-bearing
+    // clauses, proving the assertion has teeth. (Cross-platform: pure
+    // String.replace, no shell.)
+    body = body.replace('Prefer `keep-distinct` over `merge` when intent might differ', 'Prefer MERGE over keep-distinct when intent might differ (RED-STRIPPED)')
+  }
+  return body
+}
+
+console.log('# test-rfc-009-p4-prompt')
+
+// ---------------------------------------------------------------------------
+// prompt::fileExists — the prompt file ships, is non-trivially sized, the
+// directory structure is intact, and the file is readable.
+// ---------------------------------------------------------------------------
+console.log('\n## prompt::fileExists')
+test('prompts directory exists at scripts/em-consolidate/prompts/', () => {
+  const dir = path.dirname(PROMPT_PATH)
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw new Error(`prompts directory not found at ${dir}`)
+  }
+})
+
+test('prompt file exists at scripts/em-consolidate/prompts/clerk.md', () => {
+  if (!fs.existsSync(PROMPT_PATH)) {
+    throw new Error(`prompt file not found at ${PROMPT_PATH}`)
+  }
+  const stat = fs.statSync(PROMPT_PATH)
+  if (!stat.isFile()) throw new Error(`prompt path is not a regular file: ${PROMPT_PATH}`)
+  if (stat.size < 1000) throw new Error(`prompt file is trivially small (${stat.size} bytes; expected >= 1000)`)
+})
+
+test('no runtime loader ships in P4 (grep -c "readFileSync.*prompt" on em-consolidate.mjs is 0)', () => {
+  const ecPath = path.join(REPO_ROOT, 'scripts', 'em-consolidate.mjs')
+  const ec = fs.readFileSync(ecPath, 'utf8')
+  const matches = (ec.match(/readFileSync.*prompt/g) || []).length
+  if (matches !== 0) throw new Error(`expected 0 readFileSync.*prompt occurrences in em-consolidate.mjs, got ${matches}`)
+})
+
+// ---------------------------------------------------------------------------
+// prompt::loadBearingClauses — every load-bearing clause from the RFC
+// normative paragraph (lines 189-207) is present in the shipped prompt,
+// asserted by a discriminating substring. --break-prompt strips ONE clause
+// from the LOADED COPY (no file mutation); the assertion then FAILS.
+// ---------------------------------------------------------------------------
+console.log('\n## prompt::loadBearingClauses')
+const PROMPT = loadPrompt()
+test('three-verb mandate (AGGREGATE / ENRICH / MANAGE) is present', () => {
+  if (!/AGGREGATE/i.test(PROMPT)) throw new Error('missing three-verb mandate (AGGREGATE)')
+  if (!/ENRICH/i.test(PROMPT)) throw new Error('missing three-verb mandate (ENRICH)')
+  if (!/MANAGE/i.test(PROMPT)) throw new Error('missing three-verb mandate (MANAGE)')
+})
+
+test('never-enforce clause is present', () => {
+  if (!/never\s+enforce/i.test(PROMPT)) throw new Error('missing never-enforce clause')
+})
+
+test('propose-only / no-write-tools clause is present', () => {
+  if (!/PROPOSE/i.test(PROMPT)) throw new Error('missing PROPOSE mandate')
+  if (!/no\s+write\s+tools/i.test(PROMPT)) throw new Error('missing no-write-tools clause')
+})
+
+test('cite-or-discard / citation rule is present', () => {
+  if (!/cited\s+artifacts/i.test(PROMPT)) throw new Error('missing cite-or-discard (cited artifacts) clause')
+})
+
+test('no-fabricated-evidence clause is present', () => {
+  if (!/fabricate/i.test(PROMPT)) throw new Error('missing no-fabricated-evidence clause')
+})
+
+test('keep-distinct bias rule (rule 3) is present', () => {
+  // The verbatim RFC wording.
+  if (!/Prefer\s+`keep-distinct`\s+over\s+`merge`/i.test(PROMPT)) {
+    throw new Error('missing keep-distinct bias rule (rule 3)')
+  }
+})
+
+test('never-widen-scope clause (rule 4) is present', () => {
+  if (!/Never\s+widen\s+scope/i.test(PROMPT)) throw new Error('missing never-widen-scope clause')
+})
+
+test('respect-recorded-judgment clause (rule 5) is present', () => {
+  if (!/Respect\s+recorded/i.test(PROMPT)) throw new Error('missing respect-recorded-judgment clause')
+})
+
+test('report-JSON-only clause (rule 6) is present', () => {
+  if (!/Output\s+ONLY\s+the\s+report\s+JSON/i.test(PROMPT)) throw new Error('missing report-JSON-only clause')
+})
+
+test('no-questions / deferred clause (rule 7) is present', () => {
+  if (!/Do not ask/i.test(PROMPT)) throw new Error('missing no-questions clause (rule 7)')
+  if (!/deferred/i.test(PROMPT)) throw new Error('missing deferred marker clause (rule 7)')
+})
+
+test('escalation-audit surfacing (rule 8a) is present', () => {
+  if (!/escalation\s+audit/i.test(PROMPT)) throw new Error('missing escalation-audit surfacing (rule 8a)')
+})
+
+test('demotion-review surfacing (rule 8b) is present', () => {
+  if (!/demotion[\s-]review/i.test(PROMPT)) throw new Error('missing demotion-review surfacing (rule 8b)')
+})
+
+test('drift surfacing / R10 drift queue (rule 8c) is present', () => {
+  if (!/drift/i.test(PROMPT)) throw new Error('missing drift surfacing (rule 8c)')
+  if (!/R10\s+drift/i.test(PROMPT)) throw new Error('missing R10 drift queue reference')
+})
+
+// ---------------------------------------------------------------------------
+// prompt::sampleReportSchemaValid — the embedded fenced-json sample parses,
+// has mode==='clerk-report', every clusters[].proposed_action is in the
+// {merge,dedupe,keep-distinct} enum, every cluster carries
+// members[].id+summary, and the sample includes at least one citation-
+// bearing cluster and one deferred item (REQ-15).
+// ---------------------------------------------------------------------------
+console.log('\n## prompt::sampleReportSchemaValid')
+test('embedded fenced-json sample parses', () => {
+  const raw = extractFencedJson(PROMPT)
+  try { JSON.parse(raw) } catch (e) { throw new Error(`sample JSON parse failed: ${e.message}`) }
+})
+
+test('sample has mode === "clerk-report"', () => {
+  const sample = JSON.parse(extractFencedJson(PROMPT))
+  if (sample.mode !== 'clerk-report') throw new Error(`sample.mode is ${JSON.stringify(sample.mode)}, want "clerk-report"`)
+})
+
+test('every clusters[].proposed_action is in {merge,dedupe,keep-distinct}', () => {
+  const sample = JSON.parse(extractFencedJson(PROMPT))
+  const VALID = new Set(['merge', 'dedupe', 'keep-distinct'])
+  for (const c of sample.clusters || []) {
+    if (!VALID.has(c.proposed_action)) {
+      throw new Error(`cluster proposed_action is ${JSON.stringify(c.proposed_action)}, want one of ${[...VALID].join(', ')}`)
+    }
+  }
+})
+
+test('every cluster carries members[].id + members[].summary', () => {
+  const sample = JSON.parse(extractFencedJson(PROMPT))
+  for (const c of sample.clusters || []) {
+    if (!Array.isArray(c.members)) throw new Error('cluster.members is not an array')
+    for (const m of c.members) {
+      if (typeof m.id !== 'string' || !m.id) throw new Error(`cluster member missing id (${JSON.stringify(m)})`)
+      if (typeof m.summary !== 'string' || !m.summary) throw new Error(`cluster member missing summary (${JSON.stringify(m)})`)
+    }
+  }
+})
+
+test('sample includes at least one citation-bearing cluster', () => {
+  const sample = JSON.parse(extractFencedJson(PROMPT))
+  const hasCitations = (sample.clusters || []).some(c => Array.isArray(c.citations) && c.citations.length > 0)
+  if (!hasCitations) throw new Error('no cluster in the sample carries a citations field (REQ-15 sample contract)')
+})
+
+test('sample includes at least one deferred item (rule 7 marker)', () => {
+  const sample = JSON.parse(extractFencedJson(PROMPT))
+  if (!Array.isArray(sample.deferred) || sample.deferred.length < 1) {
+    throw new Error('sample.deferred is empty (rule 7 requires low-confidence items to be marked deferred)')
+  }
+})
+
+// GLM review F6: the embedded sample report carries a conversion block
+// matching the shipped envelope (per_band imperative/plain n,d + per_lesson +
+// torn_skipped + carried_forward + lower_bound:true). The sample now
+// mirrors the real report shape so a downstream consumer that pattern-
+// matches the sample against the envelope finds the conversion fields
+// where it expects them.
+test('sample includes a conversion block (per_band + per_lesson + lower_bound:true)', () => {
+  const sample = JSON.parse(extractSampleReport(PROMPT))
+  if (!sample.conversion || typeof sample.conversion !== 'object') {
+    throw new Error('sample.conversion is missing or not an object (F6 sample mirrors the report envelope)')
+  }
+  const conv = sample.conversion
+  if (!conv.per_band || typeof conv.per_band !== 'object') throw new Error('sample.conversion.per_band is missing or not an object')
+  for (const band of ['imperative', 'plain']) {
+    const b = conv.per_band[band]
+    if (!b || typeof b !== 'object') throw new Error(`sample.conversion.per_band.${band} is missing or not an object`)
+    if (typeof b.n !== 'number') throw new Error(`sample.conversion.per_band.${band}.n is not a number (got ${typeof b.n})`)
+    if (typeof b.d !== 'number') throw new Error(`sample.conversion.per_band.${band}.d is not a number (got ${typeof b.d})`)
+  }
+  if (!Array.isArray(conv.per_lesson)) throw new Error('sample.conversion.per_lesson is not an array')
+  if (typeof conv.torn_skipped !== 'number') throw new Error('sample.conversion.torn_skipped is not a number')
+  if (typeof conv.carried_forward !== 'number') throw new Error('sample.conversion.carried_forward is not a number')
+  if (conv.lower_bound !== true) throw new Error(`sample.conversion.lower_bound is not true (got ${JSON.stringify(conv.lower_bound)})`)
+})
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-rfc-009-p4-report.mjs
+++ b/tests/test-rfc-009-p4-report.mjs
@@ -195,18 +195,22 @@ function parseLastJson(stdout) {
 function sha256(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')
 }
-// FIX-4 (S3 review F7): full source-store manifest as sorted (relpath, sha256)
-// tuples for every file under a store dir, EXCEPT trigger-index.json — the
-// REQ-1 carve-out (R2 lazy rebuild may produce or change it; the rest of the
-// store MUST be byte-identical). Returned as a sorted array of arrays so deep
-// equality is unambiguous; missing dir → empty array.
-function manifestExcludingTriggerIndex(dataDir) {
+// FIX-4 (S3 review F7) + GLM review F1: full source-store manifest as sorted
+// (relpath, sha256) tuples for every file under a store dir, EXCEPT the
+// carve-out files: trigger-index.json (REQ-1, R2 lazy rebuild may produce or
+// change it), activation-log.jsonl and activation-log.jsonl.processing
+// (P4-S5 rotation surface — the S5 rotate-and-consume mutates the .processing
+// path AND carries open-window lines back to a fresh activation-log.jsonl;
+// the rest of the store MUST be byte-identical). Returned as a sorted array
+// of arrays so deep equality is unambiguous; missing dir → empty array.
+const STORE_MANIFEST_EXCLUSIONS = new Set(['trigger-index.json', 'activation-log.jsonl', 'activation-log.jsonl.processing'])
+function manifestExcludingTransient(dataDir) {
   const out = []
   if (!fs.existsSync(dataDir)) return out
   function walk(dir, relBase) {
     for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
       const rel = relBase ? `${relBase}/${ent.name}` : ent.name
-      if (rel === 'trigger-index.json') continue
+      if (STORE_MANIFEST_EXCLUSIONS.has(rel)) continue
       const full = path.join(dir, ent.name)
       if (ent.isDirectory()) walk(full, rel)
       else if (ent.isFile()) out.push([rel, sha256(full)])
@@ -236,15 +240,60 @@ function main() {
     const globalDir = path.join(fixtureHome, '.episodic-memory')
     fs.mkdirSync(globalDir, { recursive: true })
     seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-byteident-aaaa', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['t-byteidentical'], summary: 'byteidentical baseline lesson', body: 'body' })
-    const localPre = manifestExcludingTriggerIndex(S.dataDir)
-    const globalPre = manifestExcludingTriggerIndex(globalDir)
+    const localPre = manifestExcludingTransient(S.dataDir)
+    const globalPre = manifestExcludingTransient(globalDir)
     const r = runClerk({ root: S.root, home: fixtureHome })
     eq(r.status, 0, 'clerk exits 0')
     eq(r.json && r.json.status, 'ok', 'status:ok')
-    const localPost = manifestExcludingTriggerIndex(S.dataDir)
-    const globalPost = manifestExcludingTriggerIndex(globalDir)
+    const localPost = manifestExcludingTransient(S.dataDir)
+    const globalPost = manifestExcludingTransient(globalDir)
     eq(JSON.stringify(localPost), JSON.stringify(localPre), `local manifest unchanged pre/post (pre=${JSON.stringify(localPre)} post=${JSON.stringify(localPost)})`)
     eq(JSON.stringify(globalPost), JSON.stringify(globalPre), `isolated-global manifest unchanged pre/post (pre=${JSON.stringify(globalPre)} post=${JSON.stringify(globalPost)})`)
+  })
+
+  // 1b. report::byteIdenticalStoreWithLog (GLM review F1) — the S5 rotation
+  //     surface (P4-S5 REQ-18 rotate-and-consume) is unguarded by the original
+  //     byteIdenticalStore test (it runs without an activation log). Seed a
+  //     closed-window line into activation-log.jsonl so the clerk report
+  //     rotation IS exercised; assert the LOCAL manifest (episodes/ + index.jsonl)
+  //     is byte-identical while ONLY the carve-out files (trigger-index.json,
+  //     activation-log.jsonl, activation-log.jsonl.processing) change.
+  t('report::byteIdenticalStoreWithLog', () => {
+    const S = mkStore('byteidenticalwithlog')
+    seedLesson({ dataDir: S.dataDir, episodesDir: S.episodesDir, id: '20260101-000000-bidl-aaaa', date: '2026-01-01', project: 'acme', category: 'lesson', tags: ['t-bidl'], summary: 'bidl baseline lesson with activation log', body: 'body' })
+    // Seed a closed-window activation-log line (in the past, well before NOW)
+    // so the report-mode rotation consumes it. The line names a UNIQUE
+    // sentinel id so the test is discriminating.
+    const SENTINEL_ID = '20260101-000000-bidl-logline-aaaa'
+    const injectTs = '2026-07-12T10:00:00Z'
+    fs.appendFileSync(path.join(S.dataDir, 'activation-log.jsonl'), JSON.stringify({
+      v: 1, ts: injectTs, project: 'bidl', event: 'inject', surface: 'per_prompt',
+      entries: [{ id: SENTINEL_ID, effective_priority: 8, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 }],
+    }) + '\n')
+    // Pre-run: manifest snapshot (excludes the activation log itself; the log
+    // is mutated by the rotation, so it must NOT be in the byte-identical
+    // assertion set).
+    const localPre = manifestExcludingTransient(S.dataDir)
+    // The activation log file IS present pre-run (we just seeded it).
+    const preLog = fs.readFileSync(path.join(S.dataDir, 'activation-log.jsonl'), 'utf8')
+    ok(preLog.includes(SENTINEL_ID), 'pre-run: activation-log.jsonl carries the seeded sentinel line')
+    // Run the clerk report — this rotates + consumes the activation log
+    // (the rotation is the S5 surface we're proving is byte-identical-safe).
+    const r = runClerk({ root: S.root })
+    eq(r.status, 0, 'clerk exits 0')
+    eq(r.json && r.json.status, 'ok', 'status:ok')
+    // Post-run: manifest snapshot. The carve-out files (trigger-index.json,
+    // activation-log.jsonl, activation-log.jsonl.processing) are excluded;
+    // the rest of the store (episodes/ + index.jsonl) MUST be byte-identical.
+    const localPost = manifestExcludingTransient(S.dataDir)
+    eq(JSON.stringify(localPost), JSON.stringify(localPre), `local manifest (episodes/ + index.jsonl) unchanged pre/post (pre=${JSON.stringify(localPre)} post=${JSON.stringify(localPost)})`)
+    // Also assert: the conversion ran (the rotation exercised the S5
+    // surface — the report carries the lower-bound per_band + per_lesson).
+    const conv = r.json.conversion
+    ok(conv, 'green: conversion ran (rotation surface exercised)')
+    eq(conv.lower_bound, true, 'green: lower_bound:true labeled')
+    // The .processing leftover must be gone (atomic rotate consumed it).
+    ok(!fs.existsSync(path.join(S.dataDir, 'activation-log.jsonl.processing')), 'green: no .processing leftover (atomic rotate consumed it)')
   })
 
   // 2. report::signalTagJaccard — pair with tag-Jaccard >= 0.5 + same category +


### PR DESCRIPTION
Completes RFC-009 Phase 4: the PR-B remainder (S5+S6+S7) on top of shipped S1-S4 (#523, #525).

## S5 - R6 conversion metric + rotate-and-consume (REQ-18, 19, 20, 21)
- `clerkComputeConversion`: atomic rename rotate-and-consume of `activation-log.jsonl`, open-window carry-forward (NSP F5), torn/unknown-v lines skipped+counted, binary lower-bound attribution per entry via `source_scope` store's `last_accessed` in the half-open `(T, T+window]`; unknown/missing `source_scope` and unreadable stores count UNCONVERTED (never inflating); duplicate-id index rows resolved by MIN `last_accessed` (order-independent, provably lower-bound); REQ-18 crash recovery consumes a leftover `.processing` before rotating.
- Wired into both report mode (under the single `CLERK_LOCK_FILE`, lock-held degrades to empty conversion, release-on-throw proven) and apply mode (ConversionReport folded into the existing run-record via `clerkWrite`). REQ-21 zero-conversion candidates surfaced from N consecutive zero-conversion run-records. New flag-tunables `--window-ms`, `--zero-conversion-runs` (RFC :148).
- `tests/test-rfc-009-p4-conversion.mjs`: 10 tests, 5 discriminating `--break-*` red controls.

## S6 - R9c enrichment backfill (REQ-14)
- `--clerk --enrich`: lexical trigger/applies_to/activity candidates from the episode's OWN provenance only (hard stop, `--break-scope` red control), per-item confirmation fail-closed gate (`code:'unconfirmed'`), apply via `em-revise` AS-IS subprocess (cwd-bound, env-inherited), run-record under the same single lock.
- `tests/test-rfc-009-p4-enrich.mjs`: 5 tests incl. `noConfirmNoWrite` + `--break-confirm` red control.

## S7 - R9d clerk prompt (REQ-15)
- `scripts/em-consolidate/prompts/clerk.md` shipped as versioned DATA carrying every normative RFC :191-205 clause + embedded sample report matching the shipped envelope (incl. conversion block).
- `tests/test-rfc-009-p4-prompt.mjs`: 23 conformance assertions + `--break-prompt` red control.

## Review
GLM-5.2 cross-vendor frozen-diff review: round 1 HOLD-2 (2 P2 test-coverage gaps, 4 P3s incl. two lower-bound inflation paths) -> all six folded -> round 2 ACCEPT, zero new findings, all red controls verified discriminating. Plan doc updated ($19.12 pre-build deltas, $12 envelope contract, status surfaces).

Suites: conversion 10/10, enrich 5/5, prompt 23/23, apply 30/30, report 16/16, telemetry 7/7, ci-suite-registration 16/16. All three new suites CI-wired in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)