### PR TITLE
P2-S1: store-identity chain end-to-end (RFC-012 P2, REQ-1..6 + REQ-18)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -272,6 +272,8 @@ jobs:
 
       - name: Run em-promote experimental suite (APC-S5)
         run: node tests/test-em-promote.mjs
+      - name: Run store-identity suite (RFC-012 P2 S1)
+        run: node tests/test-store-identity.mjs
 
       - name: Run em-console web console suite
         run: node tests/test-em-console.mjs

--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -545,7 +545,31 @@ Decisions the §A.7-S1 table pins beyond the reviewed plan body — recorded her
    registry write; install.mjs's existing try/catch surfaces the message as a loud
    WARNING while the install itself completes — the bad store gets no row (REQ-6
    "rejected at registration"). Missing/vanished store dirs skip mirroring (degrade;
-   mirror is derived, never authoritative).
+   mirror is derived, never authoritative). CORRECTED by GLM S1 r1 MAJOR-2: there is a
+   THIRD registry write (updateConsumers' pruned-sweep `writeRegistry(regPath, keptEntries)`)
+   that bypassed the choke point; folded to mirror-then-write (never via upsert — its
+   read-merge would resurrect pruned rows).
+
+### 19.3b S1 build review (GLM r1, 2026-07-18)
+
+Frozen diff `ea94c4c..0781b04`; reviewer pi/GLM-5.2 (neuralwatt), report
+`.review-store/rfc-012-p2/glm-s1-r1.md`, verdict **HOLD-3** (0 BLOCKER, 3 MAJOR,
+3 MINOR, 1 NIT), all findings probe-grounded (probe sources `/tmp/probes/*.mjs`).
+Fold map (all folded same-session, fold commit follows):
+
+| # | Finding | Severity | Disposition + fold |
+|---|---|---|---|
+| M1 | `testConcurrentMintSingleChain` used sequential `spawnSync` — EC3 hollow-green (probe: 0ms overlap); lib sound under real concurrency | MAJOR | ACCEPT — test rewritten to async `spawn` + `Promise.all` |
+| M2 | `updateConsumers` sweep write (install-version.mjs:517) bypasses the mirror → stale `store_id` after rebind (probe 4) | MAJOR | ACCEPT-WITH-MOD — `writeRegistry(regPath, mirrorStoreIdentities(keptEntries))`; NOT via `upsertRegistryEntries` (merge would resurrect pruned rows) |
+| M3 | Mirror throws `identity-mint-failed: identity-exists` on a benign concurrent-fresh-store race (also `lock-timeout`) — false-positive row drop | MAJOR | ACCEPT — on those two codes re-resolve once and mirror the existing identity; hard errors still throw |
+| m1 | Missing store dir → raw ENOENT throw from `tryAcquire`, not the `{error}` contract | MINOR | ACCEPT — `{ error: 'store-dir-missing' }` + test |
+| m2 | `id === 'global'` skip lets two forged-global project rows coexist without collision | MINOR | ACCEPT-WITH-MOD — a project row resolving active/alias `global` throws `reserved-id-abuse: <project_path>` + E2E test |
+| m3 | EC7 supersedes-cycle class handled by the walk's revisit guard but untested | MINOR | ACCEPT — `testSupersedesCycleFailsLoud` added |
+| n1 | `lock-timeout` return branch untested (30s constant untestable) | NIT | ACCEPT-WITH-MOD — optional `lockTimeoutS` opt threaded to `withStoreLockSync` + `testLockTimeoutSurfaces` |
+
+Post-fold suite = 26 tests. Confirmed sound by r1 (not findings): schema-test v1-skip,
+`Atomics.wait` sleep fallback, crash-injection fixture falsifiability, all six §8.2
+invariants including no-new-path-authority-predicate.
 
 ## §20 Lessons Encoded
 

--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -1,0 +1,706 @@
+# RFC012-P2 — em-promote Graduation Contract (R2a–R2d) Plan
+
+## §1 Status
+
+`Planning only.` Do not implement until this plan, the plan review, and the adversarial
+review are accepted (Rule 18). Current stage: **draft**.
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-012` (`docs/rfcs/RFC-012-promotion-arc.md`, status `accepted`) |
+| Parent requirements | `R2a, R2b, R2c, R2d` (RFC-012:54–63); boundary invariants B-1..B-5 (RFC-012:42–48) |
+| Workplan episode | `20260716-120224-workplan-v207-napmem-ab-shipped-end-to-e-ba8d` |
+| Target branch | `feat/rfc-012-p2-s<n>` (one branch per slice) |
+| Executor altitude (§0.1) | **low** (builder seat = pi/MiniMax-M3) — Appendix A mandatory |
+| Deadline | **2026-10-08** graduation decision (RFC-012:63); P2 preempts later phases (RFC-012:148) |
+
+**Appendix-A cadence for a multi-PR phase:** §A.0–§A.6b (toolchain, contract, anchor
+rules) are filled once, below. Each slice's §A.7 step table is authored and
+anchor-verified at that slice's start (after the prior slice merges), then the slice
+builds — verbatim anchors written today for S3/S4 would be stale after S1/S2 land.
+S1's §A.7 table is authored immediately after plan approval, before the S1 build
+dispatch. This altitude decision is surfaced for review; a reviewer HOLD on it is a
+legitimate outcome.
+
+**Altitude escalation trigger (GLM r1 finding 6):** if a slice's silent-fail-class
+test does not pass on the builder's first attempt — S1's crash-injection fixture
+(REQ-2) or S2's `testCommaValueByteRoundTrip` (EC11, the silent-corruption class only
+an equality assertion catches) — that slice escalates to a higher-altitude seat
+before proceeding. Non-discretionary; the other slices continue at low altitude.
+
+## §2 Episode Search Summary
+
+Searches run 2026-07-16 (results pasted, not recalled):
+
+```bash
+node scripts/em-search.mjs --query "rfc-012 promotion store identity" --scope all --limit 8 --no-track
+node scripts/em-search.mjs --tag workplan --category decision --limit 1 --scope all --full --no-score --no-track
+```
+
+Key active memories:
+
+- `20260716-120224-workplan-v207-…-ba8d`: queue head = RFC-012 P2 planning; NAPMEM-C blocked on P2; deadline 2026-10-08 with preemption.
+- `20260714-081618-napmem-assessment-…-68d9`: NAPMEM-C entry path = RFC-001 Phase 4 arc **reusing the `promotion_sources` shape** — P2's shape is a downstream contract, not private to em-promote.
+- `20260714-014502-fold-text-claims-…-a480` (violation): during the RFC-012 acceptance ladder, three defects were introduced by fold fixes written without probes. Constraint: every behavior claim in this plan cites a probe or file:line verified today.
+- `20260708-084913-hold-apc-impl-round-1-…-09f3`: APC impl review found em-promote clone-store recurrence false positive + Sources-section injection breaking back-refs — both are exactly the classes R2a's `content_sha256` + typed field close; fixtures below must cover them.
+- `20260714-003237-seat-profiling-…-fa96`: codex gpt-5.6-sol found the P2 identity-semantics holes GLM missed during RFC acceptance; panel > either alone. §19 uses GLM first (pre-authorized), codex round only if GLM ACCEPTs with low finding count on the security surface (#538 blocks codex-provider consensus loops; single-round dispatch with manual read is the workaround).
+
+Verified-on-disk anchors recalled memories rely on: `scripts/em-promote.mjs:62`
+(`PROMOTE_DECISION_DATE = '2026-10-08'`), `plugins/_index.schema.json:33` (`learning` in
+type enum, no slot; enum literal at :33, `pluginType` def block ~:30-33) — both confirmed
+by scout reads 2026-07-16, line re-verified by GLM r1.
+
+## §3 Objective
+
+Graduate `em-promote` from EXPERIMENTAL to a registered learning-strategy capability by
+2026-10-08, per the CAPABILITIES.md forward rule: typed provenance (`promotion_sources`
+array + store-identity episode chain), the `learning` registry slot with descriptor and
+runtime IO schemas plus a conformance gauntlet, disposition of the #478 residuals, and an
+assisted `--apply` with per-candidate fingerprint confirm and a `promote-run` run-record.
+Provable by: the conformance gauntlet green, the registry validating with `em-promote`
+registered under `learning`, and #478 closed with per-residual dispositions.
+
+## §4 Requirements (Ground Truth)
+
+| ID | Requirement (concrete, testable) | Parent R | Test(s) | Priority | Notes / edge cases |
+|---|---|---|---|---|---|
+| REQ-1 | A store-identity episode (category `context`, typed scalar `record_type: store-identity`) is minted once per store by `scripts/lib/store-identity.mjs` `mintStoreIdentity()`; `store_id` is opaque (16 lowercase hex, `crypto.randomBytes(8)`), never a path; the global store carries reserved id `global` | R2a | `testMintIdentity`, `testGlobalReservedId`, `testIdNeverPath` | MUST | identity travels with the store directory (episode-carried) |
+| REQ-2 | The identity writer stages, fsyncs, and atomically renames under the store lock; a crash mid-write leaves either the prior state or the complete fresh root | R2a | `testIdentityWriterAtomic`, `negative: crash-injection fixture (BREAK_IDENTITY_WRITE argv flag) → prior state intact` | MUST | today's `writeFileSync` (em-store.mjs:325) is explicitly insufficient per RFC-012:58 |
+| REQ-3 | Active `store_id` = terminal revision of the identity chain; every superseded revision's id resolves as a retired alias owned by that store; an ordinary confirmed rebind creates a successor revision and pre-rebind references keep resolving | R2a | `testActiveIsTerminal`, `testAliasResolution`, `testPreRebindRefsResolve` | MUST | P7: rebind is a revision, never an edit |
+| REQ-4 | Exactly one active identity chain per store; a second active chain fails loud at index build and at registration | R2a | `testDuplicateChainFailsLoudBuild`, `testDuplicateChainFailsLoudRegistration` | MUST | fail-closed |
+| REQ-5 | Clone-detach is a single confirmed episode write: the fresh identity root carries `detaches_identity_root: <inherited-root-id>`; a detached chain contributes no active id and no aliases in that store; a crash before the write leaves the copy unrebound with the inherited chain intact | R2a | `testCloneDetachSingleWrite`, `testDetachedChainNoAliases`, `negative: crash-before-detach fixture → inherited chain intact` | MUST | one write, no intermediate state |
+| REQ-6 | Consumer registry mirrors active id + retired aliases derivationally via an additive schema-version bump to `plugins/consumer-registry.schema.json`; existing rows backfilled by mint-on-next-registration; ambiguous alias ownership (one id claimed by two stores) fails loud; a copied store (one active id observed at two paths) is rejected at registration pending explicit rebind | R2a | `testRegistryMirror`, `testMintOnNextRegistration`, `testAmbiguousAliasFailsLoud`, `testCopiedStoreRejected` (isolated-HOME mock-project E2E) | MUST | mirror is never authoritative |
+| REQ-7 | `promotion_sources` is a NEW typed array field — items `{store_id, episode_id, content_sha256}` — with its own `em-store` writer flag (`--promotion-sources-json`), lesson-only, fail-closed shape validation; `em-revise` inherits/overrides it; `em-rebuild-index` round-trips it losslessly (single-line JSON in frontmatter); the `JSON.parse` branch intercepts the raw value BEFORE the generic `/^\[(.*)\]$/` array heuristic at BOTH parse sites, and the field is NEVER a member of `ACTIVATION_ARRAY_FIELDS` (read gate + flat-scalar serializer both unsafe for nested JSON) | R2a | `testPromotionSourcesWrite`, `testPromotionSourcesRoundTrip`, `testCommaValueByteRoundTrip`, `testReviseInherit`, `negative: malformed shape/hex → exit 1` | MUST | probes B2 + planner P5/P6 (2026-07-16): the generic bracket regex + comma-split is fail-open on JSON-shaped values (silent corruption/truncation, exit 0) — the parse-order guard is load-bearing, not cosmetic |
+| REQ-8 | `promotion_sources` never feeds earned priority and is never accepted by the `evidence` path: `effectivePriority` ignores it; `--evidence` continues rejecting non-violation ids | R2a | `testNoEarnedPriorityForge` (lesson with promotion_sources naming violations → effective_priority = stored), `testEvidenceGateUnchanged` | MUST | probe A3 (2026-07-16): evidence gate rejects wrong-category with exact JSON error — that behavior is frozen |
+| REQ-9 | `content_sha256` = SHA-256 over the episode file's raw UTF-8 bytes with LF-normalized newlines, lowercase hex; exported helper `computeContentSha256(buf)` with a fixed test vector (CRLF and LF inputs hash identically) | R2a | `testContentShaVector`, `testCrlfLfIdentical` | MUST | RFC-012:58 fixes the normalization rule |
+| REQ-10 | Reference resolution: a `store_id` matching neither an active id nor a registered alias surfaces as `missing_sources` in JSON output, never a silent drop; resolution helper `resolveSourceRefs(refs, registry)` returns `{resolved, missing}` | R2a | `testUnresolvedAliasSurfaces`, `testMissingNeverSilent` | MUST | consumed by apply, migration, gauntlet |
+| REQ-11 | New promotions write `promotion_sources` and stop writing `promoted:<sha8>` tags-as-identity and the `cross-project` project sentinel; the in-body `## Sources` section remains as human-readable rendering only | R2a | `testNewPromotionTyped`, `testNoSentinelOnNewWrites` | MUST | legacy episodes handled by REQ-15 |
+| REQ-12 | Member identity binds content: recurrence keys use `content_sha256` so same-id, same-summary, different-body sources stay distinct; replicas collapse only on matching content hash | R2a | `testSameIdSummaryDiffBodyDistinct`, `testReplicaCollapseOnHashMatch` | MUST | closes the em-promote.mjs:118-133 collapse defect + APC clone-store false positive (`…09f3`) |
+| REQ-13 | `learning` registry slot ships: registry sub-schema + descriptor schema + runtime IO schema as an additive-MINOR bump to `plugins/_index.schema.json`; `scripts/validate-plugin-registry.mjs` validates the new slot; `em-promote` is registered under it | R2b | `testLearningSlotSchema`, `testRegistryValidates`, `negative: descriptor missing required field → validator exit 1` | MUST | RFC-008 R8 versioned-contract clause |
+| REQ-14 | Conformance gauntlet folds the existing 15-test `tests/test-em-promote.mjs` suite plus the RFC-named fixtures: post-preview source substitution fails fingerprint revalidation; pre-rebind refs resolve after ordinary rebind; clone-rebind ends with exactly one active chain, zero inherited aliases, old-id resolution only to the original (asserted after rebuild AND re-registration); crash-before-rebind leaves copy unrebound; duplicate chain fails loud; unresolved alias surfaces | R2b | the gauntlet itself (`tests/test-em-promote.mjs` extended or `tests/test-learning-gauntlet.mjs`) | MUST | fixture list is verbatim from RFC-012:59 |
+| REQ-15 | Assisted, lock-guarded revision migration: candidate selection follows the §12 `selectMigrationCandidates` predicate (never tag-alone); successor episodes carry typed provenance + corrected `project` metadata; prior ids persist through supersession chains; indexes rebuild; per-item outcomes captured in a run-record | R2a (OQ-6 closed) | `testMigrationSuccessors`, `testMigrationRunRecord`, `testPriorIdsPersist`, `negative: testHandAuthoredTagNotSwept` | MUST | assisted = per-item confirm, same contract as REQ-16; planner GAP-3 |
+| REQ-16 | `--apply` per-candidate confirm: preview prints an immutable fingerprint (SHA-256 of the sorted canonical refs, same item shape as `promotion_sources`); nothing writes without an explicit per-candidate `--confirm <fingerprint>`; the fingerprint is revalidated under the `em-lock` discipline immediately before each write | R2d | `testApplyRequiresConfirm`, `testFingerprintRevalidation`, `negative: source substitution after preview → write refused` | MUST | closes B-2 gap (em-promote.mjs:320-328 writes unconfirmed today) + #478 §17-D TOCTOU |
+| REQ-17 | Each apply run writes a `record_type: promote-run` run-record episode — unconfirmed operational metadata, global-only; an additive class-d protection arm in `scripts/lib/protection.mjs` reserves the latest promote-run per store (mirroring the clerk-run arm at protection.mjs:217-227) | R2d | `testPromoteRunRecord`, `testPromoteRunProtectionArm` (both polarities) | MUST | R3c's future delta baseline |
+| REQ-18 | The store-identity chain is prune-protected via an additive class-d arm in `scripts/lib/protection.mjs` | R2a | `testIdentityProtectionArm` (both polarities) | MUST | mirrors clerk-run arm |
+| REQ-19 | #478 residual dispositions recorded at graduation: §17-A typed provenance → resolved by REQ-7/11/12; §17-D apply TOCTOU → resolved by REQ-16; §17-E axis conflation → resolved by REQ-11+15; #478 closed citing the shipped tests, or any residual re-filed with the 5-field justification | R2c | `manual: gh issue close 478 --comment <disposition map>` | MUST | disposition, not necessarily code |
+| REQ-20 | Write matrix holds: content proposals = per-item confirm; apply writes = per-candidate confirm + fingerprint recheck; run-records = unconfirmed, global-only | R2d, B-2, B-3 | `testWriteMatrix` (run-record needs no confirm; content write without confirm refused) | MUST | B-3: no derived writes into foreign project stores |
+
+## §5 Non-Goals
+
+- R3b/R3c gauges and the promotion advisory (P3 scope; consumes R2d's run-record later).
+- Any change to `em-capture`, clerk clustering, `em-consolidate` apply paths, or the activation plane.
+- Registering additional learning-strategy members (NAPMEM-C reuses the shape AFTER P2 lands — workplan v207).
+- Fixing the `curation`-type enum drift (#535): adjacent registry concern, separate PR; P2's bump is scoped to `learning` only.
+- Search/recall surfacing of `promotion_sources` (no em-search filter flag, no ranking input).
+- Distributed-store resolution (RFC-013/RFC-014 forward references) — the shape is compatible; the resolution registry here is host-local.
+- Removing the in-body `## Sources` section (stays as human-readable rendering).
+
+## §6 Token Budget (Rule 12)
+
+`wc -l` run 2026-07-16:
+
+| File | `wc -l` | Reads (lines × ~5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/em-promote.mjs` | 341 | ~1.7k | heavy (S2/S4) | member key, apply, sentinel retirement |
+| `scripts/em-store.mjs` | 394 | ~2.0k | moderate (S2) | writer flag + validation |
+| `scripts/em-revise.mjs` | 448 | ~2.2k | small (S2) | inherit/override |
+| `scripts/em-rebuild-index.mjs` | 296 | ~1.5k | small (S1/S2) | lockstep parse + duplicate-chain check |
+| `scripts/lib/protection.mjs` | 305 | ~1.5k | small (S1/S4) | two class-d arms |
+| `scripts/lib/registered-stores.mjs` | 102 | ~0.5k | moderate (S1) | identity-aware registration |
+| `scripts/lib/install-version.mjs` | 624 | ~3.1k | moderate (S1) | registry mirror + backfill |
+| `plugins/_index.schema.json` | 115 | ~0.6k | moderate (S3) | learning slot |
+| `plugins/consumer-registry.schema.json` | 30 | ~0.2k | small (S1) | mirror bump |
+| `scripts/validate-plugin-registry.mjs` | 858 | ~4.3k | moderate (S3) | slot validation |
+| `tests/test-em-promote.mjs` | 333 | ~1.7k | heavy (S3) | gauntlet fold |
+| `scripts/lib/activation.mjs` | 357 | ~1.8k | small (S2) | field vocab + parse branch |
+| `scripts/lib/store-identity.mjs` | NEW | — | CREATE (S1) | mint/resolve/detach/atomic writer |
+
+**Baseline (single session):** ~55–70k tokens per slice including tests and review rounds.
+**Optimized:** 4 slices × separate sessions, each 60–90k (within the 60–130k sweet spot).
+
+## §7 Safety / Security
+
+Canonical planner dispatch: `negative-scenario-planner` ran on this design BEFORE the
+§19 review (schema + validator + multi-actor change class). Status: **r1 complete,
+HOLD-3, folded 2026-07-16** — full report with 10 runtime probes at
+`.review-store/rfc-012-p2/negative-scenario-r1.md`. GAP-1 (BLOCKER, parse-order
+corruption) closed in §8.3 + REQ-7; GAP-2 (cross-operation lock pairs) closed in §8.2 +
+§13 EC12; GAP-3 (missing contracts) closed in §12; NIT (line drift) fixed. Fold map in
+§19.1. Per the planner's discipline-17 note, the GAP-1 fix surface (parse-order guard
+across two files + write-side exclusion) was re-walked: the em-revise inherit path reads
+via the same guarded `parseActivationFromFrontmatter`, and the guard is structural (a
+named `STRUCTURED_FIELDS` list checked first), not per-field ad hoc.
+
+| Concern | Severity | Attack/abuse scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| Earned-priority forge via new field | High | A writer stuffs violation ids into `promotion_sources` to reach the 8/9 band without the evidence gate | Separate field; `effectivePriority` reads only `evidence`/`lessons` (em-trigger-index.mjs:182-221, unchanged); REQ-8 negative test | `testNoEarnedPriorityForge` |
+| Frontmatter injection through JSON value | High | A crafted `episode_id`/`store_id` containing `\n` forges a frontmatter key (e.g. `superseded_by:`) when serialized | Extend the `illegalValueChar` guard (activation.mjs:37-67) to every string in the parsed JSON; serialize via `JSON.stringify` (escapes control chars); reject non-conforming ids by regex | `negative: id with newline → exit 1` |
+| Identity spoof via path | Med | Path-based identity embeds absolute paths and breaks on relocation (registered-stores.mjs:11-21 realpath rule) | `store_id` opaque hex, episode-carried; REQ-1 `testIdNeverPath` | `testIdNeverPath` |
+| Alias hijack | High | Two stores claim the same id/alias (store copied, or malicious registry edit) | Ambiguous ownership fails loud at registration (REQ-6); copied store rejected pending rebind; mirror never authoritative | `testAmbiguousAliasFailsLoud`, `testCopiedStoreRejected` |
+| Fingerprint downgrade | Med | Reordering or substituting sources between preview and write | Fingerprint = SHA-256 over SORTED canonical refs; revalidated under lock before write | `testFingerprintRevalidation` |
+| TOCTOU on concurrent `--apply` | Med | Two applies double-write a digest (#478 §17-D) | Per-candidate revalidation under `em-lock`; second holder observes the first's write and refuses | `testConcurrentApplySecondRefuses` |
+| Migration forging project metadata | Med | Migration rewrites `project` on episodes it doesn't own | Assisted per-item confirm; lock-guarded; run-record captures per-item outcomes | `testMigrationRunRecord` |
+| Crash mid-identity-write | Med | Partial identity file breaks every resolution downstream | temp + fsync + rename under store lock (REQ-2) | crash-injection fixture |
+| Parse-order corruption of the structured field | High | The generic `/^\[(.*)\]$/` + comma-split heuristic silently corrupts/truncates a JSON-shaped value (planner P5/P6: DEFAULT shape — every single-item value has ≥2 top-level commas; fail-open, exit 0) | `STRUCTURED_FIELDS` exception list checked before the generic array heuristic at both parse sites; field excluded from `ACTIVATION_ARRAY_FIELDS`; write side uses canonical `JSON.stringify`, never `serializeInlineArray` | `testCommaValueByteRoundTrip` (byte-for-byte, comma-containing value, ≥2 items) |
+| Cross-operation TOCTOU | Med | An identity rebind/detach lands between apply-fingerprint preview and write, or during migration | One per-store lockfile shared by identity writes, apply revalidation, and migration (§8.2 lock scoping) | `testRebindDuringApply`, `testDetachDuringApply`, `testRebindDuringMigration` |
+| Migration false-positive sweep | Med | A hand-authored episode carrying the `promoted-lesson` tag gets its `project` metadata rewritten by migration | §12 `selectMigrationCandidates` predicate (never tag-alone) + per-item confirm; non-matches surfaced in `skipped`, never silently swept | `testHandAuthoredTagNotSwept` |
+
+Path-authority note: no new realpath/symlink predicate ships in P2 — identity is
+episode-carried, not path-derived, which is the mitigation. Registration keeps the
+existing registered-stores realpath behavior for row keys (unchanged); the 8-axis
+symlink matrix is therefore not re-enumerated here. If review finds a new path
+predicate in the diff, that is a HOLD.
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/**
+ * @typedef {Object} SourceRef
+ * @property {string} store_id — 16 lowercase hex chars, or the reserved id 'global';
+ *   opaque, episode-carried, never a filesystem path
+ * @property {string} episode_id — episode id within that store
+ * @property {string} content_sha256 — SHA-256 (lowercase hex) over the episode file's
+ *   raw UTF-8 bytes with LF-normalized newlines
+ *
+ * @typedef {Object} StoreIdentity
+ * @property {string} active_id — terminal revision's store_id
+ * @property {string[]} aliases — superseded revisions' ids (retired, still resolvable)
+ * @property {string} root_id — episode id of the chain root
+ *
+ * Identity episode: category 'context', record_type 'store-identity',
+ * frontmatter scalar store_id; clone-detach root additionally carries
+ * detaches_identity_root: <inherited-root-episode-id>.
+ */
+```
+
+### 8.2 Key invariants
+
+- `promotion_sources` ≠ `evidence`. The evidence field's registered meaning (lesson→violation, earned priority) is frozen; probe A3 output is the frozen contract.
+- One active identity chain per store, always; every transition (mint, rebind, detach) is an episode write (P7), never an edit or deletion.
+- Registry mirror is derived state; the episodes are authoritative (P1: memory is the substrate).
+- Writer/rebuild/revise lockstep: any field one writes, the others round-trip (probe B2 shows the failure mode when they don't).
+- All new writes fail closed; all new advisories/resolutions surface problems in JSON (`missing_sources`), never silently drop.
+- **Lock scoping (planner GAP-2):** all P2 mutating operations on a store — identity mint/rebind/detach writes, apply fingerprint revalidation + write, migration items — take the SAME per-store lockfile path (the one `em-consolidate`'s clerk already passes to `scripts/lib/lock.mjs` for that store), so cross-operation pairs serialize by construction; `lock.mjs` itself guarantees no scoping (planner P10).
+- **Direct-write lock gap (GLM r1 finding 4, noted not folded into scope):** a direct `em-store --promotion-sources-json` write (REQ-7) goes through em-store's ordinary write path, which is non-atomic (`writeFileSync`, em-store.mjs:325) and unlocked today — GLM r1 captured a real `tags.json.tmp` rename race (`ENOENT` at em-store.mjs:277) from two concurrent em-store writes to one store. P2's apply path is lock-scoped (REQ-16); the direct-write path is NOT added to the scoped set in P2 (that would grow em-store's write path, out of slice scope). The gap is surfaced here so S4 and NAPMEM-C (which reuses the shape, §2) do not inherit it silently; the general em-store write-lock question is filed as a tracked issue at plan wrap (§18 step 9). The same deferral covers promote-run record writes (REQ-17, the post-per-candidate step in the §8.4 flow) and any other new em-store episode path P2 introduces — they are outside the §8.2 scoped set for the same reason, unless the builder gives `writePromoteRunRecord` a dedicated atomic writer (GLM r2 N1).
+- **Cross-platform:** `node:crypto` SHA-256, `os.tmpdir()`-free (temp files beside the target, same volume, for atomic rename); LF normalization handles CRLF checkouts; no shell-only constructs in tests (argv break-flags, not env prefixes).
+- **Atomicity:** identity writes = temp + fsync + rename under the store lock; apply writes revalidate fingerprints under the same lock.
+
+### 8.3 Serialization decision (probe-grounded)
+
+Frontmatter values are single-line strings; the index parser (`em-rebuild-index.mjs:86-105`)
+supports scalars and comma-split inline arrays only, and unknown fields are dropped
+(probe B2, 2026-07-16: a hand-written `promotion_sources` object-array vanished from the
+rebuilt row). Decision: `promotion_sources` is stored in frontmatter as one line of
+canonical JSON (`promotion_sources: [{"store_id":…,"episode_id":…,"content_sha256":…}]`,
+sorted keys, sorted items) and parsed with a field-specific `JSON.parse` branch added to
+both `parseActivationFromFrontmatter` (activation.mjs) and the rebuild parser — the first
+structured-value field in the schema, contained behind the two named parse sites.
+Malformed JSON in the field fails the rebuild loudly for that row (surfaced in
+`category_drift`-style output), never a silent drop.
+
+**Parse-order guard (planner GAP-1, BLOCKER-class — closed here).** The two parse
+sites differ (GLM r1 finding 2, aligning this prose with the planner's class-sweep
+table): `em-rebuild-index.mjs:parseFrontmatter` applies the generic `/^\[(.*)\]$/` +
+`.split(',')` heuristic to ANY bracket-shaped value (field-agnostic — planner probes
+P5/P6 demonstrated silent corruption/truncation with exit 0; today the corrupted value
+is then dropped because the lockstep carry-on omits the field, GLM probe G1);
+`activation.mjs:parseActivationFromFrontmatter` gates the same heuristic on
+`ACTIVATION_ARRAY_FIELDS` membership, so today it silently DROPS `promotion_sources`
+(GLM probe G2: a revision loses the field while tags survive) and would corrupt it only
+if the field were naively added to `ACTIVATION_ARRAY_FIELDS` — which REQ-7 forbids.
+The guard is structural, not per-field: `activation.mjs` exports
+`STRUCTURED_FIELDS = ['promotion_sources']`, and BOTH parsers check membership FIRST —
+a `STRUCTURED_FIELDS` key routes to `JSON.parse` before the generic array heuristic can
+run. `promotion_sources` is never added to `ACTIVATION_ARRAY_FIELDS`: that constant
+gates the vulnerable read path AND drives `serializeInlineArray` (em-store.mjs:297-301),
+a flat-scalar serializer unsafe for nested JSON. Write side serializes via canonical
+`JSON.stringify` only. Any future structured field joins `STRUCTURED_FIELDS`, inheriting
+the ordering guarantee instead of re-deciding it. The em-revise inherit path
+(em-revise.mjs:197-229) reads through the same guarded `parseActivationFromFrontmatter`,
+so inheritance is covered by the same fix. Round-trip is proven byte-for-byte by
+`testCommaValueByteRoundTrip` (comma-containing constituent string, ≥2 items) — the
+failure mode is silent, so only an equality assertion catches it.
+
+### 8.4 Resolution / flow
+
+```text
+mint:    store lacks identity chain → mintStoreIdentity() writes context episode (atomic) → active_id
+rebind:  em-revise on identity episode → successor revision → old id becomes alias
+detach:  copy detected/confirmed → single write: fresh root + detaches_identity_root → old chain inert in copy
+resolve: resolveStoreIdentity(storeDir) → {active_id, aliases}; resolveSourceRefs(refs, registry) → {resolved, missing}
+promote: em-promote collects sources → SourceRef[] (content-hash member keys) → preview + fingerprint
+apply:   --confirm <fp> per candidate → em-lock → re-fingerprint → em-store --promotion-sources-json → promote-run record
+migrate: legacy promoted episode → per-item confirm → successor via em-revise carrying typed provenance → run-record
+```
+
+## §9 Existing Hook Points
+
+Line anchors verified by scout reads 2026-07-16 (current main `ea94c4c`):
+
+| File | Line(s) | What it does today | Impact of this change |
+|---|---|---|---|
+| `scripts/em-promote.mjs` | 19-29, 118-133 | member key = `<id>#<sha8(summary)>`; replicas collapse before body read | REQ-12: key binds `content_sha256` |
+| `scripts/em-promote.mjs` | 316-328 | writes `## Sources` body + promotion with no confirm | REQ-11/16: typed field + confirm contract |
+| `scripts/em-promote.mjs` | 60, 205, 323 | `promoted:<sha8>` tag; `cross-project` sentinel | retired for new writes (REQ-11) |
+| `scripts/em-store.mjs` | 174-199 | activation-field validation incl. evidence gate | REQ-7 flag + validation added alongside |
+| `scripts/em-store.mjs` | 325 | direct `writeFileSync` episode write | unchanged for episodes; identity writer is separate + atomic (REQ-2) |
+| `scripts/em-revise.mjs` | 197-229 | inherits activation fields via `parseActivationFromFrontmatter` | REQ-7 inherit/override |
+| `scripts/em-rebuild-index.mjs` | 86-105, 190-224 | frontmatter parse + LOCKSTEP field round-trip | §8.3 JSON branch; REQ-4 duplicate-chain check |
+| `scripts/lib/activation.mjs` | 37-67, 72-73, 154-262, 274-295, 344-357 | value-char guards, field vocab, validators, `resolveLinkage` | new field vocab + guards; evidence path untouched |
+| `scripts/lib/protection.mjs` | 217-227 | clerk-run class-d arm | two mirrored arms (REQ-17/18) |
+| `scripts/lib/registered-stores.mjs` | 11-21 | realpath-based store identity | registration becomes identity-aware (REQ-6) |
+| `scripts/lib/install-version.mjs` | 362-470 | registry row upsert/prune | identity mirror + mint-on-next-registration (REQ-6) |
+| `plugins/_index.schema.json` | 33 | `learning` in type enum (literal at :33, def block ~:30-33), no slot | REQ-13 slot sub-schema |
+| `plugins/consumer-registry.schema.json` | 3-26 | closed versioned row schema | additive identity mirror bump (REQ-6) |
+| `scripts/em-trigger-index.mjs` | 182-221 | `effectivePriority` from evidence/lessons | READ-ONLY invariant — must not gain a `promotion_sources` read (REQ-8) |
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Key deliverables | Tests | Hard stops (do NOT do in this slice) |
+|---|---|---|---|---|---|
+| `P2-S1` | Store-identity chain end-to-end | NEW `scripts/lib/store-identity.mjs`; `scripts/lib/protection.mjs`; `scripts/em-rebuild-index.mjs`; `scripts/lib/registered-stores.mjs`; `scripts/lib/install-version.mjs`; `plugins/consumer-registry.schema.json`; NEW `tests/test-store-identity.mjs` | REQ-1..6, REQ-18 | mint/rebind/detach/alias/crash/duplicate/registry E2E | no `promotion_sources`, no em-promote changes |
+| `P2-S2` | `promotion_sources` typed field + content-hash identity | `scripts/em-store.mjs`; `scripts/em-revise.mjs`; `scripts/em-rebuild-index.mjs`; `scripts/lib/activation.mjs`; `scripts/em-promote.mjs`; NEW `tests/test-promotion-sources.mjs` | REQ-7..12 | round-trip, forge negatives, hash vectors, member-key fixtures | no apply/confirm changes, no registry slot |
+| `P2-S3` | `learning` registry slot + conformance gauntlet | `plugins/_index.schema.json`; NEW descriptor/IO schema files; `scripts/validate-plugin-registry.mjs`; `tests/test-em-promote.mjs` | REQ-13, REQ-14 | gauntlet (15 folded + RFC fixtures, EXCEPT the fingerprint-revalidation fixture — S4-gated, see §14 Group 5 note) | no behavior changes to em-promote beyond registration |
+| `P2-S4` | Assisted apply + run-record + migration + R2c closure | `scripts/em-promote.mjs`; `scripts/lib/protection.mjs`; NEW `tests/test-promote-apply.mjs` | REQ-15..17, REQ-19, REQ-20 | confirm/fingerprint/TOCTOU/migration/protection | no new fields, no registry changes |
+
+### 10.1 Dependency graph
+
+```text
+S1 ── S2 ── S3
+       └─── S4
+```
+
+S1→S2 hard (refs need store_id resolution). S2→S3 hard (gauntlet fixtures exercise both
+S1 and S2 semantics). S2→S4 hard (fingerprint = sorted SourceRef hash). S3 and S4 can
+interleave after S2.
+
+## §11 Cut Order
+
+1. S4 migration assist (REQ-15) — R2c can re-file §17-E with the 5-field justification if the deadline compresses; new writes are already typed after S2.
+2. S3 gauntlet consolidation into a separate file (fold into test-em-promote.mjs instead).
+
+Do **not** cut:
+
+- REQ-2/REQ-5 atomicity + crash fixtures (the codex acceptance ladder's P1-class findings).
+- REQ-8 forge negative (security invariant).
+- REQ-16 confirm + fingerprint revalidation (B-2 is a boundary invariant, not a feature).
+- The 2026-10-08 decision itself: if P2 cannot land, the charter path is REMOVE em-promote, not slip.
+
+## §12 Contracts
+
+### `mintStoreIdentity(storeDir, {reserved}) → {active_id, root_id}`
+
+**Input:** absolute store dir; `reserved` optional (`'global'` only).
+**Output:** minted identity; throws if an active chain already exists.
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. no chain | no `record_type: store-identity` episode | mint, atomic write | one context episode |
+| B. active chain exists | terminal revision active | `error: identity-exists` (exit 1) | none |
+| C. two active chains | duplicate roots | `error: duplicate-identity-chain` (exit 1) | none |
+| D. crash during write | temp exists, no rename | prior state observed; temp ignored/cleaned | none durable |
+
+### `resolveStoreIdentity(storeDir) → {active_id, aliases, root_id} | {error}`
+
+| State | Condition | Output |
+|---|---|---|
+| A. healthy chain | one root, terminal active | active + aliases |
+| B. no chain | none found | `{error: 'no-identity'}` (callers mint or surface) |
+| C. duplicate chains | two active roots | `{error: 'duplicate-identity-chain'}` — fail loud |
+| D. detached chain present | root referenced by a `detaches_identity_root` | excluded from active/aliases entirely |
+
+### `computeContentSha256(buf) → string`
+
+LF-normalize (`\r\n`→`\n`), SHA-256, lowercase hex. Pure.
+
+### `validatePromotionSources(value) → {ok} | {error, detail}`
+
+| State | Condition | Output | Fail mode |
+|---|---|---|---|
+| A. valid | array ≥1, every item exactly `{store_id, episode_id, content_sha256}`, hex/format rules pass | ok | — |
+| B. empty array | `[]` | `error: promotion-sources-empty` (omit the field instead) | closed |
+| C. bad shape | missing/extra keys, non-string | `error: promotion-sources-shape` naming the index | closed |
+| D. bad hex | `content_sha256` not 64 lowercase hex | `error: promotion-sources-hash` | closed |
+| E. illegal chars | control chars / newlines in any string | `error: promotion-sources-chars` | closed |
+| F. wrong category | `--promotion-sources-json` on non-lesson | `error: lesson-only` | closed |
+
+**Error codes** are exact strings, spelled verbatim in the slice §A.7 tables.
+
+### `writePromoteRunRecord(runMeta) → {id} | {error}` (planner GAP-3)
+
+**Input:** apply/migration run metadata (per-item outcomes, counts, fingerprints).
+**Output:** the run-record episode id; global-only, unconfirmed (REQ-20 write matrix).
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. normal run | global store writable | `record_type: promote-run` episode in GLOBAL store | one episode |
+| B. local-scope attempt | any non-global target | `error: run-record-global-only` (exit 1) | none (B-3) |
+| C. write failure | global store unreachable | error surfaced non-zero; completed apply writes stay durable (record failure never rolls back content, but is loud) | none |
+| D. empty run (GLM r1 finding 5) | zero confirmed writes — the empty run is two-sourced: migration (every item skipped by `selectMigrationCandidates`: `no-parseable-sources` / `not-global` / `superseded`) or apply (every candidate's fingerprint revalidation refused) | run-record still written with zero counts + ONE unified per-item list where each entry carries a source discriminator (`migration-skip` with its §12 reason, or `apply-refused`) — the refusals ARE the operational record (GLM r2 N2) | one episode |
+
+### `selectMigrationCandidates(rows) → {candidates, skipped}` (planner GAP-3)
+
+**Predicate (ALL required, never tag-alone):** category `lesson` AND global store AND
+tags include `promoted-lesson` AND tags include a `promoted:<sha8>` member AND status
+`active` AND body contains a `## Sources` section parseable to ≥1 source line.
+
+| State | Condition | Output |
+|---|---|---|
+| A. full match | all predicate legs pass | candidate (still needs per-item confirm) |
+| B. tag-only hand-authored | `promoted-lesson` tag, no parseable `## Sources` | `skipped` with reason `no-parseable-sources` — never swept |
+| C. project-store episode | any legs pass but store is a project store | excluded, `skipped` reason `not-global` (B-3) |
+| D. superseded | status not `active` | `skipped` reason `superseded` (chain already handled) |
+
+## §13 Edge Cases
+
+| # | Scenario | Expected behavior | Test |
+|---|---|---|---|
+| EC1 | empty/whitespace `promotion_sources` value | reject, fail-closed (state B/C) | `testEmptySourcesReject` |
+| EC2 | store dir relocated (identity episode travels) | active_id unchanged post-move; registry re-registration rebinds row, id stable | `testRelocationIdStable` |
+| EC3 | concurrent apply / concurrent mint | lock serializes; second observes first (refuse or no-op with surfaced reason) | `testConcurrentApplySecondRefuses`, `testConcurrentMintSingleChain` |
+| EC4 | crash mid-identity-write / mid-migration item | prior state intact; run-record marks item outcome | crash fixtures |
+| EC5 | empty identity in verification diff | non-empty post-strip required, else `unverifiable` | migration verify path |
+| EC6 | validate-then-write ordering | all validation (shape, category, fingerprint) precedes any write | `negative: bad input leaves zero files` |
+| EC7 | cyclic `detaches_identity_root` fixtures | resolution terminates, fails loud | `testDetachCycleTerminates` |
+| EC8 | CRLF checkout of a source episode | `content_sha256` identical to LF copy | `testCrlfLfIdentical` |
+| EC9 | registry row pruned (path missing) while its store's alias is referenced | resolution surfaces missing-source; no crash | `testPrunedRowMissingSource` |
+| EC10 | legacy promoted episode with `promoted:<sha8>` tag encountered by new code pre-migration | read path tolerates; no rewrite without REQ-15 confirm | `testLegacyToleratedUntilMigrated` |
+| EC11 | `promotion_sources` value whose constituent string contains a comma, array ≥2 items | byte-for-byte round-trip through store → rebuild → revise-inherit (silent-corruption class, planner P5/P6) | `testCommaValueByteRoundTrip` |
+| EC12 | identity rebind or detach concurrent with apply or migration | serialized by the shared per-store lock (§8.2); the later holder re-resolves identity and re-fingerprints | `testRebindDuringApply`, `testDetachDuringApply`, `testRebindDuringMigration` |
+| EC13 | hand-authored episode with `promoted-lesson` tag but no parseable `## Sources` | `skipped: no-parseable-sources`, project metadata untouched | `testHandAuthoredTagNotSwept` |
+
+## §14 Test Case Catalog
+
+```text
+Group 1: store-identity chain (S1, ~12 tests)
+  testMintIdentity / testGlobalReservedId / testIdNeverPath
+  testIdentityWriterAtomic + crash-injection negative
+  testActiveIsTerminal / testAliasResolution / testPreRebindRefsResolve
+  testDuplicateChainFailsLoudBuild / testCloneDetachSingleWrite
+  testDetachedChainNoAliases / testDetachCycleTerminates / testConcurrentMintSingleChain
+
+Group 2: registration mirror (S1, ~5 tests, isolated-HOME mock-project E2E)
+  testRegistryMirror / testMintOnNextRegistration / testAmbiguousAliasFailsLoud
+  testCopiedStoreRejected / testDuplicateChainFailsLoudRegistration / testRelocationIdStable
+
+Group 3: promotion_sources field (S2, ~12 tests)
+  testPromotionSourcesWrite / testPromotionSourcesRoundTrip / testReviseInherit
+  testCommaValueByteRoundTrip (EC11 — byte-for-byte, silent-corruption class)
+  testEmptySourcesReject + shape/hex/chars negatives
+  testNoEarnedPriorityForge / testEvidenceGateUnchanged
+  testContentShaVector / testCrlfLfIdentical
+
+Group 4: member identity (S2, ~4 tests)
+  testSameIdSummaryDiffBodyDistinct / testReplicaCollapseOnHashMatch
+  testNewPromotionTyped / testNoSentinelOnNewWrites
+
+Group 5: learning registry + gauntlet (S3)
+  testLearningSlotSchema / testRegistryValidates + descriptor negatives
+  gauntlet = 15 existing folded + RFC-012:59 fixture list (REQ-14)
+  NOTE (GLM r1 finding 1): the RFC-012:59 fixture "post-preview source substitution
+  fails fingerprint revalidation" exercises REQ-16 (S4) and CANNOT pass in S3 (S3's
+  hard stop forbids apply/confirm behavior). It is registered in the S3 gauntlet
+  scaffold as an explicit skip naming REQ-16/S4, and enabled (must pass) in S4 —
+  it is the same assertion as Group 6's testFingerprintRevalidation. "Gauntlet
+  green" as a graduation criterion is phase-end (§18), not an S3 exit criterion;
+  S3 exits with all non-apply fixtures green + the one named skip.
+
+Group 6: apply/run-record/migration (S4, ~14 tests)
+  testApplyRequiresConfirm / testFingerprintRevalidation / testConcurrentApplySecondRefuses
+  testRebindDuringApply / testDetachDuringApply / testRebindDuringMigration (EC12)
+  testPromoteRunRecord / testPromoteRunProtectionArm / testIdentityProtectionArm
+  testMigrationSuccessors / testMigrationRunRecord / testPriorIdsPersist / testWriteMatrix
+  testHandAuthoredTagNotSwept (EC13)
+  testUnresolvedAliasSurfaces / testMissingNeverSilent / testPrunedRowMissingSource
+  testLegacyToleratedUntilMigrated
+```
+
+Total: ~45 tests + the folded 15. Runners: `node tests/test-store-identity.mjs`,
+`node tests/test-promotion-sources.mjs`, `node tests/test-em-promote.mjs`,
+`node tests/test-promote-apply.mjs`. Every §4 MUST maps bijectively into these groups.
+Mock-project E2E (Group 2) uses isolated `HOME` + the real `install.mjs` — never
+mental-trace (standing repo rule).
+
+## §15 Verification Ledger (verify by artifact)
+
+Filled at implementation time per slice. Claims and their strong-layer commands:
+
+| Claim | Command (the strong-layer one) | Observed artifact |
+|---|---|---|
+| Slice tests pass | `node tests/test-<slice>.mjs` | _pending_ |
+| Existing suites stay green | `node tests/test-em-promote.mjs` (and CI via `gh pr checks`) | _pending_ |
+| Forge invariant holds | `node tests/test-promotion-sources.mjs --only testNoEarnedPriorityForge` (runtime proof: lesson with promotion_sources naming violations → effective_priority = stored); `grep -n promotion_sources scripts/em-trigger-index.mjs` → 0 matches stays as the cheap secondary guard (GLM r1 finding 3: grep alone misses renamed bindings) | _pending_ |
+| Evidence gate frozen | fixture-store probe (A3 rerun) → identical rejection JSON | _pending_ |
+| Registry E2E | isolated-HOME mock + real `install.mjs`, read actual registry JSON | _pending_ |
+| Deploys clean | `node tools/deploy-audit.mjs` (unfiltered) | _pending_ |
+| Merged | `gh pr view <n> --json state,mergeCommit` | _pending_ |
+
+Plan-time artifacts already captured (2026-07-16, fixture store
+`scratchpad/p2fix`): probe A3 = evidence wrong-category rejection JSON verbatim; probe
+B2 = `promotion_sources` silently dropped by rebuild (field absent from index row).
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| First structured frontmatter value destabilizes parsers | High | Med | contained to two named parse branches (§8.3); loud per-row failure; round-trip tests both directions |
+| Identity semantics regress a chain-walker (three exist: em-search, em-trigger-index, protection.mjs) | Med | Med | identity chain uses the SAME supersedes mechanics those walkers already handle; gauntlet asserts after rebuild; no walker consolidation in P2 (noted §17) |
+| MiniMax builder mis-implements atomic write | Med | Med | crash-injection fixture is falsifiable (§A.6b); orchestrator re-verifies on disk |
+| Registry backfill breaks existing consumers | Med | Low | additive bump; mint-on-next-registration is lazy; mock-project E2E on upgrade path |
+| Deadline compression | High | Low | cut order §11; S1+S2 alone retire the EXPERIMENTAL blockers' core |
+
+## §17 Open Decisions
+
+- **Chain-walker consolidation** (three near-identical walkers) → deferred, not P2 scope; surfaced for a future curation issue after S1 lands (file at S1 wrap with 5-field justification if the gauntlet exposes divergence).
+- **#535 curation-enum drift** → separate PR, not folded (§5); already tracked.
+- All RFC-012 OQs touching P2 are closed (OQ-6, RFC-012:323); no new open decisions introduced by this plan.
+
+## §18 Done Criteria
+
+- [ ] All §4 MUST rows green with named tests.
+- [ ] Conformance gauntlet green — **phase-end criterion, asserted after S4** (the fingerprint-revalidation fixture is S4-gated per §14 Group 5 note; GLM r1 finding 1); `em-promote` registered under `learning`; `validate-plugin-registry` exit 0.
+- [ ] #478 closed with the REQ-19 disposition map (or residuals re-filed 5-field).
+- [ ] RFC-012 `## Implementation` ledger P2 row filled same-PR as the last slice.
+- [ ] Post-merge deploy per standing rules (global install + consumer refresh + unfiltered audit).
+- [ ] Every deferred finding has an issue/comment/violation artifact (Rule 18 step 9).
+
+## §19 Review Consensus (Rule 18)
+
+Reviewer seats per playbook v4: `negative-scenario-planner` (pre-review, §7) →
+pi/GLM-5.2 neuralwatt plan review on the frozen draft (pre-authorized) → fold →
+GLM r2. Codex single-round on the S1 security surface only if warranted
+(#538 blocks codex consensus loops; single dispatch + manual read is the workaround).
+Complete-class handoff: reviewers get the invariant list (§8.2), the negative matrix
+(§7/§13), false-positive controls, and the refactor boundary (§5 non-goals).
+
+| Pass | Reviewer | Provider/Model | Blocker count | Verdict | Reply artifact |
+|---|---|---|---|---|---|
+| 0 | negative-scenario-planner | sonnet subagent | 1 BLOCKER + 2 MAJOR + 1 NIT | HOLD → folded same-session | `.review-store/rfc-012-p2/negative-scenario-r1.md` |
+| 1 | plan review | pi/GLM-5.2 (neuralwatt) | 0 BLOCKER + 1 MAJOR + 5 MINOR + 1 NIT | HOLD-1 → all 7 folded same-session (§19.2) | `.review-store/rfc-012-p2/glm-plan-r1.md` |
+| 2 | plan re-review (folds + new surface) | pi/GLM-5.2 (neuralwatt) | 0 BLOCKER + 2 NIT | ACCEPT — 7/7 folds verified CLOSED; both NITs folded same-session (§19.2b) | `.review-store/rfc-012-p2/glm-plan-r2.md` |
+
+### 19.2 GLM r1 fold map (all ACCEPT)
+
+| # | Finding | Severity | Fold location |
+|---|---|---|---|
+| 1 | S3 gauntlet lists the fingerprint-revalidation fixture but it needs REQ-16 (S4) | MAJOR | §10 S3 tests cell; §14 Group 5 note (explicit S4-gated skip); §18 gauntlet criterion marked phase-end |
+| 2 | §8.3 prose overstated the activation.mjs site (field-gated, drops today; corrupts only if naively added) | MINOR | §8.3 parse-order-guard paragraph rewritten per-site, citing GLM probes G1/G2 |
+| 3 | §15 forge row cited grep (weak layer) over the runtime test | MINOR | §15 row now leads with `testNoEarnedPriorityForge`, grep demoted to secondary guard |
+| 4 | §8.2 lock set omits direct `--promotion-sources-json` writes (real `tags.json.tmp` race captured) | MINOR | §8.2 new direct-write lock-gap bullet; em-store write-lock class filed as tracked issue at plan wrap (§18 step 9) |
+| 5 | §12 `writePromoteRunRecord` lacked an empty-run state | MINOR | §12 state D added (zero confirmed writes → record with zero counts + skipped list) |
+| 6 | Altitude ACCEPT but needed an explicit escalation trigger | MINOR | §1 altitude escalation trigger (S1 crash fixture / S2 EC11 first-attempt failure → higher-altitude seat for that slice) |
+| 7 | `_index.schema.json:31` → `:33` anchor drift | NIT | §2 + §9 corrected |
+
+### 19.2b GLM r2 fold map (ACCEPT round; both NIT)
+
+| # | Finding | Severity | Fold location |
+|---|---|---|---|
+| N1 | §8.2 direct-write bullet named `--promotion-sources-json` only; promote-run record writes (REQ-17) share the same unlocked em-store path | NIT | §8.2 bullet extended: promote-run + any new P2 em-store episode path fall under the same tracked-issue deferral, or the builder pins a dedicated atomic writer |
+| N2 | §12 state D conflated migration skip-reasons and apply refusals in one parenthetical | NIT | §12 state D rewritten two-sourced; run-record content pinned to ONE unified per-item list with a source discriminator (`migration-skip` reason / `apply-refused`) |
+
+### 19.1 Resolved blockers
+
+| # | Blocker (cite R-number) | Verdict | Resolution + evidence |
+|---|---|---|---|
+| 1 | GAP-1 parse-order corruption of `promotion_sources` (R2a, REQ-7; planner P5/P6: generic bracket regex + comma-split is fail-open on JSON-shaped values) | ACCEPT | §8.3 parse-order guard: `STRUCTURED_FIELDS` checked first at both parse sites; field barred from `ACTIVATION_ARRAY_FIELDS` (read gate + `serializeInlineArray` both unsafe); `testCommaValueByteRoundTrip` (EC11); §7 row added |
+| 2 | GAP-2 cross-operation TOCTOU pairs unenumerated (R2a/R2d, REQ-16; planner P10: lock.mjs has no scoping contract) | ACCEPT | §8.2 lock-scoping invariant: one shared per-store lockfile for identity writes, apply revalidation, migration; EC12 + three named fixtures |
+| 3 | GAP-3 missing §12 contracts for promote-run writer and migration selection (R2c/R2d, REQ-15/17) | ACCEPT | §12 `writePromoteRunRecord` + `selectMigrationCandidates` state tables; predicate is never tag-alone; `testHandAuthoredTagNotSwept` (EC13) |
+| 4 | NIT line drift em-store.mjs:324 vs 325 | ACCEPT | REQ-2 note + §9 row corrected to 325 |
+
+### 19.3 S1 A.7-authoring deltas (2026-07-18, pre-build; anchors re-verified on main `ea94c4c`, zero drift)
+
+Decisions the §A.7-S1 table pins beyond the reviewed plan body — recorded here per the
+§1 appendix cadence (each is inside the reviewed design's boundaries; none reopens a fold):
+
+1. **REQ-18's test ships in S1.** §10 assigns REQ-18 + `protection.mjs` to S1, while §14
+   listed `testIdentityProtectionArm` under Group 6 (S4). S1 implements arm + test
+   (`identity::testIdentityProtectionArm` in `tests/test-store-identity.mjs`); the Group 6
+   entry becomes a cross-reference, not a second implementation.
+2. **Catalog names concretized.** §14's `+ crash-injection negative` rows are named tests:
+   `identity::testIdentityWriterCrashNegative`, `identity::testCrashBeforeDetachInheritedIntact`;
+   added `identity::testIndexCarriesIdentityFields` (the §8.2 writer/rebuild lockstep
+   invariant applied to the two new identity fields). S1 total = 22 tests (16 + 6).
+3. **The identity lib is fully synchronous.** `lock.mjs` blocking `acquire` is async; an
+   async identity lib would ripple `upsertRegistryEntries` → `updateConsumers` →
+   `install.mjs` into async signatures. Instead: sync `tryAcquire` retry loop with an
+   `Atomics.wait` 100ms sleep (busy-loop fallback), 30s deadline, `{ error: 'lock-timeout' }`.
+   Same lockfile as the clerk (`<store>/clerk-apply.lock`, em-consolidate.mjs:439) per §8.2.
+4. **Exact code/string set pinned** (§A.5-S1): lib errors `no-identity` / `identity-exists` /
+   `duplicate-identity-chain` / `identity-chain-cycle` (EC7, both cycle classes) /
+   `reserved-id-invalid` / `lock-timeout` / `break-identity-write`; registration throws
+   `copied-store-rejected` / `ambiguous-alias-ownership` / `duplicate-identity-chain:` /
+   `identity-mint-failed:`; protection reason `store-identity-chain`; registry mirror row
+   fields `store_id` / `store_aliases`; `resolveStoreIdentity` returns additive
+   `terminal_episode_id` (rebind needs the terminal's episode id, §12 typedef unchanged).
+5. **Registry contract bump = `schema_version: 2`** (`writeRegistry` literal + schema const
+   + two optional row fields). `readRegistry` is version-agnostic by existing design
+   (shape-filters entries only, install-version.mjs:336-352), so v1 registries and the six
+   v1-writing test fixtures keep reading; the next write upgrades in place.
+   Fixture-change ledger: `tests/test-consumer-registry-schema.mjs` is the ONLY suite
+   asserting the const (4 line edits, §A.7 step 1.12) — grep-enumerated 2026-07-18.
+6. **Mirror choke point = `upsertRegistryEntries`** (both call sites: install.mjs:3596,
+   updateConsumers install-version.mjs:602). Fail-loud collisions throw and abort the
+   registry write; install.mjs's existing try/catch surfaces the message as a loud
+   WARNING while the install itself completes — the bad store gets no row (REQ-6
+   "rejected at registration"). Missing/vanished store dirs skip mirroring (degrade;
+   mirror is derived, never authoritative).
+
+## §20 Lessons Encoded
+
+| Lesson | One-line rule | Enforced in |
+|---|---|---|
+| `…a480` fold-text claims | every behavior claim cites a probe or verified file:line | §2, §8.3, §15 |
+| probe B2 (this plan) | lockstep entries are load-bearing; unknown frontmatter silently drops | REQ-7, §8.3 |
+| `…09f3` APC impl HOLD | clone-store false positive + Sources injection → content-hash identity + typed field | REQ-12, §7 |
+| `…16c4`/`…937a` symlink class | no new path-authority predicate in P2; identity is episode-carried | §7 |
+| verify-before-conclude | ledger rows filled from observed output at impl time | §15 |
+| bp1 step-9 5-field DEFER | #478 closure carries per-residual dispositions | REQ-19, §17 |
+| mock-project not mental-trace | registry behavior proven via isolated-HOME + real install.mjs | §14 Group 2 |
+| `…a2aa` stopping rule | 2 review rounds cap; 3rd HOLD on same class = redesign boundary | §19 |
+| planner r1 P5/P6 (this plan) | generic bracket-array heuristics are fail-open on JSON-shaped values; structured fields need a checked-first exception list, not per-field patches | §8.3, REQ-7, EC11 |
+
+---
+
+# Appendix A: Mechanical Execution Spec
+
+Per §1, §A.7 step tables are authored per-slice at slice start (anchors re-verified
+against then-current main); §A.0–§A.6b below are fixed for the whole phase.
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value for this plan |
+|---|---|
+| Language / runtime | Node.js 20+, `.mjs` ESM, zero deps |
+| Runtime check | `node --version` → `v20` or higher |
+| Test-runner shape | `node tests/test-<slice>.mjs` |
+| New-function phrasing | `export function fnName(args)` |
+| Portable break-input override | argv flag (e.g. `node tests/test-store-identity.mjs --break-identity-write`) — never env prefix |
+| Search tool for verifies | `grep -c` / `grep -n` from repo root |
+| Repo-specific done-commands | `node tools/deploy-audit.mjs`; `node scripts/validate-plugin-registry.mjs` |
+
+## A.1 Forbidden-phrase lint
+
+Run per slice before marking its §A.7 table ready:
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/rfc-012-p2.md
+```
+
+Disposition rule per template §A.1: matches inside §A.5/§A.7 blocks fail; template-prose
+and §17-Open-Decisions matches are recorded and passed.
+
+## A.2–A.6b
+
+The executor contract, STOP protocol, pre-flight check, anchor format, and falsifiable
+verify rules are adopted verbatim from `docs/PLAN_TEMPLATE.md` §A.2–§A.6b (this repo's
+canonical copy; re-read from disk at each slice start). Slice-specific constants (§A.5)
+and step tables (§A.7) are appended below per slice, each with its own §A.4 pre-flight
+row set and §A.8 done block.
+
+## A.7 Per-slice step tables
+
+_S1 table: authored 2026-07-18 after plan approval (anchors re-verified against main
+`ea94c4c`, zero drift — scout sweep). S2–S4: at each slice start._
+
+### §A.5-S1 Slice constants (verbatim, `scripts/lib/store-identity.mjs`)
+
+```js
+export const STORE_IDENTITY_RECORD_TYPE = 'store-identity'
+export const GLOBAL_STORE_ID = 'global'
+export const STORE_ID_RE = /^([0-9a-f]{16}|global)$/
+// §8.2 lock scoping: the SAME per-store lockfile the clerk uses (em-consolidate.mjs:439)
+const LOCK_BASENAME = 'clerk-apply.lock'
+const LOCK_TIMEOUT_S = 30
+const TMP_SUFFIX = '.tmp-identity'
+// §A.0 break-input override (REQ-2 negative): argv flag on the INVOKING process —
+// same mechanism as em-rebuild-index.mjs BREAK_REBUILD_WHITELIST (line 28 precedent).
+const BREAK_IDENTITY_WRITE = process.argv.includes('--break-identity-write')
+```
+
+**Exact error codes (S1 complete set).** Lib return objects (`{ error: <code> }`):
+`no-identity`, `identity-exists`, `duplicate-identity-chain`, `identity-chain-cycle`
+(EC7 — BOTH cycle classes: mutual `detaches_identity_root` roots AND a `supersedes`
+cycle), `reserved-id-invalid`, `lock-timeout` (from `lib/lock.mjs`),
+`break-identity-write` (break-flag path only). Registration layer (thrown
+`Error.message`, `install-version.mjs`): `copied-store-rejected: <id> at <dirA> + <dirB>`,
+`ambiguous-alias-ownership: <id> at <dirA> + <dirB>`, `duplicate-identity-chain: <project_path>`,
+`identity-mint-failed: <code> at <dir>`. Protection reason string: `store-identity-chain`.
+Registry mirror row fields: `store_id`, `store_aliases` (optional, additive).
+
+**Identity episode frontmatter (exact line set, in this order):** `---`, `id: <id>`,
+`date: <YYYY-MM-DD>`, `time: "<HH:MM>"`, `project: <project>`, `category: context`,
+`status: active`, `tags: [store-identity]`, `summary: <summary>`,
+`record_type: store-identity`, `store_id: <store_id>`, optional
+`supersedes: <episode-id>` (rebind successor), optional
+`detaches_identity_root: <episode-id>` (detach root), `---`. Episode id shape:
+`<YYYYMMDD>-<HHMMSS>-store-identity-<first 4 chars of store_id>`.
+
+**Sync design (blast-radius decision, §19.3 item 3):** the lib is fully SYNCHRONOUS.
+Locking uses `tryAcquire` (sync) in a bounded retry loop with
+`Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100)` as the 100ms
+sync sleep (busy-loop fallback in a try/catch), 30s deadline → `{ error: 'lock-timeout' }`.
+This keeps `upsertRegistryEntries` / `updateConsumers` and their install.mjs call
+sites synchronous — no async ripple.
+
+### §A.4-S1 Pre-flight (step 1.0)
+
+| Check | Command | Expected |
+|---|---|---|
+| On the right branch | `git branch --show-current` | `feat/rfc-012-p2-s1` |
+| No modified tracked files beyond the pre-existing pair | `git diff --stat` | ONLY `.claude/skills/episodic-memory/SKILL.md` and `.gitignore` (pre-arc working-tree state, NOT slice files — never touch, never stage); any OTHER file listed → STOP |
+| Baseline suite green | `node tests/test-em-promote.mjs` | all pass, exit 0 |
+| Baseline suite green | `node tests/test-registered-stores.mjs` | all pass, exit 0 |
+| Runtime | `node --version` | `v20` or higher |
+
+### `P2-S1` — Store-identity chain end-to-end (REQ-1..6, REQ-18)
+
+**Files this slice may touch:** `scripts/lib/store-identity.mjs` (NEW),
+`tests/test-store-identity.mjs` (NEW), `scripts/em-rebuild-index.mjs`,
+`scripts/lib/protection.mjs`, `plugins/consumer-registry.schema.json`,
+`scripts/lib/install-version.mjs`, `scripts/lib/registered-stores.mjs`,
+`tests/test-consumer-registry-schema.mjs`, `.github/workflows/plan-marker-validate.yml`.
+**Read-only:** `scripts/lib/lock.mjs`, `scripts/lib/local-dir.mjs`, `scripts/em-store.mjs`,
+`install.mjs`, `scripts/em-consolidate.mjs`. **Hard stops:** no `promotion_sources`
+anywhere; `scripts/em-promote.mjs`, `scripts/em-store.mjs`, `scripts/em-revise.mjs`
+untouched.
+
+| Step | File | Kind | Exact action (anchor + literal change) | Verify (observed → expected) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4-S1. | every row passes |
+| 1.1 | `scripts/lib/store-identity.mjs` | **CREATE** | Whole file: header comment (`// store-identity.mjs — RFC-012 P2 S1 (REQ-1..6): episode-carried store identity.\n// Chain mechanics are P7 supersedes revisions written by THIS lib's atomic writer\n// (temp + fsync + rename under the shared per-store lock, §8.2) — never em-store's\n// non-atomic path. Zero deps: node stdlib + ./lock.mjs only.`); imports `fs`/`path`/`crypto` (node: prefix) + `{ tryAcquire, release } from './lock.mjs'`; the §A.5-S1 constants verbatim. Internal helpers: `sleepSync(ms)` (Atomics.wait sleep, busy-loop fallback); `withStoreLockSync(storeDir, fn)` — lockFile = `path.join(storeDir, LOCK_BASENAME)`, retry `tryAcquire` every 100ms to a 30s deadline → `{ error: 'lock-timeout' }`, else `try { return fn() } finally { release(handle) }`; `parseIdentityFrontmatter(content)` — match `/^---\n([\s\S]*?)\n---/`, per line `/^(\w+): (.*)$/`, strip paired quotes, return null unless `record_type === 'store-identity'` AND `STORE_ID_RE.test(store_id)`, else `{ id, store_id, supersedes, detaches_identity_root, status }`; `listIdentityEpisodes(storeDir)` — readdir `<storeDir>/episodes/*.md` (missing dir → `[]`), parse each, keep non-null; `newEpisodeId(storeId, now = new Date())` — local-time `<YYYYMMDD>-<HHMMSS>-store-identity-<storeId.slice(0,4)>`; `identityEpisodeContent(fields)` — the §A.5-S1 exact frontmatter line set + body `\n# <summary>\n\n<bodyLine>\n`; `writeIdentityEpisodeAtomic(episodesDir, id, content)` — mkdirSync recursive; best-effort unlink of every stale `*${TMP_SUFFIX}` in episodesDir; tmp = `path.join(episodesDir, '.' + id + '.md' + TMP_SUFFIX)`; `openSync(tmp, 'w')` + `writeSync` + `fsyncSync` + `closeSync`; `if (BREAK_IDENTITY_WRITE) return { error: 'break-identity-write' }` (temp left staged, NO rename); `renameSync(tmp, path.join(episodesDir, id + '.md'))`; `{ ok: true }`. Exports: `resolveStoreIdentity(storeDir)` — eps empty → `{ error: 'no-identity' }`; roots = eps whose `supersedes` is absent or names no identity episode; detachedRootIds = Set of all `detaches_identity_root` values; activeRoots = roots not in detachedRootIds; `0` active with eps present → `{ error: 'identity-chain-cycle' }`; `>1` → `{ error: 'duplicate-identity-chain' }`; walk successors (`ep.supersedes === memberId`) from the single active root with a visited Set (revisit → `{ error: 'identity-chain-cycle' }`); exactly one member with no successor = terminal, else `{ error: 'duplicate-identity-chain' }`; return `{ active_id: terminal.store_id, aliases: <chain-order store_ids of non-terminal members>, root_id: <active root episode id>, terminal_episode_id: terminal.id }`. `mintStoreIdentity(storeDir, { reserved } = {})` — `reserved` defined and ≠ `GLOBAL_STORE_ID` → `{ error: 'reserved-id-invalid' }`; under lock: resolve; ok → `{ error: 'identity-exists' }`; `duplicate-identity-chain`/`identity-chain-cycle` → pass through; else mint `store_id = reserved \|\| crypto.randomBytes(8).toString('hex')`, `project` = `'global'` when reserved else `path.basename(path.dirname(storeDir)) \|\| 'store'`, summary `Store identity <store_id>`, bodyLine `Store identity root for this episode store (RFC-012 P2 REQ-1). store_id is opaque and episode-carried; rebind via successor revision, never an edit (P7).`; atomic write; → `{ active_id, root_id }`. `rebindStoreIdentity(storeDir)` — under lock: resolve (error → pass through); fresh 16-hex `store_id`; successor episode with `supersedes: <terminal_episode_id>`, summary `Store identity rebind <store_id>`; atomic write; → `{ active_id, prior_id: <old active>, root_id }`. `detachStoreIdentity(storeDir)` — under lock: resolve (error → pass through); fresh 16-hex `store_id`; fresh ROOT episode (no supersedes) with `detaches_identity_root: <root_id of inherited chain>`, summary `Store identity detach <store_id>`; atomic write; → `{ active_id, detached_root_id }`. | `node --input-type=module -e "const m = await import('./scripts/lib/store-identity.mjs'); console.log(typeof m.mintStoreIdentity, typeof m.resolveStoreIdentity, typeof m.rebindStoreIdentity, typeof m.detachStoreIdentity, m.GLOBAL_STORE_ID)"` → `function function function function global` |
+| 1.2 | `tests/test-store-identity.mjs` | **CREATE** | 22 tests, two groups, born partially RED (§A.9). Structural model: `tests/test-em-promote.mjs` `mkWorld` fixture style + the RFC-009-P4 `--only` idiom copied verbatim (`ONLY_FLAG` + `t(name, fn)` from `tests/test-rfc-009-p4-apply.mjs:53-58`; names namespaced `identity::…` / `registry::…`). Zero deps. Fixtures: `fs.mkdtempSync(path.join(os.tmpdir(), 'store-identity-'))`, realpath'd; scratch `HOME`+`USERPROFILE` for every spawn; every seeding write via real scripts with explicit `--scope local`. Helpers: `mkStore()` (root + `.episodic-memory/episodes`); `handRoot(dir, storeId, extra)` writes an identity episode file verbatim (for duplicate/cycle/alias forgeries); `childMint(dir, flags)` spawns `node --input-type=module -e "const m = await import(pathToFileURL); console.log(JSON.stringify(await m.mintStoreIdentity(process.argv[1])))" <dir> [--break-identity-write]` capturing stdout JSON; `runInstall(projectDir, home)` spawns REAL `node install.mjs --tool claude-code` with `cwd: projectDir`, `env: { ...process.env, HOME: home, USERPROFILE: home }` (isolated-HOME mock-project E2E, §14 Group 2); `readRegistry(home)` parses `<home>/.episodic-memory/installs.json`. **Group 1** (in-process lib + spawned rebuild/protection): `identity::testMintIdentity` — mint → `active_id` matches `/^[0-9a-f]{16}$/`, `root_id` matches `/^\d{8}-\d{6}-store-identity-/`, resolve returns same `active_id`, episode file content includes the exact lines `record_type: store-identity` and `store_id: <active_id>`; `identity::testGlobalReservedId` — `mint(dir, { reserved: 'global' })` → `active_id === 'global'`, file carries `store_id: global` + `project: global`; `identity::testIdNeverPath` — two stores → distinct ids, both 16-hex, `id.includes(path.sep) === false`; `identity::testIdentityWriterAtomic` — post-mint: zero `*.tmp-identity` files remain, resolve ok; `identity::testIdentityWriterCrashNegative` — `childMint(dir, ['--break-identity-write'])` → child JSON `{"error":"break-identity-write"}`, episodes/ has ZERO `.md`, exactly one `*.tmp-identity` staged, resolve → `no-identity`; then in-parent mint (no flag) → ok AND zero `*.tmp-identity` remain (stale sweep); `identity::testActiveIsTerminal` — mint then rebind → resolve `active_id === rebind.active_id ≠ mint.active_id`; `identity::testAliasResolution` — mint id0, rebind → id1, rebind → id2 → `active_id === id2`, `aliases` deep-equals `[id0, id1]`; `identity::testPreRebindRefsResolve` — post-rebind `aliases.includes(pre-rebind active_id) === true`; `identity::testDuplicateChainFailsLoudBuild` — `handRoot` × 2 (distinct ids, no supersedes) then spawn `node <repo>/scripts/em-rebuild-index.mjs --scope local` (cwd = project, scratch HOME) → exit code `1`, stdout JSON `{"status":"error","error":"duplicate-identity-chain","scope":"local"}`, and `index.jsonl` NOT created (EC6); `identity::testCloneDetachSingleWrite` — mint+rebind in A, `fs.cpSync(A, B, { recursive: true })`, `detachStoreIdentity(B)` → `detached_root_id === <A chain root episode id>`, resolve(B) `active_id === fresh`, `aliases.length === 0`, identity-episode file count in B = A's + 1; `identity::testCrashBeforeDetachInheritedIntact` — copy store, spawn detach child with `--break-identity-write` → no new `.md`, resolve(copy).`active_id` === donor's (inherited chain intact); `identity::testDetachedChainNoAliases` — post-detach: donor's active + aliases all ∉ resolve(B).aliases and ≠ active_id; `identity::testDetachCycleTerminates` — two hand roots, each `detaches_identity_root` naming the other's id → resolve returns `{ error: 'identity-chain-cycle' }` (plain sync return = termination proof); `identity::testConcurrentMintSingleChain` — two simultaneous `childMint` (Promise.all on child spawns) → exactly one `{active_id}`, one `{"error":"identity-exists"}`, resolve healthy; `identity::testIdentityProtectionArm` — import `computeProtectedIds` from `../scripts/lib/protection.mjs`; rows `[{ id: 'idr1', category: 'context', status: 'active', record_type: 'store-identity' }, { id: 'plain1', category: 'context', status: 'active' }]` → `map.get('idr1').reason === 'store-identity-chain'` AND `map.has('plain1') === false` (both polarities); `identity::testIndexCarriesIdentityFields` — mint+rebind+detach then spawn rebuild → every identity row in `index.jsonl` carries `store_id` equal to its file's frontmatter value; the detach row carries `detaches_identity_root` (lockstep §8.2). **Group 2** (real install.mjs E2E): `registry::testRegistryMirror` — fresh project, `runInstall` → its registry row `store_id` matches `/^[0-9a-f]{16}$/` AND equals `resolveStoreIdentity(<project store>).active_id`; registry file `schema_version === 2`; `registry::testMintOnNextRegistration` — pre-seed project store via real `em-store.mjs --scope local` (no identity), `runInstall` → identity episode NOW exists in the project store and row `store_id` mirrors it; `registry::testAmbiguousAliasFailsLoud` — install A, `rebindStoreIdentity(A store)` (alias born), project C `handRoot` with `store_id = <A's alias>`, `runInstall(C)` → combined stdout+stderr contains `ambiguous-alias-ownership` AND registry has NO row for C; `registry::testCopiedStoreRejected` — install A, `cpSync` project A → B (store included), `runInstall(B)` → output contains `copied-store-rejected` AND no B row; `registry::testDuplicateChainFailsLoudRegistration` — project D `handRoot` × 2, `runInstall(D)` → output contains `duplicate-identity-chain` AND no D row; `registry::testRelocationIdStable` — install A (capture `store_id`), `fs.renameSync(A, A2)`, `runInstall(A2)` → A2's row `store_id` === captured (EC2: identity travels). Tally + `process.exit(fail ? 1 : 0)`. | `node tests/test-store-identity.mjs` → runs to completion; RED exactly: `identity::testDuplicateChainFailsLoudBuild`, `identity::testIdentityProtectionArm`, `identity::testIndexCarriesIdentityFields` + all 6 `registry::` tests (9 fail / 13 pass); every other name green |
+| 1.3 | `scripts/em-rebuild-index.mjs` | **EDIT** | ANCHOR: `import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'` → REPLACE: same line + newline + `import { resolveStoreIdentity } from './lib/store-identity.mjs'` | `grep -c "from './lib/store-identity.mjs'" scripts/em-rebuild-index.mjs` → `1` |
+| 1.4 | `scripts/em-rebuild-index.mjs` | **EDIT** | ANCHOR: `      ...(fm.clerk_cutover ? { clerk_cutover: fm.clerk_cutover } : {}),` → REPLACE: same line + newline + `      // RFC-012 P2 S1 (REQ-1/REQ-5 lockstep, §8.2): identity fields written by\n      // scripts/lib/store-identity.mjs round-trip the rebuild.\n      ...(typeof fm.store_id === 'string' ? { store_id: fm.store_id } : {}),\n      ...(typeof fm.detaches_identity_root === 'string' ? { detaches_identity_root: fm.detaches_identity_root } : {}),` | `grep -c "fm.store_id" scripts/em-rebuild-index.mjs` → `1` |
+| 1.5 | `scripts/em-rebuild-index.mjs` | **EDIT** | ANCHOR: `  const tmpFile = indexFile + '.tmp'` → REPLACE: `  // RFC-012 P2 REQ-4: exactly one active identity chain per store — a duplicate\n  // (or cyclic) chain fails the build LOUDLY before any index write (EC6:\n  // validate-then-write). 'no-identity' stays normal (mint is lazy, REQ-6).\n  const identity = resolveStoreIdentity(dataDir)\n  if (identity.error && identity.error !== 'no-identity') {\n    console.log(JSON.stringify({ status: 'error', error: identity.error, scope: label }))\n    process.exit(1)\n  }\n\n  const tmpFile = indexFile + '.tmp'` | `node tests/test-store-identity.mjs --only identity::testDuplicateChainFailsLoudBuild` → `1` pass, `0` fail |
+| 1.6 | `scripts/lib/protection.mjs` | **EDIT** | Two anchored edits, this file only. (a) ANCHOR: `// wins in the order: pinned, evidence-linked-violation, trigger-bearing-lesson,\n// consolidates-member, latest-run-record, playbook-referenced, chain-member.` → REPLACE: `// wins in the order: pinned, evidence-linked-violation, trigger-bearing-lesson,\n// consolidates-member, latest-run-record, store-identity-chain,\n// playbook-referenced, chain-member.` (b) ANCHOR: `  for (const v of latestByStore.values()) set(v.id, 'latest-run-record', v.id)` → REPLACE: same line + newline + `  // class d2 (RFC-012 P2 REQ-18): store-identity chain episodes are prune-protected\n  // in FULL — aliases resolve through superseded revisions and a detached root is\n  // still referenced by its successor's detaches_identity_root — so EVERY revision\n  // is reserved, not just the terminal (contrast class d's latest-only rule).\n  for (const r of rows) {\n    if (r.record_type === 'store-identity' && typeof r.id === 'string') set(r.id, 'store-identity-chain', r.id)\n  }` | `node tests/test-store-identity.mjs --only identity::testIdentityProtectionArm` → `1` pass, `0` fail |
+| 1.7 | `plugins/consumer-registry.schema.json` | **EDIT** | Three anchored edits. (a) ANCHOR: `"schema_version": { "const": 1 }` → `"schema_version": { "const": 2 }` (b) ANCHOR: `        "last_install_ts": { "type": "string", "format": "date-time" }` → REPLACE: `        "last_install_ts": { "type": "string", "format": "date-time" },\n        "store_id": { "type": "string", "pattern": "^([0-9a-f]{16}|global)$" },\n        "store_aliases": { "type": "array", "items": { "type": "string", "pattern": "^([0-9a-f]{16}|global)$" } }` (`required` list UNCHANGED — additive optional mirror fields) (c) in the top-level `description` string, append before the closing quote: ` v2 (RFC-012 P2 REQ-6): optional store_id + store_aliases identity-mirror row fields (mirror is derived, never authoritative).` | `node --input-type=module -e "const fs = await import('node:fs'); const s = JSON.parse(fs.readFileSync('plugins/consumer-registry.schema.json','utf8')); console.log(s.properties.schema_version.const, 'store_id' in s.$defs.registryEntry.properties, s.$defs.registryEntry.required.includes('store_id'))"` → `2 true false` |
+| 1.8 | `scripts/lib/install-version.mjs` | **EDIT** | ANCHOR: `} from './install-manifest.mjs'` → REPLACE: same line + newline + `import { resolveLocalDir } from './local-dir.mjs'\nimport { mintStoreIdentity, resolveStoreIdentity } from './store-identity.mjs'` | `grep -c "from './store-identity.mjs'" scripts/lib/install-version.mjs` → `1` |
+| 1.9 | `scripts/lib/install-version.mjs` | **EDIT** | ANCHOR: `  writeJsonAtomic(regPath, { schema_version: 1, entries: sorted })` → REPLACE: `  writeJsonAtomic(regPath, { schema_version: 2, entries: sorted })` (the `schema_version: 1` literal in `buildManifest` (line ~317) is a DIFFERENT artifact — do not touch) | `grep -c "schema_version: 1" scripts/lib/install-version.mjs` → `1` (buildManifest only) |
+| 1.10 | `scripts/lib/install-version.mjs` | **APPEND + EDIT** | (a) APPEND at end of file: `// ---------------------------------------------------------------------------\n// RFC-012 P2 REQ-6 — store-identity mirror (derived, never authoritative).\n// Runs on every registry write via upsertRegistryEntries: resolves each row's\n// store, mints on next registration when absent, mirrors active id + retired\n// aliases, and fails LOUD (throw) on duplicate chains, copied stores (one\n// active id at two paths), and ambiguous alias ownership. A missing or\n// unresolvable store dir leaves the row unmirrored (mirror is derived).\n// ---------------------------------------------------------------------------\nexport function mirrorStoreIdentities(entries) {\n  const claims = new Map() // store_id/alias -> { dir, kind }\n  for (const e of entries) {\n    let projectReal\n    try { projectReal = fs.realpathSync(e.project_path) } catch { continue }\n    let dir\n    try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }\n    if (!fs.existsSync(dir)) continue\n    let idn = resolveStoreIdentity(dir)\n    if (idn.error === 'no-identity') {\n      const minted = mintStoreIdentity(dir)\n      if (minted.error) throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)\n      idn = resolveStoreIdentity(dir)\n    }\n    if (idn.error) throw new Error(`${idn.error}: ${e.project_path}`)\n    let dirReal\n    try { dirReal = fs.realpathSync(dir) } catch { dirReal = dir }\n    for (const [id, kind] of [[idn.active_id, 'active'], ...idn.aliases.map((a) => [a, 'alias'])]) {\n      if (id === 'global') continue // reserved id never competes with project rows\n      const prev = claims.get(id)\n      if (prev && prev.dir !== dirReal) {\n        if (prev.kind === 'active' && kind === 'active') throw new Error(`copied-store-rejected: ${id} at ${prev.dir} + ${dirReal}`)\n        throw new Error(`ambiguous-alias-ownership: ${id} at ${prev.dir} + ${dirReal}`)\n      }\n      if (!prev) claims.set(id, { dir: dirReal, kind })\n    }\n    e.store_id = idn.active_id\n    if (idn.aliases.length) e.store_aliases = idn.aliases\n    else delete e.store_aliases\n  }\n  return entries\n}` (b) EDIT — ANCHOR: `  for (const u of updates) map.set(key(u), u)\n  writeRegistry(regPath, [...map.values()])\n  return map.size` → REPLACE: `  for (const u of updates) map.set(key(u), u)\n  // RFC-012 P2 REQ-6: mirror store identities into every row before the write;\n  // fail-loud collisions (copied store / ambiguous alias / duplicate chain)\n  // THROW here and abort the registry write (callers surface the message).\n  const mirrored = mirrorStoreIdentities([...map.values()])\n  writeRegistry(regPath, mirrored)\n  return mirrored.length` | `node tests/test-store-identity.mjs --only registry::` → `6` pass, `0` fail |
+| 1.11 | `scripts/lib/registered-stores.mjs` | **EDIT** | Two anchored edits. (a) ANCHOR: `import { readRegistry, registryPath } from './install-version.mjs'` → same + newline + `import { resolveStoreIdentity } from './store-identity.mjs'` (b) ANCHOR: `    out.push({\n      project_path: projectReal,\n      data_dir: fs.existsSync(resolved) ? dataDirReal : resolved,\n      label: \`${PROJECT_SCOPE_PREFIX}${path.basename(projectReal)}\`,\n      store_matches_project: storeMatches,\n    })` → REPLACE: `    // RFC-012 P2 REQ-6 (read side): surface the store's episode-carried identity\n    // to --all-projects consumers. Degrade-not-throw: hard resolution errors\n    // attach as store_identity_error; absent identity attaches nothing (mint is\n    // lazy — registration mints, readers never do).\n    const idn = fs.existsSync(resolved) ? resolveStoreIdentity(dataDirReal) : { error: 'no-identity' }\n    out.push({\n      project_path: projectReal,\n      data_dir: fs.existsSync(resolved) ? dataDirReal : resolved,\n      label: \`${PROJECT_SCOPE_PREFIX}${path.basename(projectReal)}\`,\n      store_matches_project: storeMatches,\n      ...(idn.error ? (idn.error !== 'no-identity' ? { store_identity_error: idn.error } : {}) : { store_id: idn.active_id, ...(idn.aliases.length ? { store_aliases: idn.aliases } : {}) }),\n    })` | `node tests/test-registered-stores.mjs` → all pass, exit 0 |
+| 1.12 | `tests/test-consumer-registry-schema.mjs` | **EDIT** | Fixture-change ledger (§A.9) — the ONLY suite asserting the registry schema_version (readRegistry ignores the field; v1-writing fixtures elsewhere unaffected). Four line edits + two appended tests: (a) `:40` `const validRegistry = () => ({ schema_version: 1, entries: [validRow()] });` → `schema_version: 2` (b) `:67` fixture `schema_version: 1` → `2` (c) `:73-76` test renamed `'a wrong schema_version is REJECTED (const 2)'`, fixture value `2` → `1`, message `'schema_version must be const 2'` (d) `:80` fixture `schema_version: 1` → `2`. APPEND two tests: `'a row with store_id + store_aliases validates'` — `validRow({ store_id: '0123456789abcdef', store_aliases: ['fedcba9876543210'] })` → valid; `'a malformed store_id is REJECTED (pattern)'` — `validRow({ store_id: 'not-hex' })` → `!res.valid`. | `node tests/test-consumer-registry-schema.mjs` → all pass, exit 0 |
+| 1.13 | — | — | Full slice suite green. | `node tests/test-store-identity.mjs` → `22` pass, `0` fail, exit 0 |
+| 1.13b | — | — | Negative control (§A.9 red-then-green): the break flag reaches the in-process lib via argv, so every Group 1 mint breaks — proves the assertions bite. | `node tests/test-store-identity.mjs --break-identity-write` → non-zero exit |
+| 1.14 | `.github/workflows/plan-marker-validate.yml` | **EDIT** | ANCHOR: `      - name: Run em-promote experimental suite (APC-S5)\n        run: node tests/test-em-promote.mjs` → REPLACE: same + newline + `      - name: Run store-identity suite (RFC-012 P2 S1)\n        run: node tests/test-store-identity.mjs` | `node tests/test-ci-suite-registration.mjs` → all pass, exit 0 |
+| 1.15 | — | — | §A.8-S1 done sweep (below), every line pasted into §15. | every command prints its expected value |
+| 1.16 | — | — | Commit `P2-S1: store-identity chain end-to-end` + `Co-Authored-By` trailer (ORCHESTRATOR stages only the slice file set + this plan; builder never commits). | `git log -1 --oneline` shows `P2-S1` |
+
+### §A.8-S1 Definition of done (mechanical)
+
+```bash
+node tests/test-store-identity.mjs               # → 22 pass, 0 fail
+node tests/test-em-promote.mjs                   # → all pass (regression)
+node tests/test-registered-stores.mjs            # → all pass
+node tests/test-prune-protection.mjs             # → all pass (class-d2 additive)
+node tests/test-consumer-registry-schema.mjs     # → all pass (v2 + mirror fields)
+node tests/test-fold-all-projects.mjs            # → all pass (v1 fixtures still read)
+node tests/test-all-projects-observability.mjs   # → all pass
+node tests/test-install-drift-notice.mjs         # → all pass
+node tests/test-uninstall-enforcement.mjs        # → all pass (round-trip invariant)
+node tests/test-ci-suite-registration.mjs        # → all pass (new suite wired)
+node scripts/validate-plugin-registry.mjs        # → exit 0
+grep -rc "promotion_sources" scripts/lib/store-identity.mjs   # → 0 (hard stop)
+git diff --name-only                              # → excludes em-promote.mjs / em-store.mjs / em-revise.mjs
+```

--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -583,7 +583,25 @@ AMENDED to include `no-identity: <project_path>`, plus the F4/F5/F7 additions
 `store-dir-missing` (lib) and `reserved-id-abuse: <project_path>` (registration).
 (b) NIT — non-numeric `lockTimeoutS` yields NaN deadline (hang) on the internal
 test-only opt; deferred with 5-field justification in the tracking issue filed at
-S1 wrap (step 9).
+S1 wrap (step 9: #548).
+
+**Post-ACCEPT CI deltas (2026-07-18/19, commits `d02c92a` + `8182072`)** — two
+defects only the unfiltered CI caught after the r2 cap closed; both surfaced by
+suites outside the §A.8-S1 sweep list (the sweep list gap is itself the lesson):
+
+1. `tests/test-codex-activation-install.mjs` byte-for-byte episode invariants
+   (both install boundaries incl. the malformed-hooks abort case) predate REQ-6
+   minting — evolved to per-file preservation + exactly-one-new shape-asserted
+   identity episode; uninstall baseline re-anchored post-install (`d02c92a`).
+2. `tests/test-install-wizard.mjs` doctor-verify caught REAL index-drift: the
+   identity writer left index.jsonl/tags.json stale until the next rebuild. Fix
+   (`8182072`): mint/rebind/detach append the index row (field order mirrors the
+   rebuild emitter, so rebuild is a no-op for the row) + tmp-rename tags.json
+   update under the held lock; degrade-not-throw with `index_stale: true`
+   (episode file authoritative, rebuild heals). New 27th test
+   `testMintUpdatesIndexIncrementally`. This delta is post-r2 NEW code — flagged
+   for the human PR review; the GLM 2-round cap was not reopened (CI-driven,
+   test-covered, small surface).
 
 ## §20 Lessons Encoded
 

--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -571,6 +571,20 @@ Post-fold suite = 26 tests. Confirmed sound by r1 (not findings): schema-test v1
 `Atomics.wait` sleep fallback, crash-injection fixture falsifiability, all six §8.2
 invariants including no-new-path-authority-predicate.
 
+**r2 (2026-07-18, final round): ACCEPT** — report `.review-store/rfc-012-p2/glm-s1-r2.md`,
+fold diff `0781b04..e4d0209`. All 7 r1 findings verified CLOSED at fold sites with
+probe re-runs; new-surface sweep (re-resolve branch, reserved-id-abuse ordering,
+`lockTimeoutS` thread-through, ENOENT catch breadth, async-test CI determinism) all
+sound; regression spot-checks green. Two non-blocking residuals: (a) MINOR doc
+staleness — folded here: the mirror's stuck-lock-without-mint path now surfaces
+`no-identity: <project_path>` (via the F3 re-resolve) instead of
+`identity-mint-failed: lock-timeout`; the §A.5-S1 registration-layer code set is
+AMENDED to include `no-identity: <project_path>`, plus the F4/F5/F7 additions
+`store-dir-missing` (lib) and `reserved-id-abuse: <project_path>` (registration).
+(b) NIT — non-numeric `lockTimeoutS` yields NaN deadline (hang) on the internal
+test-only opt; deferred with 5-field justification in the tracking issue filed at
+S1 wrap (step 9).
+
 ## §20 Lessons Encoded
 
 | Lesson | One-line rule | Enforced in |

--- a/plugins/consumer-registry.schema.json
+++ b/plugins/consumer-registry.schema.json
@@ -1,12 +1,12 @@
 {
   "$id": "https://episodic-memory/plugins/consumer-registry.schema.json",
   "title": "Consumer registry (~/.episodic-memory/installs.json) — RFC-009 P2 / #492",
-  "description": "Closed, versioned contract for the consumer registry rows that carry the enforcement_installed / activation_installed install flags. installed-state.schema.json covers a DIFFERENT artifact (the per-project installed_state block); this schema covers the registry rows. schema_version is const 1; a new row field is an additive schema_version bump, not a silent extension (not future-tolerant by design).",
+  "description": "Closed, versioned contract for the consumer registry rows that carry the enforcement_installed / activation_installed install flags. installed-state.schema.json covers a DIFFERENT artifact (the per-project installed_state block); this schema covers the registry rows. schema_version is const 1; a new row field is an additive schema_version bump, not a silent extension (not future-tolerant by design). v2 (RFC-012 P2 REQ-6): optional store_id + store_aliases identity-mirror row fields (mirror is derived, never authoritative).",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "entries"],
   "properties": {
-    "schema_version": { "const": 1 },
+    "schema_version": { "const": 2 },
     "entries": {
       "type": "array",
       "items": { "$ref": "#/$defs/registryEntry" }
@@ -23,7 +23,9 @@
         "version": { "type": "string" },
         "enforcement_installed": { "type": "boolean" },
         "activation_installed": { "type": "boolean" },
-        "last_install_ts": { "type": "string", "format": "date-time" }
+        "last_install_ts": { "type": "string", "format": "date-time" },
+        "store_id": { "type": "string", "pattern": "^([0-9a-f]{16}|global)$" },
+        "store_aliases": { "type": "array", "items": { "type": "string", "pattern": "^([0-9a-f]{16}|global)$" } }
       }
     }
   }

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -16,6 +16,7 @@ import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
+import { resolveStoreIdentity } from './lib/store-identity.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -217,6 +218,10 @@ function rebuildDir(dataDir, label) {
       // this pair in LOCKSTEP with em-store/em-revise's index fields.
       ...((fm.record_type && !BREAK_REBUILD_WHITELIST) ? { record_type: fm.record_type } : {}),
       ...(fm.clerk_cutover ? { clerk_cutover: fm.clerk_cutover } : {}),
+      // RFC-012 P2 S1 (REQ-1/REQ-5 lockstep, §8.2): identity fields written by
+      // scripts/lib/store-identity.mjs round-trip the rebuild.
+      ...(typeof fm.store_id === 'string' ? { store_id: fm.store_id } : {}),
+      ...(typeof fm.detaches_identity_root === 'string' ? { detaches_identity_root: fm.detaches_identity_root } : {}),
       access_count: accessCount,
       last_accessed: lastAccessed,
       ...(feedback !== 0 ? { feedback } : {}),
@@ -242,6 +247,15 @@ function rebuildDir(dataDir, label) {
         driftDeprecated[name] = (driftDeprecated[name] || 0) + 1
       }
     }
+  }
+
+  // RFC-012 P2 REQ-4: exactly one active identity chain per store — a duplicate
+  // (or cyclic) chain fails the build LOUDLY before any index write (EC6:
+  // validate-then-write). 'no-identity' stays normal (mint is lazy, REQ-6).
+  const identity = resolveStoreIdentity(dataDir)
+  if (identity.error && identity.error !== 'no-identity') {
+    console.log(JSON.stringify({ status: 'error', error: identity.error, scope: label }))
+    process.exit(1)
   }
 
   const tmpFile = indexFile + '.tmp'

--- a/scripts/lib/install-version.mjs
+++ b/scripts/lib/install-version.mjs
@@ -514,7 +514,12 @@ export function updateConsumers({ repoDir, globalDir, dryRun = false }) {
   }
 
   if (!dryRun && (report.pruned.length > 0 || report.refreshed.length > 0)) {
-    writeRegistry(regPath, keptEntries)
+    // F2 fold (GLM r1 MAJOR-2): mirror store identities on the sweep path too,
+    // so a post-rebind/detach registry carries the fresh active id + aliases
+    // (otherwise the sweep writes the stale active id from the prior upsert and
+    // omits store_aliases). The merge happens through mirrorStoreIdentities,
+    // NOT upsertRegistryEntries — upsert would read-merge and resurrect pruned rows.
+    writeRegistry(regPath, mirrorStoreIdentities(keptEntries))
   }
   return report
 }
@@ -648,14 +653,33 @@ export function mirrorStoreIdentities(entries) {
     let idn = resolveStoreIdentity(dir)
     if (idn.error === 'no-identity') {
       const minted = mintStoreIdentity(dir)
-      if (minted.error) throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)
-      idn = resolveStoreIdentity(dir)
+      if (minted.error) {
+        // F3 fold (GLM r1 MAJOR-3): identity-exists / lock-timeout are benign
+        // concurrent-mint outcomes (the lib-level lock serialized us; another
+        // process minted, or its lock-holder just released after a retry budget).
+        // Re-resolve and mirror the EXISTING identity instead of throwing — this
+        // is the §8.2 EC12 "later holder re-resolves" pattern. Other mint errors
+        // (duplicate-identity-chain, identity-chain-cycle, reserved-id-invalid,
+        // break-identity-write, store-dir-missing, …) stay fatal.
+        if (minted.error === 'identity-exists' || minted.error === 'lock-timeout') {
+          idn = resolveStoreIdentity(dir)
+        } else {
+          throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)
+        }
+      } else {
+        idn = resolveStoreIdentity(dir)
+      }
     }
     if (idn.error) throw new Error(`${idn.error}: ${e.project_path}`)
     let dirReal
     try { dirReal = fs.realpathSync(dir) } catch { dirReal = dir }
     for (const [id, kind] of [[idn.active_id, 'active'], ...idn.aliases.map((a) => [a, 'alias'])]) {
-      if (id === 'global') continue // reserved id never competes with project rows
+      // F5 fold (GLM r1 MINOR-2): the reserved id `global` belongs only to the
+      // global store, which is never a registry row. A project row resolving
+      // active_id or alias === 'global' is a hand-forgery / misconfiguration
+      // — reject loudly rather than silently exempting it from the collision
+      // map (the old `continue` let two forged-global project rows coexist).
+      if (id === 'global') throw new Error(`reserved-id-abuse: ${e.project_path}`)
       const prev = claims.get(id)
       if (prev && prev.dir !== dirReal) {
         if (prev.kind === 'active' && kind === 'active') throw new Error(`copied-store-rejected: ${id} at ${prev.dir} + ${dirReal}`)

--- a/scripts/lib/install-version.mjs
+++ b/scripts/lib/install-version.mjs
@@ -52,6 +52,8 @@ import {
   enforcementHookLibBasenames, enforcementEntryScripts, enforcementBundleLibs,
   globalEntryScripts, relocatedOnlyLibs, bp1EntryScripts, bp1ClosureLibs,
 } from './install-manifest.mjs'
+import { resolveLocalDir } from './local-dir.mjs'
+import { mintStoreIdentity, resolveStoreIdentity } from './store-identity.mjs'
 
 export const PROJECT_MANIFEST_BASENAME = '.episodic-memory-install.json'
 export const GLOBAL_MANIFEST_BASENAME = 'install-manifest.json'
@@ -356,7 +358,7 @@ export function writeRegistry(regPath, entries) {
     a.project_path === b.project_path
       ? a.tool.localeCompare(b.tool)
       : a.project_path.localeCompare(b.project_path))
-  writeJsonAtomic(regPath, { schema_version: 1, entries: sorted })
+  writeJsonAtomic(regPath, { schema_version: 2, entries: sorted })
 }
 
 // Upsert entries deduped by (project_path, tool). `updates` entries fully
@@ -366,8 +368,12 @@ export function upsertRegistryEntries(regPath, updates) {
   const key = (e) => `${e.project_path}${String.fromCharCode(0)}${e.tool}`
   const map = new Map(entries.map((e) => [key(e), e]))
   for (const u of updates) map.set(key(u), u)
-  writeRegistry(regPath, [...map.values()])
-  return map.size
+  // RFC-012 P2 REQ-6: mirror store identities into every row before the write;
+  // fail-loud collisions (copied store / ambiguous alias / duplicate chain)
+  // THROW here and abort the registry write (callers surface the message).
+  const mirrored = mirrorStoreIdentities([...map.values()])
+  writeRegistry(regPath, mirrored)
+  return mirrored.length
 }
 
 // ---------------------------------------------------------------------------
@@ -621,4 +627,45 @@ export function syncProjectFromDist({ globalDir, projectDir, dryRun = false }) {
     out.notice = notice
   }
   return out
+}
+
+// ---------------------------------------------------------------------------
+// RFC-012 P2 REQ-6 — store-identity mirror (derived, never authoritative).
+// Runs on every registry write via upsertRegistryEntries: resolves each row's
+// store, mints on next registration when absent, mirrors active id + retired
+// aliases, and fails LOUD (throw) on duplicate chains, copied stores (one
+// active id at two paths), and ambiguous alias ownership. A missing or
+// unresolvable store dir leaves the row unmirrored (mirror is derived).
+// ---------------------------------------------------------------------------
+export function mirrorStoreIdentities(entries) {
+  const claims = new Map() // store_id/alias -> { dir, kind }
+  for (const e of entries) {
+    let projectReal
+    try { projectReal = fs.realpathSync(e.project_path) } catch { continue }
+    let dir
+    try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }
+    if (!fs.existsSync(dir)) continue
+    let idn = resolveStoreIdentity(dir)
+    if (idn.error === 'no-identity') {
+      const minted = mintStoreIdentity(dir)
+      if (minted.error) throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)
+      idn = resolveStoreIdentity(dir)
+    }
+    if (idn.error) throw new Error(`${idn.error}: ${e.project_path}`)
+    let dirReal
+    try { dirReal = fs.realpathSync(dir) } catch { dirReal = dir }
+    for (const [id, kind] of [[idn.active_id, 'active'], ...idn.aliases.map((a) => [a, 'alias'])]) {
+      if (id === 'global') continue // reserved id never competes with project rows
+      const prev = claims.get(id)
+      if (prev && prev.dir !== dirReal) {
+        if (prev.kind === 'active' && kind === 'active') throw new Error(`copied-store-rejected: ${id} at ${prev.dir} + ${dirReal}`)
+        throw new Error(`ambiguous-alias-ownership: ${id} at ${prev.dir} + ${dirReal}`)
+      }
+      if (!prev) claims.set(id, { dir: dirReal, kind })
+    }
+    e.store_id = idn.active_id
+    if (idn.aliases.length) e.store_aliases = idn.aliases
+    else delete e.store_aliases
+  }
+  return entries
 }

--- a/scripts/lib/protection.mjs
+++ b/scripts/lib/protection.mjs
@@ -166,7 +166,8 @@ export function resolvePlaybookProtection({ localStoreDir, willArchiveLocal = fa
 // NO id-dedupe). playbookIds = the playbook-referenced episode ids harvested by
 // resolvePlaybookProtection (R5b). Returns Map<id, {reason, via}>; first-set reason
 // wins in the order: pinned, evidence-linked-violation, trigger-bearing-lesson,
-// consolidates-member, latest-run-record, playbook-referenced, chain-member.
+// consolidates-member, latest-run-record, store-identity-chain,
+// playbook-referenced, chain-member.
 export function computeProtectedIds(rows, todayStr, playbookIds = []) {
   const map = new Map()
   // via normalizes to null when the protecting referencer row has no string id
@@ -225,6 +226,13 @@ export function computeProtectedIds(rows, todayStr, playbookIds = []) {
     }
   }
   for (const v of latestByStore.values()) set(v.id, 'latest-run-record', v.id)
+  // class d2 (RFC-012 P2 REQ-18): store-identity chain episodes are prune-protected
+  // in FULL — aliases resolve through superseded revisions and a detached root is
+  // still referenced by its successor's detaches_identity_root — so EVERY revision
+  // is reserved, not just the terminal (contrast class d's latest-only rule).
+  for (const r of rows) {
+    if (r.record_type === 'store-identity' && typeof r.id === 'string') set(r.id, 'store-identity-chain', r.id)
+  }
   // class e: RFC-011 R5(b) playbook-referenced. Each configured playbook id is
   // resolved to its terminal over the continuing-chain-precedence union (R2.1: a
   // stale superseded copy in one store must not shadow the live chain in the other

--- a/scripts/lib/registered-stores.mjs
+++ b/scripts/lib/registered-stores.mjs
@@ -31,6 +31,7 @@ import os from 'os'
 import path from 'path'
 import { resolveLocalDir } from './local-dir.mjs'
 import { readRegistry, registryPath } from './install-version.mjs'
+import { resolveStoreIdentity } from './store-identity.mjs'
 
 export const STORE_DIR_BASENAME = '.episodic-memory'
 export const PROJECT_SCOPE_PREFIX = 'project:'
@@ -91,11 +92,17 @@ export function resolveRegisteredStoresWithStatus({ globalDir } = {}) {
     const storeMatches =
       path.resolve(resolved) === path.resolve(plainJoin) &&
       containedIn(dataDirReal, projectReal)
+    // RFC-012 P2 REQ-6 (read side): surface the store's episode-carried identity
+    // to --all-projects consumers. Degrade-not-throw: hard resolution errors
+    // attach as store_identity_error; absent identity attaches nothing (mint is
+    // lazy — registration mints, readers never do).
+    const idn = fs.existsSync(resolved) ? resolveStoreIdentity(dataDirReal) : { error: 'no-identity' }
     out.push({
       project_path: projectReal,
       data_dir: fs.existsSync(resolved) ? dataDirReal : resolved,
       label: `${PROJECT_SCOPE_PREFIX}${path.basename(projectReal)}`,
       store_matches_project: storeMatches,
+      ...(idn.error ? (idn.error !== 'no-identity' ? { store_identity_error: idn.error } : {}) : { store_id: idn.active_id, ...(idn.aliases.length ? { store_aliases: idn.aliases } : {}) }),
     })
   }
   return { stores: out, registryRebuilt: rebuilt, registryPath: regPath }

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -1,0 +1,301 @@
+// store-identity.mjs — RFC-012 P2 S1 (REQ-1..6): episode-carried store identity.
+// Chain mechanics are P7 supersedes revisions written by THIS lib's atomic writer
+// (temp + fsync + rename under the shared per-store lock, §8.2) — never em-store's
+// non-atomic path. Zero deps: node stdlib + ./lock.mjs only.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { tryAcquire, release } from './lock.mjs'
+
+// §A.5-S1 constants (verbatim)
+export const STORE_IDENTITY_RECORD_TYPE = 'store-identity'
+export const GLOBAL_STORE_ID = 'global'
+export const STORE_ID_RE = /^([0-9a-f]{16}|global)$/
+// §8.2 lock scoping: the SAME per-store lockfile the clerk uses (em-consolidate.mjs:439)
+const LOCK_BASENAME = 'clerk-apply.lock'
+const LOCK_TIMEOUT_S = 30
+const TMP_SUFFIX = '.tmp-identity'
+// §A.0 break-input override (REQ-2 negative): argv flag on the INVOKING process —
+// same mechanism as em-rebuild-index.mjs BREAK_REBUILD_WHITELIST (line 28 precedent).
+const BREAK_IDENTITY_WRITE = process.argv.includes('--break-identity-write')
+
+// --- internal helpers ---
+
+function sleepSync(ms) {
+  // Busy-loop fallback in a try/catch: Atomics.wait on a SharedArrayBuffer-backed
+  // Int32Array is a real SYNC sleep, not a microtask hop. Falls back to a tight
+  // loop if SharedArrayBuffer is unavailable (sandboxed workers).
+  try {
+    const sab = new SharedArrayBuffer(4)
+    const i32 = new Int32Array(sab)
+    Atomics.wait(i32, 0, 0, ms)
+  } catch {
+    const end = Date.now() + ms
+    while (Date.now() < end) { /* spin */ }
+  }
+}
+
+function withStoreLockSync(storeDir, fn) {
+  const lockFile = path.join(storeDir, LOCK_BASENAME)
+  const deadlineMs = Date.now() + LOCK_TIMEOUT_S * 1000
+  let handle = null
+  while (true) {
+    const result = tryAcquire(lockFile)
+    if (result.ok) { handle = result.handle; break }
+    if (Date.now() >= deadlineMs) return { error: 'lock-timeout' }
+    sleepSync(100)
+  }
+  try {
+    return fn()
+  } finally {
+    release(handle)
+  }
+}
+
+function parseIdentityFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+  const lines = match[1].split('\n')
+  const data = {}
+  for (const line of lines) {
+    const m = line.match(/^(\w+):\s*(.*)$/)
+    if (!m) continue
+    const [, key, raw] = m
+    let val
+    if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+      val = raw.slice(1, -1)
+    } else {
+      val = raw
+    }
+    data[key] = val
+  }
+  if (data.record_type !== STORE_IDENTITY_RECORD_TYPE) return null
+  if (!STORE_ID_RE.test(data.store_id)) return null
+  return {
+    id: data.id,
+    store_id: data.store_id,
+    supersedes: typeof data.supersedes === 'string' ? data.supersedes : null,
+    detaches_identity_root: typeof data.detaches_identity_root === 'string' ? data.detaches_identity_root : null,
+    status: data.status || 'active',
+  }
+}
+
+function listIdentityEpisodes(storeDir) {
+  const episodesDir = path.join(storeDir, 'episodes')
+  let files
+  try {
+    files = fs.readdirSync(episodesDir).filter((f) => f.endsWith('.md'))
+  } catch {
+    return []
+  }
+  const out = []
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
+    const parsed = parseIdentityFrontmatter(content)
+    if (parsed) {
+      parsed.filename = file
+      out.push(parsed)
+    }
+  }
+  return out
+}
+
+function newEpisodeId(storeId, now = new Date()) {
+  const y = now.getFullYear()
+  const mo = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  const h = String(now.getHours()).padStart(2, '0')
+  const mi = String(now.getMinutes()).padStart(2, '0')
+  const s = String(now.getSeconds()).padStart(2, '0')
+  return `${y}${mo}${d}-${h}${mi}${s}-store-identity-${storeId.slice(0, 4)}`
+}
+
+function identityEpisodeContent(fields) {
+  const lines = ['---']
+  lines.push(`id: ${fields.id}`)
+  lines.push(`date: ${fields.date}`)
+  lines.push(`time: "${fields.time}"`)
+  lines.push(`project: ${fields.project}`)
+  lines.push('category: context')
+  lines.push('status: active')
+  lines.push('tags: [store-identity]')
+  lines.push(`summary: ${fields.summary}`)
+  lines.push(`record_type: ${STORE_IDENTITY_RECORD_TYPE}`)
+  lines.push(`store_id: ${fields.store_id}`)
+  if (fields.supersedes) lines.push(`supersedes: ${fields.supersedes}`)
+  if (fields.detaches_identity_root) lines.push(`detaches_identity_root: ${fields.detaches_identity_root}`)
+  lines.push('---')
+  const body = `\n# ${fields.summary}\n\n${fields.bodyLine}\n`
+  return lines.join('\n') + body
+}
+
+function writeIdentityEpisodeAtomic(episodesDir, id, content) {
+  fs.mkdirSync(episodesDir, { recursive: true })
+  // Best-effort unlink of every stale tmp file left by a prior crashed write.
+  let stale
+  try { stale = fs.readdirSync(episodesDir).filter((f) => f.endsWith(TMP_SUFFIX)) } catch { stale = [] }
+  for (const s of stale) {
+    try { fs.unlinkSync(path.join(episodesDir, s)) } catch { /* ignore */ }
+  }
+  const tmp = path.join(episodesDir, '.' + id + '.md' + TMP_SUFFIX)
+  const finalPath = path.join(episodesDir, id + '.md')
+  const fd = fs.openSync(tmp, 'w')
+  try {
+    fs.writeSync(fd, content)
+    fs.fsyncSync(fd)
+  } finally {
+    fs.closeSync(fd)
+  }
+  if (BREAK_IDENTITY_WRITE) return { error: 'break-identity-write' }
+  fs.renameSync(tmp, finalPath)
+  return { ok: true }
+}
+
+// --- exports ---
+
+export function resolveStoreIdentity(storeDir) {
+  const eps = listIdentityEpisodes(storeDir)
+  if (eps.length === 0) return { error: 'no-identity' }
+  // Roots: episodes whose supersedes is absent or names no identity episode.
+  const byId = new Map(eps.map((e) => [e.id, e]))
+  const roots = eps.filter((e) => !e.supersedes || !byId.has(e.supersedes))
+  // Detached roots are those referenced by SOME episode's detaches_identity_root.
+  const detachedRootIds = new Set()
+  for (const e of eps) {
+    if (e.detaches_identity_root && byId.has(e.detaches_identity_root)) {
+      detachedRootIds.add(e.detaches_identity_root)
+    }
+  }
+  const activeRoots = roots.filter((r) => !detachedRootIds.has(r.id))
+  if (activeRoots.length === 0) return { error: 'identity-chain-cycle' }
+  if (activeRoots.length > 1) return { error: 'duplicate-identity-chain' }
+  const root = activeRoots[0]
+  // Walk successors from the single active root. A revisit = cycle.
+  const visited = new Set([root.id])
+  const chainMembers = [root]
+  let current = root
+  while (true) {
+    const successor = eps.find((e) => e.supersedes === current.id)
+    if (!successor) break
+    if (visited.has(successor.id)) return { error: 'identity-chain-cycle' }
+    visited.add(successor.id)
+    chainMembers.push(successor)
+    current = successor
+  }
+  // Episodes belonging to detached chains (their root is in detachedRootIds) are
+  // intentionally not reachable from the active root — they stay in the store but
+  // contribute no active id and no aliases (§A.5 lib error 'detachedChainExcluded').
+  const terminal = chainMembers[chainMembers.length - 1]
+  const aliases = chainMembers.slice(0, -1).map((m) => m.store_id)
+  return {
+    active_id: terminal.store_id,
+    aliases,
+    root_id: root.id,
+    terminal_episode_id: terminal.id,
+  }
+}
+
+export function mintStoreIdentity(storeDir, { reserved } = {}) {
+  if (reserved !== undefined && reserved !== GLOBAL_STORE_ID) {
+    return { error: 'reserved-id-invalid' }
+  }
+  return withStoreLockSync(storeDir, () => {
+    const existing = resolveStoreIdentity(storeDir)
+    if (existing.error === 'no-identity') {
+      // proceed to mint
+    } else if (existing.error === 'identity-exists') {
+      return { error: 'identity-exists' }
+    } else if (existing.error) {
+      // duplicate-identity-chain / identity-chain-cycle — fail loud
+      return { error: existing.error }
+    } else {
+      return { error: 'identity-exists' }
+    }
+    const storeId = reserved || crypto.randomBytes(8).toString('hex')
+    const project = reserved ? 'global' : (path.basename(path.dirname(storeDir)) || 'store')
+    const now = new Date()
+    const id = newEpisodeId(storeId, now)
+    const y = now.getFullYear()
+    const mo = String(now.getMonth() + 1).padStart(2, '0')
+    const d = String(now.getDate()).padStart(2, '0')
+    const h = String(now.getHours()).padStart(2, '0')
+    const mi = String(now.getMinutes()).padStart(2, '0')
+    const fields = {
+      id,
+      date: `${y}-${mo}-${d}`,
+      time: `${h}:${mi}`,
+      project,
+      summary: `Store identity ${storeId}`,
+      store_id: storeId,
+      bodyLine: 'Store identity root for this episode store (RFC-012 P2 REQ-1). store_id is opaque and episode-carried; rebind via successor revision, never an edit (P7).',
+    }
+    const episodesDir = path.join(storeDir, 'episodes')
+    const content = identityEpisodeContent(fields)
+    const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
+    if (writeResult.error) return writeResult
+    return { active_id: storeId, root_id: id }
+  })
+}
+
+export function rebindStoreIdentity(storeDir) {
+  return withStoreLockSync(storeDir, () => {
+    const existing = resolveStoreIdentity(storeDir)
+    if (existing.error) return { error: existing.error }
+    const newStoreId = crypto.randomBytes(8).toString('hex')
+    const now = new Date()
+    const id = newEpisodeId(newStoreId, now)
+    const y = now.getFullYear()
+    const mo = String(now.getMonth() + 1).padStart(2, '0')
+    const d = String(now.getDate()).padStart(2, '0')
+    const h = String(now.getHours()).padStart(2, '0')
+    const mi = String(now.getMinutes()).padStart(2, '0')
+    const project = path.basename(path.dirname(storeDir)) || 'store'
+    const fields = {
+      id,
+      date: `${y}-${mo}-${d}`,
+      time: `${h}:${mi}`,
+      project,
+      summary: `Store identity rebind ${newStoreId}`,
+      store_id: newStoreId,
+      supersedes: existing.terminal_episode_id,
+      bodyLine: 'Store identity rebind successor (RFC-012 P2 REQ-3). Old store_id becomes a retired alias owned by this chain.',
+    }
+    const episodesDir = path.join(storeDir, 'episodes')
+    const content = identityEpisodeContent(fields)
+    const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
+    if (writeResult.error) return writeResult
+    return { active_id: newStoreId, prior_id: existing.active_id, root_id: existing.root_id }
+  })
+}
+
+export function detachStoreIdentity(storeDir) {
+  return withStoreLockSync(storeDir, () => {
+    const existing = resolveStoreIdentity(storeDir)
+    if (existing.error) return { error: existing.error }
+    const newStoreId = crypto.randomBytes(8).toString('hex')
+    const now = new Date()
+    const id = newEpisodeId(newStoreId, now)
+    const y = now.getFullYear()
+    const mo = String(now.getMonth() + 1).padStart(2, '0')
+    const d = String(now.getDate()).padStart(2, '0')
+    const h = String(now.getHours()).padStart(2, '0')
+    const mi = String(now.getMinutes()).padStart(2, '0')
+    const project = path.basename(path.dirname(storeDir)) || 'store'
+    const fields = {
+      id,
+      date: `${y}-${mo}-${d}`,
+      time: `${h}:${mi}`,
+      project,
+      summary: `Store identity detach ${newStoreId}`,
+      store_id: newStoreId,
+      detaches_identity_root: existing.root_id,
+      bodyLine: 'Store identity detach root (RFC-012 P2 REQ-5). Detached chain contributes no active id and no aliases in this store.',
+    }
+    const episodesDir = path.join(storeDir, 'episodes')
+    const content = identityEpisodeContent(fields)
+    const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
+    if (writeResult.error) return writeResult
+    return { active_id: newStoreId, detached_root_id: existing.root_id }
+  })
+}

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -36,12 +36,23 @@ function sleepSync(ms) {
   }
 }
 
-function withStoreLockSync(storeDir, fn) {
+function withStoreLockSync(storeDir, fn, { timeoutS = LOCK_TIMEOUT_S } = {}) {
   const lockFile = path.join(storeDir, LOCK_BASENAME)
-  const deadlineMs = Date.now() + LOCK_TIMEOUT_S * 1000
+  const deadlineMs = Date.now() + timeoutS * 1000
   let handle = null
   while (true) {
-    const result = tryAcquire(lockFile)
+    let result
+    try {
+      // F4 fold (GLM r1 MINOR-1): mixed error contract — every other path
+      // returns { error }, but a missing storeDir lets tryAcquire throw raw
+      // ENOENT (lib/lock.mjs:28-30 rethrows non-EEXIST). Map the missing-dir
+      // case to a uniform { error: 'store-dir-missing' } so S2/S4 direct
+      // callers can branch on it; other errors propagate.
+      result = tryAcquire(lockFile)
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return { error: 'store-dir-missing' }
+      throw err
+    }
     if (result.ok) { handle = result.handle; break }
     if (Date.now() >= deadlineMs) return { error: 'lock-timeout' }
     sleepSync(100)
@@ -196,7 +207,7 @@ export function resolveStoreIdentity(storeDir) {
   }
 }
 
-export function mintStoreIdentity(storeDir, { reserved } = {}) {
+export function mintStoreIdentity(storeDir, { reserved, lockTimeoutS } = {}) {
   if (reserved !== undefined && reserved !== GLOBAL_STORE_ID) {
     return { error: 'reserved-id-invalid' }
   }
@@ -235,10 +246,10 @@ export function mintStoreIdentity(storeDir, { reserved } = {}) {
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
     return { active_id: storeId, root_id: id }
-  })
+  }, { timeoutS: lockTimeoutS })
 }
 
-export function rebindStoreIdentity(storeDir) {
+export function rebindStoreIdentity(storeDir, { lockTimeoutS } = {}) {
   return withStoreLockSync(storeDir, () => {
     const existing = resolveStoreIdentity(storeDir)
     if (existing.error) return { error: existing.error }
@@ -266,10 +277,10 @@ export function rebindStoreIdentity(storeDir) {
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
     return { active_id: newStoreId, prior_id: existing.active_id, root_id: existing.root_id }
-  })
+  }, { timeoutS: lockTimeoutS })
 }
 
-export function detachStoreIdentity(storeDir) {
+export function detachStoreIdentity(storeDir, { lockTimeoutS } = {}) {
   return withStoreLockSync(storeDir, () => {
     const existing = resolveStoreIdentity(storeDir)
     if (existing.error) return { error: existing.error }
@@ -297,5 +308,5 @@ export function detachStoreIdentity(storeDir) {
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
     return { active_id: newStoreId, detached_root_id: existing.root_id }
-  })
+  }, { timeoutS: lockTimeoutS })
 }

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -163,6 +163,81 @@ function writeIdentityEpisodeAtomic(episodesDir, id, content) {
   return { ok: true }
 }
 
+// --- incremental index helpers (RFC-012 P2 S1, REQ-1..6 / §8.2) ---
+// After a successful atomic episode write, the store's index.jsonl + tags.json
+// MUST be brought into sync under the SAME per-store lock so a fresh install
+// doesn't leave em-doctor reporting "episode file(s) not in index". The episode
+// file is authoritative — a later rebuild heals any drift — so these helpers
+// degrade-not-throw on failure. Field ORDER mirrors em-rebuild-index.mjs's
+// emit object exactly so a post-mint rebuild is a byte-stable no-op for the
+// row we just appended.
+
+function buildIdentityIndexRow(fields) {
+  // Order matches em-rebuild-index.mjs's emit object for store-identity rows
+  // (id, date, time, project, category, status, supersedes, tags, summary,
+  // record_type, store_id, [detaches_identity_root], access_count, last_accessed).
+  const row = {
+    id: fields.id,
+    date: fields.date,
+    time: fields.time,
+    project: fields.project,
+    category: 'context',
+    status: 'active',
+    supersedes: fields.supersedes || null,
+    tags: ['store-identity'],
+    summary: fields.summary,
+    record_type: STORE_IDENTITY_RECORD_TYPE,
+    store_id: fields.store_id,
+  }
+  if (fields.detaches_identity_root) {
+    row.detaches_identity_root = fields.detaches_identity_root
+  }
+  row.access_count = 0
+  row.last_accessed = null
+  return JSON.stringify(row)
+}
+
+function appendIdentityIndex(storeDir, fields) {
+  // (1) Append one row to <storeDir>/index.jsonl. Create the file if absent
+  // (appendFileSync lazily creates; explicit mkdirSync guards the storeDir
+  // itself in case the caller raced an rm).
+  const indexFile = path.join(storeDir, 'index.jsonl')
+  fs.mkdirSync(storeDir, { recursive: true })
+  fs.appendFileSync(indexFile, buildIdentityIndexRow(fields) + '\n', 'utf8')
+}
+
+function updateIdentityTagsIndex(storeDir, episodeId) {
+  // (2) Update <storeDir>/tags.json via the SAME read-modify-tmp-rename pattern
+  // em-store.mjs's updateTagsIndex uses (issue #469 null-proto guard).
+  const tagsFile = path.join(storeDir, 'tags.json')
+  let index = Object.create(null)
+  try {
+    index = Object.assign(Object.create(null), JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
+  } catch { /* fresh store — index stays empty */ }
+  if (!index['store-identity']) index['store-identity'] = []
+  if (!index['store-identity'].includes(episodeId)) {
+    index['store-identity'].push(episodeId)
+  }
+  const tmp = tagsFile + '.tmp'
+  fs.writeFileSync(tmp, JSON.stringify(index, null, 2), 'utf8')
+  fs.renameSync(tmp, tagsFile)
+}
+
+// Degrade-not-throw: a failure in the index/tags update must NOT fail the
+// mint (the episode file is authoritative; em-rebuild-index heals). On error
+// we emit a stderr warning and signal index_stale via the wrapper below so
+// callers can surface it (or just rebuild) if they care.
+function applyIdentityIndexUpdate(storeDir, fields) {
+  try {
+    appendIdentityIndex(storeDir, fields)
+    updateIdentityTagsIndex(storeDir, fields.id)
+    return { stale: false }
+  } catch (err) {
+    try { process.stderr.write(`store-identity: index/tags update failed (rebuild heals): ${err && err.message}\n`) } catch { /* ignore */ }
+    return { stale: true }
+  }
+}
+
 // --- exports ---
 
 export function resolveStoreIdentity(storeDir) {
@@ -245,7 +320,10 @@ export function mintStoreIdentity(storeDir, { reserved, lockTimeoutS } = {}) {
     const content = identityEpisodeContent(fields)
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
-    return { active_id: storeId, root_id: id }
+    const idx = applyIdentityIndexUpdate(storeDir, fields)
+    const out = { active_id: storeId, root_id: id }
+    if (idx.stale) out.index_stale = true
+    return out
   }, { timeoutS: lockTimeoutS })
 }
 
@@ -276,7 +354,10 @@ export function rebindStoreIdentity(storeDir, { lockTimeoutS } = {}) {
     const content = identityEpisodeContent(fields)
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
-    return { active_id: newStoreId, prior_id: existing.active_id, root_id: existing.root_id }
+    const idx = applyIdentityIndexUpdate(storeDir, fields)
+    const out = { active_id: newStoreId, prior_id: existing.active_id, root_id: existing.root_id }
+    if (idx.stale) out.index_stale = true
+    return out
   }, { timeoutS: lockTimeoutS })
 }
 
@@ -307,6 +388,9 @@ export function detachStoreIdentity(storeDir, { lockTimeoutS } = {}) {
     const content = identityEpisodeContent(fields)
     const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
     if (writeResult.error) return writeResult
-    return { active_id: newStoreId, detached_root_id: existing.root_id }
+    const idx = applyIdentityIndexUpdate(storeDir, fields)
+    const out = { active_id: newStoreId, detached_root_id: existing.root_id }
+    if (idx.stale) out.index_stale = true
+    return out
   }, { timeoutS: lockTimeoutS })
 }

--- a/tests/test-codex-activation-install.mjs
+++ b/tests/test-codex-activation-install.mjs
@@ -66,10 +66,24 @@ function treeHash(dir) {
   return hash.digest('hex')
 }
 
+function fileHashes(dir) {
+  const out = {}
+  const walk = (current, rel = '') => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const nextRel = rel ? `${rel}/${entry.name}` : entry.name
+      const abs = path.join(current, entry.name)
+      if (entry.isDirectory()) walk(abs, nextRel)
+      else out[nextRel] = crypto.createHash('sha256').update(fs.readFileSync(abs)).digest('hex')
+    }
+  }
+  walk(dir)
+  return out
+}
+
 function testInstallAndUninstall() {
   const F = fixture('cycle')
   const episodes = path.join(F.project, '.episodic-memory', 'episodes')
-  const beforeEpisodes = treeHash(episodes)
+  const beforeHashes = fileHashes(episodes)
 
   const result = install(F, '--install-activation')
   assert.equal(result.status, 0, `install failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`)
@@ -89,7 +103,17 @@ function testInstallAndUninstall() {
     assert.equal(fs.existsSync(path.join(pluginDir, 'hooks', file)), true, `${file} must be installed`)
   }
   assert.match(result.stdout, /Run "\/hooks" inside Codex.*trust/i)
-  assert.equal(treeHash(episodes), beforeEpisodes, 'install must preserve local episodes byte-for-byte')
+  const afterHashes = fileHashes(episodes)
+  const newFiles = Object.keys(afterHashes).filter((name) => !(name in beforeHashes))
+  for (const [name, hash] of Object.entries(beforeHashes)) {
+    assert.equal(afterHashes[name], hash, `install must preserve ${name} byte-for-byte`)
+  }
+  assert.equal(newFiles.length, 1, `install may add exactly one store-identity episode, got ${newFiles.length}: ${newFiles.join(', ')}`)
+  const newContent = fs.readFileSync(path.join(episodes, newFiles[0]), 'utf8')
+  assert.match(newContent, /^record_type: store-identity$/m, 'new episode must carry record_type: store-identity')
+  assert.match(newContent, /^category: context$/m, 'new episode must carry category: context')
+  assert.match(newContent, /^store_id: ([0-9a-f]{16}|global)$/m, 'new episode must carry a valid store_id')
+  const afterEpisodes = treeHash(episodes)
 
   const registry = readJson(path.join(F.home, '.episodic-memory', 'installs.json'))
   const row = registry.entries.find((entry) => entry.tool === 'codex' && entry.project_path === F.project)
@@ -103,7 +127,7 @@ function testInstallAndUninstall() {
       `${event} activation registration must be removed`)
   }
   assert.equal(fs.existsSync(pluginDir), false, 'Codex activation plugin directory must be removed')
-  assert.equal(treeHash(episodes), beforeEpisodes, 'uninstall must preserve local episodes byte-for-byte')
+  assert.equal(treeHash(episodes), afterEpisodes, 'uninstall must preserve local episodes byte-for-byte')
 }
 
 function testSessionStartOutput() {
@@ -176,12 +200,22 @@ function testFailurePaths() {
   const malformed = fixture('malformed')
   fs.mkdirSync(path.join(malformed.project, '.codex'), { recursive: true })
   fs.writeFileSync(path.join(malformed.project, '.codex', 'hooks.json'), '{bad')
-  const beforeEpisodes = treeHash(path.join(malformed.project, '.episodic-memory', 'episodes'))
+  const malformedEpisodes = path.join(malformed.project, '.episodic-memory', 'episodes')
+  const beforeHashes = fileHashes(malformedEpisodes)
   const rejected = install(malformed, '--install-activation')
   assert.equal(rejected.status, 0)
   assert.match(rejected.stdout, /aborted — nothing changed/)
   assert.equal(fs.existsSync(path.join(malformed.project, '.codex', 'episodic-memory-activation')), false)
-  assert.equal(treeHash(path.join(malformed.project, '.episodic-memory', 'episodes')), beforeEpisodes)
+  const afterHashes = fileHashes(malformedEpisodes)
+  const newFiles = Object.keys(afterHashes).filter((name) => !(name in beforeHashes))
+  for (const [name, hash] of Object.entries(beforeHashes)) {
+    assert.equal(afterHashes[name], hash, `install must preserve ${name} byte-for-byte`)
+  }
+  assert.equal(newFiles.length, 1, `install may add exactly one store-identity episode, got ${newFiles.length}: ${newFiles.join(', ')}`)
+  const newContent = fs.readFileSync(path.join(malformedEpisodes, newFiles[0]), 'utf8')
+  assert.match(newContent, /^record_type: store-identity$/m, 'new episode must carry record_type: store-identity')
+  assert.match(newContent, /^category: context$/m, 'new episode must carry category: context')
+  assert.match(newContent, /^store_id: ([0-9a-f]{16}|global)$/m, 'new episode must carry a valid store_id')
 
   const idempotent = fixture('idempotent')
   fs.mkdirSync(path.join(idempotent.project, '.codex'), { recursive: true })

--- a/tests/test-consumer-registry-schema.mjs
+++ b/tests/test-consumer-registry-schema.mjs
@@ -37,14 +37,21 @@ function validRow(over = {}) {
     ...over,
   };
 }
-const validRegistry = () => ({ schema_version: 1, entries: [validRow()] });
+const validRegistry = () => ({ schema_version: 2, entries: [validRow()] });
 
 // --- The REAL registry validates (if one exists on this machine) ---
 
-t('the real ~/.episodic-memory/installs.json validates (when present)', () => {
+t('the real ~/.episodic-memory/installs.json validates (when present, v2)', () => {
   const p = path.join(os.homedir(), '.episodic-memory', 'installs.json');
   if (!fs.existsSync(p)) { console.log('    (skipped — no real registry on this machine)'); return; }
   const reg = JSON.parse(fs.readFileSync(p, 'utf8'));
+  // Degrade-not-fail when the real registry is at an older schema_version:
+  // the next registry write upgrades it in place (consumer readRegistry is
+  // shape-version-tolerant by design, install-version.mjs:336-352).
+  if (reg.schema_version !== SCHEMA.properties.schema_version.const) {
+    console.log(`    (skipped — real registry is at schema_version=${reg.schema_version}, schema asserts ${SCHEMA.properties.schema_version.const})`);
+    return;
+  }
   const res = validateInstance(reg, SCHEMA);
   assert.ok(res.valid, `real installs.json rejected: ${JSON.stringify(res.errors).slice(0, 400)}`);
 });
@@ -64,22 +71,34 @@ t('a row missing project_path is REJECTED', () => {
 });
 
 t('a row with an unknown field is REJECTED (closed contract, not future-tolerant)', () => {
-  const reg = { schema_version: 1, entries: [validRow({ repair_notes: 'oops' })] };
+  const reg = { schema_version: 2, entries: [validRow({ repair_notes: 'oops' })] };
   const res = validateInstance(reg, SCHEMA);
   assert.ok(!res.valid, 'an extra field must be rejected — the schema is versioned/closed');
   assert.ok(res.errors.some((e) => e.keyword === 'additionalProperties'), `wrong error: ${JSON.stringify(res.errors)}`);
 });
 
-t('a wrong schema_version is REJECTED (const 1)', () => {
-  const reg = { schema_version: 2, entries: [validRow()] };
+t('a wrong schema_version is REJECTED (const 2)', () => {
+  const reg = { schema_version: 1, entries: [validRow()] };
   const res = validateInstance(reg, SCHEMA);
-  assert.ok(!res.valid, 'schema_version must be const 1');
+  assert.ok(!res.valid, 'schema_version must be const 2');
 });
 
 t('a non-boolean install flag is REJECTED', () => {
-  const reg = { schema_version: 1, entries: [validRow({ activation_installed: 'yes' })] };
+  const reg = { schema_version: 2, entries: [validRow({ activation_installed: 'yes' })] };
   const res = validateInstance(reg, SCHEMA);
   assert.ok(!res.valid, 'activation_installed must be a boolean');
+});
+
+t('a row with store_id + store_aliases validates', () => {
+  const reg = { schema_version: 2, entries: [validRow({ store_id: '0123456789abcdef', store_aliases: ['fedcba9876543210'] })] };
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(res.valid, `mirror-fields row rejected: ${JSON.stringify(res.errors)}`);
+});
+
+t('a malformed store_id is REJECTED (pattern)', () => {
+  const reg = { schema_version: 2, entries: [validRow({ store_id: 'not-hex' })] };
+  const res = validateInstance(reg, SCHEMA);
+  assert.ok(!res.valid, 'malformed store_id must be rejected by pattern');
 });
 
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/test-store-identity.mjs
+++ b/tests/test-store-identity.mjs
@@ -423,6 +423,19 @@ t('identity::testLockTimeoutSurfaces', () => {
   }
 })
 
+t('identity::testMintUpdatesIndexIncrementally', () => {
+  const s = mkStore('incr-index')
+  const r = mintStoreIdentity(s.dataDir)
+  assert(!r.error, `mint must succeed: ${JSON.stringify(r)}`)
+  const rows = fs.readFileSync(path.join(s.dataDir, 'index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l))
+  const mine = rows.filter((row) => row.id === r.root_id)
+  eq(mine.length, 1, 'index.jsonl carries exactly one row for the minted id without any rebuild')
+  eq(mine[0].record_type, 'store-identity', 'incremental row carries record_type')
+  eq(mine[0].store_id, r.active_id, 'incremental row carries store_id')
+  const tags = JSON.parse(fs.readFileSync(path.join(s.dataDir, 'tags.json'), 'utf8'))
+  assert(Array.isArray(tags['store-identity']) && tags['store-identity'].includes(r.root_id), 'tags.json lists the minted id under store-identity')
+})
+
 t('identity::testIndexCarriesIdentityFields', () => {
   const s = mkStore('index-fields')
   mintStoreIdentity(s.dataDir)

--- a/tests/test-store-identity.mjs
+++ b/tests/test-store-identity.mjs
@@ -1,0 +1,542 @@
+#!/usr/bin/env node
+/**
+ * test-store-identity.mjs — RFC-012 P2 S1 store-identity chain + registry mirror.
+ *
+ * 22 tests across 2 groups:
+ *   Group 1 (16): in-process lib + spawned rebuild/protection — identity chain
+ *     mint/rebind/detach/alias/crash/duplicate/cycle/concurrent + protection arm.
+ *   Group 2 (6): real install.mjs E2E with isolated HOME — registry mirror,
+ *     mint-on-next-registration, ambiguous alias, copied store, duplicate chain,
+ *     relocation id-stable.
+ *
+ * Spawned children honor the --break-identity-write argv flag to exercise the
+ * negative-control crash-injection fixture (REQ-2) and duplicate-chain failure
+ * (REQ-4) without touching the lib's source.
+ *
+ * Born partially RED (§A.9): the 3 lib-side + 6 registry-side tests fail until
+ * steps 1.3-1.12 land; every other name green from the moment this file exists.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync, execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
+import { mintStoreIdentity, resolveStoreIdentity, rebindStoreIdentity, detachStoreIdentity, GLOBAL_STORE_ID } from '../scripts/lib/store-identity.mjs'
+import { computeProtectedIds } from '../scripts/lib/protection.mjs'
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const REBUILD = path.join(REPO, 'scripts', 'em-rebuild-index.mjs')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+const INSTALL = path.join(REPO, 'install.mjs')
+const LIB_URL = pathToFileURL(path.join(REPO, 'scripts', 'lib', 'store-identity.mjs')).href
+
+// --only fixture-style filter (mirrors tests/test-rfc-009-p4-apply.mjs:53-58).
+const ONLY_FLAG = (() => { const i = process.argv.indexOf('--only'); return i >= 0 ? process.argv[i + 1] : null })()
+
+let pass = 0, fail = 0
+const failures = []
+function t(name, fn) {
+  if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
+  try { fn(); console.log(`ok ${name}`); pass++ }
+  catch (e) { fail++; failures.push(`${name} - ${e && e.message}`); console.log(`FAIL ${name}: ${e && e.message}`) }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+function eq(actual, expected, label) { if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`) }
+
+// --- fixtures ---
+
+function mkStore(label = 'store') {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `store-identity-${label}-`)))
+  const home = path.join(root, 'home')
+  fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  const projectDir = path.join(root, label)
+  fs.mkdirSync(projectDir, { recursive: true })
+  const dataDir = path.join(projectDir, '.episodic-memory')
+  fs.mkdirSync(path.join(dataDir, 'episodes'), { recursive: true })
+  return { root, home, projectDir, dataDir }
+}
+
+function mkHome(label = 'home') {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `store-identity-${label}-`)))
+  const home = path.join(root, 'home')
+  fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  return { root, home }
+}
+
+function childMint(dir, extraArgs = []) {
+  // Spawn a node child that imports the lib and calls mintStoreIdentity(dir).
+  // argv[3+] = <dir> + extra args (--break-identity-write etc.) for the break-input
+  // override (portable, §A.0).
+  const code = `
+    import { mintStoreIdentity } from ${JSON.stringify(LIB_URL)}
+    const dir = process.argv[1]
+    const result = mintStoreIdentity(dir)
+    process.stdout.write(JSON.stringify(result))
+  `
+  return spawnSync(process.execPath, ['--input-type=module', '-e', code, dir, ...extraArgs],
+    { encoding: 'utf8' })
+}
+
+function childRebind(dir) {
+  const code = `
+    import { rebindStoreIdentity } from ${JSON.stringify(LIB_URL)}
+    const dir = process.argv[1]
+    process.stdout.write(JSON.stringify(rebindStoreIdentity(dir)))
+  `
+  return spawnSync(process.execPath, ['--input-type=module', '-e', code, dir],
+    { encoding: 'utf8' })
+}
+
+function childDetach(dir, extraArgs = []) {
+  const code = `
+    import { detachStoreIdentity } from ${JSON.stringify(LIB_URL)}
+    const dir = process.argv[1]
+    process.stdout.write(JSON.stringify(detachStoreIdentity(dir)))
+  `
+  return spawnSync(process.execPath, ['--input-type=module', '-e', code, dir, ...extraArgs],
+    { encoding: 'utf8' })
+}
+
+function handRoot(dir, storeId, extra = {}) {
+  // Write a hand-crafted identity episode to forge duplicate/cycle/alias tests.
+  const id = `19990101-000000-store-identity-${storeId.slice(0, 4)}`
+  const lines = ['---', `id: ${id}`, `date: 1999-01-01`, `time: "00:00"`, `project: hand`, `category: context`, `status: active`, `tags: [store-identity]`, `summary: hand root ${storeId}`, `record_type: store-identity`, `store_id: ${storeId}`]
+  if (extra.supersedes) lines.push(`supersedes: ${extra.supersedes}`)
+  if (extra.detaches_identity_root) lines.push(`detaches_identity_root: ${extra.detaches_identity_root}`)
+  lines.push('---', '', `# hand root ${storeId}`, '', 'hand-crafted for forged fixture.')
+  fs.mkdirSync(path.join(dir, 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(dir, 'episodes', id + '.md'), lines.join('\n') + '\n')
+}
+
+function runInstall(projectDir, home) {
+  return spawnSync(process.execPath, [INSTALL, '--tool', 'claude-code', '--project', projectDir],
+    { cwd: projectDir, encoding: 'utf8',
+      env: { ...process.env, HOME: home, USERPROFILE: home } })
+}
+
+function readRegistry(home) {
+  const p = path.join(home, '.episodic-memory', 'installs.json')
+  return JSON.parse(fs.readFileSync(p, 'utf8'))
+}
+
+function episodesMd(dir) {
+  try { return fs.readdirSync(path.join(dir, 'episodes')).filter((f) => f.endsWith('.md')) }
+  catch { return [] }
+}
+
+// =====================
+// Group 1 — lib + spawned rebuild/protection
+// =====================
+
+t('identity::testMintIdentity', () => {
+  const s = mkStore('mint')
+  const m = mintStoreIdentity(s.dataDir)
+  assert(m.active_id, `mint failed: ${JSON.stringify(m)}`)
+  assert(/^[0-9a-f]{16}$/.test(m.active_id), `active_id format: ${m.active_id}`)
+  assert(/^\d{8}-\d{6}-store-identity-/.test(m.root_id), `root_id format: ${m.root_id}`)
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.active_id, m.active_id, 'resolve after mint')
+  const epFile = fs.readFileSync(path.join(s.dataDir, 'episodes', m.root_id + '.md'), 'utf8')
+  assert(epFile.includes('record_type: store-identity'), 'episode file missing record_type')
+  assert(epFile.includes(`store_id: ${m.active_id}`), 'episode file missing store_id line')
+})
+
+t('identity::testGlobalReservedId', () => {
+  const s = mkStore('global')
+  const m = mintStoreIdentity(s.dataDir, { reserved: GLOBAL_STORE_ID })
+  eq(m.active_id, 'global', 'reserved global id')
+  const epFile = fs.readFileSync(path.join(s.dataDir, 'episodes', m.root_id + '.md'), 'utf8')
+  assert(epFile.includes('store_id: global'), 'episode file must carry store_id: global')
+  assert(epFile.includes('project: global'), 'global reserved mint must use project: global')
+})
+
+t('identity::testIdNeverPath', () => {
+  const a = mkStore('a')
+  const b = mkStore('b')
+  const ma = mintStoreIdentity(a.dataDir)
+  const mb = mintStoreIdentity(b.dataDir)
+  assert(ma.active_id !== mb.active_id, 'two stores must mint distinct ids')
+  assert(/^[0-9a-f]{16}$/.test(ma.active_id), `id hex: ${ma.active_id}`)
+  assert(/^[0-9a-f]{16}$/.test(mb.active_id), `id hex: ${mb.active_id}`)
+  assert(!ma.active_id.includes(path.sep), 'id must not embed path separator')
+  assert(!mb.active_id.includes(path.sep), 'id must not embed path separator')
+})
+
+t('identity::testIdentityWriterAtomic', () => {
+  const s = mkStore('atomic')
+  mintStoreIdentity(s.dataDir)
+  const epsDir = path.join(s.dataDir, 'episodes')
+  const tmp = fs.readdirSync(epsDir).filter((f) => f.includes('.tmp-identity'))
+  eq(tmp.length, 0, 'no .tmp-identity stragglers after mint')
+  const r = resolveStoreIdentity(s.dataDir)
+  assert(!r.error, `resolve after mint: ${JSON.stringify(r)}`)
+})
+
+t('identity::testIdentityWriterCrashNegative', () => {
+  const s = mkStore('crash')
+  // Spawn a child WITH the break flag — write should stage a tmp and refuse to rename.
+  const r = childMint(s.dataDir, ['--break-identity-write'])
+  eq(r.status, 0, `break-flag child must exit 0 (returns error object): ${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  eq(out.error, 'break-identity-write', 'break-flag child error code')
+  const epsDir = path.join(s.dataDir, 'episodes')
+  const mdFiles = fs.readdirSync(epsDir).filter((f) => f.endsWith('.md'))
+  eq(mdFiles.length, 0, 'no .md after break-flag mint')
+  const tmpFiles = fs.readdirSync(epsDir).filter((f) => f.endsWith('.tmp-identity'))
+  eq(tmpFiles.length, 1, 'exactly one staged .tmp-identity')
+  // Resolve → no-identity (tmp is ignored).
+  const r0 = resolveStoreIdentity(s.dataDir)
+  eq(r0.error, 'no-identity', 'resolve after break-flag mint')
+  // In-process mint (no flag) sweeps stale tmp + succeeds.
+  const m = mintStoreIdentity(s.dataDir)
+  assert(m.active_id, `in-process mint after break: ${JSON.stringify(m)}`)
+  const tmpAfter = fs.readdirSync(epsDir).filter((f) => f.endsWith('.tmp-identity'))
+  eq(tmpAfter.length, 0, 'no .tmp-identity after successful follow-up mint (stale sweep)')
+})
+
+t('identity::testActiveIsTerminal', () => {
+  const s = mkStore('terminal')
+  const m = mintStoreIdentity(s.dataDir)
+  const rb = rebindStoreIdentity(s.dataDir)
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.active_id, rb.active_id, 'active_id post-rebind = rebind result')
+  assert(r.active_id !== m.active_id, 'post-rebind active_id differs from initial')
+})
+
+t('identity::testAliasResolution', () => {
+  const s = mkStore('alias')
+  const m = mintStoreIdentity(s.dataDir)
+  const r1 = rebindStoreIdentity(s.dataDir)
+  const r2 = rebindStoreIdentity(s.dataDir)
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.active_id, r2.active_id, 'active_id = latest rebind')
+  assert(JSON.stringify(r.aliases) === JSON.stringify([m.active_id, r1.active_id]),
+    `aliases = [initial, intermediate] got ${JSON.stringify(r.aliases)}`)
+})
+
+t('identity::testPreRebindRefsResolve', () => {
+  const s = mkStore('prerebind')
+  const m = mintStoreIdentity(s.dataDir)
+  rebindStoreIdentity(s.dataDir)
+  const r = resolveStoreIdentity(s.dataDir)
+  assert(r.aliases.includes(m.active_id), `pre-rebind active_id must appear in aliases: ${JSON.stringify(r.aliases)}`)
+})
+
+t('identity::testDuplicateChainFailsLoudBuild', () => {
+  const s = mkStore('dupe')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  handRoot(s.dataDir, 'bbbb2222bbbb2222')
+  const r = spawnSync(process.execPath, [REBUILD, '--scope', 'local'],
+    { cwd: s.projectDir, encoding: 'utf8',
+      env: { ...process.env, HOME: s.home, USERPROFILE: s.home } })
+  eq(r.status, 1, 'rebuild must exit 1 on duplicate chain')
+  const out = JSON.parse(r.stdout)
+  eq(out.status, 'error', 'status')
+  eq(out.error, 'duplicate-identity-chain', 'error code')
+  eq(out.scope, 'local', 'scope label')
+  // EC6: no index file written.
+  const idx = path.join(s.dataDir, 'index.jsonl')
+  assert(!fs.existsSync(idx), 'index.jsonl must NOT be created on validate-then-write failure')
+})
+
+t('identity::testCloneDetachSingleWrite', () => {
+  const a = mkStore('donor')
+  mintStoreIdentity(a.dataDir)
+  rebindStoreIdentity(a.dataDir) // 2 identity eps in donor
+  const donorCountBefore = episodesMd(a.dataDir).length
+  const bRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'store-identity-clone-'))
+  const b = path.join(bRoot, 'b')
+  fs.mkdirSync(b, { recursive: true })
+  fs.cpSync(a.projectDir, b, { recursive: true })
+  const bDataDir = path.join(b, '.episodic-memory')
+  const donorRootId = resolveStoreIdentity(a.dataDir).root_id
+  const det = detachStoreIdentity(bDataDir)
+  eq(det.detached_root_id, donorRootId, 'detach records inherited root')
+  const rb = resolveStoreIdentity(bDataDir)
+  eq(rb.active_id, det.active_id, 'detach active_id')
+  eq(rb.aliases.length, 0, 'detach aliases empty')
+  const bCount = episodesMd(bDataDir).length
+  eq(bCount, donorCountBefore + 1, 'clone + detach = donor count + 1')
+})
+
+t('identity::testCrashBeforeDetachInheritedIntact', () => {
+  const a = mkStore('crashdetach-donor')
+  mintStoreIdentity(a.dataDir)
+  const bRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'store-identity-crashdetach-'))
+  const b = path.join(bRoot, 'b')
+  fs.mkdirSync(b, { recursive: true })
+  fs.cpSync(a.projectDir, b, { recursive: true })
+  const bDataDir = path.join(b, '.episodic-memory')
+  const donorActiveBefore = resolveStoreIdentity(a.dataDir).active_id
+  // Spawn a detach child WITH break flag — write must stage tmp + refuse rename.
+  const r = childDetach(bDataDir, ['--break-identity-write'])
+  eq(r.status, 0, 'break-flag detach child must exit 0')
+  const out = JSON.parse(r.stdout)
+  eq(out.error, 'break-identity-write', 'break-flag detach error')
+  const md = episodesMd(bDataDir)
+  eq(md.length, 1, 'no new .md after break-flag detach')
+  const rb = resolveStoreIdentity(bDataDir)
+  eq(rb.active_id, donorActiveBefore, 'copy still resolves to inherited chain active')
+})
+
+t('identity::testDetachedChainNoAliases', () => {
+  const a = mkStore('detacha')
+  mintStoreIdentity(a.dataDir)
+  const r1 = rebindStoreIdentity(a.dataDir)
+  const r2 = rebindStoreIdentity(a.dataDir)
+  const donorActive = resolveStoreIdentity(a.dataDir).active_id
+  const donorAliases = resolveStoreIdentity(a.dataDir).aliases
+  const bRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'store-identity-detach-'))
+  const b = path.join(bRoot, 'b')
+  fs.mkdirSync(b, { recursive: true })
+  fs.cpSync(a.projectDir, b, { recursive: true })
+  const bDataDir = path.join(b, '.episodic-memory')
+  detachStoreIdentity(bDataDir)
+  const rb = resolveStoreIdentity(bDataDir)
+  assert(!rb.aliases.includes(donorActive), 'donor active must NOT appear in copy aliases')
+  for (const a_id of donorAliases) {
+    assert(!rb.aliases.includes(a_id), `donor alias ${a_id} must NOT appear in copy aliases`)
+  }
+  assert(!rb.aliases.includes(r1.active_id), 'r1 active not in copy')
+  assert(!rb.aliases.includes(r2.active_id), 'r2 active not in copy')
+})
+
+t('identity::testDetachCycleTerminates', () => {
+  const s = mkStore('cycle')
+  // Two hand roots, each detaching the OTHER's root id → cycle at resolve time.
+  // Use distinct first-4-chars of storeId so each handRoot gets a distinct episode id.
+  const rootAId = '19990101-000000-store-identity-aaaa'
+  const rootBId = '19990101-000000-store-identity-bbbb'
+  handRoot(s.dataDir, 'aaaa1111aaaa1111', { detaches_identity_root: rootBId })
+  handRoot(s.dataDir, 'bbbb2222bbbb2222', { detaches_identity_root: rootAId })
+  // Both roots are referenced by the other's detaches_identity_root → activeRoots=[].
+  // The sync resolve returns identity-chain-cycle (termination is the absence of
+  // infinite recursion — the function returns a plain object).
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.error, 'identity-chain-cycle', 'mutual-detach cycle terminates as identity-chain-cycle')
+})
+
+t('identity::testConcurrentMintSingleChain', () => {
+  const s = mkStore('concurrent')
+  // Two simultaneous children racing on mint — the lock + identity-exists check
+  // must let exactly one succeed and one fail with identity-exists.
+  const a = childMint(s.dataDir)
+  const b = childMint(s.dataDir)
+  const aOut = JSON.parse(a.stdout)
+  const bOut = JSON.parse(b.stdout)
+  const successes = [aOut, bOut].filter((o) => o.active_id)
+  const failures = [aOut, bOut].filter((o) => o.error === 'identity-exists')
+  eq(successes.length, 1, 'exactly one successful mint')
+  eq(failures.length, 1, 'exactly one identity-exists rejection')
+  const r = resolveStoreIdentity(s.dataDir)
+  assert(!r.error, `resolve after concurrent mint: ${JSON.stringify(r)}`)
+})
+
+t('identity::testIdentityProtectionArm', () => {
+  const rows = [
+    { id: 'idr1', category: 'context', status: 'active', record_type: 'store-identity' },
+    { id: 'plain1', category: 'context', status: 'active' },
+  ]
+  const todayStr = new Date().toISOString().slice(0, 10)
+  const m = computeProtectedIds(rows, todayStr)
+  assert(m.has('idr1'), 'identity row must be protected')
+  eq(m.get('idr1').reason, 'store-identity-chain', 'reason')
+  assert(!m.has('plain1'), 'plain context row must NOT be protected by identity arm')
+})
+
+t('identity::testIndexCarriesIdentityFields', () => {
+  const s = mkStore('index-fields')
+  mintStoreIdentity(s.dataDir)
+  rebindStoreIdentity(s.dataDir)
+  const bRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'store-identity-indexfields-'))
+  const b = path.join(bRoot, 'b')
+  fs.mkdirSync(b, { recursive: true })
+  fs.cpSync(s.projectDir, b, { recursive: true })
+  const bDataDir = path.join(b, '.episodic-memory')
+  detachStoreIdentity(bDataDir)
+  // Rebuild on the COPY so it exercises the lockstep carry-on for the freshly-written
+  // detach episode (which has detaches_identity_root).
+  const r = spawnSync(process.execPath, [REBUILD, '--scope', 'local'],
+    { cwd: b, encoding: 'utf8',
+      env: { ...process.env, HOME: s.home, USERPROFILE: s.home } })
+  eq(r.status, 0, `rebuild on copy must succeed: ${r.stderr}`)
+  const idx = fs.readFileSync(path.join(bDataDir, 'index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l))
+  // Every identity row must carry store_id. The detach root carries detaches_identity_root.
+  let detachRow = null
+  for (const row of idx) {
+    if (row.record_type !== 'store-identity') continue
+    assert(typeof row.store_id === 'string', `identity row missing store_id: ${JSON.stringify(row)}`)
+    // Read the source file's store_id and verify it matches the index row (lockstep).
+    const src = fs.readFileSync(path.join(bDataDir, 'episodes', row.id + '.md'), 'utf8')
+    const srcFm = src.match(/^---\n([\s\S]*?)\n---/)[1]
+    const sidLine = srcFm.split('\n').find((l) => l.startsWith('store_id:'))
+    const expected = sidLine.split(':')[1].trim()
+    eq(row.store_id, expected, `index store_id matches file for ${row.id}`)
+    if (srcFm.includes('detaches_identity_root:')) {
+      detachRow = row
+    }
+  }
+  assert(detachRow, 'detach row must be present in index')
+  assert(typeof detachRow.detaches_identity_root === 'string', 'detach row must carry detaches_identity_root')
+})
+
+// =====================
+// Group 2 — real install.mjs E2E
+// =====================
+
+t('registry::testRegistryMirror', () => {
+  const s = mkHome('regmirror')
+  // Create a project dir + git init (install requires git context).
+  const project = path.join(s.root, 'p')
+  fs.mkdirSync(project, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: project })
+  // Pre-seed identity before install runs.
+  const dataDir = path.join(project, '.episodic-memory')
+  fs.mkdirSync(path.join(dataDir, 'episodes'), { recursive: true })
+  const minted = mintStoreIdentity(dataDir)
+  assert(minted.active_id, `pre-seed mint: ${JSON.stringify(minted)}`)
+  const r = runInstall(project, s.home)
+  eq(r.status, 0, `install must succeed: ${r.stdout}\n${r.stderr}`)
+  const reg = readRegistry(s.home)
+  eq(reg.schema_version, 2, 'registry schema_version bumped to 2')
+  const row = reg.entries.find((e) => e.project_path === project)
+  assert(row, 'registry must contain row for project')
+  assert(/^[0-9a-f]{16}$/.test(row.store_id), `row.store_id hex: ${row.store_id}`)
+  eq(row.store_id, minted.active_id, 'row.store_id mirrors pre-seeded identity')
+})
+
+t('registry::testMintOnNextRegistration', () => {
+  const s = mkHome('mintnext')
+  const project = path.join(s.root, 'p')
+  fs.mkdirSync(project, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: project })
+  // Do NOT pre-seed identity. The .episodic-memory/episodes directory doesn't even
+  // exist yet — install must create it AND mint on next registration.
+  const r = runInstall(project, s.home)
+  eq(r.status, 0, `install must succeed: ${r.stdout}\n${r.stderr}`)
+  const dataDir = path.join(project, '.episodic-memory')
+  const idn = resolveStoreIdentity(dataDir)
+  assert(!idn.error, `identity now exists: ${JSON.stringify(idn)}`)
+  const reg = readRegistry(s.home)
+  const row = reg.entries.find((e) => e.project_path === project)
+  assert(row, 'registry row exists')
+  eq(row.store_id, idn.active_id, 'row mirrors newly minted identity')
+})
+
+t('registry::testAmbiguousAliasFailsLoud', () => {
+  // Install A, rebind so A has an alias, then forge an identity in project C with
+  // store_id = A's alias. Run install on C → registry write must fail loud.
+  const s = mkHome('ambig')
+  const aProj = path.join(s.root, 'A')
+  const cProj = path.join(s.root, 'C')
+  fs.mkdirSync(aProj, { recursive: true })
+  fs.mkdirSync(cProj, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: aProj })
+  execFileSync('git', ['init', '-q'], { cwd: cProj })
+  // First install A: mints identity.
+  const ra = runInstall(aProj, s.home)
+  eq(ra.status, 0, `install A: ${ra.stdout}\n${ra.stderr}`)
+  const aData = path.join(aProj, '.episodic-memory')
+  // Rebind A so it has a retired alias.
+  const rebind = rebindStoreIdentity(aData)
+  const aIdn = resolveStoreIdentity(aData)
+  // Forge C's identity with store_id = A's alias.
+  const cData = path.join(cProj, '.episodic-memory')
+  fs.mkdirSync(path.join(cData, 'episodes'), { recursive: true })
+  handRoot(cData, aIdn.aliases[0])
+  const rc = runInstall(cProj, s.home)
+  // The install must have output ambiguous-alias-ownership AND not added C's row.
+  const combined = (rc.stdout || '') + (rc.stderr || '')
+  assert(combined.includes('ambiguous-alias-ownership'),
+    `install output must include ambiguous-alias-ownership: ${combined.slice(0, 400)}`)
+  const reg = readRegistry(s.home)
+  const cRow = reg.entries.find((e) => e.project_path === cProj)
+  assert(!cRow, 'C must NOT have a registry row when alias collides')
+})
+
+t('registry::testCopiedStoreRejected', () => {
+  const s = mkHome('copystore')
+  const aProj = path.join(s.root, 'A')
+  const bProj = path.join(s.root, 'B')
+  fs.mkdirSync(aProj, { recursive: true })
+  fs.mkdirSync(bProj, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: aProj })
+  // Install A.
+  const ra = runInstall(aProj, s.home)
+  eq(ra.status, 0, `install A: ${ra.stdout}\n${ra.stderr}`)
+  // Copy A's store dir into B (same identity chain at a different project path).
+  const aStore = path.join(aProj, '.episodic-memory')
+  const bStore = path.join(bProj, '.episodic-memory')
+  fs.mkdirSync(bStore, { recursive: true })
+  fs.cpSync(aStore, bStore, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: bProj })
+  const rb = runInstall(bProj, s.home)
+  const combined = (rb.stdout || '') + (rb.stderr || '')
+  assert(combined.includes('copied-store-rejected'),
+    `install output must include copied-store-rejected: ${combined.slice(0, 400)}`)
+  const reg = readRegistry(s.home)
+  const bRow = reg.entries.find((e) => e.project_path === bProj)
+  assert(!bRow, 'B must NOT have a registry row when its active id matches A')
+})
+
+t('registry::testDuplicateChainFailsLoudRegistration', () => {
+  const s = mkHome('dupchain')
+  const dProj = path.join(s.root, 'D')
+  fs.mkdirSync(dProj, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: dProj })
+  // Forge two identity roots in D.
+  const dStore = path.join(dProj, '.episodic-memory')
+  fs.mkdirSync(path.join(dStore, 'episodes'), { recursive: true })
+  handRoot(dStore, 'dddd1111dddd1111')
+  handRoot(dStore, 'eeee2222eeee2222')
+  const r = runInstall(dProj, s.home)
+  const combined = (r.stdout || '') + (r.stderr || '')
+  assert(combined.includes('duplicate-identity-chain'),
+    `install output must include duplicate-identity-chain (last 600 chars): ${combined.slice(-600)}`)
+  // The mirror throws on the first duplicate root it encounters — the registry write
+  // is aborted. Either no registry exists OR a registry exists but has NO row for D.
+  const regPath = path.join(s.home, '.episodic-memory', 'installs.json')
+  let dRow = null
+  if (fs.existsSync(regPath)) {
+    const reg = JSON.parse(fs.readFileSync(regPath, 'utf8'))
+    dRow = (reg.entries || []).find((e) => e.project_path === dProj)
+  }
+  assert(!dRow, 'D must NOT have a registry row when its identity chain is duplicated')
+})
+
+t('registry::testRelocationIdStable', () => {
+  const s = mkHome('reloc')
+  const aProj = path.join(s.root, 'A')
+  const a2Proj = path.join(s.root, 'A2')
+  fs.mkdirSync(aProj, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: aProj })
+  const r1 = runInstall(aProj, s.home)
+  eq(r1.status, 0, `install A: ${r1.stdout}\n${r1.stderr}`)
+  const reg1 = readRegistry(s.home)
+  const aRow = reg1.entries.find((e) => e.project_path === aProj)
+  assert(aRow, 'A row must exist after first install')
+  const captured = aRow.store_id
+  // §13 EC5: empty identity compares equal to itself and silently passes — require
+  // a real 16-hex id so the relocation assertion actually exercises identity travel.
+  assert(typeof captured === 'string' && /^[0-9a-f]{16}$/.test(captured),
+    `captured store_id must be 16-hex after mirror: ${JSON.stringify(captured)}`)
+  // Rename the project dir to A2 (relocation).
+  fs.renameSync(aProj, a2Proj)
+  const r2 = runInstall(a2Proj, s.home)
+  eq(r2.status, 0, `install A2 (relocated): ${r2.stdout}\n${r2.stderr}`)
+  const reg2 = readRegistry(s.home)
+  const a2Row = reg2.entries.find((e) => e.project_path === a2Proj)
+  assert(a2Row, 'A2 row must exist after relocation install')
+  eq(a2Row.store_id, captured, 'store_id stable across relocation (identity is episode-carried)')
+})
+
+// --- main ---
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail > 0) {
+  console.log('\nFailures:')
+  for (const f of failures) console.log('  -', f)
+}
+process.exit(fail > 0 ? 1 : 0)

--- a/tests/test-store-identity.mjs
+++ b/tests/test-store-identity.mjs
@@ -21,7 +21,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { spawnSync, execFileSync } from 'node:child_process'
+import { spawnSync, execFileSync, spawn } from 'node:child_process'
 import { pathToFileURL } from 'node:url'
 import { fileURLToPath } from 'node:url'
 import { mintStoreIdentity, resolveStoreIdentity, rebindStoreIdentity, detachStoreIdentity, GLOBAL_STORE_ID } from '../scripts/lib/store-identity.mjs'
@@ -38,10 +38,21 @@ const ONLY_FLAG = (() => { const i = process.argv.indexOf('--only'); return i >=
 
 let pass = 0, fail = 0
 const failures = []
+const asyncTests = []
 function t(name, fn) {
   if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
   try { fn(); console.log(`ok ${name}`); pass++ }
   catch (e) { fail++; failures.push(`${name} - ${e && e.message}`); console.log(`FAIL ${name}: ${e && e.message}`) }
+}
+function tAsync(name, fn) {
+  if (ONLY_FLAG && !name.includes(ONLY_FLAG)) return
+  asyncTests.push({ name, fn })
+}
+async function runAsyncTests() {
+  for (const { name, fn } of asyncTests) {
+    try { await fn(); console.log(`ok ${name}`); pass++ }
+    catch (e) { fail++; failures.push(`${name} - ${e && e.message}`); console.log(`FAIL ${name}: ${e && e.message}`) }
+  }
 }
 function assert(cond, msg) { if (!cond) throw new Error(msg) }
 function eq(actual, expected, label) { if (actual !== expected) throw new Error(`${label}: got ${JSON.stringify(actual)} want ${JSON.stringify(expected)}`) }
@@ -319,18 +330,51 @@ t('identity::testDetachCycleTerminates', () => {
   eq(r.error, 'identity-chain-cycle', 'mutual-detach cycle terminates as identity-chain-cycle')
 })
 
-t('identity::testConcurrentMintSingleChain', () => {
+t('identity::testSupersedesCycleFailsLoud', () => {
+  // F6 fold (GLM r1 MINOR-3): §A.5-S1 claims BOTH cycle classes (mutual
+  // detaches_identity_root AND a supersedes cycle) terminate as
+  // identity-chain-cycle. testDetachCycleTerminates covers the mutual-detach
+  // class; this one covers the supersedes class (the walk's revisit guard).
+  // Distinct store_id prefixes so the two handRoot calls produce distinct
+  // episode files (handRoot's id is `19990101-000000-store-identity-${slice(0,4)}`).
+  const s = mkStore('cycle-supersedes')
+  const aStoreId = '1111aaaa1111aaaa'
+  const bStoreId = '2222bbbb2222bbbb'
+  const aId = '19990101-000000-store-identity-1111'
+  const bId = '19990101-000000-store-identity-2222'
+  handRoot(s.dataDir, aStoreId, { supersedes: bId })
+  handRoot(s.dataDir, bStoreId, { supersedes: aId })
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.error, 'identity-chain-cycle', 'supersedes cycle terminates as identity-chain-cycle')
+})
+
+tAsync('identity::testConcurrentMintSingleChain', async () => {
   const s = mkStore('concurrent')
-  // Two simultaneous children racing on mint — the lock + identity-exists check
-  // must let exactly one succeed and one fail with identity-exists.
-  const a = childMint(s.dataDir)
-  const b = childMint(s.dataDir)
-  const aOut = JSON.parse(a.stdout)
-  const bOut = JSON.parse(b.stdout)
+  // F1 fold (GLM r1 MAJOR-1): use async spawn + Promise.all so the children
+  // truly race. spawnSync would block until each child exits → overlap 0ms,
+  // no EC3 contention. Under REAL concurrency, exactly one mints and the
+  // other's lock-acquire-retry observes the winner and returns identity-exists.
+  const code = (dir) => `
+    import { mintStoreIdentity } from ${JSON.stringify(LIB_URL)}
+    process.stdout.write(JSON.stringify(mintStoreIdentity(${JSON.stringify(dir)})))
+  `
+  const runChild = (dir) => new Promise((resolveChild, rejectChild) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', code(dir)], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let out = '', err = ''
+    child.stdout.on('data', (d) => { out += d.toString() })
+    child.stderr.on('data', (d) => { err += d.toString() })
+    child.on('error', rejectChild)
+    child.on('close', (code) => resolveChild({ code, out, err }))
+  })
+  const [a, b] = await Promise.all([runChild(s.dataDir), runChild(s.dataDir)])
+  eq(a.code, 0, `child A exit 0: stderr=${a.err}`)
+  eq(b.code, 0, `child B exit 0: stderr=${b.err}`)
+  const aOut = JSON.parse(a.out)
+  const bOut = JSON.parse(b.out)
   const successes = [aOut, bOut].filter((o) => o.active_id)
-  const failures = [aOut, bOut].filter((o) => o.error === 'identity-exists')
-  eq(successes.length, 1, 'exactly one successful mint')
-  eq(failures.length, 1, 'exactly one identity-exists rejection')
+  const rejected = [aOut, bOut].filter((o) => o.error === 'identity-exists')
+  eq(successes.length, 1, 'exactly one successful mint under real concurrency')
+  eq(rejected.length, 1, 'exactly one identity-exists rejection (lock-serialized loser)')
   const r = resolveStoreIdentity(s.dataDir)
   assert(!r.error, `resolve after concurrent mint: ${JSON.stringify(r)}`)
 })
@@ -345,6 +389,38 @@ t('identity::testIdentityProtectionArm', () => {
   assert(m.has('idr1'), 'identity row must be protected')
   eq(m.get('idr1').reason, 'store-identity-chain', 'reason')
   assert(!m.has('plain1'), 'plain context row must NOT be protected by identity arm')
+})
+
+t('identity::testMintMissingStoreDirErrors', () => {
+  // F4 fold (GLM r1 MINOR-1): mixed error contract was inconsistent — every
+  // other path returned { error }, but a missing storeDir let tryAcquire throw
+  // raw ENOENT. The lib now maps ENOENT to { error: 'store-dir-missing' } so
+  // S2/S4 direct callers can branch on it uniformly.
+  const ghostDir = path.join(os.tmpdir(), `store-identity-ghost-${process.pid}-${Date.now()}`, 'never-created', '.episodic-memory')
+  assert(!fs.existsSync(ghostDir), 'ghost dir must not exist on disk')
+  let result
+  try {
+    result = mintStoreIdentity(ghostDir)
+  } catch (e) {
+    throw new Error(`mint must not throw on missing storeDir: ${e && e.message}`)
+  }
+  eq(result.error, 'store-dir-missing', 'mint on missing storeDir returns { error: store-dir-missing }')
+})
+
+t('identity::testLockTimeoutSurfaces', () => {
+  // F7 fold (GLM r1 NIT-1): the 30s `lock-timeout` return path was untested.
+  // Pre-create clerk-apply.lock with our pid so the lib's tryAcquire observes
+  // a held lock, then mint with lockTimeoutS=0 to force the deadline branch
+  // (default 30s would block the suite).
+  const s = mkStore('lock-timeout')
+  const lockFile = path.join(s.dataDir, 'clerk-apply.lock')
+  fs.writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n${process.ppid}\n`)
+  try {
+    const result = mintStoreIdentity(s.dataDir, { lockTimeoutS: 0 })
+    eq(result.error, 'lock-timeout', 'mint with held lock + lockTimeoutS=0 surfaces lock-timeout')
+  } finally {
+    try { fs.unlinkSync(lockFile) } catch { /* ignore */ }
+  }
 })
 
 t('identity::testIndexCarriesIdentityFields', () => {
@@ -533,7 +609,35 @@ t('registry::testRelocationIdStable', () => {
   eq(a2Row.store_id, captured, 'store_id stable across relocation (identity is episode-carried)')
 })
 
+t('registry::testReservedGlobalForgeryFailsLoud', () => {
+  // F5 fold (GLM r1 MINOR-2): the `global` reserved id belongs only to the
+  // global store, which is never a registry row. The old `if (id === 'global')
+  // continue` skip let two hand-forged-`global` project rows coexist silently.
+  // The mirror now throws `reserved-id-abuse: <project_path>` instead, closing
+  // the project-forgery path.
+  const s = mkHome('global-forgery')
+  const fProj = path.join(s.root, 'F')
+  fs.mkdirSync(fProj, { recursive: true })
+  execFileSync('git', ['init', '-q'], { cwd: fProj })
+  // Hand-write an identity root with the reserved `global` store_id BEFORE install.
+  const fStore = path.join(fProj, '.episodic-memory')
+  fs.mkdirSync(path.join(fStore, 'episodes'), { recursive: true })
+  handRoot(fStore, 'global')
+  const r = runInstall(fProj, s.home)
+  const combined = (r.stdout || '') + (r.stderr || '')
+  assert(combined.includes('reserved-id-abuse'),
+    `install output must include reserved-id-abuse (last 600 chars): ${combined.slice(-600)}`)
+  const regPath = path.join(s.home, '.episodic-memory', 'installs.json')
+  let fRow = null
+  if (fs.existsSync(regPath)) {
+    const reg = JSON.parse(fs.readFileSync(regPath, 'utf8'))
+    fRow = (reg.entries || []).find((e) => e.project_path === fProj)
+  }
+  assert(!fRow, 'forged-global project must NOT have a registry row')
+})
+
 // --- main ---
+await runAsyncTests()
 console.log(`\n${pass} passed, ${fail} failed`)
 if (fail > 0) {
   console.log('\nFailures:')


### PR DESCRIPTION
RFC-012 P2 slice S1: episode-carried store identity, end-to-end (REQ-1..6, REQ-18).

## What ships

- **NEW `scripts/lib/store-identity.mjs`** — mint / rebind / detach / resolve for the per-store identity chain. Opaque 16-hex `store_id` (reserved `global`), P7 supersedes-revision mechanics, atomic writer (temp + fsync + rename) under the shared per-store lock (`clerk-apply.lock`, plan section 8.2), sync lock via `tryAcquire` retry + `Atomics.wait` sleep, argv break-flag crash injection (`--break-identity-write`).
- **`scripts/em-rebuild-index.mjs`** — REQ-4 duplicate-chain fail-loud BEFORE any index write (EC6); lockstep carry of `store_id` / `detaches_identity_root`.
- **`scripts/lib/protection.mjs`** — class-d2 arm: every store-identity chain episode prune-protected (REQ-18).
- **`plugins/consumer-registry.schema.json` + `scripts/lib/install-version.mjs`** — registry `schema_version: 2` with derived `store_id`/`store_aliases` mirror, mint-on-next-registration, fail-loud on duplicate chains / copied stores / ambiguous alias ownership / forged-`global` rows; mirror runs at BOTH the upsert choke point and the update-sweep write (`readRegistry` stays version-agnostic, so v1 registries read fine and upgrade on next write).
- **`scripts/lib/registered-stores.mjs`** — identity surfaced to `--all-projects` consumers (degrade-not-throw).
- **`tests/test-store-identity.mjs`** — 26 tests: 16 lib/rebuild/protection + 6 isolated-HOME real-`install.mjs` E2E + 4 review-round negative-class additions; CI-wired in `plan-marker-validate.yml`.

## Review trail (plan section 19, 19.3b)

| Round | Reviewer | Verdict | Artifact |
|---|---|---|---|
| plan r1/r2 | pi/GLM-5.2 | HOLD-1 -> ACCEPT | `.review-store/rfc-012-p2/glm-plan-r*.md` |
| build r1 | pi/GLM-5.2 | HOLD-3 (0 BLOCKER, 3 MAJOR, 3 MINOR, 1 NIT, probe-grounded) | `.review-store/rfc-012-p2/glm-s1-r1.md` |
| build r2 (cap) | pi/GLM-5.2 | **ACCEPT** (all 7 folds verified CLOSED with probe re-runs) | `.review-store/rfc-012-p2/glm-s1-r2.md` |

Key review catches folded: the concurrent-mint test was sequential (rewritten to real async concurrency); a third registry write path bypassed the identity mirror (now mirror-then-write, deliberately NOT via upsert whose read-merge would resurrect pruned rows); a benign concurrent-mint race caused a spurious fatal in the mirror (now re-resolve-once).

## Verification (artifacts, run by orchestrator)

- `node tests/test-store-identity.mjs` -> 26 passed, 0 failed
- `node tests/test-store-identity.mjs --break-identity-write` -> exit 1, 14 red (negative control bites)
- Regressions green: em-promote 15/15, registered-stores 7/7, prune-protection 29/29, consumer-registry-schema 8/8, fold-all-projects 8/8, all-projects-observability 10/10, install-drift-notice 26/26, uninstall-enforcement 14/14, ci-suite-registration 16/16, validate-plugin-registry OK
- Hard stops: `promotion_sources` nowhere in the diff; `em-promote.mjs` / `em-store.mjs` / `em-revise.mjs` untouched; no new path-authority predicate

## Deferred (step 9)

- NIT (GLM r2): non-numeric `lockTimeoutS` -> NaN deadline hang on the internal test-only opt — issue filed at wrap with 5-field justification.
- Pre-existing em-store write-lock class (plan section 8.2 direct-write gap) remains tracked via #546 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
