### PR TITLE
RFC-007 Phase 3: wiki-link + composes-with edges with slugify() resolution and dangling tracking (fixes #589)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -404,6 +404,9 @@ jobs:
       - name: Run em-graph node-projection suite (RFC-007 Phase 2)
         run: node tests/test-em-graph-nodes.mjs
 
+      - name: Run em-graph link-edge suite (RFC-007 Phase 3)
+        run: node tests/test-em-graph-links.mjs
+
       - name: Run em-doctor suite
         run: node tests/test-em-doctor.mjs
 

--- a/docs/plans/RFC-007-P3-wiki-link-composes-with.md
+++ b/docs/plans/RFC-007-P3-wiki-link-composes-with.md
@@ -257,7 +257,7 @@ empty strings. Never null.
 | EC2 | `[[Name]]` vs `[[name]]` in two files | both slugify to `name`, one deduped edge | `t_case_folded_targets_dedupe` |
 | EC3 | Slug collision already exits 2 at `:152-155` before any body scan | Phase 3 never runs on a colliding corpus | `t_collision_still_exits_2_before_extraction` |
 | EC4 | `## Composes with` present, section empty | 0 edges AND 0 dangling (REQ-6) | `t_composes_empty_section_no_dangling` |
-| EC5 | Unclosed fence — ` ``` ` opened and never closed | remainder of file treated as fenced, no edges (matches `cites` regex behavior) | `t_unclosed_fence_swallows_remainder` |
+| EC5 | Unclosed fence — ` ``` ` opened and never closed | **remainder is NOT treated as fenced**; a wiki-link after it IS extracted. `stripFenced` is non-greedy and requires a closing fence, which is exactly what shipped `cites` does at `em-graph.mjs:207`. Parity with `cites` is the requirement (REQ-4), so this is the correct behavior, not a gap | `t_unclosed_fence_does_not_swallow_remainder` |
 | EC6 | `## Composes with` followed immediately by `## Other` | section is empty, next heading terminates it | `t_composes_terminated_by_next_heading` |
 | EC7 | Live corpus run — 68 files carry `[[…]]`, 21 carry the heading | real run completes, emits both edges and dangling entries | `manual:` §15 row |
 
@@ -274,7 +274,7 @@ Group 1: wiki-link shape matrix (15)
 Group 2: exclusion (3)
   t_wikilink_fence_exclusion
   t_wikilink_inline_backtick_exclusion
-  t_unclosed_fence_swallows_remainder
+  t_unclosed_fence_does_not_swallow_remainder   (EC5, corrected: parity with cites)
 
 Group 3: composes-with (8)
   t_composes_toplevel_only

--- a/docs/plans/RFC-007-P3-wiki-link-composes-with.md
+++ b/docs/plans/RFC-007-P3-wiki-link-composes-with.md
@@ -1,0 +1,776 @@
+# RFC-007-P3 — `wiki-link` + `composes-with` edges Plan
+
+## §1 Status
+
+`Planning only.` Do not implement until this plan and its review are accepted (Rule 18).
+Current stage: **round-1 review folded, awaiting final approval**. Round 1 returned HOLD with
+7 findings; all 7 are dispositioned in §19.1 and the 6 actionable ones are applied.
+
+| Field | Value |
+|---|---|
+| RFC | `RFC-007` (graph projection) |
+| Parent requirements | Phase 3 row `RFC-007-graph-projection.md:384`; test plan `:421-425` |
+| Workplan episode | `20260725-143851-workplan-v268-587-merged-at-8e6e699-with-687e` (v268) |
+| Target branch | `feat/rfc-007-p3-wiki-link-composes-with` |
+| Executor altitude (§0.1) | **low** — Appendix A is the build path |
+| GitHub issue | #589 |
+
+## §2 Episode Search Summary
+
+```bash
+node scripts/em-search.mjs --tag rfc-007 --scope all --limit 12 --no-track --no-score
+```
+
+Returned 3 rows, none carrying design constraints beyond the workplan/handoff pair:
+
+- `20260725-143851-…-687e` (workplan v268): queue head is #589; `main` = `8e6e699`; no open PRs.
+- `20260725-143935-…-7a63` (handoff 93): Phase 2 and #587 both touched `em-graph.mjs`; the
+  surface is warm. Carries "never accept a seat's verify summary" — the builder seat on the
+  #587 arc reported 9 verifies matched spec and silently omitted the one that failed.
+- `20260722-133545-…-99bf` (playbook v15, pinned, `authoritative`): pipeline order and role lock.
+
+Verified-still-present (memories are point-in-time): `slugify()` at `scripts/lib/rule-nodes.mjs:30-38`
+and `scanRuleNodes` imported at `scripts/em-graph.mjs:48` — both confirmed by direct read, not recall.
+
+## §3 Objective
+
+`em-graph.mjs` projects two new rule-to-rule edge types from rule-file bodies — `wiki-link`
+(`[[name]]`) and `composes-with` (top-level bullets under `## Composes with`) — resolved to rule
+slugs through the existing `slugify()`, with unresolved targets recorded in per-edge-type dangling
+buckets. Provable by: a new suite whose 15+ shape-variant fixture asserts
+`(resolved | dangling | ignored)` per row, and by `--from <rule-slug>` returning a multi-node
+traversal where today it returns exactly one node.
+
+## §4 Requirements (Ground Truth)
+
+| ID | Requirement (concrete, testable) | Parent | Test(s) | Priority | Notes |
+|---|---|---|---|---|---|
+| REQ-1 | `slugify` is imported from `scripts/lib/rule-nodes.mjs`; `em-graph.mjs` defines no second slug function | P2 `PRINCIPLES.md:27`; RFC `:129-143` | `manual: grep -c 'function slugify' scripts/em-graph.mjs` → 0 | MUST | Fork = principle violation |
+| REQ-2 | `wiki-link` and `composes-with` appear in `EDGE_TYPES` and NOT in `DEFAULT_EDGES` | RFC `:669`, `:681` | `t_edge_types_registered`, `t_default_edges_unchanged` | MUST | Opt-in keeps default output byte-identical |
+| REQ-3 | wiki-link parser classifies all 15 fixture shapes as `resolved`/`dangling`/`ignored` | RFC `:150`, `:422` | `t_wikilink_shape_matrix` (15 rows) | MUST | The ten RFC-named shapes + 5 extension rows |
+| REQ-4 | Fenced code blocks and inline backticks are excluded from wiki-link extraction | RFC `:149`, `:423` | `t_wikilink_fence_exclusion`, `t_wikilink_inline_backtick_exclusion` | MUST | Mirrors the shipped `cites` behavior at `em-graph.mjs:207` |
+| REQ-5 | `composes-with` reads top-level bullets only until the next `## ` or EOF; nested bullets ignored; `- [text](path.md)` resolved by basename | RFC `:151`, `:424` | `t_composes_toplevel_only`, `t_composes_nested_ignored`, `t_composes_markdown_link_basename` | MUST | |
+| REQ-6 | An empty `## Composes with` section yields 0 edges AND 0 dangling entries | RFC `:152`, `:518` | `t_composes_empty_section_no_dangling` | MUST | Explicit false-pass trap in the RFC |
+| REQ-7 | Unresolved targets land in `dangling[]` with `kind` = the edge type; dangling is distinct from orphans | RFC `:237`, `:242`, `:425` | `t_dangling_distinct_from_orphans`, `t_dangling_kind_values` | MUST | Bucket names per Decision 2 |
+| REQ-8 | With no `--nodes` and no `--edges` flag, output is byte-identical to `8e6e699` and no rule file is read | Phase 2 REQ-8 (`em-graph.mjs:144-145`) | `t_default_output_byte_identical`, `t_default_mode_does_not_read_bodies` | MUST | Regression guard on the live 135-file corpus |
+| REQ-9 | `--from <rule-slug>` traverses wiki-link/composes-with adjacency instead of early-returning a single node | `em-graph.mjs:290-292` (the comment promises this) | `t_from_rule_slug_traverses` | MUST | Requires editing the `:288-304` branch |
+| REQ-10 | A rule node with ≥1 edge is NOT reported by `--orphans` | `em-graph.mjs:272-276` | `t_linked_rule_not_orphan`, `t_unlinked_rule_still_orphan` | MUST | Current code pushes every rule id unconditionally |
+| REQ-11 | Rule nodes participate in `--hubs` degree ranking | `em-graph.mjs:262`, `:279` | `t_rule_node_can_be_hub` | MUST | `degree` map is episode-only today |
+| REQ-12 | RFC-007 status rows, both contradictions, the stale Mermaid label, and `_shipped_use` are corrected in the same PR | #589 Acceptance | `manual: git diff docs/rfcs/RFC-007-graph-projection.md` | MUST | See §9 for the exact six sites |
+| REQ-13 | The new suite is step-wired in `.github/workflows/tests.yml` | `tests.yml:401-405`; `test-ci-suite-registration.mjs` | `node tests/test-ci-suite-registration.mjs` → pass | MUST | Unwired suite fails CI by design |
+| REQ-14 | An Implementation-ledger row for Phase 3 whose SHA comes from `git log --follow` | #589 Acceptance; lesson: #582 class | `manual: git log --follow --oneline scripts/em-graph.mjs` | MUST | Never copy a SHA from an adjacent row |
+| REQ-15 | Target resolution tries the name-derived id first, then a filename-basename alias index; unresolvable targets dangle. Node ids are unchanged | Operator decision 2026-07-26; RFC `:151` basename clause | `t_alias_resolves_filename_style_link`, `t_name_id_wins_over_alias`, `t_ambiguous_alias_dangles` | MUST | Raises live-corpus resolution from 13/132 to 122/132 (wiki) and 0/76 to 51/76 (composes) |
+| REQ-16 | `composes-with` extraction strips fenced blocks but NOT inline backticks | RFC `:149` scopes the exclusion to `wiki-link` + `cites` only | `t_composes_backticked_target_resolves` | MUST | Real bullets are `` - `file.md` — text ``; stripping inline code deletes every target |
+| REQ-17 | RFC-007 gains a target-resolution subsection defining the alias index and reconciling `:142` with `:151` | Operator decision | `manual: git diff docs/rfcs/RFC-007-graph-projection.md` | MUST | The `:142` node-id rule stays untouched |
+
+## §5 Non-Goals
+
+- `--graph-health`, `entry_points[]`, the CI validator, `rfc-graph-contract-validate.mjs` — Phase 4 (#590), still blocked on #585.
+- Persisted `graph.json` / `envelope_version` — Phase 6 (#592, DEFERRED).
+- `cites-pr`, `trigger-phrase`, the MEMORY.md machine-readable trigger block — Phase 5 (#591).
+- Absolute-path disclosure on rule/rfc nodes — #602, untouched.
+- `em-console.mjs:114` flag passthrough — the new edges stay invisible through the console; not in scope, called out in §17.
+- Folding `em-graph` modes into `em-search` — #593, an architecture call that should precede Phase 5.
+- `em-restore.mjs`'s independent dangling-link mechanism (`:495`, `:963`) — different syntax, different corpus role; not unified here.
+
+## §6 Token Budget (Rule 12)
+
+| File | `wc -l` | Reads (lines × ~5) | Writes | Notes |
+|---|---|---|---|---|
+| `scripts/em-graph.mjs` | 358 | ~1.8k | ~1.2k | 5 edit sites |
+| `scripts/lib/rule-nodes.mjs` | 194 | ~1.0k | 0 | read-only; import source |
+| `docs/rfcs/RFC-007-graph-projection.md` | 737 | ~3.7k | ~0.8k | 6 edit sites |
+| `tests/test-em-graph-links.mjs` | 0 (new) | 0 | ~2.5k | ~22 cases |
+| `.github/workflows/tests.yml` | 405+ | ~0.3k | ~0.1k | 1 step |
+
+**Baseline (single session):** ~12k tokens of file I/O plus reasoning.
+**Optimized:** two slices, S1 (wiki-link) then S2 (composes-with), sharing the extraction scaffold.
+
+## §7 Safety / Security
+
+No new trust boundary, no privilege vector, no child process, no path-authority predicate. The
+feature reads files the script already reads and writes nothing (`t_no_writes` already exists in the
+Phase 2 suite and must stay green).
+
+Two input-handling concerns worth rows, both regex-shaped rather than security-shaped:
+
+| Concern | Severity | Abuse scenario | Mitigation | Test(s) (incl. ≥1 negative) |
+|---|---|---|---|---|
+| Catastrophic backtracking on a hostile rule body | Low | A rule file with thousands of unclosed `[[` runs the parser super-linearly | Both regexes are bounded by negated character classes (`[^\]|#]+`, `[^\]]*`) with no nested quantifier over an alternation — linear | `t_wikilink_pathological_input_bounded` (10k unclosed `[[`, asserts completion) |
+| Prototype-key rule slug | Low | A rule named `constructor` / `__proto__` corrupts the edge map | Slug maps are `new Map()`, not object literals — already the Phase 1 fix for `#469` | `t_proto_key_wiki_target` (negative: asserts no prototype pollution) |
+
+No `negative-scenario-planner` dispatch: this is not a schema / validator / security / multi-actor
+change. It is a parser addition behind an opt-in flag with no write path. Recorded here as a
+deliberate call, not an omission.
+
+**Cross-platform:** no new path handling. Fixtures use `os.tmpdir()` + `path.join`, matching
+`test-em-graph-nodes.mjs:27-29`. No GNU-only flags, no `sed -i`, no `readlink -f`.
+
+## §8 Design
+
+### 8.1 Two decisions this PR must settle (both are RFC self-contradictions)
+
+**Decision 1 — the wiki-link regex.** The RFC states it twice, non-equivalently:
+
+| Site | Form |
+|---|---|
+| Prose, `:150` | `\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]` |
+| Contract, `:674` | `\[\[([^\]|#]+)([|#][^\]]*)?\]\]` |
+
+Both produce the **same capture group 1**, so target resolution is identical either way; the
+difference is that the prose form keeps `#anchor` and `|alias` as two distinct non-capturing groups
+while the contract form merges them into one capturing blob. **Recommendation: adopt the prose form
+at `:150` as canonical and rewrite `:674` to match.** Rationale: it is the form documented alongside
+the ten named shapes, and separating anchor from alias is what shape 6 (`[[name#anchor|alias]]` →
+anchor stripped, alias dropped) actually describes. No behavioral difference either way, so this is
+a documentation-coherence call, not a functional one.
+
+**Decision 2 — the dangling bucket name.** Three sites, two spellings:
+
+| Site | Value |
+|---|---|
+| Prose `:103` | `wiki-link-dangling` |
+| Contract `:677` | `wiki-link` |
+| Persisted-index `kind` enum `:237` | `wiki-link` |
+
+**Recommendation: `wiki-link`, and rewrite the prose at `:103`.** Two of three sites already say it;
+it is consistent with `composes-with` at `:689` (which is not `composes-with-dangling`); and the
+string `wiki-link-dangling` appears nowhere else in the 737-line file.
+
+### 8.2 Key types
+
+```js
+/**
+ * @typedef {Object} DanglingEntry
+ * @property {string} source — rule slug the unresolved link was found in
+ * @property {string} ref    — the slugified target that did not resolve
+ * @property {string} kind   — 'wiki-link' | 'composes-with'
+ */
+```
+
+### 8.3 Key invariants
+
+- **Opt-in.** Rule bodies are read only when `--nodes` includes `rule` AND `--edges` includes at
+  least one of the two new types. Default invocation performs zero extra I/O (REQ-8).
+- **One slug function.** `slugify` is imported, never redefined (REQ-1, P2).
+- **Dangling ≠ orphan.** `dangling` = an edge whose target does not resolve. `orphan` = a node with
+  degree 0. A rule can be both, neither, or either (RFC `:242`).
+- **Rule-node edges are rule→rule only.** Neither edge type ever points at an episode or a tag.
+
+### 8.4 Resolution flow
+
+```text
+rule file body
+  → strip fenced blocks + inline backticks   (same treatment as cites, em-graph.mjs:207)
+  → wiki-link regex  |  ## Composes with section scan
+  → strip .md extension, strip #anchor, drop |alias
+  → slugify(name)
+  → ruleById.has(slug) ?  addEdge(source, slug, type)  :  dangling.push({source, ref, kind})
+```
+
+## §9 Existing Hook Points
+
+Line numbers verified against `8e6e699` at plan time.
+
+| File | Line(s) | What it does today | Impact |
+|---|---|---|---|
+| `scripts/em-graph.mjs` | 102-103 | `EDGE_TYPES` (5) / `DEFAULT_EDGES` (4) | Add 2 to `EDGE_TYPES` only |
+| `scripts/em-graph.mjs` | 150-158 | `scanRuleNodes` + collision exit 2 | Body extraction hooks in after this |
+| `scripts/em-graph.mjs` | 212-230 | Edge-building loop over episode `rows` | New rule-edge loop added after it |
+| `scripts/em-graph.mjs` | 262 | `degree` map built from `rows` only | Rule ids must be seeded (REQ-11) |
+| `scripts/em-graph.mjs` | 272-276 | Pushes **every** rule id as an orphan | Must become degree-aware (REQ-10) |
+| `scripts/em-graph.mjs` | 288-304 | `--from <rule-slug>` early-returns 1 node | Must fall through to BFS (REQ-9) |
+| `scripts/lib/rule-nodes.mjs` | 30-38 | `slugify()` | Imported, unchanged |
+
+**RFC-007 edit sites (six), all corrected for drift:**
+
+| # | Line | Change |
+|---|---|---|
+| 1 | 84, 85 | `UNBUILT — Phase 3` → `SHIPPED` + `em-graph.mjs:<line>` anchors |
+| 2 | 103 | `wiki-link-dangling` → `wiki-link` (Decision 2) |
+| 3 | 384 | Phase 3 row → **SHIPPED** |
+| 4 | 394 | `P2[Phase 2 UNBUILT: …]` → `SHIPPED` (pre-existing stale label, contradicts `:383`) |
+| 5 | 588 | `_shipped_use` rewritten — the "not used by the shipped script" claim is already false at `8e6e699` |
+| 6 | 674, 669, 681 | Regex per Decision 1; both `status` fields flip |
+
+Plus REQ-14's ledger row after `:447`.
+
+## §10 Slice Ladder
+
+| Slice | Objective | Primary files | Tests | Hard stops |
+|---|---|---|---|---|
+| `P3-S1` | wiki-link edge + dangling scaffold + mode integration (REQ-9/10/11) | `em-graph.mjs`, `tests/test-em-graph-links.mjs` | shape matrix, fence exclusion, dangling, mode tests | Do NOT touch `composes-with`; do NOT edit the RFC |
+| `P3-S2` | `composes-with` edge reusing S1's scaffold | `em-graph.mjs`, `tests/test-em-graph-links.mjs` | section parsing, nested-ignored, empty-section | Do NOT touch S1 assertions |
+| `P3-S3` | RFC coherence + ledger + CI wiring | `RFC-007-graph-projection.md`, `tests.yml` | `test-ci-suite-registration.mjs` | Do NOT touch `em-graph.mjs` |
+
+```text
+S1 ── S2 ── S3
+```
+All three are hard deps in order. One commit each, one PR.
+
+## §11 Cut Order
+
+Cut in this order if scope grows:
+
+1. REQ-11 (rule nodes in `--hubs`) — file as a follow-up issue; orphans correctness matters more.
+2. The 5 extension fixture rows beyond the RFC's ten named shapes (keep 15 total only if cheap).
+3. S2 `composes-with` entirely — ship wiki-link alone, re-file Phase 3b.
+
+Do **not** cut:
+
+- REQ-8 (default output byte-identical) — this is the regression guard on a live 135-file corpus.
+- REQ-1 (single `slugify`) — a forked slug function is a P2 violation.
+- REQ-6 (empty section yields no dangling) — the RFC names it a non-negotiable false-pass trap.
+- REQ-10 (linked rule is not an orphan) — shipping S1 without it makes `--orphans` actively wrong.
+
+## §12 Contracts
+
+### `extractWikiLinks(body) → { targets: string[], danglingRefs: string[] }`
+
+**Input contract:** `body` is the full rule-file text including frontmatter. Non-string input
+returns empty arrays rather than throwing.
+**Output contract:** `targets` are slugs present in `ruleById`. `danglingRefs` are slugs that
+resolved to a non-empty string but are absent from `ruleById`. Neither array contains duplicates or
+empty strings. Never null.
+
+**State table (exhaustive):**
+
+| State | Condition | Output | Side effects |
+|---|---|---|---|
+| A. resolved | `[[X]]`, `slugify(X)` in `ruleById` | `targets:[slug]` | none |
+| B. dangling | `[[X]]`, slug non-empty, not in `ruleById` | `danglingRefs:[slug]` | none |
+| C. ignored-empty | `[[]]` or `[[   ]]` | both empty | none |
+| D. ignored-fenced | inside ` ``` ` or `~~~` | both empty | none |
+| E. ignored-inline | inside single backticks | both empty | none |
+| F. ignored-not-wiki | `[link](path.md)` | both empty | none |
+| G. nested | `[[[[x]]]]` | outermost only, one entry | none |
+| H. self-link | `slugify(X)` equals the source rule's own slug | both empty (self-loop guard, `em-graph.mjs:183`) | none |
+
+**Error codes:** none — the extractor never exits. Malformed input degrades to "no edges", matching
+`bodyCitations`'s `catch { return [] }` at `em-graph.mjs:209`.
+
+## §13 Edge Cases
+
+| # | Scenario | Expected | Test |
+|---|---|---|---|
+| EC1 | Rule file with no `name:` frontmatter contains `[[x]]` | file is not a node at all (`rule-nodes.mjs:118-121`), so it is not an edge source | `t_no_name_rule_emits_no_edges` |
+| EC2 | `[[Name]]` vs `[[name]]` in two files | both slugify to `name`, one deduped edge | `t_case_folded_targets_dedupe` |
+| EC3 | Slug collision already exits 2 at `:152-155` before any body scan | Phase 3 never runs on a colliding corpus | `t_collision_still_exits_2_before_extraction` |
+| EC4 | `## Composes with` present, section empty | 0 edges AND 0 dangling (REQ-6) | `t_composes_empty_section_no_dangling` |
+| EC5 | Unclosed fence — ` ``` ` opened and never closed | remainder of file treated as fenced, no edges (matches `cites` regex behavior) | `t_unclosed_fence_swallows_remainder` |
+| EC6 | `## Composes with` followed immediately by `## Other` | section is empty, next heading terminates it | `t_composes_terminated_by_next_heading` |
+| EC7 | Live corpus run — 68 files carry `[[…]]`, 21 carry the heading | real run completes, emits both edges and dangling entries | `manual:` §15 row |
+
+## §14 Test Case Catalog
+
+Runner: `node tests/test-em-graph-links.mjs`. Harness shape copies
+`tests/test-em-graph-nodes.mjs:22-48` (local `t()`, `node:assert/strict`, `spawnSync`, temp
+`HOME`, `writeRule()` helper, `process.exit(fail ? 1 : 0)`).
+
+```text
+Group 1: wiki-link shape matrix (15)
+  t_wikilink_shape_matrix — 15 rows, each asserting resolved | dangling | ignored
+
+Group 2: exclusion (3)
+  t_wikilink_fence_exclusion
+  t_wikilink_inline_backtick_exclusion
+  t_unclosed_fence_swallows_remainder
+
+Group 3: composes-with (8)
+  t_composes_toplevel_only
+  t_composes_nested_ignored
+  t_composes_markdown_link_basename
+  t_composes_empty_section_no_dangling
+  t_composes_terminated_by_next_heading
+  t_composes_backticked_target_resolves    (REQ-16 — the zero-edge trap)
+  t_composes_prose_bullet_skipped          (review r1 finding 5)
+  t_composes_first_backtick_run_wins       (review r1 finding 6)
+
+Group 3b: target resolution (3)
+  t_alias_resolves_filename_style_link
+  t_name_id_wins_over_alias
+  t_ambiguous_alias_dangles
+
+Group 4: dangling (2)
+  t_dangling_distinct_from_orphans
+  t_dangling_kind_values
+
+Group 5: mode integration (4)
+  t_from_rule_slug_traverses
+  t_linked_rule_not_orphan
+  t_unlinked_rule_still_orphan
+  t_rule_node_can_be_hub
+
+Group 6: regression + robustness (6)
+  t_default_output_byte_identical
+  t_default_mode_does_not_read_bodies
+  t_edge_types_registered
+  t_default_edges_unchanged
+  t_edges_all_emits_empty_dangling
+  t_collision_still_exits_2_before_extraction
+
+Group 7: hostile input (2)
+  t_wikilink_pathological_input_bounded
+  t_proto_key_wiki_target
+```
+
+Total: **29 named cases** — 21 in S1 (groups 1, 2, 3b, 4, 5, 6, 7), 8 added by S2 (group 3).
+The count of individual assertions is fixed at build time and recorded in
+§15; the suite prints `N passed, 0 failed` where N is the case count, matching both sibling suites.
+
+Every fixture uses a unique sentinel slug (`sentinel-a1b2c3`) so a passing assertion cannot be
+satisfied by an unrelated corpus entry (§A.9 discriminating-sentinel).
+
+## §15 Verification Ledger
+
+| Claim | Command | Observed |
+|---|---|---|
+| New suite passes | `node tests/test-em-graph-links.mjs` | _fill at build time_ |
+| Phase 1 suite still green | `node tests/test-em-graph.mjs` | baseline `10 passed, 0 failed` |
+| Phase 2 suite still green | `node tests/test-em-graph-nodes.mjs` | baseline `28 passed, 0 failed` |
+| Suite is CI-wired | `node tests/test-ci-suite-registration.mjs` | _fill_ |
+| Default output unchanged | `node scripts/em-graph.mjs --hubs --top 5` | must equal the `8e6e699` bytes |
+| Live corpus behaves | `node scripts/em-graph.mjs --nodes rule --edges wiki-link --from <slug>` | _fill: real edges + dangling_ |
+| No second slugify | `grep -c 'function slugify' scripts/em-graph.mjs` | `0` |
+| CI green | `gh pr checks <PR>` | _fill — never claim from a local run_ |
+
+## §16 Risk Analysis
+
+| Risk | Sev | Likelihood | Mitigation |
+|---|---|---|---|
+| REQ-9/10/11 mode changes regress Phase 2's 28 cases | Med | Med | Both prior suites are §15 rows; S1 runs them before S2 starts |
+| Live corpus produces a flood of dangling entries (many `[[…]]` targets may not be rule nodes — 8 of 135 files lack `name:`) | Low | **High** | Expected, not a failure; §15 row records the real count. Thresholding is OQ-2 / Phase 4 |
+| The 15-shape fixture is written to match the implementation rather than the spec | Med | Med | Fixture rows are transcribed from RFC `:150` before any parser code is written (S1 step order) |
+| Builder seat reports success on unrun verifies | Med | Med | Handoff 93's lesson: re-run every verify myself; never accept the seat's summary |
+
+## §17 Open Decisions
+
+- **Decision 1 (regex form)** and **Decision 2 (bucket name)** — resolved in §8.1 as recommendations; both need operator sign-off before S3.
+- **`--hubs` omits `skipped_nodes` (#603)** → the hubs branch at `em-graph.mjs:282` is already being
+  edited for REQ-11, so adding `...nodeDiag()` would close #603 in one token. Deferred by default
+  under the surgical-changes rule; **flagged for an explicit fold/no-fold call.** 5-field DEFER:
+  (1) reproduced live — scout confirmed 8 real skips silently dropped on `--nodes rule --hubs`;
+  (2) no RFC requirement mandates it; (3) filed as #603, no prior reviewer round; (4) same class is
+  `--orphans`/`--from`, both of which already emit it, so hubs is the lone sibling left out;
+  (5) residual: a diagnostic is silently absent — graceful, no corruption.
+- **`em-console.mjs:114` passthrough** → new edges unreachable via the console. Not in Phase 3's
+  primary-files row. Needs its own issue if we want console parity.
+- **Suite filename** → `test-em-graph-links.mjs`, following the `-nodes` feature-slice precedent.
+  No repo doc commits to a Phase 3 filename.
+
+## §18 Done Criteria
+
+- [ ] All 14 MUST requirements passing.
+- [ ] Both existing em-graph suites still green.
+- [ ] RFC-007's six edit sites corrected; `grep -c 'wiki-link-dangling'` → 0.
+- [ ] Ledger row present with a `git log --follow`-derived SHA.
+- [ ] Every deferred finding has an issue/comment/violation artifact (Rule 18 step 9).
+
+## §19 Review Consensus (Rule 18)
+
+Plan review before implementation, then a frozen-diff review after. Reviewer seat per the standing
+directive: `pi --provider neuralwatt --model glm-5.2` (pre-authorized).
+
+| Pass | Reviewer | Provider/Model | Blockers | Verdict | Artifact |
+|---|---|---|---|---|---|
+| 1 (plan) | pi seat, Herdr `drv-rfc007p3-20260726` | neuralwatt / glm-5.2, thinking high | 1 BLOCKER, 2 MAJOR, 4 MINOR | **HOLD** → folded | §19.1 below; seat spend $0.418 |
+| 2 (diff) | _pending, post-implementation_ | neuralwatt / glm-5.2 | | | |
+
+Cap at 2 rounds. A third HOLD on the same class means the patch boundary is wrong.
+
+### 19.1 Resolved blockers (round 1)
+
+| # | Finding | Disposition | Resolution + evidence |
+|---|---|---|---|
+| 1 | **BLOCKER** — §A.5.4 (step 1.8) calls `danglingOut()`, which step 1.9 defines. Verbatim application gives `ReferenceError`, dropping Phase 2 from 28 to 27 with no clean in-step fix | **ACCEPT** | Independently confirmed: `grep -n danglingOut <plan>` returned line 492 (definition, step 1.9) and 633 (use, §A.5.4). Removed the stray `...danglingOut(),` from §A.5.4; step 1.9 adds all three call sites |
+| 2 | **MAJOR** — step 1.4's verify asserts the output carries a `dangling` key, but nothing surfaces that array until step 1.9. Unsatisfiable in-step | **ACCEPT** | Verify rewritten to a loop-presence grep, with an explicit note that the output-shape check belongs to step 1.9 |
+| 3 | **MAJOR** — step 1.9's verify expected `grep -c 'danglingOut()'` → 4 "one definition + three call sites", but the definition reads `danglingOut = ()`, so that substring never matches it | **ACCEPT** | Corrected to `3`, with the reason stated inline so a future editor does not re-inflate it |
+| 4 | **MINOR** — step 3.5's verify said "drops by exactly 5 from the pre-edit value", ambiguous because step 3.2 already removed 2 | **ACCEPT** | Confirmed `grep -c UNBUILT` = **17** at `8e6e699`. Restated as absolute counts (15 before → 10 after) naming the five sites |
+| 5 | **MINOR** — `composesTargets`'s fallback slugified an entire prose bullet, manufacturing garbage dangling refs like `rule-17-claude-md-global-bot-reviews` | **ACCEPT** | A bullet that is neither a markdown link nor backtick-led now yields no target. New test `t_composes_prose_bullet_skipped` |
+| 6 | **MINOR** — a bullet with two backticked spans silently keeps only the first | **ACCEPT-WITH-MOD** | Behavior kept (one bullet names one target) but made explicit in a code comment. New test `t_composes_first_backtick_run_wins` |
+| 7 | **MINOR** — several step verifies are presence-only greps that a stub would pass | **NOTED, no change** | Reviewer's own assessment: each is back-stopped by the functional suites at 1.10 / 2.3 and by REQ-1. Recorded here for the §A.6b ledger rather than fixed |
+
+**Verified sound by the reviewer, with commands actually run** (not reasoned about): REQ-8's
+byte-identical default output traced through every payload at module scope; the §A.5.4 control flow
+on all three paths; the wiki-link regex against all ten RFC shapes plus four adversarial extras
+(shape 10 `[[[[x]]]]` → capture group 1 `[[x` → `x`, confirming the plan's claim); the alias index's
+shadow-prevention and ambiguity handling; and REQ-16's backtick preservation.
+
+## §20 Lessons Encoded
+
+| Lesson | Rule | Enforced in |
+|---|---|---|
+| #606 / #582 stale-anchor class | Every RFC anchor re-verified against the file, never trusted from an issue body | §9, and the §9 drift table |
+| Handoff 93 seat-summary lesson | Re-run every verify personally; a seat's "all matched" is a claim | §16, §15 |
+| `…4a52` three-leg deploy | Post-merge deploy is global + consumer `shasum` sweep + marketplace pull | post-merge, not in this plan's scope |
+| ledger provenance (#582) | Ledger SHA from `git log --follow`, never an adjacent row | REQ-14 |
+| P2 single-adapter-contract | One `slugify`, imported | REQ-1 |
+| discriminating sentinel | Fixtures carry a unique token; assertions inspect that token | §14 |
+| verify-before-conclude | Artifact precedes the claim | §15 |
+
+---
+
+# Appendix A: Mechanical Execution Spec
+
+## A.0 Target-toolchain instantiation
+
+| Key | Value |
+|---|---|
+| Language / runtime | Node.js 20+, `.mjs` ESM, zero deps |
+| Runtime check | `node --version` → `v20` or higher |
+| Test-runner shape | `node tests/test-em-graph-links.mjs` |
+| New-function phrasing | `function fnName(args)` (module-local; `em-graph.mjs` is a CLI, not a module — it exports nothing) |
+| Portable break-input override | argv flag `--break-<x>` (cross-platform; no `VAR=x cmd` prefix) |
+| Search tool for verifies | `grep -c` / `grep -n` from repo root |
+| Repo-specific done-commands | `node tests/test-ci-suite-registration.mjs` |
+
+## A.1 Forbidden-phrase lint
+
+```bash
+grep -niE "decide|choose|figure out|as appropriate|if needed|handle accordingly|\betc\.|and so on|TBD|should probably|something like|or similar" docs/plans/RFC-007-P3-wiki-link-composes-with.md
+```
+
+Acceptance: matches are permitted only outside §A.5 blocks and §A.7 step rows. Record the match list
+and per-match disposition beside the lint run. A reading pass over Appendix A is required in addition
+to the grep, because line-based grep misses wrapped occurrences.
+
+## A.2 Executor contract (copy verbatim into the handoff)
+
+1. Do the steps in numeric order. Do not skip, reorder, or batch.
+2. Each step names exactly one file, the exact change, and how to verify it.
+3. Make no design decisions. If a step is ambiguous or an anchor is not found verbatim, STOP (§A.3).
+4. Run the verify after each step. If it fails, fix only that step before proceeding.
+5. Edit exactly ONE file per step. Read-only references (look, never edit): `scripts/lib/rule-nodes.mjs`, `tests/test-em-graph.mjs`, `tests/test-em-graph-nodes.mjs`.
+6. Each verify is a single command — no `;`, `&&`, `||`, pipes, or subshells.
+7. One slice = one commit, message `RFC-007-P3-S<n>: <slice title>`.
+8. Do not commit, push, or open a PR until §18 is green and the human has approved.
+9. No aspirational output: every printed line describing a check is backed by an assertion performing it.
+
+## A.3 STOP-and-ask protocol
+
+```text
+STOP — step <n.m> blocked.
+Reason: <anchor not found | ambiguous instruction | verify failed after fix>.
+File: <path>
+Expected anchor (verbatim): <text>
+What I found instead: <actual surrounding text, ±3 lines>
+Question: <the single decision the plan owner must make>
+```
+
+## A.4 Pre-flight (step 0 of every slice)
+
+| Check | Command | Expected |
+|---|---|---|
+| Branch | `git branch --show-current` | `feat/rfc-007-p3-wiki-link-composes-with` |
+| Clean tree | `git status --porcelain` | empty except the known `.gitignore` carry |
+| Phase 1 green | `node tests/test-em-graph.mjs` | `10 passed, 0 failed` |
+| Phase 2 green | `node tests/test-em-graph-nodes.mjs` | `28 passed, 0 failed` |
+| Runtime | `node --version` | `v20` or higher |
+
+## A.5 Shared constants
+
+```js
+// Added to scripts/em-graph.mjs. Exact values — no placeholders.
+const WIKI_LINK_RE = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]/g
+const COMPOSES_HEADING_RE = /^##[ \t]+Composes with[ \t]*$/im
+const RULE_EDGE_TYPES = ['wiki-link', 'composes-with']
+```
+
+`WIKI_LINK_RE` is Decision 1's prose form verbatim from `RFC-007-graph-projection.md:150`, with the
+global flag added for iteration.
+
+## A.6 Anchor format
+
+- **ANCHOR** is a verbatim unique substring already in the file. Not unique or not present → STOP.
+- **CREATE** = whole-file `Write` of a new file, its own step, the only place a whole-file write is allowed.
+- **EDIT** = anchored `ANCHOR → REPLACE`, smallest diff, no reformatting of untouched lines.
+- **APPEND** = add a new block at end of file.
+
+## A.7 Per-slice step tables
+
+Decisions signed off by the operator: **Decision 1 = prose form at `:150`**, **Decision 2 =
+`wiki-link`**, **#603 = do not fold**. Every literal below is instantiated from those three answers.
+
+### `P3-S1` — wiki-link edge, dangling scaffold, mode integration (REQ-1/2/3/4/7/8/9/10/11)
+
+**Files this slice may touch:** `scripts/em-graph.mjs`, `tests/test-em-graph-links.mjs`.
+**Read-only:** `scripts/lib/rule-nodes.mjs`, `tests/test-em-graph.mjs`, `tests/test-em-graph-nodes.mjs`.
+
+**Marked "focused review before build"** — steps 1.6 through 1.9 edit three mode branches that all
+three suites exercise.
+
+| Step | File | Kind | Exact action | Verify (observed → expected) |
+|---|---|---|---|---|
+| 1.0 | — | — | Pre-flight §A.4. | every row passes |
+| 1.1 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `import { resolveRuleDir, scanRuleNodes, scanRfcNodes } from './lib/rule-nodes.mjs'` → `REPLACE:` `import { resolveRuleDir, scanRuleNodes, scanRfcNodes, slugify } from './lib/rule-nodes.mjs'` | `grep -c "scanRfcNodes, slugify" scripts/em-graph.mjs` → `1` |
+| 1.2 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `const EDGE_TYPES = ['supersedes', 'consolidates', 'evidence', 'cites', 'tags']` → `REPLACE:` `const EDGE_TYPES = ['supersedes', 'consolidates', 'evidence', 'cites', 'tags', 'wiki-link', 'composes-with']`. Do NOT touch the `DEFAULT_EDGES` line below it. | `node scripts/em-graph.mjs --edges wiki-link --orphans --scope local` → exit `0` (before this step the same command exits `2` with `Unknown edge type "wiki-link"`) |
+| 1.3 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` the three lines ending `bodyCitations`, verbatim:<br>`    return [...new Set(cleaned.match(ID_RE) \|\| [])].filter(id => id !== row.id && byId.has(id))`<br>`  } catch { return [] }`<br>`}`<br>`REPLACE:` those three lines unchanged, then a blank line, then the §A.5 constants block plus `ruleBody(file)`, `targetSlug(raw)` and `linkTargets(cleaned)` exactly as spelled in §A.5.1 below. | `node -e "import('./scripts/lib/rule-nodes.mjs').then(m=>console.log(m.slugify('Alpha Rule')))"` → `alpha-rule` |
+| 1.4 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `  if (edgeTypes.includes('tags')) {`<br>`    for (const tag of strings(r.tags)) addEdge(r.id, \`tag:${tag.toLowerCase().trim()}\`, 'tags')`<br>`  }`<br>`}`<br>`REPLACE:` those four lines unchanged, then the wiki-link edge loop in §A.5.2. | `grep -c "edgeTypes.includes('wiki-link')" scripts/em-graph.mjs` → `1`. (The `dangling` array is populated here but is NOT yet in the output: `danglingOut()` is added at step 1.9, so an output-shape verify is unsatisfiable at this step.) |
+| 1.5 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `  const degree = new Map(rows.map(r => [r.id, 0]))` → `REPLACE:` that line, then `  for (const id of ruleById.keys()) degree.set(id, 0)` | `grep -c 'for (const id of ruleById.keys()) degree.set' scripts/em-graph.mjs` → `1` |
+| 1.6 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `  const reportable = r => includeSuperseded \|\| r.status !== 'superseded'` → `REPLACE:` `  const reportable = r => includeSuperseded \|\| r?.status !== 'superseded'`. **Reason (do not skip):** step 1.5 puts rule ids into `degree`, and the hubs filter calls `reportable(byId.get(id))`, which is `undefined` for a rule id. Without the optional chain this throws `TypeError: Cannot read properties of undefined`. | `node scripts/em-graph.mjs --nodes rule --edges wiki-link --hubs --scope local` → exit `0`, not a stack trace |
+| 1.7 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` the five lines from `    // Phase 2 gives rule/rfc nodes no edges, so every one is degree 0 and is an orphan` through `    for (const id of rfcById.keys()) out.push(nodeOut(id, 0))` → `REPLACE:` the block in §A.5.3 (rule ids filtered to degree 0; rfc ids unchanged). | `node tests/test-em-graph-nodes.mjs` → `28 passed, 0 failed` |
+| 1.8 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` the whole `--from` root-resolution branch, lines beginning `if (!byId.has(from)) {` through `  process.exit(1)`<br>`}` → `REPLACE:` the restructured branch in §A.5.4. A rule/rfc node **with** adjacency now falls through to the BFS; one **without** keeps the existing single-node reply; an unknown id still exits 1. | `node tests/test-em-graph-nodes.mjs` → `28 passed, 0 failed` (covers `t_from_rule_id_returns_single_node` and `t_from_unknown_id_still_exits_1`) |
+| 1.9 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `const nodeDiag = () => (nodesRaw === undefined ? {} : { skipped_nodes: skippedNodes })` → `REPLACE:` that line, then `const danglingOut = () => (edgeTypes.some(e => RULE_EDGE_TYPES.includes(e)) ? { dangling } : {})`. Then add `...danglingOut(),` immediately after each existing `...nodeDiag()` occurrence — there are exactly three (orphans output, from-single output, final BFS output). Do NOT add it to the hubs branch (#603 stays out of scope per the operator's fold decision). | `grep -c 'danglingOut()' scripts/em-graph.mjs` → `3`. The definition reads `danglingOut = ()`, so the substring `danglingOut()` matches call sites ONLY, never the definition line. |
+| 1.10 | `tests/test-em-graph-links.mjs` | **CREATE** | Whole-file write. Harness copied from `tests/test-em-graph-nodes.mjs:22-48` (`t()` helper, `node:assert/strict`, `spawnSync`, temp `HOME` via `fs.mkdtempSync`, `resetRuleDir()`/`writeRule()`, `process.exit(fail ? 1 : 0)`). Contains Groups 1, 2, 3b, 4, 5, 6, 7 from §14 — **not** Group 3, which is S2. Every fixture rule slug carries the token `sentinel-a1b2c3`; every assertion inspects that token, never "non-empty". Full verbatim contents authored at build time under the §A.7 executor-ready gate. | `node tests/test-em-graph-links.mjs` → `21 passed, 0 failed` |
+| 1.11 | — | — | Negative control (§A.9): run the suite with the break-input override, which forces `linkTargets()` to return `[]`. | `node tests/test-em-graph-links.mjs --break-wikilink` → non-zero exit |
+| 1.12 | — | — | Commit `RFC-007-P3-S1: wiki-link edge, dangling scaffold, rule-node mode integration`. | `git log -1 --oneline` → shows `RFC-007-P3-S1` |
+
+### `P3-S2` — `composes-with` (REQ-5/6)
+
+**Files this slice may touch:** `scripts/em-graph.mjs`, `tests/test-em-graph-links.mjs`.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 2.0 | — | — | Pre-flight §A.4 plus `node tests/test-em-graph-links.mjs` → `21 passed, 0 failed`. | every row passes |
+| 2.1 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` `function linkTargets(cleaned) {` → `REPLACE:` `composesTargets(cleaned)` from §A.5.5 inserted immediately above it, then `function linkTargets(cleaned) {` unchanged. Section runs from the `## Composes with` heading to the next line matching `^## ` or EOF; only lines matching `^-[ \t]+` are read; `^[ \t]+-` (nested) are skipped; `- [text](path.md)` resolves by basename via `path.basename(p, '.md')`. | `grep -c 'function composesTargets' scripts/em-graph.mjs` → `1` |
+| 2.2 | `scripts/em-graph.mjs` | **EDIT** | `ANCHOR:` the closing brace of the wiki-link loop added in 1.4, verbatim from §A.5.2 → `REPLACE:` that brace, then the `composes-with` loop in §A.5.6, which reuses `ruleBody()` and pushes into the same `dangling` array with `kind: 'composes-with'`. | `node scripts/em-graph.mjs --nodes rule --edges composes-with --orphans --scope local` → exit `0`, JSON has `dangling` |
+| 2.3 | `tests/test-em-graph-links.mjs` | **EDIT** | `ANCHOR:` the `main()` registration list added in 1.10 → `REPLACE:` same list plus Group 3's eight cases. Do NOT alter any S1 assertion. | `node tests/test-em-graph-links.mjs` → `29 passed, 0 failed` |
+| 2.4 | — | — | Commit `RFC-007-P3-S2: composes-with edge`. | `git log -1 --oneline` → shows `RFC-007-P3-S2` |
+
+### `P3-S3` — RFC coherence, ledger, CI wiring (REQ-12/13/14)
+
+**Files this slice may touch:** `docs/rfcs/RFC-007-graph-projection.md`, `.github/workflows/tests.yml`.
+**Hard stop:** do not touch `scripts/em-graph.mjs` or any test file in this slice.
+
+| Step | File | Kind | Exact action | Verify |
+|---|---|---|---|---|
+| 3.0 | — | — | Pre-flight §A.4 plus all three suites green. | every row passes |
+| 3.1 | `.github/workflows/tests.yml` | **EDIT** | `ANCHOR:` `      - name: Run em-graph node-projection suite (RFC-007 Phase 2)`<br>`        run: node tests/test-em-graph-nodes.mjs` → `REPLACE:` those two lines, then a blank line, then:<br>`      - name: Run em-graph link-edge suite (RFC-007 Phase 3)`<br>`        run: node tests/test-em-graph-links.mjs` | `node tests/test-ci-suite-registration.mjs` → pass |
+| 3.2 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | Line 84 `ANCHOR:` `| \`wiki-link\` | UNBUILT — Phase 3 |` → `REPLACE:` `| \`wiki-link\` | SHIPPED — \`em-graph.mjs:<line>\` |` with `<line>` the real line of the wiki-link loop. Line 85 same treatment for `composes-with`. | `grep -c 'UNBUILT — Phase 3' docs/rfcs/RFC-007-graph-projection.md` → `0` |
+| 3.3 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | Line 103 `ANCHOR:` `dangling links recorded as \`wiki-link-dangling\`` → `REPLACE:` `dangling links recorded in the \`wiki-link\` bucket` (Decision 2). | `grep -c 'wiki-link-dangling' docs/rfcs/RFC-007-graph-projection.md` → `0` |
+| 3.4 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | Line 674 `ANCHOR:` `"parser": "regex:\\\\[\\\\[([^\\\\]\|#]+)([\|#][^\\\\]]*)?\\\\]\\\\]",` → `REPLACE:` the JSON-escaped form of Decision 1's prose regex, so the contract matches `:150` character for character after unescaping. | `node -e "const s=require('fs').readFileSync('docs/rfcs/RFC-007-graph-projection.md','utf8');console.log(s.includes('(?:#[^\\\\]\|]*)?'))"` → `true` |
+| 3.5 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | Line 384 Phase 3 row `UNBUILT` → `**SHIPPED**`. Line 395 `P3[Phase 3 UNBUILT: wiki-link + composes-with]` → `SHIPPED`. Line 394 `P2[Phase 2 UNBUILT: rule + rfc node types]` → `SHIPPED` (pre-existing staleness; contradicts `:383` and ledger `:447`). Lines 669 and 681 `"status": "UNBUILT (Phase 3)"` → `"SHIPPED"`. | `grep -c 'UNBUILT' docs/rfcs/RFC-007-graph-projection.md` → **15 before this step, 10 after**. (Absolute, not relative: the file holds **17** at `8e6e699`; step 3.2 already removed 2 at lines 84-85. The five this step removes are lines **384, 394, 395, 670, 682**.) |
+| 3.6 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | Line 588 `ANCHOR:` `"_shipped_use": "not used by the shipped script` … → `REPLACE:` a statement of actual use: slugify is called by `scanRuleNodes` (`lib/rule-nodes.mjs:117`) for rule-node ids since Phase 2, and by the Phase 3 link parsers for edge-target resolution. Tag ids still lowercase inline and do NOT use it. Correct the stale `em-graph.mjs:185` anchor to the real current line. | `grep -c 'not used by the shipped script' docs/rfcs/RFC-007-graph-projection.md` → `0` |
+| 3.7 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | `ANCHOR:` the last ledger row (the Phase 2 row beginning `| Phase 2 — PR #604`) → `REPLACE:` that row, then a Phase 3 row. **The SHA comes from `git log --follow --oneline scripts/em-graph.mjs` on the merge commit — never copied from an adjacent row (#582 class).** | `git log --follow --oneline scripts/em-graph.mjs` → the SHA written into the row appears in this output |
+| 3.9 | `docs/rfcs/RFC-007-graph-projection.md` | **EDIT** | `ANCHOR:` `Rule-file slugs derive from frontmatter \`name:\`. Filename-derived slugs are NOT used` … (the full `:143` paragraph) → `REPLACE:` that paragraph unchanged, then the §A.5.7 "Target resolution" subsection. Do NOT alter the `:142` node-id rule itself. | `grep -c '### Target resolution' docs/rfcs/RFC-007-graph-projection.md` → `1` |
+| 3.10 | — | — | Commit `RFC-007-P3-S3: RFC coherence, target resolution, ledger row, CI wiring`. | `git log -1 --oneline` → shows `RFC-007-P3-S3` |
+
+### A.5.1 – A.5.6 — verbatim code blocks referenced above
+
+Copy-paste payloads. Plain Node ESM, zero deps, matching the surrounding file's style: no
+semicolons, two-space indent, single quotes, `const` arrow helpers.
+
+#### A.5.1 — extraction helpers + alias index (step 1.3)
+
+```js
+// --- Phase 3: rule-body edge extraction (RFC-007 wiki-link + composes-with) ---
+// Fenced blocks are stripped for both edge types. Inline backticks are stripped
+// for wiki-link ONLY (RFC-007:149 scopes that rule to wiki-link and cites): real
+// "## Composes with" bullets write their target inside backticks, so stripping
+// inline code there would delete every target and silently emit zero edges.
+const WIKI_LINK_RE = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]/g
+const RULE_EDGE_TYPES = ['wiki-link', 'composes-with']
+const dangling = []
+
+const stripFenced = s => s.replace(/```[\s\S]*?```/g, '').replace(/~~~[\s\S]*?~~~/g, '')
+const stripInline = s => s.replace(/`[^`\n]*`/g, '')
+
+function ruleBody(file) {
+  try {
+    const content = fs.readFileSync(file, 'utf8')
+    const parts = content.split('---')
+    return parts.length >= 3 ? parts.slice(2).join('---') : content
+  } catch { return '' }
+}
+
+// Secondary index for TARGET resolution only. Node ids stay frontmatter-name
+// derived (RFC-007:142 is untouched); authors nonetheless link by filename, so a
+// slugified basename maps back to the owning node id. An ambiguous basename (two
+// files slugifying alike) is dropped rather than guessed — the link dangles.
+const ruleAlias = new Map()
+for (const [slug, node] of ruleById) {
+  const base = slugify(path.basename(node.file, '.md'))
+  if (!base || ruleById.has(base)) continue
+  if (ruleAlias.has(base)) ruleAlias.set(base, null)
+  else ruleAlias.set(base, slug)
+}
+
+function resolveTarget(slug) {
+  if (ruleById.has(slug)) return slug
+  return ruleAlias.get(slug) || null
+}
+
+function targetSlug(raw) {
+  return slugify(String(raw).trim().replace(/\.md$/i, ''))
+}
+
+function linkTargets(cleaned) {
+  const out = []
+  for (const m of cleaned.matchAll(WIKI_LINK_RE)) {
+    const slug = targetSlug(m[1])
+    if (slug) out.push(slug)
+  }
+  return [...new Set(out)]
+}
+```
+
+#### A.5.2 — wiki-link edge loop (step 1.4)
+
+```js
+
+// Rule-to-rule edges. Rule bodies are read ONLY when a rule-edge type was
+// requested, so a default invocation still performs zero rule I/O (REQ-8).
+if (edgeTypes.includes('wiki-link')) {
+  for (const [slug, node] of ruleById) {
+    for (const raw of linkTargets(stripInline(stripFenced(ruleBody(node.file))))) {
+      const target = resolveTarget(raw)
+      if (target === slug) continue
+      if (target) addEdge(slug, target, 'wiki-link')
+      else dangling.push({ source: slug, ref: raw, kind: 'wiki-link' })
+    }
+  }
+}
+```
+
+#### A.5.3 — orphans block (step 1.7)
+
+```js
+    // Phase 3 gives rule nodes real edges, so a rule is an orphan only at degree 0.
+    // rfc nodes still have no edge type of their own, so every one stays degree 0 by
+    // definition. Appended only when --nodes opted them in; both maps are empty
+    // otherwise, so the default result set is unchanged (REQ-8).
+    for (const id of ruleById.keys()) if ((degree.get(id) || 0) === 0) out.push(nodeOut(id, 0))
+    for (const id of rfcById.keys()) out.push(nodeOut(id, 0))
+```
+
+#### A.5.4 — restructured `--from` root branch (step 1.8)
+
+```js
+if (!byId.has(from)) {
+  if (ruleById.has(from) || rfcById.has(from)) {
+    // A projected rule/rfc node is a legitimate traversal root. With no adjacency
+    // (no rule-edge type requested, or a genuinely unlinked node) the result is the
+    // node itself at depth 0. With adjacency it falls through to the BFS below.
+    if (!adjacency.has(from)) {
+      console.log(JSON.stringify({
+        status: 'ok',
+        root: from,
+        depth,
+        edge_types: edgeTypes,
+        count: 1,
+        nodes: [nodeOut(from, 0)],
+        edges: [],
+        ...nodeDiag(),
+      }))
+      process.exit(0)
+    }
+  } else {
+    console.log(JSON.stringify({ status: 'error', message: `Episode "${from}" not found in the selected scope.` }))
+    process.exit(1)
+  }
+}
+```
+
+#### A.5.5 — `composesTargets` (step 2.1)
+
+```js
+// Section runs from the "## Composes with" heading to the next "## " or EOF.
+// Top-level bullets only: a leading-whitespace bullet is nested and ignored
+// (RFC-007:151). Markdown-link form resolves by basename; the common real form
+// wraps the target in backticks, which is why the caller does NOT strip inline
+// code for this edge type (REQ-16).
+const COMPOSES_HEADING_RE = /^##[ \t]+Composes with[ \t]*$/i
+const MD_LINK_RE = /^\[[^\]]*\]\(([^)]+)\)/
+
+function composesTargets(cleaned) {
+  const out = []
+  let inSection = false
+  for (const line of cleaned.split('\n')) {
+    if (COMPOSES_HEADING_RE.test(line.trim())) { inSection = true; continue }
+    if (!inSection) continue
+    if (/^##[ \t]/.test(line)) break
+    if (/^[ \t]+-[ \t]/.test(line)) continue
+    const bullet = /^-[ \t]+(.*)$/.exec(line)
+    if (!bullet) continue
+    const item = bullet[1].trim()
+    const link = MD_LINK_RE.exec(item)
+    const tick = /^`([^`]+)`/.exec(item)
+    // One bullet names at most one target: a markdown link, or the FIRST
+    // backtick run (a second backticked span on the same bullet is ignored).
+    // A bullet that is neither — plain prose such as
+    // "- Rule 17 (CLAUDE.md global) — bot reviews" — names no target and is
+    // skipped. Slugifying the whole line instead would manufacture a garbage
+    // dangling entry like "rule-17-claude-md-global-bot-reviews".
+    if (!link && !tick) continue
+    const raw = link ? path.basename(link[1], '.md') : tick[1]
+    const slug = targetSlug(raw)
+    if (slug) out.push(slug)
+  }
+  return [...new Set(out)]
+}
+```
+
+#### A.5.6 — `composes-with` edge loop (step 2.2)
+
+```js
+
+// Fenced blocks stripped, inline backticks deliberately NOT (REQ-16).
+if (edgeTypes.includes('composes-with')) {
+  for (const [slug, node] of ruleById) {
+    for (const raw of composesTargets(stripFenced(ruleBody(node.file)))) {
+      const target = resolveTarget(raw)
+      if (target === slug) continue
+      if (target) addEdge(slug, target, 'composes-with')
+      else dangling.push({ source: slug, ref: raw, kind: 'composes-with' })
+    }
+  }
+}
+```
+
+#### A.5.7 — RFC-007 target-resolution subsection (step 3.9, REQ-17)
+
+Inserted immediately after the `slugify()` block at `:143`:
+
+```markdown
+### Target resolution
+
+Node ids are `slugify(frontmatter name)` and nothing else — the rule above is unchanged. Link
+*targets* resolve in two steps, because authors write links by filename:
+
+1. `slugify(target)` matched against the node-id index.
+2. Failing that, matched against a filename-alias index: `slugify(basename)` of each rule file,
+   mapped to that file's node id. A basename shared by two files is ambiguous and is dropped, so
+   the link dangles rather than resolving to a guess.
+3. Failing both, the link is recorded in the edge type's dangling bucket.
+
+This is what the `composes-with` "resolved by file basename" clause below already requires, and it
+does not reintroduce filename-derived node *ids*. Measured against the reference corpus at adoption
+(135 rule files, 127 with `name:`): wiki-link resolution 13 → 122 of 132, composes-with 0 → 51 of 76.
+```
+
+## A.8 Definition of done
+
+```bash
+node tests/test-em-graph-links.mjs        # → 29 passed, 0 failed
+node tests/test-em-graph.mjs              # → 10 passed, 0 failed
+node tests/test-em-graph-nodes.mjs        # → 28 passed, 0 failed
+node tests/test-ci-suite-registration.mjs # → pass
+grep -c 'function slugify' scripts/em-graph.mjs   # → 0
+grep -c 'wiki-link-dangling' docs/rfcs/RFC-007-graph-projection.md  # → 0
+```
+
+`deploy-audit.mjs` is NOT in this list: `scripts/em-graph.mjs` is a deployed script, so the audit
+belongs to the post-merge deploy legs, not the slice gate.
+
+## A.9 Blast-radius patterns applied
+
+- **Red-then-green:** `t_default_output_byte_identical` must be shown failing under a deliberately
+  broken build before it counts as a guard. Break input reaches the test via `--break-default-output`.
+- **Pure-extraction first:** S1 lands the extraction scaffold and dangling plumbing; S2 adds a second
+  caller. No shared core is carved out of existing functions.
+- **Thin wrapper:** `slugify` is imported and called directly — `rule-nodes.mjs` is not restructured.
+- **Fixture-change ledger:** checked, and **no existing assertion changes contract.** Verified rather
+  than assumed:
+  - Phase 2's `t_orphans_surfaces_rule_nodes` (`test-em-graph-nodes.mjs:232-242`) writes one rule file
+    whose body is the literal `body` with no `[[…]]`, and invokes `--orphans --nodes rule` **without**
+    any `--edges` flag. The rule-edge loop is gated on a rule-edge type being requested, so it never
+    runs; the rule stays degree 0 and stays an orphan. Assertion holds unchanged.
+  - Phase 1 uses `--edges all` twice (`test-em-graph.mjs:129`, `:131`). Neither passes `--nodes`, so
+    `ruleById` is empty and no rule body is read. Both assert on `nodes`, not on the key set, so the
+    added `dangling` key does not break them.
+  - **Known output-shape change:** `--edges all` now implies the two new types, so orphans/from output
+    gains `"dangling": []` on that path. Guarded by `t_edges_all_emits_empty_dangling`.
+  No before → after assertion edits are required. If the executor finds one, that is a STOP (§A.3).
+- **Discriminating sentinel:** every fixture rule carries `sentinel-a1b2c3` in its slug.
+- **High blast radius:** S1 is marked **focused review before build** — it edits three mode branches
+  (`:262`, `:272-276`, `:288-304`) that all three existing suites exercise.

--- a/docs/rfcs/RFC-007-graph-projection.md
+++ b/docs/rfcs/RFC-007-graph-projection.md
@@ -81,8 +81,8 @@ unprojectable. That tension is tracked on issue #585 with the other `entry_point
 | `evidence` | SHIPPED (`em-graph.mjs:177-180`) |
 | `cites` | SHIPPED (`em-graph.mjs:181-183`, `bodyCitations` at `:156-167`) |
 | `tags` | SHIPPED (`em-graph.mjs:184-186`), opt-in |
-| `wiki-link` | UNBUILT — Phase 3 |
-| `composes-with` | UNBUILT — Phase 3 |
+| `wiki-link` | SHIPPED — `em-graph.mjs:320` |
+| `composes-with` | SHIPPED — `em-graph.mjs:332` |
 | `trigger-phrase` | UNBUILT — Phase 5 |
 | `cites-pr` | UNBUILT — Phase 5 |
 
@@ -100,7 +100,7 @@ unprojectable. That tension is tracked on issue #585 with the other `entry_point
 
 **Unbuilt edge details (preserved verbatim from the original RFC).**
 
-- `wiki-link` — `[[name]]` matches in rule bodies; `source → target`; resolved against rule slug index via `slugify()`; dangling links recorded as `wiki-link-dangling`; fenced code blocks + inline backticks skipped.
+- `wiki-link` — `[[name]]` matches in rule bodies; `source → target`; resolved against rule slug index via `slugify()`; dangling links recorded in the `wiki-link` bucket; fenced code blocks + inline backticks skipped.
 - `composes-with` — top-level bullets under `## Composes with` heading in rule files; `source → target`; markdown-list-item parsing; same `slugify()` resolution as wiki-link; nested bullets ignored.
 - `trigger-phrase` — machine-readable trigger block in `MEMORY.md` (added in PR-5); `phrase → rule`; JSON-block parser; falls back to no-edges + stderr warning if block missing.
 - `cites-pr` — `pr-\d+` tag (primary). `#NNN` body mention contributes ONLY when episode is also tagged `pr-NNN`. `episode → pr` (pseudo-node); body-only mention without tag yields no edge — prevents meta-commentary false positives.
@@ -141,6 +141,16 @@ slugify(name) =
 ```
 
 Rule-file slugs derive from frontmatter `name:`. Filename-derived slugs are NOT used (filenames may carry `.md`, version suffixes, etc.). Two rule files producing the same slug = build-time error. The ASCII-after-NFC policy guarantees reproducibility across consumers in other languages (Python/Rust/etc.) reading `graph.json` directly.
+
+### Target resolution
+
+Node ids are `slugify(frontmatter name)` and nothing else — the rule above is unchanged. Link *targets* resolve in two steps, because authors write links by filename:
+
+1. `slugify(target)` matched against the node-id index.
+2. Failing that, matched against a filename-alias index: `slugify(basename)` of each rule file, mapped to that file's node id. A basename shared by two files is ambiguous and is dropped, so the link dangles rather than resolving to a guess.
+3. Failing both, the link is recorded in the edge type's dangling bucket.
+
+This is what the `composes-with` "resolved by file basename" clause below already requires, and it does not reintroduce filename-derived node *ids*. Measured against the reference corpus at adoption (135 rule files, 127 with `name:`): wiki-link resolution 13 → 122 of 132, composes-with 0 → 51 of 76.
 
 ### Edge extraction rules
 
@@ -381,7 +391,7 @@ No integration with `em-rebuild-index.mjs` exists or is needed in v1, because no
 |---|---|---|---|---|
 | Phase 1 | **SHIPPED** | Per-query typed-edge projection: `episode` + `tag` nodes; `supersedes`, `consolidates`, `evidence`, `cites`, `tags` edges; `--from` / `--orphans` / `--hubs` modes; depth + limit bounds; scope selection. Delivered by PR #468, hardened by PR #472. | `scripts/em-graph.mjs` | `tests/test-em-graph.mjs` (10 cases; CI-wired at `.github/workflows/tests.yml:401-402`) |
 | Phase 2 | **SHIPPED** | `rule` + `rfc` node projection (the feedback corpus and the RFC set become traversable); `entry_point` frontmatter convention. PR #604 (`df93920`). | `scripts/em-graph.mjs`; rule-file / RFC consumers | projection fixtures; entry-point allowlist fixture |
-| Phase 3 | **UNBUILT** | `wiki-link` + `composes-with` edges; `slugify()` resolution; dangling tracking; 15-shape variant fixture. | `scripts/em-graph.mjs` | parser fixtures |
+| Phase 3 | **SHIPPED** | `wiki-link` + `composes-with` edges; `slugify()` resolution; dangling tracking; 15-shape variant fixture. | `scripts/em-graph.mjs` | parser fixtures |
 | Phase 4 | **UNBUILT** | Graph-health audit surface: `dangling[]`, `nodes_with_no_edges[]`, `entry_points[]`, `--graph-health`; CI validator; contract-mirror validator (`scripts/rfc-graph-contract-validate.mjs` — never created). | `scripts/em-graph.mjs`; new `scripts/rfc-graph-contract-validate.mjs`; CI wiring | audit matrix; OQ-2 threshold fixture |
 | Phase 5 | **UNBUILT** | `cites-pr` edge; MEMORY.md machine-readable trigger block plus the `trigger-phrase` parser. | `MEMORY.md`; `scripts/em-graph.mjs` | parser fixtures; cluster-membership rule fixtures |
 | Phase 6 | **DEFERRED** | Persisted derived graph index (all of Storage Part 2): `graph.json` with `$schema_version` / `rebuilt_at` / `scope_root` / `node_count` / `edge_count` / `nodes` / `edges` / `dangling[]` / `nodes_with_no_edges[]`; atomic temp+rename; `entry_point` orphan allowlist; `entry_points[]` audit array; the `assertGraphFileLocation` axis-9 helper and its caller-cwd-elsewhere fixtures; the `envelope_version` envelope and `source` fallback enum. Trigger condition: rebuild cost per query becomes the binding constraint. | `scripts/em-graph.mjs`; `scripts/em-rebuild-index.mjs` | persisted-index fixtures; envelope-version migration |
@@ -391,8 +401,8 @@ No integration with `em-rebuild-index.mjs` exists or is needed in v1, because no
 ```mermaid
 graph TD
     P1[Phase 1 SHIPPED: per-query typed-edge projection]
-    P2[Phase 2 UNBUILT: rule + rfc node types]
-    P3[Phase 3 UNBUILT: wiki-link + composes-with]
+    P2[Phase 2 SHIPPED: rule + rfc node types]
+    P3[Phase 3 SHIPPED: wiki-link + composes-with]
     P4[Phase 4 UNBUILT: graph-health audit + contract-mirror validator]
     P5[Phase 5 UNBUILT: cites-pr + trigger-phrase]
     P6[Phase 6 DEFERRED: persisted derived graph.json index]
@@ -585,7 +595,7 @@ Detailed round-1 finding table preserved below for historical record.
   "_shipped_edge_types": ["supersedes", "consolidates", "evidence", "cites", "tags"],
   "_shipped_default_edges": ["supersedes", "consolidates", "evidence", "cites"],
   "slugify": {
-    "_shipped_use": "not used by the shipped script — tag names are lowercased and trimmed inline (em-graph.mjs:185); slugify() becomes load-bearing in Phase 3 (wiki-link, composes-with)",
+    "_shipped_use": "called by scanRuleNodes (lib/rule-nodes.mjs:117) for rule-node ids since Phase 2, and by the Phase 3 link parsers (em-graph.mjs:239 filename alias, em-graph.mjs:251 edge-target slug) for edge-target resolution. Tag ids still lowercase inline (em-graph.mjs:314) and do NOT use slugify.",
     "unicode_normalize": "NFC",
     "trim": true,
     "case": "lower",
@@ -667,11 +677,11 @@ Detailed round-1 finding table preserved below for historical record.
     },
     {
       "type": "wiki-link",
-      "status": "UNBUILT (Phase 3)",
+      "status": "SHIPPED",
       "source_node_type": "rule",
       "target_node_type": "rule",
       "source_field": "rule.body",
-      "parser": "regex:\\[\\[([^\\]|#]+)([|#][^\\]]*)?\\]\\]",
+      "parser": "regex:\\[\\[([^\\]|#]+)(?:#[^\\]|]*)?(?:\\|[^\\]]*)?\\]\\]",
       "slug_resolver": "slugify",
       "skip_when": ["inside-fenced-code-block", "inside-inline-backticks", "empty-name"],
       "dangling_bucket": "wiki-link",
@@ -679,7 +689,7 @@ Detailed round-1 finding table preserved below for historical record.
     },
     {
       "type": "composes-with",
-      "status": "UNBUILT (Phase 3)",
+      "status": "SHIPPED",
       "source_node_type": "rule",
       "target_node_type": "rule",
       "source_field": "rule.body['## Composes with' section, top-level bullets only]",

--- a/docs/rfcs/RFC-007-graph-projection.md
+++ b/docs/rfcs/RFC-007-graph-projection.md
@@ -333,8 +333,6 @@ No integration with `em-rebuild-index.mjs` exists or is needed in v1, because no
   - Documentation: `docs/EM_SCRIPTS_GUIDE.md:732-750` describes the shipped behavior
 
 - **Unbuilt (recorded explicitly so it is enumerable, not deleted):**
-  - `rule` + `rfc` node projection (the feedback corpus and the RFC set traversable) — Phase 2
-  - `wiki-link` + `composes-with` edges with `slugify()` resolution and dangling tracking — Phase 3
   - `entry_point` frontmatter convention + `nodes_with_no_edges[]` + `entry_points[]` audit array — Phase 4
   - Graph-health audit surface (`--graph-health`, CI validator, contract-mirror validator `scripts/rfc-graph-contract-validate.mjs` — never created) — Phase 4
   - `cites-pr` edge; MEMORY.md machine-readable trigger block plus the `trigger-phrase` parser — Phase 5
@@ -685,7 +683,8 @@ Detailed round-1 finding table preserved below for historical record.
       "slug_resolver": "slugify",
       "skip_when": ["inside-fenced-code-block", "inside-inline-backticks", "empty-name"],
       "dangling_bucket": "wiki-link",
-      "idempotent": true
+      "idempotent": true,
+      "shipped_at": "em-graph.mjs:320"
     },
     {
       "type": "composes-with",
@@ -697,7 +696,8 @@ Detailed round-1 finding table preserved below for historical record.
       "slug_resolver": "slugify",
       "skip_when": ["empty-section", "nested-bullet"],
       "dangling_bucket": "composes-with",
-      "idempotent": true
+      "idempotent": true,
+      "shipped_at": "em-graph.mjs:332"
     },
     {
       "type": "trigger-phrase",

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -262,10 +262,10 @@ const MD_LINK_RE = /^\[[^\]]*\]\(([^)]+)\)/
 function composesTargets(cleaned) {
   const out = []
   let inSection = false
-  for (const line of cleaned.split('\n')) {
+  for (const line of cleaned.split(/\r?\n/)) {
     if (COMPOSES_HEADING_RE.test(line.trim())) { inSection = true; continue }
     if (!inSection) continue
-    if (/^##[ \t]/.test(line)) break
+    if (/^##[ \t]/.test(line.trim())) break
     if (/^[ \t]+-[ \t]/.test(line)) continue
     const bullet = /^-[ \t]+(.*)$/.exec(line)
     if (!bullet) continue
@@ -279,7 +279,7 @@ function composesTargets(cleaned) {
     // skipped. Slugifying the whole line instead would manufacture a garbage
     // dangling entry like "rule-17-claude-md-global-bot-reviews".
     if (!link && !tick) continue
-    const raw = link ? path.basename(link[1], '.md') : tick[1]
+    const raw = link ? path.basename(link[1].replace(/#.*$/, ""), '.md') : tick[1]
     const slug = targetSlug(raw)
     if (slug) out.push(slug)
   }

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -251,6 +251,41 @@ function targetSlug(raw) {
   return slugify(String(raw).trim().replace(/\.md$/i, ''))
 }
 
+// Section runs from the "## Composes with" heading to the next "## " or EOF.
+// Top-level bullets only: a leading-whitespace bullet is nested and ignored
+// (RFC-007:151). Markdown-link form resolves by basename; the common real form
+// wraps the target in backticks, which is why the caller does NOT strip inline
+// code for this edge type (REQ-16).
+const COMPOSES_HEADING_RE = /^##[ \t]+Composes with[ \t]*$/i
+const MD_LINK_RE = /^\[[^\]]*\]\(([^)]+)\)/
+
+function composesTargets(cleaned) {
+  const out = []
+  let inSection = false
+  for (const line of cleaned.split('\n')) {
+    if (COMPOSES_HEADING_RE.test(line.trim())) { inSection = true; continue }
+    if (!inSection) continue
+    if (/^##[ \t]/.test(line)) break
+    if (/^[ \t]+-[ \t]/.test(line)) continue
+    const bullet = /^-[ \t]+(.*)$/.exec(line)
+    if (!bullet) continue
+    const item = bullet[1].trim()
+    const link = MD_LINK_RE.exec(item)
+    const tick = /^`([^`]+)`/.exec(item)
+    // One bullet names at most one target: a markdown link, or the FIRST
+    // backtick run (a second backticked span on the same bullet is ignored).
+    // A bullet that is neither — plain prose such as
+    // "- Rule 17 (CLAUDE.md global) — bot reviews" — names no target and is
+    // skipped. Slugifying the whole line instead would manufacture a garbage
+    // dangling entry like "rule-17-claude-md-global-bot-reviews".
+    if (!link && !tick) continue
+    const raw = link ? path.basename(link[1], '.md') : tick[1]
+    const slug = targetSlug(raw)
+    if (slug) out.push(slug)
+  }
+  return [...new Set(out)]
+}
+
 function linkTargets(cleaned) {
   const out = []
   for (const m of cleaned.matchAll(WIKI_LINK_RE)) {
@@ -289,6 +324,18 @@ if (edgeTypes.includes('wiki-link')) {
       if (target === slug) continue
       if (target) addEdge(slug, target, 'wiki-link')
       else dangling.push({ source: slug, ref: raw, kind: 'wiki-link' })
+    }
+  }
+}
+
+// Fenced blocks stripped, inline backticks deliberately NOT (REQ-16).
+if (edgeTypes.includes('composes-with')) {
+  for (const [slug, node] of ruleById) {
+    for (const raw of composesTargets(stripFenced(ruleBody(node.file)))) {
+      const target = resolveTarget(raw)
+      if (target === slug) continue
+      if (target) addEdge(slug, target, 'composes-with')
+      else dangling.push({ source: slug, ref: raw, kind: 'composes-with' })
     }
   }
 }

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -45,7 +45,7 @@ import path from 'path'
 import os from 'os'
 import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 import { loadIndex } from './lib/relevance.mjs'
-import { resolveRuleDir, scanRuleNodes, scanRfcNodes } from './lib/rule-nodes.mjs'
+import { resolveRuleDir, scanRuleNodes, scanRfcNodes, slugify } from './lib/rule-nodes.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -99,7 +99,7 @@ for (const n of nodeTypes) {
   }
 }
 
-const EDGE_TYPES = ['supersedes', 'consolidates', 'evidence', 'cites', 'tags']
+const EDGE_TYPES = ['supersedes', 'consolidates', 'evidence', 'cites', 'tags', 'wiki-link', 'composes-with']
 const DEFAULT_EDGES = ['supersedes', 'consolidates', 'evidence', 'cites']
 const edgesRaw = flag('--edges')
 const edgeTypes = edgesRaw === 'all' ? EDGE_TYPES
@@ -162,6 +162,7 @@ if (nodeTypes.includes('rfc')) {
   skippedNodes += scanned.skipped
 }
 const nodeDiag = () => (nodesRaw === undefined ? {} : { skipped_nodes: skippedNodes })
+const danglingOut = () => (edgeTypes.some(e => RULE_EDGE_TYPES.includes(e)) ? { dangling } : {})
 
 // ---------------------------------------------------------------------------
 // Edge projection. adjacency: id -> [{from,to,type}] (edge listed under BOTH
@@ -209,6 +210,56 @@ function bodyCitations(row, dataDir) {
   } catch { return [] }
 }
 
+// --- Phase 3: rule-body edge extraction (RFC-007 wiki-link + composes-with) ---
+// Fenced blocks are stripped for both edge types. Inline backticks are stripped
+// for wiki-link ONLY (RFC-007:149 scopes that rule to wiki-link and cites): real
+// "## Composes with" bullets write their target inside backticks, so stripping
+// inline code there would delete every target and silently emit zero edges.
+const WIKI_LINK_RE = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]/g
+const RULE_EDGE_TYPES = ['wiki-link', 'composes-with']
+const dangling = []
+
+const stripFenced = s => s.replace(/```[\s\S]*?```/g, '').replace(/~~~[\s\S]*?~~~/g, '')
+const stripInline = s => s.replace(/`[^`\n]*`/g, '')
+
+function ruleBody(file) {
+  try {
+    const content = fs.readFileSync(file, 'utf8')
+    const parts = content.split('---')
+    return parts.length >= 3 ? parts.slice(2).join('---') : content
+  } catch { return '' }
+}
+
+// Secondary index for TARGET resolution only. Node ids stay frontmatter-name
+// derived (RFC-007:142 is untouched); authors nonetheless link by filename, so a
+// slugified basename maps back to the owning node id. An ambiguous basename (two
+// files slugifying alike) is dropped rather than guessed — the link dangles.
+const ruleAlias = new Map()
+for (const [slug, node] of ruleById) {
+  const base = slugify(path.basename(node.file, '.md'))
+  if (!base || ruleById.has(base)) continue
+  if (ruleAlias.has(base)) ruleAlias.set(base, null)
+  else ruleAlias.set(base, slug)
+}
+
+function resolveTarget(slug) {
+  if (ruleById.has(slug)) return slug
+  return ruleAlias.get(slug) || null
+}
+
+function targetSlug(raw) {
+  return slugify(String(raw).trim().replace(/\.md$/i, ''))
+}
+
+function linkTargets(cleaned) {
+  const out = []
+  for (const m of cleaned.matchAll(WIKI_LINK_RE)) {
+    const slug = targetSlug(m[1])
+    if (slug) out.push(slug)
+  }
+  return [...new Set(out)]
+}
+
 for (const r of rows) {
   if (edgeTypes.includes('supersedes')) {
     if (typeof r.supersedes === 'string' && byId.has(r.supersedes)) addEdge(r.id, r.supersedes, 'supersedes')
@@ -226,6 +277,19 @@ for (const r of rows) {
   }
   if (edgeTypes.includes('tags')) {
     for (const tag of strings(r.tags)) addEdge(r.id, `tag:${tag.toLowerCase().trim()}`, 'tags')
+  }
+}
+
+// Rule-to-rule edges. Rule bodies are read ONLY when a rule-edge type was
+// requested, so a default invocation still performs zero rule I/O (REQ-8).
+if (edgeTypes.includes('wiki-link')) {
+  for (const [slug, node] of ruleById) {
+    for (const raw of linkTargets(stripInline(stripFenced(ruleBody(node.file))))) {
+      const target = resolveTarget(raw)
+      if (target === slug) continue
+      if (target) addEdge(slug, target, 'wiki-link')
+      else dangling.push({ source: slug, ref: raw, kind: 'wiki-link' })
+    }
   }
 }
 
@@ -260,21 +324,23 @@ function nodeOut(id, dist) {
 if (orphans || hubs) {
   // Degree over non-tag edges (tag fan-in would make everything a hub).
   const degree = new Map(rows.map(r => [r.id, 0]))
+  for (const id of ruleById.keys()) degree.set(id, 0)
   for (const key of edgeKeys) {
     const [a, b, type] = key.split(EDGE_KEY_SEP)
     if (type === 'tags') continue
     if (degree.has(a)) degree.set(a, degree.get(a) + 1)
     if (degree.has(b)) degree.set(b, degree.get(b) + 1)
   }
-  const reportable = r => includeSuperseded || r.status !== 'superseded'
+  const reportable = r => includeSuperseded || r?.status !== 'superseded'
   if (orphans) {
     const out = rows.filter(r => reportable(r) && degree.get(r.id) === 0).map(r => nodeOut(r.id, 0))
-    // Phase 2 gives rule/rfc nodes no edges, so every one is degree 0 and is an orphan
-    // by the mode's own definition. Appended only when --nodes opted them in; both maps
-    // are empty otherwise, so the default result set is unchanged (REQ-8).
-    for (const id of ruleById.keys()) out.push(nodeOut(id, 0))
+    // Phase 3 gives rule nodes real edges, so a rule is an orphan only at degree 0.
+    // rfc nodes still have no edge type of their own, so every one stays degree 0 by
+    // definition. Appended only when --nodes opted them in; both maps are empty
+    // otherwise, so the default result set is unchanged (REQ-8).
+    for (const id of ruleById.keys()) if ((degree.get(id) || 0) === 0) out.push(nodeOut(id, 0))
     for (const id of rfcById.keys()) out.push(nodeOut(id, 0))
-    console.log(JSON.stringify({ status: 'ok', mode: 'orphans', count: out.length, nodes: out, ...nodeDiag() }))
+    console.log(JSON.stringify({ status: 'ok', mode: 'orphans', count: out.length, nodes: out, ...nodeDiag(), ...danglingOut() }))
   } else {
     const ranked = [...degree.entries()].filter(([id, d]) => d > 0 && reportable(byId.get(id)))
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, top)
@@ -287,23 +353,27 @@ if (orphans || hubs) {
 // --from traversal
 if (!byId.has(from)) {
   if (ruleById.has(from) || rfcById.has(from)) {
-    // A projected rule/rfc node is a legitimate traversal root. Phase 2 gives it no
-    // edges, so the result is the node itself at depth 0. Once Phase 3 lands, these
-    // ids gain adjacency entries and fall through to the normal BFS below.
-    console.log(JSON.stringify({
-      status: 'ok',
-      root: from,
-      depth,
-      edge_types: edgeTypes,
-      count: 1,
-      nodes: [nodeOut(from, 0)],
-      edges: [],
-      ...nodeDiag(),
-    }))
-    process.exit(0)
+    // A projected rule/rfc node is a legitimate traversal root. With no adjacency
+    // (no rule-edge type requested, or a genuinely unlinked node) the result is the
+    // node itself at depth 0. With adjacency it falls through to the BFS below.
+    if (!adjacency.has(from)) {
+      console.log(JSON.stringify({
+        status: 'ok',
+        root: from,
+        depth,
+        edge_types: edgeTypes,
+        count: 1,
+        nodes: [nodeOut(from, 0)],
+        edges: [],
+        ...nodeDiag(),
+        ...danglingOut(),
+      }))
+      process.exit(0)
+    }
+  } else {
+    console.log(JSON.stringify({ status: 'error', message: `Episode "${from}" not found in the selected scope.` }))
+    process.exit(1)
   }
-  console.log(JSON.stringify({ status: 'error', message: `Episode "${from}" not found in the selected scope.` }))
-  process.exit(1)
 }
 
 const visited = new Map([[from, 0]])
@@ -355,4 +425,5 @@ console.log(JSON.stringify({
   edges: outEdges,
   ...(truncated ? { truncated: true } : {}),
   ...nodeDiag(),
+  ...danglingOut(),
 }))

--- a/tests/test-em-graph-links.mjs
+++ b/tests/test-em-graph-links.mjs
@@ -1,0 +1,574 @@
+/**
+ * test-em-graph-links.mjs — RFC-007 Phase 3 S1 (#589): wiki-link edge,
+ * dangling scaffold, rule-node mode integration.
+ *
+ * S1 scope: 21 cases from §14 groups 1, 2, 3b, 4, 5, 6, 7. S2 adds group 3
+ * (composes-with) in a follow-up slice; not authored here.
+ *
+ * Every assertion inspects REAL captured CLI output (parsed stdout JSON or
+ * exit code) from spawning scripts/em-graph.mjs. Harness shape follows
+ * tests/test-em-graph-nodes.mjs:22-48. Discriminating sentinel: every fixture
+ * rule slug carries `sentinel-a1b2c3` so a passing assertion cannot be
+ * satisfied by an unrelated corpus entry.
+ *
+ * Negative-control break: passing --break-wikilink makes the runner copy
+ * scripts/em-graph.mjs into a temp dir with linkTargets() stubbed to return
+ * [], then run all tests against the broken copy. The suite exits non-zero
+ * because the wiki-link assertions catch the break.
+ */
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.join(HERE, '..')
+const SCRIPTS = path.join(REPO, 'scripts')
+
+const BREAK_WIKILINK = process.argv.includes('--break-wikilink')
+
+let pass = 0, fail = 0
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`) }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`) }
+}
+
+const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgl-')))
+const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgl-home-')))
+const env = { HOME: home }
+
+const ruleDirFor = root => path.join(home, '.claude', 'projects', root.split(path.sep).join('-'), 'memory')
+const RULE_DIR = ruleDirFor(cwd)
+
+// Negative-control: when --break-wikilink is set, copy scripts/ to a temp dir
+// and stub linkTargets() to return []. The runner then spawns from the temp
+// dir, so wiki-link-dependent assertions fail (no edges, no dangling entries).
+let SCRIPTS_USE = SCRIPTS
+let breakTemp = null
+if (BREAK_WIKILINK) {
+  breakTemp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgl-break-')))
+  for (const f of fs.readdirSync(SCRIPTS)) {
+    const src = path.join(SCRIPTS, f)
+    const dst = path.join(breakTemp, f)
+    fs.cpSync(src, dst, { recursive: true })
+  }
+  const orig = fs.readFileSync(path.join(breakTemp, 'em-graph.mjs'), 'utf8')
+  const re = /function linkTargets\(cleaned\) \{[\s\S]*?return \[\.\.\.new Set\(out\)\]\s*\}/
+  if (!re.test(orig)) throw new Error('--break-wikilink: failed to locate linkTargets() in em-graph.mjs')
+  const broken = orig.replace(re, 'function linkTargets(cleaned) { return [] }')
+  fs.writeFileSync(path.join(breakTemp, 'em-graph.mjs'), broken)
+  SCRIPTS_USE = breakTemp
+}
+
+function resetRuleDir() {
+  fs.rmSync(RULE_DIR, { recursive: true, force: true })
+  fs.mkdirSync(RULE_DIR, { recursive: true })
+}
+function writeRule(file, frontmatter, body = 'body') {
+  fs.writeFileSync(path.join(RULE_DIR, file), `---\n${frontmatter}\n---\n\n${body}\n`, 'utf8')
+}
+function run(args) {
+  const r = spawnSync('node', [path.join(SCRIPTS_USE, 'em-graph.mjs'), ...args], {
+    cwd, encoding: 'utf8', env: { ...process.env, ...env },
+  })
+  let json = null
+  try { json = JSON.parse(r.stdout.trim()) } catch {}
+  return { code: r.status, json, stdout: r.stdout, stderr: r.stderr }
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: wiki-link shape matrix (15 rows, one test)
+// ---------------------------------------------------------------------------
+t('t_wikilink_shape_matrix', () => {
+  resetRuleDir()
+  // Source rule carries 15 distinct shapes in one body. Targets exist for
+  // 5 named shapes plus the filename-alias shape; 1 dangles; 9 are ignored.
+  const SRC = 'sentinel-a1b2c3-source'
+  writeRule('feedback_src.md', `name: ${SRC}`,
+    `[[sentinel-a1b2c3-tgt-a]]\n` +
+    `[[sentinel-a1b2c3-tgt-b#sec]]\n` +
+    `[[sentinel-a1b2c3-tgt-c|alias]]\n` +
+    `[[sentinel-a1b2c3-tgt-d#a|b]]\n` +
+    `[[SENTINEL-A1B2C3-TGT-E]]\n` +
+    `[[sentinel-a1b2c3-ghost-6]]\n` +
+    `[[]]\n` +
+    `[[   ]]\n` +
+    `\`[[sentinel-a1b2c3-ingo-back-11]]\`\n` +
+    `[sentinel-a1b2c3-md-link-12](path.md)\n` +
+    `[[[[sentinel-a1b2c3-tgt-a]]]]\n` +
+    `[[sentinel-a1b2c3-source]]\n` +
+    `[[feedback-aliased-target]]\n` +
+    `\n\`\`\`\n[[sentinel-a1b2c3-ingo-fence-9]]\n\`\`\`\n` +
+    `\n~~~\n[[sentinel-a1b2c3-ingo-fence-10]]\n~~~\n`
+  )
+  writeRule('feedback_tgt_a.md', 'name: sentinel-a1b2c3-tgt-a')
+  writeRule('feedback_tgt_b.md', 'name: sentinel-a1b2c3-tgt-b')
+  writeRule('feedback_tgt_c.md', 'name: sentinel-a1b2c3-tgt-c')
+  writeRule('feedback_tgt_d.md', 'name: sentinel-a1b2c3-tgt-d')
+  writeRule('feedback_tgt_e.md', 'name: sentinel-a1b2c3-tgt-e')
+  // Filename for the alias shape: basename 'feedback_aliased_target' slugs to
+  // 'feedback-aliased-target'. The target rule's name-id is the different
+  // string 'sentinel-a1b2c3-aliased-name', so the link MUST resolve via the
+  // alias index (not via name-id lookup).
+  writeRule('feedback_aliased_target.md', 'name: sentinel-a1b2c3-aliased-name')
+
+  // --from so the output includes `edges` and `dangling`.
+  const r = run(['--from', SRC, '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const edges = r.json.edges || []
+  const dangling = r.json.dangling || []
+  const srcEdges = edges.filter(e => e.from === SRC && e.type === 'wiki-link')
+
+  // Shape 1: basic [[name]] resolves
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-tgt-a'),
+    'shape 1: basic [[name]] resolves to name-id target')
+
+  // Shape 2: [[name#anchor]] — anchor stripped
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-tgt-b'),
+    'shape 2: [[name#anchor]] resolves with anchor stripped')
+
+  // Shape 3: [[name|alias]] — alias dropped
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-tgt-c'),
+    'shape 3: [[name|alias]] resolves with alias dropped')
+
+  // Shape 4: [[name#a|b]] — both stripped
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-tgt-d'),
+    'shape 4: [[name#a|b]] resolves with both anchor and alias stripped')
+
+  // Shape 5: [[UPPERCASE]] — case-folded to lowercase
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-tgt-e'),
+    'shape 5: [[UPPERCASE]] case-folds to lowercase target')
+
+  // Shape 6: unknown target — dangles
+  const ghostDangling = dangling.filter(d => d.source === SRC && d.ref === 'sentinel-a1b2c3-ghost-6')
+  assert.equal(ghostDangling.length, 1, 'shape 6: unknown target dangles; exactly one entry')
+
+  // Shape 7: [[]] — empty, ignored
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === ''),
+    'shape 7: empty [[]] produces no dangling entry')
+
+  // Shape 8: [[   ]] — whitespace, ignored
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === '-'),
+    'shape 8: whitespace [[   ]] slugifies to "-" and produces no dangling entry (ignored)')
+
+  // Shape 9: fenced with backticks — ignored
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === 'sentinel-a1b2c3-ingo-fence-9'),
+    'shape 9: fenced ``` [[X]] ``` produces no dangling entry')
+  assert.ok(!edges.some(e => e.from === SRC && e.to === 'sentinel-a1b2c3-ingo-fence-9'),
+    'shape 9: fenced ``` [[X]] ``` produces no edge')
+
+  // Shape 10: fenced with tildes — ignored
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === 'sentinel-a1b2c3-ingo-fence-10'),
+    'shape 10: ~~~fenced [[X]]~~~ produces no dangling entry')
+
+  // Shape 11: inline backticks — ignored (backticks stripped before regex)
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === 'sentinel-a1b2c3-ingo-back-11'),
+    'shape 11: inline `[[X]]` produces no dangling entry')
+
+  // Shape 12: markdown link, not wiki — ignored
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === 'sentinel-a1b2c3-md-link-12'),
+    'shape 12: [text](path.md) markdown link produces no dangling entry')
+
+  // Shape 13: nested [[[[X]]]] — outer match, slug dedupes
+  const edgesToA = srcEdges.filter(e => e.to === 'sentinel-a1b2c3-tgt-a')
+  assert.equal(edgesToA.length, 1,
+    'shape 13: nested [[[[X]]]] resolves to X target, deduped to single edge')
+
+  // Shape 14: self-loop — dropped
+  assert.ok(!srcEdges.some(e => e.to === SRC),
+    'shape 14: [[self]] self-loop is dropped (no self-edge)')
+  assert.ok(!dangling.some(d => d.source === SRC && d.ref === SRC),
+    'shape 14: self-loop produces no dangling entry')
+
+  // Shape 15: filename-alias resolves when name-id is absent
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-aliased-name'),
+    'shape 15: [[filename-slug]] resolves via filename-alias index')
+})
+
+// ---------------------------------------------------------------------------
+// Group 2: exclusion (3)
+// ---------------------------------------------------------------------------
+t('t_wikilink_fence_exclusion', () => {
+  resetRuleDir()
+  writeRule('feedback_fence_src.md', 'name: sentinel-a1b2c3-fence-src',
+    'before\n```\n[[sentinel-a1b2c3-ingo-fenced]]\n```\nafter')
+  writeRule('feedback_fence_tgt.md', 'name: sentinel-a1b2c3-ingo-fenced')
+  const r = run(['--from', 'sentinel-a1b2c3-fence-src', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const srcEdges = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-fence-src')
+  assert.equal(srcEdges.length, 0, 'fenced block wiki-link produces no edge')
+  assert.equal((r.json.dangling || []).length, 0, 'fenced block wiki-link produces no dangling entry')
+  // Source has degree 0 — only the source is in the traversal set
+  assert.equal(r.json.count, 1, 'source has no resolved edges; traversal visits only the source')
+})
+
+t('t_wikilink_inline_backtick_exclusion', () => {
+  resetRuleDir()
+  writeRule('feedback_inline_src.md', 'name: sentinel-a1b2c3-inline-src',
+    'before `[[sentinel-a1b2c3-ingo-inline]]` after')
+  writeRule('feedback_inline_tgt.md', 'name: sentinel-a1b2c3-ingo-inline')
+  const r = run(['--from', 'sentinel-a1b2c3-inline-src', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const srcEdges = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-inline-src')
+  assert.equal(srcEdges.length, 0, 'inline-backticked wiki-link produces no edge')
+  assert.equal((r.json.dangling || []).length, 0, 'inline-backticked wiki-link produces no dangling entry')
+})
+
+// Parity with shipped cites (em-graph.mjs:207): stripFenced is non-greedy and needs a
+// closing fence, so an unclosed fence swallows nothing. Asserted deliberately.
+t('t_unclosed_fence_does_not_swallow_remainder', () => {
+  resetRuleDir()
+  writeRule('feedback_unclosed_src.md', 'name: sentinel-a1b2c3-unclosed-src',
+    'before\n```\nafter [[sentinel-a1b2c3-ingo-unclosed]]')
+  writeRule('feedback_unclosed_tgt.md', 'name: sentinel-a1b2c3-ingo-unclosed')
+  const r = run(['--from', 'sentinel-a1b2c3-unclosed-src', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const srcEdges = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-unclosed-src')
+  assert.equal(srcEdges.length, 1, 'unclosed fence does NOT swallow remainder; the wiki-link IS extracted and produces one edge')
+  assert.ok(srcEdges.some(e => e.to === 'sentinel-a1b2c3-ingo-unclosed'),
+    'edge target is the in-body wiki-link target (proves the link was parsed after the unclosed fence)')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entry (target resolves)')
+})
+
+// ---------------------------------------------------------------------------
+// Group 3b: target resolution (3)
+// ---------------------------------------------------------------------------
+t('t_alias_resolves_filename_style_link', () => {
+  resetRuleDir()
+  // Target rule: name = 'sentinel-a1b2c3-aliased-name', filename basename
+  // 'feedback_aliased_target' slugs to 'feedback-aliased-target'. There is
+  // no rule with name-id 'feedback-aliased-target', so the alias index
+  // holds the entry. The source links by the filename slug.
+  writeRule('feedback_aliased_target.md', 'name: sentinel-a1b2c3-aliased-name')
+  writeRule('feedback_linker.md', 'name: sentinel-a1b2c3-alias-linker',
+    '[[feedback-aliased-target]]')
+  const r = run(['--from', 'sentinel-a1b2c3-alias-linker', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-alias-linker' &&
+    e.to === 'sentinel-a1b2c3-aliased-name' &&
+    e.type === 'wiki-link')
+  assert.ok(edge, 'filename-style link resolves via alias index')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries')
+})
+
+// Both guards (build-time ruleById.has(base) skip, and resolveTarget name-first
+// ordering) enforce this jointly, so this test proves the observable contract --
+// a filename cannot hijack a link away from the node that owns that id -- but it
+// cannot isolate which of the two guards is doing the work.
+t('t_name_id_wins_over_alias', () => {
+  resetRuleDir()
+  // Owner: glob-compatible filename, name-id = feedback-sentinel-a1b2c3-target
+  writeRule('feedback_alpha_owner.md', 'name: feedback-sentinel-a1b2c3-target')
+  // Decoy: glob-compatible filename whose basename slugifies to the OWNER's
+  // name-id, with a DIFFERENT name-id. The alias build loop iterates the
+  // decoy: base = 'feedback-sentinel-a1b2c3-target', and ruleById.has(base)
+  // is true (the owner holds that id), so the alias is dropped.
+  writeRule('feedback_sentinel-a1b2c3-target.md', 'name: sentinel-a1b2c3-decoy')
+  // Source: links to the owner by its name-id
+  writeRule('feedback_src.md', 'name: sentinel-a1b2c3-c',
+    '[[feedback-sentinel-a1b2c3-target]]')
+  // Precondition 1: owner is live (in ruleById). The owner has an incoming
+  // edge from the source, so it is reachable from --from source and
+  // appears in the BFS nodes[]. If it is absent, the glob dropped the
+  // owner file and the test degenerates — STOP rather than report a
+  // vacuous pass.
+  const r = run(['--from', 'sentinel-a1b2c3-c', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.ok(r.json.nodes.some(n => n.id === 'feedback-sentinel-a1b2c3-target'),
+    'fixture is live: owner is in ruleById (reachable from source via the resolved edge)')
+  // Precondition 2: decoy is live (in ruleById). The decoy has no edges
+  // (the alias was dropped), so it is degree 0 and appears in --orphans.
+  // If it is absent, the glob dropped the decoy file and the test
+  // degenerates — STOP rather than report a vacuous pass.
+  const rOrph = run(['--orphans', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(rOrph.code, 0, rOrph.stdout)
+  assert.ok(rOrph.json.nodes.some(n => n.id === 'sentinel-a1b2c3-decoy'),
+    'fixture is live: decoy is in ruleById (degree 0, in --orphans)')
+  // Main assertion: the edge from the source goes to the name-id holder, NOT the decoy.
+  const edgesFromC = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-c')
+  assert.equal(edgesFromC.length, 1, 'exactly one wiki-link edge from the source')
+  assert.ok(edgesFromC.some(e => e.to === 'feedback-sentinel-a1b2c3-target'),
+    'edge target is the name-id holder (owner), not the decoy')
+  assert.ok(!edgesFromC.some(e => e.to === 'sentinel-a1b2c3-decoy'),
+    'no edge from the source targets the decoy whose basename would have shadowed the name-id')
+})
+
+t('t_ambiguous_alias_dangles', () => {
+  resetRuleDir()
+  // Two files whose basenames slugify to the same string. Both files match
+  // the rule glob (feedback_*.md) and have distinct name-ids. The alias
+  // loop drops the alias (sets to null) when two basenames collide, so a
+  // link to the ambiguous slug dangles.
+  //   feedback_alpha.md    -> basename 'feedback_alpha'    -> slug 'feedback-alpha'
+  //   feedback_alpha_.md   -> basename 'feedback_alpha_'   -> slug 'feedback-alpha' (trailing _ stripped)
+  writeRule('feedback_alpha.md', 'name: sentinel-a1b2c3-amb-first')
+  writeRule('feedback_alpha_.md', 'name: sentinel-a1b2c3-amb-second')
+  writeRule('feedback_amb_linker.md', 'name: sentinel-a1b2c3-amb-linker',
+    '[[feedback-alpha]]')
+  const r = run(['--from', 'sentinel-a1b2c3-amb-linker', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const dangling = r.json.dangling || []
+  const ambDangling = dangling.find(d =>
+    d.source === 'sentinel-a1b2c3-amb-linker' && d.ref === 'feedback-alpha')
+  assert.ok(ambDangling, 'ambiguous alias (two files with same slugified basename) dangles')
+  assert.ok(!(r.json.edges || []).some(e => e.to === 'sentinel-a1b2c3-amb-first' && e.from === 'sentinel-a1b2c3-amb-linker'),
+    'ambiguous alias does not resolve to first holder')
+  assert.ok(!(r.json.edges || []).some(e => e.to === 'sentinel-a1b2c3-amb-second' && e.from === 'sentinel-a1b2c3-amb-linker'),
+    'ambiguous alias does not resolve to second holder')
+})
+
+// ---------------------------------------------------------------------------
+// Group 4: dangling (2)
+// ---------------------------------------------------------------------------
+t('t_dangling_distinct_from_orphans', () => {
+  resetRuleDir()
+  // Source has an outgoing wiki link that does not resolve. The source
+  // gains no edge (the addEdge is skipped when target is null), so it is
+  // still degree 0 and IS an orphan. It also appears in the dangling[]
+  // list with kind='wiki-link'. The two facts coexist on the same node.
+  const SRC = 'sentinel-a1b2c3-dangling-src'
+  writeRule('feedback_dangling_src.md', `name: ${SRC}`,
+    '[[sentinel-a1b2c3-nonexistent-1]] [[sentinel-a1b2c3-nonexistent-2]]')
+  // Run both --from (sees edges and dangling) and --orphans (sees the
+  // orphan list). The source must appear in BOTH: in dangling[] as the
+  // source of two unresolved links, AND in --orphans (degree 0).
+  const rFrom = run(['--from', SRC, '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(rFrom.code, 0, rFrom.stdout)
+  const dangling = rFrom.json.dangling || []
+  const refs = dangling.filter(d => d.source === SRC).map(d => d.ref).sort()
+  assert.deepEqual(refs, ['sentinel-a1b2c3-nonexistent-1', 'sentinel-a1b2c3-nonexistent-2'],
+    'two dangling entries with refs in dangling order')
+  assert.equal(rFrom.json.count, 1, 'source has no resolved edges; BFS visits only the source')
+  // And the source is in --orphans
+  const rOrph = run(['--orphans', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(rOrph.code, 0, rOrph.stdout)
+  assert.ok(rOrph.json.nodes.some(n => n.id === SRC),
+    'source of dangling links is an orphan (degree 0) — orphan and dangling coexist')
+})
+
+t('t_dangling_kind_values', () => {
+  resetRuleDir()
+  const SRC = 'sentinel-a1b2c3-kind-src'
+  writeRule('feedback_kind_src.md', `name: ${SRC}`,
+    '[[sentinel-a1b2c3-ghost-kind-1]] [[sentinel-a1b2c3-ghost-kind-2]] [[sentinel-a1b2c3-ghost-kind-3]]')
+  const r = run(['--from', SRC, '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const dangling = r.json.dangling || []
+  assert.ok(dangling.length >= 3, 'three dangling entries from three ghost links')
+  for (const d of dangling) {
+    assert.equal(d.kind, 'wiki-link',
+      `dangling entry kind must be 'wiki-link', got ${JSON.stringify(d.kind)} for source ${d.source}`)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Group 5: mode integration (4)
+// ---------------------------------------------------------------------------
+t('t_from_rule_slug_traverses', () => {
+  resetRuleDir()
+  writeRule('feedback_traversal_src.md', 'name: sentinel-a1b2c3-traversal-src',
+    '[[sentinel-a1b2c3-traversal-tgt]]')
+  writeRule('feedback_traversal_tgt.md', 'name: sentinel-a1b2c3-traversal-tgt')
+  const r = run(['--from', 'sentinel-a1b2c3-traversal-src', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.ok(r.json.nodes.some(n => n.id === 'sentinel-a1b2c3-traversal-src'),
+    'source node is in traversal result')
+  assert.ok(r.json.nodes.some(n => n.id === 'sentinel-a1b2c3-traversal-tgt'),
+    'target node is in traversal result (multi-node, not single)')
+  const edge = r.json.edges.find(e =>
+    e.from === 'sentinel-a1b2c3-traversal-src' && e.to === 'sentinel-a1b2c3-traversal-tgt')
+  assert.ok(edge, 'src→tgt edge is in traversal result')
+  assert.ok(r.json.count >= 2, `count must be >= 2, got ${r.json.count}`)
+})
+
+t('t_linked_rule_not_orphan', () => {
+  resetRuleDir()
+  writeRule('feedback_linked_src.md', 'name: sentinel-a1b2c3-linked-src',
+    '[[sentinel-a1b2c3-linked-tgt]]')
+  writeRule('feedback_linked_tgt.md', 'name: sentinel-a1b2c3-linked-tgt')
+  const r = run(['--orphans', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const orphanIds = r.json.nodes.map(n => n.id)
+  assert.ok(!orphanIds.includes('sentinel-a1b2c3-linked-src'),
+    'rule with a resolved wiki-link is NOT in --orphans (degree > 0)')
+  assert.ok(!orphanIds.includes('sentinel-a1b2c3-linked-tgt'),
+    'target rule with an incoming edge is NOT in --orphans (degree > 0)')
+})
+
+t('t_unlinked_rule_still_orphan', () => {
+  resetRuleDir()
+  writeRule('feedback_unlinked.md', 'name: sentinel-a1b2c3-unlinked')
+  const r = run(['--orphans', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 0, r.stdout)
+  const orphanIds = r.json.nodes.map(n => n.id)
+  assert.ok(orphanIds.includes('sentinel-a1b2c3-unlinked'),
+    'rule with no wiki-links IS in --orphans (degree 0)')
+})
+
+t('t_rule_node_can_be_hub', () => {
+  resetRuleDir()
+  writeRule('feedback_hub_src.md', 'name: sentinel-a1b2c3-hub-src',
+    '[[sentinel-a1b2c3-hub-tgt-1]] [[sentinel-a1b2c3-hub-tgt-2]] [[sentinel-a1b2c3-hub-tgt-3]]')
+  writeRule('feedback_hub_tgt_1.md', 'name: sentinel-a1b2c3-hub-tgt-1')
+  writeRule('feedback_hub_tgt_2.md', 'name: sentinel-a1b2c3-hub-tgt-2')
+  writeRule('feedback_hub_tgt_3.md', 'name: sentinel-a1b2c3-hub-tgt-3')
+  const r = run(['--hubs', '--nodes', 'rule', '--edges', 'wiki-link', '--top', '20'])
+  assert.equal(r.code, 0, r.stdout)
+  const hub = r.json.nodes.find(n => n.id === 'sentinel-a1b2c3-hub-src')
+  assert.ok(hub, 'rule with multiple wiki-link targets is in --hubs output')
+  assert.equal(hub.type, 'rule', 'hub is a rule node, not an episode')
+  assert.ok(hub.degree >= 3, `hub degree must be >= 3, got ${hub.degree}`)
+})
+
+// ---------------------------------------------------------------------------
+// Group 6: regression + robustness (6)
+// ---------------------------------------------------------------------------
+t('t_default_output_byte_identical', () => {
+  resetRuleDir()
+  // No rules, no episodes; default orphans output is the baseline.
+  const before = run(['--orphans'])
+  assert.equal(before.code, 0, before.stdout)
+  // Add several rules; default mode must NOT read the corpus, so output is
+  // byte-identical.
+  writeRule('feedback_a.md', 'name: sentinel-a1b2c3-a')
+  writeRule('feedback_b.md', 'name: sentinel-a1b2c3-b')
+  writeRule('feedback_c.md', 'name: sentinel-a1b2c3-c')
+  const after = run(['--orphans'])
+  assert.equal(after.code, 0, after.stdout)
+  assert.deepEqual(after.json, before.json,
+    'adding rule files must not change the default invocation output (byte-identical)')
+})
+
+t('t_default_mode_does_not_read_bodies', () => {
+  resetRuleDir()
+  // Corpus with a collision: two files with the same frontmatter name.
+  // The rule slug is the SLUGIFIED form of the name, so 'same name' slugs
+  // to 'same-name'. Default mode must NOT scan, so no exit 2. Opted-in
+  // mode MUST scan and must exit 2 — this proves the collision is real.
+  writeRule('feedback_x.md', 'name: same name')
+  writeRule('feedback_y.md', 'name: same name')
+  const dflt = run(['--orphans'])
+  assert.equal(dflt.code, 0,
+    'default mode (no --nodes) does not read rule bodies, so collision is invisible')
+  const opted = run(['--orphans', '--nodes', 'rule'])
+  assert.equal(opted.code, 2,
+    'opt-in mode reads rule bodies, so the collision triggers exit 2')
+  assert.equal(opted.json.status, 'error')
+  assert.ok(opted.json.message.includes('same-name'),
+    'collision error message names the slugified colliding slug')
+})
+
+t('t_edge_types_registered', () => {
+  resetRuleDir()
+  writeRule('feedback_edge_type_a.md', 'name: sentinel-a1b2c3-et-a')
+  const wikiLink = run(['--edges', 'wiki-link', '--orphans', '--nodes', 'rule'])
+  assert.equal(wikiLink.code, 0, 'wiki-link is a registered edge type')
+  // composes-with is S2 but it IS in EDGE_TYPES per step 1.2; verify the
+  // registration is already accepted even though S2 will add extraction.
+  const composesWith = run(['--edges', 'composes-with', '--orphans', '--nodes', 'rule'])
+  assert.equal(composesWith.code, 0, 'composes-with is a registered edge type')
+  // And the bad-name case still exits 2 (regression).
+  const bad = run(['--edges', 'not-a-type', '--orphans', '--nodes', 'rule'])
+  assert.equal(bad.code, 2, 'unknown edge types still rejected with exit 2')
+})
+
+t('t_default_edges_unchanged', () => {
+  resetRuleDir()
+  // With no --edges flag, default mode (no --nodes) does not include
+  // wiki-link, so the dangling key is NOT present.
+  const r = run(['--orphans'])
+  assert.equal(r.code, 0)
+  assert.ok(!('dangling' in r.json),
+    'default --edges (no wiki-link) does not produce a dangling key')
+  // With no --edges flag and --nodes rule, still no dangling.
+  const withNodes = run(['--orphans', '--nodes', 'rule'])
+  assert.equal(withNodes.code, 0)
+  assert.ok(!('dangling' in withNodes.json),
+    'default --edges + --nodes rule does not produce a dangling key')
+})
+
+t('t_edges_all_emits_empty_dangling', () => {
+  resetRuleDir()
+  writeRule('feedback_all_a.md', 'name: sentinel-a1b2c3-all-a')
+  const r = run(['--edges', 'all', '--orphans', '--nodes', 'rule'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.ok('dangling' in r.json,
+    '--edges all includes wiki-link and composes-with, so dangling key is present')
+  assert.deepEqual(r.json.dangling, [],
+    'no wiki-links in the corpus, so dangling is an empty array (not undefined)')
+})
+
+t('t_collision_still_exits_2_before_extraction', () => {
+  resetRuleDir()
+  // Two rules with identical slugs; the scanRuleNodes call must exit 2
+  // BEFORE any body is read. The wiki-link loop never runs.
+  writeRule('feedback_col1.md', 'name: same name')
+  writeRule('feedback_col2.md', 'name: same name')
+  // Add a third rule with a wiki link that, if extraction ran, would
+  // produce a dangling entry. The collision guard must fire first.
+  writeRule('feedback_col3.md', 'name: sentinel-a1b2c3-col3',
+    '[[sentinel-a1b2c3-ghost-col3]]')
+  const r = run(['--orphans', '--nodes', 'rule', '--edges', 'wiki-link'])
+  assert.equal(r.code, 2, 'collision exits 2 even with --edges wiki-link')
+  assert.equal(r.json.status, 'error')
+  assert.ok(r.json.message.includes('same-name'),
+    'collision error names the slugified colliding slug')
+})
+
+// ---------------------------------------------------------------------------
+// Group 7: hostile input (2)
+// ---------------------------------------------------------------------------
+t('t_wikilink_pathological_input_bounded', () => {
+  resetRuleDir()
+  // 10,000 unclosed [[ at the start of the body. The regex is bounded by
+  // [^\]|#]+, so it consumes greedily until the end of the file with no
+  // nested-quantifier backtracking explosion. Must complete in well under
+  // 5 seconds on a modern machine.
+  const body = '[[' .repeat(10000)
+  writeRule('feedback_pathological.md', 'name: sentinel-a1b2c3-pathological', body)
+  const t0 = Date.now()
+  const r = run(['--edges', 'wiki-link', '--orphans', '--nodes', 'rule'])
+  const elapsed = Date.now() - t0
+  assert.equal(r.code, 0, 'parser must complete without crashing on 10k unclosed [[')
+  assert.ok(elapsed < 5000, `parser must complete in <5s; took ${elapsed}ms`)
+  // And no edges / dangling entries (10k unclosed is malformed)
+  assert.equal((r.json.edges || []).length, 0, 'no edges from malformed input')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries from malformed input')
+})
+
+t('t_proto_key_wiki_target', () => {
+  resetRuleDir()
+  // Rules with name '__proto__' and 'constructor'. The slugified forms are
+  // 'proto' and 'constructor'. Slug maps are `new Map()`, so prototype keys
+  // cannot pollute Object.prototype. The edge map must remain a Map, not a
+  // plain object.
+  writeRule('feedback_proto.md', 'name: __proto__')
+  writeRule('feedback_ctor.md', 'name: constructor')
+  writeRule('feedback_proto_src.md', 'name: sentinel-a1b2c3-proto-src',
+    '[[__proto__]] [[constructor]]')
+  const protoKeysBefore = Object.getOwnPropertyNames(Object.prototype).length
+  const r = run(['--from', 'sentinel-a1b2c3-proto-src', '--nodes', 'rule', '--edges', 'wiki-link'])
+  const protoKeysAfter = Object.getOwnPropertyNames(Object.prototype).length
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal(protoKeysAfter, protoKeysBefore,
+    'Object.prototype own property count must not change after running em-graph with __proto__/constructor rules')
+  // The src should have BOTH edges (both targets exist as rule nodes)
+  const srcEdges = r.json.edges.filter(e => e.from === 'sentinel-a1b2c3-proto-src')
+  const targets = srcEdges.map(e => e.to).sort()
+  assert.deepEqual(targets, ['constructor', 'proto'],
+    'both __proto__ and constructor targets resolve via slug map (no pollution)')
+})
+
+// ---------------------------------------------------------------------------
+// teardown
+// ---------------------------------------------------------------------------
+fs.rmSync(cwd, { recursive: true, force: true })
+fs.rmSync(home, { recursive: true, force: true })
+if (breakTemp) fs.rmSync(breakTemp, { recursive: true, force: true })
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-em-graph-links.mjs
+++ b/tests/test-em-graph-links.mjs
@@ -687,6 +687,45 @@ t('t_composes_first_backtick_run_wins', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Round-2 regression tests
+// ---------------------------------------------------------------------------
+
+t('t_composes_crlf_line_endings', () => {
+  resetRuleDir()
+  // Write the source file with explicit \r\n line endings. Before FIX 1
+  // the split('\n') left a trailing \r on each line and the bullet regex
+  // /^-[ \t]+(.*)$/ (no /m flag) failed to match, silently producing zero
+  // edges and zero dangling — the same false-pass signature REQ-6 traps.
+  const crlfBody = '---\r\nname: sentinel-a1b2c3-crlf-src\r\n---\r\n\r\n## Composes with\r\n- `sentinel-a1b2c3-crlf-tgt`\r\n'
+  fs.writeFileSync(path.join(RULE_DIR, 'feedback_crlf_src.md'), crlfBody, 'utf8')
+  writeRule('feedback_crlf_tgt.md', 'name: sentinel-a1b2c3-crlf-tgt')
+  const r = run(['--from', 'sentinel-a1b2c3-crlf-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  // Same edge as the LF equivalent: src -> tgt, type composes-with
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-crlf-src' && e.to === 'sentinel-a1b2c3-crlf-tgt' && e.type === 'composes-with')
+  assert.ok(edge, 'CRLF line endings produce the same edge as LF (FIX 1: split /\\r?\\n/)')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries')
+})
+
+t('t_composes_markdown_link_fragment_stripped', () => {
+  resetRuleDir()
+  // FIX 2: a markdown-link target carrying a #fragment must have the fragment
+  // stripped before basename resolution. Before FIX 2 the fragment was
+  // slugified into the target and the link dangled.
+  writeRule('feedback_frag_target.md', 'name: sentinel-a1b2c3-frag-tgt')
+  // Source with a #fragment in the markdown link path
+  writeRule('feedback_frag_src.md', 'name: sentinel-a1b2c3-frag-src',
+    'body\n## Composes with\n- [t](feedback_frag_target.md#sec)\n')
+  const r = run(['--from', 'sentinel-a1b2c3-frag-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-frag-src' && e.to === 'sentinel-a1b2c3-frag-tgt' && e.type === 'composes-with')
+  assert.ok(edge, 'markdown link with #fragment resolves identically to one without (FIX 2: strip fragment before basename)')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries (fragment is stripped, not slugified)')
+})
+
+// ---------------------------------------------------------------------------
 // teardown
 // ---------------------------------------------------------------------------
 fs.rmSync(cwd, { recursive: true, force: true })

--- a/tests/test-em-graph-links.mjs
+++ b/tests/test-em-graph-links.mjs
@@ -564,6 +564,129 @@ t('t_proto_key_wiki_target', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Group 3: composes-with (8)
+// ---------------------------------------------------------------------------
+t('t_composes_toplevel_only', () => {
+  resetRuleDir()
+  writeRule('feedback_toplevel_src.md', 'name: sentinel-a1b2c3-toplevel-src',
+    'body\n## Composes with\n- `sentinel-a1b2c3-toplevel-tgt`\n- some other text\n')
+  writeRule('feedback_toplevel_tgt.md', 'name: sentinel-a1b2c3-toplevel-tgt')
+  const r = run(['--from', 'sentinel-a1b2c3-toplevel-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-toplevel-src' && e.to === 'sentinel-a1b2c3-toplevel-tgt' && e.type === 'composes-with')
+  assert.ok(edge, 'top-level bullet target resolves via composes-with')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries')
+})
+
+t('t_composes_nested_ignored', () => {
+  resetRuleDir()
+  // First bullet is nested (indented), second is top-level. The nested one
+  // must be IGNORED (not parsed as a target), the top-level one must resolve.
+  writeRule('feedback_nested_src.md', 'name: sentinel-a1b2c3-nested-src',
+    'body\n## Composes with\n  - `sentinel-a1b2c3-nested-ignored`\n- `sentinel-a1b2c3-nested-tgt`\n')
+  writeRule('feedback_nested_tgt.md', 'name: sentinel-a1b2c3-nested-tgt')
+  // Note: no target rule for 'nested-ignored' — the assertion is that the
+  // nested bullet was NEVER parsed, so no dangling entry exists for it.
+  const r = run(['--from', 'sentinel-a1b2c3-nested-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edges = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-nested-src' && e.type === 'composes-with')
+  assert.equal(edges.length, 1, 'exactly one composes-with edge (nested bullet ignored, not parsed)')
+  assert.ok(edges.some(e => e.to === 'sentinel-a1b2c3-nested-tgt'), 'top-level bullet is the edge target')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries (nested bullet was ignored, not parsed)')
+})
+
+t('t_composes_markdown_link_basename', () => {
+  resetRuleDir()
+  // Markdown link form: the path in (...) resolves by basename. The target
+  // rule's name-id is different from the basename-derived slug; resolution
+  // must go through the alias index.
+  writeRule('feedback_mdlink_target.md', 'name: sentinel-a1b2c3-mdlink-tgt')
+  writeRule('feedback_mdlink_src.md', 'name: sentinel-a1b2c3-mdlink-src',
+    'body\n## Composes with\n- [link text](feedback_mdlink_target.md)\n')
+  const r = run(['--from', 'sentinel-a1b2c3-mdlink-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-mdlink-src' && e.to === 'sentinel-a1b2c3-mdlink-tgt' && e.type === 'composes-with')
+  assert.ok(edge, 'markdown link target resolves by basename (feedback_mdlink_target.md -> sentinel-a1b2c3-mdlink-tgt)')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries')
+})
+
+t('t_composes_empty_section_no_dangling', () => {
+  resetRuleDir()
+  // Section heading present but no bullets before EOF: 0 edges AND 0 dangling.
+  writeRule('feedback_empty_src.md', 'name: sentinel-a1b2c3-empty-src',
+    'body\n## Composes with\n')
+  const r = run(['--from', 'sentinel-a1b2c3-empty-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal((r.json.edges || []).length, 0, 'empty composes-with section produces 0 edges (REQ-6 false-pass trap)')
+  assert.equal((r.json.dangling || []).length, 0, 'empty composes-with section produces 0 dangling entries (REQ-6 false-pass trap)')
+})
+
+t('t_composes_terminated_by_next_heading', () => {
+  resetRuleDir()
+  // Section followed immediately by another ## heading: the section is
+  // empty (EC6), so no edges and no dangling.
+  writeRule('feedback_term_src.md', 'name: sentinel-a1b2c3-term-src',
+    'body\n## Composes with\n## Other Section\n- `sentinel-a1b2c3-term-tgt`\n')
+  writeRule('feedback_term_tgt.md', 'name: sentinel-a1b2c3-term-tgt')
+  const r = run(['--from', 'sentinel-a1b2c3-term-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal((r.json.edges || []).length, 0, 'section terminated by next heading: 0 edges (EC6)')
+  assert.equal((r.json.dangling || []).length, 0, 'section terminated by next heading: 0 dangling entries')
+})
+
+t('t_composes_backticked_target_resolves', () => {
+  resetRuleDir()
+  // REQ-16: composes-with does NOT strip inline backticks. The real-world
+  // form is "- `file.md` — text" and stripping inline code would delete
+  // every target. The backticked token is the target; it resolves.
+  writeRule('feedback_back_src.md', 'name: sentinel-a1b2c3-back-src',
+    'body\n## Composes with\n- `sentinel-a1b2c3-back-tgt` — some text\n')
+  writeRule('feedback_back_tgt.md', 'name: sentinel-a1b2c3-back-tgt')
+  const r = run(['--from', 'sentinel-a1b2c3-back-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edge = (r.json.edges || []).find(e =>
+    e.from === 'sentinel-a1b2c3-back-src' && e.to === 'sentinel-a1b2c3-back-tgt' && e.type === 'composes-with')
+  assert.ok(edge, 'backticked target resolves (REQ-16: inline backticks NOT stripped for composes-with)')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries')
+})
+
+t('t_composes_prose_bullet_skipped', () => {
+  resetRuleDir()
+  // A bullet that is neither a markdown link nor backtick-led: SKIP, no target.
+  // Review r1 finding 5: earlier draft slugified the whole prose line and
+  // manufactured a garbage dangling ref. The contract is: no target, no edge,
+  // no dangling.
+  writeRule('feedback_prose_src.md', 'name: sentinel-a1b2c3-prose-src',
+    'body\n## Composes with\n- This is just prose, no link or backticks\n')
+  const r = run(['--from', 'sentinel-a1b2c3-prose-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal((r.json.edges || []).length, 0, 'prose bullet produces 0 edges (not slugified as a target)')
+  assert.equal((r.json.dangling || []).length, 0, 'prose bullet produces 0 dangling entries (review r1 finding 5)')
+})
+
+t('t_composes_first_backtick_run_wins', () => {
+  resetRuleDir()
+  // A bullet with TWO backticked spans: only the FIRST is used as the target.
+  // Review r1 finding 6: earlier draft silently kept only the first; that
+  // behavior is kept and made explicit. The second backticked span is
+  // IGNORED, not parsed as a second target.
+  writeRule('feedback_first_src.md', 'name: sentinel-a1b2c3-first-src',
+    'body\n## Composes with\n- `sentinel-a1b2c3-first-tgt` and `sentinel-a1b2c3-second-ignored`\n')
+  writeRule('feedback_first_tgt.md', 'name: sentinel-a1b2c3-first-tgt')
+  // NOTE: no target rule for 'second-ignored'. If the second backtick run
+  // were parsed, it would dangle (no target). The assertion is that the
+  // second run was NEVER parsed, so no dangling entry exists.
+  const r = run(['--from', 'sentinel-a1b2c3-first-src', '--nodes', 'rule', '--edges', 'composes-with'])
+  assert.equal(r.code, 0, r.stdout)
+  const edges = (r.json.edges || []).filter(e => e.from === 'sentinel-a1b2c3-first-src' && e.type === 'composes-with')
+  assert.equal(edges.length, 1, 'exactly one composes-with edge (first backtick run wins; review r1 finding 6)')
+  assert.ok(edges.some(e => e.to === 'sentinel-a1b2c3-first-tgt'), 'first backtick run is the edge target')
+  assert.equal((r.json.dangling || []).length, 0, 'no dangling entries (second backtick run ignored, not parsed)')
+})
+
+// ---------------------------------------------------------------------------
 // teardown
 // ---------------------------------------------------------------------------
 fs.rmSync(cwd, { recursive: true, force: true })


### PR DESCRIPTION
Implements RFC-007 Phase 3. Closes #589.

## What ships

Two rule-to-rule edge types on `em-graph.mjs`, both opt-in (registered in `EDGE_TYPES`, absent from `DEFAULT_EDGES`):

- **`wiki-link`** — `[[name]]` in rule bodies, fenced blocks and inline backticks excluded
- **`composes-with`** — top-level bullets under `## Composes with`, nested bullets ignored

Plus the shared target resolution both depend on, per-edge-type dangling tracking, and a 31-case suite wired into CI.

## The issue understated the work

#589 described two parsers and a fixture. Adding edges to rule nodes broke three assumptions Phase 2 had made explicit in its own comments:

| Site | Before | After |
|---|---|---|
| `--orphans` | reported **every** rule unconditionally | reports a rule only at degree 0 |
| `--from <rule-slug>` | early-returned a single node | falls through to the BFS, making good on the comment left at `em-graph.mjs:290` |
| `--hubs` | `degree` map was episode-only | rule ids seeded, so rules can rank |

Every line anchor #589 cited was also stale by +10 to +25 lines, drifted by Phase 2 (#604). Several pointed at blank lines; two pointed at the wrong JSON object entirely. All corrected.

## Target resolution needed a decision

Built literally, the spec resolves almost nothing. Measured against the live corpus before writing any code:

| Edge type | Spec as written | With filename-alias index |
|---|---|---|
| `wiki-link` | 13 of 132 | **122** of 132 |
| `composes-with` | **0** of 76 | **51** of 76 |

Node ids are `slugify(frontmatter name)` per `RFC-007:142`, but authors link by filename. `RFC-007:151` separately requires `composes-with` markdown links to resolve "by file basename", which needs an index `:142` disclaims. The RFC contradicted itself, functionally rather than cosmetically.

Resolution now tries the name-derived id first, then a filename-basename alias index; ambiguous basenames are dropped rather than guessed. **Node ids are unchanged and `:142` is untouched.** Documented in a new Target resolution subsection.

## Two RFC contradictions settled

- **Dangling bucket** is `wiki-link` everywhere. The prose said `wiki-link-dangling`, a spelling appearing nowhere else in the 737-line file and disagreeing with both the contract and the `kind` enum.
- **The wiki-link regex** was stated twice, non-equivalently. The prose form is canonical. Verified programmatically: the contract JSON-unescaped, the prose span, and the literal compiled into `em-graph.mjs` are now character-identical.

## Verification

| Claim | Command | Observed |
|---|---|---|
| New suite | `node tests/test-em-graph-links.mjs` | `31 passed, 0 failed` |
| Phase 1 regression | `node tests/test-em-graph.mjs` | `10 passed, 0 failed` |
| Phase 2 regression | `node tests/test-em-graph-nodes.mjs` | `28 passed, 0 failed` |
| Suite genuinely CI-wired | `node tests/test-ci-suite-registration.mjs` | `16 passed, 0 failed` |
| Negative control | `node tests/test-em-graph-links.mjs --break-wikilink` | exit 1, 11 failures |
| **REQ-8 default output** | worktree at `8e6e699`, `cmp` on `--hubs` and `--orphans` | **byte-identical** |
| RFC anchors | `sed -n '239p;251p;314p;320p;332p'` | all point where claimed |

REQ-8 was checked against the baseline commit directly rather than via the suite's own before/after comparison, which is the proxy layer one short of the claim.

**Live corpus:** 81 rule nodes carry `wiki-link` edges (9 dangling), 31 carry `composes-with` edges (1 dangling). `--from pi-minimax-m3-builder-seat --depth 2` returns 5 nodes and 4 edges where `8e6e699` returned `count: 1`.

## Review

Two rounds, both HOLD, all 12 findings dispositioned.

Round 1 on the plan caught a blocker: a step referenced a symbol a later step defined, so verbatim application would have thrown `ReferenceError`. Round 2 on the frozen diff caught a MAJOR: **CRLF line endings silently dropped every `composes-with` edge** — zero edges, zero dangling, exit 0. Latent on this corpus but the same silent-zero signature REQ-6 traps for, and inconsistent with `lib/rule-nodes.mjs:67` which already handles CRLF. Fixed with a regression test proven to fail without the fix.

Round 2 also caught a REQ-12 miss: the RFC's Scope "Unbuilt" list still enumerated Phase 2 and Phase 3.

## Pre-existing stalenesses fixed in passing

- The mermaid diagram labelled Phase 2 UNBUILT while the phases table and ledger both recorded it SHIPPED.
- `slugify._shipped_use` claimed the function was unused by the shipped script, though `scanRuleNodes` has called it since Phase 2.

`grep -c UNBUILT` on the RFC: 17 before, 10 after.

## Deliberately not included

**No Implementation ledger row.** Its provenance must come from `git log --follow` on the merge commit, which does not exist yet. Writing a branch-tip SHA there is the defect #582 was filed for and #605 had to repair. It will be filled post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
