### PR TITLE
FIX-636: codex provider marks dispatches non-interactive with CLAUDE_SCHEDULED_TASK=1 (fixes #636)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,6 +221,9 @@ jobs:
       - name: Run second-opinion maxbuffer suite (#611 — explicit 64 MiB maxBuffer on provider dispatch)
         run: node tests/test-second-opinion-maxbuffer.mjs
 
+      - name: Run codex env-propagation suite (#636 — CLAUDE_SCHEDULED_TASK marker on codex dispatch)
+        run: node tests/test-codex-env-propagation.mjs
+
       - name: Run second-opinion preamble suite (#573 wiring sweep — composer + registry validator)
         run: node tests/test-second-opinion-preamble.mjs
 

--- a/scripts/second-opinion/providers/codex.mjs
+++ b/scripts/second-opinion/providers/codex.mjs
@@ -79,6 +79,14 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdio: ['ignore', 'pipe', 'pipe'],   // stdin: ignore → codex sees EOF immediately
     timeout,
     maxBuffer: MAX_BUFFER_BYTES,
+    // CLAUDE_SCHEDULED_TASK=1 (issue #636, mirrors claude-subagent.mjs / #232):
+    // a project's session-start hooks (e.g. session-handoff-prompt.sh via
+    // .codex/hooks.json) skip non-interactive routines on this marker. Without
+    // it a headless `codex exec` seat obeys the blocking session-start y/n
+    // protocol and its entire reply is the first question — the harness then
+    // correctly rejects it as reply-too-short-no-summary, so every dispatch
+    // in a hook-bearing repo fails deterministically.
+    env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' },
   })
 
   return {

--- a/tests/test-codex-env-propagation.mjs
+++ b/tests/test-codex-env-propagation.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * test-codex-env-propagation.mjs — Issue #636 regression test.
+ *
+ * Mirrors tests/test-claude-subagent-env-propagation.mjs (#232) for the codex
+ * provider. A headless `codex exec` seat spawned WITHOUT the scheduled-task
+ * marker obeys a project's blocking session-start recall protocol (injected
+ * via .codex/hooks.json → session-handoff-prompt.sh) and replies with the
+ * first y/n question, killing every harness dispatch in a hook-bearing repo.
+ *
+ * Invariants:
+ *   I-636a: dispatch() forces CLAUDE_SCHEDULED_TASK=1 into child env
+ *           regardless of parent state.
+ *   I-636b: dispatch() preserves inherited env (PATH/HOME/auth).
+ *   I-636c: child runs with PWD === projectRoot even when caller cwd
+ *           differs; no side-effect dirs leak under caller cwd.
+ *
+ * Strategy: install a `codex` shim in a test-controlled PATH dir, point
+ * dispatch at a different `projectRoot`, run it from a third `callerDir`,
+ * and verify the shim's stdout matches the invariants.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PROVIDER_PATH = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers', 'codex.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+async function asyncTest(name, fn) {
+  try {
+    await fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+console.log('# test-codex-env-propagation (issue #636)')
+
+await asyncTest('dispatch propagates CLAUDE_SCHEDULED_TASK=1 + cwd binding + no side-effect leaks', async () => {
+  // mkdtemp three dirs; realpath each immediately (macOS /var ↔ /private/var).
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-636-bin-')))
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-636-proj-')))
+  const callerDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-636-caller-')))
+
+  const originalPath = process.env.PATH
+  const originalScheduled = process.env.CLAUDE_SCHEDULED_TASK
+  const originalCwd = process.cwd()
+
+  try {
+    // Narrow shim: 3 echoes only — no full `env` dump (avoids secret leak in
+    // CI failure logs, same rule as the #232 test). Ignores its argv
+    // (`exec --skip-git-repo-check <prompt>`).
+    const shimPath = path.join(binDir, 'codex')
+    fs.writeFileSync(
+      shimPath,
+      '#!/bin/sh\n' +
+      'echo "CLAUDE_SCHEDULED_TASK=${CLAUDE_SCHEDULED_TASK}"\n' +
+      'echo "PWD=$(pwd)"\n' +
+      'echo "PATH=${PATH}"\n',
+      { mode: 0o755 }
+    )
+
+    // Caller cwd ≠ projectRoot.
+    process.chdir(callerDir)
+
+    // Regression-state parent env: shim on PATH, marker explicitly unset so
+    // the test starts from the bug's actual parent-env shape.
+    process.env.PATH = binDir + path.delimiter + originalPath
+    delete process.env.CLAUDE_SCHEDULED_TASK
+
+    // Pre-condition negative spawn: direct shim spawn (no dispatch) must show
+    // the marker empty in the parent env — guards a vacuous pass.
+    const preCheck = spawnSync('codex', [], {
+      env: process.env,
+      cwd: callerDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    assert.strictEqual(preCheck.status, 0,
+      `pre-check shim failed: ${preCheck.stderr?.toString()}`)
+    assert.match(preCheck.stdout.toString(), /^CLAUDE_SCHEDULED_TASK=\s*$/m,
+      `pre-condition vacuous-pass guard: expected empty CLAUDE_SCHEDULED_TASK in parent env, ` +
+      `got stdout=${JSON.stringify(preCheck.stdout.toString())}`)
+
+    // Import provider + dispatch.
+    const mod = await import(`${pathToFileURL(PROVIDER_PATH).href}?cb=${Date.now()}`)
+    const result = mod.dispatch({ prompt: 'x', projectRoot: projectDir })
+    assert.strictEqual(result.exitCode, 0,
+      `dispatch exit code: expected 0, got ${result.exitCode} stderr=${result.stderr}`)
+
+    // I-636a — env override.
+    assert.match(result.stdout, /^CLAUDE_SCHEDULED_TASK=1$/m,
+      `I-636a: expected CLAUDE_SCHEDULED_TASK=1 in child env, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // I-636c — cwd binding via realpath comparison.
+    const pwdMatch = result.stdout.match(/^PWD=(.+)$/m)
+    assert.ok(pwdMatch, `I-636c: expected PWD=<value> line in stdout`)
+    const childPwdReal = fs.realpathSync(pwdMatch[1])
+    const projectDirReal = fs.realpathSync(projectDir)
+    assert.strictEqual(childPwdReal, projectDirReal,
+      `I-636c: child PWD must equal projectRoot (realpath). ` +
+      `child=${childPwdReal} expected=${projectDirReal}`)
+
+    // I-636b — PATH propagation.
+    assert.match(result.stdout, new RegExp(`^PATH=.*${escapeRegex(binDir)}`, 'm'),
+      `I-636b: expected binDir on child PATH, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // Side-effect leak: no artifact dirs under callerDir.
+    const leakNames = ['.review-store', '.episodic-memory', '.checkpoints']
+    const callerContents = fs.readdirSync(callerDir)
+    const leaked = callerContents.filter((n) => leakNames.includes(n))
+    assert.deepStrictEqual(leaked, [],
+      `I-636c: expected no side-effect dirs under callerDir, found ${JSON.stringify(leaked)}`)
+  } finally {
+    process.chdir(originalCwd)
+    process.env.PATH = originalPath
+    if (originalScheduled === undefined) {
+      delete process.env.CLAUDE_SCHEDULED_TASK
+    } else {
+      process.env.CLAUDE_SCHEDULED_TASK = originalScheduled
+    }
+    try { fs.rmSync(binDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(projectDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(callerDir, { recursive: true, force: true }) } catch {}
+  }
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
Fixes #636.

## Defect

Every harness codex dispatch in this repo failed deterministically: the headless `codex exec` seat obeyed the blocking session-start recall protocol (this repo's `.codex/hooks.json` registers `session-handoff-prompt.sh` as a codex SessionStart hook) and replied with the first y/n question, which the harness correctly rejected as `reply-too-short-no-summary` (2/2 observed, forensics on the issue). The canonical Rule 18 review channel was down.

## Fix (precedent mirror, three lines + test)

`session-handoff-prompt.sh:47-49` already skips non-interactive routines when `CLAUDE_SCHEDULED_TASK` is set, and the claude-subagent provider already sets exactly that marker for the same reason (issue #232, `claude-subagent.mjs:72`). This PR mirrors it onto the codex provider's spawn env.

## Verification

- **Red-then-green**: new `tests/test-codex-env-propagation.mjs` (mirror of the #232 twin: marker forced regardless of parent env with a vacuous-pass guard, PATH preserved, cwd binding, no side-effect leaks). Observed RED on unfixed code (I-636a: marker empty in child env), green post-fix.
- **CI wiring**: added as a `tests.yml` run step beside the other second-opinion suites (wired, not baselined; `test-ci-suite-registration.mjs` 16/16 green at 172 step-wired).
- **Adjacent suites green**: provider contract 24/24, maxbuffer 7/7, dispatch 9/9.
- **E2E on the real channel** (snapshot temporarily stamped from this branch, then restored to main): pre-fix reply was the 52-char protocol question in seconds; post-fix, a benign probe returned the requested reply verbatim including the sentinel `CHANNEL-OK-636` (forensics `20260729-230052`). A heavy security-vocabulary body ran a full 9.7-minute review turn and was then terminated upstream by OpenAI's `cyber_policy` content filter; that is a body-specific provider property, noted on #636, not a channel defect.

Review note: this is the trivial-fix class (a reviewed precedent mirrored verbatim from the sibling provider, with the mirrored test), so no seat review round was run; say the word if one is wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
