### PR TITLE
docs: point AGENTS.md template at EM_SCRIPTS_GUIDE.md

### DIFF
--- a/instructions/AGENTS.md
+++ b/instructions/AGENTS.md
@@ -6,6 +6,8 @@ You have access to a persistent episodic memory system for storing and recalling
 **Local data:** `.episodic-memory/` (this project)
 **Global data:** `~/.episodic-memory/` (cross-project)
 
+**Full per-script reference:** `~/.episodic-memory/EM_SCRIPTS_GUIDE.md`. Read it before first script use.
+
 ## When to Use
 
 **Store** an episode (0-3 per session) when:


### PR DESCRIPTION
## Summary

Adds the one-line pointer to `~/.episodic-memory/EM_SCRIPTS_GUIDE.md` in the `instructions/AGENTS.md` consumer template, mirroring the existing pointer in `instructions/SKILL.md` (line 20): agents read the full per-script reference before first script use.

The guide is deployed to `~/.episodic-memory/EM_SCRIPTS_GUIDE.md` on every install, so the referenced path always exists for installed consumers.

+2 lines, docs-only, no behavior change.
