### PR TITLE
docs(rfcs): backfill Implementation ledgers from the merged-PR record

### DIFF
--- a/docs/rfcs/RFC-001-memory-improvements.md
+++ b/docs/rfcs/RFC-001-memory-improvements.md
@@ -316,6 +316,7 @@ graph TD
 | Phase 1: Tag Normalization + Inverted Index | `em-store.mjs`, `em-revise.mjs`, `em-search.mjs`, `em-rebuild-index.mjs` | 16 E2E scenarios passed | Shipped in PR #6, commit `0e45e4d`. Bugs: #2 (P1), #3 (P2), #4 (P3), #5 (P1) — all fixed. |
 | Phase 2: Relevance Decay + Access Tracking | `em-search.mjs`, `em-rebuild-index.mjs`, `em-prune.mjs` (new) | 24 Phase 2 tests + 15 existing = 39 passed | Shipped in PR #13. Scoring default-on, access tracking, pruning, performance health checks. BPs decoupled from user-preferences, bp-007 merged into bp-006, bp-011 added. |
 | Phase 3: Proactive Recall | `em-recall.mjs` (new) | 20 Phase 3 tests + 31 existing = 51 passed | Multi-pass retrieval (project, tag, recent cross-project). Context inference from package.json, git remote, git branch, cwd. Drift detection for inlined functions. 2nd opinion review applied (8 findings). |
+| Topic tracks (NAPMEM-C) | PR #567 (`d5b5484`) | `tests/test-topic-tracks.mjs` (25 files, +4157) | Derived topic tracks with provenance; NapMem assessment entry into Phase 4 territory. Phase 4 synthesis clerk + embedding arc remain open. |
 
 ---
 

--- a/docs/rfcs/RFC-003-pluggable-tool-adapters.md
+++ b/docs/rfcs/RFC-003-pluggable-tool-adapters.md
@@ -431,7 +431,7 @@ This phase **subsumes the runtime portion of RFC-002 Phase 3b**. Issue [#59](htt
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| (no RFC-003-named implementation PR) | — | — | Accepted in docs (#74 `5526b85` draft, #83 `20e5b2c` accepted). The adapter/registry surface realizing this design shipped under RFC-008: registry+manifest #374 `0e27ad2`; per-harness enforcement adapters #424 `f5dbaef` / #431 `3b91f9b` / #437 `5da4418`. Decision-in-core stance superseded per RFC-008 Related-RFCs note. |
 
 ---
 

--- a/docs/rfcs/RFC-005-em-move.md
+++ b/docs/rfcs/RFC-005-em-move.md
@@ -263,7 +263,7 @@ Add `project-mismatch` tag to 9 episodes in Group 6 (operating-rules cluster fro
 
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| em-move v1 | PR #466 (`556bf85`) | bundled wave PR, 28 files +2176 | Introduced `scripts/em-move.mjs` (verified `--follow --diff-filter=A`). Hardened by #470 (`fc37d17`, partial-move null-proto fix); suite CI-wired by #472 (`ef0d771`). |
 
 ---
 

--- a/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
+++ b/docs/rfcs/RFC-008-decouple-enforcement-from-substrate.md
@@ -1344,7 +1344,32 @@ graph TD
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
 | **P0** — PR #367 (`bf58e8f`) | 20 P0 files (17 schemas + 3 data) + test-only `tests/lib/mini-jsonschema.mjs` + `tests/lib/version-hash.mjs` (both later promoted to `scripts/lib/` in P1b/P2a, with re-export shims left at the `tests/lib/` paths) + `tests/test-p0-schemas.mjs` + `tests/fixtures/plugins/*` (≥16 golden + `_corpus-index.json`) + `tests/fixtures/harness-events/claude-code/*` | `node tests/test-p0-schemas.mjs` → 89/0; `em-rfc-validate` consistent | Locked schema + data layer (R3, R4; F11–F51). NO shipped `.mjs` validators (T17). Validity gate = self-asserting keyword-grammar linter (closes R0b-R3 fail-open class). Plan reviewed 3 rounds; impl review ACCEPT-with-FU (4 FUs fixed inline). Post-merge FU: P2 shared negative corpus → issue #368. |
-| _P1+ pending_ | _pending_ | _pending_ | _pending_ |
+| **P1a** — PR #373 (`e4f89a5`) | see PR | see PR | git mv hooks/→plugins/claude-code/hooks/ |
+| **P1b** — PR #374 (`0e27ad2`) | see PR | see PR | plugin registry+manifest+validator |
+| **P1c** — PR #376 (`a1bf7e7`) | see PR | see PR | conformance gauntlet+field_bindings |
+| **Follow** — PR #378 (`8f1e880`) | see PR | see PR | runbook relocation |
+| **P2a** — PR #381 (`176d6c2`) | see PR | see PR | validate-schemas+negative corpus |
+| **P2b** — PR #384 (`45aceba`) | see PR | see PR | bp contracts+validate-bp-contract |
+| **P2c** — PR #388 (`b425099`) | see PR | see PR | doc sweep |
+| **P3a** — PR #389 (`fe2b61c`) | see PR | see PR | marker-state lib |
+| **P3b-1** — PR #391 (`e077f55`) | see PR | see PR | stop decision relocation |
+| **P3c** — PR #392 (`15ad76b`) | see PR | see PR | classifier taxonomy sourcing |
+| **P3b-2** — PR #393 (`f880b52`) | see PR | see PR | effective-tier layer |
+| **P3d** — PR #395 (`c6ac710`) | see PR | see PR | em-recall purification |
+| **P4a** — PR #397 (`87c9ceb`) | see PR | see PR | per-project config in gates |
+| **P4c** — PR #398 (`f117709`) | see PR | see PR | active:false kill switch |
+| **P4d S1** — PR #400 (`99f4eaa`) | see PR | see PR | E2E harness |
+| **S2** — PR #401 (`0f4edad`) | see PR | see PR | --install-enforcement |
+| **S4** — PR #402 (`ad14ae5`) | see PR | see PR | config seeding |
+| **ESC** — PR #409 (`ebc5df4`) | see PR | see PR | repo-source-only gating |
+| **S5** — PR #416 (`a40d907`) | see PR | see PR | uninstall |
+| **S6** — PR #417 (`a256b13`) | see PR | see PR | seed-identity guard |
+| **S7** — PR #418 (`b7db28d`) | see PR | see PR | phase index docs |
+| **S8** — PR #419 (`c8651f4`) | see PR | see PR | P12 CI gate |
+| **P5** — PR #424 (`f5dbaef`) + #425 (`a7f66c9`) | see PR | see PR | OpenCode plugin |
+| **P6** — PR #431 (`3b91f9b`) | see PR | see PR | Codex plugin |
+| **P7** — PR #437 (`5da4418`) | see PR | see PR | Pi Agent plugin |
+| _P8 pending (Cursor/Windsurf, not started)_ | _pending_ | _pending_ | P9 carved out to RFC-001/007 lineage; plan-gate.sh:108-115 reorder still open |
 
 ---
 

--- a/docs/rfcs/RFC-009-lesson-activation.md
+++ b/docs/rfcs/RFC-009-lesson-activation.md
@@ -488,7 +488,14 @@ Each phase's merge is gated by the R-groups below plus its phase-specific gates;
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
 | P0 (P0-S1..S3, PR #454) | `scripts/em-pattern-health.mjs` (`--hermetic`, R5a), `scripts/em-prune.mjs` (R6 protection set), docs guide + README + CI wiring | `tests/test-pattern-health-hermetic.mjs` (8), `tests/test-prune-protection.mjs` (17) | R6 blend half lands with R2 in P1; R5b CI gate is P3 |
-| _pending_ | _pending_ | _pending_ | _pending_ |
+| P1a — PR #460 (`f6936ca`) | see PR | see PR | R10 taxonomy; categories.json single vocab source |
+| P1b — PR #489 (`0f0bdba`) | see PR | see PR | activation schema + trigger index + R9a + T6 + contract mirror |
+| P2 — PR #493 (`fb9fd79`) | see PR | see PR | advisory activation adapter (R3 event plane + R4 SessionStart) |
+| P3 — PR #520 (`766ed3c`) | see PR | see PR | R7 lesson injection + R5b pattern-health CI + #512/#515 |
+| P4 PR-A — PR #523 (`c2abbe8`) | see PR | see PR | R6 telemetry writer + R9b clerk report mode (S1-S3) |
+| P4 S4 — PR #525 (`ea69b95`) | see PR | see PR | R9b clerk apply + clerkWrite + lock lib (REQ-6..13) |
+| P4 S5-S7 — PR #528 (`45125b5`) | see PR | see PR | R6 conversion + R9c enrichment + R9d clerk prompt |
+| _P5 pending (R8 assisted migration, unplanned)_ | _pending_ | _pending_ | _pending_ |
 
 ---
 

--- a/docs/rfcs/RFC-011-playbook-activation-preferences.md
+++ b/docs/rfcs/RFC-011-playbook-activation-preferences.md
@@ -186,6 +186,18 @@ Single implementation phase (P1), one PR, slice ladder in the phase plan documen
 | T11 | target-store binding | the preference-file read binds to the `--project` store under `caller_cwd != target` (extends the RFC-009 R2 binding fixture to the new per-project input) |
 | T12 | schema-version migration | a cached v2 `trigger-index.json` is treated as stale and rebuilt to v3; `test-trigger-index-schema.mjs` negatives updated (v2 rejected like v1) |
 
+---
+
+## Implementation
+
+> Populate during build stage — mark each item immediately after it ships. Do not batch at the end.
+
+| PR/Commit | Files changed | Tests | Notes |
+|---|---|---|---|
+| P1 (S1-S5) — PR #511 (`d5f6efc`) | see PR | panel ledger in ## Second opinion rows 7-11 | preference schema, derived index v3, --read surface, retention protection, docs+CI; status flip authored as `b192808` on the feature branch, landed on main in the #511 squash. P2 (body excerpts) intentionally unscheduled pending R6 evidence. |
+
+---
+
 ## Related RFCs
 
 - **RFC-009 (accepted)** — supplies every mechanism this RFC composes: R1 trigger grammar, R2 derived index + freshness + build report, R3 matcher + rendering + bounds + suppression, R4 session-start surface + strict read boundary, R6 telemetry (pending P4), R10 taxonomy. This RFC adds a declared-preference surface beside R4's earned band, one boundary CLARIFICATION (fingerprint stats, R2.5), and changes none of RFC-009's contracts. One latent RFC-009 defect (untracked `--history` in the R3 rendering) is discharged via a filed issue + R7, not a text amendment.

--- a/docs/rfcs/RFC-012-promotion-arc.md
+++ b/docs/rfcs/RFC-012-promotion-arc.md
@@ -194,6 +194,10 @@ graph TD
 | PR/Commit | Files changed | Tests | Notes |
 |---|---|---|---|
 | P1 (R3a): PR #544, `d42573c` | `scripts/lib/activation-log.mjs` (computeCadence + CADENCE_FIELDS), `scripts/em-trigger-index.mjs` (v4 + per-store stamp + merged thread), both activation hooks' `mergeSessionStart`, `scripts/lib/activation-match.mjs` + codex vendored copy (renderer line), `scripts/em-consolidate.mjs` (REQ-23 lesson-only N gauge), `schemas/trigger-index.schema.json` v4, contract mirror + validator pin, both plugin manifests (checksum pins), docs, CI wiring | `tests/test-trigger-index-cadence.mjs` (24 tests/54 asserts) + full A.8 sweep green | GLM build r1 ACCEPT 0 blockers (`.review-store/rfc-012-p1/glm-build-r1.md`); plan `docs/plans/rfc-012-p1.md` §19.3 records build deltas D1-D5 |
+| P2-S1 — PR #547 (`d2105aa`) | see PR | see PR | store-identity chain (REQ-1..6, REQ-18) |
+| P2 typed provenance — PR #550 (`0193607`) | see PR | see PR | em-promote + promotion-sources lib (subject untagged; RFC-012 files verified) |
+| P2-S3 — PR #552 (`1c2e31d`) | see PR | see PR | learning registry slot + conformance gauntlet (REQ-13/14) |
+| P2-S4 — PR #559 (`81f3cce`) | see PR | see PR | promotion apply |
 
 ---
 


### PR DESCRIPTION
## What

Backfills the six stale RFC Implementation ledgers and adds RFC-011's missing ledger section, so the RFC docs match shipped reality (2026-07-24 all-RFC audit, workplan v248/v249):

- **RFC-001**: topic-tracks row (PR #567, NAPMEM-C); Phase 4 remainder stays open.
- **RFC-003**: honest provenance note — no RFC-003-named implementation PR exists; the adapter surface shipped under RFC-008 (#374, #424/#431/#437).
- **RFC-005**: em-move ship row (#466), hardening (#470), CI wiring (#472, hunk-verified).
- **RFC-008**: 25 rows P1a-P7 (#373-#437); truthful `_P8 pending_` tail carrying the plan-gate.sh:108-115 open bug and P9 carve-out.
- **RFC-009**: P1a-P4 rows (#460, #489, #493, #520, #523, #525, #528); truthful `_P5 pending_`.
- **RFC-011**: new Implementation section, P1 row (#511); P2 recorded as intentionally unscheduled pending R6 evidence.
- **RFC-012**: P2 rows (#547, #550, #552, #559).

## Verification

- Every one of the 45 cited SHAs verified against git log by an independent reviewer loop (existence + subject-carries-PR# + reachable-from-HEAD); refuted rows #404 and #551 excluded by spec.
- `em-rfc-validate.mjs` green at every step; all 42 added rows exactly 4 cells; changes confined to Implementation sections (per-added-line containment proof).
- Adversarial review: pi/GLM-5.2 on the frozen diff, round 1 HOLD-1 (F1: b192808 feature-branch provenance) -> fold -> round 2 ACCEPT.

## Out of scope (filed separately)

RFC-006 archived/ move (validator needs a code change first), RFC-007 status/reality mismatch, and two pre-existing context rows citing feature-branch tip SHAs (bf58e8f, d42573c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)