### PR TITLE
fix: un-red main — activation-manifest temp roots need the learning descriptor schema (§19.3h)

### DIFF
--- a/docs/plans/rfc-012-p2.md
+++ b/docs/plans/rfc-012-p2.md
@@ -674,6 +674,26 @@ highest-confidence items per playbook §9). Artifacts:
 B1–B5 + the three regression tests raise the §A.8-S3 expectation to
 `30 pass, 0 fail, 1 skipped` (31 registered).
 
+### 19.3h S3 post-merge main-red (2026-07-19, second sweep gap)
+
+PR #552 merged with the full `plan-marker-validate` run still PENDING; it went
+red after merge. `tests/test-activation-manifest.mjs` failed 26/9: its
+`CONTEXT_FILES` temp-root list (lines 45-50) predates S3 and lacks
+`plugins/learning-descriptor.schema.json`, so the merged `loadContext`
+ENOENTs in every temp root — the §19.3c-F2 class in the ONE suite the
+§A.8-S3 sweep did not enumerate. The §A.8-S3 sweep covered the suites the
+slice TOUCHED; the correct rule after two CI-found gaps (§19.3g + this):
+when a slice changes a shared load-set (loadContext schemas, scan roots,
+workflow-visible file classes), the sweep must include EVERY suite that
+embeds that load-set in temp roots — discoverable by grep
+(`grep -ln "runbook-agent-manifest.schema.json" tests/`: six hits; four
+verified not-loadContext consumers). Branch protection note for the
+operator: the long `validate` run should be a required check — #552 merged
+on a pending gate. Fix: the 3.7b fold applied to
+tests/test-activation-manifest.mjs (append the descriptor schema to its
+CONTEXT_FILES), rides this fix branch; test-activation-manifest 35/35 green
+post-fold.
+
 ### 19.3g S3 CI-found placement gap (2026-07-19, PR #552 first run)
 
 The first CI run on PR #552 failed `validate-schemas` in 8s:

--- a/tests/test-activation-manifest.mjs
+++ b/tests/test-activation-manifest.mjs
@@ -46,6 +46,7 @@ const CONTEXT_FILES = [
   "plugins/_index.schema.json", "plugins/manifest.schema.json", "plugins/bypass_known.schema.json",
   "plugins/installed-state.schema.json", "schemas/runtime/structured-alert.schema.json",
   "schemas/runbook-agent-manifest.schema.json", "plugins/activation-manifest.schema.json",
+  "plugins/learning-descriptor.schema.json", // RFC-012 P2-S3 learning descriptor context schema
   "patterns/taxonomy.json", "patterns/events.json", "plugins/bypass_known.json",
 ];
 function buildMinimalContext(tmp) {


### PR DESCRIPTION
## Summary

Main went red after #552: `tests/test-activation-manifest.mjs` failed 26/9 — its `CONTEXT_FILES` temp-root list predates S3 and lacks `plugins/learning-descriptor.schema.json`, which the merged `loadContext` now reads unconditionally (the §19.3c-F2 class in the one suite the S3 sweep didn't enumerate; root cause + the corrected sweep rule in plan §19.3h). One-line fold (mirrors step 3.7b).

Also in this PR: the §19.3h plan fold, including a branch-protection note — #552 merged while the full `validate` run was still pending.

## Test plan

- `node tests/test-activation-manifest.mjs` → 35/35 (was 26/9)
- test-plugin-registry 205/205, test-em-promote 30/0/1, validate-plugin-registry exit 0, validate-schemas + self-tests green, p0-schemas 126/126, uninstall-activation 26/26, ci-suite-registration 16/16
