### PR TITLE
fix: serialize episodic memory store writers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -383,6 +383,9 @@ jobs:
       - name: Run registered-stores lib suite (APC-S1)
         run: node tests/test-registered-stores.mjs
 
+      - name: Run store-write concurrency suite (issue 546)
+        run: node tests/test-store-write-concurrency.mjs
+
       - name: Run all-projects stats+doctor observability suite (APC-S2/S3)
         run: node tests/test-all-projects-observability.mjs
 

--- a/docs/plans/issue-546-concurrent-store-writes.md
+++ b/docs/plans/issue-546-concurrent-store-writes.md
@@ -1,0 +1,317 @@
+# Issue 546 Concurrent Store Writes Plan
+
+## §1 Status
+
+Current stage: **approved**. GLM-5.2 returned ACCEPT in round 2 after every round-1 HOLD
+finding was dispositioned and the revised integration surface was re-audited.
+
+| Field | Value |
+|---|---|
+| RFC | `n/a` |
+| Parent requirements | `n/a`, issue-driven substrate integrity fix |
+| Workplan episode | `20260722-123543-workplan-v231-prioritizes-issue-546-imme-2c29` |
+| Target branch | `fix/issue-546-concurrent-writes` |
+| Executor altitude | `high`, operator-authorized Kimi K3 integration builder |
+| Executor authorization | active handoff authorizes Kimi K3 as the external builder fallback; this plan selects that fallback |
+
+## §2 Episode Search Summary
+
+Session recall and the trigger index were run before scouting. The active constraints are:
+
+- `20260722-123543-workplan-v231-prioritizes-issue-546-imme-2c29`: fix #546 after NAPMEM-C and audit the complete fixed-temporary writer class.
+- `20260722-123614-handoff-60-places-issue-546-immediately--d6cc`: the observed `em-feedback` failure extends the practical class beyond the original `em-store` report.
+- `20260711-001343-multiagent-playbook-work-first-pipeline--a6c2`: scouts precede product reads and edits.
+- `20260710-125133-session-grant-driven-seat-permissions-at-483d`: inspect driven-seat dialogs and grant only benign in-scope operations.
+
+Current-main behavior was reproduced in an isolated non-git fixture. A 64-process
+`em-store` run produced non-zero exits at the fixed temporary renames for `tags.json`,
+`category-index.json`, and `tokens.json` after all episode files landed. Separate real
+process runs reproduced fixed `index.jsonl.tmp` and `tags.json.tmp` failures in
+`em-feedback` and `em-revise`. `em-rebuild-index` restored derived-index parity.
+
+## §3 Objective
+
+Serialize every in-scope store mutation that persists episodes and rewrites shared derived
+indexes through the existing per-store `clerk-apply.lock`. Replace participating fixed
+shared temporary basenames with same-directory collision-safe names. Prove with deterministic
+external-holder tests and true concurrent processes that successful writers leave episode,
+index, tag, category, and token state mutually consistent without temporary-file litter.
+
+## §4 Requirements
+
+| ID | Requirement | Parent | Test(s) | Priority |
+|---|---|---|---|---|
+| REQ-1 | A zero-dependency store-write helper reuses `scripts/lib/lock.mjs` and `<store>/clerk-apply.lock`; it exposes synchronous one-store and ordered multi-store acquisition, release, unique temporary paths, and atomic replacement. | P1, P5, P11 | `testHelperAcquireRelease`, `testUniqueTmpPaths`, `testAtomicReplace` | MUST |
+| REQ-2 | A failed `tryAcquire` result may be inherited only when its live `heldBy` PID equals the current process or the current direct parent PID. Inherited handles are never released by the child. A null or malformed owner never inherits. This preserves `em-promote` parent-lock plus direct child `em-store` or `em-revise` serialization without deadlock. | P4, P11 | `testSameProcessInheritance`, `testParentHeldChildWrite`, `testMalformedLockTimesOut` | MUST |
+| REQ-3 | Multi-store acquisition canonicalizes existing store directories, deduplicates aliases, sorts paths lexically, acquires in that order, and releases acquired handles in reverse order. | P5, P11 | `testMultiStoreOrder`, `testSymlinkAliasDedup`, `testPartialAcquireCleanup` | MUST |
+| REQ-4 | `em-store` holds the canonical lock across episode persistence and all index, tag, category, and token updates. Validation remains before the first durable write. | P1, P4 | `testExternalHolderBlocksStore`, `testConcurrentStoreParity`, `testStoreTimeoutNoWrite` | MUST |
+| REQ-5 | `em-revise` holds all required store locks across original supersession and successor persistence. Cross-scope revision uses REQ-3 ordering. | P1, P7 | `testExternalHolderBlocksRevise`, `testCrossStoreReviseParity` | MUST |
+| REQ-6 | Both `em-feedback` modes and `em-pin` serialize their episode or index read-modify-write transactions. Their existing JSON success and error envelopes remain compatible. | P1, P11 | `testFeedbackWaits`, `testFeedbackConcurrentParity`, `testPinWaits`, `testPinParity` | MUST |
+| REQ-7 | `em-rebuild-index` serializes each store rebuild. `writeBackAccessTracking` serializes each best-effort index rewrite and skips only that store on lock timeout. | P1, P4 | `testRebuildWaits`, `testSearchWritebackDoesNotDropAppend` | MUST |
+| REQ-8 | `em-prune`, `em-move`, `em-seed-patterns`, `em-review-request`, the non-clerk legacy `em-consolidate --apply` path, and the full episode-plus-derived-index phase of `em-restore` use the canonical lock and collision-safe temporary names for shared store files. | P1, P4, P5 | `testCurationWriterAudit`, external-holder coverage, existing focused suites | MUST |
+| REQ-9 | The already-locked clerk paths in `em-consolidate`, `em-promote`, and `store-identity` remain behaviorally unchanged. Regression tests prove no nested-lock timeout while the legacy non-clerk consolidate path adopts the shared helper. | P4, P11 | `testPromoteParentHeldChildWrite`, existing consolidate and identity suites | MUST |
+| REQ-10 | Every changed shared derived-index replacement uses a unique same-directory path containing PID and cryptographic randomness, writes and fsyncs before rename, and removes its own temporary file on failure. | P5, P11 | `testUniqueTmpPaths`, `testAtomicReplaceCleanup`, `testNoTmpLitter` | MUST |
+| REQ-11 | Lock timeout fails before the first transaction write, exits non-zero for command writers, names `store-write-lock-timeout`, and leaves the target store byte-unchanged. | P4, P11 | `testStoreTimeoutNoWrite`, `testReviseTimeoutNoWrite` | MUST |
+| REQ-12 | One new true-process concurrency suite is wired into the `substrate` CI shard in the same slice that creates it and passes suite-registration lint. | P4, P6 | `test-ci-suite-registration.mjs`, workflow step | MUST |
+
+## §5 Non-Goals
+
+- Change episode IDs, schemas, categories, search ranking, or recall behavior.
+- Introduce a global lock, daemon, dependency, database, or hook.
+- Make multiple independent stores one atomic transaction.
+- Change already-accepted `em-promote`, clerk, or identity business rules.
+- Auto-merge the pull request.
+
+## §6 Token Budget
+
+`wc -l` was captured from `e6cba30` before planning.
+
+| Group | Existing lines | Expected write delta | Notes |
+|---|---:|---:|---|
+| lock helper and core writers | 2,042 | 180-260 | helper plus six focused integrations |
+| curation and specialized writers | 3,962 | 100-180 | anchored lock and atomic-replace wiring only |
+| consolidate split surface | 2,088 | 35-70 | legacy apply path changes; clerk paths remain interaction-only |
+| already-locked interaction surface | 1,195 | 0 | promote and identity review plus regression tests only |
+| CI and registration | 1,014 | 3-8 | one substrate step, no new shard |
+| new test suite | 0 | 300-450 | deterministic process harness and assertions |
+
+Baseline single-seat reading exceeds 50k tokens. The optimized run uses sequenced ownership:
+helper and tests, core writers, curation writers, then a frozen-diff reviewer. Each builder
+receives only its slice files and shared contracts.
+
+## §7 Safety and Negative Matrix
+
+| Concern | Severity | Failure scenario | Mitigation | Negative test |
+|---|---|---|---|---|
+| Lost derived-index update | High | Two writers read one index and each rename a stale snapshot | Hold one per-store lock across the full read-modify-write transaction | External holder plus concurrent parity tests |
+| Fixed temporary collision | High | Writer A renames the shared temp before writer B renames it | PID plus random same-directory temp path, `wx`, fsync, rename, owned cleanup | `testUniqueTmpPaths`, `testAtomicReplaceCleanup` |
+| Parent-child self-deadlock | High | `em-promote` holds the lock and waits for a direct child that tries to reacquire | Inherit only a live `tryAcquire().heldBy` equal to current PID or current direct parent PID; inherited release is a no-op | `testParentHeldChildWrite` |
+| Cross-store deadlock | High | Two movers or revisers acquire source and destination in opposite orders | Canonicalize, deduplicate, lexical sort, reverse release | `testMultiStoreOrder` |
+| Partial lock acquisition | Medium | First lock succeeds and second times out | Release only handles acquired by this call before returning error | `testPartialAcquireCleanup` |
+| Timeout after a write | High | Command mutates an episode before reporting lock timeout | Acquire after validation but before the first write | timeout byte-snapshot tests |
+| Symlink alias | Medium | Two spellings of one store acquire different locks | Create the store directory, then use `realpathSync` for lock identity and dedupe | `testSymlinkAliasDedup` |
+| Stale lock | Medium | Dead owner leaves `clerk-apply.lock` | Reuse `tryAcquire` stale-owner recovery | existing lock tests plus helper unit test |
+| Malformed lock | Medium | Lock payload has no positive PID and cannot be reclaimed automatically | Never inherit; time out before mutation with `heldBy:null`; document manual removal after holder verification | `testMalformedLockTimesOut` |
+| Independent stores over-serialize | Medium | A store A writer blocks unrelated store B | Lock identity remains per canonical store directory | `testIndependentStoresProceed` |
+| Windows and macOS path behavior | Medium | temp file crosses devices or `/var` aliases diverge | temp lives beside final path; all path work uses Node `path` and `fs`; no shell-only path logic | CI plus symlink fixture |
+
+## §8 Design
+
+### 8.1 Key types
+
+```js
+/** @typedef {{lockFile:string,pid:number,inherited:boolean}} StoreWriteLockHandle */
+/** @typedef {{ok:true,handles:StoreWriteLockHandle[],dirs:string[]}|{ok:false,code:'store-write-lock-timeout',heldBy:number|null}} StoreWriteLockResult */
+```
+
+### 8.2 Invariants
+
+- Exactly one lock basename exists for a store: `clerk-apply.lock`.
+- Lock identity is the real store directory, not the caller's spelling.
+- Every acquired handle is released in reverse order; inherited handles are never released.
+- Inheritance is evaluated only from a failed `tryAcquire` result with a positive live `heldBy`; malformed and null owners never inherit.
+- Validation finishes before acquisition where it does not depend on mutable store state.
+- Each writer re-reads the mutable rows and files it will modify after acquisition: collision state for store and seed/review writers, original status for revise, current counters for feedback, frontmatter and index rows for pin, current episode set for rebuild and prune, source/destination rows for move, source cluster rows for legacy consolidate, target indexes for restore, and index rows for relevance writeback.
+- No transaction reports success until all in-scope derived indexes are updated.
+- Temporary files stay in the destination directory and are unique per write.
+- Cross-platform behavior uses Node standard-library APIs only.
+
+### 8.3 Flow
+
+```mermaid
+sequenceDiagram
+  participant W as Writer
+  participant L as clerk-apply.lock
+  participant E as episodes
+  participant I as derived indexes
+  W->>W: validate immutable input
+  W->>L: acquire canonical store lock(s)
+  L-->>W: owned or inherited handle(s)
+  W->>W: re-read mutable store state
+  W->>E: atomic episode update
+  W->>I: atomic index, tag, category, token updates
+  W->>L: release owned handles in reverse order
+  W-->>W: emit success JSON
+```
+
+## §9 Existing Hook Points and Disposition Sweep
+
+| File | Current anchor | Disposition | Planned impact |
+|---|---|---|---|
+| `scripts/lib/lock.mjs` | `tryAcquire`, `release` | INTERACTS | primitive reused unchanged |
+| `scripts/lib/store-write-lock.mjs` | new | CHANGED | shared synchronous store-lock and atomic-replace API |
+| `scripts/em-store.mjs` | `// Write files` | CHANGED | one-store transaction and atomic replacements |
+| `scripts/em-revise.mjs` | `// Mark original as superseded` | CHANGED | ordered store transaction(s) |
+| `scripts/em-feedback.mjs` | `// Record: one +1 per resolved id` | CHANGED | lock both modes without changing envelopes |
+| `scripts/em-pin.mjs` | `// --- frontmatter` | CHANGED | one-store episode and index transaction |
+| `scripts/em-rebuild-index.mjs` | `function rebuildDir(dataDir, label)` | CHANGED | one-store rebuild transaction |
+| `scripts/lib/relevance.mjs` | `writeBackAccessTracking`, `updateTokensIndex` | CHANGED | bounded best-effort lock plus atomic replacement |
+| `scripts/em-prune.mjs` | `// Actual prune` | CHANGED | one-store archive and index transaction |
+| `scripts/em-move.mjs` | source and destination rewrite helpers | CHANGED | ordered two-store transaction |
+| `scripts/em-seed-patterns.mjs` | episode and derived-index write block | CHANGED | canonical global-store transaction |
+| `scripts/em-review-request.mjs` | episode and tags write block | CHANGED | canonical resolved-store transaction |
+| `scripts/em-restore.mjs` | episode apply plus per-target `mergeIndexes` loop | CHANGED | ordered target-store locks span episode persistence through derived-index merge; unique staging remains |
+| `scripts/em-consolidate.mjs` | legacy `--apply` block and clerk paths | CHANGED / INTERACTS | legacy digest transaction adopts helper; already-locked clerk paths remain behaviorally unchanged |
+| `scripts/em-promote.mjs` | local `withStoreLockSync` around child spawn | INTERACTS | no product change; parent inheritance regression coverage |
+| `scripts/lib/store-identity.mjs` | local `withStoreLockSync` | INTERACTS | already serialized; no product change |
+| all remaining `scripts/em-*.mjs` | read-only or unrelated state | UNCHANGED | no issue-546 store-index transaction |
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Verification | Hard stop |
+|---|---|---|---|---|
+| 546-S1 | Shared lock, atomic-replace contract, and CI registration | new helper, new test suite, workflow | helper, negative lock tests, registration lint | no writer wiring |
+| 546-S2 | Ordinary and hot writers | store, revise, feedback, pin, rebuild, relevance | deterministic holder, concurrency parity, promote parent-child | no curation writer |
+| 546-S3 | Remaining unguarded shared-index writers | prune, move, seed, review-request, restore, legacy consolidate | focused existing suites and writer audit | no changes to already-locked clerk business logic |
+
+Dependency: `S1 -> S2 -> S3`. Builders never commit. The orchestrator commits the final
+accepted slice files only after frozen-diff review and independent verification.
+
+## §11 Cut Order
+
+If a review proves S3 too broad, cut only writers that the reviewer classifies as not sharing
+the issue invariant and file the residual with all five defer fields. Do not cut REQ-1 through
+REQ-7, REQ-9 through REQ-12, parent inheritance, deterministic negative tests, or CI wiring.
+
+## §12 Contracts
+
+### `acquireStoreWriteLocksSync(dataDirs, options)`
+
+| State | Condition | Output | Side effect |
+|---|---|---|---|
+| owned | every lock acquired by caller | `{ok:true, handles, dirs}` | lock files created |
+| inherited | failed `tryAcquire` reports a positive live `heldBy` equal to current PID or current direct parent PID | inherited handle in success result | no file change |
+| timeout | a non-inherited owner, including `heldBy:null` from a malformed payload, remains through deadline | `{ok:false, code:'store-write-lock-timeout', heldBy}` | owned earlier handles released |
+| invalid | empty or non-string store path | throws `TypeError('store directory must be a non-empty string')` | none |
+
+### `releaseStoreWriteLocks(handles)`
+
+Reverse-iterates handles. It calls `release` only for owned handles. Repeated calls are safe.
+
+### `atomicReplaceFileSync(finalPath, data, options)`
+
+Creates a same-directory `wx` temporary file containing PID plus eight random hex bytes,
+writes the supplied bytes, fsyncs, closes, renames, and returns the final path. Any failure
+closes the descriptor and removes only that invocation's temporary file before rethrowing.
+An `EEXIST` from the random `wx` path fails loudly without deleting the existing path; the
+caller may retry the whole operation after inspecting the collision.
+
+## §13 Edge Cases
+
+| ID | Scenario | Expected | Test |
+|---|---|---|---|
+| EC1 | empty store path | reject before filesystem access | helper invalid-input test |
+| EC2 | symlink alias and canonical path name one store | one deduplicated lock | `testSymlinkAliasDedup` |
+| EC3 | 16 concurrent store writers | all exit 0 and every derived index carries every successful ID | `testConcurrentStoreParity` |
+| EC4 | atomic replacement throws before rename | prior final file survives and owned temp is removed | `testAtomicReplaceCleanup` |
+| EC5 | direct child sees parent-owned lock | child proceeds; parent remains owner | `testParentHeldChildWrite` |
+| EC6 | unrelated live owner holds lock past deadline | fail before transaction write | timeout snapshot tests |
+| EC7 | revise source and target resolve to the same store | one lock acquired | multi-store dedupe test |
+| EC8 | best-effort access tracking times out | search result still succeeds; that store's tracking write is skipped | writeback contention test |
+| EC9 | already-locked promote or clerk path calls changed writer | no nested timeout and no duplicate record | existing focused suites |
+| EC10 | malformed lock payload has no positive PID | timeout with `heldBy:null`; target bytes unchanged | `testMalformedLockTimesOut` |
+| EC11 | store A is externally locked while store B writes | B completes before A releases | `testIndependentStoresProceed` |
+| EC12 | restore spans two target stores while one is externally held | no episode or derived-index write occurs before all target locks are acquired | `testRestoreTransactionWaits` |
+| EC13 | dry-run, help, or invalid input | no lock wait and no store mutation | `testNonWriterControls` |
+
+## §14 Test Catalog
+
+New suite: `tests/test-store-write-concurrency.mjs`.
+
+- Helper: acquire, release, inherited handles, malformed-owner timeout, lexical ordering, symlink dedupe, partial cleanup, unique temporary paths, `wx` collision, and atomic replacement cleanup.
+- Deterministic writer blocking: real external holder against store, revise, feedback, pin, rebuild, prune, move, seed, review-request, restore, and legacy consolidate.
+- Concurrency parity: 16 real `em-store` processes with distinct sentinel tags and bodies.
+- Cross-store revise: local original plus global successor with both stores consistent.
+- Search writeback: concurrent append remains present after access tracking.
+- Compatibility and false-positive controls: parent-held direct child write completes; independent stores proceed; read-only, help, dry-run, and invalid-input paths do not wait; promote, clerk consolidate, and identity focused suites remain green.
+- Restore: an external holder blocks the full episode-plus-derived-index transaction; the existing restore self-test still proves `mergeIndexes` union and force-history cases.
+- Curation audit: source scan proves every CHANGED writer routes shared replacements through the helper; focused behavior suites validate each command.
+- Timeout: byte snapshots prove no mutation, including malformed lock payloads.
+
+The negative control is deterministic: the suite first holds `clerk-apply.lock` in a live
+external child. On unmodified main, the ordinary writer does not wait, so the observed
+`writerExitedBeforeRelease` value is `true` instead of the required `false`.
+
+## §15 Verification Ledger
+
+| Claim | Command | Required observed artifact |
+|---|---|---|
+| New regression suite passes | `node tests/test-store-write-concurrency.mjs` | named pass count, zero failures |
+| Suite is falsifiable on main | `node tests/test-store-write-concurrency.mjs --expect-main-red` before product edits | non-zero exit with `writerExitedBeforeRelease=true` |
+| Store tag compatibility | `node tests/test-em-store-tag-flags.mjs` | zero failures |
+| Feedback compatibility | `node tests/test-feedback-scan.mjs` | zero failures |
+| Category compatibility | `node tests/test-category-index.mjs` | zero failures |
+| Move compatibility | `node tests/test-em-move.mjs` | zero failures |
+| Prune compatibility | `node tests/test-prune-lifecycle.mjs` | zero failures |
+| Seed compatibility | `node tests/test-seed-patterns.mjs` | zero failures |
+| Review-request compatibility | `node tests/test-workflow-validate.mjs` | zero failures |
+| Restore compatibility | `node tests/test-em-restore.mjs` | reported self-test failure count is `0` |
+| Relevance compatibility | `node tests/test-relevance.mjs` | zero failures |
+| Legacy consolidate and clerk compatibility | `node tests/test-em-consolidate.mjs` | zero failures |
+| Promote compatibility | `node tests/test-em-promote.mjs` | zero failures |
+| Promote apply compatibility | `node tests/test-promote-apply.mjs` | zero failures |
+| Identity compatibility | `node tests/test-store-identity.mjs` | zero failures |
+| CI wiring is live | `node tests/test-ci-suite-registration.mjs` | zero unregistered new suites |
+| Store integrity holds | concurrency suite's isolated-fixture doctor probe | zero errors and no drift |
+| Diff whitespace is clean | `git diff --check` | no output and exit zero |
+| Diff scope is clean | `git status --short` | only approved slice files |
+| CI is green | `gh pr checks <PR>` | required `validate` and `p12-invariant-gate` pass |
+
+## §16 Risk Analysis
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Parent inheritance accepts a wrong relationship | High | Low | evaluate only failed `tryAcquire().heldBy`; require a positive PID equal to current PID or current direct parent PID; malformed owners time out |
+| Large-store write latency increases | Medium | Medium | lock only write transaction; keep reads and post-write reports outside; record timing |
+| Broad writer audit causes scope creep | Medium | Medium | anchored per-file edits, three slices, frozen diff, independent review |
+| Rebuild called from an already-held same-process path | High | Low | same-process inherited handle and no-op inherited release |
+| Restore partially completes across independent stores | Medium | Existing | acquire all affected target-store locks in canonical order before episode writes; hold all through every derived merge; release the set in reverse order at transaction end; do not claim rollback across stores |
+
+## §17 Open Decisions
+
+No design decisions are delegated to builders. Review findings that remove a writer from S3
+must include a real contention scenario, specification check, prior-review history, same-class
+sweep, residual risk, and a tracking issue before the plan can be approved.
+
+## §18 Done Criteria
+
+- [ ] Every MUST row has a passing automated test.
+- [ ] Deterministic main negative control is captured before the fix.
+- [ ] All CHANGED writers, including legacy non-clerk consolidate and full restore episode application, use the canonical lock for their complete store transaction.
+- [ ] All participating shared replacements use collision-safe same-directory temporary files.
+- [ ] Promote parent-child, independent-store, malformed-lock, non-writer control, consolidate, restore, and store-identity regression suites pass.
+- [ ] New suite is wired into `substrate` and suite-registration lint passes.
+- [ ] Frozen-diff reviewer returns ACCEPT after every finding disposition.
+- [ ] Independent verification reproduces the observable behavior, not only the unit suite.
+- [ ] Every deferred finding has an issue, issue comment, or violation artifact.
+
+## §19 Review Consensus
+
+| Pass | Reviewer | Provider | Blockers | Verdict | Artifact |
+|---|---|---|---:|---|---|
+| 1 | `plan-review` Herdr seat | GLM-5.2 | 3 | HOLD | read-only source and test-inventory audit, final telemetry ↑171k / ↓27k / $0.528 / 7.7% context |
+| 2 | `plan-review` Herdr seat | GLM-5.2 | 0 | ACCEPT | cumulative ↑186k / ↓39k / $0.771 / 7.6% context; round-2 delta ≈ ↑15k / ↓12k / $0.243 |
+
+Findings are classified as ACCEPT, ACCEPT-WITH-MOD, REJECT, DEFER, or NEEDS-EVIDENCE.
+At most two review rounds are permitted before changing the plan boundary.
+
+Round-1 dispositions:
+
+- F1 missing legacy consolidate writer: **ACCEPT**. Reclassify only the non-clerk `--apply` transaction as CHANGED; keep already-locked clerk paths interaction-only.
+- F2 low-altitude appendix failure: **ACCEPT-WITH-MOD**. Select the operator-authorized Kimi K3 integration builder as the high-capability executor and remove Appendix A instead of mislabeling prose as a mechanical build path.
+- F3 placeholder and omitted suites: **ACCEPT-WITH-MOD**. §15 now names the real seed, review-request, restore, relevance, consolidate, promote, and identity commands.
+- F4 PID-reuse expansion: **REJECT**. The inheritance condition is the live owner returned by `tryAcquire` and the current direct parent relationship, so changing the shared lock payload is not justified by a reachable direct-child scenario. Malformed owner handling is **ACCEPT-WITH-MOD**: null owners never inherit and must time out before mutation with a byte-snapshot test and manual-recovery documentation.
+- F5 delayed CI registration: **ACCEPT-WITH-MOD**. CI wiring moves into S1 with test creation.
+- F6 restore hollow-green risk: **ACCEPT-WITH-MOD**. Existing self-tests cover `mergeIndexes`; the new suite must additionally hold an affected target lock around the full restore episode-plus-index transaction.
+- F7 mutable-state revalidation: **ACCEPT-WITH-MOD**. §8.2 now enumerates the required per-writer in-lock rereads.
+- F8 `wx` collision behavior: **ACCEPT-WITH-MOD**. `EEXIST` fails loudly, preserves both the final file and pre-existing collision path, and does not delete a path the call did not create.
+
+## §20 Lessons Encoded
+
+- Verify by artifact: deterministic external-holder and parity outputs back every claim.
+- Complete bug class: review receives the invariant, full writer disposition, false-positive controls, and refactor boundary.
+- Cross-platform always: only Node standard-library path and filesystem APIs.
+- One command per verification call: no chained shell commands in build or verification steps.
+- Step 9: every residual finding receives a durable tracking artifact before wrap-up.
+- High-capability build route: the operator-authorized Kimi K3 integration builder receives the approved §1-§20 plan and bounded slice ownership; no mechanical appendix is claimed.
+- Role lock: external builders write product files; the orchestrator verifies and commits.

--- a/docs/plans/issue-546-concurrent-store-writes.md
+++ b/docs/plans/issue-546-concurrent-store-writes.md
@@ -111,7 +111,7 @@ receives only its slice files and shared contracts.
 - Every acquired handle is released in reverse order; inherited handles are never released.
 - Inheritance is evaluated only from a failed `tryAcquire` result with a positive live `heldBy`; malformed and null owners never inherit.
 - Validation finishes before acquisition where it does not depend on mutable store state.
-- Each writer re-reads the mutable rows and files it will modify after acquisition: collision state for store and seed/review writers, original status for revise, current counters for feedback, frontmatter and index rows for pin, current episode set for rebuild and prune, source/destination rows for move, source cluster rows for legacy consolidate, target indexes for restore, and index rows for relevance writeback.
+- Each writer re-reads the mutable rows and files it will modify after acquisition: collision state for store and seed/review writers, pre-lock vs in-lock (file status, index status, direct-successor set) for revise so a stable superseded original may still be revived while an actually concurrent revision is detected as stale, current counters for feedback, frontmatter and index rows for pin, current episode set for rebuild and prune, source/destination rows for move, source cluster rows for legacy consolidate, target indexes for restore, and index rows for relevance writeback.
 - No transaction reports success until all in-scope derived indexes are updated.
 - Temporary files stay in the destination directory and are unique per write.
 - Cross-platform behavior uses Node standard-library APIs only.
@@ -219,7 +219,8 @@ caller may retry the whole operation after inspecting the collision.
 New suite: `tests/test-store-write-concurrency.mjs`.
 
 - Helper: acquire, release, inherited handles, malformed-owner timeout, lexical ordering, symlink dedupe, partial cleanup, unique temporary paths, `wx` collision, and atomic replacement cleanup.
-- Deterministic writer blocking: real external holder against store, revise, feedback, pin, rebuild, prune, move, seed, review-request, restore, and legacy consolidate.
+- Deterministic writer blocking: real external holder against store, revise (including cross-scope snapshot-drift detection), feedback, pin, rebuild, prune, move, seed, review-request, restore, and legacy consolidate.
+- Deterministic cross-scope revise race: a fixture-local CJS preload fixes the pre-lock snapshot instant; the holder mutates the other store before the revise acquires its locks, proving `stale-original` with `snapshot drift` reason and no writes.
 - Concurrency parity: 16 real `em-store` processes with distinct sentinel tags and bodies.
 - Cross-store revise: local original plus global successor with both stores consistent.
 - Search writeback: concurrent append remains present after access tracking.
@@ -238,6 +239,8 @@ external child. On unmodified main, the ordinary writer does not wait, so the ob
 |---|---|---|
 | New regression suite passes | `node tests/test-store-write-concurrency.mjs` | named pass count, zero failures |
 | Suite is falsifiable on main | `node tests/test-store-write-concurrency.mjs --expect-main-red` before product edits | non-zero exit with `writerExitedBeforeRelease=true` |
+| Cross-scope revise stale-original guard (snapshot-drift) | `node tests/test-store-write-concurrency.mjs` (cross-scope snapshot-drift subtest) | `stale-original` with `snapshot drift` reason, exit 1, no writes |
+| Revise stale-original guard preserves superseded-member revival | `node tests/test-rfc-009-p4-apply.mjs --only mergeReversibleViaRevive` | one pass |
 | Store tag compatibility | `node tests/test-em-store-tag-flags.mjs` | zero failures |
 | Feedback compatibility | `node tests/test-feedback-scan.mjs` | zero failures |
 | Category compatibility | `node tests/test-category-index.mjs` | zero failures |

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -67,6 +67,14 @@ import { resolveRegisteredStores, resolveRegisteredStoresWithStatus, realpathSaf
 import { TAG_JACCARD_MIN, SUMMARY_JACCARD_MIN, HIGH_DF_MIN, CADENCE_K_SHARED, CADENCE_N_LESSONS, PROPOSED_ACTIONS, RUN_RECORD_CATEGORY, RUN_RECORD_TYPE, CLERK_CUTOVER_MARKER, ATTRIBUTION_WINDOW_MS, ACTIVATION_LOG_NAME, ACTIVATION_LOG_MAX_BYTES, LOG_FORMAT_VERSION, computeCadence } from './lib/activation-log.mjs'
 import { illegalValueChar, illegalScalarChar, serializeInlineArray, ACTIVATION_ARRAY_FIELDS } from './lib/activation.mjs'
 import { acquire, release } from './lib/lock.mjs'
+// Issue 546 (S3b): the legacy non-clerk --apply digest writer races against
+// any concurrent writer that mutates the same store. The shared
+// `<DATA_DIR>/clerk-apply.lock` is the canonical per-store mutex; the
+// clerk paths ALREADY hold it via `acquire`/`release` from lock.mjs, so
+// the legacy path adopts the same lock through the store-write-lock helper
+// (which collapses same-process inheritance onto the helper's own internal
+// tryAcquire gate). Help/dry-run/invalid-input paths stay lock-free.
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { spawnSync } from 'node:child_process'
 
@@ -799,6 +807,13 @@ if (!apply) {
   console.log(JSON.stringify({ status: 'ok', dry_run: true, clusters: report, applied: 0, hint: clusters.length ? 'Re-run with --apply to consolidate.' : undefined }))
   process.exit(0)
 }
+// No-clusters fast path: lock-free exit when --apply --confirm produced
+// zero clusters. Preserves the apply envelope exactly: status ok, clusters
+// empty, applied 0 — no dry_run field.
+if (clusters.length === 0) {
+  console.log(JSON.stringify({ status: 'ok', clusters: [], applied: 0 }))
+  process.exit(0)
+}
 if (clusters.length > 5 && !confirm) {
   console.log(JSON.stringify({ status: 'error', message: `${clusters.length} clusters would be folded (> 5). Re-run with --confirm (or narrow with --category/--project/--min-sim).` }))
   process.exit(2)
@@ -972,87 +987,197 @@ function updateInverted(fileName, id, keys, pretty) {
 }
 
 const applied = []
-for (let c = 0; c < clusters.length; c++) {
-  const members = clusters[c]
-  const memberIds = members.map(m => m.id)
-  const category = canonicalCategory(members[0].category)
-  const project = members[0].project
-  const tags = normalizeTags(members.flatMap(m => Array.isArray(m.tags) ? m.tags : []))
-  const pinned = members.some(m => m.pinned === true)
-  const summary = `Consolidated: ${members[members.length - 1].summary} (+${members.length - 1} related)`
-
-  const { dateStr, timeStr, idStamp } = nowParts()
-  const digestId = `${idStamp}-${slugify(summary)}-${crypto.randomBytes(2).toString('hex')}`
-
-  const bodySections = members.map(m =>
-    `## ${m.summary}\n\n(id: \`${m.id}\`, ${m.date})\n\n${bodyOf(contents.get(m.id))}`
-  )
-  const digestBody = [
-    `Digest of ${members.length} related episodes (em-consolidate, ${dateStr}).`,
-    '',
-    ...bodySections,
-  ].join('\n\n')
-
-  const fmLines = [
-    '---',
-    `id: ${digestId}`,
-    `date: ${dateStr}`,
-    `time: "${timeStr}"`,
-    `project: ${project}`,
-    `category: ${category}`,
-    'status: active',
-    `consolidates: [${memberIds.join(', ')}]`,
-    `tags: [${tags.join(', ')}]`,
-    `summary: ${summary}`,
-    ...(pinned ? ['pinned: true'] : []),
-    '---',
-  ]
-  const digestContent = `${fmLines.join('\n')}\n\n# ${summary}\n\n${digestBody}\n`
-
-  // 1. digest file + index row + inverted indexes
-  fs.mkdirSync(EPISODES_DIR, { recursive: true })
-  fs.writeFileSync(path.join(EPISODES_DIR, `${digestId}.md`), digestContent, 'utf8')
-  const digestRow = {
-    id: digestId, date: dateStr, time: timeStr, project, category,
-    status: 'active', supersedes: null, consolidates: memberIds,
-    tags, summary,
-    ...(pinned ? { pinned: true } : {}),
+// Issue 546 (S3b): wrap the legacy non-clerk --apply transaction in the
+// canonical per-store clerk-apply.lock. The same lockfile the clerk apply
+// path already holds (CLERK_LOCK_FILE = <DATA_DIR>/clerk-apply.lock); the
+// store-write-lock helper collapses same-process inheritance onto its
+// internal tryAcquire gate, so an em-promote-style direct-child spawn
+// inherits the parent's lock without re-acquisition or deadlock. Help,
+// dry-run, --confirm-gate, --scope validation, and the no-clusters fast
+// path stay LOCK-FREE per REQ-8/REQ-9. Collision reread (inside the lock):
+// re-read the index.jsonl-derived row map so a concurrent apply that
+// superseded one of our members between the top-level `loadIndex` and
+// this transaction surfaces as a SKIPPED cluster, not a silent double-
+// supersede. Existing tests run single-process; the skip path is silent
+// for them. Report fields preserve the prior contract (`clusters`, `applied`).
+// Collision-safe atomic replacements: every shared derived-index write
+// (digest file, member file, index.jsonl, tags.json, category-index.json)
+// routes through atomicReplaceFileSync so the same-directory tmp name is
+// PID+random and `wx` so two writers can never collide on rename. The
+// result envelope is collected INSIDE the lock, release runs in the
+// finally, and the JSON is printed AFTER the finally — release precedes
+// final output per REQ-13.
+let _csLockHandles = null
+let _applyEnvelope = null
+try {
+  // Helper owns EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS parsing and
+  // honors zero; no hand-parsed option.
+  const lockRes = acquireStoreWriteLocksSync([DATA_DIR])
+  if (!lockRes.ok) {
+    console.log(JSON.stringify({ status: 'error', code: lockRes.code, heldBy: lockRes.heldBy, message: `em-consolidate: store lock acquisition timed out (heldBy=${lockRes.heldBy}); no writes performed.` }))
+    process.exit(1)
   }
-  fs.appendFileSync(path.join(DATA_DIR, 'index.jsonl'), JSON.stringify(digestRow) + '\n', 'utf8')
-  updateInverted('tags.json', digestId, tags, true)
-  updateInverted('category-index.json', digestId, [category], true)
-  updateTokensIndex(DATA_DIR, digestId, episodeTokens({ summary, tags, body: digestContent }))
+  _csLockHandles = lockRes.handles
 
-  // 2. members: status superseded + superseded_by in file and index row
-  for (const m of members) {
-    const content = contents.get(m.id)
-    let updated = content.replace(/^status: active$/m, `status: superseded\nsuperseded_by: ${digestId}`)
-    if (updated === content) updated = content.replace(/^---\n/, `---\nsuperseded_by: ${digestId}\n`)
-    const tmp = path.join(EPISODES_DIR, `${m.id}.md.tmp`)
-    fs.writeFileSync(tmp, updated, 'utf8')
-    fs.renameSync(tmp, path.join(EPISODES_DIR, `${m.id}.md`))
+  // Re-read index rows under the lock, then read episode files only for
+  // members of the precomputed clusters. A cluster is accepted only when
+  // every fresh row and fresh file still reports status active.
+  const freshLiveRows = loadIndex(DATA_DIR, scope)
+  const freshById = new Map(freshLiveRows.map(r => [r.id, r]))
+  const freshContents = new Map()
+  const collisionSkips = []
+  const clustersToApply = [] // [{ originalIndex, members: fresh rows, memberIds }]
+  for (let c = 0; c < clusters.length; c++) {
+    const originalMembers = clusters[c]
+    const rebuilt = []
+    let skipReason = null
+    for (const m of originalMembers) {
+      const row = freshById.get(m.id)
+      if (!row) { skipReason = 'member-missing-in-index'; break }
+      if (row.status === 'superseded') { skipReason = `member-already-superseded:${m.id}`; break }
+      if (row.status !== 'active') { skipReason = `member-row-not-active:${m.id}:${String(row.status)}`; break }
+      const content = readEpisode(m.id)
+      if (content === null) { skipReason = `member-file-missing:${m.id}`; break }
+      const fileStatus = content.match(/^status:\s*(\S+)$/m)?.[1]
+      if (fileStatus !== 'active') { skipReason = `member-file-not-active:${m.id}`; break }
+      freshContents.set(m.id, content)
+      rebuilt.push(row)
+    }
+    if (skipReason) {
+      collisionSkips.push({
+        cluster_index: c,
+        members: originalMembers.map(m => m.id),
+        reason: skipReason,
+      })
+    } else {
+      clustersToApply.push({ originalIndex: c, members: rebuilt, memberIds: rebuilt.map(m => m.id) })
+    }
   }
-  const idsSet = new Set(memberIds)
+
   const indexFile = path.join(DATA_DIR, 'index.jsonl')
-  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-  const rewritten = lines.map(line => {
-    try {
-      const entry = JSON.parse(line)
-      if (idsSet.has(entry.id)) {
-        entry.status = 'superseded'
-        entry.superseded_by = digestId
-      }
-      return JSON.stringify(entry)
-    } catch { return line }
-  })
-  const tmp = indexFile + '.tmp'
-  fs.writeFileSync(tmp, rewritten.join('\n') + '\n', 'utf8')
-  fs.renameSync(tmp, indexFile)
+  const tagsFile = path.join(DATA_DIR, 'tags.json')
+  const categoryIndexFile = path.join(DATA_DIR, 'category-index.json')
 
-  applied.push({ ...report[c], digest_id: digestId, digest_summary: summary })
+  for (let c = 0; c < clustersToApply.length; c++) {
+    const { members, memberIds, originalIndex } = clustersToApply[c]
+    const category = canonicalCategory(members[0].category)
+    const project = members[0].project
+    const tags = normalizeTags(members.flatMap(m => Array.isArray(m.tags) ? m.tags : []))
+    const pinned = members.some(m => m.pinned === true)
+    const summary = `Consolidated: ${members[members.length - 1].summary} (+${members.length - 1} related)`
+
+    const { dateStr, timeStr, idStamp } = nowParts()
+    const digestId = `${idStamp}-${slugify(summary)}-${crypto.randomBytes(2).toString('hex')}`
+
+    const bodySections = members.map(m =>
+      `## ${m.summary}\n\n(id: \`${m.id}\`, ${m.date})\n\n${bodyOf(freshContents.get(m.id))}`
+    )
+    const digestBody = [
+      `Digest of ${members.length} related episodes (em-consolidate, ${dateStr}).`,
+      '',
+      ...bodySections,
+    ].join('\n\n')
+
+    const fmLines = [
+      '---',
+      `id: ${digestId}`,
+      `date: ${dateStr}`,
+      `time: "${timeStr}"`,
+      `project: ${project}`,
+      `category: ${category}`,
+      'status: active',
+      `consolidates: [${memberIds.join(', ')}]`,
+      `tags: [${tags.join(', ')}]`,
+      `summary: ${summary}`,
+      ...(pinned ? ['pinned: true'] : []),
+      '---',
+    ]
+    const digestContent = `${fmLines.join('\n')}\n\n# ${summary}\n\n${digestBody}\n`
+
+    // 1. digest file (collision-safe atomic replace).
+    fs.mkdirSync(EPISODES_DIR, { recursive: true })
+    atomicReplaceFileSync(path.join(EPISODES_DIR, `${digestId}.md`), digestContent)
+
+    // 2. members: flip status + superseded_by via collision-safe atomic replace.
+    // Use fresh contents (post-lock), not the pre-lock `contents` map: a
+    // concurrent pin / revise could have changed the file between the
+    // pre-lock scan and this transaction.
+    for (const m of members) {
+      const content = freshContents.get(m.id)
+      let updated = content.replace(/^status: active$/m, `status: superseded\nsuperseded_by: ${digestId}`)
+      if (updated === content) updated = content.replace(/^---\n/, `---\nsuperseded_by: ${digestId}\n`)
+      atomicReplaceFileSync(path.join(EPISODES_DIR, `${m.id}.md`), updated)
+    }
+
+    // 3. index.jsonl: read, append digest row, flip member rows, atomic-replace.
+    // Single read+rewrite avoids two appendFileSync windows where a concurrent
+    // reader could observe a half-written state.
+    const idsSet = new Set(memberIds)
+    let existingLines = []
+    try { existingLines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean) } catch {}
+    const digestRow = {
+      id: digestId, date: dateStr, time: timeStr, project, category,
+      status: 'active', supersedes: null, consolidates: memberIds,
+      tags, summary,
+      ...(pinned ? { pinned: true } : {}),
+    }
+    const rewritten = existingLines.map(line => {
+      try {
+        const entry = JSON.parse(line)
+        if (idsSet.has(entry.id)) {
+          entry.status = 'superseded'
+          entry.superseded_by = digestId
+        }
+        return JSON.stringify(entry)
+      } catch { return line }
+    })
+    rewritten.push(JSON.stringify(digestRow))
+    atomicReplaceFileSync(indexFile, rewritten.join('\n') + '\n')
+
+    // 4. tags.json: read, append digest id to each tag's posting, atomic-replace.
+    // Null-proto (#469/#470): a tag literally named "constructor"/"__proto__"
+    // must not resolve to an inherited Object.prototype member.
+    let tagsIndex = Object.create(null)
+    try { tagsIndex = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+    if (Object.getPrototypeOf(tagsIndex) !== null) tagsIndex = Object.assign(Object.create(null), tagsIndex)
+    for (const tag of tags) {
+      if (!tagsIndex[tag]) tagsIndex[tag] = []
+      if (!tagsIndex[tag].includes(digestId)) tagsIndex[tag].push(digestId)
+    }
+    atomicReplaceFileSync(tagsFile, JSON.stringify(tagsIndex, null, 2))
+
+    // 5. category-index.json: read, append digest id under canonical category.
+    let catIndex = Object.create(null)
+    try { catIndex = JSON.parse(fs.readFileSync(categoryIndexFile, 'utf8')) } catch {}
+    if (Object.getPrototypeOf(catIndex) !== null) catIndex = Object.assign(Object.create(null), catIndex)
+    if (!catIndex[category]) catIndex[category] = []
+    if (!catIndex[category].includes(digestId)) catIndex[category].push(digestId)
+    atomicReplaceFileSync(categoryIndexFile, JSON.stringify(catIndex, null, 2))
+
+    // 6. tokens.json via the helper (already repaired in S2b).
+    updateTokensIndex(DATA_DIR, digestId, episodeTokens({ summary, tags, body: digestContent }))
+
+    // Report index in the loop preserved (clusters were not filtered
+    // structurally — we walk clustersToApply, so `report[c]` no longer
+    // indexes 1:1 with the outer `c`. Re-derive via the original cluster
+    // index captured in collisionSkips / by reverse lookup.)
+    const reportEntry = report[originalIndex]
+    applied.push({ ...reportEntry, digest_id: digestId, digest_summary: summary })
+  }
+
+  _applyEnvelope = {
+    status: 'ok',
+    clusters: applied,
+    applied: applied.length,
+    ...(collisionSkips.length ? { collision_skips: collisionSkips } : {}),
+  }
+} finally {
+  // Release BEFORE final JSON output (REQ-13). Inherited handles, if any,
+  // are no-ops; owned handles unlink their lockfile.
+  if (_csLockHandles) releaseStoreWriteLocks(_csLockHandles)
 }
 
-console.log(JSON.stringify({ status: 'ok', clusters: applied, applied: applied.length }))
+if (_applyEnvelope) console.log(JSON.stringify(_applyEnvelope))
 
 // ===========================================================================
 // clerkWrite(kind, frontmatter, dataDir) — the F2 DIRECT-write primitive

--- a/scripts/em-feedback.mjs
+++ b/scripts/em-feedback.mjs
@@ -33,6 +33,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -92,37 +93,61 @@ if (scanTextFile !== undefined) {
   const dirs = []
   if (scanScope === 'local' || scanScope === 'all') dirs.push(['local', LOCAL_DIR])
   if (scanScope === 'global' || scanScope === 'all') dirs.push(['global', GLOBAL_DIR])
-  const idsByDir = new Map(dirs.map(([name]) => [name, new Set()]))
-  const dirIndexIds = dirs.map(([name, dir]) => {
-    const ids = new Set()
-    try {
-      for (const line of fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8').split('\n')) {
-        if (!line.trim()) continue
-        try {
-          const e = JSON.parse(line)
-          if (typeof e.id === 'string') ids.add(e.id)
-        } catch {}
+
+  // Dry-run remains a read-only path: it does not wait for a writer lock and
+  // preserves the historical report exactly. The real write path acquires
+  // every existing selected store before rereading its index, so resolving an
+  // id and incrementing its counter are one serialized read-modify-write.
+  const resolveIds = () => {
+    const idsByDir = new Map(dirs.map(([name]) => [name, new Set()]))
+    const dirIndexIds = dirs.map(([name, dir]) => {
+      const ids = new Set()
+      try {
+        for (const line of fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8').split('\n')) {
+          if (!line.trim()) continue
+          try {
+            const e = JSON.parse(line)
+            if (typeof e.id === 'string') ids.add(e.id)
+          } catch {}
+        }
+      } catch {}
+      return [name, ids]
+    })
+    const resolved = []
+    const skipped = []
+    for (const cid of unique) {
+      const hit = dirIndexIds.find(([, ids]) => ids.has(cid))
+      if (hit) {
+        resolved.push(cid)
+        idsByDir.get(hit[0]).add(cid)
+      } else {
+        skipped.push(cid)
       }
-    } catch {}
-    return [name, ids]
-  })
-  const resolved = []
-  const skipped = []
-  for (const cid of unique) {
-    const hit = dirIndexIds.find(([, ids]) => ids.has(cid))
-    if (hit) {
-      resolved.push(cid)
-      idsByDir.get(hit[0]).add(cid)
-    } else {
-      skipped.push(cid)
     }
+    return { idsByDir, resolved, skipped }
   }
 
-  // Record: one +1 per resolved id, one atomic index rewrite per store.
-  // Writer surface — fail CLOSED on any write error.
+  let resolved
+  let skipped
   let recorded = 0
-  if (!dryRun) {
+  if (dryRun) {
+    ({ resolved, skipped } = resolveIds())
+  } else {
+    const lockDirs = dirs
+      .map(([, dir]) => dir)
+      .filter(dir => fs.existsSync(path.join(dir, 'index.jsonl')))
+    const lockResult = lockDirs.length
+      ? acquireStoreWriteLocksSync(lockDirs)
+      : { ok: true, handles: [] }
+    if (!lockResult.ok) {
+      console.log(JSON.stringify({ status: 'error', message: `Feedback write failed: ${lockResult.code}`, recorded_before_failure: recorded }))
+      process.exit(1)
+    }
     try {
+      // This is deliberately after acquisition. A concurrent store append or
+      // feedback event must be part of the snapshot that is rewritten.
+      let idsByDir
+      ({ idsByDir, resolved, skipped } = resolveIds())
       for (const [name, dir] of dirs) {
         const targetIds = idsByDir.get(name)
         if (targetIds.size === 0) continue
@@ -139,14 +164,14 @@ if (scanTextFile !== undefined) {
             return JSON.stringify(entry)
           } catch { return line }
         })
-        const tmpFile = indexFile + '.tmp'
-        fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
-        fs.renameSync(tmpFile, indexFile)
+        atomicReplaceFileSync(indexFile, updated.join('\n') + '\n')
       }
     } catch (e) {
       console.log(JSON.stringify({ status: 'error', message: `Feedback write failed: ${e.message}`, recorded_before_failure: recorded }))
+      releaseStoreWriteLocks(lockResult.handles)
       process.exit(1)
     }
+    releaseStoreWriteLocks(lockResult.handles)
   }
 
   console.log(JSON.stringify({
@@ -176,35 +201,57 @@ if (!id || useful === noise) {
 
 const delta = useful ? 1 : -1
 
-// Find the index row across stores (local priority, matching read dedupe).
-let updatedRow = null
-let scopeName = null
-for (const dir of [LOCAL_DIR, GLOBAL_DIR]) {
-  const indexFile = path.join(dir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) continue
-  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-  let found = false
-  const updated = lines.map(line => {
-    try {
-      const entry = JSON.parse(line)
-      if (entry.id === id) {
-        found = true
-        const current = typeof entry.feedback === 'number' ? entry.feedback : 0
-        entry.feedback = Math.max(-10, Math.min(10, current + delta))
-        updatedRow = entry
-      }
-      return JSON.stringify(entry)
-    } catch { return line }
-  })
-  if (found) {
-    const tmpFile = indexFile + '.tmp'
-    fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
-    fs.renameSync(tmpFile, indexFile)
-    scopeName = dir === GLOBAL_DIR ? 'global' : 'local'
-    break
-  }
+// Lock every existing candidate store before reading the mutable rows. Local
+// remains first in the scan, so the historical local-priority resolution is
+// unchanged while two feedback writers now serialize the whole counter RMW.
+const candidateDirs = [LOCAL_DIR, GLOBAL_DIR]
+  .filter(dir => fs.existsSync(path.join(dir, 'index.jsonl')))
+const lockResult = candidateDirs.length
+  ? acquireStoreWriteLocksSync(candidateDirs)
+  : { ok: true, handles: [] }
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', message: `Feedback write failed: ${lockResult.code}`, recorded_before_failure: 0 }))
+  process.exit(1)
 }
 
+let updatedRow = null
+let scopeName = null
+let writeError = null
+try {
+  // Reread only after the lock is held. The row may have changed since the
+  // command began, especially when several useful/noise votes overlap.
+  for (const dir of candidateDirs) {
+    const indexFile = path.join(dir, 'index.jsonl')
+    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    let found = false
+    const updated = lines.map(line => {
+      try {
+        const entry = JSON.parse(line)
+        if (entry.id === id) {
+          found = true
+          const current = typeof entry.feedback === 'number' ? entry.feedback : 0
+          entry.feedback = Math.max(-10, Math.min(10, current + delta))
+          updatedRow = entry
+        }
+        return JSON.stringify(entry)
+      } catch { return line }
+    })
+    if (found) {
+      atomicReplaceFileSync(indexFile, updated.join('\n') + '\n')
+      scopeName = dir === GLOBAL_DIR ? 'global' : 'local'
+      break
+    }
+  }
+} catch (e) {
+  writeError = e
+} finally {
+  releaseStoreWriteLocks(lockResult.handles)
+}
+
+if (writeError) {
+  console.log(JSON.stringify({ status: 'error', message: `Feedback write failed: ${writeError.message}`, recorded_before_failure: 0 }))
+  process.exit(1)
+}
 if (!updatedRow) {
   console.log(JSON.stringify({ status: 'error', message: `Episode "${id}" not found in local or global index.` }))
   process.exit(1)

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -45,6 +45,7 @@ import { fileURLToPath } from 'url'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { normalizeTags, episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -102,9 +103,7 @@ function readIndexRows(dataDir) {
 
 function writeIndexRows(dataDir, rows) {
   const p = path.join(dataDir, 'index.jsonl')
-  const tmp = p + '.tmp'
-  fs.writeFileSync(tmp, rows.map(r => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : ''), 'utf8')
-  fs.renameSync(tmp, p)
+  atomicReplaceFileSync(p, rows.map(r => JSON.stringify(r)).join('\n') + (rows.length ? '\n' : ''))
 }
 
 // Remove an id from a { key: [ids] } inverted index; drop emptied keys.
@@ -123,9 +122,7 @@ function removeFromInverted(dataDir, fileName, id, warnings, pretty) {
     else if (filtered.length !== idx[key].length) idx[key] = filtered
     else continue
   }
-  const tmp = p + '.tmp'
-  fs.writeFileSync(tmp, JSON.stringify(idx, ...(pretty ? [null, 2] : [])), 'utf8')
-  fs.renameSync(tmp, p)
+  atomicReplaceFileSync(p, JSON.stringify(idx, ...(pretty ? [null, 2] : [])))
 }
 
 function addToInverted(dataDir, fileName, id, keys, pretty) {
@@ -139,9 +136,7 @@ function addToInverted(dataDir, fileName, id, keys, pretty) {
     if (!idx[key]) idx[key] = []
     if (!idx[key].includes(id)) idx[key].push(id)
   }
-  const tmp = p + '.tmp'
-  fs.writeFileSync(tmp, JSON.stringify(idx, ...(pretty ? [null, 2] : [])), 'utf8')
-  fs.renameSync(tmp, p)
+  atomicReplaceFileSync(p, JSON.stringify(idx, ...(pretty ? [null, 2] : [])))
 }
 
 function sha256(p) {
@@ -255,28 +250,71 @@ for (const id of ids) {
     continue
   }
 
-  const srcFile = path.join(srcDir, 'episodes', `${id}.md`)
-  const dstFile = path.join(DEST_DIR, 'episodes', `${id}.md`)
+  let srcFile = path.join(srcDir, 'episodes', `${id}.md`)
 
   // Defensive: frontmatter id must match the filename.
-  const content = fs.readFileSync(srcFile, 'utf8')
-  const fmId = (content.match(/^id:\s*(.+)$/m) || [])[1]
+  let content = fs.readFileSync(srcFile, 'utf8')
+  let fmId = (content.match(/^id:\s*(.+)$/m) || [])[1]
   if (fmId && fmId.trim() !== id) {
     errors.push({ id, error: `Frontmatter id "${fmId.trim()}" does not match filename — refusing to move.` })
     continue
   }
-
-  // Source row carries the counters + metadata to preserve.
-  const srcRows = readIndexRows(srcDir)
-  const srcRow = srcRows.find(r => r.id === id)
 
   if (dryRun) {
     moved.push({ id, from, to, dry_run: true })
     continue
   }
 
-  const steps = { preflight: true, file_move: false, src_index: false, dst_index: false, src_inverted: false, dst_inverted: false }
+  // Source and destination are one transaction. Acquire both canonical
+  // stores in helper order before the first file move/index replacement,
+  // then re-resolve location, content, and both index snapshots under lock.
+  const lockResult = acquireStoreWriteLocksSync([srcDir, DEST_DIR])
+  if (!lockResult.ok) {
+    errors.push({ id, error: `store-write-lock-timeout (heldBy=${lockResult.heldBy ?? 'unknown'})`, code: lockResult.code, heldBy: lockResult.heldBy })
+    continue
+  }
+
+  let steps = null
   try {
+    const currentInLocal = fs.existsSync(path.join(LOCAL_DIR, 'episodes', `${id}.md`))
+    const currentInGlobal = fs.existsSync(path.join(GLOBAL_DIR, 'episodes', `${id}.md`))
+    resumeCleanup = false
+    if (currentInLocal && currentInGlobal) {
+      const hLocal = sha256(path.join(LOCAL_DIR, 'episodes', `${id}.md`))
+      const hGlobal = sha256(path.join(GLOBAL_DIR, 'episodes', `${id}.md`))
+      if (hLocal !== hGlobal) {
+        errors.push({ id, error: 'Present in BOTH scopes with DIFFERENT content — manual reconciliation required (compare the two files, delete the stale one, run em-rebuild-index --scope all).' })
+        continue
+      }
+      srcDir = to === 'global' ? LOCAL_DIR : GLOBAL_DIR
+      resumeCleanup = true
+    } else if (currentInLocal) srcDir = LOCAL_DIR
+    else if (currentInGlobal) srcDir = GLOBAL_DIR
+    else {
+      errors.push({ id, error: 'Not found in local or global stores after lock acquisition.' })
+      continue
+    }
+
+    if (srcDir === DEST_DIR && !resumeCleanup) {
+      noop.push({ id, scope: to })
+      continue
+    }
+
+    const currentFrom = SRC_SCOPE_OF(srcDir)
+    srcFile = path.join(srcDir, 'episodes', `${id}.md`)
+    const dstFile = path.join(DEST_DIR, 'episodes', `${id}.md`)
+    content = fs.readFileSync(srcFile, 'utf8')
+    fmId = (content.match(/^id:\s*(.+)$/m) || [])[1]
+    if (fmId && fmId.trim() !== id) {
+      errors.push({ id, error: `Frontmatter id "${fmId.trim()}" does not match filename — refusing to move.` })
+      continue
+    }
+
+    const srcRows = readIndexRows(srcDir)
+    const dstRows = readIndexRows(DEST_DIR)
+    const srcRow = srcRows.find(r => r.id === id)
+    steps = { preflight: true, file_move: false, src_index: false, dst_index: false, src_inverted: false, dst_inverted: false }
+
     // 1. file move (atomic same-fs; copy+unlink cross-device — RFC-005 F9)
     fs.mkdirSync(path.join(DEST_DIR, 'episodes'), { recursive: true })
     if (!resumeCleanup) {
@@ -303,9 +341,9 @@ for (const id of ids) {
     steps.src_index = true
 
     // 3. destination index: append the preserved row (dedupe first)
-    const dstRows = readIndexRows(DEST_DIR).filter(r => r.id !== id)
-    if (srcRow) dstRows.push(srcRow)
-    writeIndexRows(DEST_DIR, dstRows)
+    const nextDstRows = dstRows.filter(r => r.id !== id)
+    if (srcRow) nextDstRows.push(srcRow)
+    writeIndexRows(DEST_DIR, nextDstRows)
     steps.dst_index = true
 
     // 4. inverted indexes both sides (tags pretty-printed, category pretty,
@@ -320,38 +358,40 @@ for (const id of ids) {
     if (srcRow?.category) addToInverted(DEST_DIR, 'category-index.json', id, [canonicalCategory(srcRow.category)], true)
     updateTokensIndex(DEST_DIR, id, episodeTokens({ summary: srcRow?.summary || '', tags, body: content }))
     steps.dst_inverted = true
-  } catch (e) {
-    errors.push({ id, error: e.message, steps_succeeded: steps, recovery: 'run em-rebuild-index --scope all after resolving the reported paths' })
-    continue
-  }
-
-  // 5. audit episode — written LAST, to the DESTINATION scope, only on full
-  //    success (RFC-005 F4/F8). em-store is the writer so the audit episode
-  //    is itself a first-class, indexed record.
-  let auditId = null
-  if (!noAudit) {
-    try {
-      const body = [
-        `ts: ${new Date().toISOString()}`,
-        `reason: ${JSON.stringify(reason)}`,
-        `steps_succeeded: ${JSON.stringify(steps)}`,
-      ].join('\n')
-      const r = execFileSync(process.execPath, [
-        path.join(SCRIPT_DIR, 'em-store.mjs'),
-        '--project', srcRow?.project || 'em-move',
-        '--category', 'context',
-        '--tags', ['em-move', 'audit', from, to].join(','),
-        '--summary', `em-move: ${id} moved from ${from} to ${to}`,
-        '--body', body,
-        '--scope', to,
-      ], { encoding: 'utf8', cwd: process.cwd() })
-      try { auditId = JSON.parse(r.trim()).id || null } catch {}
-    } catch {
-      warnings.push(`audit episode write failed for ${id} (move itself completed)`)
+    // 5. audit episode — written LAST, to the DESTINATION scope, only on full
+    //    success (RFC-005 F4/F8). The direct child inherits the destination
+    //    lock, so the move keeps both locks until all destination persistence
+    //    for this operation is complete.
+    let auditId = null
+    if (!noAudit) {
+      try {
+        const body = [
+          `ts: ${new Date().toISOString()}`,
+          `reason: ${JSON.stringify(reason)}`,
+          `steps_succeeded: ${JSON.stringify(steps)}`,
+        ].join('\n')
+        const r = execFileSync(process.execPath, [
+          path.join(SCRIPT_DIR, 'em-store.mjs'),
+          '--project', srcRow?.project || 'em-move',
+          '--category', 'context',
+          '--tags', ['em-move', 'audit', currentFrom, to].join(','),
+          '--summary', `em-move: ${id} moved from ${currentFrom} to ${to}`,
+          '--body', body,
+          '--scope', to,
+        ], { encoding: 'utf8', cwd: process.cwd() })
+        try { auditId = JSON.parse(r.trim()).id || null } catch {}
+      } catch {
+        warnings.push(`audit episode write failed for ${id} (move itself completed)`)
+      }
     }
-  }
 
-  moved.push({ id, from, to, ...(auditId ? { audit_id: auditId } : {}) })
+    moved.push({ id, from: currentFrom, to, ...(auditId ? { audit_id: auditId } : {}) })
+  } catch (e) {
+    errors.push({ id, error: e.message, ...(steps ? { steps_succeeded: steps } : {}), recovery: 'run em-rebuild-index --scope all after resolving the reported paths' })
+    continue
+  } finally {
+    releaseStoreWriteLocks(lockResult.handles)
+  }
 }
 
 const result = {

--- a/scripts/em-pin.mjs
+++ b/scripts/em-pin.mjs
@@ -23,6 +23,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -60,43 +61,64 @@ if (!dataDir) {
   process.exit(1)
 }
 
-// --- frontmatter: insert or remove the `pinned: true` line -----------------
-const content = fs.readFileSync(filePath, 'utf8')
-const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
-if (!fmMatch) {
-  console.log(JSON.stringify({ status: 'error', message: `Episode "${id}" has no parseable frontmatter.` }))
+// Pinning is one transaction over the episode frontmatter and its index row.
+// Locate the immutable path above, then acquire before rereading either
+// mutable representation so a concurrent rebuild/pin cannot lose one side.
+const lockResult = acquireStoreWriteLocksSync(dataDir)
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', message: `Pin write failed: ${lockResult.code}` }))
   process.exit(1)
 }
-const fmLines = fmMatch[1].split('\n').filter(l => !/^pinned:/.test(l))
-if (!unpin) fmLines.push('pinned: true')
-const newContent = content.replace(fmMatch[0], `---\n${fmLines.join('\n')}\n---`)
-const tmpFile = filePath + '.tmp'
-fs.writeFileSync(tmpFile, newContent, 'utf8')
-fs.renameSync(tmpFile, filePath)
 
-// --- index row: set/delete pinned (atomic rewrite, mirrors access tracking) -
-const indexFile = path.join(dataDir, 'index.jsonl')
+let result
+let exitCode = 0
 try {
-  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-  const updated = lines.map(line => {
+  // --- frontmatter: insert or remove the `pinned: true` line -------------
+  const content = fs.readFileSync(filePath, 'utf8')
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!fmMatch) {
+    result = { status: 'error', message: `Episode "${id}" has no parseable frontmatter.` }
+    exitCode = 1
+  } else {
+    const fmLines = fmMatch[1].split('\n').filter(l => !/^pinned:/.test(l))
+    if (!unpin) fmLines.push('pinned: true')
+    const newContent = content.replace(fmMatch[0], `---\n${fmLines.join('\n')}\n---`)
+
+    // Read and prepare the index snapshot before the first durable write.
+    // Missing/corrupt index behavior remains unchanged: frontmatter is the
+    // durable source and a later rebuild can regenerate its row.
+    const indexFile = path.join(dataDir, 'index.jsonl')
+    let indexReplacement = null
     try {
-      const entry = JSON.parse(line)
-      if (entry.id === id) {
-        if (unpin) delete entry.pinned
-        else entry.pinned = true
-      }
-      return JSON.stringify(entry)
-    } catch { return line }
-  })
-  const idxTmp = indexFile + '.tmp'
-  fs.writeFileSync(idxTmp, updated.join('\n') + '\n', 'utf8')
-  fs.renameSync(idxTmp, indexFile)
-} catch {
-  // Index missing/corrupt: frontmatter is the durable source; a rebuild
-  // regenerates the row with the new pinned state.
+      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      const updated = lines.map(line => {
+        try {
+          const entry = JSON.parse(line)
+          if (entry.id === id) {
+            if (unpin) delete entry.pinned
+            else entry.pinned = true
+          }
+          return JSON.stringify(entry)
+        } catch { return line }
+      })
+      indexReplacement = { indexFile, data: updated.join('\n') + '\n' }
+    } catch {
+      // Keep the historical best-effort index behavior.
+    }
+
+    atomicReplaceFileSync(filePath, newContent)
+    if (indexReplacement) atomicReplaceFileSync(indexReplacement.indexFile, indexReplacement.data)
+    result = {
+      status: 'ok', id, pinned: !unpin,
+      scope: dataDir === GLOBAL_DIR ? 'global' : 'local'
+    }
+  }
+} catch (e) {
+  result = { status: 'error', message: `Pin write failed: ${e.message}` }
+  exitCode = 1
+} finally {
+  releaseStoreWriteLocks(lockResult.handles)
 }
 
-console.log(JSON.stringify({
-  status: 'ok', id, pinned: !unpin,
-  scope: dataDir === GLOBAL_DIR ? 'global' : 'local'
-}))
+console.log(JSON.stringify(result))
+if (exitCode) process.exit(exitCode)

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -28,6 +28,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { categoryLifecycle, canonicalCategory } from './lib/categories.mjs'
 import { computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
 import { resolveRegisteredStoresWithStatus } from './lib/registered-stores.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -82,23 +83,19 @@ function loadIndexRows(dataDir, storeLabel) {
 }
 
 
-function loadTagsIndex(dataDir) {
-  const tagsFile = path.join(dataDir, 'tags.json')
+function loadInvertedIndex(dataDir, fileName) {
+  const indexPath = path.join(dataDir, fileName)
   try {
-    return JSON.parse(fs.readFileSync(tagsFile, 'utf8'))
+    return JSON.parse(fs.readFileSync(indexPath, 'utf8'))
   } catch {
     return {}
   }
 }
 
-function pruneDir(dataDir, label, protectedIds) {
+function partitionPrunable(dataDir, protectedIds) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  const episodesDir = path.join(dataDir, 'episodes')
-  const archivedDir = path.join(dataDir, 'archived')
-  const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
-
   if (!fs.existsSync(indexFile)) {
-    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, protected: 0, episodes: [] }
+    return { missing: true, entries: [], toPrune: [], toKeep: [], protectedEntries: [] }
   }
 
   const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
@@ -140,71 +137,102 @@ function pruneDir(dataDir, label, protectedIds) {
     }
   }
 
+  return { missing: false, entries, toPrune, toKeep, protectedEntries }
+}
+
+function pruneDir(dataDir, label, protectedIds) {
+  const indexFile = path.join(dataDir, 'index.jsonl')
+  const episodesDir = path.join(dataDir, 'episodes')
+  const archivedDir = path.join(dataDir, 'archived')
+  const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+  const initial = partitionPrunable(dataDir, protectedIds)
+
+  if (initial.missing) {
+    return { scope: label, pruned: 0, remaining: 0, freed_bytes: 0, protected: 0, episodes: [] }
+  }
+
   if (checkOnly) {
-    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, protected: protectedEntries.length }
+    return { scope: label, prunable: initial.toPrune.length, remaining: initial.toKeep.length, protected: initial.protectedEntries.length }
   }
 
   if (dryRun) {
     let totalSize = 0
-    const preview = toPrune.map(e => {
+    const preview = initial.toPrune.map(e => {
       const filePath = path.join(episodesDir, `${e.id}.md`)
       let size = 0
       try { size = fs.statSync(filePath).size } catch {}
       totalSize += size
       return { id: e.id, score: Math.round(e._pruneScore * 1000) / 1000, size }
     })
-    return { scope: label, prunable: toPrune.length, remaining: toKeep.length, freed_bytes: totalSize, protected: protectedEntries.length, protected_episodes: protectedEntries, episodes: preview }
+    return { scope: label, prunable: initial.toPrune.length, remaining: initial.toKeep.length, freed_bytes: totalSize, protected: initial.protectedEntries.length, protected_episodes: initial.protectedEntries, episodes: preview }
   }
 
-  // Actual prune
-  if (toPrune.length === 0) {
-    return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0, protected: protectedEntries.length }
+  // A true no-op is lock-free. If the unlocked preview found work, acquire
+  // the canonical store lock and repeat the mutable-state read before the
+  // first archive/index write (Issue 546 REQ-8).
+  if (initial.toPrune.length === 0) {
+    return { scope: label, pruned: 0, remaining: initial.toKeep.length, freed_bytes: 0, protected: initial.protectedEntries.length }
   }
 
-  fs.mkdirSync(archivedDir, { recursive: true })
-
-  let freedBytes = 0
-  const archivedEntries = []
-
-  for (const entry of toPrune) {
-    const srcFile = path.join(episodesDir, `${entry.id}.md`)
-    const dstFile = path.join(archivedDir, `${entry.id}.md`)
-    try {
-      const stat = fs.statSync(srcFile)
-      freedBytes += stat.size
-      fs.renameSync(srcFile, dstFile)
-    } catch {}
-    const { _pruneScore, ...clean } = entry
-    archivedEntries.push(JSON.stringify(clean))
+  const lockResult = acquireStoreWriteLocksSync(dataDir)
+  if (!lockResult.ok) {
+    const error = new Error(`em-prune: ${lockResult.code}`)
+    error.code = lockResult.code
+    error.heldBy = lockResult.heldBy
+    throw error
   }
 
-  // Update index.jsonl — keep only non-pruned entries
-  const tmpIndex = indexFile + '.tmp'
-  fs.writeFileSync(tmpIndex, toKeep.map(e => JSON.stringify(e)).join('\n') + (toKeep.length ? '\n' : ''), 'utf8')
-  fs.renameSync(tmpIndex, indexFile)
+  try {
+    const current = partitionPrunable(dataDir, protectedIds)
+    const { toPrune, toKeep, protectedEntries } = current
+    if (current.missing || toPrune.length === 0) {
+      return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0, protected: protectedEntries.length }
+    }
 
-  // Update tags.json — remove pruned episode IDs
-  const prunedIds = new Set(toPrune.map(e => e.id))
-  const tagsIndex = loadTagsIndex(dataDir)
-  for (const tag of Object.keys(tagsIndex)) {
-    tagsIndex[tag] = tagsIndex[tag].filter(id => !prunedIds.has(id))
-    if (tagsIndex[tag].length === 0) delete tagsIndex[tag]
+    fs.mkdirSync(archivedDir, { recursive: true })
+
+    let freedBytes = 0
+    const archivedEntries = []
+
+    for (const entry of toPrune) {
+      const srcFile = path.join(episodesDir, `${entry.id}.md`)
+      const dstFile = path.join(archivedDir, `${entry.id}.md`)
+      try {
+        const stat = fs.statSync(srcFile)
+        freedBytes += stat.size
+        fs.renameSync(srcFile, dstFile)
+      } catch {}
+      const { _pruneScore, ...clean } = entry
+      archivedEntries.push(JSON.stringify(clean))
+    }
+
+    // Update index.jsonl — keep only non-pruned entries.
+    atomicReplaceFileSync(indexFile, toKeep.map(e => JSON.stringify(e)).join('\n') + (toKeep.length ? '\n' : ''))
+
+    // Remove pruned IDs from every present inverted index. Keeping category
+    // and token postings in step with index.jsonl is part of the transaction,
+    // not a later rebuild obligation.
+    const prunedIds = new Set(toPrune.map(e => e.id))
+    for (const [fileName, pretty] of [['tags.json', true], ['category-index.json', true], ['tokens.json', false]]) {
+      const indexPath = path.join(dataDir, fileName)
+      if (!fs.existsSync(indexPath)) continue
+      const inverted = loadInvertedIndex(dataDir, fileName)
+      for (const key of Object.keys(inverted)) {
+        if (!Array.isArray(inverted[key])) continue
+        inverted[key] = inverted[key].filter(id => !prunedIds.has(id))
+        if (inverted[key].length === 0) delete inverted[key]
+      }
+      atomicReplaceFileSync(indexPath, JSON.stringify(inverted, ...(pretty ? [null, 2] : [])))
+    }
+
+    // Read-merge-replace archived-index while still holding the same lock.
+    const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
+    atomicReplaceFileSync(archivedIndexFile, existingArchived + archivedEntries.join('\n') + '\n')
+
+    return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes, protected: protectedEntries.length }
+  } finally {
+    releaseStoreWriteLocks(lockResult.handles)
   }
-  const tagsFile = path.join(dataDir, 'tags.json')
-  const tagsTmp = tagsFile + '.tmp'
-  fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
-  fs.renameSync(tagsTmp, tagsFile)
-
-  // Append to archived-index.jsonl (read-merge-write, preserves previous prune runs)
-  // Note: prune has a read-rewrite race with em-store.mjs (same pattern as search write-back).
-  // A concurrent append between read and rename could lose the appended entry. This is a known
-  // limitation — prune is a maintenance operation, not a hot path.
-  const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
-  const archivedTmp = archivedIndexFile + '.tmp'
-  fs.writeFileSync(archivedTmp, existingArchived + archivedEntries.join('\n') + '\n', 'utf8')
-  fs.renameSync(archivedTmp, archivedIndexFile)
-
-  return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes, protected: protectedEntries.length }
 }
 
 // R6 reference scan: UNION of both stores regardless of prune scope — a global
@@ -246,8 +274,16 @@ if (pbAbort) {
 const protectedIds = computeProtectedIds(referenceRows, TODAY, playbookIds)
 
 const results = []
-if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local', protectedIds))
-if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global', protectedIds))
+try {
+  if (scope === 'local' || scope === 'all') results.push(pruneDir(LOCAL_DIR, 'local', protectedIds))
+  if (scope === 'global' || scope === 'all') results.push(pruneDir(GLOBAL_DIR, 'global', protectedIds))
+} catch (error) {
+  if (error?.code === 'store-write-lock-timeout') {
+    console.log(JSON.stringify({ status: 'error', code: error.code, heldBy: error.heldBy, message: error.message }))
+    process.exit(1)
+  }
+  throw error
+}
 
 const totalPruned = results.reduce((sum, r) => sum + (r.pruned || r.prunable || 0), 0)
 

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -18,6 +18,7 @@ import { loadCategories, validateCategory, canonicalCategory } from './lib/categ
 import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
 import { resolveStoreIdentity } from './lib/store-identity.mjs'
 import { STRUCTURED_FIELDS } from './lib/promotion-sources.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -49,6 +50,13 @@ function normalizeTags(raw) {
     .map(t => t.trim().toLowerCase())
     .filter(Boolean)
   return [...new Set(arr)].sort()
+}
+
+class RebuildFailure extends Error {
+  constructor(payload) {
+    super(payload.error || 'rebuild failed')
+    this.payload = payload
+  }
 }
 
 // --check: drift DETECTION only (R10f). Lists every episode whose stored category is unknown or
@@ -139,13 +147,20 @@ function loadOldIndex(dataDir) {
 }
 
 function rebuildDir(dataDir, label) {
+  // Hold the per-store lock from the episode scan through every derived
+  // replacement. Rebuild is a full snapshot transaction, not four unrelated
+  // renames that can interleave with a writer.
+  const lockResult = acquireStoreWriteLocksSync(dataDir)
+  if (!lockResult.ok) throw new RebuildFailure({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy, scope: label })
+  const lockHandles = lockResult.handles
+  try {
   // Scans episodes/ only — archived/ is intentionally ignored
   const episodesDir = path.join(dataDir, 'episodes')
   const indexFile = path.join(dataDir, 'index.jsonl')
 
   if (!fs.existsSync(episodesDir)) {
     fs.mkdirSync(episodesDir, { recursive: true })
-    fs.writeFileSync(indexFile, '', 'utf8')
+    atomicReplaceFileSync(indexFile, '')
     return { scope: label, count: 0 }
   }
 
@@ -172,8 +187,7 @@ function rebuildDir(dataDir, label) {
     const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
     let fm
     try { fm = parseFrontmatter(content) } catch (e) {
-      console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null, scope: label }))
-      process.exit(1)
+      throw new RebuildFailure({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null, scope: label })
     }
     if (!fm || !fm.id) continue
     const normalizedTags = normalizeTags(Array.isArray(fm.tags) ? fm.tags : [])
@@ -273,18 +287,13 @@ function rebuildDir(dataDir, label) {
   // validate-then-write). 'no-identity' stays normal (mint is lazy, REQ-6).
   const identity = resolveStoreIdentity(dataDir)
   if (identity.error && identity.error !== 'no-identity') {
-    console.log(JSON.stringify({ status: 'error', error: identity.error, scope: label }))
-    process.exit(1)
+    throw new RebuildFailure({ status: 'error', error: identity.error, scope: label })
   }
 
-  const tmpFile = indexFile + '.tmp'
-  fs.writeFileSync(tmpFile, entries.join('\n') + (entries.length ? '\n' : ''), 'utf8')
-  fs.renameSync(tmpFile, indexFile)
+  atomicReplaceFileSync(indexFile, entries.join('\n') + (entries.length ? '\n' : ''))
 
   const tagsFile = path.join(dataDir, 'tags.json')
-  const tagsTmp = tagsFile + '.tmp'
-  fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
-  fs.renameSync(tagsTmp, tagsFile)
+  atomicReplaceFileSync(tagsFile, JSON.stringify(tagsIndex, null, 2))
 
   // tokens.json diet (S2): drop posting lists for tokens whose document
   // frequency exceeds DF_DROP_RATIO (40%) of the corpus. Such tokens do not
@@ -306,24 +315,30 @@ function rebuildDir(dataDir, label) {
   // tokens.json — compact (no pretty-print: the vocabulary is large and this
   // file is machine-read only).
   const tokensFile = path.join(dataDir, 'tokens.json')
-  const tokensTmp = tokensFile + '.tmp'
-  fs.writeFileSync(tokensTmp, JSON.stringify(tokensIndex), 'utf8')
-  fs.renameSync(tokensTmp, tokensFile)
+  atomicReplaceFileSync(tokensFile, JSON.stringify(tokensIndex))
 
   if (vocabLoaded) {
     const catFile = path.join(dataDir, 'category-index.json')
-    const catTmp = catFile + '.tmp'
-    fs.writeFileSync(catTmp, JSON.stringify(categoryIndex, null, 2), 'utf8')
-    fs.renameSync(catTmp, catFile)
+    atomicReplaceFileSync(catFile, JSON.stringify(categoryIndex, null, 2))
   } else {
     process.stderr.write(`em-rebuild-index: categories.json unloadable; ${label} category-index.json skipped (index.jsonl + tags.json built normally)\n`)
   }
 
   return { scope: label, count: entries.length, category_drift: { unknown: driftUnknown, deprecated: driftDeprecated } }
+  } finally {
+    releaseStoreWriteLocks(lockHandles)
+  }
 }
 
 const rebuilt = []
-if (scope === 'local' || scope === 'all') rebuilt.push(rebuildDir(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') rebuilt.push(rebuildDir(GLOBAL_DIR, 'global'))
-
-console.log(JSON.stringify({ status: 'ok', rebuilt }))
+try {
+  if (scope === 'local' || scope === 'all') rebuilt.push(rebuildDir(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') rebuilt.push(rebuildDir(GLOBAL_DIR, 'global'))
+  console.log(JSON.stringify({ status: 'ok', rebuilt }))
+} catch (e) {
+  if (e instanceof RebuildFailure) {
+    console.log(JSON.stringify(e.payload))
+    process.exit(1)
+  }
+  throw e
+}

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -31,6 +31,16 @@ import os from 'os'
 import { execFileSync } from 'child_process'
 import { loadCategories, validateCategory, canonicalCategory } from './lib/categories.mjs'
 import { nullProtoIndex } from './lib/relevance.mjs'
+// Issue 546 (S3b): the legacy fixed-temporary writers in em-restore used a
+// process+timestamp+random suffix that still races against a concurrent
+// collision on rename when two em-restore writers target the same file from
+// different processes. The canonical helper's atomicReplaceFileSync adds
+// cryptographic randomness and the `wx` (O_EXCL) flag so the temp file is
+// created exclusively and never silently loses a writer's rename. The store
+// lock acquisition in run() spans episode persistence through every
+// derived-index merge so two restore targets cannot diverge before both
+// locks are held.
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -377,13 +387,16 @@ function ensureUnder(root, candidate) {
 // Atomic write helpers
 // ---------------------------------------------------------------------------
 function writeAtomic(filePath, content) {
+  // Issue 546 (S3b): route the same-directory atomic replacement through
+  // the canonical helper. The helper generates a unique tmp name with PID
+  // + 8 bytes of cryptographic randomness and uses the `wx` (O_EXCL) flag
+  // so two concurrent em-restore writers on the same final path never
+  // silently lose a rename (the prior `${pid}.${ts}.${rand6}` suffix
+  // collided under fast repeat writes). The mkdirSync stays here because
+  // writeAtomic is also called for first-time episode targets whose
+  // parent dir does not yet exist.
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
-  // F12 (code review): unique tmp suffix per process+timestamp so concurrent
-  // em-restore runs targeting the same file can't overwrite each other's
-  // tmp before rename (last-rename-wins would silently lose A's writes).
-  const tmp = `${filePath}.em-restore.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`
-  fs.writeFileSync(tmp, content)
-  fs.renameSync(tmp, filePath)
+  atomicReplaceFileSync(filePath, content)
 }
 
 function writeJSONAtomic(filePath, obj) {
@@ -1071,129 +1084,153 @@ function run(opts) {
     sidecarRefuseExisting: true
   })
 
-  // Codex round-1 F1: validation-timing checklist (`feedback_validation_
-  // timing_checklist.md`) step 3 — "imagine the validator throws AFTER the
-  // operation is partway done. What state is left on disk?" Pre-PR, an
-  // applyDocWrites mkdir failure (e.g. target has 'dir' as a regular file
-  // blocking 'dir/file.md') threw AFTER applyEpisodeWrites already wrote
-  // episodes, leaving episodes on disk but indexes unwritten — exactly the
-  // partial-state class the checklist closes. Solution: writability preflight
-  // collects every unique parent dir across the plan and pre-creates them.
-  // Any mkdir failure is raised BEFORE any episode write.
-  if (apply) {
+  // Issue 546 (S3b): one try/finally wraps the entire post-acquisition
+  // restore region — preflightTargetDirs, ref-integrity, summary build,
+  // episode/doc writes, and every derived-index merge. The canonical store
+  // locks are acquired BEFORE preflight (mkdir is a disk write) and held
+  // through every write so a concurrent restore target cannot interleave.
+  // Release runs in exactly one finally; inherited handles are no-ops.
+  // The every-target resolution: canonicalize, dedupe, sort per §12 so two
+  // restore runs targeting the same pair of stores acquire the same order.
+  // Dry-run returns BEFORE acquisition so it stays lock-free.
+  let _lockHandles = null
+  try {
+    if (apply) {
+      const targetDirs = []
+      const seenDirs = new Set()
+      for (const targetDir of sourceMap.values()) {
+        const key = targetDir
+        if (!seenDirs.has(key)) { seenDirs.add(key); targetDirs.push(targetDir) }
+      }
+      // Helper owns EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS parsing and
+      // honors zero; no hand-parsed option.
+      const lockRes = acquireStoreWriteLocksSync(targetDirs)
+      if (!lockRes.ok) {
+        out({ status: 'error', code: lockRes.code, heldBy: lockRes.heldBy, message: `em-restore: store lock acquisition timed out (heldBy=${lockRes.heldBy}); no writes performed.` })
+        process.exit(1)
+      }
+      _lockHandles = lockRes.handles
+    }
+
+    // MEMORY.md ref-integrity
+    const refReports = includeDocs ? buildRefIntegrityReport(plan, sourceMap, docs) : []
+
+    // Skipped-files manifest summary
+    const skipManifest = readSkipManifest(backupDir)
+
+    const summary = {
+      matched: { episodes: filteredIds.size, after_chain_expansion: expanded.size, docs: includeDocs ? docs.length : 0 },
+      expansion_added: expansionAdded,
+      by_category: countBy(expanded, e => e.fm.category),
+      by_label: countBy(expanded, e => e.label),
+      conflicts: countBy(plan.episodeWrites, w => w.conflict),
+      actions: countBy(plan.episodeWrites, w => w.action),
+      doc_actions: countBy(plan.docWrites, w => w.action),
+      refused_claude_md: plan.refusedClaudeMd,
+      sidecar_collisions: plan.sidecarConflicts,
+      symlink_rejects: { source: [...epSymlinkRejects, ...docSymlinkRejects], target: plan.symlinkSkips },
+      duplicate_skips: plan.duplicateSkips,
+      category_skips: plan.categorySkips,
+      ref_integrity: refReports,
+      chain_breaks: chainBreaks, // reviewer n1: actually surface dangling supersedes refs
+      skipped_in_backup: skipManifest
+    }
+
+    if (!apply) {
+      return { status: 'ok', mode: 'dry-run', summary, plan: { episodeWrites: plan.episodeWrites.map(redactPlanItem), docWrites: plan.docWrites.map(redactPlanItem) } }
+    }
+
+    // Apply: preflight target dirs (mkdir pre-check), writes, merges.
+    // Codex round-1 F1: validation-timing checklist step 3 — any mkdir failure
+    // raises BEFORE any episode write.
     preflightTargetDirs(plan, sourceMap)
-  }
 
-  // MEMORY.md ref-integrity
-  const refReports = includeDocs ? buildRefIntegrityReport(plan, sourceMap, docs) : []
+    const epResult = applyEpisodeWrites(plan)
+    const docResult = applyDocWrites(plan, sourceMap)
 
-  // Skipped-files manifest summary
-  const skipManifest = readSkipManifest(backupDir)
-
-  const summary = {
-    matched: { episodes: filteredIds.size, after_chain_expansion: expanded.size, docs: includeDocs ? docs.length : 0 },
-    expansion_added: expansionAdded,
-    by_category: countBy(expanded, e => e.fm.category),
-    by_label: countBy(expanded, e => e.label),
-    conflicts: countBy(plan.episodeWrites, w => w.conflict),
-    actions: countBy(plan.episodeWrites, w => w.action),
-    doc_actions: countBy(plan.docWrites, w => w.action),
-    refused_claude_md: plan.refusedClaudeMd,
-    sidecar_collisions: plan.sidecarConflicts,
-    symlink_rejects: { source: [...epSymlinkRejects, ...docSymlinkRejects], target: plan.symlinkSkips },
-    duplicate_skips: plan.duplicateSkips,
-    category_skips: plan.categorySkips,
-    ref_integrity: refReports,
-    chain_breaks: chainBreaks, // reviewer n1: actually surface dangling supersedes refs
-    skipped_in_backup: skipManifest
-  }
-
-  if (!apply) {
-    return { status: 'ok', mode: 'dry-run', summary, plan: { episodeWrites: plan.episodeWrites.map(redactPlanItem), docWrites: plan.docWrites.map(redactPlanItem) } }
-  }
-
-  // Apply
-  const epResult = applyEpisodeWrites(plan)
-  const docResult = applyDocWrites(plan, sourceMap)
-
-  // Index merge per target dir
-  const indexResults = []
-  const warnings = []
-  if (rebuildIndex !== false) {
-    const writtenByTarget = new Map()
-    for (const w of epResult.written) {
-      const targetDir = sourceMap.get(w.label)
-      if (!writtenByTarget.has(targetDir)) writtenByTarget.set(targetDir, [])
-      // Codex round-1 F2: w.fm is the per-(label,id) frontmatter, not byId's
-      // first-encountered version. Each cross-label dup updates ITS target's
-      // index correctly.
-      writtenByTarget.get(targetDir).push(w.fm)
-    }
-    for (const [targetDir, fms] of writtenByTarget) {
-      const restoredEntries = fms.map(fm => ({
-        id: fm.id,
-        date: fm.date,
-        time: fm.time,
-        project: fm.project,
-        category: fm.category,
-        status: fm.status || 'active',
-        supersedes: fm.supersedes || null,
-        tags: Array.isArray(fm.tags) ? fm.tags.map(t => String(t).toLowerCase()) : [],
-        summary: fm.summary,
-        access_count: 0,
-        last_accessed: null
-      }))
-      mergeIndexes(targetDir, restoredEntries, force ? 'force' : conflictMode)
-      // RFC-009 R10d: merge the restored ids into category-index.json under their canonical
-      // category key (temp+rename), mirroring the store/revise incremental maintenance.
-      const catFile = path.join(targetDir, 'category-index.json')
-      // Null-proto: unknown categories index under their literal key (issue #469)
-      let catIndex = Object.create(null)
-      try { catIndex = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8'))) } catch {}
-      for (const fm of fms) {
-        const key = canonicalCategory(fm.category)
-        if (!catIndex[key]) catIndex[key] = []
-        if (!catIndex[key].includes(fm.id)) catIndex[key].push(fm.id)
+    // Index merge per target dir
+    const indexResults = []
+    const warnings = []
+    if (rebuildIndex !== false) {
+      const writtenByTarget = new Map()
+      for (const w of epResult.written) {
+        const targetDir = sourceMap.get(w.label)
+        if (!writtenByTarget.has(targetDir)) writtenByTarget.set(targetDir, [])
+        // Codex round-1 F2: w.fm is the per-(label,id) frontmatter, not byId's
+        // first-encountered version. Each cross-label dup updates ITS target's
+        // index correctly.
+        writtenByTarget.get(targetDir).push(w.fm)
       }
-      const catTmp = catFile + '.tmp'
-      fs.writeFileSync(catTmp, JSON.stringify(catIndex, null, 2), 'utf8')
-      fs.renameSync(catTmp, catFile)
-      indexResults.push({ targetDir, merged: restoredEntries.length })
-    }
-  } else {
-    // #495 review finding (codex + negative-scenario-reviewer, converged):
-    // --no-rebuild-index skips the merge block above, so index.jsonl is never
-    // written (applyDocWrites also skips it — single-writer discipline). Since
-    // backups now EXCLUDE index.jsonl (#495 never carries it), a restore into a
-    // target that ends up with NO index.jsonl leaves a store em-list/em-search
-    // read as EMPTY (count:0) — silently unreadable, with no backup artifact to
-    // recover from. Warn LOUDLY per such target, naming the recovery command.
-    // A target that already carries its own index.jsonl is legitimate (the
-    // operator opted out to preserve it), so it draws no warning. Warn, not
-    // hard-error: --no-rebuild-index is a deliberate opt-out and the
-    // already-indexed path is a valid workflow that a hard error would break.
-    const targetDirs = new Set()
-    for (const w of epResult.written) {
-      const t = sourceMap.get(w.label)
-      if (t) targetDirs.add(t)
-    }
-    for (const targetDir of targetDirs) {
-      if (!fs.existsSync(path.join(targetDir, 'index.jsonl'))) {
-        const msg = `em-restore: --no-rebuild-index left ${targetDir} with NO index.jsonl (backups exclude derived indexes since #495); em-list/em-search will read this store as EMPTY. Recover with: node em-rebuild-index.mjs, or re-run restore WITHOUT --no-rebuild-index.`
-        warnings.push(msg)
-        process.stderr.write(msg + '\n')
+      for (const [targetDir, fms] of writtenByTarget) {
+        const restoredEntries = fms.map(fm => ({
+          id: fm.id,
+          date: fm.date,
+          time: fm.time,
+          project: fm.project,
+          category: fm.category,
+          status: fm.status || 'active',
+          supersedes: fm.supersedes || null,
+          tags: Array.isArray(fm.tags) ? fm.tags.map(t => String(t).toLowerCase()) : [],
+          summary: fm.summary,
+          access_count: 0,
+          last_accessed: null
+        }))
+        mergeIndexes(targetDir, restoredEntries, force ? 'force' : conflictMode)
+        // RFC-009 R10d: merge the restored ids into category-index.json under
+        // their canonical category key. atomicReplaceFileSync gives collision-
+        // safe same-directory tmp+rename so a concurrent reader on a
+        // different process can never observe a torn snapshot.
+        const catFile = path.join(targetDir, 'category-index.json')
+        // Null-proto: unknown categories index under their literal key (issue #469)
+        let catIndex = Object.create(null)
+        try { catIndex = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8'))) } catch {}
+        for (const fm of fms) {
+          const key = canonicalCategory(fm.category)
+          if (!catIndex[key]) catIndex[key] = []
+          if (!catIndex[key].includes(fm.id)) catIndex[key].push(fm.id)
+        }
+        atomicReplaceFileSync(catFile, JSON.stringify(catIndex, null, 2))
+        indexResults.push({ targetDir, merged: restoredEntries.length })
+      }
+    } else {
+      // #495 review finding (codex + negative-scenario-reviewer, converged):
+      // --no-rebuild-index skips the merge block above, so index.jsonl is never
+      // written (applyDocWrites also skips it — single-writer discipline). Since
+      // backups now EXCLUDE index.jsonl (#495 never carries it), a restore into a
+      // target that ends up with NO index.jsonl leaves a store em-list/em-search
+      // read as EMPTY (count:0) — silently unreadable, with no backup artifact to
+      // recover from. Warn LOUDLY per such target, naming the recovery command.
+      // A target that already carries its own index.jsonl is legitimate (the
+      // operator opted out to preserve it), so it draws no warning. Warn, not
+      // hard-error: --no-rebuild-index is a deliberate opt-out and the
+      // already-indexed path is a valid workflow that a hard error would break.
+      const targetDirs = new Set()
+      for (const w of epResult.written) {
+        const t = sourceMap.get(w.label)
+        if (t) targetDirs.add(t)
+      }
+      for (const targetDir of targetDirs) {
+        if (!fs.existsSync(path.join(targetDir, 'index.jsonl'))) {
+          const msg = `em-restore: --no-rebuild-index left ${targetDir} with NO index.jsonl (backups exclude derived indexes since #495); em-list/em-search will read this store as EMPTY. Recover with: node em-rebuild-index.mjs, or re-run restore WITHOUT --no-rebuild-index.`
+          warnings.push(msg)
+          process.stderr.write(msg + '\n')
+        }
       }
     }
-  }
 
-  return {
-    status: 'ok',
-    mode: 'apply',
-    summary,
-    written: { episodes: epResult.written.length, docs: docResult.written.length, sidecars: epResult.sidecarsWritten.length + docResult.sidecarsWritten.length },
-    skipped: { episodes: epResult.skipped.length, docs: docResult.skipped.length },
-    indexes: indexResults,
-    ...(warnings.length ? { warnings } : {})
+    return {
+      status: 'ok',
+      mode: 'apply',
+      summary,
+      written: { episodes: epResult.written.length, docs: docResult.written.length, sidecars: epResult.sidecarsWritten.length + docResult.sidecarsWritten.length },
+      skipped: { episodes: epResult.skipped.length, docs: docResult.skipped.length },
+      indexes: indexResults,
+      ...(warnings.length ? { warnings } : {})
+    }
+  } finally {
+    // Issue 546 (S3b): every-target reverse-order release in ONE finally.
+    // Inherited handles, if any, are no-ops; owned handles unlink their lockfile.
+    if (_lockHandles) releaseStoreWriteLocks(_lockHandles)
   }
 }
 

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -47,7 +47,8 @@ import os from 'os'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
-import { nullProtoIndex } from './lib/relevance.mjs'
+import { nullProtoIndex, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -462,18 +463,7 @@ const frontmatter = fmLines.join('\n')
 const bodyJson = JSON.stringify(payload, null, 2)
 const episodeContent = `${frontmatter}\n\n# ${summary}\n\nReview-request lifecycle event for task **${task}** at HEAD ${headFlag}.\n\n\`\`\`json\n${bodyJson}\n\`\`\`\n`
 
-fs.mkdirSync(episodesDir, { recursive: true })
 const filePath = path.join(episodesDir, `${id}.md`)
-fs.writeFileSync(filePath, episodeContent, 'utf8')
-
-// Index entry: clean serialization. _source / _dataDir are load-time
-// decorations added by loadIndex (review n3 — explicit so future readers
-// don't "fix" the apparent omission).
-const indexEntry = JSON.stringify({
-  id, date: dateStr, time: timeStr, project,
-  category: 'workflow.lifecycle', status: 'active', supersedes: null, tags, summary,
-})
-fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
 
 function updateTagsIndex(dir, episodeId, tagList) {
   const tagsFile = path.join(dir, 'tags.json')
@@ -484,11 +474,61 @@ function updateTagsIndex(dir, episodeId, tagList) {
     if (!idx[t]) idx[t] = []
     if (!idx[t].includes(episodeId)) idx[t].push(episodeId)
   }
-  const tmp = tagsFile + '.tmp'
-  fs.writeFileSync(tmp, JSON.stringify(idx, null, 2), 'utf8')
-  fs.renameSync(tmp, tagsFile)
+  atomicReplaceFileSync(tagsFile, JSON.stringify(idx, null, 2))
 }
-updateTagsIndex(dataDir, id, tags)
+
+function updateCategoryIndex(dir, episodeId, category) {
+  const categoryFile = path.join(dir, 'category-index.json')
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(categoryFile, 'utf8'))) } catch {}
+  if (!idx[category]) idx[category] = []
+  if (!idx[category].includes(episodeId)) idx[category].push(episodeId)
+  atomicReplaceFileSync(categoryFile, JSON.stringify(idx, null, 2))
+}
+
+const lockResult = acquireStoreWriteLocksSync(dataDir)
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', message: `em-review-request: ${lockResult.code}`, errors: [], code: lockResult.code, heldBy: lockResult.heldBy }))
+  process.exit(1)
+}
+
+try {
+  // The generated ID participated in pre-write self-reference validation.
+  // Re-read both collision surfaces under lock rather than silently
+  // overwriting an episode or duplicating its index row.
+  let idInIndex = false
+  if (fs.existsSync(indexFile)) {
+    for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+      if (!line.trim()) continue
+      try {
+        if (JSON.parse(line).id === id) { idInIndex = true; break }
+      } catch {}
+    }
+  }
+  if (idInIndex || fs.existsSync(filePath)) {
+    console.log(JSON.stringify({ status: 'error', message: `Generated episode id collision: ${id}`, errors: [], code: 'episode-id-collision' }))
+    process.exitCode = 1
+  } else {
+    fs.mkdirSync(episodesDir, { recursive: true })
+    atomicReplaceFileSync(filePath, episodeContent)
+
+    // Index entry: clean serialization. _source / _dataDir are load-time
+    // decorations added by loadIndex (review n3 — explicit so future readers
+    // don't "fix" the apparent omission).
+    const indexEntry = JSON.stringify({
+      id, date: dateStr, time: timeStr, project,
+      category: 'workflow.lifecycle', status: 'active', supersedes: null, tags, summary,
+    })
+    fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
+    updateTagsIndex(dataDir, id, tags)
+    updateCategoryIndex(dataDir, id, 'workflow.lifecycle')
+    updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeContent }))
+  }
+} finally {
+  releaseStoreWriteLocks(lockResult.handles)
+}
+
+if (process.exitCode) process.exit(process.exitCode)
 
 console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope: resolvedScope, valid: true }))
 process.exit(0)

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -36,6 +36,7 @@ import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinka
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -257,19 +258,66 @@ let promotionSources
 }
 
 // ---------------------------------------------------------------------------
-// Mark original as superseded
+// Resolve BOTH store directories BEFORE ordered lock acquisition (issue 546 /
+// REQ-5): the original's store (supersession target) and the revision's store
+// (successor target). Cross-scope revisions lock both stores in canonical
+// order; a same-store revision dedupes to a single lock.
 // ---------------------------------------------------------------------------
-let originalContent = fs.readFileSync(original.filePath, 'utf8')
-originalContent = originalContent.replace(/^status: active$/m, 'status: superseded')
-const origTmpFile = original.filePath + '.tmp'
-fs.writeFileSync(origTmpFile, originalContent, 'utf8')
-fs.renameSync(origTmpFile, original.filePath)
+const dataDir = scope === 'inherit'
+  ? original.dir
+  : (scope === 'global' ? GLOBAL_DIR : LOCAL_DIR)
+const episodesDir = path.join(dataDir, 'episodes')
+const indexFile = path.join(dataDir, 'index.jsonl')
 
-// Update the index entry for the original + capture origTags in one pass
-const originalIndexFile = path.join(original.dir, 'index.jsonl')
-let origTagsFromIndex = []
-let origPinned = false
-if (fs.existsSync(originalIndexFile)) {
+const lockResult = acquireStoreWriteLocksSync([original.dir, dataDir])
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy }))
+  process.exit(1)
+}
+const lockHandles = lockResult.handles
+
+// Final payload + revision id. Emitted ONLY after the locks are released:
+// no process.exit while a lock is held, and the collision report runs
+// post-release (revise-side parity with em-store).
+let result
+let newId
+try {
+  // ---------------------------------------------------------------------------
+  // Reread the mutable original state UNDER the lock and verify BOTH the
+  // episode file and its index row are still active BEFORE any write (§8.2
+  // in-lock reread). A stale original fails the transaction with zero writes.
+  // ---------------------------------------------------------------------------
+  const currentOriginalContent = fs.readFileSync(original.filePath, 'utf8')
+  const originalIndexFile = path.join(original.dir, 'index.jsonl')
+  let originalRow = null
+  if (fs.existsSync(originalIndexFile)) {
+    for (const line of fs.readFileSync(originalIndexFile, 'utf8').split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const entry = JSON.parse(line)
+        if (entry && entry.id === originalId) { originalRow = entry; break }
+      } catch { /* tolerate a malformed index line */ }
+    }
+  }
+  const fileActive = /^status: active$/m.test(currentOriginalContent)
+  const rowActive = originalRow !== null && originalRow.status === 'active'
+  if (!fileActive || !rowActive) {
+    result = {
+      status: 'error',
+      code: 'stale-original',
+      message: `Original episode "${originalId}" is not active (file active: ${fileActive}, index row status: ${originalRow ? originalRow.status : 'missing'}); no revision written.`
+    }
+  } else {
+
+  // ---------------------------------------------------------------------------
+  // Mark original as superseded
+  // ---------------------------------------------------------------------------
+  const supersededContent = currentOriginalContent.replace(/^status: active$/m, 'status: superseded')
+  atomicReplaceFileSync(original.filePath, supersededContent)
+
+  // Update the index entry for the original + capture origTags in one pass
+  let origTagsFromIndex = []
+  let origPinned = false
   const lines = fs.readFileSync(originalIndexFile, 'utf8').trim().split('\n').filter(Boolean)
   const updated = lines.map(line => {
     try {
@@ -283,185 +331,183 @@ if (fs.existsSync(originalIndexFile)) {
       return line
     } catch { return line }
   })
-  // Atomic write — best-effort file integrity, not full concurrency protection
-  const idxTmpFile = originalIndexFile + '.tmp'
-  fs.writeFileSync(idxTmpFile, updated.join('\n') + '\n', 'utf8')
-  fs.renameSync(idxTmpFile, originalIndexFile)
-}
+  // Collision-safe atomic replacement (issue 546 / REQ-10)
+  atomicReplaceFileSync(originalIndexFile, updated.join('\n') + '\n')
 
-// ---------------------------------------------------------------------------
-// Extract original's metadata for inheritance
-// ---------------------------------------------------------------------------
-const origFmMatch = originalContent.match(/^---\n([\s\S]*?)\n---/)
-let origProject = project
-let origCategory = 'decision'
-if (origFmMatch) {
-  const fmLines = origFmMatch[1].split('\n')
-  for (const line of fmLines) {
-    const m = line.match(/^(\w+):\s*(.*)$/)
-    if (!m) continue
-    if (m[1] === 'project' && !project) origProject = m[2]
-    if (m[1] === 'category') origCategory = m[2]
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Create the revision episode in the same store as the original
-// ---------------------------------------------------------------------------
-const dataDir = scope === 'inherit'
-  ? original.dir
-  : (scope === 'global' ? GLOBAL_DIR : LOCAL_DIR)
-const episodesDir = path.join(dataDir, 'episodes')
-const indexFile = path.join(dataDir, 'index.jsonl')
-
-const now = new Date()
-const dateStr = now.toISOString().slice(0, 10)
-const timeStr = now.toISOString().slice(11, 16)
-const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
-const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
-const randSuffix = crypto.randomBytes(2).toString('hex')
-const id = `${ts}-${slug}-${randSuffix}`
-
-function normalizeTags(raw, repeats = []) {
-  let fromRaw = []
-  if (Array.isArray(raw)) {
-    fromRaw = raw
-  } else if (raw) {
-    fromRaw = raw.split(',')
-  }
-  const all = [...fromRaw, ...repeats]
-    .map(t => t.trim().toLowerCase())
-    .filter(Boolean)
-  return [...new Set(all)].sort()
-}
-
-function updateTagsIndex(dataDir, episodeId, tags) {
-  const tagsFile = path.join(dataDir, 'tags.json')
-  // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
-  let index = Object.create(null)
-  try {
-    index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
-  } catch {}
-  for (const tag of tags) {
-    if (!index[tag]) index[tag] = []
-    if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
-  }
-  const tmpFile = tagsFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
-  fs.renameSync(tmpFile, tagsFile)
-}
-
-// Mirror em-store's category-index maintenance (RFC-009 R10d); duplicated locally the same
-// way updateTagsIndex is, rather than imported from em-store (which runs top-level on import).
-function updateCategoryIndex(dataDir, episodeId, category) {
-  const catFile = path.join(dataDir, 'category-index.json')
-  // Null-proto: unknown categories index under their literal key, which could
-  // collide with Object.prototype names (issue #469)
-  let index = Object.create(null)
-  try {
-    index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
-  } catch {}
-  const key = canonicalCategory(category)
-  if (!index[key]) index[key] = []
-  if (!index[key].includes(episodeId)) index[key].push(episodeId)
-  const tmpFile = catFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
-  fs.renameSync(tmpFile, catFile)
-}
-
-const tags = normalizeTags(tagsRaw, tagRepeats)
-const resolvedProject = origProject || path.basename(process.cwd())
-
-// Inherit original episode's tags (captured during first index pass above)
-const mergedTags = normalizeTags([...origTagsFromIndex, ...tags])
-
-// Pinning survives revision: a corrected pinned decision is still a pinned
-// decision. --pin additionally pins an unpinned chain at revision time.
-const pinned = origPinned || argv.includes('--pin')
-
-// RFC-009 R1 activation frontmatter — present-only, arrays UNQUOTED inline
-// (REQ-2/I4); mirrors em-store's serialization (revise-side parity).
-const activationFmLines = []
-if (activation) {
-  for (const field of ACTIVATION_ARRAY_FIELDS) {
-    if (Array.isArray(activation[field]) && activation[field].length) {
-      activationFmLines.push(`${field}: [${serializeInlineArray(activation[field])}]`)
+  // ---------------------------------------------------------------------------
+  // Extract original's metadata for inheritance
+  // ---------------------------------------------------------------------------
+  const origFmMatch = currentOriginalContent.match(/^---\n([\s\S]*?)\n---/)
+  let origProject = project
+  let origCategory = 'decision'
+  if (origFmMatch) {
+    const fmLines = origFmMatch[1].split('\n')
+    for (const line of fmLines) {
+      const m = line.match(/^(\w+):\s*(.*)$/)
+      if (!m) continue
+      if (m[1] === 'project' && !project) origProject = m[2]
+      if (m[1] === 'category') origCategory = m[2]
     }
   }
-  activationFmLines.push(`priority: ${activation.priority}`)
-  if (activation.review_by !== undefined) activationFmLines.push(`review_by: ${activation.review_by}`)
+
+  // ---------------------------------------------------------------------------
+  // Create the revision episode in the revision's store
+  // ---------------------------------------------------------------------------
+  const now = new Date()
+  const dateStr = now.toISOString().slice(0, 10)
+  const timeStr = now.toISOString().slice(11, 16)
+  const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
+  const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
+  const randSuffix = crypto.randomBytes(2).toString('hex')
+  const id = `${ts}-${slug}-${randSuffix}`
+
+  function normalizeTags(raw, repeats = []) {
+    let fromRaw = []
+    if (Array.isArray(raw)) {
+      fromRaw = raw
+    } else if (raw) {
+      fromRaw = raw.split(',')
+    }
+    const all = [...fromRaw, ...repeats]
+      .map(t => t.trim().toLowerCase())
+      .filter(Boolean)
+    return [...new Set(all)].sort()
+  }
+
+  function updateTagsIndex(dataDir, episodeId, tags) {
+    const tagsFile = path.join(dataDir, 'tags.json')
+    // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+    let index = Object.create(null)
+    try {
+      index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
+    } catch {}
+    for (const tag of tags) {
+      if (!index[tag]) index[tag] = []
+      if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
+    }
+    atomicReplaceFileSync(tagsFile, JSON.stringify(index, null, 2))
+  }
+
+  // Mirror em-store's category-index maintenance (RFC-009 R10d); duplicated locally the same
+  // way updateTagsIndex is, rather than imported from em-store (which runs top-level on import).
+  function updateCategoryIndex(dataDir, episodeId, category) {
+    const catFile = path.join(dataDir, 'category-index.json')
+    // Null-proto: unknown categories index under their literal key, which could
+    // collide with Object.prototype names (issue #469)
+    let index = Object.create(null)
+    try {
+      index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
+    } catch {}
+    const key = canonicalCategory(category)
+    if (!index[key]) index[key] = []
+    if (!index[key].includes(episodeId)) index[key].push(episodeId)
+    atomicReplaceFileSync(catFile, JSON.stringify(index, null, 2))
+  }
+
+  const tags = normalizeTags(tagsRaw, tagRepeats)
+  const resolvedProject = origProject || path.basename(process.cwd())
+
+  // Inherit original episode's tags (captured during first index pass above)
+  const mergedTags = normalizeTags([...origTagsFromIndex, ...tags])
+
+  // Pinning survives revision: a corrected pinned decision is still a pinned
+  // decision. --pin additionally pins an unpinned chain at revision time.
+  const pinned = origPinned || argv.includes('--pin')
+
+  // RFC-009 R1 activation frontmatter — present-only, arrays UNQUOTED inline
+  // (REQ-2/I4); mirrors em-store's serialization (revise-side parity).
+  const activationFmLines = []
+  if (activation) {
+    for (const field of ACTIVATION_ARRAY_FIELDS) {
+      if (Array.isArray(activation[field]) && activation[field].length) {
+        activationFmLines.push(`${field}: [${serializeInlineArray(activation[field])}]`)
+      }
+    }
+    activationFmLines.push(`priority: ${activation.priority}`)
+    if (activation.review_by !== undefined) activationFmLines.push(`review_by: ${activation.review_by}`)
+  }
+  // F3: violation-side fields inherit verbatim (no revise-side flags exist for them)
+  if (inheritedLessons.length) activationFmLines.push(`lessons: [${serializeInlineArray(inheritedLessons)}]`)
+  if (inheritedViolatedPattern !== undefined) activationFmLines.push(`violated_pattern: ${inheritedViolatedPattern}`)
+  if (promotionSources) activationFmLines.push(`promotion_sources: ${serializePromotionSources(promotionSources)}`)
+
+  const frontmatter = [
+    '---',
+    `id: ${id}`,
+    `date: ${dateStr}`,
+    `time: "${timeStr}"`,
+    `project: ${resolvedProject}`,
+    `category: ${origCategory}`,
+    `status: active`,
+    `supersedes: ${originalId}`,
+    `tags: [${mergedTags.join(', ')}]`,
+    `summary: ${summary}`,
+    ...activationFmLines,
+    ...(pinned ? ['pinned: true'] : []),
+    '---',
+  ].join('\n')
+
+  const episodeContent = `${frontmatter}\n\n# ${summary}\n\nRevises: \`${originalId}\`\n\n${body}\n`
+
+  fs.mkdirSync(episodesDir, { recursive: true })
+
+  const filePath = path.join(episodesDir, `${id}.md`)
+  atomicReplaceFileSync(filePath, episodeContent)
+
+  // Keep in LOCKSTEP with em-rebuild-index.mjs's emit (REQ-9 parity note).
+  const activationIndexFields = {
+    ...(activation ? Object.fromEntries(
+      ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
+        .map(f => [f, activation[f]])
+    ) : {}),
+    ...(inheritedLessons.length ? { lessons: inheritedLessons } : {}),
+    ...(activation ? { priority: activation.priority } : {}),
+    ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
+    ...(inheritedViolatedPattern !== undefined ? { violated_pattern: inheritedViolatedPattern } : {}),
+    ...(promotionSources ? { promotion_sources: promotionSources } : {}),
+  }
+  const indexEntry = JSON.stringify({
+    id, date: dateStr, time: timeStr, project: resolvedProject,
+    category: origCategory, status: 'active', supersedes: originalId,
+    tags: mergedTags, summary,
+    ...activationIndexFields,
+    ...(pinned ? { pinned: true } : {})
+  })
+  fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
+
+  // Update tags.json
+  updateTagsIndex(dataDir, id, mergedTags)
+  updateCategoryIndex(dataDir, id, origCategory)
+  // Token source is the FULL FILE content (frontmatter + body): the search
+  // body tier greps the whole file, so pruning must see the same text.
+  updateTokensIndex(dataDir, id, episodeTokens({ summary, tags: mergedTags, body: episodeContent }))
+  // If revision crosses scopes, also update original scope's tags.json + category-index.json
+  if (original.dir !== dataDir) {
+    updateTagsIndex(original.dir, id, mergedTags)
+    updateCategoryIndex(original.dir, id, origCategory)
+    updateTokensIndex(original.dir, id, episodeTokens({ summary, tags: mergedTags, body: episodeContent }))
+  }
+
+  newId = id
+  result = {
+    status: 'ok', id, file: filePath,
+    supersedes: originalId, scope: dataDir === GLOBAL_DIR ? 'global' : 'local'
+  }
+  }
+} finally {
+  releaseStoreWriteLocks(lockHandles)
 }
-// F3: violation-side fields inherit verbatim (no revise-side flags exist for them)
-if (inheritedLessons.length) activationFmLines.push(`lessons: [${serializeInlineArray(inheritedLessons)}]`)
-if (inheritedViolatedPattern !== undefined) activationFmLines.push(`violated_pattern: ${inheritedViolatedPattern}`)
-if (promotionSources) activationFmLines.push(`promotion_sources: ${serializePromotionSources(promotionSources)}`)
 
-const frontmatter = [
-  '---',
-  `id: ${id}`,
-  `date: ${dateStr}`,
-  `time: "${timeStr}"`,
-  `project: ${resolvedProject}`,
-  `category: ${origCategory}`,
-  `status: active`,
-  `supersedes: ${originalId}`,
-  `tags: [${mergedTags.join(', ')}]`,
-  `summary: ${summary}`,
-  ...activationFmLines,
-  ...(pinned ? ['pinned: true'] : []),
-  '---',
-].join('\n')
-
-const episodeContent = `${frontmatter}\n\n# ${summary}\n\nRevises: \`${originalId}\`\n\n${body}\n`
-
-fs.mkdirSync(episodesDir, { recursive: true })
-
-const filePath = path.join(episodesDir, `${id}.md`)
-fs.writeFileSync(filePath, episodeContent, 'utf8')
-
-// Keep in LOCKSTEP with em-rebuild-index.mjs's emit (REQ-9 parity note).
-const activationIndexFields = {
-  ...(activation ? Object.fromEntries(
-    ACTIVATION_ARRAY_FIELDS.filter(f => Array.isArray(activation[f]) && activation[f].length)
-      .map(f => [f, activation[f]])
-  ) : {}),
-  ...(inheritedLessons.length ? { lessons: inheritedLessons } : {}),
-  ...(activation ? { priority: activation.priority } : {}),
-  ...(activation && activation.review_by !== undefined ? { review_by: activation.review_by } : {}),
-  ...(inheritedViolatedPattern !== undefined ? { violated_pattern: inheritedViolatedPattern } : {}),
-  ...(promotionSources ? { promotion_sources: promotionSources } : {}),
-}
-const indexEntry = JSON.stringify({
-  id, date: dateStr, time: timeStr, project: resolvedProject,
-  category: origCategory, status: 'active', supersedes: originalId,
-  tags: mergedTags, summary,
-  ...activationIndexFields,
-  ...(pinned ? { pinned: true } : {})
-})
-fs.appendFileSync(indexFile, indexEntry + '\n', 'utf8')
-
-// Update tags.json
-updateTagsIndex(dataDir, id, mergedTags)
-updateCategoryIndex(dataDir, id, origCategory)
-// Token source is the FULL FILE content (frontmatter + body): the search
-// body tier greps the whole file, so pruning must see the same text.
-updateTokensIndex(dataDir, id, episodeTokens({ summary, tags: mergedTags, body: episodeContent }))
-// If revision crosses scopes, also update original scope's tags.json + category-index.json
-if (original.dir !== dataDir) {
-  updateTagsIndex(original.dir, id, mergedTags)
-  updateCategoryIndex(original.dir, id, origCategory)
-  updateTokensIndex(original.dir, id, episodeTokens({ summary, tags: mergedTags, body: episodeContent }))
-}
-
-// R9a write-time collision report (REQ-18) — mirrors em-store's post-write
-// block (revise-side parity): stderr-only, self-excluded, never fatal.
-if (activation && Array.isArray(activation.triggers) && activation.triggers.length) {
+// R9a write-time collision report (REQ-18) — mirrors em-store's post-release
+// block (revise-side parity): stderr-only, self-excluded, never fatal, and
+// only AFTER the store-write locks are released (issue 546).
+if (result.status === 'ok' && activation && Array.isArray(activation.triggers) && activation.triggers.length) {
   try {
     const merged = loadMergedTriggerIndex()
     const mine = new Set(activation.triggers)
     const reported = new Set()
     for (const e of merged.entries) {
-      if (e.episode_id === id) continue // self-exclusion (CX5)
+      if (e.episode_id === newId) continue // self-exclusion (CX5)
       if (!mine.has(e.value)) continue
       const key = `${e.episode_id} ${e.value}`
       if (reported.has(key)) continue
@@ -471,7 +517,5 @@ if (activation && Array.isArray(activation.triggers) && activation.triggers.leng
   } catch {}
 }
 
-console.log(JSON.stringify({
-  status: 'ok', id, file: filePath,
-  supersedes: originalId, scope: dataDir === GLOBAL_DIR ? 'global' : 'local'
-}))
+console.log(JSON.stringify(result))
+if (result.status === 'error') process.exit(1)

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -269,6 +269,59 @@ const dataDir = scope === 'inherit'
 const episodesDir = path.join(dataDir, 'episodes')
 const indexFile = path.join(dataDir, 'index.jsonl')
 
+// ---------------------------------------------------------------------------
+// PR-562 snapshot helper (§8.2 in-lock reread, file/index coherence, and the
+// direct-successor set): captures (fileStatus, indexStatus, successors) so
+// the in-lock state can be compared to the pre-lock snapshot. A change in
+// any field between the two reads indicates a concurrent writer mutated the
+// original between snapshot and lock acquisition, which fails the
+// transaction. This lets a stable superseded original be revised (the
+// accepted clerk merge-Revive path) while still serializing an actually
+// concurrent revision. The helper tolerates missing files and missing index
+// rows (status=null in both cases) so the snapshot shape is stable.
+// ---------------------------------------------------------------------------
+function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
+  let fileStatus = null
+  try {
+    const content = fs.readFileSync(filePath, 'utf8')
+    const m = content.match(/^status:\s*(\S+)$/m)
+    if (m) fileStatus = m[1]
+  } catch { /* missing file → null status */ }
+  let indexStatus = null
+  const statusIndexPath = path.join(statusDir, 'index.jsonl')
+  if (fs.existsSync(statusIndexPath)) {
+    for (const line of fs.readFileSync(statusIndexPath, 'utf8').split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const entry = JSON.parse(line)
+        if (entry && entry.id === id) indexStatus = entry.status || null
+      } catch { /* tolerate a malformed index line */ }
+    }
+  }
+  const successors = []
+  for (const storeDir of successorDirs) {
+    const indexFilePath = path.join(storeDir, 'index.jsonl')
+    if (!fs.existsSync(indexFilePath)) continue
+    for (const line of fs.readFileSync(indexFilePath, 'utf8').split('\n')) {
+      if (!line.trim()) continue
+      try {
+        const entry = JSON.parse(line)
+        if (entry && entry.id !== id && entry.supersedes === id) successors.push(entry.id)
+      } catch { /* tolerate a malformed index line */ }
+    }
+  }
+  successors.sort()
+  return { fileStatus, indexStatus, successors: [...new Set(successors)] }
+}
+
+// Pre-lock snapshot (before acquireStoreWriteLocksSync). findEpisode already
+// confirmed the file exists; the snapshot captures the mutable triple so
+// the in-lock check below can prove no concurrent writer raced ahead. The
+// direct-successor set is unioned across both locked stores
+// ([original.dir, dataDir]) so a cross-scope revision detects a successor
+// appended in either the original's store or the successor's store.
+const preLock = snapshotOriginalState(original.filePath, original.dir, [original.dir, dataDir], originalId)
+
 const lockResult = acquireStoreWriteLocksSync([original.dir, dataDir])
 if (!lockResult.ok) {
   console.log(JSON.stringify({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy }))
@@ -283,35 +336,48 @@ let result
 let newId
 try {
   // ---------------------------------------------------------------------------
-  // Reread the mutable original state UNDER the lock and verify BOTH the
-  // episode file and its index row are still active BEFORE any write (§8.2
-  // in-lock reread). A stale original fails the transaction with zero writes.
+  // In-lock reread (§8.2): re-snapshot under the lock and compare to the
+  // pre-lock snapshot. A difference in any field means a concurrent writer
+  // mutated the original between snapshot and lock acquisition, which fails
+  // the transaction with stale-original and zero writes.
+  //
+  // Coherence guards (§8.2 in-lock reread + reviewer F1): the original's
+  // file status and index-row status must agree AND the index row must
+  // exist. A missing index row is a known-bad anchor (no provenance for the
+  // supersession) and is rejected even when the snapshot is stable. A
+  // stable superseded original (file: superseded, index: superseded) passes
+  // both guards and is revivable — the accepted clerk merge-Revive path.
   // ---------------------------------------------------------------------------
-  const currentOriginalContent = fs.readFileSync(original.filePath, 'utf8')
   const originalIndexFile = path.join(original.dir, 'index.jsonl')
-  let originalRow = null
-  if (fs.existsSync(originalIndexFile)) {
-    for (const line of fs.readFileSync(originalIndexFile, 'utf8').split('\n')) {
-      if (!line.trim()) continue
-      try {
-        const entry = JSON.parse(line)
-        if (entry && entry.id === originalId) { originalRow = entry; break }
-      } catch { /* tolerate a malformed index line */ }
-    }
-  }
-  const fileActive = /^status: active$/m.test(currentOriginalContent)
-  const rowActive = originalRow !== null && originalRow.status === 'active'
-  if (!fileActive || !rowActive) {
+  const inLock = snapshotOriginalState(original.filePath, original.dir, [original.dir, dataDir], originalId)
+
+  const snapshotStable =
+    preLock.fileStatus === inLock.fileStatus &&
+    preLock.indexStatus === inLock.indexStatus &&
+    preLock.successors.length === inLock.successors.length &&
+    preLock.successors.every((id, i) => id === inLock.successors[i])
+  const indexRowPresent = inLock.indexStatus !== null
+  const fileAndIndexAgree =
+    inLock.fileStatus !== null &&
+    inLock.indexStatus !== null &&
+    inLock.fileStatus === inLock.indexStatus
+
+  if (!snapshotStable || !indexRowPresent || !fileAndIndexAgree) {
+    const reasons = []
+    if (!snapshotStable) reasons.push(`snapshot drift (pre file=${preLock.fileStatus}/idx=${preLock.indexStatus}/succ=${preLock.successors.join(',')} -> in-lock file=${inLock.fileStatus}/idx=${inLock.indexStatus}/succ=${inLock.successors.join(',')})`)
+    if (!indexRowPresent) reasons.push('index row status: missing')
+    if (!fileAndIndexAgree) reasons.push(`file/index incoherent (file=${inLock.fileStatus}, index=${inLock.indexStatus})`)
     result = {
       status: 'error',
       code: 'stale-original',
-      message: `Original episode "${originalId}" is not active (file active: ${fileActive}, index row status: ${originalRow ? originalRow.status : 'missing'}); no revision written.`
+      message: `Original episode "${originalId}" is stale (${reasons.join('; ')}); no revision written.`
     }
   } else {
 
   // ---------------------------------------------------------------------------
   // Mark original as superseded
   // ---------------------------------------------------------------------------
+  const currentOriginalContent = fs.readFileSync(original.filePath, 'utf8')
   const supersededContent = currentOriginalContent.replace(/^status: active$/m, 'status: superseded')
   atomicReplaceFileSync(original.filePath, supersededContent)
 

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -16,7 +16,8 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import crypto from 'crypto'
-import { nullProtoIndex } from './lib/relevance.mjs'
+import { nullProtoIndex, episodeTokens, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 
@@ -114,9 +115,7 @@ function flushTagsIndex() {
       if (!idx[tag].includes(episodeId)) idx[tag].push(episodeId)
     }
   }
-  const tmpFile = tagsFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(idx, null, 2), 'utf8')
-  fs.renameSync(tmpFile, tagsFile)
+  atomicReplaceFileSync(tagsFile, JSON.stringify(idx, null, 2))
 }
 
 // Mirror of the tags flush for category-index.json (R10d). Without this a
@@ -137,9 +136,29 @@ function flushCategoryIndex() {
     if (!idx[category]) idx[category] = []
     if (!idx[category].includes(episodeId)) idx[category].push(episodeId)
   }
-  const tmpFile = catFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(idx, null, 2), 'utf8')
-  fs.renameSync(tmpFile, catFile)
+  atomicReplaceFileSync(catFile, JSON.stringify(idx, null, 2))
+}
+
+const pendingTokenUpdates = []
+
+function queueTokenUpdate(episodeId, tokens) {
+  pendingTokenUpdates.push({ episodeId, tokens })
+}
+
+function flushTokensIndex() {
+  if (pendingTokenUpdates.length === 0) return
+  const tokensFile = path.join(GLOBAL_DIR, 'tokens.json')
+  let idx = Object.create(null)
+  try { idx = nullProtoIndex(JSON.parse(fs.readFileSync(tokensFile, 'utf8'))) } catch {}
+  const dropped = new Set(Array.isArray(idx[TOKENS_DROPPED_KEY]) ? idx[TOKENS_DROPPED_KEY] : [])
+  for (const { episodeId, tokens } of pendingTokenUpdates) {
+    for (const token of tokens) {
+      if (dropped.has(token)) continue
+      if (!idx[token]) idx[token] = []
+      if (!idx[token].includes(episodeId)) idx[token].push(episodeId)
+    }
+  }
+  atomicReplaceFileSync(tokensFile, JSON.stringify(idx))
 }
 
 // ---------------------------------------------------------------------------
@@ -147,11 +166,13 @@ function flushCategoryIndex() {
 // ---------------------------------------------------------------------------
 const episodesDir = path.join(GLOBAL_DIR, 'episodes')
 const globalIndexFile = path.join(GLOBAL_DIR, 'index.jsonl')
-fs.mkdirSync(episodesDir, { recursive: true })
-
 let seeded = 0
 let skipped = 0
+const prepared = []
 
+// Pattern source validation is lock-free. Only entries that could write are
+// carried into the transaction; help, invalid source, dry-run, and a fully
+// seeded no-op never wait on the store lock.
 for (const entry of index.patterns || []) {
   const { pattern_id, file } = entry
 
@@ -184,56 +205,114 @@ for (const entry of index.patterns || []) {
   const project = 'global'
   const category = fm.category || 'decision'
 
+  prepared.push({ pattern_id, body, tags, summary, project, category })
+
   if (dryRun) {
     seeded++
-    continue
   }
-
-  // Generate episode
-  const now = new Date()
-  const dateStr = now.toISOString().slice(0, 10)
-  const timeStr = now.toISOString().slice(11, 16)
-  const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
-  const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
-  const randSuffix = crypto.randomBytes(2).toString('hex')
-  const id = `${ts}-${slug}-${randSuffix}`
-
-  const episodeFm = [
-    '---',
-    `id: ${id}`,
-    `date: ${dateStr}`,
-    `time: "${timeStr}"`,
-    `project: ${project}`,
-    `category: ${category}`,
-    `status: active`,
-    `tags: [${tags.join(', ')}]`,
-    `summary: ${summary}`,
-    '---',
-  ].join('\n')
-
-  const episodeContent = `${episodeFm}\n\n${body}\n`
-
-  // Write episode file
-  const episodeFilePath = path.join(episodesDir, `${id}.md`)
-  fs.writeFileSync(episodeFilePath, episodeContent, 'utf8')
-
-  // Append to index.jsonl
-  const indexEntry = JSON.stringify({
-    id, date: dateStr, time: timeStr, project, category,
-    status: 'active', supersedes: null, tags, summary
-  })
-  fs.appendFileSync(globalIndexFile, indexEntry + '\n', 'utf8')
-
-  // Queue tags.json + category-index.json updates
-  queueTagsUpdate(id, tags)
-  queueCategoryUpdate(id, category)
-
-  seeded++
 }
 
-// Flush all tag + category updates, one atomic write each
-flushTagsIndex()
-flushCategoryIndex()
+if (dryRun || prepared.length === 0) {
+  const total = (index.patterns || []).length
+  console.log(JSON.stringify({
+    status: 'ok',
+    seeded,
+    skipped,
+    total,
+    ...(dryRun ? { dry_run: true } : {})
+  }))
+  process.exit(0)
+}
+
+const lockResult = acquireStoreWriteLocksSync(GLOBAL_DIR)
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy, message: `em-seed-patterns: ${lockResult.code}` }))
+  process.exit(1)
+}
+
+try {
+  // Collision state is mutable: re-read tags and existing episode IDs only
+  // after the canonical global lock is held.
+  try {
+    tagsIndex = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
+  } catch {
+    tagsIndex = Object.create(null)
+  }
+  const existingIndex = fs.existsSync(globalIndexFile) ? fs.readFileSync(globalIndexFile, 'utf8') : ''
+  const existingIds = new Set(existingIndex.split('\n').filter(Boolean).map(line => {
+    try { return JSON.parse(line).id } catch { return null }
+  }).filter(Boolean))
+  const pendingIndexEntries = []
+  fs.mkdirSync(episodesDir, { recursive: true })
+
+  for (const candidate of prepared) {
+    const { pattern_id, body, tags, summary, project, category } = candidate
+
+    if (tagsIndex[pattern_id] && tagsIndex[pattern_id].length > 0) {
+      skipped++
+      continue
+    }
+
+    // Generate episode
+    const now = new Date()
+    const dateStr = now.toISOString().slice(0, 10)
+    const timeStr = now.toISOString().slice(11, 16)
+    const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
+    const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
+    let id
+    do {
+      const randSuffix = crypto.randomBytes(2).toString('hex')
+      id = `${ts}-${slug}-${randSuffix}`
+    } while (existingIds.has(id) || fs.existsSync(path.join(episodesDir, `${id}.md`)))
+    existingIds.add(id)
+
+    const episodeFm = [
+      '---',
+      `id: ${id}`,
+      `date: ${dateStr}`,
+      `time: "${timeStr}"`,
+      `project: ${project}`,
+      `category: ${category}`,
+      `status: active`,
+      `tags: [${tags.join(', ')}]`,
+      `summary: ${summary}`,
+      '---',
+    ].join('\n')
+
+    const episodeContent = `${episodeFm}\n\n${body}\n`
+
+    // Write episode file
+    const episodeFilePath = path.join(episodesDir, `${id}.md`)
+    atomicReplaceFileSync(episodeFilePath, episodeContent)
+
+    // Queue one batch index replacement.
+    pendingIndexEntries.push(JSON.stringify({
+      id, date: dateStr, time: timeStr, project, category,
+      status: 'active', supersedes: null, tags, summary
+    }))
+
+    // Queue tags/category/token updates for one replacement per derived index.
+    queueTagsUpdate(id, tags)
+    queueCategoryUpdate(id, category)
+    queueTokenUpdate(id, episodeTokens({ summary, tags, body: episodeContent }))
+
+    for (const tag of tags) {
+      if (!tagsIndex[tag]) tagsIndex[tag] = []
+      if (!tagsIndex[tag].includes(id)) tagsIndex[tag].push(id)
+    }
+
+    seeded++
+  }
+
+  if (pendingIndexEntries.length > 0) {
+    atomicReplaceFileSync(globalIndexFile, existingIndex + pendingIndexEntries.join('\n') + '\n')
+    flushTagsIndex()
+    flushCategoryIndex()
+    flushTokensIndex()
+  }
+} finally {
+  releaseStoreWriteLocks(lockResult.handles)
+}
 
 const total = (index.patterns || []).length
 console.log(JSON.stringify({

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -36,6 +36,7 @@ import { validateActivation, serializeInlineArray, loadMergedIndex, resolveLinka
 import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -263,16 +264,41 @@ const dataDir = scope === 'global' ? GLOBAL_DIR : LOCAL_DIR
 const episodesDir = path.join(dataDir, 'episodes')
 const indexFile = path.join(dataDir, 'index.jsonl')
 
-// ---------------------------------------------------------------------------
-// Generate episode
-// ---------------------------------------------------------------------------
+// Issue 546 / REQ-4: hold the canonical store-write lock across episode
+// persistence and every derived-index update. Validation above stays before
+// the first durable write; the collision report and final JSON emit only
+// after the lock is released.
+const lockResult = acquireStoreWriteLocksSync(dataDir)
+if (!lockResult.ok) {
+  console.log(JSON.stringify({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy }))
+  process.exit(1)
+}
+const lockHandles = lockResult.handles
+let successPayload
+let storedId
+try {
+// Issue 546 (S3c ID-collision retry): under the lock, re-read the index
+// ids and generate an ID absent from both the index and episode path.
+// Timestamp + slug stay fixed; only the 2-byte suffix is regenerated.
 const now = new Date()
 const dateStr = now.toISOString().slice(0, 10)
 const timeStr = now.toISOString().slice(11, 16)
 const ts = now.toISOString().slice(0, 19).replace(/[-:T]/g, '').replace(/(\d{8})(\d{6})/, '$1-$2')
 const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40)
-const randSuffix = crypto.randomBytes(2).toString('hex')
-const id = `${ts}-${slug}-${randSuffix}`
+const indexIdSet = (() => {
+  const set = new Set()
+  try {
+    for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+      if (!line.trim()) continue
+      try { const e = JSON.parse(line); if (e && typeof e.id === 'string') set.add(e.id) } catch {}
+    }
+  } catch {}
+  return set
+})()
+let id
+do {
+  id = `${ts}-${slug}-${crypto.randomBytes(2).toString('hex')}`
+} while (indexIdSet.has(id) || fs.existsSync(path.join(episodesDir, `${id}.md`)))
 
 function normalizeTags(raw, repeats = []) {
   const fromComma = raw ? raw.split(',') : []
@@ -293,9 +319,7 @@ function updateTagsIndex(dataDir, episodeId, tags) {
     if (!index[tag]) index[tag] = []
     if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
   }
-  const tmpFile = tagsFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
-  fs.renameSync(tmpFile, tagsFile)
+  atomicReplaceFileSync(tagsFile, JSON.stringify(index, null, 2))
 }
 
 const tags = normalizeTags(tagsRaw, tagRepeats)
@@ -344,7 +368,7 @@ const episodeContent = `${frontmatter}\n\n# ${summary}\n\n${body}\n`
 fs.mkdirSync(episodesDir, { recursive: true })
 
 const filePath = path.join(episodesDir, `${id}.md`)
-fs.writeFileSync(filePath, episodeContent, 'utf8')
+atomicReplaceFileSync(filePath, episodeContent)
 
 // Activation/T6 index fields — keep this list in LOCKSTEP with
 // em-rebuild-index.mjs's emit object (present-only, same key names) so a
@@ -375,17 +399,24 @@ updateCategoryIndex(dataDir, id, category)
 // body tier greps the whole file, so pruning must see the same text.
 updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeContent }))
 
+  storedId = id
+  successPayload = { status: 'ok', id, file: filePath, scope }
+} finally {
+  releaseStoreWriteLocks(lockHandles)
+}
+
 // R9a write-time collision report (REQ-18) — INFORMATIONAL, stderr-only, runs
-// AFTER the write so the lazy R2 rebuild it triggers already contains this
-// episode (self-excluded, CX5). Best-effort: any failure means NO report,
-// never a blocked write; stdout JSON below is untouched.
+// AFTER the write AND after the store-write lock is released (issue 546) so
+// the lazy R2 rebuild it triggers already contains this episode
+// (self-excluded, CX5). Best-effort: any failure means NO report, never a
+// blocked write; stdout JSON below is untouched.
 if (activation && Array.isArray(activation.triggers) && activation.triggers.length) {
   try {
     const merged = loadMergedTriggerIndex()
     const mine = new Set(activation.triggers)
     const reported = new Set()
     for (const e of merged.entries) {
-      if (e.episode_id === id) continue // self-exclusion: the just-written episode
+      if (e.episode_id === storedId) continue // self-exclusion: the just-written episode
       if (!mine.has(e.value)) continue
       const key = `${e.episode_id} ${e.value}`
       if (reported.has(key)) continue
@@ -395,7 +426,7 @@ if (activation && Array.isArray(activation.triggers) && activation.triggers.leng
   } catch {}
 }
 
-console.log(JSON.stringify({ status: 'ok', id, file: filePath, scope }))
+console.log(JSON.stringify(successPayload))
 
 // Incrementally maintain category-index.json under the episode's canonical category key,
 // structurally mirroring updateTagsIndex (RFC-009 R10d). Deprecated names map to the successor
@@ -411,7 +442,5 @@ export function updateCategoryIndex(dataDir, episodeId, category) {
   const key = canonicalCategory(category)
   if (!index[key]) index[key] = []
   if (!index[key].includes(episodeId)) index[key].push(episodeId)
-  const tmpFile = catFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(index, null, 2), 'utf8')
-  fs.renameSync(tmpFile, catFile)
+  atomicReplaceFileSync(catFile, JSON.stringify(index, null, 2))
 }

--- a/scripts/lib/relevance.mjs
+++ b/scripts/lib/relevance.mjs
@@ -23,6 +23,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './store-write-lock.mjs'
 
 // Per-token field weights for the multi-term tier. Summary tokens count just
 // under a contiguous summary substring (0.7); tags sit between summary and
@@ -32,6 +33,20 @@ export const FIELD_WEIGHTS = { summary: 0.7, tags: 0.6, body: 0.4 }
 // Discount applied to the averaged token weights so a scattered token match
 // can never tie a contiguous substring match in the same field.
 const TOKEN_MATCH_DISCOUNT = 0.95
+
+// Access tracking is interactive best-effort work, not a durable writer.
+// Keep it responsive by default while preserving the shared timeout override
+// used by deterministic contention tests. Invalid, negative, or blank values
+// fall back to the relevance-local default rather than weakening the bound.
+const DEFAULT_ACCESS_TRACKING_TIMEOUT_MS = 250
+function resolveAccessTrackingTimeoutMs() {
+  const raw = process.env.EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS
+  if (raw === undefined || raw.trim() === '') return DEFAULT_ACCESS_TRACKING_TIMEOUT_MS
+  const value = Number(raw)
+  return Number.isFinite(value) && value >= 0
+    ? value
+    : DEFAULT_ACCESS_TRACKING_TIMEOUT_MS
+}
 
 // ---------------------------------------------------------------------------
 // normalizeTags(raw) — comma string or array → lowercased, trimmed, deduped,
@@ -156,12 +171,21 @@ export function writeBackAccessTracking(results) {
   }
 
   const now = new Date().toISOString().slice(0, 19) + 'Z'
+  const lockTimeoutMs = resolveAccessTrackingTimeoutMs()
 
   for (const [dataDir, ids] of byDir) {
     const indexFile = path.join(dataDir, 'index.jsonl')
+    let lockResult
     try {
-      // Re-read just before writing to narrow race window with concurrent em-store appends.
-      // This is best-effort — last-writer-wins for concurrent searches is acceptable.
+      // Access tracking is best-effort, but its read-modify-write is still a
+      // canonical per-store transaction. The helper's bounded acquisition
+      // honors the shared timeout environment and a contended store is simply
+      // skipped so search/recall remains successful.
+      lockResult = acquireStoreWriteLocksSync(dataDir, { timeoutMs: lockTimeoutMs })
+      if (!lockResult.ok) continue
+
+      // Reread only after acquisition. An em-store append that was waiting on
+      // this lock is therefore retained in the replacement snapshot.
       const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
       const updated = lines.map(line => {
         try {
@@ -173,11 +197,11 @@ export function writeBackAccessTracking(results) {
           return JSON.stringify(entry)
         } catch { return line }
       })
-      const tmpFile = indexFile + '.tmp'
-      fs.writeFileSync(tmpFile, updated.join('\n') + '\n', 'utf8')
-      fs.renameSync(tmpFile, indexFile)
+      atomicReplaceFileSync(indexFile, updated.join('\n') + '\n')
     } catch {
       // Access tracking is best-effort — skip silently on failure
+    } finally {
+      if (lockResult?.ok) releaseStoreWriteLocks(lockResult.handles)
     }
   }
 }
@@ -312,19 +336,31 @@ export function loadTokensIndex(dataDir) {
 // Dropped stays dropped until the next em-rebuild-index recomputes df.
 export function updateTokensIndex(dataDir, episodeId, tokens) {
   const tokensFile = path.join(dataDir, 'tokens.json')
-  let index = Object.create(null)
-  try {
-    index = nullProtoIndex(JSON.parse(fs.readFileSync(tokensFile, 'utf8')))
-  } catch {}
-  const dropped = new Set(Array.isArray(index[TOKENS_DROPPED_KEY]) ? index[TOKENS_DROPPED_KEY] : [])
-  for (const tok of tokens) {
-    if (dropped.has(tok)) continue
-    if (!index[tok]) index[tok] = []
-    if (!index[tok].includes(episodeId)) index[tok].push(episodeId)
+  const lockResult = acquireStoreWriteLocksSync(dataDir)
+  if (!lockResult.ok) {
+    const error = new Error(`Token index write failed: ${lockResult.code}`)
+    error.code = lockResult.code
+    error.heldBy = lockResult.heldBy
+    throw error
   }
-  const tmpFile = tokensFile + '.tmp'
-  fs.writeFileSync(tmpFile, JSON.stringify(index), 'utf8')
-  fs.renameSync(tmpFile, tokensFile)
+  try {
+    // The nested acquire is inherited when em-store/em-revise already hold
+    // the canonical store lock. This keeps direct callers safe without
+    // introducing a second lock protocol or a self-deadlock.
+    let index = Object.create(null)
+    try {
+      index = nullProtoIndex(JSON.parse(fs.readFileSync(tokensFile, 'utf8')))
+    } catch {}
+    const dropped = new Set(Array.isArray(index[TOKENS_DROPPED_KEY]) ? index[TOKENS_DROPPED_KEY] : [])
+    for (const tok of tokens) {
+      if (dropped.has(tok)) continue
+      if (!index[tok]) index[tok] = []
+      if (!index[tok].includes(episodeId)) index[tok].push(episodeId)
+    }
+    atomicReplaceFileSync(tokensFile, JSON.stringify(index))
+  } finally {
+    releaseStoreWriteLocks(lockResult.handles)
+  }
 }
 
 // tokenCandidates(indexes, queryTokens) — resolve query tokens against one or

--- a/scripts/lib/store-write-lock.mjs
+++ b/scripts/lib/store-write-lock.mjs
@@ -1,0 +1,417 @@
+// lib/store-write-lock.mjs — zero-dep synchronous store-write lock + atomic
+// replace helper (Issue 546, Slice 546-S1).
+//
+// Why this file exists: scripts/lib/lock.mjs already owns O_EXCL atomic
+// acquisition of <store>/clerk-apply.lock, but it is a single-primitive
+// primitive with no canonicalization, no inheritance policy, no multi-store
+// ordering, and no same-directory atomic-replace. Every writer that mutates
+// an episodic-memory store needs (a) canonical lock identity so a symlink
+// alias and its target share one lock, (b) ordered multi-store acquisition
+// so revise/move/restore never deadlock on source-vs-destination, (c) live
+// parent inheritance so em-promote can hold the lock across its child spawn
+// without the child re-acquiring or deadlocking, and (d) collision-safe
+// temporary paths so two concurrent writers do not both rename the same
+// `<base>.jsonl.tmp` over each other's snapshot.
+//
+// Contract reference: docs/plans/issue-546-concurrent-store-writes.md §12
+// (acquire/release/atomic-replace), §13 (edge cases), §14 (test catalog).
+//
+// F1 (S1 review): public surface is exactly the six named exports below.
+// F2 (S1 review): validate-then-mkdir-then-realpath-then-dedupe-then-sort;
+// no lexical identity fallback after mkdir (realpath is required).
+// F3 (S1 review): single ordered handles array; inheritance condition is
+// strictly heldBy === process.pid or heldBy === process.ppid.
+// F4 (S1 review): tmpPath must resolve to the same directory as finalPath
+// BEFORE open; full-write loop protects against partial writes.
+//
+// Zero external deps. Node stdlib only.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+
+import { tryAcquire, release as releasePrimitive } from './lock.mjs'
+
+// One basename per store directory. Mirrors the canonical clerk contract.
+// F1: required public export name.
+export const STORE_WRITE_LOCK_BASENAME = 'clerk-apply.lock'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const DEFAULT_POLL_MS = 50
+function resolveTimeoutMs(options = {}) {
+  if (Object.prototype.hasOwnProperty.call(options, 'timeoutMs')) {
+    return Number.isFinite(options.timeoutMs) ? options.timeoutMs : DEFAULT_TIMEOUT_MS
+  }
+  const raw = process.env.EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS
+  return raw !== undefined && /^\d+$/.test(raw) ? Number(raw) : DEFAULT_TIMEOUT_MS
+}
+
+
+/**
+ * Reusable SharedArrayBuffer-backed Int32Array used as the synchronization
+ * primitive for sleepSync. Atomics.wait on this array blocks the current
+ * thread for a bounded interval without timers; in contexts where
+ * Atomics.wait throws or is unavailable, sleepSync falls back to a
+ * bounded Date.now busy-loop instead. The buffer is module-level so all
+ * sleeps share one allocation and the wait index (0) is unambiguous.
+ */
+const SHARED_I32 = new Int32Array(new SharedArrayBuffer(4))
+
+/**
+ * Synchronous sleep using Atomics.wait over a module-level reusable
+ * SharedArrayBuffer-backed Int32Array. Falls back to a bounded Date.now
+ * busy-loop if Atomics.wait throws or is unavailable. The fallback is
+ * bounded by `ms` itself — we never spin forever.
+ *
+ * @param {number} ms
+ */
+function sleepSync(ms) {
+  if (!(ms > 0)) return
+  try {
+    Atomics.wait(SHARED_I32, 0, 0, ms)
+    return
+  } catch {
+    // This host or execution context does not permit blocking waits.
+    // (Node permits Atomics.wait on its main thread.) Fall through to the
+    // bounded Date.now busy-loop fallback.
+  }
+  const end = Date.now() + ms
+  while (Date.now() < end) { /* bounded spin */ }
+}
+
+/**
+ * F1: resolve the canonical lock-file path for a store directory WITHOUT
+ * touching the filesystem. Pure path computation; the caller still owns
+ * canonicalization at acquire time. Useful for inspection, assertions,
+ * and assertion helpers that need to reference the same path the helper
+ * uses after canonicalization.
+ *
+ * @param {string} dataDir
+ * @returns {string}
+ */
+export function storeWriteLockPath(dataDir) {
+  if (typeof dataDir !== 'string' || dataDir.length === 0) {
+    throw new TypeError('store directory must be a non-empty string')
+  }
+  return path.join(dataDir, STORE_WRITE_LOCK_BASENAME)
+}
+
+/**
+ * @typedef {{lockFile:string, pid:number, inherited:boolean}} StoreWriteLockHandle
+ * @typedef {{ok:true, handles:StoreWriteLockHandle[], dirs:string[]}
+ *          |{ok:false, code:'store-write-lock-timeout', heldBy:number|null}} StoreWriteLockResult
+ */
+
+/**
+ * Acquire clerk-apply.lock on every supplied store directory in canonical
+ * order. Returns either `ok:true` with one handle per UNIQUE canonical store
+ * directory (preserved acquisition order, owned or inherited interleaved in
+ * the order each canonical dir was processed), or `ok:false` with a
+ * `store-write-lock-timeout` code naming the live owner that prevented
+ * acquisition.
+ *
+ * F2: input is validated with NO filesystem side effect first. We only
+ * mkdirSync after the type check, then realpathSync (which now CANNOT
+ * ENOENT-fall-back into lexical identity), then dedupe, then lexical sort.
+ * F3: one ordered handles array; on timeout we release only the OWNED
+ * entries from that array in reverse-acquisition order, leaving inherited
+ * entries untouched.
+ *
+ * @param {string|string[]} dataDirsArg  one path, or an array of paths
+ * @param {{timeoutMs?:number, pollMs?:number}} [options]
+ * @returns {StoreWriteLockResult}
+ */
+export function acquireStoreWriteLocksSync(dataDirsArg, options = {}) {
+  const dirs = canonicalizeAndSort(dataDirsArg)
+  if (!dirs.length) {
+    // canonicalizeAndSort already enforces non-empty, but be defensive.
+    throw new TypeError('store directory must be an array with at least one element')
+  }
+
+  const timeoutMs = resolveTimeoutMs(options)
+
+  const pollMs = Number.isFinite(options.pollMs) ? options.pollMs : DEFAULT_POLL_MS
+  const deadline = Date.now() + Math.max(0, timeoutMs)
+
+  // F3: a single ordered handles array. Owned or inherited are appended in
+  // the order each canonical dir was processed; on timeout, reverse-iterate
+  // and release ONLY the owned entries.
+  /** @type {StoreWriteLockHandle[]} */
+  const handles = []
+
+  for (const dir of dirs) {
+    const lockFile = path.join(dir, STORE_WRITE_LOCK_BASENAME)
+    const outcome = tryAcquireUntil(lockFile, deadline, pollMs)
+    if (outcome.kind === 'owned') {
+      handles.push({ lockFile, pid: process.pid, inherited: false })
+      continue
+    }
+    if (outcome.kind === 'inherited') {
+      handles.push({ lockFile, pid: outcome.heldBy, inherited: true })
+      continue
+    }
+    // timeout: F3 requires reverse-order release of only OWNED handles from
+    // this ordered array. Inherited handles in the array are NOT released
+    // here — the actual owner (caller's pid or direct parent) remains
+    // responsible and an inherited release would corrupt unrelated state.
+    releaseOwnedOnly(handles)
+    return {
+      ok: false,
+      code: 'store-write-lock-timeout',
+      heldBy: outcome.heldBy,
+    }
+  }
+
+  return { ok: true, handles, dirs }
+}
+
+/**
+ * Release the handles returned by acquireStoreWriteLocksSync in REVERSE
+ * acquisition order. Inherited handles are NEVER released — the owner
+ * (caller's own pid or direct parent pid) remains responsible and will
+ * release itself. Repeated calls are safe (releasePrimitive is already
+ * idempotent against missing files).
+ *
+ * @param {StoreWriteLockHandle[] | undefined | null} handles
+ */
+export function releaseStoreWriteLocks(handles) {
+  if (!Array.isArray(handles) || handles.length === 0) return
+  for (let i = handles.length - 1; i >= 0; i--) {
+    const h = handles[i]
+    if (!h || h.inherited) continue
+    releasePrimitive({ lockFile: h.lockFile, pid: h.pid })
+  }
+}
+
+/**
+ * Compute a unique same-directory temporary path for atomic replacement of
+ * `finalPath`. The temporary name embeds PID plus eight bytes of
+ * cryptographic randomness so two writers on the same store never collide.
+ *
+ * F1: required public export name.
+ *
+ * @param {string} finalPath
+ * @returns {string}
+ */
+export function uniqueStoreTmpPath(finalPath) {
+  if (typeof finalPath !== 'string' || finalPath.length === 0) {
+    throw new TypeError('finalPath must be a non-empty string')
+  }
+  const dir = path.dirname(finalPath)
+  const base = path.basename(finalPath)
+  const rnd = crypto.randomBytes(8).toString('hex')
+  return path.join(dir, `${base}.tmp.${process.pid}.${rnd}`)
+}
+
+/**
+ * Atomically replace `finalPath` with `data`. Writes to a unique
+ * same-directory `wx` (O_EXCL) temporary, fsyncs, closes, then renames. On
+ * any failure before the rename, removes only THIS invocation's temporary
+ * and rethrows.
+ *
+ * F4: if `options.tmpPath` is provided, it MUST resolve to the same
+ * directory as `finalPath` (cross-device rename is unsafe and crosses
+ * the contract's same-directory invariant). The check happens BEFORE
+ * any open/write so no temp file is created on rejection. The write uses
+ * fs.writeFileSync(fd, data) which guarantees a full-data write loop
+ * (a single fs.writeSync can short-write on large buffers).
+ *
+ * If `options.tmpPath` already exists (EEXIST), the failure is loud: the
+ * prior final file AND the pre-existing collision path are preserved (no
+ * deletion of paths the call did not create).
+ *
+ * @param {string} finalPath
+ * @param {string|Buffer} data
+ * @param {{tmpPath?:string}} [options]
+ * @returns {string} the finalPath that was written
+ */
+export function atomicReplaceFileSync(finalPath, data, options = {}) {
+  if (typeof finalPath !== 'string' || finalPath.length === 0) {
+    throw new TypeError('finalPath must be a non-empty string')
+  }
+
+  // F4: cross-directory tmpPath rejection happens BEFORE any open/write.
+  // We resolve both paths and require identical dirname strings; a cross-
+  // device tmpPath would silently lose atomicity via fs.renameSync.
+  if (options.tmpPath !== undefined) {
+    if (typeof options.tmpPath !== 'string' || options.tmpPath.length === 0) {
+      throw new TypeError('options.tmpPath must be a non-empty string when provided')
+    }
+    const finalDir = path.resolve(path.dirname(finalPath))
+    const tmpDir = path.resolve(path.dirname(options.tmpPath))
+    if (finalDir !== tmpDir) {
+      throw new Error(
+        `options.tmpPath must resolve to the same directory as finalPath; ` +
+        `got tmpDir=${tmpDir} finalDir=${finalDir}`,
+      )
+    }
+  }
+
+  const tmpPath = options.tmpPath || uniqueStoreTmpPath(finalPath)
+  const finalDir = path.dirname(finalPath)
+  fs.mkdirSync(finalDir, { recursive: true })
+
+  let fd = -1
+  let opened = false
+  try {
+    // O_EXCL (wx): if tmpPath already exists, fail loudly. We never unlink
+    // a path we did not create.
+    fd = fs.openSync(tmpPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644)
+    opened = true
+    // F4: full-write loop. fs.writeFileSync(fd, data) loops internally
+    // until the entire buffer lands; a single fs.writeSync can short-write
+    // on large buffers and silently leave a partial snapshot on disk.
+    fs.writeFileSync(fd, data)
+    fs.fsyncSync(fd)
+    fs.closeSync(fd)
+    fd = -1
+    fs.renameSync(tmpPath, finalPath)
+    return finalPath
+  } catch (err) {
+    if (fd !== -1) {
+      try { fs.closeSync(fd) } catch { /* best effort */ }
+    }
+    if (opened) {
+      try { fs.unlinkSync(tmpPath) } catch { /* best effort: collision path preserved */ }
+    }
+    throw err
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the input, ensure every supplied store directory exists, then
+ * resolve each through realpathSync, dedupe, and return a lexically-sorted
+ * unique list.
+ *
+ * F2 ordering:
+ *   1. Validate type/shape of every entry with NO filesystem side effect.
+ *   2. mkdirSync every entry (recursive). This means a store path that
+ *      points through a symlinked parent or one that does not yet exist
+ *      is now a real on-disk directory before we attempt identity.
+ *   3. realpathSync every entry. After mkdir has run, ENOENT is a true
+ *      filesystem failure (realpath does NOT fall back to lexical path;
+ *      lexical identity would mask the canonical-vs-symlink distinction
+ *      that the §12 contract relies on).
+ *   4. Dedupe canonical spellings.
+ *   5. Lexical sort for deterministic ordered acquisition.
+ *
+ * @param {unknown} arg  a string or an array of strings
+ * @returns {string[]}
+ */
+function canonicalizeAndSort(arg) {
+  // Step 1a: validate positional arg type/shape with NO filesystem side effect.
+  let raw
+  if (Array.isArray(arg)) {
+    raw = arg
+  } else if (typeof arg === 'string' && arg.length > 0) {
+    raw = [arg]
+  } else {
+    throw new TypeError('store directory must be a non-empty string')
+  }
+  if (raw.length === 0) {
+    throw new TypeError('store directory must be an array with at least one element')
+  }
+  // Step 1b: validate every entry's type/shape before touching disk.
+  for (const entry of raw) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw new TypeError('store directory must be a non-empty string')
+    }
+  }
+
+  // Step 2: mkdirSync every store dir FIRST. After this point every supplied
+  // path resolves to an on-disk directory; a missing entry is now an error
+  // (or already canonicalized to its realpath destination via the symlink
+  // chain the caller passed in).
+  const canonDirs = []
+  for (const entry of raw) {
+    fs.mkdirSync(entry, { recursive: true })
+    // Step 3: realpathSync, no lexical-identity fallback. ENOENT here means
+    // a real filesystem failure (e.g. permission, vanished dir between
+    // mkdir and realpath), not an opportunity to dedupe by spelling.
+    canonDirs.push(fs.realpathSync(entry))
+  }
+
+  // Step 4: dedupe canonical spellings.
+  const seen = new Set()
+  const out = []
+  for (const c of canonDirs) {
+    if (!seen.has(c)) {
+      seen.add(c)
+      out.push(c)
+    }
+  }
+  // Step 5: lexical sort. §12 requires deterministic ordering for deadlock
+  // avoidance — two callers passing the same two stores in different input
+  // orders acquire them in the same canonical order.
+  out.sort()
+  return out
+}
+
+/**
+ * Poll tryAcquire until we own the lock, inherit a live parent owner, or
+ * hit the deadline. F3: inheritance is strictly heldBy === process.pid or
+ * heldBy === process.ppid (the in-process re-entry and the em-promote-
+ * style direct-child scenarios). A null or any other live PID never
+ * inherits — the helper times out instead so the caller never writes
+ * through an unowned lock.
+ *
+ * @returns {{kind:'owned'} | {kind:'inherited', heldBy:number} | {kind:'timeout', heldBy:number|null}}
+ */
+function tryAcquireUntil(lockFile, deadlineMs, pollMs) {
+  // busy wait budget: deadlineMs. Honor caller by sleeping pollMs between
+  // attempts. Spin instead of recursing so we can re-evaluate deadlines.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const attempt = tryAcquire(lockFile)
+    if (attempt.ok) return { kind: 'owned' }
+
+    const heldBy = attempt.heldBy
+    // F3 inheritance gate: ONLY current PID (in-process re-entry, e.g. the
+    // clerk's nested call) or current direct-parent PID (em-promote-style
+    // spawn) qualifies. heldBy:null (malformed), foreign live PIDs, and
+    // grand-parent PIDs do NOT inherit and must time out so the caller
+    // never mutates state under an unowned lock. There is no multi-store
+    // inheritedOwner shortcut — every canonical dir is judged independently.
+    if (typeof heldBy === 'number' && heldBy > 0) {
+      if (heldBy === process.pid || heldBy === process.ppid) {
+        return { kind: 'inherited', heldBy }
+      }
+    }
+
+    if (Date.now() >= deadlineMs) {
+      return { kind: 'timeout', heldBy: typeof heldBy === 'number' && heldBy > 0 ? heldBy : null }
+    }
+    // Sleep, but cap at remaining budget. We deliberately do not use
+    // setTimeout — this whole helper is synchronous by contract (§12).
+    // sleepSync uses Atomics.wait over a module-level reusable
+    // SharedArrayBuffer-backed Int32Array, with a bounded Date.now
+    // busy-loop fallback for the rare context where Atomics.wait throws
+    // or is unavailable. Either way the sleep is bounded by `sleep`.
+    const remaining = deadlineMs - Date.now()
+    const sleep = Math.max(1, Math.min(pollMs, remaining))
+    sleepSync(sleep)
+  }
+}
+
+/**
+ * F3: on acquisition timeout, release only the OWNED entries of an ordered
+ * handles array, in reverse-acquisition order. Inherited entries are
+ * skipped — the real owner (caller's pid or direct parent pid) is
+ * responsible for releasing its own lock. After running, the array is
+ * emptied so the caller's failure path can safely discard it without risk
+ * of double-release on a re-attempt.
+ *
+ * @param {StoreWriteLockHandle[]} handles
+ */
+function releaseOwnedOnly(handles) {
+  for (let i = handles.length - 1; i >= 0; i--) {
+    const h = handles[i]
+    if (!h || h.inherited) continue
+    releasePrimitive({ lockFile: h.lockFile, pid: h.pid })
+  }
+  handles.length = 0
+}

--- a/tests/test-store-write-concurrency.mjs
+++ b/tests/test-store-write-concurrency.mjs
@@ -1204,6 +1204,122 @@ async function testMissingOriginalIndexRowNoWrite() {
   }
 }
 
+async function testReviseCrossScopeStaleOriginalSnapshotDrift() {
+  const fixture = mkStoreFixture('store-write-revise-snapshot-drift-')
+  // Seed original in local and a first global successor so the original is
+  // stably superseded.
+  const original = seedLocalOriginal(fixture, 'cross-drift')
+  const firstRevise = runJsonSync(REVISE, [
+    '--original', original.id,
+    '--project', 'issue-546-fixture',
+    '--tag', 'cross-drift-first',
+    '--summary', 'first cross scope successor',
+    '--body', 'first cross scope body crossdriftfirsttoken',
+    '--scope', 'global',
+  ], fixture)
+  assert.equal(firstRevise.code, 0, `first revise seed failed: ${firstRevise.stdout} ${firstRevise.stderr}`)
+  assert.equal(firstRevise.json?.status, 'ok', `first revise JSON: ${firstRevise.stdout}`)
+  assert.equal(episodeStatus(fixture.localDir, original.id), 'superseded')
+
+  const originalDir = fs.realpathSync(fixture.localDir)
+  const dataDir = fs.realpathSync(fixture.globalDir)
+  const canonical = [originalDir, dataDir].sort()
+  const firstLockFile = path.join(canonical[0], 'clerk-apply.lock')
+  const otherStoreDir = canonical[1]
+  const markerFile = path.join(fixture.root, 'prelock-marker')
+
+  // CJS preload: intercept the first fs.readFileSync of the successor-store
+  // index (dataDir), write a marker, and patch the builtin ESM exports so
+  // the em-revise ESM import sees the wrapped function.
+  const preloadPath = path.join(fixture.root, 'snapshot-drift-preload.cjs')
+  fs.writeFileSync(preloadPath, `
+    const fs = require('fs');
+    const moduleObj = require('module');
+    const origReadFileSync = fs.readFileSync;
+    const markerFile = ${JSON.stringify(markerFile)};
+    const targetIndex = ${JSON.stringify(path.join(dataDir, 'index.jsonl'))};
+    let marked = false;
+    fs.readFileSync = function (...args) {
+      const result = origReadFileSync.apply(fs, args);
+      if (!marked && args[0] === targetIndex) {
+        fs.writeFileSync(markerFile, 'prelock-complete');
+        marked = true;
+      }
+      return result;
+    };
+    moduleObj.syncBuiltinESMExports();
+  `)
+
+  await withLiveHolder(firstLockFile, async ({ child }) => {
+    // Spawn a cross-scope revise. The preload fixes the instant when the
+    // pre-lock snapshot has completed, so we can mutate the other store
+    // before the revise acquires its locks.
+    const completion = spawnJson(REVISE, [
+      '--original', original.id,
+      '--project', 'issue-546-fixture',
+      '--tag', 'cross-drift-second',
+      '--summary', 'second cross scope successor',
+      '--body', 'second cross scope body crossdriftsecondtoken',
+      '--scope', 'global',
+    ], fixture, { NODE_OPTIONS: `--require ${preloadPath}` })
+
+    await waitForFile(markerFile, 5000)
+
+    // Holder-owned mutation in the other store: append a direct successor
+    // episode + index row. The pre-lock snapshot has already completed, so
+    // this new successor is not in preLock.successors.
+    const holderId = `${original.id}-holder-successor`
+    const holderFile = path.join(otherStoreDir, 'episodes', `${holderId}.md`)
+    fs.mkdirSync(path.dirname(holderFile), { recursive: true })
+    const holderContent = [
+      '---',
+      `id: ${holderId}`,
+      'date: 2026-07-15',
+      'time: "12:00"',
+      'project: issue-546-fixture',
+      'category: decision',
+      'status: active',
+      `supersedes: ${original.id}`,
+      'tags: [holder-successor]',
+      'summary: holder injected successor',
+      '---',
+      '',
+      '# holder injected successor',
+      '',
+      'holder body holdersuccessortoken\n',
+    ].join('\n')
+    fs.writeFileSync(holderFile, holderContent)
+    const indexFile = path.join(otherStoreDir, 'index.jsonl')
+    const indexRow = JSON.stringify({
+      id: holderId, date: '2026-07-15', time: '12:00', project: 'issue-546-fixture',
+      category: 'decision', status: 'active', supersedes: original.id,
+      tags: ['holder-successor'], summary: 'holder injected successor',
+    })
+    fs.appendFileSync(indexFile, indexRow + '\n', 'utf8')
+
+    // Snapshot bytes after the holder mutation; the revise must not write
+    // anything once it detects the drift.
+    const expected = [storeDataSnapshot(fixture.localDir), storeDataSnapshot(fixture.globalDir)]
+
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 1, `revise must exit 1 on stale original; got ${result.code}; stdout=${result.stdout}; stderr=${result.stderr}`)
+    assert.equal(result.json?.status, 'error', `stale JSON status missing: ${result.stdout}`)
+    assert.equal(result.json?.code, 'stale-original', `stale reason must be stale-original: ${result.stdout}`)
+    assert.match(result.json?.message || '', /snapshot drift/, `stale message must mention snapshot drift: ${result.stdout}`)
+
+    const actual = [storeDataSnapshot(fixture.localDir), storeDataSnapshot(fixture.globalDir)]
+    assert.deepEqual(actual, expected, 'revise mutated store bytes after detecting snapshot drift')
+
+    telemetry.reviseCrossScopeSnapshotDrift = {
+      heldFirst: path.basename(path.dirname(canonical[0])),
+      mutatedStore: otherStoreDir === originalDir ? 'original' : 'data',
+      staleCode: result.json?.code,
+      unchanged: true,
+    }
+  })
+}
+
 async function runS2aIntegrationTests() {
   console.log('# S2a real-process store/revise integration tests')
   await asyncTap('S2a: 16 concurrent stores preserve episode/index/tag/category/token parity with no temp litter', testConcurrentStoreParity)
@@ -1211,6 +1327,7 @@ async function runS2aIntegrationTests() {
   await asyncTap('S2a: cross-store revise preserves source/destination derived-index parity', testCrossStoreReviseParity)
   await asyncTap('S2a: revise lock timeout is a byte-for-byte no-write', testReviseTimeoutNoWrite)
   await asyncTap('S2a: same-store lock inputs dedupe and revise preserves full parity', testSameStoreReviseParity)
+  await asyncTap('S2a: cross-scope revise detects a successor appended in the other store as snapshot-drift stale-original', testReviseCrossScopeStaleOriginalSnapshotDrift)
   await asyncTap('S2a: missing original index row is stale and writes nothing', testMissingOriginalIndexRowNoWrite)
 }
 
@@ -1357,7 +1474,14 @@ async function testSearchWritebackRetainsConcurrentAppend() {
   const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
 
   await withLiveHolder(lockFile, async ({ child }) => {
-    const search = spawnJson(SEARCH, ['--query', 'original', '--scope', 'local'], fixture)
+    // PR-562 (issue 546 substrate repair): production best-effort access
+    // tracking intentionally times out at 250 ms. The 300 ms assertion
+    // exceeds that bound, but on a fast runner or due to startup variance
+    // the search may exit before the window. Bump the per-process shared
+    // timeout ONLY in this test's spawn env so the search stays blocked
+    // until the holder releases — production timing is unchanged.
+    const raceEnvExtra = { EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '5000' }
+    const search = spawnJson(SEARCH, ['--query', 'original', '--scope', 'local'], fixture, raceEnvExtra)
     const append = spawnJson(STORE, [
       '--project', 'issue-546-fixture', '--category', 'decision',
       '--tag', 'search-race-append', '--summary', 'search race append',
@@ -1432,6 +1556,21 @@ async function runS2bIntegrationTests() {
   await asyncTap('S2b: concurrent pin and rebuild preserve episode/index parity', testPinAndRebuildConcurrentParity)
   await asyncTap('S2b: search writeback retains an append serialized through the store lock', testSearchWritebackRetainsConcurrentAppend)
   await asyncTap('S2b: contended search store is skipped while another store writes back', testSearchWritebackSkipsOnlyContendedStore)
+}
+
+function waitForFile(filePath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolve, reject) => {
+    const timer = setInterval(() => {
+      if (fs.existsSync(filePath)) {
+        clearInterval(timer)
+        resolve()
+      } else if (Date.now() >= deadline) {
+        clearInterval(timer)
+        reject(new Error(`timeout waiting for marker file ${filePath}`))
+      }
+    }, 50)
+  })
 }
 
 function waitForMarker(child, marker, timeoutMs) {

--- a/tests/test-store-write-concurrency.mjs
+++ b/tests/test-store-write-concurrency.mjs
@@ -1,0 +1,2405 @@
+#!/usr/bin/env node
+/**
+ * test-store-write-concurrency.mjs — Issue 546 concurrent store-write suite.
+ *
+ * Slice 546-S1 contract (docs/plans/issue-546-concurrent-store-writes.md):
+ *   - helper: acquire/release/inheritance/malformed-timeout/lexical-order/
+ *     symlink-dedupe/symlinked-parent-dedupe/partial-cleanup/unique-tmp/
+ *     atomic-success/atomic-failure/deterministic-EEXIST/cross-dir-reject/
+ *     no-litter
+ *   - end-to-end: a real external child holding <store>/clerk-apply.lock
+ *     while the real `em-store` runs against an isolated local fixture.
+ *     The PARENT owns the release timing so writerExitedBeforeRelease is
+ *     observed from the actual ordering, not a hidden timer. On
+ *     unmodified main the writer exits before the parent sends release
+ *     (writerExitedBeforeRelease = true). After the fix, the writer waits
+ *     for the parent's release (writerExitedBeforeRelease = false).
+ *
+ * Usage:
+ *   node tests/test-store-write-concurrency.mjs --helper-only
+ *   node tests/test-store-write-concurrency.mjs --expect-main-red   # red on current main
+ *   node tests/test-store-write-concurrency.mjs                    # both halves (needs fix)
+ *
+ * F1 (S1 review): tests use the required public names
+ * (STORE_WRITE_LOCK_BASENAME, storeWriteLockPath, uniqueStoreTmpPath).
+ * F6 (S1 review): every mkTmp() root is tracked in tmpRoots and removed
+ * in main()'s finally, including failure paths. Unused imports and
+ * variables are gone.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { spawn, spawnSync } from 'node:child_process'
+
+const SELF = fileURLToPath(import.meta.url)
+const REPO = path.resolve(path.dirname(SELF), '..')
+const STORE = path.join(REPO, 'scripts', 'em-store.mjs')
+const REVISE = path.join(REPO, 'scripts', 'em-revise.mjs')
+const FEEDBACK = path.join(REPO, 'scripts', 'em-feedback.mjs')
+const PIN = path.join(REPO, 'scripts', 'em-pin.mjs')
+const REBUILD = path.join(REPO, 'scripts', 'em-rebuild-index.mjs')
+const SEARCH = path.join(REPO, 'scripts', 'em-search.mjs')
+const PRUNE = path.join(REPO, 'scripts', 'em-prune.mjs')
+const MOVE = path.join(REPO, 'scripts', 'em-move.mjs')
+const SEED_PATTERNS = path.join(REPO, 'scripts', 'em-seed-patterns.mjs')
+const REVIEW_REQUEST = path.join(REPO, 'scripts', 'em-review-request.mjs')
+// Issue 546 (S3b): restore + consolidate paths under test.
+const RESTORE = path.join(REPO, 'scripts', 'em-restore.mjs')
+const CONSOLIDATE = path.join(REPO, 'scripts', 'em-consolidate.mjs')
+const HELPER_URL = new URL('../scripts/lib/store-write-lock.mjs', import.meta.url).href
+
+const ARGV = process.argv.slice(2)
+const HELPER_ONLY = ARGV.includes('--helper-only')
+const EXPECT_MAIN_RED = ARGV.includes('--expect-main-red')
+
+let pass = 0
+let fail = 0
+
+// F6: every mkTmp() root is registered here. main()'s finally removes all
+// of them, including failure paths. No more leaked /tmp fixtures.
+const tmpRoots = []
+
+// Every live-holder child spawned via spawnLiveHolder is tracked here so
+// main()'s finally can release/await any orphans after a test throws.
+const liveChildren = new Set()
+const commandChildren = new Set()
+const telemetry = Object.create(null)
+
+function tap(name, fn) {
+  try { fn(); pass++; console.log(`ok ${pass + fail} - ${name}`) }
+  catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+// F7: asyncTap mirrors tap but for tests that need to await async helpers
+// (live-holder children, etc.). Synchronous throw inside fn() still counts.
+async function asyncTap(name, fn) {
+  try {
+    await fn()
+    pass++
+    console.log(`ok ${pass + fail} - ${name}`)
+  } catch (e) {
+    fail++
+    console.log(`not ok ${pass + fail} - ${name}\n  ${(e.stack || e.message).split('\n').join('\n  ')}`)
+  }
+}
+
+function mkTmp(prefix) {
+  const p = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  tmpRoots.push(p)
+  return p
+}
+
+function mkStoreFixture(prefix) {
+  const root = mkTmp(prefix)
+  const home = path.join(root, 'home')
+  const cwd = path.join(root, 'cwd')
+  fs.mkdirSync(home, { recursive: true })
+  fs.mkdirSync(cwd, { recursive: true })
+  return {
+    root,
+    home,
+    cwd,
+    localDir: path.join(cwd, '.episodic-memory'),
+    globalDir: path.join(home, '.episodic-memory'),
+    env: { ...process.env, HOME: home },
+  }
+}
+
+function runJsonSync(script, args, fixture, envExtra = {}) {
+  const started = Date.now()
+  const r = spawnSync(process.execPath, [script, ...args], {
+    cwd: fixture.cwd,
+    env: { ...fixture.env, ...envExtra },
+    encoding: 'utf8',
+  })
+  let json = null
+  try { json = JSON.parse((r.stdout || '').trim()) } catch { /* asserted by caller */ }
+  return { code: r.status, signal: r.signal, stdout: r.stdout || '', stderr: r.stderr || '', json, elapsedMs: Date.now() - started }
+}
+
+function spawnJson(script, args, fixture, envExtra = {}) {
+  const child = spawn(process.execPath, [script, ...args], {
+    cwd: fixture.cwd,
+    env: { ...fixture.env, ...envExtra },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  commandChildren.add(child)
+  const started = Date.now()
+  let stdout = ''
+  let stderr = ''
+  child.stdout.on('data', d => { stdout += d.toString() })
+  child.stderr.on('data', d => { stderr += d.toString() })
+  const completion = new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      commandChildren.delete(child)
+      let json = null
+      try { json = JSON.parse(stdout.trim()) } catch { /* asserted by caller */ }
+      resolve({ child, code, signal, stdout, stderr, json, elapsedMs: Date.now() - started })
+    })
+  })
+  completion.child = child
+  return completion
+}
+
+async function stopChildren(children) {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) {
+      try { child.kill('SIGTERM') } catch { /* best effort */ }
+    }
+  }
+  await Promise.all(children.map(child => awaitChild(child)))
+}
+
+function byteSnapshot(root) {
+  if (!fs.existsSync(root)) return []
+  const entries = []
+  function visit(dir, rel) {
+    const names = fs.readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))
+    if (rel) entries.push([`${rel}/`, 'directory'])
+    for (const ent of names) {
+      const abs = path.join(dir, ent.name)
+      const childRel = rel ? path.join(rel, ent.name) : ent.name
+      if (ent.isDirectory()) visit(abs, childRel)
+      else if (ent.isSymbolicLink()) entries.push([childRel, `symlink:${fs.readlinkSync(abs)}`])
+      else entries.push([childRel, fs.readFileSync(abs).toString('base64')])
+    }
+  }
+  visit(root, '')
+  return entries
+}
+
+function readIndexRows(storeDir) {
+  const text = fs.readFileSync(path.join(storeDir, 'index.jsonl'), 'utf8')
+  return text.split('\n').filter(Boolean).map(JSON.parse)
+}
+
+function readJson(storeDir, name) {
+  return JSON.parse(fs.readFileSync(path.join(storeDir, name), 'utf8'))
+}
+
+function episodeIds(storeDir) {
+  const dir = path.join(storeDir, 'episodes')
+  return fs.readdirSync(dir).filter(name => name.endsWith('.md')).map(name => name.slice(0, -3)).sort()
+}
+
+function episodeStatus(storeDir, id) {
+  const text = fs.readFileSync(path.join(storeDir, 'episodes', `${id}.md`), 'utf8')
+  const match = text.match(/^status:\s*(\S+)$/m)
+  return match ? match[1] : null
+}
+
+function assertIds(actual, expected, label) {
+  assert.deepEqual([...actual].sort(), [...expected].sort(), label)
+}
+
+function assertPosting(index, key, expectedIds, label) {
+  assert.ok(Array.isArray(index[key]), `${label}: missing posting ${key}`)
+  assertIds(index[key], expectedIds, `${label}: posting ${key}`)
+}
+
+function tmpLitter(storeDir) {
+  if (!fs.existsSync(storeDir)) return []
+  const found = []
+  function visit(dir) {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, ent.name)
+      if (ent.isDirectory()) visit(abs)
+      else if (/\.tmp(?:\.|$)/.test(ent.name)) found.push(path.relative(storeDir, abs))
+    }
+  }
+  visit(storeDir)
+  return found.sort()
+}
+
+// F4/F5: raw live-holder child utility. Acquires `lockFile` exclusively,
+// writes its PID + ISO timestamp + 0 (no ppid inheritance), and waits for
+// "release" on stdin before unlinking and exiting. The PARENT owns the
+// release timing. A 15-second safety ceiling unlinks the lockfile and
+// exits with code 2 if the parent dies before sending release.
+function spawnLiveHolder(lockFile) {
+  const script = `
+    import fs from 'node:fs'
+    const lockFile = ${JSON.stringify(lockFile)}
+    let fd
+    try {
+      fd = fs.openSync(lockFile, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644)
+    } catch (e) {
+      process.stdout.write(JSON.stringify({ held: false, err: String(e) }))
+      process.exit(0)
+    }
+    const pid = process.pid
+    const iso = new Date().toISOString()
+    fs.writeSync(fd, pid + '\\n' + iso + '\\n0\\n')
+    fs.closeSync(fd)
+    process.stdout.write(JSON.stringify({ held: true, pid, lockFile }))
+    process.stdin.setEncoding('utf8')
+    let buf = ''
+    process.stdin.on('data', (chunk) => {
+      buf += chunk
+      if (buf.includes('release')) {
+        try { fs.unlinkSync(lockFile) } catch {}
+        process.stdout.write(JSON.stringify({ released: true }))
+        process.exit(0)
+      }
+    })
+    process.stdin.on('end', () => { try { fs.unlinkSync(lockFile) } catch {}; process.exit(0) })
+    setTimeout(() => { try { fs.unlinkSync(lockFile) } catch {}; process.exit(2) }, 15000)
+  `
+  const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  liveChildren.add(child)
+  child.once('exit', () => liveChildren.delete(child))
+  return child
+}
+
+
+// safe to call multiple times, safe to call after the child has already
+// exited (the writes throw EINVAL/EPIPE which we silently swallow).
+function releaseChild(child) {
+  if (!child.stdin || child.stdin.destroyed || child.stdin.writableEnded) return
+  // A second release can race the holder's own process.exit and otherwise
+  // emits ERR_STREAM_WRITE_AFTER_END asynchronously, outside the test body.
+  child.stdin.once('error', () => {})
+  try { child.stdin.write('release\n') } catch { /* best effort */ }
+  try { child.stdin.end() } catch { /* best effort */ }
+}
+
+// F7: Resolves when the child has exited. Safe to call before or after
+// the child has already exited (in which case it resolves immediately).
+function awaitChild(child) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve()
+      return
+    }
+    child.once('exit', () => resolve())
+  })
+}
+
+// F7: Drive a spawnLiveHolder end-to-end for a single test body. Waits
+// for the child to print "{held:true,...}" on stdout (with a 5-second
+// ceiling), clears the ceiling timer after readiness regardless of which
+// side won, parses the child PID, then runs `body({child, childPid, buf})`.
+// The finally block clears any still-pending ceiling timer and releases
+// + awaits the child, even if body throws.
+async function withLiveHolder(lockFile, body) {
+  const child = spawnLiveHolder(lockFile)
+  let ceiling = null
+  try {
+    const buf = await Promise.race([
+      waitForMarker(child, '"held":true', 5000),
+      new Promise((resolve) => { ceiling = setTimeout(() => resolve(''), 5000) }),
+    ])
+    if (ceiling) { clearTimeout(ceiling); ceiling = null }
+    if (!/"held":true/.test(buf)) {
+      const stderr = child.stderr ? (child.stderr.read ? child.stderr.read() : '') : ''
+      throw new Error(`holder did not acquire ${lockFile}; stdout=${buf}; stderr=${stderr}`)
+    }
+    const m = buf.match(/"pid":\s*(\d+)/)
+    if (!m) throw new Error(`holder output missing pid: ${buf}`)
+    const childPid = parseInt(m[1], 10)
+    return await body({ child, childPid, buf })
+  } finally {
+    // F7: clear any still-pending readiness-ceiling timer and release/
+    // await the holder child even when body threw.
+    if (ceiling) { clearTimeout(ceiling); ceiling = null }
+    if (child.exitCode === null && child.signalCode === null) {
+      releaseChild(child)
+      await awaitChild(child)
+    }
+  }
+}
+
+// --- helper dynamic loader (allows --expect-main-red before helper exists) ---
+async function tryLoadHelper() {
+  try {
+    return await import(HELPER_URL)
+  } catch (e) {
+    if (e.code === 'ERR_MODULE_NOT_FOUND' || /Cannot find module/.test(e.message)) return null
+    throw e
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper-only unit tests (Slice 546-S1)
+// ---------------------------------------------------------------------------
+async function runHelperTests() {
+  console.log('# store-write-lock.mjs unit tests')
+  const helper = await tryLoadHelper()
+  if (!helper) {
+    console.log(`not ok 1 - helper missing (scripts/lib/store-write-lock.mjs)\n  Run from a tree where the helper has been created.`)
+    fail++
+    return
+  }
+
+  // --- F1: required public API surface. Every name below is required.
+  tap('helper: F1 public API exports the six required names', () => {
+    for (const name of [
+      'STORE_WRITE_LOCK_BASENAME',
+      'storeWriteLockPath',
+      'acquireStoreWriteLocksSync',
+      'releaseStoreWriteLocks',
+      'uniqueStoreTmpPath',
+      'atomicReplaceFileSync',
+    ]) {
+      assert.notEqual(helper[name], undefined,
+        `helper.${name} must be exported (got ${typeof helper[name]})`)
+    }
+    // STORE_WRITE_LOCK_BASENAME is a string; the rest are functions.
+    assert.equal(typeof helper.STORE_WRITE_LOCK_BASENAME, 'string',
+      `helper.STORE_WRITE_LOCK_BASENAME must be a string`)
+    assert.equal(helper.STORE_WRITE_LOCK_BASENAME, 'clerk-apply.lock',
+      `helper.STORE_WRITE_LOCK_BASENAME must equal 'clerk-apply.lock'`)
+    for (const name of [
+      'storeWriteLockPath',
+      'acquireStoreWriteLocksSync',
+      'releaseStoreWriteLocks',
+      'uniqueStoreTmpPath',
+      'atomicReplaceFileSync',
+    ]) {
+      assert.equal(typeof helper[name], 'function',
+        `helper.${name} must be a function`)
+    }
+  })
+
+  tap('helper: storeWriteLockPath — pure path.join, no FS access, never-created path remains absent', () => {
+    // The dir passed in has NEVER existed (we did NOT call mkTmp for it).
+    // storeWriteLockPath is pure path.join — it must NOT create the dir,
+    // and the dir must remain absent on disk after the call.
+    const phantom = path.join(
+      os.tmpdir(),
+      'store-write-lock-path-phantom-' + Date.now() + '-' + Math.random().toString(36).slice(2),
+    )
+    assert.equal(fs.existsSync(phantom), false, 'phantom must not exist pre-call')
+    const lockPath = helper.storeWriteLockPath(phantom)
+    assert.equal(lockPath, path.join(phantom, helper.STORE_WRITE_LOCK_BASENAME))
+    assert.equal(path.basename(lockPath), helper.STORE_WRITE_LOCK_BASENAME)
+    assert.equal(fs.existsSync(phantom), false, 'storeWriteLockPath must not create the phantom dir')
+    assert.equal(fs.existsSync(lockPath), false, 'lockfile must not exist after pure path computation')
+    // Type validation: rejects empty / non-string inputs.
+    assert.throws(() => helper.storeWriteLockPath(''), /non-empty string/)
+    assert.throws(() => helper.storeWriteLockPath(null), /non-empty string/)
+    assert.throws(() => helper.storeWriteLockPath(42), /non-empty string/)
+  })
+
+  // --- F2 type validation: rejects empty / non-string path before filesystem
+  tap('helper: invalid input — non-string / empty / non-array rejects (no FS touch)', () => {
+    assert.throws(() => helper.acquireStoreWriteLocksSync(null), /non-empty string/)
+    assert.throws(() => helper.acquireStoreWriteLocksSync(''), /non-empty string/)
+    assert.throws(() => helper.acquireStoreWriteLocksSync(42), /non-empty string/)
+    assert.throws(() => helper.acquireStoreWriteLocksSync([], {}), /at least one/)
+  })
+
+  // --- testHelperAcquireRelease: basic acquire + release path
+  tap('helper: acquire + release — owned handle returns ok; release clears lockfile', () => {
+    const dir = mkTmp('store-write-lock-h1-')
+    const res = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(res.ok, true, `expected ok; got ${JSON.stringify(res)}`)
+    assert.equal(res.dirs.length, 1)
+    assert.equal(path.dirname(res.handles[0].lockFile), dir)
+    assert.equal(res.handles[0].inherited, false)
+    assert.ok(fs.existsSync(res.handles[0].lockFile), 'lockfile present while held')
+    helper.releaseStoreWriteLocks(res.handles)
+    assert.equal(fs.existsSync(res.handles[0].lockFile), false, 'lockfile removed after release')
+  })
+
+  // --- testSameProcessInheritance: same-process inheritance
+  tap('helper: same-process inheritance — re-acquire when caller pid is the live heldBy returns inherited', () => {
+    const dir = mkTmp('store-write-lock-spi-')
+    const first = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(first.ok, true)
+    const second = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(second.ok, true)
+    assert.equal(second.handles[0].inherited, true)
+    assert.equal(second.handles[0].pid, process.pid)
+    helper.releaseStoreWriteLocks(second.handles)
+    assert.ok(fs.existsSync(first.handles[0].lockFile), 'original lockfile preserved after inherited release')
+    helper.releaseStoreWriteLocks(first.handles)
+    assert.equal(fs.existsSync(first.handles[0].lockFile), false)
+  })
+
+  // --- F5: real direct-child test. Parent acquires, spawnSync child which
+  //     imports the helper and acquires the SAME store. The child MUST
+  //     report inherited=true (its process.ppid === our process.pid).
+  //     The child's release is a no-op for the inherited handle. The
+  //     parent lockfile MUST survive the child's exit.
+  tap('helper: F5 direct-child — parent acquires; spawnSync child inherits and no-op releases; parent lock survives', () => {
+    const dir = mkTmp('store-write-lock-dchild-')
+    const parent = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(parent.ok, true)
+    assert.equal(parent.handles[0].inherited, false)
+    const parentLockFile = parent.handles[0].lockFile
+    const parentPid = process.pid
+
+    // The child's process.ppid equals our process.pid. The helper's
+    // heldBy === process.ppid check fires and the child returns an
+    // inherited handle. Child's release is a no-op because inherited=true.
+    const childScript = `
+      const helper = await import(${JSON.stringify(HELPER_URL)})
+      const dir = process.env.EM_DIR
+      const res = helper.acquireStoreWriteLocksSync([dir])
+      const h0 = res && res.handles && res.handles[0]
+      helper.releaseStoreWriteLocks(res && res.handles)
+      process.stdout.write(JSON.stringify({
+        ok: !!(res && res.ok),
+        inherited: !!(h0 && h0.inherited),
+        pid: h0 ? h0.pid : null,
+        expectedPpid: process.ppid,
+      }))
+    `
+    const r = spawnSync(process.execPath, ['--input-type=module', '-e', childScript], {
+      env: { ...process.env, EM_DIR: dir },
+      encoding: 'utf8',
+    })
+    assert.equal(r.status, 0, `child must exit 0; got status=${r.status}; stderr=${r.stderr || ''}`)
+    const trimmed = (r.stdout || '').trim()
+    assert.ok(trimmed.length > 0, `child stdout must contain JSON; got '${r.stdout}'`)
+    const childRes = JSON.parse(trimmed)
+    assert.equal(childRes.ok, true, `child acquire must succeed; stdout='${r.stdout}'; stderr='${r.stderr || ''}'`)
+    assert.equal(childRes.inherited, true,
+      `child must report inherited=true (ppid=${childRes.expectedPpid} === parent=${parentPid}); got '${r.stdout}'`)
+    assert.equal(childRes.pid, parentPid,
+      `child's inherited pid must equal parent pid ${parentPid}; got '${r.stdout}'`)
+
+    // Parent's lockfile survives the child's no-op inherited release.
+    assert.ok(fs.existsSync(parentLockFile),
+      'parent lockfile must survive the inherited-release from the child')
+    helper.releaseStoreWriteLocks(parent.handles)
+    assert.equal(fs.existsSync(parentLockFile), false,
+      'parent lockfile removed after parent release')
+  })
+
+  // --- testMalformedLockTimesOut: heldBy=null OR garbage owner times out
+  tap('helper: malformed lock (heldBy=null) — times out with code store-write-lock-timeout', () => {
+    const dir = mkTmp('store-write-lock-mal-')
+    const lockFile = helper.storeWriteLockPath(dir)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(lockFile, `not-a-pid\n${new Date().toISOString()}\n0\n`)
+    const res = helper.acquireStoreWriteLocksSync([dir], { timeoutMs: 200, pollMs: 25 })
+    assert.equal(res.ok, false)
+    assert.equal(res.code, 'store-write-lock-timeout')
+    assert.equal(res.heldBy, null)
+    fs.unlinkSync(lockFile)
+  })
+
+  tap('helper: malformed lock (alive non-parent pid) — times out, no inheritance', () => {
+    const dir = mkTmp('store-write-lock-mal2-')
+    const lockFile = helper.storeWriteLockPath(dir)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(lockFile, `0\n${new Date().toISOString()}\n0\n`)
+    const res = helper.acquireStoreWriteLocksSync([dir], { timeoutMs: 150, pollMs: 25 })
+    assert.equal(res.ok, false)
+    assert.equal(res.code, 'store-write-lock-timeout')
+    assert.equal(res.heldBy, null)
+    fs.unlinkSync(lockFile)
+  })
+
+  // --- testMultiStoreOrder: ordered acquisition + reverse release.
+  //     F3 ordered handles array: dirs are listed in the order returned
+  //     by canonicalizeAndSort (lexical-sorted, deduped canonical).
+  tap('helper: multi-store order — canonicalize, dedupe, lexical acquisition; reverse release', () => {
+    const base = mkTmp('store-write-lock-multi-')
+    const b = path.join(base, 'b')
+    const a = path.join(base, 'a')
+    const c = path.join(base, 'c')
+    fs.mkdirSync(b); fs.mkdirSync(a); fs.mkdirSync(c)
+    const res = helper.acquireStoreWriteLocksSync([c, a, b, a])
+    assert.equal(res.ok, true)
+    assert.deepEqual(res.dirs, [a, b, c],
+      `dirs should be lexically-sorted unique canonicalized; got ${JSON.stringify(res.dirs)}`)
+    // F3: handles array preserves acquisition order. With no inheritance
+    // every handle is owned; reverse-release removes them c, b, a.
+    assert.equal(res.handles.length, 3)
+    for (let i = 0; i < res.handles.length; i++) {
+      assert.equal(res.handles[i].inherited, false)
+    }
+    for (const d of [a, b, c]) {
+      assert.ok(fs.existsSync(helper.storeWriteLockPath(d)),
+        `lockfile for ${d} should exist while held`)
+    }
+    helper.releaseStoreWriteLocks(res.handles)
+    for (const d of [a, b, c]) {
+      assert.equal(fs.existsSync(helper.storeWriteLockPath(d)), false,
+        `lockfile for ${d} should be removed after release`)
+    }
+  })
+
+  // --- testSymlinkAliasDedup: two spellings of one canonical directory.
+  tap('helper: symlink alias dedup — two paths to one existing store produce one lock', () => {
+    const base = mkTmp('store-write-lock-sym-')
+    const target = path.join(base, 'canonical')
+    const link = path.join(base, 'alias')
+    fs.mkdirSync(target)
+    try { fs.symlinkSync(target, link) } catch (e) {
+      console.log(`  # SKIP symlink not permitted: ${e.message}`)
+      return
+    }
+    const res = helper.acquireStoreWriteLocksSync([target, link])
+    assert.equal(res.ok, true)
+    assert.equal(res.dirs.length, 1, `expected 1 canonical dir; got ${res.dirs.length}: ${res.dirs.join(',')}`)
+    helper.releaseStoreWriteLocks(res.handles)
+    assert.equal(fs.existsSync(helper.storeWriteLockPath(target)), false)
+  })
+
+  // --- F2 NEW: symlinked-parent dedupe — a missing store reached through
+  //     a symlinked parent dedupes with its real parent spelling. After
+  //     the F2 redesign (validate → mkdir → realpath → dedupe → sort),
+  //     mkdirSync creates the once-missing entry, both realpaths land on
+  //     the same canonical path, and the helper owns ONE lock.
+  tap('helper: F2 symlinked-parent dedupe — missing store through symlinked parent dedupes with real parent spelling', () => {
+    const base = mkTmp('store-write-lock-symparent-')
+    const aliasHolder = mkTmp('store-write-lock-symparent-alias-')
+    const aliasParent = path.join(aliasHolder, 'alias-parent')
+    try {
+      fs.symlinkSync(base, aliasParent)
+    } catch (e) {
+      console.log(`  # SKIP symlink not permitted: ${e.message}`)
+      return
+    }
+    const realSpelling = path.join(base, 'real-store')
+    const symSpelling = path.join(aliasParent, 'real-store')
+    // Sanity: neither the real dir nor the symlinked alias exists yet.
+    assert.equal(fs.existsSync(realSpelling), false, 'real spelling must not exist pre-call')
+    assert.equal(fs.existsSync(symSpelling), false, 'sym spelling must not exist pre-call')
+
+    const res = helper.acquireStoreWriteLocksSync([realSpelling, symSpelling])
+    assert.equal(res.ok, true, `expected ok; got ${JSON.stringify(res)}`)
+    assert.equal(res.dirs.length, 1,
+      `expected ONE canonical dir (symlinked-parent dedupe); got ${res.dirs.length}: ${JSON.stringify(res.dirs)}`)
+    // The single canonical dir is the realpath of base/real-store — i.e.,
+    // the real (non-symlinked) spelling. Both inputs collapse to it.
+    assert.equal(res.dirs[0], fs.realpathSync(base) + path.sep + 'real-store')
+    // One lockfile exists, owned.
+    assert.equal(res.handles.length, 1)
+    assert.equal(fs.existsSync(res.handles[0].lockFile), true)
+    helper.releaseStoreWriteLocks(res.handles)
+    assert.equal(fs.existsSync(res.handles[0].lockFile), false)
+  })
+
+  // --- testPartialAcquireCleanup: failure on second store releases the first
+  //     using a REAL live foreign holder on canonical store B (not malformed
+  //     PID 0). The helper acquires A, times out on B, releases A, and
+  //     preserves B until the child is told to release.
+  await asyncTap('helper: partial acquire cleanup — live foreign holder on B; A released; B preserved until child releases', async () => {
+    const base = mkTmp('store-write-lock-partial-')
+    const a = path.join(base, 'a')
+    const b = path.join(base, 'b')
+    fs.mkdirSync(a); fs.mkdirSync(b)
+    const bLock = helper.storeWriteLockPath(b)
+    await withLiveHolder(bLock, async ({ child, childPid }) => {
+      const res = helper.acquireStoreWriteLocksSync([a, b], { timeoutMs: 200, pollMs: 25 })
+      assert.equal(res.ok, false, 'helper must time out while child holds B')
+      assert.equal(res.code, 'store-write-lock-timeout')
+      assert.equal(res.heldBy, childPid, `heldBy must equal child PID ${childPid}; got ${res.heldBy}`)
+      // F3: the FIRST acquired (owned) lock on store A MUST be released even
+      // though the second acquire failed. The B lock is the child's, not ours,
+      // so it remains in place until the child is told to release.
+      assert.equal(fs.existsSync(helper.storeWriteLockPath(a)), false,
+        'first acquired lockfile must be released on second-acquire timeout')
+      assert.ok(fs.existsSync(bLock),
+        'live foreign holder lockfile must be preserved while child still owns it')
+    })
+    // After withLiveHolder's finally released the child, B's lockfile is gone.
+    assert.equal(fs.existsSync(bLock), false, 'B lockfile removed after child released')
+  })
+
+  // --- F4 NEW: foreign positive live PID — helper returns heldBy equal to
+  //     the child's PID and leaves the holder lock untouched until release.
+  await asyncTap('helper: foreign positive live PID — times out with heldBy equal to child PID; holder lock untouched until release', async () => {
+    const dir = mkTmp('store-write-lock-foreign-')
+    const lockFile = helper.storeWriteLockPath(dir)
+    await withLiveHolder(lockFile, async ({ childPid }) => {
+      const res = helper.acquireStoreWriteLocksSync([dir], { timeoutMs: 200, pollMs: 25 })
+      assert.equal(res.ok, false, 'helper must time out while foreign child holds the lock')
+      assert.equal(res.code, 'store-write-lock-timeout')
+      assert.equal(res.heldBy, childPid,
+        `heldBy must equal child PID ${childPid}; got ${res.heldBy}`)
+      assert.ok(fs.existsSync(lockFile),
+        'holder lockfile must remain untouched while child holds it')
+    })
+    assert.equal(fs.existsSync(lockFile), false,
+      'holder lockfile removed after child released')
+  })
+
+  // --- F6 NEW: mixed-order nested acquire. Parent owns A. Nested acquire
+  //     of [A, B] must return handles in canonical order [A inherited, B
+  //     owned]. Releasing the nested handles removes only B's owned
+  //     handle; A's inherited handle is skipped so the outer A lock
+  //     survives. Releasing the outer handles then removes A.
+  tap('helper: mixed-order nested — parent owns A; nested [A,B] returns [A inherited, B owned]; release nested keeps A', () => {
+    const base = mkTmp('store-write-lock-mixed-')
+    const a = path.join(base, 'a')
+    const b = path.join(base, 'b')
+    fs.mkdirSync(a); fs.mkdirSync(b)
+    const aLock = helper.storeWriteLockPath(a)
+    const bLock = helper.storeWriteLockPath(b)
+    // Outer: acquire A only.
+    const outer = helper.acquireStoreWriteLocksSync([a])
+    assert.equal(outer.ok, true)
+    assert.equal(outer.handles.length, 1)
+    assert.equal(outer.handles[0].inherited, false)
+    assert.equal(outer.handles[0].pid, process.pid)
+    assert.ok(fs.existsSync(aLock), 'A lockfile present while outer holds it')
+
+    // Nested: [A, B]. A is held by the parent (pid match → inherited).
+    // B is a new canonical store → owned.
+    const nested = helper.acquireStoreWriteLocksSync([a, b])
+    assert.equal(nested.ok, true)
+    assert.equal(nested.handles.length, 2)
+    // Canonical order is lexical: 'a' < 'b'.
+    assert.equal(nested.handles[0].lockFile, aLock)
+    assert.equal(nested.handles[0].inherited, true,
+      'A must be inherited — parent already holds it')
+    assert.equal(nested.handles[0].pid, process.pid,
+      'A inherited pid must equal the parent pid (process.pid)')
+    assert.equal(nested.handles[1].lockFile, bLock)
+    assert.equal(nested.handles[1].inherited, false,
+      'B must be owned — no one else holds it')
+    assert.equal(nested.handles[1].pid, process.pid)
+    assert.ok(fs.existsSync(bLock), 'B lockfile present while nested holds it')
+
+    // Release nested: only the OWNED B handle is released. A's inherited
+    // handle is skipped, so the outer A lockfile survives.
+    helper.releaseStoreWriteLocks(nested.handles)
+    assert.equal(fs.existsSync(bLock), false,
+      'B lockfile removed after releasing nested (owned)')
+    assert.ok(fs.existsSync(aLock),
+      'A lockfile preserved because nested handle was inherited (no release)')
+
+    // Release outer: A's owned handle is released.
+    helper.releaseStoreWriteLocks(outer.handles)
+    assert.equal(fs.existsSync(aLock), false, 'A lockfile removed after releasing outer')
+  })
+
+  // --- testUniqueTmpPaths: tmp paths are unique per call (F1: rename).
+  tap('helper: unique tmp paths — same finalPath produces different tmp paths across calls', () => {
+    const finalPath = path.join(mkTmp('store-write-lock-uniq-'), 'index.json')
+    const seen = new Set()
+    for (let i = 0; i < 25; i++) seen.add(helper.uniqueStoreTmpPath(finalPath))
+    assert.equal(seen.size, 25, 'each call must yield a distinct tmp path')
+    for (const p of seen) assert.equal(path.dirname(p), path.dirname(finalPath))
+    // Required public name: rejects empty finalPath.
+    assert.throws(() => helper.uniqueStoreTmpPath(''), /non-empty string/)
+  })
+
+  // --- testAtomicReplace: success path replaces final + cleans tmp
+  tap('helper: atomic replace — writes final, no tmp left', () => {
+    const dir = mkTmp('store-write-lock-atomic-ok-')
+    const finalPath = path.join(dir, 'index.json')
+    helper.atomicReplaceFileSync(finalPath, '{"ok":1}\n')
+    assert.ok(fs.existsSync(finalPath))
+    const text = fs.readFileSync(finalPath, 'utf8')
+    assert.equal(text, '{"ok":1}\n')
+    const tmps = fs.readdirSync(dir).filter(f => /\.tmp\./.test(f))
+    assert.equal(tmps.length, 0, `tmp litter: ${tmps.join(',')}`)
+  })
+
+  // --- testAtomicReplaceCleanup: failure before rename cleans own tmp,
+  //     prior final file survives. F4's full-write loop surfaces partial
+  //     failures here just as well.
+  tap('helper: atomic replace failure — own tmp cleaned, prior final preserved', () => {
+    const dir = mkTmp('store-write-lock-atomic-fail-')
+    const finalPath = path.join(dir, 'tags.json')
+    fs.writeFileSync(finalPath, '{"prior":"keep"}\n')
+    const origFsync = fs.fsyncSync
+    fs.fsyncSync = function patchedFsync() {
+      throw new Error('injected fsync failure')
+    }
+    try {
+      let threw = false
+      try { helper.atomicReplaceFileSync(finalPath, '{"new":"data"}') }
+      catch (e) { threw = true }
+      assert.ok(threw, 'helper must propagate the failure')
+      assert.equal(fs.readFileSync(finalPath, 'utf8'), '{"prior":"keep"}\n',
+        'pre-existing final file must survive a failed replace')
+      const tmps = fs.readdirSync(dir).filter(f => /\.tmp\./.test(f))
+      assert.equal(tmps.length, 0, `tmp litter after failure: ${tmps.join(',')}`)
+    } finally {
+      fs.fsyncSync = origFsync
+    }
+  })
+
+  // --- F4 NEW: cross-directory tmpPath rejection. The check happens
+  //     BEFORE any open/write, so neither tmpPath nor finalPath is
+  //     created; both dirs are unchanged.
+  tap('helper: F4 atomic replace cross-dir tmpPath — rejects before opening, no files changed', () => {
+    const dirA = mkTmp('store-write-lock-xdir-a-')
+    const dirB = mkTmp('store-write-lock-xdir-b-')
+    const finalPath = path.join(dirA, 'final.json')
+    const crossTmp = path.join(dirB, 'final.json.tmp.x')
+    let threw = false
+    let caughtErr = null
+    try {
+      helper.atomicReplaceFileSync(finalPath, '{"x":1}', { tmpPath: crossTmp })
+    } catch (e) { threw = true; caughtErr = e }
+    assert.ok(threw, 'cross-directory tmpPath must throw')
+    assert.match((caughtErr && caughtErr.message) || String(caughtErr), /same directory/i,
+      'error must call out the directory invariant')
+    // No tmp file ever materialized in either directory; finalPath was
+    // never created either. Both dirs are unchanged.
+    assert.equal(fs.existsSync(crossTmp), false, 'cross-dir tmpPath must not be created')
+    assert.equal(fs.existsSync(finalPath), false, 'finalPath must not be created on rejection')
+    // Empty/non-string tmpPath is its own TypeError.
+    assert.throws(() => helper.atomicReplaceFileSync(finalPath, 'x', { tmpPath: '' }), /non-empty string/)
+    assert.throws(() => helper.atomicReplaceFileSync(finalPath, 'x', { tmpPath: 99 }), /non-empty string/)
+  })
+
+  // --- testDeterministicEexistPreserves: pre-existing tmpPath → EEXIST
+  //     propagates WITHOUT deleting the collision or the final file.
+  tap('helper: deterministic EEXIST — pre-existing tmpPath raises, preserves both files', () => {
+    const dir = mkTmp('store-write-lock-eexist-')
+    const finalPath = path.join(dir, 'category-index.json')
+    fs.writeFileSync(finalPath, '{"prior":"keep"}')
+    const collision = path.join(dir, 'collision.tmp')
+    fs.writeFileSync(collision, '{"collider":"keep"}')
+    let threw = false
+    let caughtErr = null
+    try {
+      helper.atomicReplaceFileSync(finalPath, '{"new":"data"}', { tmpPath: collision })
+    } catch (e) { threw = true; caughtErr = e }
+    assert.ok(threw, 'EEXIST must propagate')
+    assert.match(caughtErr.message || String(caughtErr), /EEXIST|exists/i)
+    assert.equal(fs.readFileSync(finalPath, 'utf8'), '{"prior":"keep"}')
+    assert.equal(fs.readFileSync(collision, 'utf8'), '{"collider":"keep"}')
+  })
+
+  // --- testNoTmpLitter: full helper cycle leaves no tmp litter
+  tap('helper: no tmp litter across a full lifecycle', () => {
+    const dir = mkTmp('store-write-lock-nolitter-')
+    const res = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(res.ok, true)
+    const finals = ['index.json', 'tags.json', 'category-index.json', 'tokens.json', 'x.json']
+    for (const name of finals) {
+      helper.atomicReplaceFileSync(path.join(dir, name), `{"name":"${name}"}`)
+    }
+    helper.releaseStoreWriteLocks(res.handles)
+    const litter = fs.readdirSync(dir).filter(f => /\.tmp\./.test(f))
+    assert.equal(litter.length, 0, `tmp litter in lifecycle: ${litter.join(',')}`)
+  })
+
+  // --- testIndependentStoresProceed
+  tap('helper: independent stores proceed in parallel (acquire A does not block acquire B)', () => {
+    const base = mkTmp('store-write-lock-indep-')
+    const a = path.join(base, 'A'); const b = path.join(base, 'B')
+    fs.mkdirSync(a); fs.mkdirSync(b)
+    const ra = helper.acquireStoreWriteLocksSync([a])
+    assert.equal(ra.ok, true)
+    const rb = helper.acquireStoreWriteLocksSync([b])
+    assert.equal(rb.ok, true, 'store B must proceed while store A is held')
+    helper.releaseStoreWriteLocks(ra.handles)
+    helper.releaseStoreWriteLocks(rb.handles)
+  })
+
+  // --- testReleaseIdempotent
+  tap('helper: releaseStoreWriteLocks is idempotent — repeated calls are no-ops', () => {
+    const dir = mkTmp('store-write-lock-idem-')
+    const res = helper.acquireStoreWriteLocksSync([dir])
+    assert.equal(res.ok, true)
+    helper.releaseStoreWriteLocks(res.handles)
+    helper.releaseStoreWriteLocks(res.handles)
+    assert.equal(fs.existsSync(res.handles[0].lockFile), false)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: external live holder against real `em-store`
+// ---------------------------------------------------------------------------
+//
+// External-holder protocol (parallelize the §15 negative-control artifact):
+//   - holder acquires the lock, then WAITS for a "release" message on its
+//     stdin. The PARENT owns the release timing (no fixed holdMs).
+//   - parent spawns holder, confirms "{held:true}", then spawns the writer
+//     and races writer.exit against a bounded 3-second window.
+//   - writerExitedBeforeRelease is the actual race outcome:
+//       * true  → writer exited before the 3s window expired. Current-main
+//                 observable: writer raced past the held lock.
+//       * false → window expired first; the writer is still alive waiting
+//                 for the lock. Post-fix observable.
+//   - parent sends "release\n" to the holder's stdin AFTER the race, then
+//     awaits both children cleanly.
+//   - The §15 assertion requires writerExitedBeforeRelease === false. On
+//     current main this fails (exit non-zero) and prints
+//     writerExitedBeforeRelease=true. After the fix it passes.
+async function runExternalHolderTest() {
+  console.log('# external live holder vs real em-store')
+  const fixture = mkTmp('store-write-e2e-')
+  const storeCwd = path.join(fixture, 'store-cwd')
+  fs.mkdirSync(storeCwd, { recursive: true })
+  const storeDir = path.join(storeCwd, '.episodic-memory')
+  fs.mkdirSync(storeDir, { recursive: true })
+  const lockFile = path.join(storeDir, 'clerk-apply.lock')
+  const env = { ...process.env, HOME: fixture }
+
+  const holderScript = `
+    import fs from 'node:fs'
+    import path from 'node:path'
+    const lockFile = ${JSON.stringify(lockFile)}
+    fs.mkdirSync(path.dirname(lockFile), { recursive: true })
+    let fd
+    try {
+      fd = fs.openSync(lockFile, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o644)
+    } catch (e) {
+      process.stdout.write(JSON.stringify({ held: false, code: 'eexist', err: String(e) }))
+      process.exit(0)
+    }
+    const pid = process.pid
+    const ppid = process.ppid
+    const iso = new Date().toISOString()
+    fs.writeSync(fd, pid + '\\n' + iso + '\\n' + ppid + '\\n')
+    fs.closeSync(fd)
+    process.stdout.write(JSON.stringify({ held: true, pid, lockFile }))
+    process.stdin.setEncoding('utf8')
+    let buf = ''
+    process.stdin.on('data', (chunk) => {
+      buf += chunk
+      if (buf.includes('release')) {
+        try { fs.unlinkSync(lockFile) } catch {}
+        process.stdout.write(JSON.stringify({ released: true }))
+        process.exit(0)
+      }
+    })
+    process.stdin.on('end', () => { try { fs.unlinkSync(lockFile) } catch {}; process.exit(0) })
+    // Safety ceiling: the parent owns the release decision, but if the
+    // parent dies we exit and unlink so the lockfile is not orphaned.
+    setTimeout(() => { try { fs.unlinkSync(lockFile) } catch {}; process.exit(2) }, 15_000)
+  `
+  const holder = spawn(process.execPath, ['--input-type=module', '-e', holderScript], {
+    env, stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  liveChildren.add(holder)
+  holder.once('exit', () => liveChildren.delete(holder))
+  // Wait for holder to confirm acquisition before spawning the writer.
+  const holderBuf = await waitForMarker(holder, '"held":true', 5000)
+  if (!/"held":true/.test(holderBuf)) {
+    throw new Error(
+      `holder did not acquire clerk-apply.lock; stdout=${holderBuf}; ` +
+      `stderr=${holder.stderr.read() || ''}`,
+    )
+  }
+
+  const writerStart = Date.now()
+  const writer = spawn(process.execPath, [
+    STORE,
+    '--project', 'issue-546',
+    '--category', 'decision',
+    '--tags', 'issue-546-fixture',
+    '--summary', 'concurrency fixture',
+    '--body', 'body',
+    '--scope', 'local',
+  ], { cwd: storeCwd, env, stdio: ['ignore', 'pipe', 'pipe'] })
+  commandChildren.add(writer)
+  writer.once('exit', () => commandChildren.delete(writer))
+  let writerErr = ''
+  writer.stderr.on('data', (d) => writerErr += d.toString())
+
+  // Bounded 3-second window: the parent owns whether the writer raced
+  // past the held lock (current main) or actually waited for it (fix).
+  const WINDOW_MS = 3000
+  const exitPromise = new Promise((resolve) => {
+    writer.once('exit', (code) => resolve({ kind: 'exit', code }))
+  })
+  const windowPromise = new Promise((resolve) => {
+    setTimeout(() => resolve({ kind: 'window' }), WINDOW_MS)
+  })
+  const winner = await Promise.race([exitPromise, windowPromise])
+  const writerExitedBeforeRelease = winner.kind === 'exit'
+  console.log(`writerExitedBeforeRelease=${writerExitedBeforeRelease}`)
+
+  // Send release; the holder's stdin parser unlinks the lockfile.
+  try { holder.stdin.write('release\n') } catch {}
+  try { holder.stdin.end() } catch {}
+
+  // Await both children. `exitPromise` is a single listener; if writer
+  // exited during the race it has already resolved, else it resolves now.
+  const finalWriterCode = (await exitPromise).code
+  const writerExitAt = Date.now() - writerStart
+  await waitForExit(holder)
+
+  tap(EXPECT_MAIN_RED
+    ? 'E2E (--expect-main-red): writer must WAIT for live external holder (issue 546 fix)'
+    : 'E2E: writer must WAIT for live external holder (issue 546 fix)', () => {
+    assert.equal(writerExitedBeforeRelease, false,
+      `writerExitedBeforeRelease must be false (writer waited for the holder); got ${writerExitedBeforeRelease} (exit=${finalWriterCode}, ms=${writerExitAt}, stderr=${writerErr}). On current main this proves the bug: writer raced past the live lock.`)
+    assert.equal(finalWriterCode, 0,
+      `writer must exit 0 after fix; got ${finalWriterCode}; stderr=${writerErr}`)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Slice 546-S2a integration coverage: real store/revise processes only,
+// always against mkTmp fixture stores with explicit cwd and isolated HOME.
+// ---------------------------------------------------------------------------
+function storeArgs(i, scope = 'local') {
+  return [
+    '--project', 'issue-546-fixture',
+    '--category', 'decision',
+    '--tag', `writer-${i}-sentinel`,
+    '--summary', `concurrent writer ${i}`,
+    '--body', `unique body uniquetoken${i}`,
+    '--scope', scope,
+  ]
+}
+
+function seedLocalOriginal(fixture, suffix) {
+  const r = runJsonSync(STORE, [
+    '--project', 'issue-546-fixture',
+    '--category', 'decision',
+    '--tag', `original-${suffix}`,
+    '--summary', `original ${suffix}`,
+    '--body', `original body originaltoken${suffix}`,
+    '--scope', 'local',
+  ], fixture)
+  assert.equal(r.code, 0, `seed store failed: stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.equal(r.json?.status, 'ok', `seed store returned invalid JSON: ${r.stdout}`)
+  return r.json
+}
+
+async function testConcurrentStoreParity() {
+  const fixture = mkStoreFixture('store-write-concurrent-')
+  const completions = []
+  const children = []
+  const started = Date.now()
+  try {
+    for (let i = 0; i < 16; i++) {
+      const completion = spawnJson(STORE, storeArgs(i), fixture)
+      completions.push(completion)
+      children.push(completion.child)
+    }
+    const results = await Promise.all(completions)
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]
+      assert.equal(r.code, 0, `store ${i} failed: stdout=${r.stdout} stderr=${r.stderr}`)
+      assert.equal(r.json?.status, 'ok', `store ${i} returned invalid JSON: ${r.stdout}`)
+    }
+
+    const ids = results.map(r => r.json.id)
+    assert.equal(new Set(ids).size, 16, 'all concurrent stores must return unique ids')
+    assertIds(episodeIds(fixture.localDir), ids, 'episode files and successful ids diverged')
+    const rows = readIndexRows(fixture.localDir)
+    assert.equal(rows.length, 16, 'index must contain exactly 16 rows')
+    assertIds(rows.map(row => row.id), ids, 'index rows and episode files diverged')
+    assert.ok(rows.every(row => row.category === 'decision' && row.status === 'active'),
+      'all concurrent rows must be active decisions')
+
+    const tags = readJson(fixture.localDir, 'tags.json')
+    const categories = readJson(fixture.localDir, 'category-index.json')
+    const tokens = readJson(fixture.localDir, 'tokens.json')
+    assertPosting(categories, 'decision', ids, 'category parity')
+    for (let i = 0; i < 16; i++) {
+      assertPosting(tags, `writer-${i}-sentinel`, [results[i].json.id], `tag parity writer ${i}`)
+      assertPosting(tokens, `uniquetoken${i}`, [results[i].json.id], `token parity writer ${i}`)
+    }
+    const litter = tmpLitter(fixture.localDir)
+    assert.deepEqual(litter, [], `temporary-file litter: ${litter.join(', ')}`)
+    assert.equal(fs.existsSync(path.join(fixture.localDir, 'clerk-apply.lock')), false,
+      'store lock must be released after all writers')
+    telemetry.concurrentStoreParity = {
+      writers: 16,
+      elapsedMs: Date.now() - started,
+      episodes: episodeIds(fixture.localDir).length,
+      indexRows: rows.length,
+      categoryIds: categories.decision.length,
+      tmpLitter: litter.length,
+    }
+  } finally {
+    await stopChildren(children)
+  }
+}
+
+async function testStoreTimeoutNoWrite() {
+  const fixture = mkStoreFixture('store-write-timeout-')
+  fs.mkdirSync(fixture.localDir, { recursive: true })
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  await withLiveHolder(lockFile, async ({ childPid }) => {
+    const before = byteSnapshot(fixture.localDir)
+    const r = runJsonSync(STORE, storeArgs('timeout'), fixture, {
+      EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '200',
+    })
+    const after = byteSnapshot(fixture.localDir)
+    assert.notEqual(r.code, 0, 'store must fail while a foreign live holder owns the lock')
+    assert.equal(r.json?.status, 'error', `store timeout JSON missing: ${r.stdout}`)
+    assert.equal(r.json?.code, 'store-write-lock-timeout', `wrong timeout code: ${r.stdout}`)
+    assert.equal(r.json?.heldBy, childPid, 'timeout must report the live holder pid')
+    assert.deepEqual(after, before, 'store timeout changed fixture bytes before returning')
+    assert.deepEqual(tmpLitter(fixture.localDir), [], 'store timeout left temporary litter')
+    telemetry.storeTimeoutNoWrite = {
+      elapsedMs: r.elapsedMs,
+      exitCode: r.code,
+      heldByMatched: r.json?.heldBy === childPid,
+      unchanged: true,
+    }
+  })
+}
+
+async function testCrossStoreReviseParity() {
+  const fixture = mkStoreFixture('store-write-cross-revise-')
+  const original = seedLocalOriginal(fixture, 'cross')
+  const r = runJsonSync(REVISE, [
+    '--original', original.id,
+    '--project', 'issue-546-fixture',
+    '--tag', 'cross-new',
+    '--summary', 'cross scope successor',
+    '--body', 'cross scope body crossrevisiontoken',
+    '--scope', 'global',
+  ], fixture)
+  assert.equal(r.code, 0, `cross-store revise failed: stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.equal(r.json?.status, 'ok', `cross-store revise returned invalid JSON: ${r.stdout}`)
+  assert.equal(r.json?.scope, 'global')
+  const successor = r.json.id
+
+  assertIds(episodeIds(fixture.localDir), [original.id], 'source episode set')
+  assert.equal(episodeStatus(fixture.localDir, original.id), 'superseded')
+  const localRows = readIndexRows(fixture.localDir)
+  assert.equal(localRows.length, 1)
+  assert.equal(localRows[0].id, original.id)
+  assert.equal(localRows[0].status, 'superseded')
+
+  assertIds(episodeIds(fixture.globalDir), [successor], 'destination episode set')
+  assert.equal(episodeStatus(fixture.globalDir, successor), 'active')
+  const globalRows = readIndexRows(fixture.globalDir)
+  assert.equal(globalRows.length, 1)
+  assert.equal(globalRows[0].id, successor)
+  assert.equal(globalRows[0].supersedes, original.id)
+  assert.equal(globalRows[0].status, 'active')
+
+  const localTags = readJson(fixture.localDir, 'tags.json')
+  const localCategories = readJson(fixture.localDir, 'category-index.json')
+  const localTokens = readJson(fixture.localDir, 'tokens.json')
+  assertPosting(localTags, 'original-cross', [original.id, successor], 'source inherited tag parity')
+  assertPosting(localTags, 'cross-new', [successor], 'source new tag parity')
+  assertPosting(localCategories, 'decision', [original.id, successor], 'source category parity')
+  assertPosting(localTokens, 'crossrevisiontoken', [successor], 'source token parity')
+
+  const globalTags = readJson(fixture.globalDir, 'tags.json')
+  const globalCategories = readJson(fixture.globalDir, 'category-index.json')
+  const globalTokens = readJson(fixture.globalDir, 'tokens.json')
+  assertPosting(globalTags, 'original-cross', [successor], 'destination inherited tag parity')
+  assertPosting(globalTags, 'cross-new', [successor], 'destination new tag parity')
+  assertPosting(globalCategories, 'decision', [successor], 'destination category parity')
+  assertPosting(globalTokens, 'crossrevisiontoken', [successor], 'destination token parity')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'source temporary litter')
+  assert.deepEqual(tmpLitter(fixture.globalDir), [], 'destination temporary litter')
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'clerk-apply.lock')), false)
+  assert.equal(fs.existsSync(path.join(fixture.globalDir, 'clerk-apply.lock')), false)
+  telemetry.crossStoreReviseParity = {
+    elapsedMs: r.elapsedMs,
+    sourceEpisodes: 1,
+    sourceIndexRows: localRows.length,
+    destinationEpisodes: 1,
+    destinationIndexRows: globalRows.length,
+    tmpLitter: 0,
+  }
+}
+
+async function testReviseTimeoutNoWrite() {
+  const fixture = mkStoreFixture('store-write-revise-timeout-')
+  const original = seedLocalOriginal(fixture, 'timeout')
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  await withLiveHolder(lockFile, async ({ childPid }) => {
+    const before = byteSnapshot(fixture.localDir)
+    const r = runJsonSync(REVISE, [
+      '--original', original.id,
+      '--project', 'issue-546-fixture',
+      '--summary', 'must not be written',
+      '--body', 'must not be written',
+      '--scope', 'inherit',
+    ], fixture, { EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '200' })
+    const after = byteSnapshot(fixture.localDir)
+    assert.notEqual(r.code, 0, 'revise must fail while a foreign live holder owns the lock')
+    assert.equal(r.json?.status, 'error', `revise timeout JSON missing: ${r.stdout}`)
+    assert.equal(r.json?.code, 'store-write-lock-timeout', `wrong revise timeout code: ${r.stdout}`)
+    assert.equal(r.json?.heldBy, childPid, 'revise timeout must report the live holder pid')
+    assert.deepEqual(after, before, 'revise timeout changed fixture bytes before returning')
+    assert.equal(episodeStatus(fixture.localDir, original.id), 'active')
+    assert.deepEqual(tmpLitter(fixture.localDir), [], 'revise timeout left temporary litter')
+    telemetry.reviseTimeoutNoWrite = {
+      elapsedMs: r.elapsedMs,
+      exitCode: r.code,
+      heldByMatched: r.json?.heldBy === childPid,
+      unchanged: true,
+    }
+  })
+}
+
+async function testSameStoreReviseParity() {
+  const fixture = mkStoreFixture('store-write-same-revise-')
+  const original = seedLocalOriginal(fixture, 'same')
+  const r = runJsonSync(REVISE, [
+    '--original', original.id,
+    '--project', 'issue-546-fixture',
+    '--tag', 'same-new',
+    '--summary', 'same store successor',
+    '--body', 'same store body samerevisiontoken',
+    '--scope', 'inherit',
+  ], fixture)
+  assert.equal(r.code, 0, `same-store revise failed (lock inputs must dedupe): stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.equal(r.json?.status, 'ok')
+  assert.equal(r.json?.scope, 'local')
+  const successor = r.json.id
+  const ids = [original.id, successor]
+  assertIds(episodeIds(fixture.localDir), ids, 'same-store episode parity')
+  assert.equal(episodeStatus(fixture.localDir, original.id), 'superseded')
+  assert.equal(episodeStatus(fixture.localDir, successor), 'active')
+  const rows = readIndexRows(fixture.localDir)
+  assertIds(rows.map(row => row.id), ids, 'same-store index parity')
+  assert.equal(rows.find(row => row.id === original.id)?.status, 'superseded')
+  assert.equal(rows.find(row => row.id === successor)?.status, 'active')
+  assert.equal(rows.find(row => row.id === successor)?.supersedes, original.id)
+  const tags = readJson(fixture.localDir, 'tags.json')
+  const categories = readJson(fixture.localDir, 'category-index.json')
+  const tokens = readJson(fixture.localDir, 'tokens.json')
+  assertPosting(tags, 'original-same', ids, 'same-store inherited tag parity')
+  assertPosting(tags, 'same-new', [successor], 'same-store new tag parity')
+  assertPosting(categories, 'decision', ids, 'same-store category parity')
+  assertPosting(tokens, 'originaltokensame', [original.id], 'same-store original token parity')
+  assertPosting(tokens, 'samerevisiontoken', [successor], 'same-store successor token parity')
+  const litter = tmpLitter(fixture.localDir)
+  assert.deepEqual(litter, [], `same-store temporary litter: ${litter.join(', ')}`)
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'clerk-apply.lock')), false,
+    'deduped same-store lock must be fully released')
+  telemetry.sameStoreReviseParity = {
+    elapsedMs: r.elapsedMs,
+    episodes: 2,
+    indexRows: rows.length,
+    categoryIds: categories.decision.length,
+    tmpLitter: litter.length,
+  }
+}
+
+async function testMissingOriginalIndexRowNoWrite() {
+  const fixture = mkStoreFixture('store-write-stale-revise-')
+  const original = seedLocalOriginal(fixture, 'stale')
+  fs.writeFileSync(path.join(fixture.localDir, 'index.jsonl'), '', 'utf8')
+  const before = byteSnapshot(fixture.localDir)
+  const r = runJsonSync(REVISE, [
+    '--original', original.id,
+    '--project', 'issue-546-fixture',
+    '--summary', 'stale successor must not exist',
+    '--body', 'stale successor must not exist',
+    '--scope', 'inherit',
+  ], fixture)
+  const after = byteSnapshot(fixture.localDir)
+  assert.notEqual(r.code, 0, 'missing original index row must fail as stale')
+  assert.equal(r.json?.status, 'error', `missing-row stale JSON missing: ${r.stdout}`)
+  assert.equal(r.json?.code, 'stale-original', `missing-row error must be stale-original: ${r.stdout}`)
+  assert.match(r.json?.message || '', /index row status: missing/)
+  assert.deepEqual(after, before, 'missing original index row caused a write')
+  assert.equal(episodeStatus(fixture.localDir, original.id), 'active')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'missing-row stale path left temporary litter')
+  telemetry.missingOriginalIndexRow = {
+    elapsedMs: r.elapsedMs,
+    exitCode: r.code,
+    unchanged: true,
+  }
+}
+
+async function runS2aIntegrationTests() {
+  console.log('# S2a real-process store/revise integration tests')
+  await asyncTap('S2a: 16 concurrent stores preserve episode/index/tag/category/token parity with no temp litter', testConcurrentStoreParity)
+  await asyncTap('S2a: store lock timeout is a byte-for-byte no-write', testStoreTimeoutNoWrite)
+  await asyncTap('S2a: cross-store revise preserves source/destination derived-index parity', testCrossStoreReviseParity)
+  await asyncTap('S2a: revise lock timeout is a byte-for-byte no-write', testReviseTimeoutNoWrite)
+  await asyncTap('S2a: same-store lock inputs dedupe and revise preserves full parity', testSameStoreReviseParity)
+  await asyncTap('S2a: missing original index row is stale and writes nothing', testMissingOriginalIndexRowNoWrite)
+}
+
+function rowById(storeDir, id) {
+  return readIndexRows(storeDir).find(row => row.id === id) || null
+}
+
+function pinnedInEpisode(storeDir, id) {
+  return /^pinned: true$/m.test(fs.readFileSync(path.join(storeDir, 'episodes', `${id}.md`), 'utf8'))
+}
+
+async function testS2bExternalHolderWriters() {
+  const fixture = mkStoreFixture('store-write-s2b-holder-')
+  const original = seedLocalOriginal(fixture, 's2b-holder')
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+
+  await assertWaitsForExternalHolder(
+    'feedback single-id', FEEDBACK,
+    ['--id', original.id, '--useful'], fixture, lockFile,
+  )
+
+  const handoff = path.join(fixture.cwd, 's2b-handoff.md')
+  fs.writeFileSync(handoff, `cited episode ${original.id}\n`)
+  await assertWaitsForExternalHolder(
+    'feedback scan-text', FEEDBACK,
+    ['--scan-text', handoff, '--scope', 'local'], fixture, lockFile,
+  )
+
+  await assertWaitsForExternalHolder(
+    'pin', PIN,
+    ['--id', original.id], fixture, lockFile,
+  )
+  await assertWaitsForExternalHolder(
+    'rebuild', REBUILD,
+    ['--scope', 'local'], fixture, lockFile,
+  )
+
+  assert.equal(rowById(fixture.localDir, original.id)?.feedback, 2,
+    'both feedback modes must retain their increments through rebuild')
+  assert.equal(rowById(fixture.localDir, original.id)?.pinned, true,
+    'pin index row must survive rebuild')
+  assert.equal(pinnedInEpisode(fixture.localDir, original.id), true,
+    'pin frontmatter must survive rebuild')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'S2b holder tests left temporary litter')
+  telemetry.s2bExternalHolders = {
+    writers: ['feedback-id', 'feedback-scan-text', 'pin', 'rebuild'],
+    feedback: 2,
+    pinned: true,
+    tmpLitter: 0,
+  }
+}
+
+async function testFeedbackConcurrentParity() {
+  const fixture = mkStoreFixture('store-write-feedback-parity-')
+  const single = seedLocalOriginal(fixture, 'feedback-single')
+  const scan = seedLocalOriginal(fixture, 'feedback-scan')
+  const handoff = path.join(fixture.cwd, 'feedback-parity.md')
+  fs.writeFileSync(handoff, `reference ${scan.id}\n`)
+
+  const singleCompletions = []
+  for (let i = 0; i < 12; i++) {
+    singleCompletions.push(spawnJson(FEEDBACK, ['--id', single.id, '--useful'], fixture))
+  }
+  const singleResults = await Promise.all(singleCompletions)
+  for (const result of singleResults) {
+    assert.equal(result.code, 0, `single feedback failed: ${result.stdout} ${result.stderr}`)
+    assert.deepEqual(result.json && Object.keys(result.json).sort(), ['feedback', 'id', 'scope', 'status'])
+  }
+
+  const scanCompletions = []
+  for (let i = 0; i < 12; i++) {
+    scanCompletions.push(spawnJson(FEEDBACK, ['--scan-text', handoff, '--scope', 'local'], fixture))
+  }
+  const scanResults = await Promise.all(scanCompletions)
+  for (const result of scanResults) {
+    assert.equal(result.code, 0, `scan feedback failed: ${result.stdout} ${result.stderr}`)
+    assert.equal(result.json?.status, 'ok')
+    assert.equal(result.json?.recorded, 1)
+  }
+
+  assert.equal(rowById(fixture.localDir, single.id)?.feedback, 10,
+    'concurrent single-id feedback must serialize and clamp at +10')
+  assert.equal(rowById(fixture.localDir, scan.id)?.feedback, 10,
+    'concurrent scan-text feedback must serialize and clamp at +10')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'feedback parity left temporary litter')
+  telemetry.feedbackConcurrentParity = {
+    singleWriters: singleCompletions.length,
+    scanWriters: scanCompletions.length,
+    singleFeedback: rowById(fixture.localDir, single.id)?.feedback,
+    scanFeedback: rowById(fixture.localDir, scan.id)?.feedback,
+    tmpLitter: 0,
+  }
+}
+
+async function testPinAndRebuildConcurrentParity() {
+  const fixture = mkStoreFixture('store-write-pin-rebuild-parity-')
+  const first = seedLocalOriginal(fixture, 'pin-parity-one')
+  const second = seedLocalOriginal(fixture, 'pin-parity-two')
+
+  const pinCompletions = []
+  for (let i = 0; i < 10; i++) {
+    pinCompletions.push(spawnJson(PIN, ['--id', first.id], fixture))
+  }
+  const pinResults = await Promise.all(pinCompletions)
+  for (const result of pinResults) {
+    assert.equal(result.code, 0, `concurrent pin failed: ${result.stdout} ${result.stderr}`)
+    assert.deepEqual(result.json && Object.keys(result.json).sort(), ['id', 'pinned', 'scope', 'status'])
+  }
+  assert.equal(pinnedInEpisode(fixture.localDir, first.id), true)
+  assert.equal(rowById(fixture.localDir, first.id)?.pinned, true)
+
+  const rebuildCompletions = []
+  for (let i = 0; i < 8; i++) {
+    rebuildCompletions.push(spawnJson(REBUILD, ['--scope', 'local'], fixture))
+  }
+  const rebuildResults = await Promise.all(rebuildCompletions)
+  for (const result of rebuildResults) {
+    assert.equal(result.code, 0, `concurrent rebuild failed: ${result.stdout} ${result.stderr}`)
+    assert.equal(result.json?.status, 'ok')
+  }
+
+  const ids = [first.id, second.id]
+  const rows = readIndexRows(fixture.localDir)
+  assertIds(episodeIds(fixture.localDir), ids, 'pin/rebuild episode parity')
+  assertIds(rows.map(row => row.id), ids, 'pin/rebuild index parity')
+  assert.equal(rowById(fixture.localDir, first.id)?.pinned, true,
+    'rebuild must carry pinned metadata from frontmatter')
+  assert.equal(rowById(fixture.localDir, second.id)?.pinned, undefined)
+  assertPosting(readJson(fixture.localDir, 'category-index.json'), 'decision', ids,
+    'pin/rebuild category parity')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'pin/rebuild parity left temporary litter')
+  telemetry.pinRebuildConcurrentParity = {
+    pinWriters: pinCompletions.length,
+    rebuildWriters: rebuildCompletions.length,
+    episodes: ids.length,
+    indexRows: rows.length,
+    tmpLitter: 0,
+  }
+}
+
+async function testSearchWritebackRetainsConcurrentAppend() {
+  const fixture = mkStoreFixture('store-write-search-race-')
+  const original = seedLocalOriginal(fixture, 'search-race-original')
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+
+  await withLiveHolder(lockFile, async ({ child }) => {
+    const search = spawnJson(SEARCH, ['--query', 'original', '--scope', 'local'], fixture)
+    const append = spawnJson(STORE, [
+      '--project', 'issue-546-fixture', '--category', 'decision',
+      '--tag', 'search-race-append', '--summary', 'search race append',
+      '--body', 'append body searchracetoken', '--scope', 'local',
+    ], fixture)
+    await waitMs(300)
+    assert.equal(search.child.exitCode, null,
+      'search should still be waiting on the externally held store lock')
+    assert.equal(append.child.exitCode, null,
+      'append should still be waiting on the externally held store lock')
+    releaseChild(child)
+    const [searchResult, appendResult] = await Promise.all([search, append])
+    assert.equal(searchResult.code, 0, `search failed: ${searchResult.stdout} ${searchResult.stderr}`)
+    assert.equal(searchResult.json?.status, 'ok')
+    assert.equal(appendResult.code, 0, `append failed: ${appendResult.stdout} ${appendResult.stderr}`)
+    assert.equal(appendResult.json?.status, 'ok')
+    const appendedId = appendResult.json.id
+    const rows = readIndexRows(fixture.localDir)
+    assertIds(rows.map(row => row.id), [original.id, appendedId],
+      'search writeback must retain a concurrent append')
+    assert.equal(rowById(fixture.localDir, original.id)?.access_count, 1,
+      'search result must still receive access tracking')
+    telemetry.searchWritebackRace = {
+      originalId: original.id,
+      appendedId,
+      indexRows: rows.length,
+      appendRetained: rows.some(row => row.id === appendedId),
+    }
+  })
+}
+
+async function testSearchWritebackSkipsOnlyContendedStore() {
+  const fixture = mkStoreFixture('store-write-search-contended-')
+  const local = seedLocalOriginal(fixture, 'contended-local')
+  const global = runJsonSync(STORE, [
+    '--project', 'issue-546-fixture', '--category', 'decision',
+    '--tag', 'contended-global', '--summary', 'contended shared result',
+    '--body', 'global body', '--scope', 'global',
+  ], fixture)
+  assert.equal(global.code, 0, `global seed failed: ${global.stdout} ${global.stderr}`)
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+
+  await withLiveHolder(lockFile, async ({ childPid, child }) => {
+    const result = await spawnJson(SEARCH, ['--query', 'contended', '--scope', 'all'], fixture)
+    assert.equal(result.code, 0, `contended search failed: ${result.stdout} ${result.stderr}`)
+    assert.equal(result.json?.status, 'ok')
+    assert.equal(result.json?.count, 2, `search should still return both stores: ${result.stdout}`)
+    assert.ok(result.elapsedMs >= 200, `search should spend the built-in bounded timeout on local: ${result.elapsedMs}ms`)
+    assert.ok(result.elapsedMs < 1500, `search writeback must remain interactive: ${result.elapsedMs}ms`)
+    assert.equal(rowById(fixture.localDir, local.id)?.access_count || 0, 0,
+      'contended local store write must be skipped')
+    assert.equal(rowById(fixture.globalDir, global.json.id)?.access_count, 1,
+      'uncontended global store write must succeed')
+    assert.ok(fs.existsSync(path.join(fixture.localDir, 'clerk-apply.lock')),
+      `holder ${childPid} must remain owner until the test releases it`)
+    telemetry.searchWritebackPerStore = {
+      contendedScope: 'local',
+      successfulScope: 'global',
+      localAccess: rowById(fixture.localDir, local.id)?.access_count || 0,
+      globalAccess: rowById(fixture.globalDir, global.json.id)?.access_count,
+      searchExitCode: result.code,
+      elapsedMs: result.elapsedMs,
+    }
+    releaseChild(child)
+  })
+}
+
+async function runS2bIntegrationTests() {
+  console.log('# S2b real-process feedback/pin/rebuild/relevance integration tests')
+  await asyncTap('S2b: feedback, pin, and rebuild wait for deterministic external holders', testS2bExternalHolderWriters)
+  await asyncTap('S2b: concurrent feedback modes preserve exact counter parity', testFeedbackConcurrentParity)
+  await asyncTap('S2b: concurrent pin and rebuild preserve episode/index parity', testPinAndRebuildConcurrentParity)
+  await asyncTap('S2b: search writeback retains an append serialized through the store lock', testSearchWritebackRetainsConcurrentAppend)
+  await asyncTap('S2b: contended search store is skipped while another store writes back', testSearchWritebackSkipsOnlyContendedStore)
+}
+
+function waitForMarker(child, marker, timeoutMs) {
+  return new Promise((resolve) => {
+    let buf = ''
+    let done = false
+    let timer = null
+    const finish = () => {
+      if (done) return
+      done = true
+      if (timer !== null) clearTimeout(timer)
+      resolve(buf)
+    }
+    child.stdout.on('data', (d) => {
+      buf += d.toString()
+      if (buf.includes(marker)) finish()
+    })
+    child.on('exit', finish)
+    timer = setTimeout(finish, timeoutMs)
+  })
+}
+
+function waitForExit(child) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) resolve()
+    else child.once('exit', () => resolve())
+  })
+}
+
+function waitMs(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+// Deterministic external-holder assertion used by every S2b writer. The
+// holder child owns release timing; a command that exits before the window
+// proves it raced past the canonical lock rather than waiting for it.
+async function assertWaitsForExternalHolder(name, script, args, fixture, lockFile, envExtra = {}) {
+  await withLiveHolder(lockFile, async ({ child }) => {
+    const completion = spawnJson(script, args, fixture, envExtra)
+    const winner = await Promise.race([
+      completion.then(() => 'exit'),
+      waitMs(300).then(() => 'window'),
+    ])
+    assert.equal(winner, 'window', `${name} exited before external holder release`)
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 0, `${name} failed after lock release: stdout=${result.stdout} stderr=${result.stderr}`)
+    assert.equal(result.json?.status, 'ok', `${name} returned invalid JSON: ${result.stdout}`)
+  })
+}
+
+function storeDataSnapshot(storeDir) {
+  return byteSnapshot(storeDir).filter(([name]) => !name.endsWith('clerk-apply.lock'))
+}
+
+async function assertTimeoutLeavesStoresUnchanged(name, script, args, fixture, lockFile, storeDirs) {
+  await withLiveHolder(lockFile, async ({ childPid }) => {
+    const before = storeDirs.map(storeDataSnapshot)
+    const result = runJsonSync(script, args, fixture, {
+      EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '200',
+    })
+    const after = storeDirs.map(storeDataSnapshot)
+    assert.notEqual(result.code, 0, `${name} must fail while the external holder owns the lock`)
+    assert.equal(result.json?.status, 'error', `${name} timeout envelope missing: ${result.stdout}`)
+    const reportedCode = result.json?.code || result.json?.errors?.[0]?.code
+    assert.equal(reportedCode, 'store-write-lock-timeout', `${name} timeout code missing: ${result.stdout}`)
+    const heldBy = result.json?.heldBy ?? result.json?.errors?.[0]?.heldBy
+    assert.equal(heldBy, childPid, `${name} timeout must report holder pid`)
+    assert.deepEqual(after, before, `${name} timeout changed store data`)
+    for (const dir of storeDirs) assert.deepEqual(tmpLitter(dir), [], `${name} timeout left temp litter in ${dir}`)
+  })
+}
+
+async function assertLockFreeControl(name, script, args, fixture, lockFile, expectedCodes = [0]) {
+  await withLiveHolder(lockFile, async () => {
+    const before = storeDataSnapshot(path.dirname(lockFile))
+    const completion = spawnJson(script, args, fixture, {
+      EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '5000',
+    })
+    const winner = await Promise.race([
+      completion.then(() => 'exit'),
+      waitMs(350).then(() => 'window'),
+    ])
+    assert.equal(winner, 'exit', `${name} waited on a store lock despite being non-writing`)
+    const result = await completion
+    assert.ok(expectedCodes.includes(result.code), `${name} exit=${result.code}; stdout=${result.stdout}; stderr=${result.stderr}`)
+    assert.ok(result.json && typeof result.json.status === 'string', `${name} must preserve a JSON envelope`)
+    assert.deepEqual(storeDataSnapshot(path.dirname(lockFile)), before, `${name} changed store data`)
+  })
+}
+
+function makePatternsDir(fixture, patternId, token = 'seedfixturetoken') {
+  const dir = path.join(fixture.root, `patterns-${patternId}`)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, '_index.json'), JSON.stringify({
+    patterns: [{ pattern_id: patternId, file: `${patternId}.md`, name: `Pattern ${patternId}` }],
+  }))
+  fs.writeFileSync(path.join(dir, `${patternId}.md`), [
+    '---',
+    `pattern_id: ${patternId}`,
+    `name: Pattern ${patternId}`,
+    'category: decision',
+    `tags: [${patternId}, behavioral-pattern]`,
+    '---',
+    '',
+    `Pattern body ${token}.`,
+    '',
+  ].join('\n'))
+  return dir
+}
+
+function seedWorkflowEvent(fixture, task, event, tag) {
+  const body = `workflow fixture\n\n\`\`\`json\n${JSON.stringify({ event, task })}\n\`\`\``
+  const result = runJsonSync(STORE, [
+    '--project', 'issue-546-fixture',
+    '--category', 'workflow.lifecycle',
+    '--tag', tag,
+    '--summary', `${event} ${task}`,
+    '--body', body,
+    '--scope', 'local',
+  ], fixture)
+  assert.equal(result.code, 0, `workflow seed failed: ${result.stdout} ${result.stderr}`)
+  return result.json.id
+}
+
+function makeReviewFixture(prefix, task = 'S3A-REVIEW') {
+  const fixture = mkStoreFixture(prefix)
+  const plan = path.join(fixture.cwd, 'plan.md')
+  const tests = path.join(fixture.cwd, 'tests.md')
+  fs.writeFileSync(plan, 'approved plan\n')
+  fs.writeFileSync(tests, 'passing tests\n')
+  const approval = seedWorkflowEvent(fixture, task, 'plan-approved', 'review-approval')
+  const pre = seedWorkflowEvent(fixture, task, 'pre-checkpoint', 'review-pre')
+  const post = seedWorkflowEvent(fixture, task, 'post-checkpoint', 'review-post')
+  const args = [
+    '--task', task,
+    '--plan-ref', `file:${plan}`,
+    '--approval-ref', `episode:${approval}`,
+    '--pre-checkpoint-ref', `episode:${pre}`,
+    '--post-checkpoint-ref', `episode:${post}`,
+    '--tests-ref', `file:${tests}`,
+    '--code-review-ref', `episode:${post}`,
+    '--no-new-bugs',
+    '--head', 'abcdef1234567890',
+    '--branch', 'fixture-branch',
+    '--worktree', fixture.cwd,
+    '--project', 'issue-546-fixture',
+    '--scope', 'local',
+  ]
+  return { fixture, args }
+}
+
+function assertInvertedExcludes(storeDir, fileName, id, label) {
+  const index = readJson(storeDir, fileName)
+  for (const [key, ids] of Object.entries(index)) {
+    if (Array.isArray(ids)) assert.equal(ids.includes(id), false, `${label}: ${fileName}[${key}] still contains ${id}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// S3b helpers: restore fixture (fake em-backup repo) + consolidate fixture
+// (already-seeded near-duplicate cluster) — zero-dep, isolated under mkTmp
+// with explicit HOME so neither the real local store nor ~/.episodic-memory
+// is touched.
+// ---------------------------------------------------------------------------
+function makeRestoreFixture(prefix) {
+  const root = mkTmp(prefix)
+  const backupDir = path.join(root, 'backup')
+  fs.mkdirSync(backupDir, { recursive: true })
+  // em-restore requires the backup to be a clean git repo.
+  spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: backupDir })
+  spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: backupDir })
+  spawnSync('git', ['config', 'user.name', 'test'], { cwd: backupDir })
+  // HOME isolation — the spawn JSON env passes the root's home override.
+  const env = { ...process.env, HOME: root }
+  return { root, backupDir, env }
+}
+
+function makeRestoreEpisode(id, opts = {}) {
+  const fm = {
+    id,
+    date: opts.date || '2026-05-01',
+    time: opts.time || '"10:00"',
+    project: opts.project || 'issue-546-fixture',
+    category: opts.category || 'decision',
+    status: 'active',
+    tags: opts.tags || [],
+    summary: opts.summary || `summary for ${id}`,
+  }
+  const fmLines = ['---']
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) fmLines.push(`${k}: [${v.join(', ')}]`)
+    else fmLines.push(`${k}: ${v}`)
+  }
+  fmLines.push('---')
+  return fmLines.join('\n') + `\n\n# ${fm.summary}\n\nbody ${opts.token || 'restorefixturetoken'}${id}\n`
+}
+
+function seedRestoreBackup(fixture, label, episodes) {
+  const epDir = path.join(fixture.backupDir, label, 'episodes')
+  fs.mkdirSync(epDir, { recursive: true })
+  for (const e of episodes) {
+    fs.writeFileSync(path.join(epDir, `${e.id}.md`), e.content)
+  }
+  spawnSync('git', ['add', '-A'], { cwd: fixture.backupDir })
+  spawnSync('git', ['commit', '-q', '-m', 'test', '--allow-empty'], { cwd: fixture.backupDir })
+}
+
+function makeConsolidateFixture(prefix, nearDupes) {
+  const fixture = mkStoreFixture(prefix)
+  const ids = []
+  for (const e of nearDupes) {
+    const r = runJsonSync(STORE, [
+      '--project', e.project || 'issue-546-fixture',
+      '--category', e.category || 'lesson',
+      '--summary', e.summary,
+      '--body', e.body,
+      '--tag', ...(e.tags || ['issue-546-fixture']),
+      '--scope', 'local',
+    ], fixture)
+    assert.equal(r.code, 0, `consolidate seed failed: ${r.stdout} ${r.stderr}`)
+    ids.push(r.json.id)
+  }
+  return { fixture, ids }
+}
+
+async function testPruneLockingParityAndControls() {
+  const fixture = mkStoreFixture('store-write-prune-holder-')
+  const seeded = seedLocalOriginal(fixture, 'prune-holder')
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  await assertWaitsForExternalHolder(
+    'prune', PRUNE, ['--scope', 'local', '--threshold', '2'], fixture, lockFile,
+  )
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'episodes', `${seeded.id}.md`)), false)
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'archived', `${seeded.id}.md`)), true)
+  assert.equal(readIndexRows(fixture.localDir).some(row => row.id === seeded.id), false)
+  const archivedRows = fs.readFileSync(path.join(fixture.localDir, 'archived-index.jsonl'), 'utf8')
+    .split('\n').filter(Boolean).map(JSON.parse)
+  assert.equal(archivedRows.some(row => row.id === seeded.id), true)
+  for (const name of ['tags.json', 'category-index.json', 'tokens.json']) {
+    assertInvertedExcludes(fixture.localDir, name, seeded.id, 'prune parity')
+  }
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'prune left temporary litter')
+
+  const timeoutFixture = mkStoreFixture('store-write-prune-timeout-')
+  seedLocalOriginal(timeoutFixture, 'prune-timeout')
+  const timeoutLock = path.join(timeoutFixture.localDir, 'clerk-apply.lock')
+  await assertTimeoutLeavesStoresUnchanged(
+    'prune', PRUNE, ['--scope', 'local', '--threshold', '2'], timeoutFixture,
+    timeoutLock, [timeoutFixture.localDir],
+  )
+  await assertLockFreeControl('prune help', PRUNE, ['--help'], timeoutFixture, timeoutLock)
+  await assertLockFreeControl('prune dry-run', PRUNE, ['--scope', 'local', '--threshold', '2', '--dry-run'], timeoutFixture, timeoutLock)
+  await assertLockFreeControl('prune check', PRUNE, ['--scope', 'local', '--threshold', '2', '--check'], timeoutFixture, timeoutLock, [1])
+  await assertLockFreeControl('prune no-op', PRUNE, ['--scope', 'local', '--threshold', '0'], timeoutFixture, timeoutLock)
+  telemetry.s3Prune = { blocked: true, timeoutNoWrite: true, archived: 1, parity: true, tmpLitter: 0, lockFreeControls: 4 }
+}
+
+async function testMoveAllLocksParityAndControls() {
+  const fixture = mkStoreFixture('store-write-move-holder-')
+  const seeded = seedLocalOriginal(fixture, 'move-holder')
+  fs.mkdirSync(fixture.globalDir, { recursive: true })
+  const destinationLock = path.join(fixture.globalDir, 'clerk-apply.lock')
+
+  await withLiveHolder(destinationLock, async ({ child }) => {
+    const before = [storeDataSnapshot(fixture.localDir), storeDataSnapshot(fixture.globalDir)]
+    const completion = spawnJson(MOVE, ['--id', seeded.id, '--to', 'global', '--no-audit'], fixture)
+    const winner = await Promise.race([completion.then(() => 'exit'), waitMs(350).then(() => 'window')])
+    assert.equal(winner, 'window', 'move exited before destination holder released')
+    assert.deepEqual(
+      [storeDataSnapshot(fixture.localDir), storeDataSnapshot(fixture.globalDir)], before,
+      'move wrote source or destination data before every lock was acquired',
+    )
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 0, `move failed after release: ${result.stdout} ${result.stderr}`)
+    assert.equal(result.json?.status, 'ok')
+  })
+
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'episodes', `${seeded.id}.md`)), false)
+  assert.equal(fs.existsSync(path.join(fixture.globalDir, 'episodes', `${seeded.id}.md`)), true)
+  assert.equal(readIndexRows(fixture.localDir).some(row => row.id === seeded.id), false)
+  assert.equal(readIndexRows(fixture.globalDir).some(row => row.id === seeded.id), true)
+  for (const name of ['tags.json', 'category-index.json', 'tokens.json']) {
+    assertInvertedExcludes(fixture.localDir, name, seeded.id, 'move source parity')
+    const destination = readJson(fixture.globalDir, name)
+    assert.ok(Object.values(destination).some(ids => Array.isArray(ids) && ids.includes(seeded.id)),
+      `move destination ${name} does not contain ${seeded.id}`)
+  }
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'move source temp litter')
+  assert.deepEqual(tmpLitter(fixture.globalDir), [], 'move destination temp litter')
+
+  const timeoutFixture = mkStoreFixture('store-write-move-timeout-')
+  const timeoutSeed = seedLocalOriginal(timeoutFixture, 'move-timeout')
+  fs.mkdirSync(timeoutFixture.globalDir, { recursive: true })
+  const timeoutLock = path.join(timeoutFixture.globalDir, 'clerk-apply.lock')
+  await assertTimeoutLeavesStoresUnchanged(
+    'move', MOVE, ['--id', timeoutSeed.id, '--to', 'global', '--no-audit'], timeoutFixture,
+    timeoutLock, [timeoutFixture.localDir, timeoutFixture.globalDir],
+  )
+
+  const globalSeed = runJsonSync(STORE, storeArgs('move-noop', 'global'), timeoutFixture)
+  assert.equal(globalSeed.code, 0, `move no-op seed failed: ${globalSeed.stdout}`)
+  await assertLockFreeControl('move help', MOVE, ['--help'], timeoutFixture, timeoutLock)
+  await assertLockFreeControl('move invalid', MOVE, ['--id', timeoutSeed.id, '--to', 'nowhere'], timeoutFixture, timeoutLock, [2])
+  await assertLockFreeControl('move dry-run', MOVE, ['--id', timeoutSeed.id, '--to', 'global', '--dry-run'], timeoutFixture, timeoutLock)
+  await assertLockFreeControl('move no-op', MOVE, ['--id', globalSeed.json.id, '--to', 'global'], timeoutFixture, timeoutLock)
+  telemetry.s3Move = { blocked: true, allLocksBeforeWrite: true, timeoutNoWrite: true, parity: true, tmpLitter: 0, lockFreeControls: 4 }
+}
+
+async function testSeedLockingParityAndControls() {
+  const fixture = mkStoreFixture('store-write-seed-holder-')
+  const patterns = makePatternsDir(fixture, 'bp-546-seed', 'seedfixturetoken')
+  fs.mkdirSync(fixture.globalDir, { recursive: true })
+  const lockFile = path.join(fixture.globalDir, 'clerk-apply.lock')
+  await assertWaitsForExternalHolder('seed-patterns', SEED_PATTERNS, ['--dir', patterns], fixture, lockFile)
+  const rows = readIndexRows(fixture.globalDir)
+  assert.equal(rows.length, 1)
+  const id = rows[0].id
+  assertIds(episodeIds(fixture.globalDir), [id], 'seed episode/index parity')
+  assertPosting(readJson(fixture.globalDir, 'tags.json'), 'bp-546-seed', [id], 'seed tag parity')
+  assertPosting(readJson(fixture.globalDir, 'category-index.json'), 'decision', [id], 'seed category parity')
+  assertPosting(readJson(fixture.globalDir, 'tokens.json'), 'seedfixturetoken', [id], 'seed token parity')
+  assert.deepEqual(tmpLitter(fixture.globalDir), [], 'seed left temporary litter')
+
+  const timeoutFixture = mkStoreFixture('store-write-seed-timeout-')
+  const timeoutPatterns = makePatternsDir(timeoutFixture, 'bp-546-timeout', 'seedtimeouttoken')
+  fs.mkdirSync(timeoutFixture.globalDir, { recursive: true })
+  const timeoutLock = path.join(timeoutFixture.globalDir, 'clerk-apply.lock')
+  await assertTimeoutLeavesStoresUnchanged(
+    'seed-patterns', SEED_PATTERNS, ['--dir', timeoutPatterns], timeoutFixture,
+    timeoutLock, [timeoutFixture.globalDir],
+  )
+  await assertLockFreeControl('seed help', SEED_PATTERNS, ['--help'], fixture, lockFile)
+  await assertLockFreeControl('seed invalid', SEED_PATTERNS, ['--dir', path.join(fixture.root, 'missing-patterns')], fixture, lockFile, [1])
+  const dryPatterns = makePatternsDir(fixture, 'bp-546-dry', 'seeddrytoken')
+  await assertLockFreeControl('seed dry-run', SEED_PATTERNS, ['--dir', dryPatterns, '--dry-run'], fixture, lockFile)
+  await assertLockFreeControl('seed no-op', SEED_PATTERNS, ['--dir', patterns], fixture, lockFile)
+  telemetry.s3Seed = { blocked: true, timeoutNoWrite: true, episodes: 1, parity: true, tmpLitter: 0, lockFreeControls: 4 }
+}
+
+async function testReviewRequestLockingParityAndControls() {
+  const { fixture, args } = makeReviewFixture('store-write-review-holder-')
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  await assertWaitsForExternalHolder('review-request', REVIEW_REQUEST, args, fixture, lockFile)
+  const reviewRows = readIndexRows(fixture.localDir).filter(row => row.category === 'workflow.lifecycle' && row.tags?.includes('review-request'))
+  assert.equal(reviewRows.length, 1, 'exactly one review-request row expected')
+  const id = reviewRows[0].id
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'episodes', `${id}.md`)), true)
+  assertPosting(readJson(fixture.localDir, 'tags.json'), 'review-request', [id], 'review tag parity')
+  const categories = readJson(fixture.localDir, 'category-index.json')
+  assert.ok(categories['workflow.lifecycle'].includes(id), 'review category parity')
+  const tokens = readJson(fixture.localDir, 'tokens.json')
+  assert.ok(Object.values(tokens).some(ids => Array.isArray(ids) && ids.includes(id)), 'review token parity')
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'review-request left temporary litter')
+
+  const timeout = makeReviewFixture('store-write-review-timeout-', 'S3A-TIMEOUT')
+  const timeoutLock = path.join(timeout.fixture.localDir, 'clerk-apply.lock')
+  await assertTimeoutLeavesStoresUnchanged(
+    'review-request', REVIEW_REQUEST, timeout.args, timeout.fixture,
+    timeoutLock, [timeout.fixture.localDir],
+  )
+  await assertLockFreeControl('review help', REVIEW_REQUEST, ['--help'], timeout.fixture, timeoutLock)
+  await assertLockFreeControl('review invalid', REVIEW_REQUEST, ['--task', 'missing-rest'], timeout.fixture, timeoutLock, [2])
+  await assertLockFreeControl('review dry-run', REVIEW_REQUEST, [...timeout.args, '--dry-run'], timeout.fixture, timeoutLock)
+  telemetry.s3ReviewRequest = { blocked: true, timeoutNoWrite: true, episodes: 1, parity: true, tmpLitter: 0, lockFreeControls: 3 }
+}
+
+async function runS3aIntegrationTests() {
+  console.log('# S3a real-process prune/move/seed/review-request integration tests')
+  await asyncTap('S3a: prune blocks, times out without writes, preserves parity, and keeps controls lock-free', testPruneLockingParityAndControls)
+  await asyncTap('S3a: move acquires all locks before writes and preserves two-store parity', testMoveAllLocksParityAndControls)
+  await asyncTap('S3a: seed-patterns serializes its batch with full derived-index parity', testSeedLockingParityAndControls)
+  await asyncTap('S3a: review-request serializes collision check and full store persistence', testReviewRequestLockingParityAndControls)
+}
+
+// ---------------------------------------------------------------------------
+// Slice 546-S3b: restore + legacy non-clerk consolidate coverage.
+// ---------------------------------------------------------------------------
+async function testRestoreAllLocksBeforeWrite() {
+  // Two target stores (local + global). An external holder owns the
+  // destination store's clerk-apply.lock. Restore must NOT write to the
+  // SOURCE store either, even though it is unheld, until BOTH locks are
+  // acquired. The fixture isolates HOME so the real ~/.episodic-memory is
+  // untouched.
+  const restoreFx = makeRestoreFixture('store-write-restore-alllocks-')
+  const idA = 'restore-al-1'
+  const idB = 'restore-al-2'
+  seedRestoreBackup(restoreFx, 'proj-a', [{ id: idA, content: makeRestoreEpisode(idA, { tags: ['alpha'], token: 'restorealtokena' }) }])
+  seedRestoreBackup(restoreFx, 'proj-b', [{ id: idB, content: makeRestoreEpisode(idB, { tags: ['bravo'], token: 'restorealtokenb' }) }])
+  // Create the source-map targets. These are STANDALONE non-cwd stores
+  // (the restore honors --source-map, not scope); we drive them through
+  // absolute paths and HOME override so nothing in the real env writes.
+  const cwd = path.join(restoreFx.root, 'cwd')
+  fs.mkdirSync(cwd, { recursive: true })
+  const targetA = path.join(restoreFx.root, 'store-a')
+  const targetB = path.join(restoreFx.root, 'store-b')
+  fs.mkdirSync(targetA, { recursive: true })
+  fs.mkdirSync(targetB, { recursive: true })
+  const lockB = path.join(targetB, 'clerk-apply.lock')
+
+  const args = [
+    '--from', restoreFx.backupDir,
+    '--source-map', `proj-a=${targetA}`,
+    '--source-map', `proj-b=${targetB}`,
+    '--apply',
+    '--rebuild-index',
+  ]
+
+  await withLiveHolder(lockB, async ({ child }) => {
+    const before = [storeDataSnapshot(targetA), storeDataSnapshot(targetB)]
+    const completion = spawnJson(RESTORE, args, { cwd, env: restoreFx.env })
+    const winner = await Promise.race([completion.then(() => 'exit'), waitMs(450).then(() => 'window')])
+    assert.equal(winner, 'window',
+      'restore exited before BOTH target locks were acquired (must wait on the held target)')
+    // CRITICAL: targetA is UNheld but its bytes must not have changed
+    // either, because restore acquires ALL locks before ANY write.
+    assert.deepEqual([storeDataSnapshot(targetA), storeDataSnapshot(targetB)], before,
+      'restore wrote a target before every lock was acquired')
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 0, `restore failed after release: stdout=${result.stdout}; stderr=${result.stderr}`)
+    assert.equal(result.json?.status, 'ok', `restore envelope status: ${result.stdout}`)
+  })
+
+  // After release: both targets have the episode + index + tags + category
+  // parity preserved.
+  assert.equal(fs.existsSync(path.join(targetA, 'episodes', `${idA}.md`)), true, 'target A episode missing')
+  assert.equal(fs.existsSync(path.join(targetB, 'episodes', `${idB}.md`)), true, 'target B episode missing')
+  assertIds(episodeIds(targetA), [idA], 'target A episode parity')
+  assertIds(episodeIds(targetB), [idB], 'target B episode parity')
+  assertIds(readIndexRows(targetA).map(r => r.id), [idA], 'target A index parity')
+  assertIds(readIndexRows(targetB).map(r => r.id), [idB], 'target B index parity')
+  assertPosting(readJson(targetA, 'tags.json'), 'alpha', [idA], 'target A tag parity')
+  assertPosting(readJson(targetB, 'tags.json'), 'bravo', [idB], 'target B tag parity')
+  assertPosting(readJson(targetA, 'category-index.json'), 'decision', [idA], 'target A category parity')
+  assertPosting(readJson(targetB, 'category-index.json'), 'decision', [idB], 'target B category parity')
+  // tokens.json is rebuilt by em-rebuild-index, not by em-restore itself.
+  assert.equal(fs.existsSync(path.join(targetA, 'tokens.json')), false, 'restore does not write tokens.json')
+  assert.equal(fs.existsSync(path.join(targetB, 'tokens.json')), false, 'restore does not write tokens.json')
+  assert.deepEqual(tmpLitter(targetA), [], 'restore left temp litter in target A')
+  assert.deepEqual(tmpLitter(targetB), [], 'restore left temp litter in target B')
+  telemetry.s3bRestoreAllLocks = { sources: 2, blocked: true, allLocksBeforeWrite: true, tmpLitter: 0 }
+}
+
+async function testRestoreTimeoutNoWrite() {
+  const restoreFx = makeRestoreFixture('store-write-restore-timeout-')
+  const id = 'restore-to-1'
+  seedRestoreBackup(restoreFx, 'proj', [{ id, content: makeRestoreEpisode(id, { tags: ['tm'], token: 'restoretimetoken' }) }])
+  const cwd = path.join(restoreFx.root, 'cwd')
+  fs.mkdirSync(cwd, { recursive: true })
+  const target = path.join(restoreFx.root, 'store')
+  fs.mkdirSync(target, { recursive: true })
+  const lockFile = path.join(target, 'clerk-apply.lock')
+
+  await assertTimeoutLeavesStoresUnchanged(
+    'restore', RESTORE, [
+      '--from', restoreFx.backupDir,
+      '--source-map', `proj=${target}`,
+      '--apply', '--rebuild-index',
+    ], { cwd, env: { ...restoreFx.env, EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '200' } },
+    lockFile, [target],
+  )
+  assert.equal(fs.existsSync(path.join(target, 'episodes', `${id}.md`)), false, 'restore wrote episode after timeout')
+  assert.equal(fs.existsSync(path.join(target, 'index.jsonl')), false, 'restore wrote index.jsonl after timeout')
+  assert.deepEqual(tmpLitter(target), [], 'restore timeout left temp litter')
+  telemetry.s3bRestoreTimeout = { blocked: true, timeoutNoWrite: true, tmpLitter: 0 }
+}
+
+async function testRestoreParityAndLockFreeControls() {
+  // Single-target parity: restore writes episode + index + tags + category,
+  // no temp litter, no leftover staging dir, no leftover lockfile.
+  const restoreFx = makeRestoreFixture('store-write-restore-parity-')
+  const id1 = 'restore-par-1'
+  const id2 = 'restore-par-2'
+  seedRestoreBackup(restoreFx, 'proj', [
+    { id: id1, content: makeRestoreEpisode(id1, { tags: ['parity-1'], token: 'restorepartoken1', date: '2026-04-01' }) },
+    { id: id2, content: makeRestoreEpisode(id2, { tags: ['parity-2'], token: 'restorepartoken2', date: '2026-04-15' }) },
+  ])
+  const cwd = path.join(restoreFx.root, 'cwd')
+  fs.mkdirSync(cwd, { recursive: true })
+  const target = path.join(restoreFx.root, 'store')
+  fs.mkdirSync(target, { recursive: true })
+  const lockFile = path.join(target, 'clerk-apply.lock')
+
+  const applyArgs = [
+    '--from', restoreFx.backupDir,
+    '--source-map', `proj=${target}`,
+    '--apply', '--rebuild-index',
+  ]
+  const r = runJsonSync(RESTORE, applyArgs, { cwd, env: restoreFx.env })
+  assert.equal(r.code, 0, `restore parity apply failed: ${r.stdout} ${r.stderr}`)
+  assert.equal(r.json?.status, 'ok')
+  assertIds(episodeIds(target), [id1, id2], 'restore parity episode ids')
+  assertIds(readIndexRows(target).map(row => row.id), [id1, id2], 'restore parity index rows')
+  const tags = readJson(target, 'tags.json')
+  assertPosting(tags, 'parity-1', [id1], 'restore parity tag-1')
+  assertPosting(tags, 'parity-2', [id2], 'restore parity tag-2')
+  const categories = readJson(target, 'category-index.json')
+  assertPosting(categories, 'decision', [id1, id2], 'restore parity category')
+  // tokens.json is rebuilt by em-rebuild-index, not by em-restore itself.
+  assert.equal(fs.existsSync(path.join(target, 'tokens.json')), false, 'restore does not write tokens.json')
+  assert.deepEqual(tmpLitter(target), [], 'restore parity left temp litter')
+  // Staging dir must be cleaned up (preserved by mkdtempSync + try/finally
+  // regardless of fixture-write success).
+  const stagingLeftover = fs.readdirSync(target)
+    .filter(n => n.startsWith('.em-restore-staging-') && !fs.lstatSync(path.join(target, n)).isSymbolicLink())
+  assert.equal(stagingLeftover.length, 0, `staging leftover: ${stagingLeftover.join(',')}`)
+  assert.equal(fs.existsSync(lockFile), false, 'restore parity released the store lock')
+
+  // Lock-free controls: help, dry-run, invalid input must NOT wait on the
+  // store lock and must NOT change the target.
+  await assertLockFreeControl('restore help', RESTORE, ['--help'], { cwd, env: restoreFx.env }, lockFile)
+  await assertLockFreeControl('restore dry-run', RESTORE, [
+    '--from', restoreFx.backupDir, '--source-map', `proj=${target}`,
+  ], { cwd, env: restoreFx.env }, lockFile)
+  await assertLockFreeControl('restore invalid category', RESTORE, [
+    '--from', restoreFx.backupDir, '--source-map', `proj=${target}`,
+    '--category', 'BOGUS_CATEGORY', '--apply',
+  ], { cwd, env: restoreFx.env }, lockFile, [1])
+  await assertLockFreeControl('restore missing --from', RESTORE, [
+    '--source-map', `proj=${target}`, '--apply',
+  ], { cwd, env: restoreFx.env }, lockFile, [2])
+  telemetry.s3bRestoreParity = {
+    episodes: 2, indexRows: 2, parity: true, tmpLitter: 0, lockFreeControls: 4,
+  }
+}
+
+async function testConsolidateBlocksAndTimeoutNoWrite() {
+  // External holder blocks the legacy non-clerk --apply path until release.
+  // Timeout path: a second external holder that never releases MUST
+  // surface a store-write-lock-timeout envelope and leave the store byte-
+  // identical. Single-fixture: the helper provides a fresh fixture per
+  // test, both below.
+  const fixture = makeConsolidateFixture('store-write-consolidate-holder-', [
+    { summary: 'Atomic rename prevents torn index reads', body: 'We hit a torn read; the fix is temp file plus atomic rename for every index write.', tags: ['issue-546-fixture', 'storage'] },
+    { summary: 'Use temp file plus rename for index writes', body: 'Torn index reads again — atomic rename via temp file is mandatory for index writes.', tags: ['issue-546-fixture', 'index'] },
+  ])
+  const lockFile = path.join(fixture.fixture.localDir, 'clerk-apply.lock')
+
+  // 1. Blocking path: holder owns the lock; consolidate waits; release →
+  // apply succeeds and produces a digest.
+  await withLiveHolder(lockFile, async ({ child }) => {
+    const completion = spawnJson(CONSOLIDATE, [
+      '--scope', 'local', '--min-sim', '0.3', '--apply', '--confirm',
+    ], fixture.fixture)
+    const winner = await Promise.race([completion.then(() => 'exit'), waitMs(450).then(() => 'window')])
+    assert.equal(winner, 'window', 'consolidate exited before lock release')
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 0, `consolidate failed after release: ${result.stdout} ${result.stderr}`)
+    assert.equal(result.json?.status, 'ok', `consolidate envelope: ${result.stdout}`)
+    assert.equal(result.json?.applied, 1, `expected exactly one applied cluster; got ${result.stdout}`)
+    assert.equal(typeof result.json?.clusters?.[0]?.digest_id, 'string',
+      `digest_id missing: ${result.stdout}`)
+    const digestId = result.json.clusters[0].digest_id
+    assert.ok(fs.existsSync(path.join(fixture.fixture.localDir, 'episodes', `${digestId}.md`)),
+      'digest episode file missing after consolidate apply')
+    assertIds(readIndexRows(fixture.fixture.localDir).map(r => r.id), [...fixture.ids, digestId].sort(),
+      'consolidate apply parity: index.jsonl contains every member (superseded) plus the digest')
+    for (const mid of fixture.ids) {
+      const row = readIndexRows(fixture.fixture.localDir).find(r => r.id === mid)
+      assert.equal(row?.status, 'superseded',
+        `member ${mid} not marked superseded; rows=${JSON.stringify(readIndexRows(fixture.fixture.localDir))}`)
+    }
+    assert.deepEqual(tmpLitter(fixture.fixture.localDir), [],
+      'consolidate apply left temp litter in the store')
+    assert.equal(fs.existsSync(lockFile), false,
+      'consolidate apply released the store lock')
+  })
+
+  // 2. Timeout path: a separate fixture + an external holder that does NOT
+  // release before consolidate's deadline. Verify byte-identical snapshot.
+  const timeoutFx = makeConsolidateFixture('store-write-consolidate-timeout-', [
+    { summary: 'Timeout body lesson alpha', body: 'Timeout alpha duplicate body for the timeout test case.', tags: ['issue-546-fixture'] },
+    { summary: 'Timeout body lesson beta', body: 'Timeout alpha duplicate body for the timeout test case.', tags: ['issue-546-fixture'] },
+  ])
+  const timeoutLock = path.join(timeoutFx.fixture.localDir, 'clerk-apply.lock')
+  await assertTimeoutLeavesStoresUnchanged(
+    'consolidate legacy', CONSOLIDATE, [
+      '--scope', 'local', '--min-sim', '0.3', '--apply', '--confirm',
+    ], { ...timeoutFx.fixture, env: { ...timeoutFx.fixture.env, EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '200' } },
+    timeoutLock, [timeoutFx.fixture.localDir],
+  )
+  assert.equal(fs.existsSync(path.join(timeoutFx.fixture.localDir, 'index.jsonl')), true,
+    'timeout fixture still has its seeded index.jsonl (no apply write)')
+  assert.equal(readIndexRows(timeoutFx.fixture.localDir).length, 2,
+    'timeout fixture still has its 2 seeded rows (no apply write)')
+  assert.deepEqual(tmpLitter(timeoutFx.fixture.localDir), [],
+    'consolidate timeout left temp litter')
+  telemetry.s3bConsolidate = {
+    blocked: true,
+    timeoutNoWrite: true,
+    applied: 1,
+    parity: true,
+    tmpLitter: 0,
+  }
+}
+
+async function testConsolidateLockFreeControls() {
+  // Help, dry-run, --scope validation, and the >5-cluster confirm gate
+  // must NOT acquire the store lock. Even with a live holder holding
+  // <DATA_DIR>/clerk-apply.lock, these paths exit promptly without
+  // modifying the store.
+  const fixture = mkStoreFixture('store-write-consolidate-controls-')
+  // Holder needs the parent dir to exist before O_CREAT can succeed.
+  fs.mkdirSync(fixture.localDir, { recursive: true })
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  await assertLockFreeControl('consolidate help', CONSOLIDATE, ['--help'], fixture, lockFile)
+  await assertLockFreeControl('consolidate dry-run', CONSOLIDATE, ['--scope', 'local', '--min-sim', '0.3'], fixture, lockFile)
+  await assertLockFreeControl('consolidate invalid scope', CONSOLIDATE, ['--scope', 'nope'], fixture, lockFile, [2])
+  await assertLockFreeControl('consolidate invalid min-sim', CONSOLIDATE, ['--min-sim', '0'], fixture, lockFile, [2])
+  // The >5 cluster confirm gate runs BEFORE the lock; with an empty store
+  // there are no clusters so the gate trivially exits 0 (dry-run-by-default
+  // branch). Verify the gate is lock-free in isolation too.
+  await assertLockFreeControl('consolidate apply no-clusters', CONSOLIDATE, ['--scope', 'local', '--apply', '--confirm'], fixture, lockFile)
+  telemetry.s3bConsolidateControls = { lockFreeControls: 5 }
+}
+
+async function runS3bIntegrationTests() {
+  console.log('# S3b real-process restore + legacy consolidate integration tests')
+  await asyncTap('S3b: restore acquires every target lock before any write (two-target parity)', testRestoreAllLocksBeforeWrite)
+  await asyncTap('S3b: restore lock timeout is a byte-for-byte no-write across the target', testRestoreTimeoutNoWrite)
+  await asyncTap('S3b: restore parity + lock-free controls preserve all self-tests', testRestoreParityAndLockFreeControls)
+  await asyncTap('S3b: consolidate legacy --apply blocks, applies under lock, and times out without writes', testConsolidateBlocksAndTimeoutNoWrite)
+  await asyncTap('S3b: consolidate help/dry-run/invalid inputs are lock-free controls', testConsolidateLockFreeControls)
+}
+
+// ---------------------------------------------------------------------------
+// Slice 546-S3c: ID-collision retry (em-store) + legacy consolidate fresh-
+// reread (em-consolidate). Both tests are isolated, deterministic, and do
+// NOT add any production hook.
+// ---------------------------------------------------------------------------
+
+// Build a CommonJS preload that:
+//   (a) fixes Date.now and the no-arg constructor to a deterministic instant
+//   (b) sequences crypto.randomBytes(2) (the only size the ID loop uses);
+//       size-8 calls (atomicReplaceFileSync uniqueStoreTmpPath) fall through
+//       to the original function so the temp-name randomness is unaffected
+//   (c) calls module.syncBuiltinESMExports() so an ESM `import crypto from
+//       'crypto'` sees the patched randomBytes (ESM caches the namespace
+//       snapshot at first load; syncBuiltinESMExports pushes the CJS
+//       mutation into the ESM namespace)
+// No production hook: the preload lives only inside the test fixture's
+// mkTmp directory and is removed by main()'s tmpRoots sweep.
+function writeIdCollisionPreload(fixtureRoot, suffixSequence, fixedIso) {
+  const preloadPath = path.join(fixtureRoot, 'id-collision-preload.cjs')
+  const seqLiteral = JSON.stringify(suffixSequence)
+  fs.writeFileSync(preloadPath, `
+    const crypto = require('crypto');
+    const moduleObj = require('module');
+    const OrigRandomBytes = crypto.randomBytes;
+    const sequence = ${seqLiteral}.map(s => Buffer.from(s, 'hex'));
+    let idx = 0;
+    crypto.randomBytes = function patched(n) {
+      if (n === 2 && idx < sequence.length) {
+        const out = sequence[idx++];
+        return Buffer.from(out);
+      }
+      return OrigRandomBytes.call(crypto, n);
+    };
+    moduleObj.syncBuiltinESMExports();
+    const FIXED_ISO = ${JSON.stringify(fixedIso)};
+    const FIXED_TS = new Date(FIXED_ISO).getTime();
+    const OrigDate = Date;
+    class FixedDate extends OrigDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          super(FIXED_TS);
+        } else {
+          super(...args);
+        }
+      }
+      static now() { return FIXED_TS; }
+      static parse(s) { return OrigDate.parse(s); }
+      static UTC(...args) { return OrigDate.UTC(...args); }
+    }
+    globalThis.Date = FixedDate;
+  `)
+  return preloadPath
+}
+
+async function testStoreIdCollisionRetry() {
+  // Pre-seed the store with an episode whose id matches the FIRST candidate
+  // the loader will generate. The preload pins Date and sequences
+  // crypto.randomBytes(2) so the first candidate collides with the seed
+  // and the second candidate is fresh. The test proves the loader retries
+  // inside the lock, the second id is used, the pre-seeded file bytes are
+  // untouched, and the resulting index.jsonl has unique ids.
+  const fixture = mkStoreFixture('store-write-id-collision-')
+  const fixedIso = '2026-07-15T12:00:00.000Z'
+  const ts = '20260715-120000'
+  const slug = 'collision-retry-fixture'
+  const collidingId = `${ts}-${slug}-aaaa`
+  const retryId = `${ts}-${slug}-bbbb`
+
+  // Pre-seed the colliding episode (file + index row).
+  const episodesDir = path.join(fixture.localDir, 'episodes')
+  fs.mkdirSync(episodesDir, { recursive: true })
+  const collidingFile = path.join(episodesDir, `${collidingId}.md`)
+  const collidingContent = [
+    '---',
+    `id: ${collidingId}`,
+    'date: 2026-07-15',
+    'time: "12:00"',
+    'project: issue-546-fixture',
+    'category: decision',
+    'status: active',
+    'tags: [collision-collider]',
+    'summary: original collider',
+    '---',
+    '',
+    '# original collider',
+    '',
+    'original body collisionsentinel\n',
+  ].join('\n')
+  fs.writeFileSync(collidingFile, collidingContent)
+  fs.writeFileSync(path.join(fixture.localDir, 'index.jsonl'),
+    JSON.stringify({ id: collidingId, date: '2026-07-15', time: '12:00', project: 'issue-546-fixture', category: 'decision', status: 'active', tags: ['collision-collider'], summary: 'original collider' }) + '\n',
+    'utf8',
+  )
+  const originalBytes = fs.readFileSync(collidingFile)
+
+  // Sequence: first randomBytes(2) call returns 'aaaa' (collision), second
+  // returns 'bbbb' (fresh). Any subsequent size-2 calls fall through to
+  // the original function but the retry loop needs at most 2 attempts.
+  const preloadPath = writeIdCollisionPreload(fixture.root, ['aaaa', 'bbbb'], fixedIso)
+
+  // Spawn em-store with the preload. --require must come before the script
+  // path; we use spawnSync directly so the flag order is preserved.
+  const started = Date.now()
+  const r = spawnSync(process.execPath, [
+    '--require', preloadPath,
+    STORE,
+    '--project', 'issue-546-fixture',
+    '--category', 'decision',
+    '--summary', 'collision retry fixture',
+    '--body', 'retry body collisionsuccesstoken',
+    '--scope', 'local',
+  ], {
+    cwd: fixture.cwd,
+    env: { ...fixture.env },
+    encoding: 'utf8',
+  })
+  let json = null
+  try { json = JSON.parse((r.stdout || '').trim()) } catch { /* asserted below */ }
+  assert.equal(r.status, 0, `em-store failed: stdout=${r.stdout} stderr=${r.stderr}`)
+  assert.equal(json && json.status, 'ok', `em-store returned invalid JSON: ${r.stdout}`)
+  assert.equal(json.id, retryId, `expected retry id ${retryId}, got ${json.id} (stdout=${r.stdout})`)
+
+  // Old bytes survive — the pre-seeded file is byte-for-byte identical.
+  const originalAfter = fs.readFileSync(collidingFile)
+  assert.equal(Buffer.compare(originalBytes, originalAfter), 0,
+    'pre-seeded collider bytes must survive the retry path')
+
+  // Index IDs are unique and both present.
+  const rows = readIndexRows(fixture.localDir)
+  const ids = rows.map(row => row.id)
+  assert.ok(ids.includes(collidingId), 'pre-seeded collider id must remain in index')
+  assert.ok(ids.includes(retryId), 'retry id must be in index')
+  assert.equal(new Set(ids).size, ids.length, 'index ids must be unique (no collision survived)')
+
+  // The retry episode file exists and is different from the collider.
+  const retryFile = path.join(episodesDir, `${retryId}.md`)
+  assert.ok(fs.existsSync(retryFile), 'retry episode file must exist')
+  const retryContent = fs.readFileSync(retryFile, 'utf8')
+  assert.ok(retryContent.includes('collisionsuccesstoken'),
+    'retry episode body must contain the new sentinel (proves it was actually written)')
+  // The two files have different content.
+  assert.notEqual(retryContent, collidingContent,
+    'retry file must differ from the collider file')
+
+  // No temp litter.
+  assert.deepEqual(tmpLitter(fixture.localDir), [], 'id-collision retry left temp litter')
+  // Lockfile was released.
+  assert.equal(fs.existsSync(path.join(fixture.localDir, 'clerk-apply.lock')), false,
+    'id-collision retry released the store lock')
+  telemetry.s3cIdCollisionRetry = {
+    collidingId,
+    retryId,
+    oldBytesSurvived: Buffer.compare(originalBytes, originalAfter) === 0,
+    uniqueIndexIds: new Set(ids).size,
+    episodes: ids.length,
+    elapsedMs: Date.now() - started,
+  }
+}
+
+async function testConsolidateFreshRereadInheritsPin() {
+  // Race scenario: pre-seed two near-duplicate lessons (NEITHER pinned).
+  // An external holder takes the store lock and waits. Spawn em-consolidate
+  // --apply --confirm; it performs its pre-lock scan, then blocks on the
+  // lock. The holder-owned update rewrites one member's file body (adds a
+  // unique token) AND sets pinned: true on that member's index row.
+  // Release the holder; em-consolidate acquires the lock and reads FRESH
+  // rows + fresh contents. The test asserts: the digest body contains the
+  // unique token (proves fresh contents), the digest frontmatter has
+  // pinned: true (proves fresh rows), and the digest index row has
+  // pinned: true (proves fresh pin survived).
+  const fixture = mkStoreFixture('store-write-consolidate-reread-')
+  const seeded = []
+  for (const e of [
+    { summary: 'Atomic rename prevents torn index reads', body: 'We hit a torn read; the fix is temp file plus atomic rename for every index write.' },
+    { summary: 'Use temp file plus rename for index writes', body: 'Torn index reads again — atomic rename via temp file is mandatory for index writes.' },
+  ]) {
+    const r = runJsonSync(STORE, [
+      '--project', 'issue-546-fixture',
+      '--category', 'lesson',
+      '--summary', e.summary,
+      '--body', e.body,
+      '--tag', 'issue-546-fixture',
+      '--scope', 'local',
+    ], fixture)
+    assert.equal(r.code, 0, `seed failed: ${r.stdout} ${r.stderr}`)
+    assert.equal(r.json?.status, 'ok', `seed JSON: ${r.stdout}`)
+    seeded.push(r.json.id)
+  }
+  // Pre-condition: neither seeded row is pinned.
+  for (const id of seeded) {
+    const row = rowById(fixture.localDir, id)
+    assert.equal(row?.pinned, undefined, `seeded ${id} must not be pinned pre-race`)
+  }
+
+  const lockFile = path.join(fixture.localDir, 'clerk-apply.lock')
+  const uniqueToken = `holderinjectedtoken${Date.now()}${Math.random().toString(36).slice(2, 8)}`
+  const memberId = seeded[0]
+  const memberFile = path.join(fixture.localDir, 'episodes', `${memberId}.md`)
+  const preRaceBefore = fs.readFileSync(memberFile, 'utf8')
+
+  await withLiveHolder(lockFile, async ({ child }) => {
+    // Spawn em-consolidate --apply --confirm. It will block on the lock
+    // (long timeout so the holder update has time to land).
+    const completion = spawnJson(CONSOLIDATE, [
+      '--scope', 'local', '--min-sim', '0.3', '--apply', '--confirm',
+    ], fixture, { EPISODIC_MEMORY_STORE_WRITE_LOCK_TIMEOUT_MS: '5000' })
+    // Wait until em-consolidate is blocked on the lock acquisition. The
+    // pre-lock scan is fast; the lock poll is 50ms. 300ms is enough.
+    await waitMs(300)
+    assert.equal(completion.child.exitCode, null,
+      'em-consolidate must still be waiting on the lock before the holder-owned update')
+
+    // Holder-owned update (1): rewrite the member file to add a unique
+    // token in the body AND pin it via the frontmatter. This is the
+    // FRESH content the in-lock reread must observe (body + frontmatter).
+    const pinnedFrontmatter = preRaceBefore.replace(/^---\n/, `---\npinned: true\n`)
+    const updatedContent = pinnedFrontmatter + `\n\n${uniqueToken}\n`
+    fs.writeFileSync(memberFile, updatedContent)
+
+    // Holder-owned update (2): rewrite index.jsonl so the member is
+    // pinned: true. The in-lock fresh row map must carry this pin.
+    const indexFile = path.join(fixture.localDir, 'index.jsonl')
+    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    const rewritten = lines.map(line => {
+      try {
+        const entry = JSON.parse(line)
+        if (entry.id === memberId) entry.pinned = true
+        return JSON.stringify(entry)
+      } catch { return line }
+    })
+    fs.writeFileSync(indexFile, rewritten.join('\n') + '\n', 'utf8')
+
+    // Release the holder; em-consolidate acquires the lock and reads
+    // fresh rows + fresh contents.
+    releaseChild(child)
+    const result = await completion
+    assert.equal(result.code, 0, `em-consolidate failed: stdout=${result.stdout} stderr=${result.stderr}`)
+    assert.equal(result.json?.status, 'ok', `em-consolidate envelope: ${result.stdout}`)
+    assert.equal(result.json?.applied, 1, `expected 1 applied cluster; got ${result.stdout}`)
+    const digestId = result.json.clusters[0]?.digest_id
+    assert.equal(typeof digestId, 'string', `digest_id missing: ${result.stdout}`)
+
+    // Digest body contains the unique token (proves fresh contents).
+    const digestFile = path.join(fixture.localDir, 'episodes', `${digestId}.md`)
+    const digestContent = fs.readFileSync(digestFile, 'utf8')
+    assert.ok(digestContent.includes(uniqueToken),
+      `digest body must contain holder-injected token '${uniqueToken}' (proves fresh contents; digest=${digestContent.slice(0, 400)})`)
+
+    // Digest frontmatter has pinned: true (proves fresh rows).
+    assert.ok(/^pinned: true$/m.test(digestContent),
+      `digest frontmatter must have pinned: true (proves fresh rows); content=${digestContent.slice(0, 400)}`)
+
+    // Digest index row has pinned: true (proves fresh pin survived the
+    // atomically rewritten index.jsonl).
+    const postRows = readIndexRows(fixture.localDir)
+    const digestRow = postRows.find(r => r.id === digestId)
+    assert.ok(digestRow, 'digest row must exist in index.jsonl')
+    assert.equal(digestRow.pinned, true,
+      'digest index row must have pinned: true (proves fresh pin survived)')
+
+    // Member row is marked superseded, pinned still true post-rewrite.
+    const memberRow = postRows.find(r => r.id === memberId)
+    assert.equal(memberRow?.status, 'superseded', 'member row must be superseded')
+    assert.equal(memberRow?.pinned, true, 'member row pin must survive the supersede rewrite')
+
+    // Member file: frontmatter carries superseded_by + pinned: true.
+    const memberAfter = fs.readFileSync(memberFile, 'utf8')
+    assert.ok(/^superseded_by: /m.test(memberAfter),
+      'member file must have superseded_by frontmatter')
+    assert.ok(/^pinned: true$/m.test(memberAfter),
+      'member file must retain pinned: true after the supersede rewrite')
+
+    // No temp litter; lock released.
+    assert.deepEqual(tmpLitter(fixture.localDir), [], 'consolidate fresh-reread left temp litter')
+    assert.equal(fs.existsSync(lockFile), false, 'consolidate fresh-reread released the lock')
+
+    telemetry.s3cConsolidateFreshReread = {
+      memberId,
+      digestId,
+      pinInheritedFrontmatter: /^pinned: true$/m.test(digestContent),
+      pinInheritedIndexRow: digestRow.pinned === true,
+      tokenInherited: digestContent.includes(uniqueToken),
+      memberPinSurvived: /^pinned: true$/m.test(memberAfter),
+    }
+  })
+}
+
+async function runS3cIntegrationTests() {
+  console.log('# S3c ID-collision retry + consolidate fresh-reread race')
+  await asyncTap('S3c: em-store ID-collision retry — preload fixes Date and sequences randomBytes(2); old bytes survive; index ids unique', testStoreIdCollisionRetry)
+  await asyncTap('S3c: consolidate legacy --apply fresh-reread — holder-owned update survives; digest inherits content and pin', testConsolidateFreshRereadInheritsPin)
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+async function main() {
+  let exitCode = 0
+  try {
+    if (HELPER_ONLY) {
+      await runHelperTests()
+    } else if (EXPECT_MAIN_RED) {
+      await runExternalHolderTest()
+    } else {
+      await runHelperTests()
+      await runExternalHolderTest()
+      await runS2aIntegrationTests()
+      await runS2bIntegrationTests()
+      await runS3aIntegrationTests()
+      await runS3bIntegrationTests()
+      await runS3cIntegrationTests()
+    }
+  } catch (e) {
+    console.error('FATAL', e)
+    exitCode = 1
+  } finally {
+    // F7: release and await any orphan live-holder children that escaped
+    // a test throw before withLiveHolder's own finally could clean them
+    // up. liveChildren is mutated by the child's 'exit' listener, so we
+    // snapshot first to avoid mutating during iteration.
+    for (const child of Array.from(liveChildren)) {
+      releaseChild(child)
+      try { await awaitChild(child) } catch { /* best effort */ }
+    }
+    await stopChildren(Array.from(commandChildren))
+    // F6: every mkTmp() root is removed here, including failure paths.
+    // No more leaked /tmp fixtures from this suite.
+    for (const root of tmpRoots) {
+      try { fs.rmSync(root, { recursive: true, force: true }) } catch { /* best effort */ }
+    }
+    console.log(`\n# tests ${pass + fail}`)
+    console.log(`# pass  ${pass}`)
+    console.log(`# fail  ${fail}`)
+    if (Object.keys(telemetry).length) console.log(`# telemetry ${JSON.stringify(telemetry)}`)
+    if (fail > 0) exitCode = 1
+  }
+  process.exit(exitCode)
+}
+
+main().catch((e) => {
+  console.error('FATAL', e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Serialize every in-scope episodic-memory store mutation through the existing per-store `clerk-apply.lock`.
- Add a zero-dependency lock helper with canonical multi-store ordering, direct-parent inheritance, bounded timeout reporting, and collision-safe atomic replacement.
- Migrate ordinary, revision, feedback, pin, rebuild, curation, restore, relevance writeback, and legacy consolidate transactions to the shared contract.
- Add a deterministic 46-case process concurrency suite and register it in the substrate CI shard.

## Root cause

Store writers could overlap the episode write and derived-index read-modify-write sequence. Several paths also reused fixed temporary names such as `tags.json.tmp`, allowing one process to rename or remove another process's temporary file. The reported outcome was a committed episode file followed by an `ENOENT` and inconsistent derived indexes.

The fix holds one canonical lock for the complete transaction and uses same-directory temporary files containing the PID and cryptographic randomness, written with `wx`, fsynced, and renamed atomically.

## Behavior

- Concurrent writers to one store serialize.
- Writers spanning multiple stores acquire canonical paths in lexical order and release in reverse order.
- A direct child may inherit only a live lock owned by its own PID or direct parent PID, preserving `em-promote` without weakening foreign-owner exclusion.
- Lock timeout returns `store-write-lock-timeout` before any transaction write.
- Independent stores remain independent.
- Best-effort access tracking skips only the contended store after its bounded timeout.
- `em-store` retries a colliding generated ID while holding the lock.
- `em-revise` preserves stable superseded-member revival and rejects pre-lock to in-lock status or direct-successor drift across both locked stores.
- Legacy consolidate re-reads member rows and files after acquiring the lock.

## Validation

- `node tests/test-store-write-concurrency.mjs`: 46/46
- `node tests/test-rfc-009-p4-apply.mjs`: 30/30
- `node tests/test-em-restore.mjs`: 129/129
- `node tests/test-em-consolidate.mjs`: 8/8
- `node tests/test-em-store-tag-flags.mjs`: 11/11
- `node tests/test-em-revise-scope-inherit.mjs`: 18/18
- `node tests/test-feedback-scan.mjs`: 8/8
- `node tests/test-relevance.mjs`: 17/17
- `node tests/test-category-index.mjs`: 11/11
- `node tests/test-em-promote.mjs`: 31/31
- `node tests/test-promote-apply.mjs`: 29/29
- `node tests/test-prune-lifecycle.mjs`: 6/6
- `node tests/test-em-move.mjs`: 14/14
- `node tests/test-seed-patterns.mjs`: 15/15
- `node tests/test-workflow-validate.mjs`: 110/110
- `node tests/test-ci-suite-registration.mjs`: 16/16
- `git diff --check`: clean
- Independent amended-diff verification: PASS
- GitHub Actions: all six checks green on `edf8124`
- Post-merge global install: `1d5c1479c1fc`
- Consumer refresh: all 14 registered projects current; final scan had no remaining refreshes or skips
- Post-cycle deploy audit: CLEAN with `MISSING=0 DIFFER=0 EXTRA=0 UNDEPLOYED=0`
- Env-manager sync: paused after existing env-manager issue #10 reproduced stale-index rollback twice; repaired indexes published through an exact allowlist

## Execution records

- Workplan: `20260722-231359-workplan-v238-issue-546-deployed-env-man-23c5`
- Handoff: `20260722-231426-handoff-66-issue-546-deployed-consumers--fbcf`
- Multi-agent playbook: `20260722-133545-consolidated-tiered-multi-agent-orchestr-99bf`

Closes #546
