### PR TITLE
FIX-435: gate consults literal-lane markers for env-prefixed commands (fixes #435)

### DIFF
--- a/plugins/claude-code/hooks/lib/agent-classifier.sh
+++ b/plugins/claude-code/hooks/lib/agent-classifier.sh
@@ -189,17 +189,22 @@ agent_classify_command() {
     return 1
   fi
 
-  # FU-1 (codex plan-review R2): env-prefix refusal at the marker-cache AUTHORITY
-  # itself, not only at the shell call sites. A leading `FOO=bar` assignment is a
-  # cross-session attack vector (PR #271/#272 F-4): a command-local env override
-  # can desync session_id and, under the script-identity key, let an env-prefixed
-  # invocation reuse a clean script marker. Refuse here so "env-prefix never
-  # reaches the marker cache" is locally verifiable in ONE place; the call-site
-  # guards (Site A + the interpreter Tier-2/3 branch) remain as defense-in-depth.
-  local _first_tok="${command%%[[:space:]]*}"
-  case "$_first_tok" in
-    [A-Za-z_]*=*) return 1 ;;
-  esac
+  # FIX-435 (revises FU-1): env-prefixed commands MAY consult the marker cache.
+  # Safety lives in the KEY, not in a categorical refusal: the helper keys an
+  # env-prefixed command under the LITERAL lane only — the full prefix-bearing
+  # normalized_command plus session_id ride in the sha256 tuple — so a verdict
+  # for `FOO=bar node x.mjs` can never serve `node x.mjs`, another prefix value,
+  # or another session (PR #271/#272 F-4 invariants preserved; pinned by
+  # tests §EP1-§EP9 in tests/test-canonical-cache-key.mjs). Generalizing lanes
+  # still refuse the shape: command-canonical.mjs returns none('env_prefix') and
+  # isInterpreterScriptIdentity requires toks[0] to be the interpreter. An env
+  # prefix on the classifier-marker.mjs INVOCATION itself remains hard-denied
+  # (classifier_marker_env_override) upstream in _classify_segment. Beyond the
+  # marker cache, this authority also reaches the config-gated legacy
+  # direct-fetch fallback and the autopersist hook (CREV F1); both stay
+  # env-prefix-safe downstream — classifier-override-persist.mjs silent-skips
+  # the shape (hasEnvPrefix) and the legacy dispatcher is per-invocation with
+  # no session cache.
 
   local session_id
   session_id="$(__agent_classifier_session_id)"

--- a/plugins/claude-code/hooks/lib/command-classifier.sh
+++ b/plugins/claude-code/hooks/lib/command-classifier.sh
@@ -979,13 +979,13 @@ _detect_helper_invocation() {
 # structural hard-deny lane — env-prefix classifier-marker override, shell
 # wrappers, marker writes, push_or_pr_create, unsafe_complex, git/gh, rm/tee/
 # touch — classifies and RETURNS earlier in _classify_segment, so it can never
-# reach this helper and can never be downgraded by a planted marker. As
-# defense-in-depth, env_prefix_count>0 additionally short-circuits (mirrors the
-# Tier-0 lookup's env-prefix gate — cross-session attack class, PR #271).
+# reach this helper and can never be downgraded by a planted marker.
+# FIX-435: env-prefixed forms now consult too — the literal-lane key (full
+# prefix-bearing text + session_id) is the isolation mechanism (§EP tests).
 #
 # Reads _classify_segment locals via dynamic scope (TOKS, target_root,
-# caller_cwd_authoritative, env_prefix_count) — identical to how the
-# interpreter branch reads them.
+# caller_cwd_authoritative) — identical to how the interpreter branch
+# reads them.
 # ---------------------------------------------------------------------------
 # Resolve the command text used for the marker cache-key lookup. PREFER the raw
 # command threaded from classify_command (_seg_raw_command via dynamic scope) —
@@ -1013,10 +1013,9 @@ _resolve_marker_cmd_text() {
 }
 
 _try_agent_marker_verdict() {
-  # env-prefix forms never escape (cross-session attack class, PR #271).
-  if [ "${env_prefix_count:-0}" -ne 0 ]; then
-    return 1
-  fi
+  # FIX-435: env-prefix forms may consult the marker cache; the literal-lane
+  # key carries the full prefix-bearing text + session_id, so no cross-shape
+  # or cross-session reuse is possible (see agent_classify_command's FIX-435 note).
   # Lazy-source the agent-classifier wrapper once (same guard + resolution the
   # interpreter branch uses).
   if [ -z "${__AGENT_CLASSIFIER_SOURCED:-}" ]; then
@@ -1949,14 +1948,16 @@ _classify_segment() {
           __AGENT_CLASSIFIER_SOURCED=0
         fi
       fi
-      # R1-finding-1 (codex plan-review BLOCKER): env-prefix forms must NOT
-      # consult the marker cache. Under the script-identity key the env prefix
-      # no longer rides in normalized_command, so `SKIP_PREFLIGHT=1 node x.mjs`
-      # could otherwise reuse the clean `node x.mjs` marker. Guard on the shell's
-      # authoritative env_prefix_count (reliable even when the token/raw
-      # reconstruction drops the prefix) — mirrors Site A (_try_agent_marker_verdict)
-      # and composes with FU-1's guard inside agent_classify_command.
-      if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" = "1" ] && [ "${env_prefix_count:-0}" -eq 0 ]; then
+      # FIX-435 (revises R1-finding-1): env-prefix forms may consult the marker
+      # cache. R1-finding-1's concern — script-identity reuse where the prefix
+      # no longer rides in normalized_command — is closed at the KEY layer:
+      # isInterpreterScriptIdentity() rejects env-prefixed text (toks[0] is not
+      # an interpreter), so these shapes key under the LITERAL lane where the
+      # prefix and session_id ride in the sha256 tuple; `SKIP_PREFLIGHT=1 node
+      # x.mjs` can never reuse the clean `node x.mjs` marker (§EP1/§EP3/§EP7).
+      # Raw threading via _resolve_marker_cmd_text preserves the prefix so
+      # normalizeCommand(read) == normalizeCommand(write).
+      if [ "${__AGENT_CLASSIFIER_SOURCED:-0}" = "1" ]; then
         # Command text via the shared helper (raw threaded command preferred so
         # normalizeCommand(read)==normalizeCommand(write) for the residual
         # non-digest interpreter case; identical resolution to Site A so the two

--- a/tests/test-canonical-cache-key.mjs
+++ b/tests/test-canonical-cache-key.mjs
@@ -349,6 +349,96 @@ test('§E3 gate E2E polarity: redirect variant of the SAME cached command is sti
   assert.ok((r.stdout || '').includes('"block"'), `expected block, got: ${r.stdout || r.stderr}`)
 })
 
+// ===== §EP: env-prefixed commands — literal-lane consult (issue #435) ======
+
+test('§EP1 unit: env-prefixed and bare forms produce DISTINCT cache keys', () => {
+  const repo = mkrepo('ep1')
+  const sid = 's_ep1'
+  const wPrefixed = markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const wBare = markerWrite(repo, 'node craftool.mjs --alpha 1', sid, 'read_only')
+  assert.notStrictEqual(wPrefixed.cache_key, wBare.cache_key, 'env prefix must ride in the key')
+})
+
+test('§EP2 unit: env-prefixed write/read use the LITERAL lane and hit same-session', () => {
+  const repo = mkrepo('ep2')
+  const sid = 's_ep2'
+  const w = markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const body = JSON.parse(fs.readFileSync(w.file, 'utf8'))
+  assert.strictEqual(body.key_form, 'literal', `expected literal lane, got ${body.key_form}`)
+  const r = markerRead(repo, 'FOO=bar node craftool.mjs --alpha 1', sid)
+  assert.strictEqual(r.json && r.json.status, 'hit', `expected hit: ${JSON.stringify(r.json)}`)
+  assert.strictEqual(r.json.key_form, 'literal')
+  assert.strictEqual(r.json.cache_key, w.cache_key)
+})
+
+test('§EP3 unit polarity: bare↔prefixed never share a verdict (both directions)', () => {
+  const repo = mkrepo('ep3')
+  const sid = 's_ep3'
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const rBare = markerRead(repo, 'node craftool.mjs --alpha 1', sid)
+  assert.notStrictEqual(rBare.json && rBare.json.status, 'hit', `bare must miss: ${JSON.stringify(rBare.json)}`)
+  const repo2 = mkrepo('ep3b')
+  markerWrite(repo2, 'node craftool.mjs --alpha 1', sid, 'read_only')
+  const rPref = markerRead(repo2, 'FOO=bar node craftool.mjs --alpha 1', sid)
+  assert.notStrictEqual(rPref.json && rPref.json.status, 'hit', `prefixed must miss: ${JSON.stringify(rPref.json)}`)
+})
+
+test('§EP4 unit polarity: a different prefix VALUE is a different shape', () => {
+  const repo = mkrepo('ep4')
+  const sid = 's_ep4'
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const r = markerRead(repo, 'FOO=other node craftool.mjs --alpha 1', sid)
+  assert.notStrictEqual(r.json && r.json.status, 'hit', `value variant must miss: ${JSON.stringify(r.json)}`)
+})
+
+test('§EP5 unit polarity: another session never reads the prefixed verdict', () => {
+  const repo = mkrepo('ep5')
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', 's_ep5a', 'read_only')
+  const r = markerRead(repo, 'FOO=bar node craftool.mjs --alpha 1', 's_ep5b')
+  assert.notStrictEqual(r.json && r.json.status, 'hit', `cross-session must miss: ${JSON.stringify(r.json)}`)
+})
+
+test('§EP6 gate E2E: same-session verdict for an env-prefixed command satisfies the gate on retry (issue #435)', () => {
+  const repo = mkrepo('ep6')
+  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canonkey-home-'))
+  const sid = 's_ep6'
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const r = runGate(repo, testHome, sid, 'FOO=bar node craftool.mjs --alpha 1')
+  assert.strictEqual(r.status, 0, `gate errored: ${r.stderr}`)
+  assert.ok(!(r.stdout || '').includes('"block"'), `expected allow, got: ${r.stdout}`)
+})
+
+test('§EP7 gate E2E polarity: the bare variant is still held after the prefixed verdict', () => {
+  const repo = mkrepo('ep7')
+  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canonkey-home-'))
+  const sid = 's_ep7'
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', sid, 'read_only')
+  const r = runGate(repo, testHome, sid, 'node craftool.mjs --alpha 1')
+  assert.ok((r.stdout || '').includes('"block"'), `expected block, got: ${r.stdout || r.stderr}`)
+})
+
+test('§EP8 gate E2E polarity: another session\'s prefixed verdict does not satisfy the gate', () => {
+  const repo = mkrepo('ep8')
+  const testHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canonkey-home-'))
+  markerWrite(repo, 'FOO=bar node craftool.mjs --alpha 1', 's_ep8a', 'read_only')
+  const r = runGate(repo, testHome, 's_ep8b', 'FOO=bar node craftool.mjs --alpha 1')
+  assert.ok((r.stdout || '').includes('"block"'), `expected block, got: ${r.stdout || r.stderr}`)
+})
+
+test('§EP9 unit: multi-prefix is its own literal shape (exact hit; set and order variants miss)', () => {
+  const repo = mkrepo('ep9')
+  const sid = 's_ep9'
+  const wMulti = markerWrite(repo, 'A=1 B=2 node craftool.mjs --alpha 1', sid, 'read_only')
+  const bodyMulti = JSON.parse(fs.readFileSync(wMulti.file, 'utf8'))
+  assert.strictEqual(bodyMulti.key_form, 'literal', `expected literal lane, got ${bodyMulti.key_form}`)
+  const wSingle = markerWrite(repo, 'A=1 node craftool.mjs --alpha 1', sid, 'read_only')
+  assert.notStrictEqual(wMulti.cache_key, wSingle.cache_key, 'prefix-set variant must not share a key')
+  const rHit = markerRead(repo, 'A=1 B=2 node craftool.mjs --alpha 1', sid)
+  assert.strictEqual(rHit.json && rHit.json.status, 'hit', `exact multi-prefix shape must hit: ${JSON.stringify(rHit.json)}`)
+  const rOrder = markerRead(repo, 'B=2 A=1 node craftool.mjs --alpha 1', sid)
+  assert.notStrictEqual(rOrder.json && rOrder.json.status, 'hit', `reordered prefixes are a different literal shape: ${JSON.stringify(rOrder.json)}`)
+})
+
 console.log(`\n${passed}/${passed + failed} pass`)
 if (failed > 0) {
   for (const f of failures) console.error(`FAIL: ${f.name}: ${f.error}`)

--- a/tests/test-script-identity-key.mjs
+++ b/tests/test-script-identity-key.mjs
@@ -4,7 +4,7 @@
  *
  * Locks in the script-identity cache-key behavior across both buildTuple
  * implementations (classifier-marker.mjs and scripts/lib/classifier-cache.mjs)
- * + the agent_classify_command env-prefix guard (FU-1).
+ * + agent_classify_command literal-lane behavior for env-prefixed commands (FIX-435).
  *
  * Acceptance contract:
  *   1. In-repo interpreter command (`node scripts/X.mjs <args>`) keys on script
@@ -16,7 +16,7 @@
  *      (predicate rejects; digest is null anyway).
  *   6. External (non-in-repo) interpreter script stays arg-sensitive (digest null).
  *   7. Marker plant + read with varied args round-trips via the same key.
- *   8. agent_classify_command refuses env-prefix at the cache authority (FU-1).
+ *   8. agent_classify_command returns 1 for an env-prefixed command when only a clean marker exists (FIX-435: literal-lane miss; the FU-1 categorical refusal was removed — safety lives in the key).
  *   9. Predicate parity: classifier-marker and classifier-cache use the SAME
  *      shared predicate (no parallel divergence).
  */
@@ -210,11 +210,12 @@ test('SI-M03 marker: env-prefix variant does NOT hit clean script marker', () =>
 
 // === agent_classify_command env-prefix guard (FU-1) =======================
 
-test('SI-A01 agent_classify_command: env-prefix command returns 1 (FU-1)', () => {
+test('SI-A01 agent_classify_command: env-prefix returns 1 (literal-lane miss; FIX-435)', () => {
   const repo = mkrepo('agent-env-guard')
   const sid = 'sik-fu1'
-  // Even with a CLEAN script marker present, the agent_classify_command guard
-  // must refuse to consult the cache for an env-prefixed command.
+  // With only a CLEAN script marker present, an env-prefixed command consults
+  // the literal lane and MISSES (FIX-435): rc 1, no decision. The old FU-1
+  // categorical refusal was removed; safety lives in the key (§EP2/§K4).
   markerWrite(repo, 'node scripts/hello.mjs', sid, 'read_only')
 
   const out = spawnSync('bash', ['-c', `
@@ -222,7 +223,7 @@ test('SI-A01 agent_classify_command: env-prefix command returns 1 (FU-1)', () =>
     source "${SHELL_LIB}"
     # source emits agent-classifier.sh too via internal sourcing; call directly.
     source "${path.join(ROOT, 'plugins', 'claude-code', 'hooks/lib/agent-classifier.sh')}"
-    # FU-1 guard: env-prefix command returns 1 (no decision).
+    # FIX-435: env-prefix command returns 1 (literal-lane miss, no decision).
     if agent_classify_command "FOO=bar node scripts/hello.mjs" "${repo}" "${repo}"; then
       echo "UNEXPECTED_HIT"
     else
@@ -230,7 +231,7 @@ test('SI-A01 agent_classify_command: env-prefix command returns 1 (FU-1)', () =>
     fi
   `], { env: { ...process.env, CLAUDE_CODE_SESSION_ID: sid }, encoding: 'utf8' })
 
-  assert.ok(out.stdout.includes('REFUSED_OK'), `FU-1 guard must refuse env-prefix; got stdout=${out.stdout} stderr=${out.stderr}`)
+  assert.ok(out.stdout.includes('REFUSED_OK'), `env-prefix with only a clean marker must miss (rc 1); got stdout=${out.stdout} stderr=${out.stderr}`)
 })
 
 // === Run ==================================================================


### PR DESCRIPTION
Fixes #435.

## Defect

A verdict written by `classifier-marker.mjs --write` for an env-prefixed command (`FOO=bar node x.mjs`) was structurally unreachable: three deliberate read-side refusals (`command-classifier.sh` Site A + interpreter Tier-2/3 branch, `agent-classifier.sh` FU-1 authority guard) sent every leading-`NAME=value` shape to the conservative `shared_write/interpreter_other` default, so the gate re-held forever with the same pending token while the deny-hint promised "asked at most once per command shape". Reproduced pre-fix on a fixture repo with the real gate (plan §15).

## Fix (issue's "decide one policy": keep the prefix verbatim on both sides)

The writer already keys the full prefix-bearing text under the LITERAL lane; this PR makes the three read-side refusals consult it. No key change, no JS change. Every PR #271/#272 F-4 invariant is preserved at the key layer:

- the sha256 tuple carries the full literal text + session_id, so cross-shape, cross-session, prefix-value, and prefix-order reuse are impossible (tests §EP1/§EP3/§EP4/§EP5/§EP7/§EP8/§EP9);
- canonical (E3) and script-identity lanes still refuse env-prefixed shapes, pinned by `key_form === 'literal'` (§EP2, §K4);
- an env prefix on the helper INVOCATION itself remains hard-denied (`classifier_marker_env_override`, NC-6 green);
- hard-deny lanes still classify and return before any consult site (probed live: `FOO=bar git push` and `BYPASS=1 node ... classifier-marker.mjs --write` both still block post-fix).

`tests/test-script-identity-key.mjs` SI-A01 keeps its assertion (rc 1) with the rationale corrected to the post-fix reason (literal-lane miss).

## Verification

- Red-then-green: §EP6 (write verdict, retry same env-prefixed command through the REAL gate → allow) observed failing on unfixed code, green post-fix.
- Suites (all run post-fix): canonical-cache-key 28/28 (9 new §EP tests), checkpoint-gate 373/0, command-classifier 430/0, classifier-marker 36/0, agent-classifier 40/0, script-identity 17/0.
- Plan: `docs/plans/fix-435-env-prefix-marker-consult.md` (2-round adversarial plan review, R2 ACCEPT with all dispositions probe-verified; frozen-diff code review round 1 ACCEPT, 0 blockers, 1 NIT applied — consult-reach comment precision). Review artifacts in `.review-store/fix-435-REVIEW-REPLY-r{1,2}.md`.

## Deferred (5-field justification in plan §17)

Tier-0 override lookup stays env-prefix-gated (`command-classifier.sh:1639`): an operator-persisted override for a prefixed shape is ignored and the shape is classified once per session via the marker lane instead; fail-closed, no corruption; tracked as a comment on #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
