### PR TITLE
P2-S2: typed promotion_sources provenance (RFC-012 P2, REQ-7..12)

### DIFF
--- a/.github/workflows/plan-marker-validate.yml
+++ b/.github/workflows/plan-marker-validate.yml
@@ -274,6 +274,8 @@ jobs:
         run: node tests/test-em-promote.mjs
       - name: Run store-identity suite (RFC-012 P2 S1)
         run: node tests/test-store-identity.mjs
+      - name: Run promotion-sources suite (RFC-012 P2 S2)
+        run: node tests/test-promotion-sources.mjs
 
       - name: Run em-console web console suite
         run: node tests/test-em-console.mjs

--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -658,7 +658,8 @@ row set and §A.8 done block.
 ## A.7 Per-slice step tables
 
 _S1 table: authored 2026-07-18 after plan approval (anchors re-verified against main
-`ea94c4c`, zero drift — scout sweep). S2–S4: at each slice start._
+`ea94c4c`, zero drift — scout sweep). S2 table: authored 2026-07-19 against merged
+main `d2105aa` after two parallel MiniMax-M3 scout sweeps. S3–S4: at each slice start._
 
 ### §A.5-S1 Slice constants (verbatim, `scripts/lib/store-identity.mjs`)
 
@@ -760,3 +761,103 @@ node scripts/validate-plugin-registry.mjs        # → exit 0
 grep -rc "promotion_sources" scripts/lib/store-identity.mjs   # → 0 (hard stop)
 git diff --name-only                              # → excludes em-promote.mjs / em-store.mjs / em-revise.mjs
 ```
+
+### §A.5-S2 Slice constants (`scripts/lib/promotion-sources.mjs`)
+
+```js
+export const STRUCTURED_FIELDS = ['promotion_sources']
+export const PROMOTION_SOURCE_KEYS = ['content_sha256', 'episode_id', 'store_id']
+export const CONTENT_SHA256_RE = /^[0-9a-f]{64}$/
+```
+
+Exact validation error codes: `promotion-sources-empty`,
+`promotion-sources-shape`, `promotion-sources-hash`,
+`promotion-sources-chars`, `lesson-only`. Rebuild malformed-JSON code:
+`structured-frontmatter-invalid`. Canonical item key order is
+`content_sha256`, `episode_id`, `store_id`; items sort by their canonical JSON
+string. `promotion_sources` remains absent from `ACTIVATION_ARRAY_FIELDS`.
+
+**S2 scout fold decisions (2026-07-19).** The approved slice named five edited
+scripts but did not assign a home for the REQ-9/REQ-10 helpers. One new shared
+library, `scripts/lib/promotion-sources.mjs`, owns the typed SourceRef contract,
+canonicalization, hashing, validation, and registry resolution. This is the
+minimum non-duplicated surface and is reused by S4 plus RFC-012's named NAPMEM-C
+consumer. It imports `STORE_ID_RE` from `store-identity.mjs`; it introduces no
+dependency and no write path. EC11 controls punctuation validation: canonical
+JSON safely carries commas in `episode_id`, so `promotion-sources-chars` rejects
+control characters and line separators, not JSON-safe punctuation. `store_id`
+and `content_sha256` retain their closed regexes.
+
+### §A.4-S2 Pre-flight (step 2.0)
+
+| Check | Command | Expected |
+|---|---|---|
+| Correct isolated branch | `git branch --show-current` | `feat/rfc-012-p2-s2` |
+| Clean tracked state before plan delta | `git status --short` | empty |
+| Merged S1 base | `git rev-parse --short HEAD` | `d2105aa` |
+| Runtime | `node --version` | `v20` or higher |
+| Promotion baseline | `node tests/test-em-promote.mjs` | `15/15 pass` |
+| Identity baseline | `node tests/test-store-identity.mjs` | `27 passed, 0 failed` |
+| Parse-order vulnerability present | `grep -n "const arrMatch = raw.match" scripts/em-rebuild-index.mjs` | one current generic bracket parser anchor |
+| Structured field absent | `grep -n "promotion_sources" scripts/lib/activation.mjs scripts/em-store.mjs scripts/em-revise.mjs scripts/em-rebuild-index.mjs scripts/em-promote.mjs` | zero matches |
+| Flat-array barrier intact | `grep -n "ACTIVATION_ARRAY_FIELDS =" scripts/lib/activation.mjs` | five existing fields; no `promotion_sources` |
+
+### `P2-S2` — Typed promotion sources and content-bound member identity (REQ-7..12)
+
+**Files this slice may touch:** NEW `scripts/lib/promotion-sources.mjs`, NEW
+`tests/test-promotion-sources.mjs`, `scripts/lib/activation.mjs`,
+`scripts/em-store.mjs`, `scripts/em-revise.mjs`, `scripts/em-rebuild-index.mjs`,
+`scripts/em-promote.mjs`, `tests/test-em-promote.mjs`,
+`.github/workflows/plan-marker-validate.yml`, and this plan. **Read-only
+invariants:** `scripts/em-trigger-index.mjs`, `tests/test-ci-suite-registration.mjs`.
+**Hard stops:** no apply/confirm/fingerprint behavior, no migration, no registry
+slot/schema change, no ranking/search input, no direct-write lock expansion.
+
+| Step | File | Kind | Exact action (anchor + literal change) | Verify (observed → expected) |
+|---|---|---|---|---|
+| 2.0 | — | — | Run §A.4-S2 pre-flight. | every row passes |
+| 2.1 | `tests/test-promotion-sources.mjs` | **CREATE RED** | Build the isolated-HOME real-script harness using `tests/test-em-promote.mjs:25-60`. Register the §14 Group 3+4 names plus REQ-10 unit cases: `testPromotionSourcesWrite`, `testPromotionSourcesRoundTrip`, `testReviseInherit`, `testCommaValueByteRoundTrip`, `testEmptySourcesReject`, `testShapeReject`, `testHashReject`, `testCharsReject`, `testLessonOnly`, `testNoEarnedPriorityForge`, `testEvidenceGateUnchanged`, `testContentShaVector`, `testCrlfLfIdentical`, `testResolveSourceRefs`, `testUnresolvedAliasSurfaces`, `testMissingNeverSilent`, `testSameIdSummaryDiffBodyDistinct`, `testReplicaCollapseOnHashMatch`, `testNewPromotionTyped`, `testNoSentinelOnNewWrites`. Every rejecting writer test snapshots the target store before/after and asserts zero mutation. | `node tests/test-promotion-sources.mjs` → non-zero with failures naming unimplemented S2 behavior |
+| 2.2 | `scripts/lib/promotion-sources.mjs` | **CREATE** | Imports `node:crypto` and `{ STORE_ID_RE }` from `./store-identity.mjs`; exports §A.5-S2 constants; `validatePromotionSources(value)` enforces nonempty array, exact keys, string values, `STORE_ID_RE`, 64-lowercase-hex hash, nonempty `episode_id`, and no C0/C1/U+2028/U+2029 characters; returns the exact error codes plus item index detail. `canonicalizePromotionSources(value)` validates, rebuilds each object in §A.5 key order, sorts by `JSON.stringify`, and returns the new array. `serializePromotionSources(value)` returns canonical compact JSON. `computeContentSha256(buf)` converts to UTF-8 bytes, replaces CRLF byte pairs with LF, and returns lowercase SHA-256. `resolveSourceRefs(refs, registry)` maps active `store_id` plus every `store_aliases` member to its registry row and returns `{ resolved: [{ source, store }], missing: [source] }` without dropping or throwing on absent rows. | `node tests/test-promotion-sources.mjs --only testContentShaVector` and `--only testResolveSourceRefs` → pass |
+| 2.3 | `scripts/lib/activation.mjs` | **EDIT** | Import `STRUCTURED_FIELDS` from `./promotion-sources.mjs` and re-export it. In `parseActivationFromFrontmatter`, insert a `STRUCTURED_FIELDS.includes(key)` branch before `ACTIVATION_ARRAY_FIELDS.includes(key)`; parse with `JSON.parse(raw)` and propagate malformed JSON. Extend its return JSDoc with `promotion_sources`. Do not change `ACTIVATION_ARRAY_FIELDS` or `serializeInlineArray`. | `node tests/test-promotion-sources.mjs --only testReviseInherit` remains RED only at the writer step; `grep -n "ACTIVATION_ARRAY_FIELDS ="` still excludes `promotion_sources` |
+| 2.4 | `scripts/em-store.mjs` | **EDIT** | Add `--promotion-sources-json <json>` to help and parse it with `flag`. Before any write: JSON.parse, `validatePromotionSources`, and category `lesson` enforcement with the exact codes. Canonicalize once. After the activation-array serialization block, append `promotion_sources: <canonical compact JSON>`. Add the array as a present-only index field outside the `ACTIVATION_ARRAY_FIELDS` loop. | writer, empty, shape, hash, chars, and lesson-only tests pass; rejected-store before/after bytes match |
+| 2.5 | `scripts/em-revise.mjs` | **EDIT** | Add the same optional flag/help. Before the original supersede mutation, parse and validate an explicit override; otherwise inherit `promotion_sources` from `parseActivationFromFrontmatter`. Serialize canonical JSON outside the activation-array loop and carry it in the index object outside `ACTIVATION_ARRAY_FIELDS`. Explicit `[]` rejects and cannot erase provenance. | `testReviseInherit` and `testCommaValueByteRoundTrip` pass; bad override leaves original active and byte-identical |
+| 2.6 | `scripts/em-rebuild-index.mjs` | **EDIT** | Import `STRUCTURED_FIELDS`. In `parseFrontmatter`, route a structured key through `JSON.parse(raw)` before the generic bracket-array regex. Return a typed parse error carrying field and partial id on malformed JSON. In `--check` and rebuild mode, surface `structured-frontmatter-invalid` in JSON and exit 1 before index writes for the affected scope. Add present-only `promotion_sources` to the lockstep emit object. | round-trip and malformed-JSON tests pass; store → rebuild index field deep-equals writer index field |
+| 2.7 | `scripts/em-promote.mjs` | **EDIT** | Import `computeContentSha256`, `canonicalizePromotionSources`, `serializePromotionSources`, and `validatePromotionSources`. Read the full episode file before member dedupe. Member key becomes `<episode_id>#<content_sha256>`; identical id+content replicas collapse while each replica contributes its canonical `{store_id,episode_id,content_sha256}` source. Candidate identity/order derives from sorted canonical SourceRefs. Existing typed global promotions dedupe by canonical `promotion_sources`; the legacy `promoted:<sha8>` and final-body Sources parser remain read-only compatibility paths. New writes keep `promoted-lesson`, emit no `promoted:<sha8>`, pass `--promotion-sources-json`, and use the newest member's real `project` instead of `cross-project`. `## Sources` remains human rendering only for typed rows. Missing store identity is surfaced in `warnings`, never converted to a path identity. | member identity, typed write, sentinel, idempotency, source-store parity, injection, and superset tests pass |
+| 2.8 | `tests/test-em-promote.mjs` | **EDIT FIXTURE LEDGER** | Evolve only assertions whose registered contract REQ-11 replaces: apply test asserts `promotion_sources` and zero `promoted:<sha8>` tags; foreign-tag test expects zero identity tags; help text expects typed provenance. Convert the malformed-Sources warning fixture into a hand-authored legacy row by removing typed provenance and adding a valid legacy hash tag before stripping its body section. Preserve the remaining behavioral assertions unchanged. | `node tests/test-em-promote.mjs` → all pass; legacy warning still discriminates compatibility path |
+| 2.9 | `.github/workflows/plan-marker-validate.yml` | **EDIT** | After the store-identity suite step, add `Run promotion-sources suite (RFC-012 P2 S2)` invoking `node tests/test-promotion-sources.mjs`. | registration test below passes |
+| 2.10 | `tests/test-ci-suite-registration.mjs` | **VERIFY ONLY** | Run the existing recursive CI-registration ratchet; it discovers the new suite automatically and requires the exact workflow step from 2.9. Do not edit its shrink-only baseline. | `node tests/test-ci-suite-registration.mjs` → all pass |
+| 2.11 | — | — | Run §A.8-S2, inspect `git diff --check`, `git diff --stat`, and the full diff. | every command passes; diff contains only the allowed set |
+| 2.12 | — | — | Freeze the diff and dispatch GLM-5.2 through the repository second-opinion harness. Fold every finding with `ACCEPT`, `ACCEPT-WITH-MOD`, `REJECT`, `DEFER`, or `NEEDS-EVIDENCE`; re-run §A.8-S2 after folds. | final independent verdict `ACCEPT`; deferred findings have step-9 artifacts |
+
+### §A.7-S2 all-`em-*` interaction disposition
+
+| Disposition | Scripts | Reason |
+|---|---|---|
+| CHANGED | `em-store`, `em-revise`, `em-rebuild-index`, `em-promote` | typed write/inherit/rebuild and content-bound promotion |
+| INTERACTS, invariant-only | `em-trigger-index` | earned priority must continue reading only `evidence`/`lessons`; runtime negative plus zero-match guard |
+| INTERACTS, generic JSON-row preservation | `em-check-stale`, `em-doctor`, `em-embed`, `em-feedback`, `em-graph`, `em-list`, `em-pattern-health`, `em-prune`, `em-recall`, `em-review-request`, `em-search`, `em-semantic`, `em-stats`, `em-watch-codex`, `em-workflow-validate` | readers parse complete index JSON objects and neither rank nor filter on the new field |
+| INTERACTS, byte/index preservation | `em-backup`, `em-move`, `em-restore` | episode bytes or complete index rows move intact; rebuild becomes the structured parser authority |
+| INTERACTS, sanctioned writer delegation | `em-capture`, `em-console`, `em-violation` | delegate ordinary writes to `em-store`; no new flags or evidence semantics |
+| INTERACTS, separate typed writers | `em-consolidate`, `em-seed-patterns` | do not author promoted lessons; `ACTIVATION_ARRAY_FIELDS` stays flat and unchanged |
+| UNCHANGED | `em-audit-compliance`, `em-lock`, `em-manage`, `em-mine-transcripts`, `em-pin`, `em-rfc-validate`, `em-routines`, `em-session-end-prompt`, `em-sync-install`, `lib/em-recall-purity` | no promotion provenance parse, identity, ranking, or write responsibility |
+
+### §A.8-S2 Definition of done (mechanical)
+
+```bash
+node tests/test-promotion-sources.mjs
+node tests/test-em-promote.mjs
+node tests/test-store-identity.mjs
+node tests/test-activation-lib.mjs
+node tests/test-trigger-index.mjs
+node tests/test-ci-suite-registration.mjs
+node scripts/validate-plugin-registry.mjs
+grep -n "promotion_sources" scripts/em-trigger-index.mjs
+grep -n "ACTIVATION_ARRAY_FIELDS =" scripts/lib/activation.mjs
+git diff --check
+git diff --stat
+git status --short
+```
+
+Expected: every Node suite exits 0; the trigger-index grep prints zero matches;
+the activation constant still lists only the five flat arrays; diff checks are
+clean and the status set is a subset of the S2 allowlist.

--- a/scripts/em-promote.mjs
+++ b/scripts/em-promote.mjs
@@ -16,30 +16,29 @@
  * episodes; clusters them by token-set Jaccard (episodeTokens over
  * summary+tags+body — the same vocabulary em-consolidate uses); a cluster is
  * a promotion candidate only when it spans >=2 DISTINCT project stores with
- * >=2 distinct member identities. Replicas (same id AND same summary in
+ * >=2 distinct member identities. Replicas (same id AND same normalized file bytes in
  * multiple stores — clone/fork stores) collapse to one member and are NOT
- * recurrence by themselves; a coincident id with DIFFERENT content stays two
+ * recurrence by themselves; a coincident id with DIFFERENT bytes stays two
  * distinct members (episode ids are not proven globally unique across
  * independent stores).
  *
- * Idempotency keys on SOURCE IDENTITY, never similarity (a digest is a token
- * superset of its members, so similarity dilutes as clusters grow): each
- * member's key is `<id>#<sha8(summary)>` (stable — episode files are
- * immutable; revisions mint new ids), and the candidate hash is
- * sha8 over the newline-joined sorted key list, carried as a `promoted:<sha8>`
- * tag on the written episode. A candidate whose hash tag already exists on an
- * ACTIVE global episode is skipped (`already-promoted`). A grown cluster
- * (strict superset of an already-promoted member set) promotes under its new
- * hash with a `Supersedes-promotion:` back-reference in its Sources.
+ * Idempotency keys on typed SOURCE IDENTITY, never similarity (a digest is a
+ * token superset of its members, so similarity dilutes as clusters grow).
+ * Members bind `<episode_id>#<content_sha256>` and candidates bind the sorted
+ * canonical SourceRefs written in `promotion_sources`. A matching ACTIVE
+ * global typed promotion is skipped (`already-promoted`). A grown cluster
+ * promotes with a `Supersedes-promotion:` human-readable back-reference.
  *
- * Drift detection: existing active `promoted-lesson` episodes with a
- * malformed hash tag or an absent/malformed `## Sources` section are reported
- * in `warnings` (correction flows through em-revise; never blocks).
+ * Legacy active promotions remain read-compatible: an unambiguous candidate
+ * retains the old sorted `<id>#<sha8(summary)>` hash for exact idempotency,
+ * while final `## Sources` bare ids support fail-safe strict-superset backrefs.
+ * Typed identity remains authoritative for every new write. Malformed legacy
+ * rows surface warnings and never block.
  *
- * Candidate ordering is deterministic: sorted by promoted-hash ascending.
+ * Candidate ordering is deterministic: sorted by typed SourceRef hash.
  *
  * Outputs JSON: { status, dry_run, min_sim, candidates|promoted, skipped,
- * warnings, note? }. Exit 0; exit 1 when an --apply spawn failed; exit 2 on
+ * warnings, missing_sources, note? }. Exit 0; exit 1 when an --apply spawn failed; exit 2 on
  * usage errors.
  */
 
@@ -52,6 +51,7 @@ import { fileURLToPath } from 'url'
 import { loadIndex, episodeTokens, normalizeTags } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 import { resolveRegisteredStores } from './lib/registered-stores.mjs'
+import { canonicalizePromotionSources, computeContentSha256, resolveSourceRefs, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -70,7 +70,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
     script: 'em-promote.mjs',
     tier: 'EXPERIMENTAL',
     decision_date: PROMOTE_DECISION_DATE,
-    usage: `node em-promote.mjs [--min-sim <0..1>] [--apply] — EXPERIMENTAL (promote-or-remove decision ${PROMOTE_DECISION_DATE}): detect lessons recurring across >=2 consumer-registry project stores; dry-run by default; --apply writes ONE global lesson episode per recurrence (tags ${PROMOTED_TAG} + ${PROMOTED_HASH_TAG_PREFIX}<sha8>, body carries a ## Sources section); source stores are never written`,
+    usage: `node em-promote.mjs [--min-sim <0..1>] [--apply] — EXPERIMENTAL (promote-or-remove decision ${PROMOTE_DECISION_DATE}): detect lessons recurring across >=2 consumer-registry project stores; dry-run by default; --apply writes ONE global lesson episode per recurrence (tag ${PROMOTED_TAG}, typed promotion_sources provenance, and a human-readable ## Sources section); legacy promoted:<sha8> rows remain read-only-compatible; source stores are never written`,
   }))
   process.exit(0)
 }
@@ -110,27 +110,39 @@ function jaccard(a, b) {
 // Gather candidate members from every registered store (read-only).
 // ---------------------------------------------------------------------------
 const stores = resolveRegisteredStores()
-if (stores.length < 2) {
-  console.log(JSON.stringify({ status: 'ok', dry_run: !apply, min_sim: minSim, candidates: [], skipped: [], warnings: [], note: 'needs >=2 registered stores (consumer registry lists ' + stores.length + ')' }))
-  process.exit(0)
-}
+const insufficientStores = stores.length < 2
 
-// memberKey `<id>#<sha8(summary)>` collapses replicas (same id + same summary)
-// while keeping coincident-id-different-content rows distinct.
+const warnings = []
+const missingSources = []
+
+// Member identity binds the immutable episode bytes. Replicas collapse only
+// when id and normalized-byte content hash both match.
 const byKey = new Map() // key -> {id, summary, project, tags, tokens, stores: Set, storeShown: string}
 for (const st of stores) {
+  if (typeof st.store_id !== 'string') {
+    warnings.push({ store: st.label, problem: `store identity unavailable${st.store_identity_error ? `: ${st.store_identity_error}` : ''}` })
+    continue
+  }
   const rows = loadIndex(st.data_dir, st.label)
   for (const r of rows) {
     if (r.status === 'superseded') continue
     if (typeof r.id !== 'string' || typeof r.summary !== 'string') continue
     if (canonicalCategory(r.category) !== 'lesson') continue
-    const key = `${r.id}#${sha8(r.summary)}`
-    if (byKey.has(key)) {
-      byKey.get(key).stores.add(st.data_dir)
+    let content
+    try { content = fs.readFileSync(path.join(st.data_dir, 'episodes', `${r.id}.md`)) } catch {
+      warnings.push({ episode: r.id, store: st.label, problem: 'episode file missing' })
       continue
     }
-    let body = ''
-    try { body = bodyOf(fs.readFileSync(path.join(st.data_dir, 'episodes', `${r.id}.md`), 'utf8')) } catch {}
+    const contentSha256 = computeContentSha256(content)
+    const key = `${r.id}#${contentSha256}`
+    const source = { store_id: st.store_id, episode_id: r.id, content_sha256: contentSha256 }
+    if (byKey.has(key)) {
+      const member = byKey.get(key)
+      member.stores.add(st.data_dir)
+      member.sources.push(source)
+      continue
+    }
+    const body = bodyOf(content.toString('utf8'))
     byKey.set(key, {
       key,
       id: r.id,
@@ -140,6 +152,7 @@ for (const st of stores) {
       body,
       tokens: episodeTokens({ summary: r.summary, tags: r.tags, body }),
       stores: new Set([st.data_dir]),
+      sources: [source],
     })
   }
 }
@@ -190,11 +203,16 @@ for (const cluster of byRoot.values()) {
   if (!independent) continue
   const storeUnion = new Set(cluster.flatMap(m => [...m.stores]))
   cluster.sort((a, b) => a.id.localeCompare(b.id) || a.key.localeCompare(b.key))
-  const keys = cluster.map(m => m.key).sort()
+  const promotionSources = canonicalizePromotionSources(cluster.flatMap(m => m.sources))
+  // Transition-only compatibility identity: this is exactly the pre-S2
+  // candidate hash input. New writes never serialize it as a tag.
+  const legacyKeys = [...new Set(cluster.map(m => `${m.id}#${sha8(m.summary)}`))].sort()
   candidates.push({
-    hash: sha8(keys.join('\n')),
+    hash: sha8(serializePromotionSources(promotionSources)),
+    legacy_hash: sha8(legacyKeys.join('\n')),
     members: cluster,
     store_dirs: [...storeUnion].sort(),
+    promotion_sources: promotionSources,
   })
 }
 candidates.sort((a, b) => a.hash.localeCompare(b.hash))
@@ -205,12 +223,21 @@ candidates.sort((a, b) => a.hash.localeCompare(b.hash))
 const HASH_TAG_RE = /^promoted:[0-9a-f]{8}$/
 const globalRows = loadIndex(GLOBAL_DIR, 'global')
 const existingByHashTag = new Map() // 'promoted:<sha8>' -> episode id
-const existingSourceSets = []       // {id, ids: Set<member episode id>}
-const warnings = []
+const existingSourceSets = []       // {id, representation:'typed'|'legacy', ids:Set<string>}
 for (const r of globalRows) {
   if (r.status === 'superseded') continue
   const tags = Array.isArray(r.tags) ? r.tags.map(String) : []
   if (!tags.includes(PROMOTED_TAG)) continue
+  const typed = validatePromotionSources(r.promotion_sources)
+  if (typed.ok) {
+    const canonical = canonicalizePromotionSources(r.promotion_sources)
+    existingByHashTag.set(`typed:${serializePromotionSources(canonical)}`, r.id)
+    const resolution = resolveSourceRefs(canonical, stores)
+    missingSources.push(...resolution.missing)
+    existingSourceSets.push({ id: r.id, representation: 'typed', ids: new Set(canonical.map(s => `${s.episode_id}#${s.content_sha256}`)) })
+    continue
+  }
+  if (r.promotion_sources !== undefined) warnings.push({ episode: r.id, problem: `invalid promotion_sources: ${typed.error}` })
   const hashTags = tags.filter(t => t.startsWith(PROMOTED_HASH_TAG_PREFIX))
   for (const ht of hashTags) {
     if (HASH_TAG_RE.test(ht)) existingByHashTag.set(ht, r.id)
@@ -239,25 +266,44 @@ for (const r of globalRows) {
   }
   const srcSection = segments[segments.length - 1]
   const ids = new Set()
-  for (const m of srcSection.matchAll(/^- (\S+) \(/gm)) ids.add(m[1])
+  let ambiguous = false
+  for (const m of srcSection.matchAll(/^- (\S+) \(/gm)) {
+    if (ids.has(m[1])) ambiguous = true
+    ids.add(m[1])
+  }
   if (ids.size === 0) warnings.push({ episode: r.id, problem: 'empty/malformed ## Sources list' })
-  else existingSourceSets.push({ id: r.id, ids })
+  else existingSourceSets.push({ id: r.id, representation: 'legacy', ids, ambiguous })
 }
 
 const fresh = []
 const skipped = []
 for (const c of candidates) {
-  const tag = `${PROMOTED_HASH_TAG_PREFIX}${c.hash}`
-  const existing = existingByHashTag.get(tag)
-  if (existing) {
-    skipped.push({ hash: c.hash, reason: 'already-promoted', existing })
+  const typedKey = `typed:${serializePromotionSources(c.promotion_sources)}`
+  const typedExisting = existingByHashTag.get(typedKey)
+  if (typedExisting) {
+    skipped.push({ hash: c.hash, reason: 'already-promoted', existing: typedExisting })
     continue
   }
   // Strict-superset of an already-promoted member set → defined disposition:
-  // promote under the new hash, back-referencing the prior digest.
-  const memberIds = new Set(c.members.map(m => m.id))
-  const prior = existingSourceSets.find(s =>
-    s.ids.size < memberIds.size && [...s.ids].every(id => memberIds.has(id)))
+  // promote under the new typed hash, back-referencing the prior digest.
+  const typedMemberIds = new Set(c.members.map(m => m.key))
+  const bareMemberIds = new Set(c.members.map(m => m.id))
+  // A bare legacy id cannot distinguish two independent same-id contents.
+  // In that shape the weaker representation may neither suppress a typed
+  // write nor fabricate a superset relationship.
+  const legacyAmbiguous = bareMemberIds.size !== typedMemberIds.size
+  if (!legacyAmbiguous) {
+    const legacyExisting = existingByHashTag.get(`${PROMOTED_HASH_TAG_PREFIX}${c.legacy_hash}`)
+    if (legacyExisting) {
+      skipped.push({ hash: c.hash, reason: 'already-promoted', existing: legacyExisting })
+      continue
+    }
+  }
+  const prior = existingSourceSets.find(s => {
+    const candidateIds = s.representation === 'typed' ? typedMemberIds : bareMemberIds
+    if (s.representation === 'legacy' && (legacyAmbiguous || s.ambiguous)) return false
+    return s.ids.size < candidateIds.size && [...s.ids].every(id => candidateIds.has(id))
+  })
   if (prior) c.supersedes_promotion = prior.id
   fresh.push(c)
 }
@@ -267,12 +313,13 @@ function candidateReport(c) {
     hash: c.hash,
     stores: c.store_dirs,
     ...(c.supersedes_promotion ? { supersedes_promotion: c.supersedes_promotion } : {}),
+    promotion_sources: c.promotion_sources,
     members: c.members.map(m => ({ id: m.id, project: m.project, summary: m.summary, stores: [...m.stores].sort() })),
   }
 }
 
 if (!apply) {
-  console.log(JSON.stringify({ status: 'ok', dry_run: true, min_sim: minSim, candidates: fresh.map(candidateReport), skipped, warnings }))
+  console.log(JSON.stringify({ status: 'ok', dry_run: true, min_sim: minSim, candidates: fresh.map(candidateReport), skipped, warnings, missing_sources: missingSources, ...(insufficientStores ? { note: 'needs >=2 registered stores (consumer registry lists ' + stores.length + ')' } : {}) }))
   process.exit(0)
 }
 
@@ -293,12 +340,10 @@ for (const c of fresh) {
   const newest = c.members[c.members.length - 1]
   const summary = `Recurring lesson: ${newest.summary}`
   // Reviewer F3: member tags are untrusted for the IDENTITY axis — a stray
-  // promoted:* member tag unioned onto the digest would enter the dedupe set
-  // and silently skip a future legitimate candidate. Only OUR hash tag rides.
+  // promoted:* member tags are legacy identity and never ride a new digest.
   const tags = normalizeTags([
     ...c.members.flatMap(m => m.tags).filter(t => !String(t).startsWith(PROMOTED_HASH_TAG_PREFIX) && String(t) !== PROMOTED_TAG),
     PROMOTED_TAG,
-    `${PROMOTED_HASH_TAG_PREFIX}${c.hash}`,
   ])
   // Reviewer F2 (write side): excerpts and summaries are untrusted markdown —
   // quote any heading line so member text can never mint a section marker
@@ -320,11 +365,12 @@ for (const c of fresh) {
   const r = spawnSync(process.execPath, [
     EM_STORE,
     '--scope', 'global',
-    '--project', 'cross-project',
+    '--project', newest.project,
     '--category', 'lesson',
     '--tags', tags.join(','),
     '--summary', summary,
     '--body-file', bodyFile,
+    '--promotion-sources-json', serializePromotionSources(c.promotion_sources),
   ], { cwd: GLOBAL_DIR, encoding: 'utf8' })
   let child = null
   try { child = JSON.parse(r.stdout) } catch {}
@@ -337,5 +383,5 @@ for (const c of fresh) {
 }
 try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch {}
 
-console.log(JSON.stringify({ status: 'ok', dry_run: false, min_sim: minSim, promoted, skipped, warnings }))
+console.log(JSON.stringify({ status: 'ok', dry_run: false, min_sim: minSim, promoted, skipped, warnings, missing_sources: missingSources, ...(insufficientStores ? { note: 'needs >=2 registered stores (consumer registry lists ' + stores.length + ')' } : {}) }))
 process.exit(anyFailure ? 1 : 0)

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -17,6 +17,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
 import { resolveStoreIdentity } from './lib/store-identity.mjs'
+import { STRUCTURED_FIELDS } from './lib/promotion-sources.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -65,7 +66,11 @@ if (checkMode) {
       let files = []
       try { files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort() } catch { continue }
       for (const file of files) {
-        const fm = parseFrontmatter(fs.readFileSync(path.join(episodesDir, file), 'utf8'))
+        let fm
+        try { fm = parseFrontmatter(fs.readFileSync(path.join(episodesDir, file), 'utf8')) } catch (e) {
+          console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null }))
+          process.exit(1)
+        }
         if (!fm || !fm.id) continue
         const v = validateCategory(fm.category, { allowDeprecated: true })
         if (!v.ok) drift.push({ id: fm.id, category: fm.category ?? null, kind: 'unknown' })
@@ -93,13 +98,22 @@ function parseFrontmatter(content) {
     const m = line.match(/^(\w+):\s*(.*)$/)
     if (!m) continue
     const [, key, raw] = m
-    const arrMatch = raw.match(/^\[(.*)\]$/)
-    if (arrMatch) {
-      data[key] = arrMatch[1].split(',').map(s => s.trim()).filter(Boolean)
-    } else if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
-      data[key] = raw.slice(1, -1)
+    if (STRUCTURED_FIELDS.includes(key)) {
+      try { data[key] = JSON.parse(raw) } catch {
+        const e = new Error('structured-frontmatter-invalid')
+        e.field = key
+        e.id = data.id
+        throw e
+      }
     } else {
-      data[key] = raw === 'null' ? null : raw
+      const arrMatch = raw.match(/^\[(.*)\]$/)
+      if (arrMatch) {
+        data[key] = arrMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+      } else if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+        data[key] = raw.slice(1, -1)
+      } else {
+        data[key] = raw === 'null' ? null : raw
+      }
     }
   }
   return data
@@ -156,7 +170,11 @@ function rebuildDir(dataDir, label) {
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
-    const fm = parseFrontmatter(content)
+    let fm
+    try { fm = parseFrontmatter(content) } catch (e) {
+      console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null, scope: label }))
+      process.exit(1)
+    }
     if (!fm || !fm.id) continue
     const normalizedTags = normalizeTags(Array.isArray(fm.tags) ? fm.tags : [])
 
@@ -211,6 +229,7 @@ function rebuildDir(dataDir, label) {
       ...(fm.priority !== undefined ? { priority: Number.isFinite(priorityNum) ? priorityNum : fm.priority } : {}),
       ...(typeof fm.review_by === 'string' ? { review_by: fm.review_by } : {}),
       ...(typeof fm.violated_pattern === 'string' ? { violated_pattern: fm.violated_pattern } : {}),
+      ...(Array.isArray(fm.promotion_sources) ? { promotion_sources: fm.promotion_sources } : {}),
       ...(fm.pinned === true || fm.pinned === 'true' ? { pinned: true } : {}),
       // RFC-009 P4-S4 (round-2 N2): clerk run-record + digest markers. record_type
       // feeds protection.mjs class-d (latest-run-record reservation) + the crash

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -35,6 +35,7 @@ import { validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, parseActivationFromFrontmatter, illegalScalarChar } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
+import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -45,7 +46,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-revise.mjs', usage: 'node em-revise.mjs --original <id> --project <name> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path|->) [--scope inherit|local|global] [--pin] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...  (--body-file - reads stdin; prefer it over inline --body for bodies with backticks/$()/$VAR, which the shell corrupts before the script runs — safe form: --body-file - <<\'EOF\' … EOF)' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-revise.mjs', usage: 'node em-revise.mjs --original <id> --project <name> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path|->) [--scope inherit|local|global] [--pin] [--promotion-sources-json <json> (lesson only)] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...  (--body-file - reads stdin; prefer it over inline --body for bodies with backticks/$()/$VAR, which the shell corrupts before this script runs — safe form: --body-file - <<\'EOF\' … EOF)' }))
   process.exit(0)
 }
 
@@ -87,6 +88,7 @@ const appliesToTools = flagAll('--applies-to-tool')
 const priorityFlag = flag('--priority')
 const reviewBy = flag('--review-by')
 const evidence = flagAll('--evidence')
+const promotionSourcesJson = flag('--promotion-sources-json')
 
 const VALID_SCOPES_REVISE = ['inherit', 'local', 'global']
 if (!VALID_SCOPES_REVISE.includes(scope)) {
@@ -162,6 +164,7 @@ if (!original) {
 let activation = null // normalized RFC-009 activation fields (set in the block below)
 let inheritedLessons = [] // violation-side forward-links, inherited verbatim (F3)
 let inheritedViolatedPattern // T6 typed scalar, inherited verbatim (F3)
+let promotionSources
 {
   const origRaw = fs.readFileSync(original.filePath, 'utf8')
   const fm = origRaw.match(/^---\n([\s\S]*?)\n---/)
@@ -194,7 +197,11 @@ let inheritedViolatedPattern // T6 typed scalar, inherited verbatim (F3)
   // links). A flag passed on the revise OVERRIDES that field; absent flags keep
   // the original's values. Validation runs on the MERGED result against the
   // inherited category, BEFORE the supersede mutation below (I4).
-  const inherited = parseActivationFromFrontmatter(origRaw)
+  let inherited
+  try { inherited = parseActivationFromFrontmatter(origRaw) } catch {
+    console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: 'promotion_sources', id: originalId }))
+    process.exit(1)
+  }
   inheritedLessons = Array.isArray(inherited.lessons) ? inherited.lessons : []
   inheritedViolatedPattern = inherited.violated_pattern
   const merged = {
@@ -211,6 +218,26 @@ let inheritedViolatedPattern // T6 typed scalar, inherited verbatim (F3)
     process.exit(1)
   }
   activation = av.fields // null when neither flags nor the original carry activation
+
+  let sourceValue = inherited.promotion_sources
+  if (promotionSourcesJson !== undefined) {
+    try { sourceValue = JSON.parse(promotionSourcesJson) } catch {
+      console.log(JSON.stringify({ status: 'error', error: 'promotion-sources-shape' }))
+      process.exit(1)
+    }
+  }
+  if (sourceValue !== undefined) {
+    if (cat !== 'lesson') {
+      console.log(JSON.stringify({ status: 'error', error: 'lesson-only' }))
+      process.exit(1)
+    }
+    const pv = validatePromotionSources(sourceValue)
+    if (!pv.ok) {
+      console.log(JSON.stringify({ status: 'error', error: pv.error, ...(pv.index !== undefined ? { index: pv.index } : {}) }))
+      process.exit(1)
+    }
+    promotionSources = canonicalizePromotionSources(sourceValue)
+  }
 
   // REQ-6 (revise-side parity): merged-index resolution, never per-active-scope
   // (F1). Only NEWLY passed --evidence re-validates — inherited links carry
@@ -367,6 +394,7 @@ if (activation) {
 // F3: violation-side fields inherit verbatim (no revise-side flags exist for them)
 if (inheritedLessons.length) activationFmLines.push(`lessons: [${serializeInlineArray(inheritedLessons)}]`)
 if (inheritedViolatedPattern !== undefined) activationFmLines.push(`violated_pattern: ${inheritedViolatedPattern}`)
+if (promotionSources) activationFmLines.push(`promotion_sources: ${serializePromotionSources(promotionSources)}`)
 
 const frontmatter = [
   '---',
@@ -401,6 +429,7 @@ const activationIndexFields = {
   ...(activation ? { priority: activation.priority } : {}),
   ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
   ...(inheritedViolatedPattern !== undefined ? { violated_pattern: inheritedViolatedPattern } : {}),
+  ...(promotionSources ? { promotion_sources: promotionSources } : {}),
 }
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project: resolvedProject,

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -35,6 +35,7 @@ import { loadCategories, validateCategory, canonicalCategory } from './lib/categ
 import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinkage, ACTIVATION_ARRAY_FIELDS, illegalValueChar, illegalScalarChar } from './lib/activation.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
+import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -45,7 +46,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-store.mjs', usage: 'node em-store.mjs --project <name> --category <cat> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path|->) [--scope local|global] [--pin] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...  (--body-file - reads stdin; prefer it over inline --body for bodies with backticks/$()/$VAR, which the shell corrupts before the script runs — safe form: --body-file - <<\'EOF\' … EOF)' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-store.mjs', usage: 'node em-store.mjs --project <name> --category <cat> [--tags <t1,t2>] [--tag <t>]... --summary <text> (--body <text> | --body-file <path|->) [--scope local|global] [--pin] [--promotion-sources-json <json> (lesson only)] [lesson-only activation: --trigger <phrase|tool:T:glob|activity:class>]... [--applies-to-project <slug|*>]... [--applies-to-tool <id>]... [--priority <1-7>] [--review-by <YYYY-MM-DD>] [--evidence <violation-id>]...  (--body-file - reads stdin; prefer it over inline --body for bodies with backticks/$()/$VAR, which the shell corrupts before the script runs — safe form: --body-file - <<\'EOF\' … EOF)' }))
   process.exit(0)
 }
 
@@ -91,6 +92,7 @@ const appliesToTools = flagAll('--applies-to-tool')
 const priorityFlag = flag('--priority')
 const reviewBy = flag('--review-by')
 const evidence = flagAll('--evidence')
+const promotionSourcesJson = flag('--promotion-sources-json')
 // Typed T6 passthrough scalar (REQ-8): set by em-violation's handoff; generic
 // flag, violation-only in practice.
 const violatedPattern = flag('--violated-pattern')
@@ -164,6 +166,25 @@ if (!catV.ok) {
     : `Invalid category "${category}". Must be one of: ${(() => { try { return loadCategories().categories.map(c => c.name).join(', ') } catch { return 'see categories.json' } })()}`
   console.log(JSON.stringify({ status: 'error', message }))
   process.exit(1)
+}
+
+let promotionSources
+if (promotionSourcesJson !== undefined) {
+  let parsed
+  try { parsed = JSON.parse(promotionSourcesJson) } catch {
+    console.log(JSON.stringify({ status: 'error', error: 'promotion-sources-shape' }))
+    process.exit(1)
+  }
+  if (category !== 'lesson') {
+    console.log(JSON.stringify({ status: 'error', error: 'lesson-only' }))
+    process.exit(1)
+  }
+  const pv = validatePromotionSources(parsed)
+  if (!pv.ok) {
+    console.log(JSON.stringify({ status: 'error', error: pv.error, ...(pv.index !== undefined ? { index: pv.index } : {}) }))
+    process.exit(1)
+  }
+  promotionSources = canonicalizePromotionSources(parsed)
 }
 
 // RFC-009 R1: validate activation fields BEFORE any write (I4 — a rejected
@@ -302,6 +323,7 @@ if (activation) {
   fmLines.push(`priority: ${activation.priority}`)
   if (activation.review_by !== undefined) fmLines.push(`review_by: ${activation.review_by}`)
 }
+if (promotionSources) fmLines.push(`promotion_sources: ${serializePromotionSources(promotionSources)}`)
 // REQ-7 violation-side forward-links (validated above; unquoted inline array).
 if (lessonLinks.length) fmLines.push(`lessons: [${serializeInlineArray(lessonLinks)}]`)
 // T6 typed scalar (REQ-8): violation-side passthrough from em-violation's handoff.
@@ -336,6 +358,7 @@ const activationIndexFields = {
   ...(activation ? { priority: activation.priority } : {}),
   ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
   ...(violatedPattern !== undefined ? { violated_pattern: violatedPattern } : {}),
+  ...(promotionSources ? { promotion_sources: promotionSources } : {}),
 }
 const indexEntry = JSON.stringify({
   id, date: dateStr, time: timeStr, project, category,

--- a/scripts/lib/activation.mjs
+++ b/scripts/lib/activation.mjs
@@ -16,6 +16,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { resolveLocalDir } from './local-dir.mjs'
+import { STRUCTURED_FIELDS } from './promotion-sources.mjs'
+export { STRUCTURED_FIELDS } from './promotion-sources.mjs'
 
 // Resolved relative to this file so the path is symmetric in-repo
 // (<repo>/activation-classes.json) and deployed (~/.episodic-memory/activation-classes.json).
@@ -269,7 +271,7 @@ export function validateActivation(fields, { category } = {}) {
  * @param {string} content full episode .md content
  * @returns {{triggers?:string[], applies_to_projects?:string[], applies_to_tools?:string[],
  *            evidence?:string[], lessons?:string[], priority?:number, review_by?:string,
- *            violated_pattern?:string}}
+ *            violated_pattern?:string, promotion_sources?:object[]}}
  */
 export function parseActivationFromFrontmatter(content) {
   const out = {}
@@ -279,7 +281,9 @@ export function parseActivationFromFrontmatter(content) {
     const m = line.match(/^(\w+):\s*(.*)$/)
     if (!m) continue
     const [, key, raw] = m
-    if (ACTIVATION_ARRAY_FIELDS.includes(key)) {
+    if (STRUCTURED_FIELDS.includes(key)) {
+      out[key] = JSON.parse(raw)
+    } else if (ACTIVATION_ARRAY_FIELDS.includes(key)) {
       const arr = raw.match(/^\[(.*)\]$/)
       if (arr) out[key] = arr[1].split(',').map(s => s.trim()).filter(Boolean)
     } else if (key === 'priority') {

--- a/scripts/lib/promotion-sources.mjs
+++ b/scripts/lib/promotion-sources.mjs
@@ -1,0 +1,76 @@
+// promotion-sources.mjs — RFC-012 P2 S2 typed promotion provenance.
+
+import crypto from 'node:crypto'
+import { STORE_ID_RE } from './store-identity.mjs'
+
+export const STRUCTURED_FIELDS = ['promotion_sources']
+export const PROMOTION_SOURCE_KEYS = ['content_sha256', 'episode_id', 'store_id']
+export const CONTENT_SHA256_RE = /^[0-9a-f]{64}$/
+
+function hasIllegalChars(value) {
+  for (const ch of String(value)) {
+    const code = ch.codePointAt(0)
+    if (code < 0x20 || (code >= 0x7f && code <= 0x9f) || code === 0x2028 || code === 0x2029) return true
+  }
+  return false
+}
+
+export function validatePromotionSources(value) {
+  if (!Array.isArray(value)) return { ok: false, error: 'promotion-sources-shape' }
+  if (value.length === 0) return { ok: false, error: 'promotion-sources-empty' }
+  for (let index = 0; index < value.length; index++) {
+    const source = value[index]
+    if (!source || typeof source !== 'object' || Array.isArray(source) ||
+        Object.keys(source).sort().join('\0') !== [...PROMOTION_SOURCE_KEYS].sort().join('\0') ||
+        PROMOTION_SOURCE_KEYS.some(key => typeof source[key] !== 'string') ||
+        source.episode_id.length === 0 || !STORE_ID_RE.test(source.store_id)) {
+      return { ok: false, error: 'promotion-sources-shape', index }
+    }
+    if (!CONTENT_SHA256_RE.test(source.content_sha256)) return { ok: false, error: 'promotion-sources-hash', index }
+    if (PROMOTION_SOURCE_KEYS.some(key => hasIllegalChars(source[key]))) return { ok: false, error: 'promotion-sources-chars', index }
+  }
+  return { ok: true }
+}
+
+export function canonicalizePromotionSources(value) {
+  const validation = validatePromotionSources(value)
+  if (!validation.ok) {
+    const err = new Error(validation.error)
+    Object.assign(err, validation)
+    throw err
+  }
+  return value.map(source => ({
+    content_sha256: source.content_sha256,
+    episode_id: source.episode_id,
+    store_id: source.store_id,
+  })).sort((a, b) => {
+    const aj = JSON.stringify(a)
+    const bj = JSON.stringify(b)
+    return aj < bj ? -1 : aj > bj ? 1 : 0
+  })
+}
+
+export function serializePromotionSources(value) {
+  return JSON.stringify(canonicalizePromotionSources(value))
+}
+
+export function computeContentSha256(buf) {
+  const normalized = Buffer.from(buf).toString('utf8').replace(/\r\n/g, '\n')
+  return crypto.createHash('sha256').update(Buffer.from(normalized, 'utf8')).digest('hex')
+}
+
+export function resolveSourceRefs(refs, registry) {
+  const byId = new Map()
+  for (const store of Array.isArray(registry) ? registry : []) {
+    if (typeof store?.store_id === 'string') byId.set(store.store_id, store)
+    for (const alias of Array.isArray(store?.store_aliases) ? store.store_aliases : []) byId.set(alias, store)
+  }
+  const resolved = []
+  const missing = []
+  for (const source of Array.isArray(refs) ? refs : []) {
+    const store = byId.get(source.store_id)
+    if (store) resolved.push({ source, store })
+    else missing.push(source)
+  }
+  return { resolved, missing }
+}

--- a/tests/test-em-promote.mjs
+++ b/tests/test-em-promote.mjs
@@ -13,6 +13,7 @@ import crypto from 'crypto'
 import { spawnSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { isSubstrateScript } from '../scripts/lib/install-manifest.mjs'
+import { mintStoreIdentity, resolveStoreIdentity } from '../scripts/lib/store-identity.mjs'
 
 const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
 const PROMOTE = path.join(REPO, 'scripts', 'em-promote.mjs')
@@ -28,15 +29,17 @@ function mkWorld(name) {
   fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
   const world = {
     root, home, entries: [],
-    register(projectPath) {
-      world.entries.push({ project_path: projectPath, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z' })
+    register(projectPath, identity) {
+      world.entries.push({ project_path: projectPath, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-08T00:00:00Z', store_id: identity.active_id, store_aliases: identity.aliases })
       fs.writeFileSync(path.join(home, '.episodic-memory', 'installs.json'),
-        JSON.stringify({ schema_version: 1, entries: world.entries }, null, 2))
+        JSON.stringify({ schema_version: 2, entries: world.entries }, null, 2))
     },
     project(name) {
       const p = path.join(root, name)
-      fs.mkdirSync(p, { recursive: true })
-      world.register(p)
+      const data = path.join(p, '.episodic-memory')
+      fs.mkdirSync(data, { recursive: true })
+      mintStoreIdentity(data)
+      world.register(p, resolveStoreIdentity(data))
       return p
     },
     lesson(project, summary, body) {
@@ -67,6 +70,21 @@ const t = (name, fn) => tests.push([name, fn])
 function assert(cond, msg) { if (!cond) throw new Error(msg) }
 function parse(r) {
   try { return JSON.parse(r.stdout) } catch { throw new Error(`non-JSON stdout: ${r.stdout}\n${r.stderr}`) }
+}
+function textSha8(value) { return crypto.createHash('sha256').update(value).digest('hex').slice(0, 8) }
+function legacyCandidateHash(members) {
+  return textSha8(members.map(m => `${m.id}#${textSha8(m.summary)}`).sort().join('\n'))
+}
+function seedLegacyPromotion(w, members) {
+  const hash = legacyCandidateHash(members)
+  const body = `Legacy recurring lesson fixture.\n\n## Sources\n${members.map(m => `- ${m.id} (${m.project}, legacy-store)`).join('\n')}`
+  const r = spawnSync(process.execPath, [STORE,
+    '--scope', 'global', '--project', 'cross-project', '--category', 'lesson',
+    '--tags', `promoted-lesson,promoted:${hash}`, '--summary', 'Legacy recurring lesson', '--body', body],
+  { cwd: w.root, env: { ...process.env, HOME: w.home, USERPROFILE: w.home }, encoding: 'utf8' })
+  const out = parse(r)
+  if (r.status !== 0 || out.status !== 'ok') throw new Error(`legacy seed failed: ${r.stdout}${r.stderr}`)
+  return { id: out.id, hash }
 }
 
 t('testPromoteFindsCrossStoreRecurrence', () => {
@@ -101,7 +119,8 @@ t('testPromoteSkipsReplicaMembers', () => {
   const a = w.project('projA')
   const b = w.project('projB')
   const id = w.lesson(a, 'always quote hook command paths', RECUR_BODY)
-  fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
+  fs.copyFileSync(path.join(a, '.episodic-memory', 'episodes', `${id}.md`), path.join(b, '.episodic-memory', 'episodes', `${id}.md`))
+  fs.copyFileSync(path.join(a, '.episodic-memory', 'index.jsonl'), path.join(b, '.episodic-memory', 'index.jsonl'))
   const out = parse(w.promote())
   assert(out.candidates.length === 0, `replica must not count as recurrence: ${JSON.stringify(out.candidates)}`)
   assert(id, 'seed id must exist')
@@ -115,18 +134,31 @@ t('testPromoteSameIdDifferentContentStaysDistinct', () => {
   const w = mkWorld('sameid')
   const a = w.project('projA')
   const b = w.project('projB')
-  const id = w.lesson(a, 'always quote hook command paths', RECUR_BODY)
-  fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
+  const summaryA = 'always quote hook command paths'
+  const summaryB = 'always quote hook command paths differently worded'
+  const id = w.lesson(a, summaryA, RECUR_BODY)
+  fs.copyFileSync(path.join(a, '.episodic-memory', 'episodes', `${id}.md`), path.join(b, '.episodic-memory', 'episodes', `${id}.md`))
+  fs.copyFileSync(path.join(a, '.episodic-memory', 'index.jsonl'), path.join(b, '.episodic-memory', 'index.jsonl'))
   // Hand-edit projB's copy to a DIFFERENT summary (same id) — index row + file.
   const idxPath = path.join(b, '.episodic-memory', 'index.jsonl')
   const rows = fs.readFileSync(idxPath, 'utf8').trim().split('\n').map(l => JSON.parse(l))
-  rows[0].summary = 'always quote hook command paths differently worded'
+  rows[0].summary = summaryB
   fs.writeFileSync(idxPath, rows.map(r => JSON.stringify(r)).join('\n') + '\n')
+  const episodePath = path.join(b, '.episodic-memory', 'episodes', `${id}.md`)
+  fs.writeFileSync(episodePath, fs.readFileSync(episodePath, 'utf8').replace(RECUR_BODY, RECUR_BODY + ' independently changed bytes'))
   const out = parse(w.promote())
   assert(out.candidates.length === 1, `distinct-content same-id must form a candidate: ${JSON.stringify(out)}`)
   const memberIds = out.candidates[0].members.map(m => m.id)
   assert(memberIds.length === 2 && memberIds[0] === id && memberIds[1] === id,
     `both same-id members must be listed distinctly: ${JSON.stringify(out.candidates[0].members)}`)
+  const ambiguousLegacy = seedLegacyPromotion(w, [
+    { id, summary: summaryA, project: 'projA' },
+    { id, summary: summaryB, project: 'projB' },
+  ])
+  const applied = parse(w.promote(['--apply']))
+  assert(applied.promoted.length === 1 && applied.promoted[0].supersedes_promotion === undefined,
+    `ambiguous legacy bare id suppressed/fabricated a typed relationship: ${JSON.stringify(applied)}`)
+  assert(!applied.skipped.some(s => s.existing === ambiguousLegacy.id), 'ambiguous legacy row must not exact-match typed identity')
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
@@ -143,7 +175,9 @@ t('testPromoteApplyWritesGlobalEpisode', () => {
   assert(globals.length === 1, `global index rows ${globals.length}, want 1`)
   const tags = globals[0].tags.map(String)
   assert(tags.includes('promoted-lesson'), `promoted-lesson tag missing: ${JSON.stringify(tags)}`)
-  assert(tags.some(t2 => /^promoted:[0-9a-f]{8}$/.test(t2)), `promoted:<sha8> tag missing: ${JSON.stringify(tags)}`)
+  assert(!tags.some(t2 => /^promoted:[0-9a-f]{8}$/.test(t2)), `legacy promoted:<sha8> tag must be absent: ${JSON.stringify(tags)}`)
+  assert(Array.isArray(globals[0].promotion_sources) && globals[0].promotion_sources.length === 2,
+    `typed promotion_sources missing: ${JSON.stringify(globals[0])}`)
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
@@ -199,6 +233,66 @@ t('testPromoteApplyIdempotent', () => {
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
+t('testPromoteLegacyExactIdempotent', () => {
+  const w = mkWorld('legacy-idem')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const members = [
+    { id: w.lesson(a, 'always quote hook command paths', RECUR_BODY), summary: 'always quote hook command paths', project: 'projA' },
+    { id: w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY), summary: 'always quote hook command paths in hooks', project: 'projB' },
+  ]
+  const legacy = seedLegacyPromotion(w, members)
+  const globalEpisodes = path.join(w.home, '.episodic-memory', 'episodes')
+  const before = fs.readdirSync(globalEpisodes).sort()
+  const out = parse(w.promote(['--apply']))
+  assert(out.promoted.length === 0, `legacy exact recurrence was duplicated: ${JSON.stringify(out)}`)
+  assert(out.skipped.some(s => s.reason === 'already-promoted' && s.existing === legacy.id),
+    `legacy skip does not reference ${legacy.id}: ${JSON.stringify(out.skipped)}`)
+  assert(JSON.stringify(fs.readdirSync(globalEpisodes).sort()) === JSON.stringify(before), 'legacy replay wrote a new global episode')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteLegacySupersetBackref', () => {
+  const w = mkWorld('legacy-superset')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const c = w.project('projC')
+  const priorMembers = [
+    { id: w.lesson(a, 'always quote hook command paths', RECUR_BODY), summary: 'always quote hook command paths', project: 'projA' },
+    { id: w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY), summary: 'always quote hook command paths in hooks', project: 'projB' },
+  ]
+  const legacy = seedLegacyPromotion(w, priorMembers)
+  w.lesson(c, 'always quote hook command paths everywhere', RECUR_BODY)
+  const out = parse(w.promote(['--apply']))
+  assert(out.promoted.length === 1 && out.promoted[0].supersedes_promotion === legacy.id,
+    `legacy strict-superset backref missing: ${JSON.stringify(out)}`)
+  const content = fs.readFileSync(path.join(w.home, '.episodic-memory', 'episodes', `${out.promoted[0].digest_id}.md`), 'utf8')
+  assert(content.includes(`Supersedes-promotion: ${legacy.id}`), 'human Supersedes-promotion line missing')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+t('testPromoteLegacyContractedAmbiguityNoBackref', () => {
+  const w = mkWorld('legacy-contracted')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const summaryA = 'always quote hook command paths'
+  const idA = w.lesson(a, summaryA, RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  // The legacy row's two source lines collapse to one bare id. Without the
+  // pre-collapse ambiguity bit, {idA} looks like a strict subset of the
+  // current unique-id candidate and fabricates a back-reference.
+  const legacy = seedLegacyPromotion(w, [
+    { id: idA, summary: summaryA, project: 'projA' },
+    { id: idA, summary: `${summaryA} independently`, project: 'projB' },
+  ])
+  const out = parse(w.promote(['--apply']))
+  assert(out.promoted.length === 1 && out.promoted[0].supersedes_promotion === undefined,
+    `ambiguous contracted legacy row fabricated a superset: ${JSON.stringify(out)}`)
+  const content = fs.readFileSync(path.join(w.home, '.episodic-memory', 'episodes', `${out.promoted[0].digest_id}.md`), 'utf8')
+  assert(!content.includes(`Supersedes-promotion: ${legacy.id}`), 'ambiguous legacy row leaked a human back-reference')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
 t('testPromoteSupersetClusterPromotesWithBackref', () => {
   const w = mkWorld('superset')
   const a = w.project('projA')
@@ -229,7 +323,15 @@ t('testPromoteWarnsOnMalformedPromotedEpisode', () => {
   const digest = first.promoted[0].digest_id
   // Hand-break the written episode: strip the Sources section.
   const p = path.join(w.home, '.episodic-memory', 'episodes', `${digest}.md`)
-  fs.writeFileSync(p, fs.readFileSync(p, 'utf8').replace(/^## Sources$[\s\S]*$/m, ''))
+  const indexPath = path.join(w.home, '.episodic-memory', 'index.jsonl')
+  const rows = w.globalIndexRows()
+  delete rows[0].promotion_sources
+  rows[0].tags.push('promoted:deadbeef')
+  fs.writeFileSync(indexPath, rows.map(row => JSON.stringify(row)).join('\n') + '\n')
+  fs.writeFileSync(p, fs.readFileSync(p, 'utf8')
+    .replace(/^promotion_sources: .*\n/m, '')
+    .replace(/^tags: \[(.*)\]$/m, 'tags: [$1, promoted:deadbeef]')
+    .replace(/^## Sources$[\s\S]*$/m, ''))
   const r = w.promote()
   const out = parse(r)
   assert(r.status === 0, `warnings must never block: exit ${r.status}`)
@@ -249,6 +351,7 @@ t('testPromoteCloneStoreCannotFabricateRecurrence', () => {
   const b = w.project('projB')
   w.lesson(a, 'always quote hook command paths', RECUR_BODY)
   w.lesson(a, 'always quote hook command paths again', RECUR_BODY + ' second authored copy same store')
+  fs.rmSync(path.join(b, '.episodic-memory'), { recursive: true, force: true })
   fs.cpSync(path.join(a, '.episodic-memory'), path.join(b, '.episodic-memory'), { recursive: true })
   let out = parse(w.promote())
   assert(out.candidates.length === 0, `full clone fabricated recurrence: ${JSON.stringify(out.candidates)}`)
@@ -309,7 +412,7 @@ t('testPromoteStripsForeignIdentityTags', () => {
   const tags = row.tags.map(String)
   assert(!tags.includes('promoted:deadbeef'), `stray identity tag leaked onto digest: ${JSON.stringify(tags)}`)
   assert(tags.includes('shell-quoting'), `legitimate member tag must survive the filter: ${JSON.stringify(tags)}`)
-  assert(tags.filter(t2 => /^promoted:/.test(t2)).length === 1, `digest must carry exactly ONE identity tag: ${JSON.stringify(tags)}`)
+  assert(tags.filter(t2 => /^promoted:/.test(t2)).length === 0, `new digest must carry zero legacy identity tags: ${JSON.stringify(tags)}`)
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
@@ -319,6 +422,7 @@ t('testPromoteHelpCarriesExperimental', () => {
   assert(out.tier === 'EXPERIMENTAL', `help tier: ${out.tier}`)
   assert(out.decision_date === '2026-10-08', `decision_date: ${out.decision_date}`)
   assert(/EXPERIMENTAL/.test(out.usage), 'usage text must carry EXPERIMENTAL')
+  assert(/legacy promoted:<sha8> rows remain read-only-compatible/.test(out.usage), 'help must state the bounded legacy read contract')
 })
 
 t('testPromoteIsSubstrateScript', () => {

--- a/tests/test-promotion-sources.mjs
+++ b/tests/test-promotion-sources.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// RFC-012 P2 S2: typed promotion provenance and content-bound identity.
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { computeContentSha256, resolveSourceRefs, serializePromotionSources } from '../scripts/lib/promotion-sources.mjs'
+import { mintStoreIdentity, resolveStoreIdentity } from '../scripts/lib/store-identity.mjs'
+
+const REPO = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+const REVISE = path.join(REPO, 'scripts', 'em-revise.mjs')
+const REBUILD = path.join(REPO, 'scripts', 'em-rebuild-index.mjs')
+const PROMOTE = path.join(REPO, 'scripts', 'em-promote.mjs')
+const HASH_A = 'a'.repeat(64)
+const ONLY_FLAG = process.argv.indexOf('--only')
+const ONLY = ONLY_FLAG >= 0 ? process.argv[ONLY_FLAG + 1] : null
+
+function assert(value, message) { if (!value) throw new Error(message) }
+function json(result) {
+  try { return JSON.parse(result.stdout) } catch { throw new Error(`non-JSON stdout: ${result.stdout}\n${result.stderr}`) }
+}
+function run(script, args, cwd, home) {
+  return spawnSync(process.execPath, [script, ...args], { cwd, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+}
+function treeDigest(dir) {
+  if (!fs.existsSync(dir)) return 'absent'
+  const h = crypto.createHash('sha256')
+  function walk(p, rel = '') {
+    for (const name of fs.readdirSync(p).sort()) {
+      const full = path.join(p, name); const child = path.join(rel, name); const st = fs.statSync(full)
+      h.update(child + (st.isDirectory() ? '/' : '\0'))
+      if (st.isDirectory()) walk(full, child); else h.update(fs.readFileSync(full))
+    }
+  }
+  walk(dir)
+  return h.digest('hex')
+}
+function world(name) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `promotion-sources-${name}-`))
+  const home = path.join(root, 'home'); fs.mkdirSync(path.join(home, '.episodic-memory'), { recursive: true })
+  const entries = []
+  function project(label) {
+    const dir = path.join(root, label); const data = path.join(dir, '.episodic-memory')
+    fs.mkdirSync(data, { recursive: true }); mintStoreIdentity(data)
+    const idn = resolveStoreIdentity(data)
+    entries.push({ project_path: dir, tool: 'claude-code', version: 'v1', enforcement_installed: false, last_install_ts: '2026-07-19T00:00:00Z', store_id: idn.active_id, store_aliases: idn.aliases })
+    fs.writeFileSync(path.join(home, '.episodic-memory', 'installs.json'), JSON.stringify({ schema_version: 2, entries }, null, 2))
+    return { dir, data, store_id: idn.active_id }
+  }
+  function store(p, extra = []) {
+    return run(STORE, ['--project', path.basename(p.dir), '--category', 'lesson', '--summary', 'typed provenance lesson', '--body', 'quote hook paths consistently across tools', '--scope', 'local', ...extra], p.dir, home)
+  }
+  function lesson(p, summary, body) {
+    return run(STORE, ['--project', path.basename(p.dir), '--category', 'lesson', '--summary', summary, '--body', body, '--scope', 'local'], p.dir, home)
+  }
+  function rows(data) {
+    const f = path.join(data, 'index.jsonl'); if (!fs.existsSync(f)) return []
+    return fs.readFileSync(f, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse)
+  }
+  return { root, home, project, store, lesson, rows, cleanup() { fs.rmSync(root, { recursive: true, force: true }) } }
+}
+function source(storeId, episodeId = 'episode,with,punctuation', hash = HASH_A) {
+  return { store_id: storeId, episode_id: episodeId, content_sha256: hash }
+}
+function rejectedCase(name, value, category = 'lesson') {
+  const w = world(name); const p = w.project('p'); const before = treeDigest(p.data)
+  const r = run(STORE, ['--project', 'p', '--category', category, '--summary', 'reject me', '--body', 'no mutation', '--scope', 'local', '--promotion-sources-json', JSON.stringify(value)], p.dir, w.home)
+  const after = treeDigest(p.data); w.cleanup()
+  return { r, out: json(r), before, after }
+}
+
+const tests = []
+function t(name, fn) { if (!ONLY || name.includes(ONLY)) tests.push([name, fn]) }
+
+t('testPromotionSourcesWrite', () => {
+  const w = world('write'); const p = w.project('p'); const refs = [source(p.store_id)]
+  const r = w.store(p, ['--promotion-sources-json', JSON.stringify(refs)]); const out = json(r)
+  assert(r.status === 0, r.stdout + r.stderr)
+  const content = fs.readFileSync(out.file, 'utf8')
+  assert(content.includes(`promotion_sources: ${serializePromotionSources(refs)}`), 'canonical frontmatter missing')
+  assert(JSON.stringify(w.rows(p.data).find(row => row.id === out.id)?.promotion_sources) === serializePromotionSources(refs), 'index field missing')
+  w.cleanup()
+})
+
+t('testPromotionSourcesRoundTrip', () => {
+  const w = world('roundtrip'); const p = w.project('p'); const refs = [source(p.store_id)]
+  w.store(p, ['--promotion-sources-json', JSON.stringify(refs)])
+  const before = w.rows(p.data)[1]?.promotion_sources || w.rows(p.data)[0].promotion_sources
+  const r = run(REBUILD, ['--scope', 'local'], p.dir, w.home)
+  assert(r.status === 0, r.stdout + r.stderr)
+  const row = w.rows(p.data).find(x => x.promotion_sources)
+  assert(JSON.stringify(row.promotion_sources) === JSON.stringify(before), 'rebuild changed typed sources')
+  const indexPath = path.join(p.data, 'index.jsonl')
+  const indexBeforeMalformed = fs.readFileSync(indexPath)
+  const episodePath = fs.readdirSync(path.join(p.data, 'episodes')).map(name => path.join(p.data, 'episodes', name))
+    .find(file => fs.readFileSync(file, 'utf8').includes('promotion_sources:'))
+  fs.writeFileSync(episodePath, fs.readFileSync(episodePath, 'utf8').replace(/^promotion_sources: .*$/m, 'promotion_sources: [{'))
+  const malformed = run(REBUILD, ['--scope', 'local'], p.dir, w.home)
+  assert(malformed.status === 1 && json(malformed).error === 'structured-frontmatter-invalid', malformed.stdout + malformed.stderr)
+  assert(fs.readFileSync(indexPath).equals(indexBeforeMalformed), 'malformed rebuild mutated index')
+  w.cleanup()
+})
+
+t('testReviseInherit', () => {
+  const w = world('revise'); const p = w.project('p'); const refs = [source(p.store_id)]
+  const first = json(w.store(p, ['--promotion-sources-json', JSON.stringify(refs)]))
+  const r = run(REVISE, ['--original', first.id, '--summary', 'revised typed provenance', '--body', 'correction', '--scope', 'inherit'], p.dir, w.home)
+  assert(r.status === 0, r.stdout + r.stderr)
+  const revisionId = json(r).id
+  assert(JSON.stringify(w.rows(p.data).find(x => x.id === revisionId).promotion_sources) === serializePromotionSources(refs), 'revision lost provenance')
+  const beforeReject = treeDigest(p.data)
+  const rejected = run(REVISE, ['--original', revisionId, '--summary', 'must reject empty provenance', '--body', 'no mutation', '--scope', 'inherit', '--promotion-sources-json', '[]'], p.dir, w.home)
+  assert(rejected.status === 1 && json(rejected).error === 'promotion-sources-empty', rejected.stdout + rejected.stderr)
+  assert(treeDigest(p.data) === beforeReject, 'bad revise override mutated store')
+  w.cleanup()
+})
+
+t('testCommaValueByteRoundTrip', () => {
+  const w = world('comma'); const p = w.project('p'); const refs = [source(p.store_id, 'id,with,[json]-safe punctuation')]
+  const out = json(w.store(p, ['--promotion-sources-json', JSON.stringify(refs)]))
+  const before = fs.readFileSync(out.file, 'utf8').match(/^promotion_sources: (.*)$/m)[1]
+  run(REBUILD, ['--scope', 'local'], p.dir, w.home)
+  const after = serializePromotionSources(w.rows(p.data).find(x => x.id === out.id).promotion_sources)
+  assert(after === before, `${before} != ${after}`); w.cleanup()
+})
+
+t('testEmptySourcesReject', () => { const x = rejectedCase('empty', []); assert(x.r.status === 1 && x.out.error === 'promotion-sources-empty', JSON.stringify(x.out)); assert(x.before === x.after, 'store mutated') })
+t('testShapeReject', () => { const x = rejectedCase('shape', [{ store_id: 'bad', episode_id: 'x', content_sha256: HASH_A }]); assert(x.r.status === 1 && x.out.error === 'promotion-sources-shape', JSON.stringify(x.out)); assert(x.before === x.after, 'store mutated') })
+t('testHashReject', () => { const w = world('hash'); const p = w.project('p'); const before = treeDigest(p.data); const r = w.store(p, ['--promotion-sources-json', JSON.stringify([source(p.store_id, 'x', 'A'.repeat(64))])]); assert(r.status === 1 && json(r).error === 'promotion-sources-hash', r.stdout); assert(before === treeDigest(p.data), 'store mutated'); w.cleanup() })
+t('testCharsReject', () => { const w = world('chars'); const p = w.project('p'); const before = treeDigest(p.data); const r = w.store(p, ['--promotion-sources-json', JSON.stringify([source(p.store_id, 'bad\u0001id')])]); assert(r.status === 1 && json(r).error === 'promotion-sources-chars', r.stdout); assert(before === treeDigest(p.data), 'store mutated'); w.cleanup() })
+t('testLessonOnly', () => { const w = world('lessononly'); const p = w.project('p'); const before = treeDigest(p.data); const r = run(STORE, ['--project', 'p', '--category', 'decision', '--summary', 'wrong category', '--body', 'no', '--scope', 'local', '--promotion-sources-json', JSON.stringify([source(p.store_id)])], p.dir, w.home); assert(r.status === 1 && json(r).error === 'lesson-only', r.stdout); assert(before === treeDigest(p.data), 'store mutated'); w.cleanup() })
+
+t('testNoEarnedPriorityForge', () => {
+  const w = world('priority'); const p = w.project('p'); w.store(p, ['--priority', '4', '--promotion-sources-json', JSON.stringify([source(p.store_id, 'violation-looking-id')])])
+  const row = w.rows(p.data).find(x => x.category === 'lesson')
+  assert(row.priority === 4 && row.evidence === undefined, JSON.stringify(row)); w.cleanup()
+})
+
+t('testEvidenceGateUnchanged', () => {
+  const w = world('evidence'); const p = w.project('p'); const d = json(run(STORE, ['--project', 'p', '--category', 'decision', '--summary', 'not violation', '--body', 'x', '--scope', 'local'], p.dir, w.home))
+  const before = treeDigest(p.data); const r = w.store(p, ['--evidence', d.id])
+  assert(r.status === 1 && json(r).wrong_category.includes(d.id), r.stdout); assert(before === treeDigest(p.data), 'store mutated'); w.cleanup()
+})
+
+t('testContentShaVector', () => {
+  assert(computeContentSha256(Buffer.from('abc')) === 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad', 'fixed vector mismatch')
+  const ordered = JSON.parse(serializePromotionSources([source('global', 'é'), source('global', 'z')]))
+  assert(ordered[0].episode_id === 'z' && ordered[1].episode_id === 'é', `canonical order is not code-unit lexical: ${JSON.stringify(ordered)}`)
+})
+t('testCrlfLfIdentical', () => { assert(computeContentSha256(Buffer.from('a\r\nb\r\n')) === computeContentSha256(Buffer.from('a\nb\n')), 'CRLF normalization mismatch') })
+t('testResolveSourceRefs', () => { const ref = source('1111111111111111'); const row = { store_id: '0123456789abcdef', store_aliases: ['1111111111111111'] }; const x = resolveSourceRefs([ref], [row]); assert(x.resolved.length === 1 && x.resolved[0].store === row && x.missing.length === 0, JSON.stringify(x)) })
+t('testUnresolvedAliasSurfaces', () => { const ref = source('ffffffffffffffff'); const x = resolveSourceRefs([ref], []); assert(x.missing.length === 1 && x.missing[0] === ref, JSON.stringify(x)) })
+t('testMissingNeverSilent', () => { const refs = [source('ffffffffffffffff'), source('eeeeeeeeeeeeeeee')]; const x = resolveSourceRefs(refs, []); assert(x.resolved.length === 0 && x.missing.length === refs.length, JSON.stringify(x)) })
+
+function handLesson(p, id, summary, body) {
+  const episodes = path.join(p.data, 'episodes'); fs.mkdirSync(episodes, { recursive: true })
+  const content = `---\nid: ${id}\ndate: 2026-07-19\ntime: "00:00"\nproject: ${path.basename(p.dir)}\ncategory: lesson\nstatus: active\ntags: []\nsummary: ${summary}\n---\n\n# ${summary}\n\n${body}\n`
+  fs.writeFileSync(path.join(episodes, `${id}.md`), content)
+  fs.appendFileSync(path.join(p.data, 'index.jsonl'), JSON.stringify({ id, date: '2026-07-19', time: '00:00', project: path.basename(p.dir), category: 'lesson', status: 'active', supersedes: null, tags: [], summary }) + '\n')
+}
+
+t('testSameIdSummaryDiffBodyDistinct', () => {
+  const w = world('sameid'); const a = w.project('a'); const b = w.project('b'); const id = '20260719-000000-colliding-id'
+  handLesson(a, id, 'quote paths in hook commands', 'quote paths in hook commands because spaces split commands alpha')
+  handLesson(b, id, 'quote paths in hook commands', 'quote paths in hook commands because spaces split commands beta')
+  const out = json(run(PROMOTE, [], w.root, w.home)); assert(out.candidates.length === 1 && out.candidates[0].members.length === 2, JSON.stringify(out)); w.cleanup()
+})
+
+t('testReplicaCollapseOnHashMatch', () => {
+  const w = world('replica'); const a = w.project('a'); const b = w.project('b'); const id = '20260719-000000-replica-id'; const body = 'same immutable episode body'
+  handLesson(a, id, 'same immutable lesson', body)
+  fs.copyFileSync(path.join(a.data, 'episodes', `${id}.md`), path.join(b.data, 'episodes', `${id}.md`))
+  fs.appendFileSync(path.join(b.data, 'index.jsonl'), JSON.stringify(w.rows(a.data).find(row => row.id === id)) + '\n')
+  const out = json(run(PROMOTE, [], w.root, w.home)); assert(out.candidates.length === 0, JSON.stringify(out)); w.cleanup()
+})
+
+t('testNewPromotionTyped', () => {
+  const w = world('typed'); const a = w.project('a'); const b = w.project('b'); const body = 'always quote hook command paths because paths with spaces split execution'
+  w.lesson(a, 'always quote hook command paths', body); w.lesson(b, 'always quote hook paths in commands', body)
+  const r = run(PROMOTE, ['--apply'], w.root, w.home); const out = json(r); assert(r.status === 0 && out.promoted.length === 1, r.stdout + r.stderr)
+  const row = w.rows(path.join(w.home, '.episodic-memory'))[0]
+  assert(Array.isArray(row.promotion_sources) && row.promotion_sources.length === 2, JSON.stringify(row)); w.cleanup()
+})
+
+t('testNoSentinelOnNewWrites', () => {
+  const w = world('sentinel'); const a = w.project('a'); const b = w.project('b'); const body = 'always quote hook command paths because paths with spaces split execution'
+  w.lesson(a, 'always quote hook command paths', body); w.lesson(b, 'always quote hook paths in commands', body)
+  json(run(PROMOTE, ['--apply'], w.root, w.home)); const row = w.rows(path.join(w.home, '.episodic-memory'))[0]
+  assert(row.project !== 'cross-project', JSON.stringify(row)); assert(!row.tags.some(x => /^promoted:[0-9a-f]{8}$/.test(x)), JSON.stringify(row.tags)); w.cleanup()
+})
+
+let passed = 0
+for (const [name, fn] of tests) {
+  try { fn(); console.log(`ok ${name}`); passed++ } catch (e) { console.log(`FAIL ${name}: ${e.message}`) }
+}
+console.log(`${passed}/${tests.length} pass`)
+process.exit(passed === tests.length ? 0 : 1)


### PR DESCRIPTION
## Summary

RFC-012 P2 slice 2: typed `promotion_sources` provenance for REQ-7 through REQ-12. Plan: `docs/plans/rfc-012-p2.md`. Builds on P2-S1 (#547).

Delivered:

1. Canonical typed SourceRefs with `store_id`, `episode_id`, and normalized `content_sha256` identity.
2. Invalid-first write, revise, rebuild, and round-trip validation with zero-mutation rejection paths.
3. Typed promotion writes without the legacy `promoted:<sha8>` tag or `cross-project` sentinel.
4. Read-only legacy exact-idempotency and strict-superset compatibility.
5. Fail-safe ambiguity handling for same-ID different-content candidates and duplicate-ID legacy rows.
6. CI registration for the new promotion-sources suite.

## Independent review chain

- Round 1 HOLD (`20260719-002723-hold-rfc-012-p2-s2-legacy-compatibility-c155`) — legacy exact-idempotency and legacy superset matching; fixed.
- Round 2 HOLD (`20260719-004206-hold-rfc-012-p2-s2-legacy-row-duplicate--061f`) — contracted legacy duplicate-ID ambiguity; fixed.
- Round 3 ACCEPT (`20260719-004447-accept-rfc-012-p2-s2-legacy-ambiguity-fo-0288`) — against frozen staged SHA-256 `5e708eb916b2f59deb9e146f832aefc30c25ed3d6e5f8131d8d87ca97ebb15b3`.

## Verification

- promotion-sources 20/20
- em-promote 18/18
- store-identity 27/27
- activation-lib 22/22
- trigger-index 23/23
- CI suite registration 16/16
- plugin registry 205/205
- commit diff check clean
- `em-trigger-index.mjs` untouched; activation flat-array fields remain exactly five
