### PR TITLE
chore: gitignore install-version manifest + installer-deployed BP-1 copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,13 @@ analysis/
 .codex/
 .agents/
 AGENTS.md
+
+# Episodic memory install-version manifest
+.episodic-memory-install.json
+
+# Installer-deployed copies of tracked sources (scripts/bp1-*.mjs,
+# scripts/lib/bp1-*.mjs, skills/classify-correction/) — hash-verified
+# identical at deploy time, managed by install.mjs, never committed
+.claude/hooks/bp1-*.mjs
+.claude/hooks/lib/
+.claude/skills/classify-correction/


### PR DESCRIPTION
Resolves the two standing workplan housekeeping items (v286 operator item 3):

1. **`.episodic-memory-install.json`** — the per-project install-version manifest (handoff-102 standing uncommitted mod). Machine-managed by `install.mjs`; never committed.
2. **Installer-deployed BP-1 copies** — `.claude/hooks/bp1-*.mjs`, `.claude/hooks/lib/`, `.claude/skills/classify-correction/` are deploy-time copies of the tracked sources (`scripts/bp1-*.mjs`, `scripts/lib/bp1-*.mjs`, `skills/classify-correction/`). Verified byte-identical to sources at HEAD (`cmp` over every file, including `lib/bp1-canonicalize.mjs` vs `scripts/lib/bp1-canonicalize.mjs`). Follows the existing convention for runtime-managed `.claude/` files in this ignore set.

No tracked files are affected by the new rules (`git status` clean of these paths after applying; `git check-ignore -v` confirms each rule binds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2T1qkZLrFVePHPEEHUmfG