### PR TITLE
FIX-611: pass an explicit maxBuffer to every second-opinion provider dispatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Run second-opinion install-snapshot suite (#573 wiring sweep — I-27a/I-27b freshness + tamper)
         run: node tests/test-second-opinion-install-snapshot.mjs
 
+      - name: Run second-opinion maxbuffer suite (#611 — explicit 64 MiB maxBuffer on provider dispatch)
+        run: node tests/test-second-opinion-maxbuffer.mjs
+
       - name: Run second-opinion preamble suite (#573 wiring sweep — composer + registry validator)
         run: node tests/test-second-opinion-preamble.mjs
 

--- a/scripts/second-opinion/providers/claude-subagent.mjs
+++ b/scripts/second-opinion/providers/claude-subagent.mjs
@@ -21,6 +21,8 @@
 
 import { spawnSync } from 'node:child_process'
 
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024
+
 const HELP_SIGNATURE = /\bclaude\b/i
 
 export const id = 'claude-subagent'
@@ -66,6 +68,7 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     shell: false,
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout,
+    maxBuffer: MAX_BUFFER_BYTES,
     env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' },
   })
 

--- a/scripts/second-opinion/providers/codex.mjs
+++ b/scripts/second-opinion/providers/codex.mjs
@@ -17,6 +17,8 @@
 
 import { spawnSync } from 'node:child_process'
 
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024
+
 const HELP_SIGNATURE = /\bUsage:\s+codex\s+exec\b/
 
 export const id = 'codex'
@@ -76,6 +78,7 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     shell: false,               // CRITICAL: no shell interpretation (I-6)
     stdio: ['ignore', 'pipe', 'pipe'],   // stdin: ignore → codex sees EOF immediately
     timeout,
+    maxBuffer: MAX_BUFFER_BYTES,
   })
 
   return {

--- a/scripts/second-opinion/providers/gemini.mjs
+++ b/scripts/second-opinion/providers/gemini.mjs
@@ -15,6 +15,8 @@
 
 import { spawnSync } from 'node:child_process'
 
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024
+
 const HELP_SIGNATURE = /\bgemini\b/i
 
 export const id = 'gemini'
@@ -54,6 +56,7 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     shell: false,
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout,
+    maxBuffer: MAX_BUFFER_BYTES,
   })
 
   return {

--- a/scripts/second-opinion/providers/opencode.mjs
+++ b/scripts/second-opinion/providers/opencode.mjs
@@ -23,6 +23,8 @@
 
 import { spawnSync } from 'node:child_process'
 
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024
+
 const HELP_SIGNATURE = /\bopencode\s+run\b/
 const DEFAULT_MODEL = 'deepseek/deepseek-v4-pro'
 
@@ -84,6 +86,7 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     shell: false,               // CRITICAL: no shell interpretation (I-6)
     stdio: ['ignore', 'pipe', 'pipe'],   // stdin: ignore → no hang waiting on input
     timeout,
+    maxBuffer: MAX_BUFFER_BYTES,
   })
 
   return {

--- a/scripts/second-opinion/providers/stub.mjs
+++ b/scripts/second-opinion/providers/stub.mjs
@@ -10,6 +10,8 @@
 
 import { spawnSync } from 'node:child_process'
 
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024
+
 export const id = 'stub'
 export const binary = 'stub-provider'
 
@@ -58,6 +60,7 @@ export function dispatch({ prompt, projectRoot, timeout }) {
       stdio: ['ignore', 'pipe', 'pipe'],
       encoding: 'utf8',
       ...(timeout === undefined ? {} : { timeout }),
+      maxBuffer: MAX_BUFFER_BYTES,
     })
     if (child.signal === 'SIGTERM' && child.error?.code === 'ETIMEDOUT') {
       return { ok: false, exitCode: null, stdout: child.stdout || '', stderr: child.stderr || '', timedOut: true }

--- a/tests/test-second-opinion-maxbuffer.mjs
+++ b/tests/test-second-opinion-maxbuffer.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * test-second-opinion-maxbuffer.mjs — Regression test for issue #611.
+ *
+ * Provider dispatch spawnSync must pass an explicit maxBuffer (64 MiB) so
+ * Node's 1 MiB default does not SIGTERM the child with ENOBUFS when the
+ * review emits >1 MiB on stdout or stderr.
+ *
+ * Static: read each provider's dispatch function and assert every
+ * spawnSync call site inside it passes maxBuffer.
+ *
+ * Behavioral: demonstrate the default-buffer failure mode (SIGTERM +
+ * ENOBUFS) and that 64 MiB captures the full 1.5 MiB stderr.
+ *
+ * Zero deps. Node assert + fs + child_process.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PROVIDERS_DIR = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers')
+const PROVIDERS = ['codex.mjs', 'opencode.mjs', 'claude-subagent.mjs', 'gemini.mjs', 'stub.mjs']
+
+let passed = 0
+let failed = 0
+const failures = []
+
+function test(name, fn) {
+  try {
+    fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+/**
+ * Extract the text of the dispatch function from the provider source.
+ * Counts top-level braces while ignoring strings and comments.
+ */
+function extractDispatchBody(text) {
+  const signature = 'export function dispatch('
+  const start = text.indexOf(signature)
+  if (start === -1) throw new Error('export function dispatch not found')
+
+  // Skip the parameter list so the first '{' after it is the function body.
+  let i = start + signature.length
+  let parenDepth = 1
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  let inLineComment = false
+  let inBlockComment = false
+  let escape = false
+
+  while (i < text.length && parenDepth > 0) {
+    const ch = text[i]
+    const next = text[i + 1]
+
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false
+    } else if (inBlockComment) {
+      if (ch === '*' && next === '/') { inBlockComment = false; i++ }
+    } else if (inSingle) {
+      if (escape) { escape = false }
+      else if (ch === '\\') { escape = true }
+      else if (ch === "'") inSingle = false
+    } else if (inDouble) {
+      if (escape) { escape = false }
+      else if (ch === '\\') { escape = true }
+      else if (ch === '"') inDouble = false
+    } else if (inTemplate) {
+      if (escape) { escape = false }
+      else if (ch === '\\') { escape = true }
+      else if (ch === '`') inTemplate = false
+    } else {
+      if (ch === '/' && next === '/') { inLineComment = true; i++ }
+      else if (ch === '/' && next === '*') { inBlockComment = true; i++ }
+      else if (ch === "'") inSingle = true
+      else if (ch === '"') inDouble = true
+      else if (ch === '`') inTemplate = true
+      else if (ch === '(') parenDepth++
+      else if (ch === ')') parenDepth--
+    }
+    i++
+  }
+
+  // Find the function body '{'.
+  while (i < text.length && text[i] !== '{') i++
+  if (i >= text.length) throw new Error('dispatch function body start not found')
+
+  let depth = 0
+  inSingle = false
+  inDouble = false
+  inTemplate = false
+  inLineComment = false
+  inBlockComment = false
+  escape = false
+
+  for (; i < text.length; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false
+      continue
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') { inBlockComment = false; i++ }
+      continue
+    }
+    if (inSingle) {
+      if (escape) { escape = false; continue }
+      if (ch === '\\') { escape = true; continue }
+      if (ch === "'") inSingle = false
+      continue
+    }
+    if (inDouble) {
+      if (escape) { escape = false; continue }
+      if (ch === '\\') { escape = true; continue }
+      if (ch === '"') inDouble = false
+      continue
+    }
+    if (inTemplate) {
+      if (escape) { escape = false; continue }
+      if (ch === '\\') { escape = true; continue }
+      if (ch === '`') inTemplate = false
+      continue
+    }
+
+    if (ch === '/' && next === '/') { inLineComment = true; i++; continue }
+    if (ch === '/' && next === '*') { inBlockComment = true; i++; continue }
+    if (ch === "'") { inSingle = true; continue }
+    if (ch === '"') { inDouble = true; continue }
+    if (ch === '`') { inTemplate = true; continue }
+
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) break
+    }
+  }
+  return text.slice(start, i + 1)
+}
+
+/**
+ * Return the full spawnSync(...) call strings inside the given function body,
+ * matching parentheses while ignoring strings.
+ */
+function findSpawnSyncCalls(body) {
+  const calls = []
+  let idx = 0
+  while (true) {
+    idx = body.indexOf('spawnSync(', idx)
+    if (idx === -1) break
+    let i = idx + 'spawnSync('.length
+    let depth = 1
+    let inSingle = false
+    let inDouble = false
+    let inTemplate = false
+    let escape = false
+    while (i < body.length && depth > 0) {
+      const ch = body[i]
+      if (inSingle) {
+        if (escape) { escape = false }
+        else if (ch === '\\') { escape = true }
+        else if (ch === "'") inSingle = false
+      } else if (inDouble) {
+        if (escape) { escape = false }
+        else if (ch === '\\') { escape = true }
+        else if (ch === '"') inDouble = false
+      } else if (inTemplate) {
+        if (escape) { escape = false }
+        else if (ch === '\\') { escape = true }
+        else if (ch === '`') inTemplate = false
+      } else {
+        if (ch === "'") inSingle = true
+        else if (ch === '"') inDouble = true
+        else if (ch === '`') inTemplate = true
+        else if (ch === '(') depth++
+        else if (ch === ')') depth--
+      }
+      i++
+    }
+    calls.push(body.slice(idx, i))
+    idx = i
+  }
+  return calls
+}
+
+console.log('# test-second-opinion-maxbuffer')
+
+// ---------------------------------------------------------------------------
+// Static: every dispatch spawnSync passes maxBuffer
+// ---------------------------------------------------------------------------
+console.log('\n## Static: dispatch spawnSync options include maxBuffer')
+for (const file of PROVIDERS) {
+  test(`${file} dispatch spawnSync passes maxBuffer`, () => {
+    const text = fs.readFileSync(path.join(PROVIDERS_DIR, file), 'utf8')
+    const body = extractDispatchBody(text)
+    const calls = findSpawnSyncCalls(body)
+    assert.ok(calls.length > 0, `expected at least one spawnSync in dispatch, found ${calls.length}`)
+    for (const call of calls) {
+      assert.ok(
+        /\bmaxBuffer\s*:/.test(call),
+        `spawnSync in ${file} is missing maxBuffer in options: ${call.slice(0, 200)}`
+      )
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Behavioral: prove the default 1 MiB limit is real and that 64 MiB fixes it
+// ---------------------------------------------------------------------------
+console.log('\n## Behavioral: ENOBUFS failure mode and 64 MiB fix')
+const EMIT = 'process.stderr.write("x".repeat(1536*1024))'
+
+test('without maxBuffer: child is killed with SIGTERM + ENOBUFS', () => {
+  const result = spawnSync(process.execPath, ['-e', EMIT], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+  })
+  assert.strictEqual(result.status, null, 'status should be null on ENOBUFS')
+  assert.strictEqual(result.signal, 'SIGTERM', 'signal should be SIGTERM')
+  assert.ok(result.error, 'error should be set')
+  assert.strictEqual(result.error.code, 'ENOBUFS', 'error code should be ENOBUFS')
+})
+
+test('with maxBuffer 64 MiB: child captures full 1.5 MiB stderr', () => {
+  const result = spawnSync(process.execPath, ['-e', EMIT], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+  assert.strictEqual(result.status, 0, 'status should be 0')
+  assert.strictEqual(result.signal, null, 'signal should be null')
+  assert.strictEqual(result.stderr.length, 1572864, 'stderr should be exactly 1536 KiB')
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
Fixes #611.

`spawnSync` defaults `maxBuffer` to 1 MiB across **stdout and stderr**. On overflow Node raises `ENOBUFS` **and sends `SIGTERM` to the child** — so the review is lost entirely rather than truncated, after the reviewing agent has already spent its tokens.

This is a whole-provider-layer bug, not codex-specific, and it gets worse over time: agent CLIs stream their transcript to stderr, and the review ladder instructs the reviewer to run `em-search` sweeps whose output lands there too.

## Change

Every **dispatch** `spawnSync` now passes an explicit **64 MiB** `maxBuffer`:

- `providers/codex.mjs`
- `providers/opencode.mjs`
- `providers/claude-subagent.mjs`
- `providers/gemini.mjs`
- `providers/stub.mjs`

The `which` / `--help` probes are untouched — their output is bounded and small. No timeout handling, `timedOut` computation, or error shaping was changed.

`MAX_BUFFER_BYTES` is defined per provider rather than in a shared module **on purpose**: the providers currently import nothing but `node:child_process`, and introducing the layer's first internal import for a single constant would buy coupling for no benefit. Happy to centralise it if you'd prefer.

## Test

`tests/test-second-opinion-maxbuffer.mjs` asserts both halves:

- **static** — every dispatch call site passes `maxBuffer`, parsed from source rather than a bare grep for the word;
- **behavioral** — without `maxBuffer` the child is killed (`status null`, `SIGTERM`, `ENOBUFS`); with 64 MiB it captures the full 1.5 MiB of stderr.

**Falsifiability checked:** run against a pristine worktree at `HEAD`, the new test *fails* with real assertion errors. It is not merely green.

```
test-second-opinion-maxbuffer   7 passed, 0 failed
test-second-opinion-dispatch    9 passed, 0 failed
test-second-opinion-gate       23 passed, 0 failed
test-second-opinion-consensus  18 passed, 0 failed
```

---
Authored on an isolated agent seat VM. Verification was re-run independently rather than taken on the authoring seat's word.
