### PR TITLE
docs(NAPMEM-AB): recall routing table + stop/budget guidance

### DIFF
--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -332,6 +332,8 @@ node ~/.episodic-memory/scripts/em-search.mjs \
   [--warn-time-ms <n>] [--warn-count <n>]
 ```
 
+`--history` is the evolution-class route: use it whenever the question is "what is the CURRENT version of this decision," not "did this happen."
+
 Output:
 
 ```json
@@ -467,6 +469,8 @@ Flags that matter: `--task-type implementation` adds the violation pre-flight;
 
 Common mistakes: skipping recall and re-deriving context that a past session already
 recorded.
+
+Stopping: stop when an episode id grounds the answer, or after two empty queries (broaden scope once); at most 3 recall calls per question; session-start advisory bounds (RFC-009 R3 max_matches/max_tokens) never flex.
 
 ### em-pin
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -282,6 +282,10 @@ AI:   Here are the 5 most recent memories for this project:
       5. "Chose Stripe over PayPal" (Mar 12) — decision
 ```
 
+### Routing your question
+
+Before searching, identify what kind of answer you need. For profile-class questions about standing rules and playbooks, rely on what loaded at session start or use `em-search.mjs --tag playbook --scope global --limit 1 --full`. For event-class questions about past decisions or causes, use `em-search.mjs --query "<topic>"`; for evolution-class questions about what is current, use `em-search.mjs --history <episode-id>`. Transcript-level and topic-track routes are not shipped, and routing never re-ranks results (RFC-001 score-merge contract). Stop once an episode id grounds the answer, or after two empty queries (broaden scope once first); make at most 3 recall calls per question, and remember that session-start advisory bounds (RFC-009 R3 max_matches/max_tokens) never flex.
+
 ---
 
 ## Scenario 6: Reaching a Milestone

--- a/instructions/AGENTS.md
+++ b/instructions/AGENTS.md
@@ -46,6 +46,10 @@ node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] 
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full
 ```
 
+## Recall routing and stopping
+
+Route before searching — profile-class (standing rules, playbooks) is auto-loaded at session start or via `em-search.mjs --tag playbook --scope global --limit 1 --full`; event-class (past decisions, causes) via `em-search.mjs --query "<topic>"`; evolution-class (what is current) via `em-search.mjs --history <episode-id>`. Transcript-level and topic-track routes are not shipped; do not invent them. Routing never re-ranks results (RFC-001 score-merge contract). Stop when you can cite an episode id, or after two empty queries (broaden scope once first); at most 3 recall calls per question (operational guidance); the existing RFC-009 R3 max_matches/max_tokens caps and RFC-012 B-4 lifecycle gate are unchanged, so no separate recall budget is introduced.
+
 List recent:
 ```bash
 node ~/.episodic-memory/scripts/em-list.mjs --project <name> --limit 5

--- a/instructions/SKILL.md
+++ b/instructions/SKILL.md
@@ -8,7 +8,7 @@ description: >
   when starting work on a project to proactively recall relevant past episodes.
   Even if the user doesn't explicitly ask, store episodes for important
   decisions, discoveries, or context valuable in future sessions.
-version: 0.2.0
+version: 0.3.0
 ---
 
 # Episodic Memory
@@ -75,6 +75,24 @@ node ~/.episodic-memory/scripts/em-recall.mjs [--project <name>] [--task-type <i
 node ~/.episodic-memory/scripts/em-search.mjs [--project <name>] [--query <text>] [--tag <t>] [--category <c>] [--since <date>] [--limit <n>] [--full] [--scope local|global|all] [--include-superseded] [--history <id>]
 node ~/.episodic-memory/scripts/em-list.mjs [--project <name>] [--limit <n>]
 ```
+
+### Recall routing (pick the level before you search)
+
+Route the query to the right abstraction level first; then search within it. Routing chooses WHERE to look — it never re-weights or re-ranks `em-search` results (the RFC-001 score-merge contract is untouched: passes stay independent, results merge by highest score).
+
+| Query class | Sounds like | Shipped surface | Command |
+|---|---|---|---|
+| Profile-class — standing rules, preferences, how-we-work, playbooks | "how do I run seats", "what are the review rules" | Operator memory (MEMORY.md index + feedback files, loaded at session start) and playbooks (session_start auto-load, RFC-011) | already in context at session start; on demand: `node ~/.episodic-memory/scripts/em-search.mjs --tag playbook --scope global --limit 1 --full` |
+| Event-class — what happened: decisions, bug root causes, milestones | "what did we decide about X", "why did Y break" | Episodes | `node ~/.episodic-memory/scripts/em-search.mjs --query "<topic>" [--tag <t>] [--scope local\|global\|all] [--full]` |
+| Evolution-class — how a decision changed; what is current | "what is the latest revision of X" | Supersedes chains | `node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> [--full]` |
+
+No transcript-level or topic-track routes exist: those levels are not shipped (`em-mine-transcripts.mjs` is a one-way staging miner, not a recall surface; topic tracks are not implemented). Honest capability labels (Principle 5): route only to what ships.
+
+### When to stop (recall budget)
+
+- Stop as soon as the answer is grounded: you can cite an episode id (or a chain terminal) that answers the question.
+- Stop after two consecutive queries that surface nothing new and relevant; broaden once (drop `--project`, widen `--scope`) before concluding the memory is absent.
+- Bound the pass: default at most 3 recall calls per question. Advisory session-start surfaces are already hard-bounded (RFC-009 R3: `max_matches` 3 / `max_tokens` ~500, the cap never flexes) and all surfacing is lifecycle-gated, never polled (RFC-012 B-4). That 3-call default is operational guidance layered within those unchanged bounds; no separate recall budget is introduced.
 
 ## Revise (self-correction)
 

--- a/instructions/codex-skill.md
+++ b/instructions/codex-skill.md
@@ -31,6 +31,24 @@ node ~/.episodic-memory/scripts/em-search.mjs [--project <name>] [--query <text>
 node ~/.episodic-memory/scripts/em-list.mjs [--project <name>] [--limit <n>]
 ```
 
+### Recall routing (pick the level before you search)
+
+Route the query to the right abstraction level first; then search within it. Routing chooses WHERE to look — it never re-weights or re-ranks `em-search` results (the RFC-001 score-merge contract is untouched: passes stay independent, results merge by highest score).
+
+| Query class | Sounds like | Shipped surface | Command |
+|---|---|---|---|
+| Profile-class — standing rules, preferences, how-we-work, playbooks | "how do I run seats", "what are the review rules" | Operator memory (MEMORY.md index + feedback files, loaded at session start) and playbooks (session_start auto-load, RFC-011) | already in context at session start; on demand: `node ~/.episodic-memory/scripts/em-search.mjs --tag playbook --scope global --limit 1 --full` |
+| Event-class — what happened: decisions, bug root causes, milestones | "what did we decide about X", "why did Y break" | Episodes | `node ~/.episodic-memory/scripts/em-search.mjs --query "<topic>" [--tag <t>] [--scope local\|global\|all] [--full]` |
+| Evolution-class — how a decision changed; what is current | "what is the latest revision of X" | Supersedes chains | `node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> [--full]` |
+
+No transcript-level or topic-track routes exist: those levels are not shipped (`em-mine-transcripts.mjs` is a one-way staging miner, not a recall surface; topic tracks are not implemented). Honest capability labels (Principle 5): route only to what ships.
+
+### When to stop (recall budget)
+
+- Stop as soon as the answer is grounded: you can cite an episode id (or a chain terminal) that answers the question.
+- Stop after two consecutive queries that surface nothing new and relevant; broaden once (drop `--project`, widen `--scope`) before concluding the memory is absent.
+- Bound the pass: default at most 3 recall calls per question. Advisory session-start surfaces are already hard-bounded (RFC-009 R3: `max_matches` 3 / `max_tokens` ~500, the cap never flexes) and all surfacing is lifecycle-gated, never polled (RFC-012 B-4). That 3-call default is operational guidance layered within those unchanged bounds; no separate recall budget is introduced.
+
 ## Revise (self-correction)
 
 When a prior decision proves wrong: search for original, then revise. Original is auto-marked superseded. Use `--history <id>` to show the full chain.

--- a/instructions/cursor.mdc
+++ b/instructions/cursor.mdc
@@ -63,6 +63,10 @@ node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] 
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full
 ```
 
+### Recall routing and stopping
+
+Route before searching — profile-class (standing rules, playbooks) is auto-loaded at session start or via `em-search.mjs --tag playbook --scope global --limit 1 --full`; event-class (past decisions, causes) via `em-search.mjs --query "<topic>"`; evolution-class (what is current) via `em-search.mjs --history <episode-id>`. Transcript-level and topic-track routes are not shipped; do not invent them. Routing never re-ranks results (RFC-001 score-merge contract). Stop when you can cite an episode id, or after two empty queries (broaden scope once first); at most 3 recall calls per question (operational guidance); the existing RFC-009 R3 max_matches/max_tokens caps and RFC-012 B-4 lifecycle gate are unchanged, so no separate recall budget is introduced.
+
 ### List Recent
 ```bash
 node ~/.episodic-memory/scripts/em-list.mjs --project <name> --limit 5

--- a/instructions/windsurf.md
+++ b/instructions/windsurf.md
@@ -47,6 +47,10 @@ node ~/.episodic-memory/scripts/em-search.mjs --project <name> [--query <text>] 
 node ~/.episodic-memory/scripts/em-search.mjs --history <episode-id> --full
 ```
 
+## Recall routing and stopping
+
+Route before searching — profile-class (standing rules, playbooks) is auto-loaded at session start or via `em-search.mjs --tag playbook --scope global --limit 1 --full`; event-class (past decisions, causes) via `em-search.mjs --query "<topic>"`; evolution-class (what is current) via `em-search.mjs --history <episode-id>`. Transcript-level and topic-track routes are not shipped; do not invent them. Routing never re-ranks results (RFC-001 score-merge contract). Stop when you can cite an episode id, or after two empty queries (broaden scope once first); at most 3 recall calls per question (operational guidance); the existing RFC-009 R3 max_matches/max_tokens caps and RFC-012 B-4 lifecycle gate are unchanged, so no separate recall budget is introduced.
+
 List recent:
 ```bash
 node ~/.episodic-memory/scripts/em-list.mjs --project <name> --limit 5


### PR DESCRIPTION
## Summary

NAPMEM-AB docs-only PR (queue head, workplan v205; scope locked in NapMem assessment episode `20260714-081618-napmem-assessment-arxiv-2607-05794-routi-68d9`, user-agreed 2026-07-14).

- **ITEM-A — recall routing table.** New "Recall routing (pick the level before you search)" guidance in all 5 instruction files (`instructions/SKILL.md` + verbatim mirror in `codex-skill.md`, condensed paragraph in `AGENTS.md` / `cursor.mdc` / `windsurf.md`): profile-class -> operator memory + playbook session_start auto-load (RFC-011), event-class -> `em-search --query`, evolution-class -> `em-search --history`. Honest-labels exclusion (P5): no transcript-level or topic-track routes (not shipped; grep + `--help` verified). Routing sits above ranking; the RFC-001 score-merge contract (RFC-001:133-134) is untouched.
- **ITEM-B — stop criteria + recall budget.** Stop when an episode id grounds the answer; stop after two empty queries (broaden scope once); at most 3 recall calls per question as operational guidance layered within the unchanged RFC-009 R3 bounds (`max_matches`/`max_tokens`, cap never flexes; RFC-009:86,101) and RFC-012 B-4 lifecycle gate (RFC-012:47). No parallel budget concept introduced.
- Small mirrored additions in `docs/EM_SCRIPTS_GUIDE.md` (evolution-class note on `--history`; Stopping note under em-recall) and `docs/USER_MANUAL.md` ("Routing your question").
- `instructions/SKILL.md` frontmatter version 0.2.0 -> 0.3.0. Deployed copies (`.claude/`, `.agents/`, `plugins/`) untouched per RFC-011:150; refresh via `install.mjs` after merge.

## Review trail

- Builder: pi/MiniMax-M3. Reviewer: pi/GLM-5.2 (neuralwatt), read-only adversarial with mandatory runtime probes.
- Round 1: **HOLD-1** (`.review-store/napmem-ab-glm-r1.md`) — F1: condensed paragraphs presented the new 3-call default as *restating* R3/B-4 (Principle-5 conflation). Constraints C1/C2/C4/C5/C6/C7 passed with file:line evidence and 4 captured runtime probes (playbook-tag search, scored query, `--history` 6-member chain walk, miner `--help`).
- F1 ACCEPTED and folded with the reviewer's suggested wording across all 5 instruction files (parity preserved).
- Round 2: **ACCEPT** (`.review-store/napmem-ab-glm-r2.md`) — F1 resolved, C5 parity re-verified (SKILL/codex blocks verbatim-identical; 3 condensed paragraphs mutually identical), no new defects; delta confirmed as exactly the 5 F1 wording lines.

## Post-merge

- Run `node install.mjs` refresh so deployed instruction copies pick up the new sections (RFC-011:150 discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHFF727R1oLQ3gxr2a9BYN
