### PR TITLE
Serve the plugin from the repo root, not the frozen subtree (fixes #599)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "author": {
         "name": "Charlton Ho"
       },
-      "source": "./plugins/episodic-memory",
+      "source": ".",
       "category": "productivity"
     }
   ]

--- a/skills/episodic-memory/SKILL.md
+++ b/skills/episodic-memory/SKILL.md
@@ -1,0 +1,1 @@
+../../instructions/SKILL.md


### PR DESCRIPTION
`.claude-plugin/marketplace.json` pointed at `./plugins/episodic-memory`, a 6-script subtree last touched **2026-04-30**. The real `scripts/` has 77 files. Every plugin install shipped April code — that `em-search.mjs` is 5,982 bytes against ~27,500, with no `--read` flag at all.

## Why it drifted unnoticed

Nothing syncs the subtree. `install.mjs` deploys the root `scripts/` to `~/.episodic-memory/scripts/`, and `tools/deploy-audit.mjs` audits that global target. Neither covers `plugins/`. The root `.claude-plugin/plugin.json` references `scripts/bp1-orchestrator.mjs`, so the root manifest looked current and masked the fact that the *served* path was three months behind. Same blind-spot class as #583.

## The change

```diff
-      "source": "./plugins/episodic-memory",
+      "source": ".",
```

Plus `skills/episodic-memory/SKILL.md` as a **symlink** to `instructions/SKILL.md`. The subtree shipped its own `SKILL.md` copy and the root `skills/` had only `classify-correction`, so a bare source change would have silently dropped the skill from the plugin. The symlink is what prevents it drifting the way the subtree did, and it matches the layout `CLAUDE.md` already documents.

## What is deliberately not done

`plugins/episodic-memory/` stays in place. `tests/test-em-revise-scope-inherit.mjs` runs its matrix against that copy on purpose, labelled "drifted plugin copy" — deleting the subtree breaks a green test. Whether to remove it is a separate call, tracked in #599.

## Verification

| Suite | Result |
|---|---|
| `test-plugin-json.mjs` | 6/6 |
| `test-plugin-gauntlet.mjs` | 39/39 |
| `test-plugin-registry.mjs` | 205/205 |
| `test-em-revise-scope-inherit.mjs` | 18/18 |

Symlink resolves: `skills/episodic-memory/SKILL.md -> ../../instructions/SKILL.md`, `head -3` returns the real frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)