### PR TITLE
FIX-638: installer distinguishes clean-but-stale from operator-divergent; honest force warning (fixes #638)

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -104,11 +104,14 @@ const REPO_PLUGIN_PI = path.join(REPO_DIR, 'plugins', 'pi-agent')
 // can be suppressed and process.exitCode set on any failure.
 let installFailed = false
 
-// P2 (code review): warn if --install-hooks-force passed without --install-hooks.
-// Without the base flag, the entire hook-install block is skipped; a force flag
-// alone silently no-ops and a user might think their settings were updated.
-if (installHooksForce && !installHooks) {
-  console.log('Warning: --install-hooks-force has no effect without --install-hooks; ignoring.')
+// P2 (code review): warn if --install-hooks-force passed without any flag that
+// consumes it. Without a base flag, the entire hook-install block is skipped; a
+// force flag alone silently no-ops and a user might think their settings were
+// updated. FIX-638 REQ-3: --install-enforcement and --install-activation (the
+// latter also gates codex activation via `tool === 'codex'`) both honor the
+// force flag, so only warn when NONE of them is present.
+if (installHooksForce && !installHooks && !installEnforcement && !installActivation) {
+  console.log('Warning: --install-hooks-force has no effect without --install-hooks/--install-enforcement/--install-activation; ignoring.')
 }
 
 // ---------------------------------------------------------------------------
@@ -1468,7 +1471,7 @@ function removeHookEntryByCommand(hooks, event, command) {
   return before - hooks[event].length
 }
 
-function installHookFile(repoFile, destFile, force) {
+function installHookFile(repoFile, destFile, force, prevSha = null) {
   if (!fs.existsSync(repoFile)) return 'missing-source'
   if (!fs.existsSync(destFile)) {
     fs.mkdirSync(path.dirname(destFile), { recursive: true })
@@ -1479,6 +1482,15 @@ function installHookFile(repoFile, destFile, force) {
   const a = fs.readFileSync(repoFile)
   const b = fs.readFileSync(destFile)
   if (a.equals(b)) return 'unchanged'
+  // FIX-638 REQ-1: deployed bytes hash-match the sha the PREVIOUS install
+  // recorded for this path → provably our earlier clean deploy, just stale.
+  // Refresh without force; genuine operator edits (match neither) fall through.
+  if (typeof prevSha === 'string' &&
+      crypto.createHash('sha256').update(b).digest('hex') === prevSha) {
+    fs.copyFileSync(repoFile, destFile)
+    fs.chmodSync(destFile, 0o755)
+    return 'refreshed-stale'
+  }
   if (force) {
     fs.copyFileSync(repoFile, destFile)
     fs.chmodSync(destFile, 0o755)
@@ -1750,6 +1762,10 @@ function runInstallActivation(projectDir) {
   for (const f of activationOwnedFiles()) {
     const src = path.join(srcHooksDir, f)
     const dst = path.join(userHooksDir, f)
+    // FIX-638 NIT-2 guard: the prevSha oracle is deliberately NOT wired here
+    // (plan §17 deferral). If a follow-up passes prevSha at this site, it MUST
+    // also add 'refreshed-stale' to this block's switch arms and eligibility
+    // sets, or a refreshed file is silently unlogged and unregistered.
     const result = installHookFile(src, dst, installHooksForce)
     fileResults[f] = result
     switch (result) {
@@ -2419,6 +2435,10 @@ function installCodexActivation(projectDir) {
   for (const file of owned) {
     const src = path.join(REPO_PLUGIN_CODEX_ACTIVATION, 'hooks', file)
     const dst = path.join(P.hooksDir, file)
+    // FIX-638 NIT-2 guard: the prevSha oracle is deliberately NOT wired here
+    // (plan §17 deferral). If a follow-up passes prevSha at this site, it MUST
+    // also add 'refreshed-stale' to this block's switch arms and eligibility
+    // sets, or a refreshed file is silently unlogged and unregistered.
     const result = installHookFile(src, dst, installHooksForce)
     results.set(file, result)
     if (result === 'skipped-divergent' || result === 'missing-source') report.withheld.push(dst)
@@ -2719,6 +2739,20 @@ if (installEnforcement && tool === 'opencode') {
   const userHooksLibDir = path.join(userHooksDir, 'lib')
   const REPO_HOOKS_LIB = path.join(REPO_HOOKS, 'lib')
   const touched = { hooks: [], settings: [], hookLib: [] }
+  // FIX-638: previous-manifest sha oracle, read BEFORE the copy loops. Maps
+  // artifact.path (destRel, posix) → artifact.sha256 as recorded by the
+  // PREVIOUS install. A deployed file whose current bytes hash-match that sha
+  // is provably ours (clean-but-stale), refreshed without force; a file
+  // matching neither oracle stays skipped-divergent (operator edit protected).
+  const prevShaByPath = new Map()
+  const prevHooksManifest = readJsonSafe(projectManifestPath(projectAbs))
+  if (prevHooksManifest && Array.isArray(prevHooksManifest.artifacts)) {
+    for (const art of prevHooksManifest.artifacts) {
+      if (art && typeof art.path === 'string' && typeof art.sha256 === 'string') {
+        prevShaByPath.set(art.path, art.sha256)
+      }
+    }
+  }
   try {
    // Shared enforcement lib-install state, hoisted so every installEnforcement
    // sub-block (5_lib, 5c registration gating, classifier-sync warning) sees it.
@@ -2743,7 +2777,8 @@ if (installEnforcement && tool === 'opencode') {
       for (const file of hookLibFiles) {
         const src = path.join(REPO_HOOKS_LIB, file)
         const dst = path.join(userHooksLibDir, file)
-        const result = installHookFile(src, dst, installHooksForce)
+        const result = installHookFile(src, dst, installHooksForce,
+          prevShaByPath.get(path.relative(projectAbs, dst).split(path.sep).join('/')) ?? null)
         libResults[file] = result
         switch (result) {
           case 'copied':
@@ -2755,6 +2790,10 @@ if (installEnforcement && tool === 'opencode') {
             break
           case 'forced':
             console.log(`Force-overwrote hook lib: ${dst}`)
+            touched.hookLib.push(dst)
+            break
+          case 'refreshed-stale':
+            console.log(`Refreshed stale hook lib (matched previous install): ${dst}`)
             touched.hookLib.push(dst)
             break
           case 'skipped-divergent':
@@ -2782,7 +2821,7 @@ if (installEnforcement && tool === 'opencode') {
         reason: 'renamed → agent-classifier-dispatch.mjs (PR-B)' }
     ]
     const agentClassifierCurrent =
-      ['copied', 'unchanged', 'forced'].includes(libResults['agent-classifier.sh'])
+      ['copied', 'unchanged', 'forced', 'refreshed-stale'].includes(libResults['agent-classifier.sh'])
     const commandClassifierSafe =
       libResults['command-classifier.sh'] !== 'skipped-divergent'
     if (agentClassifierCurrent && commandClassifierSafe) {
@@ -2852,7 +2891,8 @@ if (installEnforcement && tool === 'opencode') {
     for (const spec of hookSpecs) {
       const repoFile = path.join(REPO_HOOKS, spec.file)
       const destFile = path.join(userHooksDir, spec.file)
-      const result = installHookFile(repoFile, destFile, installHooksForce)
+      const result = installHookFile(repoFile, destFile, installHooksForce,
+        prevShaByPath.get(path.relative(projectAbs, destFile).split(path.sep).join('/')) ?? null)
       fileResults[spec.file] = result
       switch (result) {
         case 'copied':
@@ -2864,6 +2904,10 @@ if (installEnforcement && tool === 'opencode') {
           break
         case 'forced':
           console.log(`Force-overwrote hook: ${destFile}`)
+          touched.hooks.push(destFile)
+          break
+        case 'refreshed-stale':
+          console.log(`Refreshed stale hook (matched previous install): ${destFile}`)
           touched.hooks.push(destFile)
           break
         case 'skipped-divergent':
@@ -2880,10 +2924,14 @@ if (installEnforcement && tool === 'opencode') {
     // hooks dir too, so its registration points at <project>/.claude/hooks/.
     const seRepo = path.join(REPO_SCRIPTS, SESSION_END_SCRIPT)
     const seDest = path.join(userHooksDir, SESSION_END_SCRIPT)
-    const seFileResult = installHookFile(seRepo, seDest, installHooksForce)
+    const seFileResult = installHookFile(seRepo, seDest, installHooksForce,
+      prevShaByPath.get(path.relative(projectAbs, seDest).split(path.sep).join('/')) ?? null)
     fileResults[SESSION_END_SCRIPT] = seFileResult
     if (seFileResult === 'copied' || seFileResult === 'forced') {
       console.log(`Installed SessionEnd hook script: ${seDest}`)
+      touched.hooks.push(seDest)
+    } else if (seFileResult === 'refreshed-stale') {
+      console.log(`Refreshed stale hook (matched previous install): ${seDest}`)
       touched.hooks.push(seDest)
     } else if (seFileResult === 'unchanged') {
       console.log(`SessionEnd hook script already current: ${seDest}`)
@@ -3022,7 +3070,7 @@ if (installEnforcement && tool === 'opencode') {
     // bootstrap circularity). A future hook (e.g. push-gate.sh in PR-E)
     // that sources hooks/lib/ is automatically included; a stateless hook
     // is automatically excluded.
-    const eligibleForReg = new Set(['copied', 'unchanged', 'forced'])
+    const eligibleForReg = new Set(['copied', 'unchanged', 'forced', 'refreshed-stale'])
     const libDependentHooks = new Set()
     // Build the set of expected lib basenames (so a hook need not literally
     // contain "hooks/lib/" — variable-built paths via $LIB_DIR/ also match).
@@ -3528,6 +3576,16 @@ try {
     buildArtifactEntries(perProjectArtifactPairs(REPO_DIR, projectAbs)),
     projectAbs,
   )
+  // FIX-638 REQ-4: entries carried forward from the previous manifest whose
+  // recorded sha no longer matches the current repo source are stale-but-ours
+  // (or operator-modified); surface the count on the recorded-version line.
+  let carriedForwardStale = 0
+  for (const art of projectArtifacts) {
+    if (!art || typeof art.source !== 'string' || typeof art.sha256 !== 'string') continue
+    const srcAbs = path.join(REPO_DIR, art.source)
+    if (!fs.existsSync(srcAbs)) continue
+    try { if (sha256File(srcAbs) !== art.sha256) carriedForwardStale++ } catch {}
+  }
   writeJsonAtomic(projectManifestPath(projectAbs), buildManifest({
     scope: 'project',
     tool,
@@ -3619,7 +3677,7 @@ try {
   // consumers without this repo checkout present. Prunes superseded versions.
   if (!uninstallEnforcement && !uninstallActivation) {
     const dist = deployDistCache(REPO_DIR, GLOBAL_DIR, sourceVersion)
-    console.log(`Recorded install version ${sourceVersion.slice(0, 12)} (manifests + registry); dist cache: ${dist.files} payload file(s) at ${dist.target}`)
+    console.log(`Recorded install version ${sourceVersion.slice(0, 12)} (manifests + registry); dist cache: ${dist.files} payload file(s) at ${dist.target}${carriedForwardStale > 0 ? `; ${carriedForwardStale} artifact(s) carried forward at non-current recorded content (stale deploy or local edit)` : ''}`)
   }
 } catch (e) {
   console.log(`WARNING: could not record install version manifests: ${e.message} (install itself is complete; --update-consumers and the drift notice need a successful manifest write)`)

--- a/tests/test-install-hooks.sh
+++ b/tests/test-install-hooks.sh
@@ -809,6 +809,111 @@ if echo "$output" | grep -q "FAIL CLOSED"; then r=true; else r=false; fi
 assert_eq "T20d post-P3c divergent classifier emits 'FAIL CLOSED' WARN" "true" "$r"
 
 # ---------------------------------------------------------------------------
+# T21: FIX-638 — clean-but-stale (deployed bytes match the sha recorded in the
+# PREVIOUS project manifest) is refreshed without force; operator-divergent
+# (matches NEITHER previous manifest sha NOR current source) still skips.
+# ---------------------------------------------------------------------------
+# T21a (REQ-1, hook libs): fabricate a "previous clean deploy at older
+# version": full install, then overwrite the DEPLOYED command-classifier.sh
+# with sentinel OLD content AND hand-edit the project manifest entry's sha256
+# to the sentinel's sha. The next --install-enforcement (no force) must
+# refresh it from the repo source, not skip it as divergent.
+echo "[T21] FIX-638 stale-vs-divergent oracle"
+reset_state
+run_installer --install-enforcement
+MANIFEST="$TEST_PROJECT/.episodic-memory-install.json"
+printf '#!/bin/bash\n# FIX-638 T21a sentinel OLD clean deploy\n' \
+  > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+SENTINEL_SHA=$(shasum -a 256 "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" | awk '{print $1}')
+tmp_m="$MANIFEST.tmp"
+jq --arg s "$SENTINEL_SHA" \
+  '(.artifacts[] | select(.path == ".claude/hooks/lib/command-classifier.sh") | .sha256) = $s' \
+  "$MANIFEST" > "$tmp_m" && mv "$tmp_m" "$MANIFEST"
+output=$(run_installer_capture --install-enforcement)
+sha_repo=$(shasum "$REPO_ROOT/plugins/claude-code/hooks/lib/command-classifier.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" | awk '{print $1}')
+assert_eq "T21a stale-but-ours hook lib refreshed to repo source without force" "$sha_repo" "$sha_dest"
+if echo "$output" | grep -q "Refreshed stale hook lib (matched previous install)"; then r=true; else r=false; fi
+assert_eq "T21a2 'Refreshed stale hook lib' log line printed" "true" "$r"
+if echo "$output" | grep -q "Skipped hook lib (divergent local edit).*command-classifier"; then r=true; else r=false; fi
+assert_eq "T21a3 no divergent-skip line for the stale-but-ours lib" "false" "$r"
+
+# T21b (REQ-1, HOOK_SPECS path): same fabrication for the deployed
+# checkpoint-gate.sh → refreshed without force via the 5b hook-specs loop.
+reset_state
+run_installer --install-enforcement
+MANIFEST="$TEST_PROJECT/.episodic-memory-install.json"
+printf '#!/bin/bash\n# FIX-638 T21b sentinel OLD clean deploy\n' \
+  > "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+SENTINEL_SHA=$(shasum -a 256 "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+tmp_m="$MANIFEST.tmp"
+jq --arg s "$SENTINEL_SHA" \
+  '(.artifacts[] | select(.path == ".claude/hooks/checkpoint-gate.sh") | .sha256) = $s' \
+  "$MANIFEST" > "$tmp_m" && mv "$tmp_m" "$MANIFEST"
+output=$(run_installer_capture --install-enforcement)
+sha_repo=$(shasum "$REPO_ROOT/plugins/claude-code/hooks/checkpoint-gate.sh" | awk '{print $1}')
+sha_dest=$(shasum "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh" | awk '{print $1}')
+assert_eq "T21b stale-but-ours hook refreshed to repo source without force" "$sha_repo" "$sha_dest"
+if echo "$output" | grep -q "Refreshed stale hook (matched previous install).*checkpoint-gate.sh"; then r=true; else r=false; fi
+assert_eq "T21b2 'Refreshed stale hook' log line printed" "true" "$r"
+if echo "$output" | grep -q "Skipped (divergent local edit).*checkpoint-gate.sh"; then r=true; else r=false; fi
+assert_eq "T21b3 no divergent-skip line for the stale-but-ours hook" "false" "$r"
+
+# T21c (REQ-2 negative control): deployed content matching NEITHER the previous
+# manifest sha NOR the current source is a genuine operator edit → still
+# skipped-divergent, file untouched.
+reset_state
+run_installer --install-enforcement
+printf '#!/bin/bash\n# FIX-638 T21c genuine operator edit\n' \
+  > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+sha_before=$(shasum "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" | awk '{print $1}')
+output=$(run_installer_capture --install-enforcement)
+sha_after=$(shasum "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" | awk '{print $1}')
+assert_eq "T21c operator-divergent lib NOT overwritten (byte-compare)" "$sha_before" "$sha_after"
+if echo "$output" | grep -q "Skipped hook lib (divergent local edit).*command-classifier"; then r=true; else r=false; fi
+assert_eq "T21c2 divergent-skip line still printed for genuine operator edit" "true" "$r"
+
+# ---------------------------------------------------------------------------
+# T22a (FIX-638 REQ-3): --install-enforcement --install-hooks-force → the
+# 'has no effect' warning must NOT fire (force IS honored by enforcement), and
+# the divergent file is Force-overwritten.
+# ---------------------------------------------------------------------------
+echo "[T22] FIX-638 force-flag warning honesty"
+reset_state
+mkdir -p "$TEST_PROJECT/.claude/hooks"
+echo "#!/bin/bash" > "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+echo "# user-customized" >> "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+chmod +x "$TEST_PROJECT/.claude/hooks/checkpoint-gate.sh"
+output=$(run_installer_capture --install-enforcement --install-hooks-force)
+if echo "$output" | grep -q "has no effect without --install-hooks"; then r=true; else r=false; fi
+assert_eq "T22a no 'has no effect' warning when enforcement consumes force" "false" "$r"
+if echo "$output" | grep -q "Force-overwrote"; then r=true; else r=false; fi
+assert_eq "T22a2 force honored: divergent file Force-overwritten" "true" "$r"
+
+# ---------------------------------------------------------------------------
+# T23 (FIX-638 REQ-4): an enforcement artifact carried forward at older
+# content (deployed bytes != current source, manifest entry kept by the merge)
+# is counted on the 'Recorded install version' line.
+# ---------------------------------------------------------------------------
+echo "[T23] FIX-638 carried-forward-stale count"
+reset_state
+run_installer --install-enforcement
+MANIFEST="$TEST_PROJECT/.episodic-memory-install.json"
+printf '#!/bin/bash\n# FIX-638 T23 sentinel OLD clean deploy\n' \
+  > "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh"
+SENTINEL_SHA=$(shasum -a 256 "$TEST_PROJECT/.claude/hooks/lib/command-classifier.sh" | awk '{print $1}')
+tmp_m="$MANIFEST.tmp"
+jq --arg s "$SENTINEL_SHA" \
+  '(.artifacts[] | select(.path == ".claude/hooks/lib/command-classifier.sh") | .sha256) = $s' \
+  "$MANIFEST" > "$tmp_m" && mv "$tmp_m" "$MANIFEST"
+# Bare --install-hooks runs NO enforcement copy loops (5_lib/5b are gated on
+# --install-enforcement), so the sentinel stays on disk and the previous
+# manifest entry is carried forward by the 7b merge.
+output=$(run_installer_capture --install-hooks)
+if echo "$output" | grep -q "Recorded install version.*; 1 artifact(s) carried forward at non-current recorded content (stale deploy or local edit)"; then r=true; else r=false; fi
+assert_eq "T23 recorded-version line reports 1 artifact carried forward at non-current recorded content" "true" "$r"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Fixes #638. Observed on the #637 deploy: an `--install-hooks` run stamps the per-project manifest while deliberately not deploying enforcement artifacts, so the follow-up `--install-enforcement` compared clean-but-stale libs against current source only and fail-skipped them as "divergent local edit" (caught only by hash-verify); and the `--install-hooks-force` warning claimed the flag was ignored on paths that honor it.

## Fix

Mirrors the modified-vs-ours oracle the sweep side (`refreshProjectArtifacts`) already uses:

- `installHookFile` gains a `prevSha` oracle from the previous `.episodic-memory-install.json`. Deployed bytes hash-matching the previously RECORDED sha are provably our earlier deploy: refreshed without force (`refreshed-stale`, logged). Bytes matching neither oracle stay `skipped-divergent` (operator edits protected, Principle 10 unchanged).
- The new state is propagated everywhere the old states flow: registration eligibility, the classifier-sync FAIL-CLOSED guard, the orphan-sweep gate, touched/summary lists (reviewer-enumerated fan-out table, all consumers verified).
- Force warning fires only when no force-consuming flag is present (`--install-hooks`/`--install-enforcement`/`--install-activation`; `--install-codex-activation` does not exist, codex activation rides `--install-activation`), and the message names all three.
- The "Recorded install version" line appends `; N artifact(s) carried forward at non-current recorded content (stale deploy or local edit)` instead of implying everything is at HEAD.

## Verification

- T21a RED observed pre-fix (old code printed the divergent skip for a fabricated clean-but-stale state), green post-fix; T21c pins the operator-edit control; T22a pins force-honored-no-false-warning; T23 pins the count line.
- Suites (run by orchestrator and independently by the reviewer): `test-install-hooks.sh` 105/105 (baseline 94/94 at `49a4e3e`), `test-install-manifest.mjs` 57/57, `test-ci-suite-registration.mjs` 16/16. Both suites already CI-wired.
- Adversarial frozen-diff review round 1: **ACCEPT**, 0 blockers/majors, 2 MINOR + 3 NIT (reply at `.review-store/fix-638-CREV-REPLY-r1.md`). MINOR-1 (count wording) and NIT-1 (warning text) and NIT-2 (guard comments at the deferred activation sites) applied in this PR; MINOR-2 was a process note (builder adapted to a nonexistent flag name after grep-verifying, outcome confirmed correct); NIT-3 (a direct refreshed-then-registered assertion) accepted as an indirect-coverage gap, not added to keep the diff scoped. Reviewer probes: operator-edit sequences across repeated reinstalls never teach the oracle to trust the edit (S1/S2); recorded-sha-equals-source case correctly uncounted (S4).

## Accepted residual (reviewer S3, by construction)

An operator who deliberately reverts a deployed hook file to byte-exact previous-deploy content is indistinguishable from a stale deploy and gets refreshed to current source. Content-only oracle; fail direction is safe (target is always current repo source, and any subsequent edit is divergent-protected again).

## Deferred (plan §17)

The two activation call sites keep `prevSha=null` (behavior unchanged there); both now carry a guard comment (NIT-2) stating the switch/eligibility fan-out a future wiring must include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
