### PR TITLE
feat(second-opinion): adversarial-depth-v1 preamble fragment (5 reviewer duties from the RFC-012 panel arc)

### DIFF
--- a/scripts/second-opinion/preambles/fragments/adversarial-depth-v1.md
+++ b/scripts/second-opinion/preambles/fragments/adversarial-depth-v1.md
@@ -1,0 +1,37 @@
+# Adversarial depth duties (v1 — apply after the ladder, before verdict)
+
+Five duties distilled from two-provider panel reviews where a second reviewer
+caught P1-class findings the checklist pass missed (RFC-012 draft arc,
+2026-07-14). Apply each to the artifact under review (spec, diff, or plan).
+
+## 1. Implementability tracing
+
+For every field / category / flag / record the artifact introduces, locate the
+existing writer / validator / consumer code that would have to accept it and
+verify the contract is implementable as written. A proposal the current code
+would reject, or whose identity / uniqueness assumptions the code contradicts,
+is a blocking finding.
+
+## 2. Design-replacement duty
+
+For each requirement, ask whether an existing mechanism could deliver the same
+outcome with no new machinery; if yes, propose the replacement design as a
+finding — patching a mechanism that should not exist is the wrong fix class.
+
+## 3. Cross-requirement interaction sweep
+
+Enumerate pairwise interactions between requirements — especially feedback
+loops where X consumes what Y produces, and contention where several
+requirements share one bounded surface. Attack each loop and each shared bound.
+
+## 4. Adversarial input construction
+
+For every threshold / window / counting rule, construct a concrete adversarial
+input sequence and trace the verdict by hand. Any sequence the rule mislabels
+is a finding.
+
+## 5. Free-hunt pass
+
+After the checklist, run one pass over the newest surface with no pointers from
+the requester and report the top 3 candidate weaknesses — even if you then
+dismiss them.

--- a/scripts/second-opinion/preambles/index.json
+++ b/scripts/second-opinion/preambles/index.json
@@ -1,17 +1,18 @@
 {
   "schema_version": 1,
   "default_per_provider": {
-    "codex": ["review-ladder-v9.4", "env-prefix-discipline-v1"],
-    "claude-subagent": ["claude-subagent-loader-ref", "env-prefix-discipline-v1"],
-    "gemini": ["gemini-ladder-v1", "env-prefix-discipline-v1"],
-    "opencode": ["opencode-ladder-v1", "env-prefix-discipline-v1"],
-    "stub": ["review-ladder-v9.4"]
+    "codex": ["review-ladder-v9.4", "env-prefix-discipline-v1", "adversarial-depth-v1"],
+    "claude-subagent": ["claude-subagent-loader-ref", "env-prefix-discipline-v1", "adversarial-depth-v1"],
+    "gemini": ["gemini-ladder-v1", "env-prefix-discipline-v1", "adversarial-depth-v1"],
+    "opencode": ["opencode-ladder-v1", "env-prefix-discipline-v1", "adversarial-depth-v1"],
+    "stub": ["review-ladder-v9.4", "adversarial-depth-v1"]
   },
   "fragments": [
     {"id": "review-ladder-v9.4", "path": "fragments/review-ladder-v9.4.md"},
     {"id": "claude-subagent-loader-ref", "path": "fragments/claude-subagent-loader-ref.md"},
     {"id": "gemini-ladder-v1", "path": "fragments/gemini-ladder-v1.md"},
     {"id": "opencode-ladder-v1", "path": "fragments/opencode-ladder-v1.md"},
-    {"id": "env-prefix-discipline-v1", "path": "fragments/env-prefix-discipline-v1.md"}
+    {"id": "env-prefix-discipline-v1", "path": "fragments/env-prefix-discipline-v1.md"},
+    {"id": "adversarial-depth-v1", "path": "fragments/adversarial-depth-v1.md"}
   ]
 }

--- a/tests/test-second-opinion-preamble.mjs
+++ b/tests/test-second-opinion-preamble.mjs
@@ -104,7 +104,7 @@ test('default preamble for codex includes review-ladder + env-prefix-discipline'
   const tmp = makeTmpProject()
   const result = compose({ provider: 'codex', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['review-ladder-v9.4', 'env-prefix-discipline-v1'])
+  assert.deepStrictEqual(result.fragmentIds, ['review-ladder-v9.4', 'env-prefix-discipline-v1', 'adversarial-depth-v1'])
 
   const reg = loadRegistry()
   const ladder = readFragment(reg.fragments.find((f) => f.id === 'review-ladder-v9.4'))
@@ -113,32 +113,42 @@ test('default preamble for codex includes review-ladder + env-prefix-discipline'
     'composed body must include review-ladder fragment content')
   assert.ok(result.preambleBody.includes(envPrefix),
     'composed body must include env-prefix-discipline fragment content')
+  const adversarial = readFragment(reg.fragments.find((f) => f.id === 'adversarial-depth-v1'))
+  assert.ok(result.preambleBody.includes(adversarial),
+    'composed body must include adversarial-depth fragment content')
 })
 
 test('default preamble for claude-subagent includes loader-ref + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'claude-subagent', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['claude-subagent-loader-ref', 'env-prefix-discipline-v1'])
+  assert.deepStrictEqual(result.fragmentIds, ['claude-subagent-loader-ref', 'env-prefix-discipline-v1', 'adversarial-depth-v1'])
 })
 
 test('default preamble for gemini includes ladder-v1 + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'gemini', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['gemini-ladder-v1', 'env-prefix-discipline-v1'])
+  assert.deepStrictEqual(result.fragmentIds, ['gemini-ladder-v1', 'env-prefix-discipline-v1', 'adversarial-depth-v1'])
 })
 
 test('default preamble for opencode includes ladder-v1 + env-prefix-discipline', () => {
   const tmp = makeTmpProject()
   const result = compose({ provider: 'opencode', projectRoot: tmp, cliFragments: null })
   assert.strictEqual(result.preambleSource, 'default')
-  assert.deepStrictEqual(result.fragmentIds, ['opencode-ladder-v1', 'env-prefix-discipline-v1'])
+  assert.deepStrictEqual(result.fragmentIds, ['opencode-ladder-v1', 'env-prefix-discipline-v1', 'adversarial-depth-v1'])
 
   const reg = loadRegistry()
   const ladder = readFragment(reg.fragments.find((f) => f.id === 'opencode-ladder-v1'))
   assert.ok(result.preambleBody.includes(ladder),
     'composed body must include opencode-ladder fragment content')
+})
+
+test('default preamble for stub includes review-ladder + adversarial-depth', () => {
+  const tmp = makeTmpProject()
+  const result = compose({ provider: 'stub', projectRoot: tmp, cliFragments: null })
+  assert.strictEqual(result.preambleSource, 'default')
+  assert.deepStrictEqual(result.fragmentIds, ['review-ladder-v9.4', 'adversarial-depth-v1'])
 })
 
 test('unknown provider with no default → no-default-preamble-for-provider', () => {


### PR DESCRIPTION
## Summary
- New composable preamble fragment scripts/second-opinion/preambles/fragments/adversarial-depth-v1.md carrying the five adversarial reviewer duties distilled from the 2026-07-14 RFC-012 two-provider panel arc (implementability tracing, design-replacement duty, cross-requirement interaction sweep, adversarial input construction, free-hunt pass; source episode 20260714-003237-...-fa96, which named this exact repo change as its follow-up).
- Registered in preambles/index.json fragments[] and appended LAST to every provider's default_per_provider list (composition order matches the fragment's 'apply after the ladder' framing).
- Tests: the four I-24 deepStrictEqual arrays updated, a content-inclusion assertion added to the codex test, and a new stub-default regression test (closes the pre-existing stub coverage gap the review widened). Suite: 45 passed, 0 failed.

## Review
pi/GLM-5.2 (neuralwatt) on the frozen staged diff (.review-store/preamble-adversarial-depth-r1.diff): round 1 ACCEPT with 3 P3 nits + 1 INFO. Dispositions: stub regression test ACCEPT (folded); missing trailing newline ACCEPT (folded); 'after the ladder' title nuance for claude-subagent NO-CHANGE (reviewer graded it not misleading in substance, loader-ref loads the ladder externally); INFO: install snapshot goes stale by design (registry-stale-at-gate observed live: expected 5a118be0... vs installed 087f3a03...) until the post-merge deploy step. Reviewer runtime probes cited verbatim: composer test suite green, validate-second-opinion-audit ok (18 paths), JSON valid, live compose() per provider shows fragment_ids ending in adversarial-depth-v1 with composed lengths 4.7k-6.7k chars (far under the 100k minimum prompt_max_chars).

## Post-merge deploy (NOT docs-only)
install.mjs copies scripts/second-opinion/ recursively (install.mjs:402-410), so the fragment deploys on the next install run; the harness snapshot needs node install.mjs --install-second-opinion to clear the intentional registry-stale-at-gate fail-close. Deploy + consumer sweep happens after merge per the deploy-after-merge rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)