### PR TITLE
FIX-635: installer sweep degrades per-row on identity defects; dry-run parity; em-identity repair CLI (fixes #635)

### DIFF
--- a/docs/plans/fix-635-update-consumers-identity-degrade.md
+++ b/docs/plans/fix-635-update-consumers-identity-degrade.md
@@ -1,0 +1,520 @@
+# FIX-635: one store's identity defect must not abort the fleet sweep; dry-run must predict it; the repair must be executable
+
+**Issue:** #635 — `install.mjs --update-consumers` throws `duplicate-identity-chain`
+from `mirrorStoreIdentities` and writes zero registry stamps for all 14 consumers;
+`--dry-run` does not reproduce it; the sanctioned data repair has no entry point.
+
+**Altitude:** LOW. The builder executes the numbered steps mechanically from the
+Appendix A listings. Prose in this document is context, NOT an edit instruction —
+only `L<N>` listings are edits (issue #627 lesson).
+
+**Branch:** `fix/635-update-consumers-identity-degrade` off `main` (`5ffd0f5`).
+**Builder writes:** `scripts/lib/install-version.mjs`, `scripts/lib/store-identity.mjs`,
+`scripts/em-identity.mjs` (new), `tests/test-install-manifest.mjs`,
+`tests/test-store-identity.mjs`. Nothing else. Builder does NOT commit.
+
+---
+
+## Evidence base (orchestrator runtime probes, 2026-07-31)
+
+Real store: `resolveStoreIdentity('<repo>/.episodic-memory')` →
+`{"error":"duplicate-identity-chain"}`; `resolveLocalDir(repo)` → `<repo>/.episodic-memory`.
+
+Fixture probe (isolated scratch store, two forged roots replicating the real store):
+
+| repair episode shape | resolver outcome |
+|---|---|
+| detach-only (`detaches_identity_root` only) | still `duplicate-identity-chain` (repair ep is itself a 3rd root) |
+| supersede-only (`supersedes` only) | still `duplicate-identity-chain` (other root untouched) |
+| **both** (`supersedes: <survivor terminal>` + `detaches_identity_root: <stray root>`) | `{"active_id":"<fresh>","aliases":["<survivor store_id>"],"root_id":"<survivor root>","terminal_episode_id":"<repair ep>"}` |
+
+Only the both-fields shape collapses to one active chain. This is what the
+`detachRootId` path (L3) writes and what the operator ceremony will execute.
+
+## Root-cause class (context, no edit)
+
+Identity-unaware bulk episode writes (`em-restore.mjs` — zero references to
+`store-identity`/`store_id`; sync flows likewise) can (re)introduce a second active
+root after a legitimate mint on a fresh clone (clone → mint → restore ordering).
+Guarding the restore path is OUT of scope (follow-up issue, step 9).
+
+## Scope
+
+- **S1** `mirrorStoreIdentities` gains an opt-in per-row degrade mode used ONLY by the
+  `updateConsumers` sweep tail. Registration path (`upsertRegistryEntries`) keeps
+  RFC-012 REQ-6 fail-loud semantics ("a second chain fails loud at build and at
+  registration" — registration only; the sweep is not registration, and the mirror is
+  "derived, never authoritative" per the header comment at `install-version.mjs:638`).
+  A degraded row is still version-stamped; only its identity mirror fields are left
+  untouched.
+- **S2** `--update-consumers --dry-run` performs a resolve-only identity probe (never
+  mints) under the same write condition as the apply-path mirror, populating the same
+  report field. Parity is RESOLVE-ERROR parity (`duplicate-identity-chain`,
+  `identity-chain-cycle` — the #635 class): for those, dry-run and apply record the
+  same `${error}: ${project_path}` strings. Apply-only failure classes the probe
+  cannot see (documented blind spots, R1-F1): `copied-store-rejected`,
+  `ambiguous-alias-ownership`, `reserved-id-abuse`, `identity-mint-failed` — mint and
+  the cross-row claims map exist only on apply. Counts may also diverge on multi-tool
+  projects: the probe dedups per store DIR, the apply degrade records per registry
+  ROW (R1-F2). Neither path runs when the sweep has nothing to prune or refresh —
+  `--dry-run` is not a standalone identity health check; that is
+  `em-identity.mjs --status` (R1-F6).
+- **S3** `detachStoreIdentity` gains `{ detachRootId }`: named-root detach that
+  collapses a duplicate-root store by writing ONE episode carrying both
+  `supersedes` (survivor chain terminal) and `detaches_identity_root` (stray root).
+  Validate-then-write: every error path returns before any write.
+- **S4** `scripts/em-identity.mjs` (new, zero-dep, JSON stdout): `--status` diagnosis
+  and `--detach-root <id> [--confirm]` repair adapter. Auto-deploys as a substrate
+  script (`isSubstrateScript` matches `em-*.mjs`).
+- **S5** Regression tests in the two existing registered suites (no new test file, no
+  workflow edit — avoids the #614 class).
+
+## Exclusions (record, do not build)
+
+- No change to `upsertRegistryEntries` / registration fail-loud behavior.
+- `syncProjectFromDist` fleet-exposure (silent SessionStart auto-refresh suppression) —
+  follow-up issue at step 9.
+- `em-restore`/backup identity-awareness guard — follow-up issue at step 9.
+- The unresolved 07-28 timeline question (why the 07-28 00:03 sweep succeeded with
+  both root files apparently on disk since 07-19; `*.pre-sync-20260728-103818`
+  artifacts suggest an identity-unaware sync may have introduced the stray root later
+  with preserved mtime) — recorded as an open question on #635, not blocking.
+- The live-store data repair itself. NOT in this PR. Operator-gated ceremony after
+  merge, using the L4 CLI.
+
+## Accepted risks (named, not built — R1-F5)
+
+- Crash mid-collapse: covered by the existing atomic identity-episode write
+  (temp+fsync+rename); a crash after the episode write but before the index update
+  leaves the index stale until `em-rebuild-index` heals it — the same fail-safe
+  precedent as mint/rebind/detach.
+- Concurrent sweeps: pre-existing registry TOCTOU (last-writer-wins on
+  `writeJsonAtomic`); the degrade path adds no new shared state.
+
+## R1 disposition (2026-08-01, GLM seat, verdict APPROVE-WITH-CHANGES)
+
+- R1-F1 MAJOR ACCEPT — S2 narrowed to resolve-error parity with enumerated
+  apply-only blind spots (this revision).
+- R1-F2 MINOR ACCEPT-WITH-MOD — per-dir/per-row divergence documented in S2; T8b
+  clarified (single-tool fixture makes the counts coincide).
+- R1-F3 MINOR ACCEPT — falsifiability note corrected: still-ambiguous (3 roots) and
+  T8c are preservation legs.
+- R1-F4 NIT DEFER — the double `identityGraph` call under the store lock is
+  correctness-neutral; the runtime-validated L3c listing stays frozen.
+- R1-F5 NIT ACCEPT — accepted-risks section added.
+- R1-F6 NIT ACCEPT — write-condition gating documented in S2.
+
+## Steps
+
+- 1.0 Branch `fix/635-update-consumers-identity-degrade` off `5ffd0f5`.
+- 1.1 Apply L1 to `scripts/lib/install-version.mjs` (`updateConsumers`).
+- 1.2 Apply L2 to `scripts/lib/install-version.mjs` (`mirrorStoreIdentities`).
+- 1.3 Apply L3 to `scripts/lib/store-identity.mjs` (`identityGraph` helper +
+  `resolveStoreIdentity` refactor + `detachStoreIdentity` extension +
+  `storeIdentityStatus` export).
+- 1.4 Create `scripts/em-identity.mjs` from L4.
+- 1.5 Apply L5 test legs to `tests/test-install-manifest.mjs`.
+- 1.6 Apply L6 test legs to `tests/test-store-identity.mjs`.
+- 1.7 Run verification block below; all green → report BUILD-DONE with counts.
+
+## Verification
+
+```bash
+node tests/test-install-manifest.mjs        # pre-existing T-legs + new T8 all green
+node tests/test-store-identity.mjs          # pre-existing + new collapse/CLI legs green
+node tests/test-consumer-registry-schema.mjs
+node --input-type=module -e "import('./scripts/lib/install-version.mjs').then(()=>console.log('import-ok'))"
+node scripts/em-identity.mjs --help
+```
+
+Falsifiability notes:
+- The T8 apply leg fails against current `main` with the uncaught
+  `duplicate-identity-chain` stack (exit ≠ 0) — it is a true repro of #635.
+- The T8 dry-run leg fails against current `main` because `identity_degraded` is
+  absent from the dry-run report.
+- The L6 collapse-success, detach-root-not-active, and store-not-duplicate legs fail
+  against current `main` because `detachStoreIdentity` has no `detachRootId`
+  parameter. The still-ambiguous (3 roots) leg and T8c are preservation legs, not
+  regressions — they pass on main too and guard the fixed code (R1-F3).
+- Greps in this plan target `scripts/` and `tests/` paths only, never `docs/plans/`
+  (a verify grep must not count its own Listing — #627).
+
+---
+
+## Appendix A — Listings
+
+### L1 — `scripts/lib/install-version.mjs`, `updateConsumers`
+
+L1a: in the `report` initializer (currently ending `dry_run: !!dryRun,`), add one field:
+
+```js
+    identity_degraded: [],
+```
+
+L1b: replace the sweep tail (the `if (!dryRun && (report.pruned.length > 0 || report.refreshed.length > 0)) { ... }` block that wraps `writeRegistry(regPath, mirrorStoreIdentities(keptEntries))`) with:
+
+```js
+  if (report.pruned.length > 0 || report.refreshed.length > 0) {
+    if (dryRun) {
+      // FIX-635: dry-run predicts the apply-path mirror with a resolve-only probe
+      // (never mints; no-identity is not a degrade — apply would mint successfully).
+      probeStoreIdentities(keptEntries, report.identity_degraded)
+    } else {
+      // F2 fold (GLM r1 MAJOR-2): mirror store identities on the sweep path too,
+      // so a post-rebind/detach registry carries the fresh active id + aliases
+      // (otherwise the sweep writes the stale active id from the prior upsert and
+      // omits store_aliases). The merge happens through mirrorStoreIdentities,
+      // NOT upsertRegistryEntries — upsert would read-merge and resurrect pruned rows.
+      // FIX-635: one row's identity defect degrades that row instead of aborting
+      // the whole sweep (the mirror is derived, never authoritative).
+      writeRegistry(regPath, mirrorStoreIdentities(keptEntries, { degraded: report.identity_degraded }))
+    }
+  }
+  return report
+```
+
+L1c: immediately above `export function mirrorStoreIdentities`, insert:
+
+```js
+// FIX-635: dry-run counterpart of the sweep-tail mirror. Resolve-only — never
+// mints, never writes. For resolve-class errors (duplicate-identity-chain,
+// identity-chain-cycle) it pushes the same `${error}: ${project_path}` strings the
+// degrade path records; apply-only classes (copied-store-rejected,
+// ambiguous-alias-ownership, reserved-id-abuse, identity-mint-failed) have no
+// dry-run counterpart, and the probe dedups per dir while apply degrades per row.
+function probeStoreIdentities(entries, out) {
+  const seenDirs = new Set()
+  for (const e of entries) {
+    let projectReal
+    try { projectReal = fs.realpathSync(e.project_path) } catch { continue }
+    let dir
+    try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }
+    if (!fs.existsSync(dir) || seenDirs.has(dir)) continue
+    seenDirs.add(dir)
+    const idn = resolveStoreIdentity(dir)
+    if (idn.error && idn.error !== 'no-identity') {
+      out.push({ project_path: e.project_path, error: `${idn.error}: ${e.project_path}` })
+    }
+  }
+}
+```
+
+### L2 — `scripts/lib/install-version.mjs`, `mirrorStoreIdentities`
+
+Change the signature and wrap the existing per-row body in a try/catch. The body
+between `for (const e of entries) {` and the loop's closing brace is byte-identical
+to current main except for the added `try {` / `} catch` frame and one indent level.
+Existing bare `continue` statements keep their meaning.
+
+```js
+export function mirrorStoreIdentities(entries, { degraded } = {}) {
+  const claims = new Map() // store_id/alias -> { dir, kind }
+  for (const e of entries) {
+    try {
+      // ... existing per-row body, unchanged, one indent deeper ...
+    } catch (err) {
+      // FIX-635: degrade mode (sweep path only) — record and continue; the row
+      // keeps its version stamp and its prior identity fields. Registration
+      // (upsertRegistryEntries) does not pass `degraded` and still fails loud.
+      if (!degraded) throw err
+      degraded.push({ project_path: e.project_path, error: err.message })
+    }
+  }
+  return entries
+}
+```
+
+Update the header comment's final sentence (currently "…A missing or unresolvable
+store dir leaves the row unmirrored (mirror is derived).") by appending:
+
+```js
+// With `degraded` (sweep path, FIX-635), resolve/mint/collision failures for a row
+// are pushed to that array and the row is skipped instead of aborting the sweep.
+```
+
+### L3 — `scripts/lib/store-identity.mjs`
+
+L3a: extract the analysis prefix of `resolveStoreIdentity` into a helper placed
+directly above it, and have `resolveStoreIdentity` use it. The logic is
+byte-equivalent; the resolver's observable behavior is unchanged.
+
+```js
+// Shared identity-graph analysis (FIX-635): roots, detached roots, active roots.
+// Single source of truth for resolveStoreIdentity and the named-root detach path.
+function identityGraph(storeDir) {
+  const eps = listIdentityEpisodes(storeDir)
+  const byId = new Map(eps.map((e) => [e.id, e]))
+  const roots = eps.filter((e) => !e.supersedes || !byId.has(e.supersedes))
+  const detachedRootIds = new Set()
+  for (const e of eps) {
+    if (e.detaches_identity_root && byId.has(e.detaches_identity_root)) {
+      detachedRootIds.add(e.detaches_identity_root)
+    }
+  }
+  const activeRoots = roots.filter((r) => !detachedRootIds.has(r.id))
+  return { eps, byId, roots, detachedRootIds, activeRoots }
+}
+
+function walkChain(eps, root) {
+  const visited = new Set([root.id])
+  const chainMembers = [root]
+  let current = root
+  while (true) {
+    const successor = eps.find((e) => e.supersedes === current.id)
+    if (!successor) break
+    if (visited.has(successor.id)) return { error: 'identity-chain-cycle' }
+    visited.add(successor.id)
+    chainMembers.push(successor)
+    current = successor
+  }
+  return { chainMembers }
+}
+```
+
+`resolveStoreIdentity` becomes:
+
+```js
+export function resolveStoreIdentity(storeDir) {
+  const { eps, activeRoots } = identityGraph(storeDir)
+  if (eps.length === 0) return { error: 'no-identity' }
+  if (activeRoots.length === 0) return { error: 'identity-chain-cycle' }
+  if (activeRoots.length > 1) return { error: 'duplicate-identity-chain' }
+  const root = activeRoots[0]
+  const walked = walkChain(eps, root)
+  if (walked.error) return { error: walked.error }
+  const chainMembers = walked.chainMembers
+  // Episodes belonging to detached chains (their root is in detachedRootIds) are
+  // intentionally not reachable from the active root — they stay in the store but
+  // contribute no active id and no aliases (§A.5 lib error 'detachedChainExcluded').
+  const terminal = chainMembers[chainMembers.length - 1]
+  const aliases = chainMembers.slice(0, -1).map((m) => m.store_id)
+  return {
+    active_id: terminal.store_id,
+    aliases,
+    root_id: root.id,
+    terminal_episode_id: terminal.id,
+  }
+}
+```
+
+L3b: new exported diagnosis surface, placed after `resolveStoreIdentity`:
+
+```js
+// FIX-635: operator-facing diagnosis. Never writes. Lists every active root so a
+// duplicate-root store can be repaired by naming which root to detach.
+export function storeIdentityStatus(storeDir) {
+  const resolution = resolveStoreIdentity(storeDir)
+  const { activeRoots, detachedRootIds } = identityGraph(storeDir)
+  return {
+    resolution,
+    active_roots: activeRoots.map((r) => ({ episode_id: r.id, store_id: r.store_id })),
+    detached_root_ids: [...detachedRootIds],
+  }
+}
+```
+
+L3c: `detachStoreIdentity` gains `detachRootId`. The legacy no-argument path is
+byte-identical to current behavior. New signature and inserted branch:
+
+```js
+export function detachStoreIdentity(storeDir, { lockTimeoutS, detachRootId } = {}) {
+  return withStoreLockSync(storeDir, () => {
+    const existing = resolveStoreIdentity(storeDir)
+    if (detachRootId) {
+      // FIX-635 duplicate-collapse: name the stray root; the surviving chain's
+      // terminal is superseded by ONE new episode that also detaches the stray
+      // root (the only single-episode shape that yields exactly one active root
+      // — see plan Evidence table). Validate-then-write: no write on any error.
+      if (existing.error && existing.error !== 'duplicate-identity-chain') {
+        return { error: existing.error }
+      }
+      if (!existing.error) return { error: 'store-not-duplicate' }
+      const { eps, activeRoots } = identityGraph(storeDir)
+      const target = activeRoots.find((r) => r.id === detachRootId)
+      if (!target) return { error: 'detach-root-not-active' }
+      const remaining = activeRoots.filter((r) => r.id !== detachRootId)
+      if (remaining.length !== 1) return { error: 'duplicate-identity-chain' }
+      const walked = walkChain(eps, remaining[0])
+      if (walked.error) return { error: walked.error }
+      const terminal = walked.chainMembers[walked.chainMembers.length - 1]
+      const newStoreId = crypto.randomBytes(8).toString('hex')
+      const now = new Date()
+      const id = newEpisodeId(newStoreId, now)
+      const y = now.getFullYear()
+      const mo = String(now.getMonth() + 1).padStart(2, '0')
+      const d = String(now.getDate()).padStart(2, '0')
+      const h = String(now.getHours()).padStart(2, '0')
+      const mi = String(now.getMinutes()).padStart(2, '0')
+      const project = path.basename(path.dirname(storeDir)) || 'store'
+      const fields = {
+        id,
+        date: `${y}-${mo}-${d}`,
+        time: `${h}:${mi}`,
+        project,
+        summary: `Store identity duplicate-collapse ${newStoreId}`,
+        store_id: newStoreId,
+        supersedes: terminal.id,
+        detaches_identity_root: detachRootId,
+        bodyLine: 'Store identity duplicate-collapse successor (issue #635; RFC-012 P2 REQ-5 detach + P7 successor revision). Detached chain contributes no active id and no aliases; the surviving chain continues through this terminal.',
+      }
+      const episodesDir = path.join(storeDir, 'episodes')
+      const content = identityEpisodeContent(fields)
+      const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
+      if (writeResult.error) return writeResult
+      const idx = applyIdentityIndexUpdate(storeDir, fields)
+      const out = {
+        active_id: newStoreId,
+        detached_root_id: detachRootId,
+        superseded_terminal: terminal.id,
+        prior_id: terminal.store_id,
+      }
+      if (idx.stale) out.index_stale = true
+      return out
+    }
+    if (existing.error) return { error: existing.error }
+    // ... legacy path below unchanged ...
+```
+
+### L4 — `scripts/em-identity.mjs` (new file)
+
+```js
+#!/usr/bin/env node
+/**
+ * em-identity.mjs — store-identity diagnosis + sanctioned duplicate-root repair
+ * (issue #635). Zero deps; JSON to stdout.
+ *
+ *   node em-identity.mjs [--project <path>|--store <dir>] [--status]
+ *   node em-identity.mjs --detach-root <episode-id> [--confirm]
+ *
+ * Without --confirm, --detach-root prints the planned write and touches nothing
+ * (#623 blast-radius discipline). The repair itself is detachStoreIdentity's
+ * named-root collapse: one successor episode carrying supersedes + 
+ * detaches_identity_root (P7: revision, never an edit).
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
+import { storeIdentityStatus, detachStoreIdentity } from './lib/store-identity.mjs'
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(name)
+const opt = (name) => {
+  const i = argv.indexOf(name)
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null
+}
+
+if (flag('--help')) {
+  console.log(JSON.stringify({
+    status: 'help',
+    script: 'em-identity.mjs',
+    usage: 'node em-identity.mjs [--project <path>|--store <dir>] [--status] | --detach-root <episode-id> [--confirm]',
+  }))
+  process.exit(0)
+}
+
+let storeDir = opt('--store')
+if (!storeDir) {
+  const project = opt('--project') || process.cwd()
+  try { storeDir = resolveLocalDir(fs.realpathSync(project)) } catch { storeDir = path.join(project, '.episodic-memory') }
+}
+if (!fs.existsSync(path.join(storeDir, 'episodes'))) {
+  console.log(JSON.stringify({ status: 'error', error: 'store-not-found', store: storeDir }))
+  process.exit(1)
+}
+
+const detachRootId = opt('--detach-root')
+if (!detachRootId) {
+  console.log(JSON.stringify({ status: 'ok', store: storeDir, ...storeIdentityStatus(storeDir) }))
+  process.exit(0)
+}
+
+const before = storeIdentityStatus(storeDir)
+const target = before.active_roots.find((r) => r.episode_id === detachRootId)
+const survivors = before.active_roots.filter((r) => r.episode_id !== detachRootId)
+if (!flag('--confirm')) {
+  console.log(JSON.stringify({
+    status: 'plan',
+    store: storeDir,
+    would_detach: target || null,
+    would_survive: survivors,
+    note: target && survivors.length === 1
+      ? 'one successor episode will supersede the survivor terminal and detach the named root; re-run with --confirm to write'
+      : 'refused: --detach-root must name one of exactly two active roots',
+  }))
+  process.exit(target && survivors.length === 1 ? 0 : 1)
+}
+const result = detachStoreIdentity(storeDir, { detachRootId })
+const ok = !result.error
+console.log(JSON.stringify({ status: ok ? 'ok' : 'error', store: storeDir, ...result, after: ok ? storeIdentityStatus(storeDir) : undefined }))
+process.exit(ok ? 0 : 1)
+```
+
+### L5 — `tests/test-install-manifest.mjs`: new group T8
+
+Follow the file's existing harness idioms exactly (its `mkSandbox`, its runner/assert
+helpers, its way of triggering a refresh for the T5 sweep legs — read them first;
+reuse, do not reinvent). Group T8 "identity degrade + dry-run parity (#635)":
+
+Setup: sandbox with TWO consumer projects (A, B) both installed/registered against
+the sandbox repo copy; then forge a second active identity root into A's
+`.episodic-memory/episodes/` with a local `handRoot`-equivalent helper copied from
+`tests/test-store-identity.mjs` (two frontmatter files, distinct 16-hex `store_id`s,
+no `supersedes`); then make the sweep refresh-eligible the same way T5 legs do.
+
+Legs and required assertions:
+
+- **T8a dry-run predicts**: run `install.mjs --update-consumers --dry-run`.
+  Exit 0. Report `identity_degraded` has exactly one entry; `entry.project_path`
+  === A's path; `entry.error` matches `/^duplicate-identity-chain: /`. A's episode
+  file count unchanged (no mint on dry-run).
+- **T8b apply degrades instead of aborting**: run `install.mjs --update-consumers`.
+  Exit 0 (this leg is the #635 repro — on unfixed main it crashes with an uncaught
+  stack). Report `identity_degraded` as in T8a and string-identical to T8a's entry
+  (resolve-error parity; the single-tool-per-project fixture makes per-dir and
+  per-row counts coincide — R1-F2). Registry: B's row(s) stamped to the new version AND carry
+  `store_id`; A's row(s) stamped to the new version (stamp survives degrade) with
+  identity fields untouched.
+- **T8c no-identity still mints on apply, silent on dry-run**: project B built with
+  an EMPTY store: dry-run reports no `identity_degraded` entry for B; apply mints
+  exactly one identity episode in B's store (count 0 → 1) and B's row gains a
+  `store_id`.
+
+### L6 — `tests/test-store-identity.mjs`: named-root detach + CLI legs
+
+Group 1 additions (in-process lib, use existing `mkStore`/`handRoot`/`episodesMd`):
+
+- **collapse success**: `handRoot(dir,'aaaa…')`, `handRoot(dir,'bbbb…')` (distinct
+  ids); `detachStoreIdentity(dir, { detachRootId: <bbbb root episode id> })` returns
+  `active_id` (fresh 16-hex), `detached_root_id`, `superseded_terminal` = aaaa-root
+  episode id, `prior_id` = `'aaaa…'`; `resolveStoreIdentity(dir)` then returns that
+  same `active_id` with `aliases` containing `'aaaa…'`; episode count went +1 only.
+- **detach-root-not-active**: two roots, `detachRootId: 'no-such-episode'` →
+  `{ error: 'detach-root-not-active' }`, episode count unchanged.
+- **still-ambiguous (3 roots)**: three `handRoot`s, detach one →
+  `{ error: 'duplicate-identity-chain' }`, episode count unchanged.
+- **store-not-duplicate**: one root, `detachRootId` = that root's episode id →
+  `{ error: 'store-not-duplicate' }`, episode count unchanged.
+- **legacy path untouched**: existing detach tests must pass unmodified.
+
+Group 2 addition (spawned CLI, use existing spawn idioms):
+
+- **CLI ceremony**: two-root store; `em-identity.mjs --store <dir>` → status JSON
+  with `resolution.error === 'duplicate-identity-chain'` and 2 `active_roots`;
+  `--detach-root <id>` WITHOUT `--confirm` → `status: 'plan'`, episode count
+  unchanged; with `--confirm` → `status: 'ok'`, subsequent `--status` resolves
+  cleanly with 1 active root and the survivor store_id in `aliases`.
+
+---
+
+## Step 9 (orchestrator, post-merge — record here so it is not lost)
+
+- File follow-up: `syncProjectFromDist` mirrors the whole registry and silently
+  suppresses SessionStart auto-refresh under the same one-bad-row condition.
+- File follow-up: `em-restore`/backup-sync flows are identity-unaware and can
+  reintroduce a detached/foreign identity root (root-cause class of #635).
+- Comment on #635: the 07-28 timeline open question (pre-sync artifacts).
+- Operator ceremony (separate from PR): `node scripts/em-identity.mjs --status`,
+  then `--detach-root 20260719-221917-store-identity-09d0` (plan), operator
+  confirms, `--confirm`, then `install.mjs --update-consumers` + verify all 14
+  stamps + audit deploy legs for `49a4e3e`/`6e82fee`/`5ffd0f5`.

--- a/scripts/em-identity.mjs
+++ b/scripts/em-identity.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * em-identity.mjs — store-identity diagnosis + sanctioned duplicate-root repair
+ * (issue #635). Zero deps; JSON to stdout.
+ *
+ *   node em-identity.mjs [--project <path>|--store <dir>] [--status]
+ *   node em-identity.mjs --detach-root <episode-id> [--confirm]
+ *
+ * Without --confirm, --detach-root prints the planned write and touches nothing
+ * (#623 blast-radius discipline). The repair itself is detachStoreIdentity's
+ * named-root collapse: one successor episode carrying supersedes + 
+ * detaches_identity_root (P7: revision, never an edit).
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { resolveLocalDir } from './lib/local-dir.mjs'
+import { storeIdentityStatus, detachStoreIdentity } from './lib/store-identity.mjs'
+
+const argv = process.argv.slice(2)
+const flag = (name) => argv.includes(name)
+const opt = (name) => {
+  const i = argv.indexOf(name)
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null
+}
+
+if (flag('--help')) {
+  console.log(JSON.stringify({
+    status: 'help',
+    script: 'em-identity.mjs',
+    usage: 'node em-identity.mjs [--project <path>|--store <dir>] [--status] | --detach-root <episode-id> [--confirm]',
+  }))
+  process.exit(0)
+}
+
+let storeDir = opt('--store')
+if (!storeDir) {
+  const project = opt('--project') || process.cwd()
+  try { storeDir = resolveLocalDir(fs.realpathSync(project)) } catch { storeDir = path.join(project, '.episodic-memory') }
+}
+if (!fs.existsSync(path.join(storeDir, 'episodes'))) {
+  console.log(JSON.stringify({ status: 'error', error: 'store-not-found', store: storeDir }))
+  process.exit(1)
+}
+
+const detachRootId = opt('--detach-root')
+if (!detachRootId) {
+  console.log(JSON.stringify({ status: 'ok', store: storeDir, ...storeIdentityStatus(storeDir) }))
+  process.exit(0)
+}
+
+const before = storeIdentityStatus(storeDir)
+const target = before.active_roots.find((r) => r.episode_id === detachRootId)
+const survivors = before.active_roots.filter((r) => r.episode_id !== detachRootId)
+if (!flag('--confirm')) {
+  console.log(JSON.stringify({
+    status: 'plan',
+    store: storeDir,
+    would_detach: target || null,
+    would_survive: survivors,
+    note: target && survivors.length === 1
+      ? 'one successor episode will supersede the survivor terminal and detach the named root; re-run with --confirm to write'
+      : 'refused: --detach-root must name one of exactly two active roots',
+  }))
+  process.exit(target && survivors.length === 1 ? 0 : 1)
+}
+const result = detachStoreIdentity(storeDir, { detachRootId })
+const ok = !result.error
+console.log(JSON.stringify({ status: ok ? 'ok' : 'error', store: storeDir, ...result, after: ok ? storeIdentityStatus(storeDir) : undefined }))
+process.exit(ok ? 0 : 1)

--- a/scripts/lib/install-version.mjs
+++ b/scripts/lib/install-version.mjs
@@ -459,6 +459,7 @@ export function updateConsumers({ repoDir, globalDir, dryRun = false }) {
     pruned: [],
     skipped_no_manifest: [],
     dry_run: !!dryRun,
+    identity_degraded: [],
   }
 
   const byProject = new Map()
@@ -513,13 +514,21 @@ export function updateConsumers({ repoDir, globalDir, dryRun = false }) {
     keptEntries.push(...projEntries)
   }
 
-  if (!dryRun && (report.pruned.length > 0 || report.refreshed.length > 0)) {
-    // F2 fold (GLM r1 MAJOR-2): mirror store identities on the sweep path too,
-    // so a post-rebind/detach registry carries the fresh active id + aliases
-    // (otherwise the sweep writes the stale active id from the prior upsert and
-    // omits store_aliases). The merge happens through mirrorStoreIdentities,
-    // NOT upsertRegistryEntries — upsert would read-merge and resurrect pruned rows.
-    writeRegistry(regPath, mirrorStoreIdentities(keptEntries))
+  if (report.pruned.length > 0 || report.refreshed.length > 0) {
+    if (dryRun) {
+      // FIX-635: dry-run predicts the apply-path mirror with a resolve-only probe
+      // (never mints; no-identity is not a degrade — apply would mint successfully).
+      probeStoreIdentities(keptEntries, report.identity_degraded)
+    } else {
+      // F2 fold (GLM r1 MAJOR-2): mirror store identities on the sweep path too,
+      // so a post-rebind/detach registry carries the fresh active id + aliases
+      // (otherwise the sweep writes the stale active id from the prior upsert and
+      // omits store_aliases). The merge happens through mirrorStoreIdentities,
+      // NOT upsertRegistryEntries — upsert would read-merge and resurrect pruned rows.
+      // FIX-635: one row's identity defect degrades that row instead of aborting
+      // the whole sweep (the mirror is derived, never authoritative).
+      writeRegistry(regPath, mirrorStoreIdentities(keptEntries, { degraded: report.identity_degraded }))
+    }
   }
   return report
 }
@@ -634,6 +643,28 @@ export function syncProjectFromDist({ globalDir, projectDir, dryRun = false }) {
   return out
 }
 
+// FIX-635: dry-run counterpart of the sweep-tail mirror. Resolve-only — never
+// mints, never writes. For resolve-class errors (duplicate-identity-chain,
+// identity-chain-cycle) it pushes the same `${error}: ${project_path}` strings the
+// degrade path records; apply-only classes (copied-store-rejected,
+// ambiguous-alias-ownership, reserved-id-abuse, identity-mint-failed) have no
+// dry-run counterpart, and the probe dedups per dir while apply degrades per row.
+function probeStoreIdentities(entries, out) {
+  const seenDirs = new Set()
+  for (const e of entries) {
+    let projectReal
+    try { projectReal = fs.realpathSync(e.project_path) } catch { continue }
+    let dir
+    try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }
+    if (!fs.existsSync(dir) || seenDirs.has(dir)) continue
+    seenDirs.add(dir)
+    const idn = resolveStoreIdentity(dir)
+    if (idn.error && idn.error !== 'no-identity') {
+      out.push({ project_path: e.project_path, error: `${idn.error}: ${e.project_path}` })
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // RFC-012 P2 REQ-6 — store-identity mirror (derived, never authoritative).
 // Runs on every registry write via upsertRegistryEntries: resolves each row's
@@ -641,55 +672,65 @@ export function syncProjectFromDist({ globalDir, projectDir, dryRun = false }) {
 // aliases, and fails LOUD (throw) on duplicate chains, copied stores (one
 // active id at two paths), and ambiguous alias ownership. A missing or
 // unresolvable store dir leaves the row unmirrored (mirror is derived).
+// With `degraded` (sweep path, FIX-635), resolve/mint/collision failures for a row
+// are pushed to that array and the row is skipped instead of aborting the sweep.
 // ---------------------------------------------------------------------------
-export function mirrorStoreIdentities(entries) {
+export function mirrorStoreIdentities(entries, { degraded } = {}) {
   const claims = new Map() // store_id/alias -> { dir, kind }
   for (const e of entries) {
-    let projectReal
-    try { projectReal = fs.realpathSync(e.project_path) } catch { continue }
-    let dir
-    try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }
-    if (!fs.existsSync(dir)) continue
-    let idn = resolveStoreIdentity(dir)
-    if (idn.error === 'no-identity') {
-      const minted = mintStoreIdentity(dir)
-      if (minted.error) {
-        // F3 fold (GLM r1 MAJOR-3): identity-exists / lock-timeout are benign
-        // concurrent-mint outcomes (the lib-level lock serialized us; another
-        // process minted, or its lock-holder just released after a retry budget).
-        // Re-resolve and mirror the EXISTING identity instead of throwing — this
-        // is the §8.2 EC12 "later holder re-resolves" pattern. Other mint errors
-        // (duplicate-identity-chain, identity-chain-cycle, reserved-id-invalid,
-        // break-identity-write, store-dir-missing, …) stay fatal.
-        if (minted.error === 'identity-exists' || minted.error === 'lock-timeout') {
-          idn = resolveStoreIdentity(dir)
+    try {
+      let projectReal
+      try { projectReal = fs.realpathSync(e.project_path) } catch { continue }
+      let dir
+      try { dir = resolveLocalDir(projectReal) } catch { dir = path.join(projectReal, '.episodic-memory') }
+      if (!fs.existsSync(dir)) continue
+      let idn = resolveStoreIdentity(dir)
+      if (idn.error === 'no-identity') {
+        const minted = mintStoreIdentity(dir)
+        if (minted.error) {
+          // F3 fold (GLM r1 MAJOR-3): identity-exists / lock-timeout are benign
+          // concurrent-mint outcomes (the lib-level lock serialized us; another
+          // process minted, or its lock-holder just released after a retry budget).
+          // Re-resolve and mirror the EXISTING identity instead of throwing — this
+          // is the §8.2 EC12 "later holder re-resolves" pattern. Other mint errors
+          // (duplicate-identity-chain, identity-chain-cycle, reserved-id-invalid,
+          // break-identity-write, store-dir-missing, …) stay fatal.
+          if (minted.error === 'identity-exists' || minted.error === 'lock-timeout') {
+            idn = resolveStoreIdentity(dir)
+          } else {
+            throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)
+          }
         } else {
-          throw new Error(`identity-mint-failed: ${minted.error} at ${dir}`)
+          idn = resolveStoreIdentity(dir)
         }
-      } else {
-        idn = resolveStoreIdentity(dir)
       }
-    }
-    if (idn.error) throw new Error(`${idn.error}: ${e.project_path}`)
-    let dirReal
-    try { dirReal = fs.realpathSync(dir) } catch { dirReal = dir }
-    for (const [id, kind] of [[idn.active_id, 'active'], ...idn.aliases.map((a) => [a, 'alias'])]) {
-      // F5 fold (GLM r1 MINOR-2): the reserved id `global` belongs only to the
-      // global store, which is never a registry row. A project row resolving
-      // active_id or alias === 'global' is a hand-forgery / misconfiguration
-      // — reject loudly rather than silently exempting it from the collision
-      // map (the old `continue` let two forged-global project rows coexist).
-      if (id === 'global') throw new Error(`reserved-id-abuse: ${e.project_path}`)
-      const prev = claims.get(id)
-      if (prev && prev.dir !== dirReal) {
-        if (prev.kind === 'active' && kind === 'active') throw new Error(`copied-store-rejected: ${id} at ${prev.dir} + ${dirReal}`)
-        throw new Error(`ambiguous-alias-ownership: ${id} at ${prev.dir} + ${dirReal}`)
+      if (idn.error) throw new Error(`${idn.error}: ${e.project_path}`)
+      let dirReal
+      try { dirReal = fs.realpathSync(dir) } catch { dirReal = dir }
+      for (const [id, kind] of [[idn.active_id, 'active'], ...idn.aliases.map((a) => [a, 'alias'])]) {
+        // F5 fold (GLM r1 MINOR-2): the reserved id `global` belongs only to the
+        // global store, which is never a registry row. A project row resolving
+        // active_id or alias === 'global' is a hand-forgery / misconfiguration
+        // — reject loudly rather than silently exempting it from the collision
+        // map (the old `continue` let two forged-global project rows coexist).
+        if (id === 'global') throw new Error(`reserved-id-abuse: ${e.project_path}`)
+        const prev = claims.get(id)
+        if (prev && prev.dir !== dirReal) {
+          if (prev.kind === 'active' && kind === 'active') throw new Error(`copied-store-rejected: ${id} at ${prev.dir} + ${dirReal}`)
+          throw new Error(`ambiguous-alias-ownership: ${id} at ${prev.dir} + ${dirReal}`)
+        }
+        if (!prev) claims.set(id, { dir: dirReal, kind })
       }
-      if (!prev) claims.set(id, { dir: dirReal, kind })
+      e.store_id = idn.active_id
+      if (idn.aliases.length) e.store_aliases = idn.aliases
+      else delete e.store_aliases
+    } catch (err) {
+      // FIX-635: degrade mode (sweep path only) — record and continue; the row
+      // keeps its version stamp and its prior identity fields. Registration
+      // (upsertRegistryEntries) does not pass `degraded` and still fails loud.
+      if (!degraded) throw err
+      degraded.push({ project_path: e.project_path, error: err.message })
     }
-    e.store_id = idn.active_id
-    if (idn.aliases.length) e.store_aliases = idn.aliases
-    else delete e.store_aliases
   }
   return entries
 }

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -240,13 +240,12 @@ function applyIdentityIndexUpdate(storeDir, fields) {
 
 // --- exports ---
 
-export function resolveStoreIdentity(storeDir) {
+// Shared identity-graph analysis (FIX-635): roots, detached roots, active roots.
+// Single source of truth for resolveStoreIdentity and the named-root detach path.
+function identityGraph(storeDir) {
   const eps = listIdentityEpisodes(storeDir)
-  if (eps.length === 0) return { error: 'no-identity' }
-  // Roots: episodes whose supersedes is absent or names no identity episode.
   const byId = new Map(eps.map((e) => [e.id, e]))
   const roots = eps.filter((e) => !e.supersedes || !byId.has(e.supersedes))
-  // Detached roots are those referenced by SOME episode's detaches_identity_root.
   const detachedRootIds = new Set()
   for (const e of eps) {
     if (e.detaches_identity_root && byId.has(e.detaches_identity_root)) {
@@ -254,10 +253,10 @@ export function resolveStoreIdentity(storeDir) {
     }
   }
   const activeRoots = roots.filter((r) => !detachedRootIds.has(r.id))
-  if (activeRoots.length === 0) return { error: 'identity-chain-cycle' }
-  if (activeRoots.length > 1) return { error: 'duplicate-identity-chain' }
-  const root = activeRoots[0]
-  // Walk successors from the single active root. A revisit = cycle.
+  return { eps, byId, roots, detachedRootIds, activeRoots }
+}
+
+function walkChain(eps, root) {
   const visited = new Set([root.id])
   const chainMembers = [root]
   let current = root
@@ -269,6 +268,18 @@ export function resolveStoreIdentity(storeDir) {
     chainMembers.push(successor)
     current = successor
   }
+  return { chainMembers }
+}
+
+export function resolveStoreIdentity(storeDir) {
+  const { eps, activeRoots } = identityGraph(storeDir)
+  if (eps.length === 0) return { error: 'no-identity' }
+  if (activeRoots.length === 0) return { error: 'identity-chain-cycle' }
+  if (activeRoots.length > 1) return { error: 'duplicate-identity-chain' }
+  const root = activeRoots[0]
+  const walked = walkChain(eps, root)
+  if (walked.error) return { error: walked.error }
+  const chainMembers = walked.chainMembers
   // Episodes belonging to detached chains (their root is in detachedRootIds) are
   // intentionally not reachable from the active root — they stay in the store but
   // contribute no active id and no aliases (§A.5 lib error 'detachedChainExcluded').
@@ -279,6 +290,18 @@ export function resolveStoreIdentity(storeDir) {
     aliases,
     root_id: root.id,
     terminal_episode_id: terminal.id,
+  }
+}
+
+// FIX-635: operator-facing diagnosis. Never writes. Lists every active root so a
+// duplicate-root store can be repaired by naming which root to detach.
+export function storeIdentityStatus(storeDir) {
+  const resolution = resolveStoreIdentity(storeDir)
+  const { activeRoots, detachedRootIds } = identityGraph(storeDir)
+  return {
+    resolution,
+    active_roots: activeRoots.map((r) => ({ episode_id: r.id, store_id: r.store_id })),
+    detached_root_ids: [...detachedRootIds],
   }
 }
 
@@ -361,9 +384,60 @@ export function rebindStoreIdentity(storeDir, { lockTimeoutS } = {}) {
   }, { timeoutS: lockTimeoutS })
 }
 
-export function detachStoreIdentity(storeDir, { lockTimeoutS } = {}) {
+export function detachStoreIdentity(storeDir, { lockTimeoutS, detachRootId } = {}) {
   return withStoreLockSync(storeDir, () => {
     const existing = resolveStoreIdentity(storeDir)
+    if (detachRootId) {
+      // FIX-635 duplicate-collapse: name the stray root; the surviving chain's
+      // terminal is superseded by ONE new episode that also detaches the stray
+      // root (the only single-episode shape that yields exactly one active root
+      // — see plan Evidence table). Validate-then-write: no write on any error.
+      if (existing.error && existing.error !== 'duplicate-identity-chain') {
+        return { error: existing.error }
+      }
+      if (!existing.error) return { error: 'store-not-duplicate' }
+      const { eps, activeRoots } = identityGraph(storeDir)
+      const target = activeRoots.find((r) => r.id === detachRootId)
+      if (!target) return { error: 'detach-root-not-active' }
+      const remaining = activeRoots.filter((r) => r.id !== detachRootId)
+      if (remaining.length !== 1) return { error: 'duplicate-identity-chain' }
+      const walked = walkChain(eps, remaining[0])
+      if (walked.error) return { error: walked.error }
+      const terminal = walked.chainMembers[walked.chainMembers.length - 1]
+      const newStoreId = crypto.randomBytes(8).toString('hex')
+      const now = new Date()
+      const id = newEpisodeId(newStoreId, now)
+      const y = now.getFullYear()
+      const mo = String(now.getMonth() + 1).padStart(2, '0')
+      const d = String(now.getDate()).padStart(2, '0')
+      const h = String(now.getHours()).padStart(2, '0')
+      const mi = String(now.getMinutes()).padStart(2, '0')
+      const project = path.basename(path.dirname(storeDir)) || 'store'
+      const fields = {
+        id,
+        date: `${y}-${mo}-${d}`,
+        time: `${h}:${mi}`,
+        project,
+        summary: `Store identity duplicate-collapse ${newStoreId}`,
+        store_id: newStoreId,
+        supersedes: terminal.id,
+        detaches_identity_root: detachRootId,
+        bodyLine: 'Store identity duplicate-collapse successor (issue #635; RFC-012 P2 REQ-5 detach + P7 successor revision). Detached chain contributes no active id and no aliases; the surviving chain continues through this terminal.',
+      }
+      const episodesDir = path.join(storeDir, 'episodes')
+      const content = identityEpisodeContent(fields)
+      const writeResult = writeIdentityEpisodeAtomic(episodesDir, id, content)
+      if (writeResult.error) return writeResult
+      const idx = applyIdentityIndexUpdate(storeDir, fields)
+      const out = {
+        active_id: newStoreId,
+        detached_root_id: detachRootId,
+        superseded_terminal: terminal.id,
+        prior_id: terminal.store_id,
+      }
+      if (idx.stale) out.index_stale = true
+      return out
+    }
     if (existing.error) return { error: existing.error }
     const newStoreId = crypto.randomBytes(8).toString('hex')
     const now = new Date()

--- a/tests/test-install-manifest.mjs
+++ b/tests/test-install-manifest.mjs
@@ -354,7 +354,131 @@ console.log('=== T7: --update-consumers with an empty registry is a no-op ===')
 }
 
 // ===========================================================================
-console.log('=== T8: --uninstall-enforcement never touches global Layer-1 state; flag heals on next install ===')
+console.log('=== T8: identity degrade + dry-run parity (#635) ===')
+// ===========================================================================
+// Forge a duplicate-identity-chain in project A and an empty store in project C;
+// make A, B, C refresh-eligible. T8a/b exercise the duplicate-chain behavior
+// (dry-run predicts, apply degrades instead of aborting); T8c exercises the
+// no-identity case (dry-run silent, apply mints).
+// ===========================================================================
+{
+  const S8 = mkSandbox('identity-degrade')
+  const SA = S8.project
+  const SB = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'l1-proj-identity-degrade-b-')))
+  execFileSync('git', ['init', '-q'], { cwd: SB })
+  fs.mkdirSync(path.join(SB, '.episodic-memory', 'episodes'), { recursive: true })
+  cleanups.push(SB)
+  const SC = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'l1-proj-identity-degrade-c-')))
+  execFileSync('git', ['init', '-q'], { cwd: SC })
+  fs.mkdirSync(path.join(SC, '.episodic-memory', 'episodes'), { recursive: true })
+  cleanups.push(SC)
+
+  // Install A, B, C (each mints identity via upsertRegistryEntries during install).
+  truthy('T8: install A exits 0',
+    runInstall({ home: S8.home, project: SA, extra: ['--install-enforcement'] }).status === 0, 'install A failed')
+  truthy('T8: install B exits 0',
+    runInstall({ home: S8.home, project: SB }).status === 0, 'install B failed')
+  truthy('T8: install C exits 0',
+    runInstall({ home: S8.home, project: SC }).status === 0, 'install C failed')
+
+  // Capture A's row before the apply so we can verify "identity fields untouched".
+  const regBeforeApply = readJson(registryFilePath(S8.home))
+  const aRowBefore = regBeforeApply.entries.find((e) => e.project_path === SA)
+  const aStoreIdBefore = aRowBefore.store_id
+  const aAliasesBefore = aRowBefore.store_aliases || []
+
+  // Forge a second active identity root into A's local store (two frontmatter
+  // files, distinct 16-hex store_ids, no supersedes).
+  const aStoreEpisodes = path.join(SA, '.episodic-memory', 'episodes')
+  const handRoot = (storeId) => {
+    const id = `19990101-000000-store-identity-${storeId.slice(0, 4)}`
+    const lines = ['---', `id: ${id}`, `date: 1999-01-01`, `time: "00:00"`, `project: hand`, `category: context`, `status: active`, `tags: [store-identity]`, `summary: hand root ${storeId}`, `record_type: store-identity`, `store_id: ${storeId}`, '---', '', `# hand root ${storeId}`, '', 'hand-crafted for forged fixture.']
+    fs.writeFileSync(path.join(aStoreEpisodes, id + '.md'), lines.join('\n') + '\n')
+  }
+  handRoot('cccc3333cccc3333')
+  handRoot('dddd4444dddd4444')
+
+  // Empty C's store (delete the identity episode that install minted) so the
+  // no-identity path is exercised on the sweep.
+  const cEpisodesDir = path.join(SC, '.episodic-memory', 'episodes')
+  for (const f of fs.readdirSync(cEpisodesDir)) {
+    if (f.endsWith('.md')) fs.unlinkSync(path.join(cEpisodesDir, f))
+  }
+  const cEpCountBefore = fs.readdirSync(cEpisodesDir).filter((f) => f.endsWith('.md')).length
+
+  // Make A, B, C refresh-eligible the same way T5 legs do (stale skill bytes +
+  // old sha + old version stamp).
+  const makeRefreshEligible = (projectDir, contentLabel) => {
+    const oldSkill = Buffer.from(`OLD SKILL CONTENT (${contentLabel})\n`)
+    fs.writeFileSync(path.join(projectDir, SKILL_REL), oldSkill)
+    const m = readJson(projManifestPath(projectDir))
+    m.artifacts.find((a) => a.path === SKILL_REL).sha256 = sha256(oldSkill)
+    m.source_version = '1'.repeat(40)
+    fs.writeFileSync(projManifestPath(projectDir), JSON.stringify(m, null, 2))
+  }
+  makeRefreshEligible(SA, 'simulated older install A')
+  makeRefreshEligible(SB, 'simulated older install B')
+  makeRefreshEligible(SC, 'simulated older install C')
+
+  // --- T8a dry-run predicts -----------------------------------------------
+  const dr = runSweep(S8.home, true)
+  truthy('T8a: dry-run exits 0', dr.status === 0, `status=${dr.status} stderr=${(dr.stderr || '').slice(-300)}`)
+  const dryReport = JSON.parse(dr.stdout)
+  truthy('T8a: report.identity_degraded has exactly one entry',
+    Array.isArray(dryReport.identity_degraded) && dryReport.identity_degraded.length === 1,
+    JSON.stringify(dryReport.identity_degraded))
+  const dryEntry = dryReport.identity_degraded[0]
+  truthy('T8a: entry.project_path === A path', dryEntry.project_path === SA,
+    `${dryEntry.project_path} vs ${SA}`)
+  truthy('T8a: entry.error matches /^duplicate-identity-chain: /',
+    /^duplicate-identity-chain: /.test(dryEntry.error), dryEntry.error)
+  // A's episode file count unchanged (no mint on dry-run). The original install
+  // minted 1 identity episode, then we forged 2 more → 3 total.
+  const dryEpCount = fs.readdirSync(aStoreEpisodes).filter((f) => f.endsWith('.md')).length
+  truthy('T8a: A episode file count unchanged (no mint on dry-run)', dryEpCount === 3,
+    `count=${dryEpCount}`)
+  // T8c dry-run half: no identity_degraded entry for C (probe skips no-identity).
+  truthy('T8c dry-run: no identity_degraded entry for C (no-identity is silent)',
+    !dryReport.identity_degraded.some((e) => e.project_path === SC),
+    JSON.stringify(dryReport.identity_degraded))
+
+  // --- T8b apply degrades instead of aborting -----------------------------
+  const ar = runSweep(S8.home, false)
+  truthy('T8b: apply exits 0', ar.status === 0, `status=${ar.status} stderr=${(ar.stderr || '').slice(-300)}`)
+  const applyReport = JSON.parse(ar.stdout)
+  truthy('T8b: report.identity_degraded has exactly one entry',
+    Array.isArray(applyReport.identity_degraded) && applyReport.identity_degraded.length === 1,
+    JSON.stringify(applyReport.identity_degraded))
+  const applyEntry = applyReport.identity_degraded[0]
+  truthy('T8b: entry string-identical to T8a entry (resolve-error parity)',
+    JSON.stringify(applyEntry) === JSON.stringify(dryEntry),
+    `dry=${JSON.stringify(dryEntry)} apply=${JSON.stringify(applyEntry)}`)
+  const reg = readJson(registryFilePath(S8.home))
+  const aRow = reg.entries.find((e) => e.project_path === SA)
+  truthy('T8b: A registry row stamped to new version (stamp survives degrade)',
+    aRow && aRow.version === GIT_HEAD, JSON.stringify(aRow))
+  truthy('T8b: A identity fields untouched (degrade skips the row)',
+    aRow && aRow.store_id === aStoreIdBefore &&
+    JSON.stringify(aRow.store_aliases || []) === JSON.stringify(aAliasesBefore),
+    `before=${JSON.stringify(aRowBefore)} after=${JSON.stringify(aRow)}`)
+  const bRow = reg.entries.find((e) => e.project_path === SB)
+  truthy('T8b: B registry row stamped to new version',
+    bRow && bRow.version === GIT_HEAD, JSON.stringify(bRow))
+  truthy('T8b: B registry row carries store_id',
+    bRow && /^[0-9a-f]{16}$/.test(bRow.store_id || ''), JSON.stringify(bRow))
+
+  // --- T8c apply mint on no-identity -------------------------------------
+  const cEpCountAfter = fs.readdirSync(cEpisodesDir).filter((f) => f.endsWith('.md')).length
+  truthy('T8c: apply mints exactly one identity episode in C store (count 0 → 1)',
+    cEpCountBefore === 0 && cEpCountAfter === 1,
+    `before=${cEpCountBefore} after=${cEpCountAfter}`)
+  const cRow = reg.entries.find((e) => e.project_path === SC)
+  truthy('T8c: C registry row gains a store_id',
+    cRow && /^[0-9a-f]{16}$/.test(cRow.store_id || ''), JSON.stringify(cRow))
+}
+
+// ===========================================================================
+console.log('=== T9: --uninstall-enforcement never touches global Layer-1 state; flag heals on next install ===')
 // Regression (found by test-uninstall-enforcement t_no_global_touch during
 // Layer 1 implementation, 2026-07-08): the first cut wrote the global
 // manifest + registry + dist cache on EVERY run, so an uninstall run mutated
@@ -364,20 +488,20 @@ console.log('=== T8: --uninstall-enforcement never touches global Layer-1 state;
 // from disk truth (engine file gone) on the next regular install run.
 // ===========================================================================
 {
-  const S8 = mkSandbox('uninstall')
-  runInstall({ home: S8.home, project: S8.project, extra: ['--install-enforcement'] })
-  const preGlobal = snapshotTree(path.join(S8.home, '.episodic-memory'))
-  const u = runInstall({ home: S8.home, project: S8.project, extra: ['--uninstall-enforcement'] })
-  truthy('T8: uninstall run exits 0', u.status === 0, `status=${u.status}`)
-  truthy('T8: global ~/.episodic-memory byte-identical across the uninstall run',
-    snapshotsEqual(preGlobal, snapshotTree(path.join(S8.home, '.episodic-memory'))), 'global scope changed')
-  const pm = readJson(projManifestPath(S8.project))
-  truthy('T8: project manifest dropped the removed enforcement entries',
+  const S9 = mkSandbox('uninstall')
+  runInstall({ home: S9.home, project: S9.project, extra: ['--install-enforcement'] })
+  const preGlobal = snapshotTree(path.join(S9.home, '.episodic-memory'))
+  const u = runInstall({ home: S9.home, project: S9.project, extra: ['--uninstall-enforcement'] })
+  truthy('T9: uninstall run exits 0', u.status === 0, `status=${u.status}`)
+  truthy('T9: global ~/.episodic-memory byte-identical across the uninstall run',
+    snapshotsEqual(preGlobal, snapshotTree(path.join(S9.home, '.episodic-memory'))), 'global scope changed')
+  const pm = readJson(projManifestPath(S9.project))
+  truthy('T9: project manifest dropped the removed enforcement entries',
     !pm.artifacts.some((a) => a.path === '.claude/hooks/checkpoint-gate.sh'), 'stale enforcement entry kept')
-  const r2 = runInstall({ home: S8.home, project: S8.project })
-  truthy('T8: next regular install exits 0', r2.status === 0, `status=${r2.status}`)
-  const reg = readJson(registryFilePath(S8.home))
-  truthy('T8: enforcement_installed healed to false from disk truth',
+  const r2 = runInstall({ home: S9.home, project: S9.project })
+  truthy('T9: next regular install exits 0', r2.status === 0, `status=${r2.status}`)
+  const reg = readJson(registryFilePath(S9.home))
+  truthy('T9: enforcement_installed healed to false from disk truth',
     reg.entries.find((e) => e.tool === 'claude-code').enforcement_installed === false,
     JSON.stringify(reg.entries))
 }

--- a/tests/test-store-identity.mjs
+++ b/tests/test-store-identity.mjs
@@ -472,6 +472,61 @@ t('identity::testIndexCarriesIdentityFields', () => {
   assert(typeof detachRow.detaches_identity_root === 'string', 'detach row must carry detaches_identity_root')
 })
 
+// --- FIX-635 named-root detach legs (issue #635, L6 Group 1) ---
+// handRoot's id is `19990101-000000-store-identity-${storeId.slice(0,4)}` so we
+// can construct the root episode id directly from the storeId argument.
+
+t('identity::testNamedRootCollapseSuccess', () => {
+  const s = mkStore('collapse-success')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  handRoot(s.dataDir, 'bbbb2222bbbb2222')
+  const epsBefore = episodesMd(s.dataDir).length
+  const aaaaId = '19990101-000000-store-identity-aaaa'
+  const bbbbId = '19990101-000000-store-identity-bbbb'
+  const result = detachStoreIdentity(s.dataDir, { detachRootId: bbbbId })
+  assert(!result.error, `detach returned error: ${JSON.stringify(result)}`)
+  assert(/^[0-9a-f]{16}$/.test(result.active_id), `active_id hex: ${result.active_id}`)
+  eq(result.detached_root_id, bbbbId, 'detached_root_id')
+  eq(result.superseded_terminal, aaaaId, 'superseded_terminal')
+  eq(result.prior_id, 'aaaa1111aaaa1111', 'prior_id')
+  const r = resolveStoreIdentity(s.dataDir)
+  eq(r.active_id, result.active_id, 'resolve active_id after collapse')
+  assert(r.aliases.includes('aaaa1111aaaa1111'), `aliases includes survivor: ${JSON.stringify(r.aliases)}`)
+  eq(episodesMd(s.dataDir).length, epsBefore + 1, 'episode count went +1 only')
+})
+
+t('identity::testDetachRootNotActive', () => {
+  const s = mkStore('detach-root-not-active')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  handRoot(s.dataDir, 'bbbb2222bbbb2222')
+  const epsBefore = episodesMd(s.dataDir).length
+  const result = detachStoreIdentity(s.dataDir, { detachRootId: 'no-such-episode' })
+  eq(result.error, 'detach-root-not-active', 'detach-root-not-active error')
+  eq(episodesMd(s.dataDir).length, epsBefore, 'episode count unchanged')
+})
+
+t('identity::testStillAmbiguousAfterDetach', () => {
+  const s = mkStore('still-ambiguous')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  handRoot(s.dataDir, 'bbbb2222bbbb2222')
+  handRoot(s.dataDir, 'cccc3333cccc3333')
+  const epsBefore = episodesMd(s.dataDir).length
+  const ccccId = '19990101-000000-store-identity-cccc'
+  const result = detachStoreIdentity(s.dataDir, { detachRootId: ccccId })
+  eq(result.error, 'duplicate-identity-chain', 'still-ambiguous returns duplicate-identity-chain')
+  eq(episodesMd(s.dataDir).length, epsBefore, 'episode count unchanged')
+})
+
+t('identity::testStoreNotDuplicate', () => {
+  const s = mkStore('store-not-duplicate')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  const epsBefore = episodesMd(s.dataDir).length
+  const aaaaId = '19990101-000000-store-identity-aaaa'
+  const result = detachStoreIdentity(s.dataDir, { detachRootId: aaaaId })
+  eq(result.error, 'store-not-duplicate', 'store-not-duplicate error')
+  eq(episodesMd(s.dataDir).length, epsBefore, 'episode count unchanged')
+})
+
 // =====================
 // Group 2 — real install.mjs E2E
 // =====================
@@ -647,6 +702,49 @@ t('registry::testReservedGlobalForgeryFailsLoud', () => {
     fRow = (reg.entries || []).find((e) => e.project_path === fProj)
   }
   assert(!fRow, 'forged-global project must NOT have a registry row')
+})
+
+// --- FIX-635 CLI ceremony (issue #635, L6 Group 2) ---
+// Spawned em-identity.mjs exercises the operator ceremony without going through
+// install.mjs: --status diagnosis, --detach-root plan (no write), --detach-root
+// --confirm (writes), and a follow-up --status verifying the collapse.
+
+t('identity::testEmIdentityCLICeremony', () => {
+  const s = mkStore('cli-ceremony')
+  handRoot(s.dataDir, 'aaaa1111aaaa1111')
+  handRoot(s.dataDir, 'bbbb2222bbbb2222')
+  const identityScript = path.join(REPO, 'scripts', 'em-identity.mjs')
+  const bbbbId = '19990101-000000-store-identity-bbbb'
+
+  // --status (no --detach-root) reports duplicate-identity-chain + 2 active roots.
+  const r1 = spawnSync(process.execPath, [identityScript, '--store', s.dataDir], { encoding: 'utf8' })
+  eq(r1.status, 0, `em-identity --status exits 0: stderr=${r1.stderr}`)
+  const o1 = JSON.parse(r1.stdout)
+  eq(o1.resolution.error, 'duplicate-identity-chain', 'resolution.error')
+  eq(o1.active_roots.length, 2, '2 active roots')
+
+  // --detach-root without --confirm MUST NOT touch the store.
+  const epsBefore = episodesMd(s.dataDir).length
+  const r2 = spawnSync(process.execPath, [identityScript, '--store', s.dataDir, '--detach-root', bbbbId], { encoding: 'utf8' })
+  eq(r2.status, 0, `plan invocation exits 0: stderr=${r2.stderr}`)
+  const o2 = JSON.parse(r2.stdout)
+  eq(o2.status, 'plan', 'plan status')
+  eq(episodesMd(s.dataDir).length, epsBefore, 'episode count unchanged after plan')
+
+  // --detach-root --confirm collapses the duplicate chain.
+  const r3 = spawnSync(process.execPath, [identityScript, '--store', s.dataDir, '--detach-root', bbbbId, '--confirm'], { encoding: 'utf8' })
+  eq(r3.status, 0, `confirm invocation exits 0: stderr=${r3.stderr}`)
+  const o3 = JSON.parse(r3.stdout)
+  eq(o3.status, 'ok', 'ok status')
+
+  // Follow-up --status: 1 active root, survivor store_id in aliases.
+  const r4 = spawnSync(process.execPath, [identityScript, '--store', s.dataDir], { encoding: 'utf8' })
+  eq(r4.status, 0, `post-confirm --status exits 0: stderr=${r4.stderr}`)
+  const o4 = JSON.parse(r4.stdout)
+  assert(!o4.resolution.error, `post-confirm resolution: ${JSON.stringify(o4.resolution)}`)
+  eq(o4.active_roots.length, 1, '1 active root after collapse')
+  assert(o4.resolution.aliases.includes('aaaa1111aaaa1111'),
+    `survivor store_id in aliases: ${JSON.stringify(o4.resolution.aliases)}`)
 })
 
 // --- main ---


### PR DESCRIPTION
## Summary
- `install.mjs --update-consumers` no longer aborts all 14 consumers when one store has an identity defect: `mirrorStoreIdentities` gains an opt-in per-row degrade mode used only by the sweep tail (`identity_degraded` report field; the row keeps its version stamp, identity fields untouched). Registration (`upsertRegistryEntries`) stays RFC-012 REQ-6 fail-loud.
- `--dry-run` now performs a resolve-only identity probe with **resolve-error parity** to apply (`duplicate-identity-chain` / `identity-chain-cycle` — the #635 class). Apply-only classes (`copied-store-rejected`, `ambiguous-alias-ownership`, `reserved-id-abuse`, `identity-mint-failed`) are documented blind spots (plan §S2, R1-F1).
- `detachStoreIdentity({ detachRootId })`: named-root duplicate-collapse writing ONE episode carrying `supersedes` (survivor terminal) + `detaches_identity_root` (stray root) — the only single-episode shape that collapses to one active chain (runtime-probed evidence table in the plan doc). Validate-then-write; every error path returns before any write.
- New `scripts/em-identity.mjs` (zero-dep, JSON stdout): `--status` diagnosis, `--detach-root <id> [--confirm]` sanctioned repair entry point; plan-without-write unless `--confirm`. Auto-deploys as a substrate script.
- Regression legs in the existing registered suites: T8 group (identity degrade + dry-run parity) in `test-install-manifest.mjs` (pre-existing uninstall-enforcement group renumbered T8→T9, label-only); named-root collapse + CLI ceremony legs in `test-store-identity.mjs`.
- Plan doc `docs/plans/fix-635-update-consumers-identity-degrade.md` rides with R1/R2 dispositions.

**Excluded by design:** the live-store data repair (operator ceremony post-merge via the new CLI), `em-restore`/sync identity-awareness and `syncProjectFromDist` exposure (step-9 follow-up issues).

## Review provenance (multiagent)
- GLM R1 on the frozen plan: APPROVE-WITH-CHANGES — 6 findings dispositioned in the plan doc (MAJOR R1-F1 parity over-claim → S2 narrowed).
- MiniMax build, mechanical from listings; deviations reviewed and confirmed correct in R2.
- GLM R2 on the frozen diff: SHIP-WITH-FIXES — out-of-scope `.gitignore` hunk excluded from the commit; NITs ride.

## Test plan
- [x] `node tests/test-install-manifest.mjs` — 75/75 (T8a dry-run predicts; T8b apply degrades, stamp survives, parity string-identical; T8c mint-on-apply/silent-dry-run)
- [x] `node tests/test-store-identity.mjs` — 32 pass (collapse success, detach-root-not-active, still-ambiguous preservation, store-not-duplicate, legacy path, CLI ceremony)
- [x] `node tests/test-consumer-registry-schema.mjs` — 8 pass
- [x] import smoke + `em-identity.mjs --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLPA1YTjke1y9Dzkd5AhZJ