### PR TITLE
FIX-644: CI gate — plugin content changes require a plugin.json version bump (fixes #644)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -156,10 +156,14 @@ jobs:
 
       # #644: claude plugin update is version-gated on plugin.json, so a merge
       # that changes plugin content without a bump makes the update a permanent
-      # no-op. Diffs against the merge-base (fetch-depth 0 above is load-bearing
-      # here too) and fails when content changed without a semver advance.
+      # no-op. Diffs against an EVENT-SPECIFIC immutable baseline (codex R1 F1):
+      # github.base_ref exists only on pull_request; on push the checkout IS the
+      # pushed tip, so a ref baseline degenerates to comparing HEAD with itself —
+      # github.event.before is the pre-push sha instead (all-zeros on branch
+      # creation, which the gate passes explicitly). fetch-depth 0 above is
+      # load-bearing here too.
       - name: Check plugin.json version bump on content changes (#644)
-        run: node scripts/check-plugin-version-bump.mjs --base-ref origin/${{ github.base_ref || 'main' }}
+        run: node scripts/check-plugin-version-bump.mjs --project "$GITHUB_WORKSPACE" --base-ref "${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}"
 
       - name: Run plugin version-bump gate suite (#644)
         run: node tests/test-plugin-version-bump.mjs

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -156,14 +156,21 @@ jobs:
 
       # #644: claude plugin update is version-gated on plugin.json, so a merge
       # that changes plugin content without a bump makes the update a permanent
-      # no-op. Diffs against an EVENT-SPECIFIC immutable baseline (codex R1 F1):
-      # github.base_ref exists only on pull_request; on push the checkout IS the
-      # pushed tip, so a ref baseline degenerates to comparing HEAD with itself —
-      # github.event.before is the pre-push sha instead (all-zeros on branch
-      # creation, which the gate passes explicitly). fetch-depth 0 above is
-      # load-bearing here too.
+      # no-op. Diffs against an EVENT-SPECIFIC immutable baseline (codex R1 F1,
+      # R2 F7): github.base_ref exists only on pull_request; on push the
+      # checkout IS the pushed tip, so a ref baseline degenerates to comparing
+      # HEAD with itself — github.event.before is the pre-push sha instead,
+      # passed as --base-sha (EXACT, no merge-base reduction: on a
+      # non-fast-forward push the merge-base walks past the pre-push tip and
+      # hides a downgrade; all-zeros on branch creation passes explicitly).
+      # fetch-depth 0 above is load-bearing here too.
       - name: Check plugin.json version bump on content changes (#644)
-        run: node scripts/check-plugin-version-bump.mjs --project "$GITHUB_WORKSPACE" --base-ref "${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}"
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            node scripts/check-plugin-version-bump.mjs --project "$GITHUB_WORKSPACE" --base-ref "origin/${{ github.base_ref }}"
+          else
+            node scripts/check-plugin-version-bump.mjs --project "$GITHUB_WORKSPACE" --base-sha "${{ github.event.before }}"
+          fi
 
       - name: Run plugin version-bump gate suite (#644)
         run: node tests/test-plugin-version-bump.mjs

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -153,3 +153,13 @@ jobs:
 
       - name: Run pattern-health CI gate suite (RFC-009 R5b, P3-S4)
         run: node tests/test-pattern-health-check-gate.mjs
+
+      # #644: claude plugin update is version-gated on plugin.json, so a merge
+      # that changes plugin content without a bump makes the update a permanent
+      # no-op. Diffs against the merge-base (fetch-depth 0 above is load-bearing
+      # here too) and fails when content changed without a semver advance.
+      - name: Check plugin.json version bump on content changes (#644)
+        run: node scripts/check-plugin-version-bump.mjs --base-ref origin/${{ github.base_ref || 'main' }}
+
+      - name: Run plugin version-bump gate suite (#644)
+        run: node tests/test-plugin-version-bump.mjs

--- a/scripts/check-plugin-version-bump.mjs
+++ b/scripts/check-plugin-version-bump.mjs
@@ -55,6 +55,7 @@ export const CONTENT_PREFIXES = [
   'instructions/',
   'patterns/',
   'schemas/', // runtime data of installed libs, e.g. structured-alert.mjs reads schemas/runtime/ (codex R2 F9)
+  'learning/', // live registry descriptors — plugins/_index.json points at learning/*.json (codex R3 F13)
   'install.mjs',
   'categories.json',
   'activation-classes.json',
@@ -135,6 +136,13 @@ export function parseArgs(argv) {
     i++
   }
   if ('--base-ref' in opts && '--base-sha' in opts) return { error: '--base-ref and --base-sha are mutually exclusive' }
+  // --base-sha is an IMMUTABLE baseline: full 40-hex object names only.
+  // HEAD, branch names, abbreviations, and revision expressions would let the
+  // baseline float — --base-sha HEAD self-compares to an empty diff (codex R3
+  // F12). Mutable baselines belong to --base-ref's merge-base semantics.
+  if ('--base-sha' in opts && !/^[0-9a-f]{40}$/.test(opts['--base-sha'])) {
+    return { error: `--base-sha must be a full 40-hex commit sha, got ${JSON.stringify(opts['--base-sha'])}` }
+  }
   return { opts }
 }
 
@@ -153,7 +161,14 @@ function main() {
   } catch (err) {
     fail({ reason: `cannot resolve --project: ${err.message}` })
   }
-  const git = (args) => execFileSync('git', args, { cwd: projectRoot, encoding: 'utf8' })
+  // Sanitized environment: inherited repository-selection variables (GIT_DIR,
+  // GIT_WORK_TREE, …) override cwd and would silently rebind every read to a
+  // different repository while the JSON still names projectRoot (codex R3 F11).
+  const gitEnv = { ...process.env }
+  for (const k of ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_ALTERNATE_OBJECT_DIRECTORIES', 'GIT_NAMESPACE', 'GIT_INDEX_FILE']) {
+    delete gitEnv[k]
+  }
+  const git = (args) => execFileSync('git', args, { cwd: projectRoot, encoding: 'utf8', env: gitEnv })
 
   if (baseSha !== undefined && ZERO_SHA.test(baseSha)) {
     // push event with no previous tip (branch creation): nothing to diff against.

--- a/scripts/check-plugin-version-bump.mjs
+++ b/scripts/check-plugin-version-bump.mjs
@@ -11,12 +11,15 @@
 // install-surface path changed, .claude-plugin/plugin.json must carry a
 // strictly greater semver than the merge-base copy.
 //
-// Baseline is event-specific (codex R1 F1): github.base_ref exists only on
-// pull_request events; on push the checkout IS the pushed tip, so a ref
-// baseline degenerates to merge-base(HEAD, HEAD) and the gate sees an empty
-// diff. Callers pass an immutable pre-change baseline instead — the PR base
-// ref on pull_request, github.event.before on push. The all-zeros before-sha
-// (branch creation) is the one case with no baseline and passes explicitly.
+// Baseline is event-specific (codex R1 F1, R2 F7): github.base_ref exists
+// only on pull_request events; on push the checkout IS the pushed tip, so a
+// ref baseline degenerates to merge-base(HEAD, HEAD) and the gate sees an
+// empty diff. PRs pass --base-ref (merge-base semantics against the target
+// branch); pushes pass --base-sha github.event.before, which is EXACT — no
+// merge-base reduction, because on a non-fast-forward push the merge-base
+// walks past the pre-push tip and hides a version downgrade. The all-zeros
+// before-sha (branch creation) is the one case with no baseline and passes
+// explicitly.
 //
 // Content paths are the plugin's install surface, not the whole repo: docs,
 // tests, and workflow edits change the marketplace clone's sha but not the
@@ -27,7 +30,7 @@
 // locked by tests/test-plugin-version-bump.mjs's conformance axis against the
 // install-version.mjs artifact enumerator.
 //
-// Usage: node scripts/check-plugin-version-bump.mjs [--project <path>] [--base-ref <ref|sha>]
+// Usage: node scripts/check-plugin-version-bump.mjs [--project <path>] [--base-ref <ref> | --base-sha <sha>]
 // Output: exactly one JSON report on stdout in every reachable outcome; exit 1
 // when a required bump is missing or the comparison cannot be made (fail
 // closed, matching the validate-bp-contract stable-ID precedent).
@@ -51,6 +54,7 @@ export const CONTENT_PREFIXES = [
   'plugins/',
   'instructions/',
   'patterns/',
+  'schemas/', // runtime data of installed libs, e.g. structured-alert.mjs reads schemas/runtime/ (codex R2 F9)
   'install.mjs',
   'categories.json',
   'activation-classes.json',
@@ -116,48 +120,79 @@ function fail(report) {
   process.exit(1)
 }
 
-function main() {
-  const argv = process.argv.slice(2)
-  const flag = (name, dflt) => {
-    const i = argv.indexOf(name)
-    return i !== -1 ? argv[i + 1] : dflt
+// Strict fail-closed parser (codex R2 F10): known value-flags only — no
+// unknown flags, positionals, duplicates, or missing values.
+export function parseArgs(argv) {
+  const KNOWN = new Set(['--project', '--base-ref', '--base-sha'])
+  const opts = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (!KNOWN.has(a)) return { error: `unknown argument ${JSON.stringify(a)}; expected --project/--base-ref/--base-sha` }
+    if (a in opts) return { error: `duplicate flag ${a}` }
+    const v = argv[i + 1]
+    if (v === undefined || v.startsWith('--')) return { error: `flag ${a} requires a value` }
+    opts[a] = v
+    i++
   }
-  const baseRef = flag('--base-ref', 'origin/main')
+  if ('--base-ref' in opts && '--base-sha' in opts) return { error: '--base-ref and --base-sha are mutually exclusive' }
+  return { opts }
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2))
+  if (parsed.error) fail({ reason: parsed.error })
+  const opts = parsed.opts
+  const baseSha = opts['--base-sha']
+  const baseRef = opts['--base-ref'] ?? (baseSha === undefined ? 'origin/main' : undefined)
 
   // One explicit project root; every git call binds to it and the report
   // names it (codex R1 F2 — no ambient-cwd authority).
   let projectRoot
   try {
-    projectRoot = fs.realpathSync(path.resolve(flag('--project', '.')))
+    projectRoot = fs.realpathSync(path.resolve(opts['--project'] ?? '.'))
   } catch (err) {
     fail({ reason: `cannot resolve --project: ${err.message}` })
   }
   const git = (args) => execFileSync('git', args, { cwd: projectRoot, encoding: 'utf8' })
 
-  if (ZERO_SHA.test(baseRef)) {
+  if (baseSha !== undefined && ZERO_SHA.test(baseSha)) {
     // push event with no previous tip (branch creation): nothing to diff against.
     console.log(JSON.stringify({
-      status: 'ok', project_root: projectRoot, base_ref: baseRef, ok: true,
+      status: 'ok', project_root: projectRoot, base_sha: baseSha, ok: true,
       bump_required: false, content_paths: [], reason: 'no pre-push baseline (all-zeros before sha)',
     }, null, 2))
     return
   }
 
-  let mergeBase
-  try {
-    mergeBase = git(['merge-base', 'HEAD', baseRef]).trim()
-  } catch (err) {
-    // Fail closed: shallow clone or missing baseline means the gate cannot run.
-    fail({ project_root: projectRoot, reason: `merge-base with ${baseRef} failed: ${err.message}` })
+  // Baseline commit: --base-sha is EXACT (codex R2 F7 — merge-base reduction
+  // hides non-fast-forward downgrades); --base-ref keeps merge-base semantics
+  // for PR branches that are behind their target.
+  let baseline
+  if (baseSha !== undefined) {
+    try {
+      baseline = git(['rev-parse', '--verify', `${baseSha}^{commit}`]).trim()
+    } catch (err) {
+      // Fail closed: an unreachable pre-push sha means the gate cannot run.
+      fail({ project_root: projectRoot, reason: `--base-sha ${baseSha} does not resolve to a commit: ${err.message}` })
+    }
+  } else {
+    try {
+      baseline = git(['merge-base', 'HEAD', baseRef]).trim()
+    } catch (err) {
+      // Fail closed: shallow clone or missing baseline means the gate cannot run.
+      fail({ project_root: projectRoot, reason: `merge-base with ${baseRef} failed: ${err.message}` })
+    }
   }
 
   let changedPaths
   try {
     // -z: NUL-delimited raw paths — core.quotePath octal-escapes non-ASCII in
-    // newline mode and breaks prefix matching (codex R1 F5).
-    changedPaths = git(['diff', '--name-only', '-z', mergeBase, 'HEAD']).split('\0').filter(Boolean)
+    // newline mode and breaks prefix matching (codex R1 F5). --no-renames:
+    // rename detection would report only the destination endpoint, hiding a
+    // content-path source that moved out of the surface (codex R2 F8).
+    changedPaths = git(['diff', '--no-renames', '--name-only', '-z', baseline, 'HEAD']).split('\0').filter(Boolean)
   } catch (err) {
-    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `git diff failed: ${err.message}` })
+    fail({ project_root: projectRoot, baseline, reason: `git diff failed: ${err.message}` })
   }
 
   // Base manifest state: 'absent' only on a PROVEN missing path (empty
@@ -165,35 +200,35 @@ function main() {
   // decideBump — corruption is never "first introduction" (codex R1 F4).
   let base
   try {
-    const entry = git(['ls-tree', '--name-only', mergeBase, '--', MANIFEST]).trim()
+    const entry = git(['ls-tree', '--name-only', baseline, '--', MANIFEST]).trim()
     if (entry === '') {
       base = { state: 'absent' }
     } else {
       let version
       try {
-        version = JSON.parse(git(['show', `${mergeBase}:${MANIFEST}`])).version
+        version = JSON.parse(git(['show', `${baseline}:${MANIFEST}`])).version
       } catch (err) {
         version = `<unreadable: ${err.message.split('\n')[0]}>`
       }
       base = { state: 'present', version }
     }
   } catch (err) {
-    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `reading base ${MANIFEST} state failed: ${err.message}` })
+    fail({ project_root: projectRoot, baseline, reason: `reading base ${MANIFEST} state failed: ${err.message}` })
   }
 
   let headVersion
   try {
     headVersion = JSON.parse(git(['show', `HEAD:${MANIFEST}`])).version
   } catch (err) {
-    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `cannot read HEAD ${MANIFEST}: ${err.message}` })
+    fail({ project_root: projectRoot, baseline, reason: `cannot read HEAD ${MANIFEST}: ${err.message}` })
   }
 
   const verdict = decideBump({ changedPaths, base, headVersion })
   console.log(JSON.stringify({
     status: 'ok',
     project_root: projectRoot,
-    base_ref: baseRef,
-    merge_base: mergeBase,
+    ...(baseSha !== undefined ? { base_sha: baseSha } : { base_ref: baseRef }),
+    baseline,
     base_manifest: base,
     head_version: headVersion,
     ...verdict,

--- a/scripts/check-plugin-version-bump.mjs
+++ b/scripts/check-plugin-version-bump.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// check-plugin-version-bump.mjs — CI gate for #644.
+//
+// `claude plugin update` is version-gated on .claude-plugin/plugin.json, so a
+// merge that changes plugin content without bumping the version makes the
+// update a permanent no-op: the installed cache silently pins the old commit
+// until a manual uninstall+reinstall (observed: cache sat at 97a4309 while
+// main advanced to 6964ea0).
+//
+// This gate compares HEAD against the merge-base with the base ref. If any
+// plugin-content path changed, .claude-plugin/plugin.json must carry a
+// strictly greater semver than the merge-base copy.
+//
+// Content paths are the plugin's install surface, not the whole repo: docs,
+// tests, and workflow edits change the marketplace clone's sha but not the
+// behavior an installed plugin executes, and requiring a bump for those would
+// be pure churn.
+//
+// Usage: node scripts/check-plugin-version-bump.mjs [--base-ref origin/main]
+// Output: one JSON report on stdout; exit 1 when a required bump is missing
+// (or the comparison cannot be made — fail closed, matching the
+// validate-bp-contract stable-ID precedent).
+
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const MANIFEST = '.claude-plugin/plugin.json'
+
+// The install surface: what an installed plugin actually executes or exposes.
+export const CONTENT_PREFIXES = [
+  '.claude-plugin/',
+  'scripts/',
+  'skills/',
+  'plugins/',
+  'instructions/',
+  'install.mjs',
+]
+
+export function parseSemver(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(v ?? ''))
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
+export function semverGreater(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i]
+  }
+  return false
+}
+
+// Pure decision core (unit-tested in tests/test-plugin-version-bump.mjs).
+export function decideBump({ changedPaths, baseVersion, headVersion }) {
+  const content = changedPaths.filter((p) =>
+    CONTENT_PREFIXES.some((pre) => (pre.endsWith('/') ? p.startsWith(pre) : p === pre))
+  )
+  if (content.length === 0) {
+    return { ok: true, bump_required: false, content_paths: [], reason: 'no plugin-content changes' }
+  }
+  const head = parseSemver(headVersion)
+  if (!head) {
+    return {
+      ok: false, bump_required: true, content_paths: content,
+      reason: `head ${MANIFEST} version ${JSON.stringify(headVersion)} is not plain X.Y.Z semver`,
+    }
+  }
+  // No manifest at the merge-base (first introduction): any valid version passes.
+  const base = parseSemver(baseVersion)
+  if (baseVersion == null) {
+    return { ok: true, bump_required: true, content_paths: content, reason: 'manifest introduced in this change' }
+  }
+  if (!base) {
+    return {
+      ok: false, bump_required: true, content_paths: content,
+      reason: `merge-base ${MANIFEST} version ${JSON.stringify(baseVersion)} is not plain X.Y.Z semver; cannot prove a bump`,
+    }
+  }
+  if (!semverGreater(head, base)) {
+    return {
+      ok: false, bump_required: true, content_paths: content,
+      reason: `plugin content changed but version did not advance (${baseVersion} -> ${headVersion}); claude plugin update will no-op (#644)`,
+    }
+  }
+  return { ok: true, bump_required: true, content_paths: content, reason: `version advanced ${baseVersion} -> ${headVersion}` }
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+}
+
+function main() {
+  const argv = process.argv.slice(2)
+  const baseRefIdx = argv.indexOf('--base-ref')
+  const baseRef = baseRefIdx !== -1 ? argv[baseRefIdx + 1] : 'origin/main'
+
+  let mergeBase
+  try {
+    mergeBase = git(['merge-base', 'HEAD', baseRef])
+  } catch (err) {
+    // Fail closed: shallow clone or missing ref means the gate cannot run.
+    console.log(JSON.stringify({ status: 'error', ok: false, reason: `merge-base with ${baseRef} failed: ${err.message}` }))
+    process.exit(1)
+  }
+
+  const changedPaths = git(['diff', '--name-only', mergeBase, 'HEAD']).split('\n').filter(Boolean)
+
+  let baseVersion = null
+  try {
+    baseVersion = JSON.parse(git(['show', `${mergeBase}:${MANIFEST}`])).version
+  } catch {
+    baseVersion = null // manifest absent at merge-base
+  }
+  let headVersion
+  try {
+    headVersion = JSON.parse(git(['show', `HEAD:${MANIFEST}`])).version
+  } catch (err) {
+    console.log(JSON.stringify({ status: 'error', ok: false, reason: `cannot read HEAD ${MANIFEST}: ${err.message}` }))
+    process.exit(1)
+  }
+
+  const verdict = decideBump({ changedPaths, baseVersion, headVersion })
+  console.log(JSON.stringify({
+    status: 'ok',
+    merge_base: mergeBase,
+    base_version: baseVersion,
+    head_version: headVersion,
+    ...verdict,
+  }, null, 2))
+  process.exit(verdict.ok ? 0 : 1)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main()

--- a/scripts/check-plugin-version-bump.mjs
+++ b/scripts/check-plugin-version-bump.mjs
@@ -7,39 +7,66 @@
 // until a manual uninstall+reinstall (observed: cache sat at 97a4309 while
 // main advanced to 6964ea0).
 //
-// This gate compares HEAD against the merge-base with the base ref. If any
-// plugin-content path changed, .claude-plugin/plugin.json must carry a
+// This gate compares HEAD against the merge-base with the baseline. If any
+// install-surface path changed, .claude-plugin/plugin.json must carry a
 // strictly greater semver than the merge-base copy.
+//
+// Baseline is event-specific (codex R1 F1): github.base_ref exists only on
+// pull_request events; on push the checkout IS the pushed tip, so a ref
+// baseline degenerates to merge-base(HEAD, HEAD) and the gate sees an empty
+// diff. Callers pass an immutable pre-change baseline instead — the PR base
+// ref on pull_request, github.event.before on push. The all-zeros before-sha
+// (branch creation) is the one case with no baseline and passes explicitly.
 //
 // Content paths are the plugin's install surface, not the whole repo: docs,
 // tests, and workflow edits change the marketplace clone's sha but not the
 // behavior an installed plugin executes, and requiring a bump for those would
-// be pure churn.
+// be pure churn. The set errs over-inclusive (all of scripts/ forces a bump
+// even though repo-dev scripts ship nowhere — install-manifest.mjs P12
+// classes) because over-inclusion is the safe direction; under-inclusion is
+// locked by tests/test-plugin-version-bump.mjs's conformance axis against the
+// install-version.mjs artifact enumerator.
 //
-// Usage: node scripts/check-plugin-version-bump.mjs [--base-ref origin/main]
-// Output: one JSON report on stdout; exit 1 when a required bump is missing
-// (or the comparison cannot be made — fail closed, matching the
-// validate-bp-contract stable-ID precedent).
+// Usage: node scripts/check-plugin-version-bump.mjs [--project <path>] [--base-ref <ref|sha>]
+// Output: exactly one JSON report on stdout in every reachable outcome; exit 1
+// when a required bump is missing or the comparison cannot be made (fail
+// closed, matching the validate-bp-contract stable-ID precedent).
 
 import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const MANIFEST = '.claude-plugin/plugin.json'
+const ZERO_SHA = /^0{40}$/
 
-// The install surface: what an installed plugin actually executes or exposes.
+// The install surface: what an installed plugin or substrate deploy actually
+// executes or reads. Directory entries end with '/'; anything else is an
+// exact-file entry. Under-inclusion drift is caught by the conformance test.
 export const CONTENT_PREFIXES = [
   '.claude-plugin/',
+  '.claude/', // tracked hook shells, agents, skill links — per-project artifact sources
   'scripts/',
   'skills/',
   'plugins/',
   'instructions/',
+  'patterns/',
   'install.mjs',
+  'categories.json',
+  'activation-classes.json',
+  'docs/EM_SCRIPTS_GUIDE.md',
 ]
 
+export function isContentPath(p) {
+  return CONTENT_PREFIXES.some((pre) => (pre.endsWith('/') ? p.startsWith(pre) : p === pre))
+}
+
+// Strict plain X.Y.Z: numeric identifiers without leading zeros (codex R1 F6).
+// BigInt components so ordering never loses precision.
 export function parseSemver(v) {
-  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(v ?? ''))
+  const m = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.exec(String(v ?? ''))
   if (!m) return null
-  return [Number(m[1]), Number(m[2]), Number(m[3])]
+  return [BigInt(m[1]), BigInt(m[2]), BigInt(m[3])]
 }
 
 export function semverGreater(a, b) {
@@ -50,10 +77,11 @@ export function semverGreater(a, b) {
 }
 
 // Pure decision core (unit-tested in tests/test-plugin-version-bump.mjs).
-export function decideBump({ changedPaths, baseVersion, headVersion }) {
-  const content = changedPaths.filter((p) =>
-    CONTENT_PREFIXES.some((pre) => (pre.endsWith('/') ? p.startsWith(pre) : p === pre))
-  )
+// `base` is an explicit state, never a bare nullable (codex R1 F4):
+//   { state: 'absent' }                — manifest path proven missing at base
+//   { state: 'present', version: any } — manifest exists; version may be junk
+export function decideBump({ changedPaths, base, headVersion }) {
+  const content = changedPaths.filter(isContentPath)
   if (content.length === 0) {
     return { ok: true, bump_required: false, content_paths: [], reason: 'no plugin-content changes' }
   }
@@ -64,65 +92,109 @@ export function decideBump({ changedPaths, baseVersion, headVersion }) {
       reason: `head ${MANIFEST} version ${JSON.stringify(headVersion)} is not plain X.Y.Z semver`,
     }
   }
-  // No manifest at the merge-base (first introduction): any valid version passes.
-  const base = parseSemver(baseVersion)
-  if (baseVersion == null) {
+  if (base.state === 'absent') {
     return { ok: true, bump_required: true, content_paths: content, reason: 'manifest introduced in this change' }
   }
-  if (!base) {
+  const baseParsed = parseSemver(base.version)
+  if (!baseParsed) {
     return {
       ok: false, bump_required: true, content_paths: content,
-      reason: `merge-base ${MANIFEST} version ${JSON.stringify(baseVersion)} is not plain X.Y.Z semver; cannot prove a bump`,
+      reason: `base ${MANIFEST} exists but its version ${JSON.stringify(base.version)} is not plain X.Y.Z semver; cannot prove a bump — fail closed`,
     }
   }
-  if (!semverGreater(head, base)) {
+  if (!semverGreater(head, baseParsed)) {
     return {
       ok: false, bump_required: true, content_paths: content,
-      reason: `plugin content changed but version did not advance (${baseVersion} -> ${headVersion}); claude plugin update will no-op (#644)`,
+      reason: `plugin content changed but version did not advance (${base.version} -> ${headVersion}); claude plugin update will no-op (#644)`,
     }
   }
-  return { ok: true, bump_required: true, content_paths: content, reason: `version advanced ${baseVersion} -> ${headVersion}` }
+  return { ok: true, bump_required: true, content_paths: content, reason: `version advanced ${base.version} -> ${headVersion}` }
 }
 
-function git(args) {
-  return execFileSync('git', args, { encoding: 'utf8' }).trim()
+function fail(report) {
+  console.log(JSON.stringify({ status: 'error', ok: false, ...report }))
+  process.exit(1)
 }
 
 function main() {
   const argv = process.argv.slice(2)
-  const baseRefIdx = argv.indexOf('--base-ref')
-  const baseRef = baseRefIdx !== -1 ? argv[baseRefIdx + 1] : 'origin/main'
+  const flag = (name, dflt) => {
+    const i = argv.indexOf(name)
+    return i !== -1 ? argv[i + 1] : dflt
+  }
+  const baseRef = flag('--base-ref', 'origin/main')
+
+  // One explicit project root; every git call binds to it and the report
+  // names it (codex R1 F2 — no ambient-cwd authority).
+  let projectRoot
+  try {
+    projectRoot = fs.realpathSync(path.resolve(flag('--project', '.')))
+  } catch (err) {
+    fail({ reason: `cannot resolve --project: ${err.message}` })
+  }
+  const git = (args) => execFileSync('git', args, { cwd: projectRoot, encoding: 'utf8' })
+
+  if (ZERO_SHA.test(baseRef)) {
+    // push event with no previous tip (branch creation): nothing to diff against.
+    console.log(JSON.stringify({
+      status: 'ok', project_root: projectRoot, base_ref: baseRef, ok: true,
+      bump_required: false, content_paths: [], reason: 'no pre-push baseline (all-zeros before sha)',
+    }, null, 2))
+    return
+  }
 
   let mergeBase
   try {
-    mergeBase = git(['merge-base', 'HEAD', baseRef])
+    mergeBase = git(['merge-base', 'HEAD', baseRef]).trim()
   } catch (err) {
-    // Fail closed: shallow clone or missing ref means the gate cannot run.
-    console.log(JSON.stringify({ status: 'error', ok: false, reason: `merge-base with ${baseRef} failed: ${err.message}` }))
-    process.exit(1)
+    // Fail closed: shallow clone or missing baseline means the gate cannot run.
+    fail({ project_root: projectRoot, reason: `merge-base with ${baseRef} failed: ${err.message}` })
   }
 
-  const changedPaths = git(['diff', '--name-only', mergeBase, 'HEAD']).split('\n').filter(Boolean)
-
-  let baseVersion = null
+  let changedPaths
   try {
-    baseVersion = JSON.parse(git(['show', `${mergeBase}:${MANIFEST}`])).version
-  } catch {
-    baseVersion = null // manifest absent at merge-base
+    // -z: NUL-delimited raw paths — core.quotePath octal-escapes non-ASCII in
+    // newline mode and breaks prefix matching (codex R1 F5).
+    changedPaths = git(['diff', '--name-only', '-z', mergeBase, 'HEAD']).split('\0').filter(Boolean)
+  } catch (err) {
+    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `git diff failed: ${err.message}` })
   }
+
+  // Base manifest state: 'absent' only on a PROVEN missing path (empty
+  // ls-tree). A manifest that exists but does not parse fails closed in
+  // decideBump — corruption is never "first introduction" (codex R1 F4).
+  let base
+  try {
+    const entry = git(['ls-tree', '--name-only', mergeBase, '--', MANIFEST]).trim()
+    if (entry === '') {
+      base = { state: 'absent' }
+    } else {
+      let version
+      try {
+        version = JSON.parse(git(['show', `${mergeBase}:${MANIFEST}`])).version
+      } catch (err) {
+        version = `<unreadable: ${err.message.split('\n')[0]}>`
+      }
+      base = { state: 'present', version }
+    }
+  } catch (err) {
+    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `reading base ${MANIFEST} state failed: ${err.message}` })
+  }
+
   let headVersion
   try {
     headVersion = JSON.parse(git(['show', `HEAD:${MANIFEST}`])).version
   } catch (err) {
-    console.log(JSON.stringify({ status: 'error', ok: false, reason: `cannot read HEAD ${MANIFEST}: ${err.message}` }))
-    process.exit(1)
+    fail({ project_root: projectRoot, merge_base: mergeBase, reason: `cannot read HEAD ${MANIFEST}: ${err.message}` })
   }
 
-  const verdict = decideBump({ changedPaths, baseVersion, headVersion })
+  const verdict = decideBump({ changedPaths, base, headVersion })
   console.log(JSON.stringify({
     status: 'ok',
+    project_root: projectRoot,
+    base_ref: baseRef,
     merge_base: mergeBase,
-    base_version: baseVersion,
+    base_manifest: base,
     head_version: headVersion,
     ...verdict,
   }, null, 2))

--- a/tests/test-plugin-version-bump.mjs
+++ b/tests/test-plugin-version-bump.mjs
@@ -15,7 +15,7 @@ import path from 'node:path'
 import { execFileSync, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { decideBump, isContentPath, parseSemver, semverGreater } from '../scripts/check-plugin-version-bump.mjs'
+import { decideBump, isContentPath, parseArgs, parseSemver, semverGreater } from '../scripts/check-plugin-version-bump.mjs'
 import { perProjectArtifactPairs } from '../scripts/lib/install-version.mjs'
 
 const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
@@ -69,8 +69,18 @@ const present = (v) => ({ state: 'present', version: v })
   assert(r.ok === true && r.bump_required === false, 'exact-file entry does not prefix-match siblings', r.reason)
 }
 {
-  // codex R1 F3: the runtime data surface is content.
-  for (const p of ['patterns/taxonomy.json', 'categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md', '.claude/hooks/bp1-approval-check.sh']) {
+  // codex R2 F10: strict fail-closed argv contract.
+  assert(parseArgs([]).opts !== undefined, 'parseArgs: empty argv ok')
+  assert(parseArgs(['--base-reff', 'main']).error !== undefined, 'parseArgs: unknown flag rejected')
+  assert(parseArgs(['main']).error !== undefined, 'parseArgs: positional rejected')
+  assert(parseArgs(['--base-ref']).error !== undefined, 'parseArgs: missing value rejected')
+  assert(parseArgs(['--base-ref', 'a', '--base-ref', 'b']).error !== undefined, 'parseArgs: duplicate flag rejected')
+  assert(parseArgs(['--base-ref', 'a', '--base-sha', 'b']).error !== undefined, 'parseArgs: base-ref + base-sha mutually exclusive')
+  assert(parseArgs(['--project', '.', '--base-sha', 'abc']).opts !== undefined, 'parseArgs: valid combination ok')
+}
+{
+  // codex R1 F3 + R2 F9: the runtime data surface is content.
+  for (const p of ['patterns/taxonomy.json', 'categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md', '.claude/hooks/bp1-approval-check.sh', 'schemas/runtime/structured-alert.schema.json']) {
     const r = decideBump({ changedPaths: [p], base: present('0.1.0'), headVersion: '0.1.0' })
     assert(r.ok === false, `runtime surface path requires bump: ${p}`, r.reason)
   }
@@ -175,10 +185,55 @@ function runGate(cwd, ...extra) {
   fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
   git(repo, 'commit', '-aqm', 'pushed content change, no bump')
   git(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD') // ref now useless as baseline
-  const r = runGate(repo, '--base-ref', beforeSha)
+  const r = runGate(repo, '--base-sha', beforeSha)
   assert(r.status === 1 && r.json?.ok === false, 'E2E push baseline: explicit before-sha catches missing bump', JSON.stringify(r.json))
-  const zero = runGate(repo, '--base-ref', '0'.repeat(40))
+  const zero = runGate(repo, '--base-sha', '0'.repeat(40))
   assert(zero.status === 0 && zero.json?.ok === true, 'E2E push baseline: all-zeros before sha (branch creation) passes', JSON.stringify(zero.json))
+}
+{
+  // codex R2 F7: non-fast-forward push. Ancestor A (1.0.0) -> pre-push tip B
+  // (5.0.0); force-pushed HEAD H based on A carries 2.0.0. --base-sha B must
+  // treat B as the exact baseline and fail the 5.0.0 -> 2.0.0 downgrade;
+  // merge-base reduction would compare against A and false-accept.
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '1.0.0' }))
+  git(repo, 'commit', '-aqm', 'A: 1.0.0')
+  const shaA = git(repo, 'rev-parse', 'HEAD')
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '5.0.0' }))
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// B\n')
+  git(repo, 'commit', '-aqm', 'B: 5.0.0')
+  const shaB = git(repo, 'rev-parse', 'HEAD')
+  git(repo, 'checkout', '-q', shaA)
+  git(repo, 'checkout', '-qb', 'rewrite')
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '2.0.0' }))
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// H\n')
+  git(repo, 'commit', '-aqm', 'H: 2.0.0 (force-push shape)')
+  const r = runGate(repo, '--base-sha', shaB)
+  assert(r.status === 1 && r.json?.ok === false && r.json?.baseline === shaB,
+    'E2E non-fast-forward push: exact base-sha catches the downgrade merge-base would hide', JSON.stringify(r.json))
+}
+{
+  // codex R2 F8: rename out of the surface must still gate (the source
+  // endpoint is removed installed content). And into the surface likewise.
+  const repo = mkRepo()
+  git(repo, 'mv', 'scripts/a.mjs', 'docs/a.mjs')
+  git(repo, 'commit', '-qm', 'rename runtime -> excluded')
+  const out = runGate(repo)
+  assert(out.status === 1 && out.json?.content_paths?.includes('scripts/a.mjs'),
+    'E2E rename runtime->excluded: source endpoint still gates', JSON.stringify(out.json))
+
+  const repo2 = mkRepo()
+  git(repo2, 'mv', 'docs/readme.md', 'scripts/readme.md')
+  git(repo2, 'commit', '-qm', 'rename excluded -> runtime')
+  const into = runGate(repo2)
+  assert(into.status === 1 && into.json?.content_paths?.includes('scripts/readme.md'),
+    'E2E rename excluded->runtime: destination endpoint gates', JSON.stringify(into.json))
+}
+{
+  // codex R2 F10 E2E: unknown flag fails closed with one JSON error.
+  const repo = mkRepo()
+  const r = runGate(repo, '--base-reff', 'main')
+  assert(r.status === 1 && r.json?.status === 'error', 'E2E unknown flag: JSON error, fail closed', JSON.stringify(r.json ?? r.stdout))
 }
 {
   // codex R1 F2: --project binds authority; ambient cwd must not.

--- a/tests/test-plugin-version-bump.mjs
+++ b/tests/test-plugin-version-bump.mjs
@@ -75,12 +75,17 @@ const present = (v) => ({ state: 'present', version: v })
   assert(parseArgs(['main']).error !== undefined, 'parseArgs: positional rejected')
   assert(parseArgs(['--base-ref']).error !== undefined, 'parseArgs: missing value rejected')
   assert(parseArgs(['--base-ref', 'a', '--base-ref', 'b']).error !== undefined, 'parseArgs: duplicate flag rejected')
-  assert(parseArgs(['--base-ref', 'a', '--base-sha', 'b']).error !== undefined, 'parseArgs: base-ref + base-sha mutually exclusive')
-  assert(parseArgs(['--project', '.', '--base-sha', 'abc']).opts !== undefined, 'parseArgs: valid combination ok')
+  assert(parseArgs(['--base-ref', 'a', '--base-sha', 'b'.repeat(40)]).error !== undefined, 'parseArgs: base-ref + base-sha mutually exclusive')
+  // codex R3 F12: --base-sha must be an immutable full object name.
+  for (const bad of ['HEAD', 'main', 'abc123', 'HEAD~1', 'a'.repeat(39), 'A'.repeat(40)]) {
+    assert(parseArgs(['--base-sha', bad]).error !== undefined, `parseArgs: mutable/abbreviated --base-sha rejected: ${bad}`)
+  }
+  assert(parseArgs(['--project', '.', '--base-sha', 'a1b2c3d4'.repeat(5)]).opts !== undefined, 'parseArgs: full 40-hex sha ok')
+  assert(parseArgs(['--base-sha', '0'.repeat(40)]).opts !== undefined, 'parseArgs: forty-zero sha ok (branch creation)')
 }
 {
   // codex R1 F3 + R2 F9: the runtime data surface is content.
-  for (const p of ['patterns/taxonomy.json', 'categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md', '.claude/hooks/bp1-approval-check.sh', 'schemas/runtime/structured-alert.schema.json']) {
+  for (const p of ['patterns/taxonomy.json', 'categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md', '.claude/hooks/bp1-approval-check.sh', 'schemas/runtime/structured-alert.schema.json', 'learning/em-promote.json']) {
     const r = decideBump({ changedPaths: [p], base: present('0.1.0'), headVersion: '0.1.0' })
     assert(r.ok === false, `runtime surface path requires bump: ${p}`, r.reason)
   }
@@ -234,6 +239,35 @@ function runGate(cwd, ...extra) {
   const repo = mkRepo()
   const r = runGate(repo, '--base-reff', 'main')
   assert(r.status === 1 && r.json?.status === 'error', 'E2E unknown flag: JSON error, fail closed', JSON.stringify(r.json ?? r.stdout))
+}
+{
+  // codex R3 F12 E2E: --base-sha HEAD would self-compare to an empty diff.
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'change script')
+  const r = runGate(repo, '--base-sha', 'HEAD')
+  assert(r.status === 1 && r.json?.status === 'error', 'E2E --base-sha HEAD: rejected, no self-compare', JSON.stringify(r.json ?? r.stdout))
+}
+{
+  // codex R3 F11 E2E: inherited GIT_DIR/GIT_WORK_TREE must not rebind the
+  // gate's reads to a decoy repository (--base-ref and --base-sha shapes).
+  const target = mkRepo()
+  const beforeSha = git(target, 'rev-parse', 'HEAD')
+  fs.writeFileSync(path.join(target, 'scripts/a.mjs'), '// v2\n')
+  git(target, 'commit', '-aqm', 'content change, no bump')
+  const decoy = mkRepo() // clean: no delta vs its origin/main
+  const poisoned = {
+    ...process.env,
+    GIT_DIR: path.join(decoy, '.git'),
+    GIT_WORK_TREE: decoy,
+  }
+  for (const extra of [[], ['--base-sha', beforeSha]]) {
+    const r = spawnSync(process.execPath, [GATE, '--project', target, ...extra], { cwd: decoy, encoding: 'utf8', env: poisoned })
+    let json = null
+    try { json = JSON.parse(r.stdout) } catch {}
+    assert(r.status === 1 && json?.ok === false && json?.project_root === target,
+      `E2E poisoned GIT_DIR/GIT_WORK_TREE (${extra[0] ?? '--base-ref default'}): reads stay bound to --project`, JSON.stringify(json))
+  }
 }
 {
   // codex R1 F2: --project binds authority; ambient cwd must not.

--- a/tests/test-plugin-version-bump.mjs
+++ b/tests/test-plugin-version-bump.mjs
@@ -2,10 +2,12 @@
 /**
  * test-plugin-version-bump.mjs - #644: the plugin version-bump CI gate.
  *
- * Unit-tests the pure decideBump() core, then drives the REAL
- * scripts/check-plugin-version-bump.mjs against an isolated fixture git repo
- * OUTSIDE the checkout (red-then-green): content change without a bump must
- * exit 1, with a bump exit 0, docs-only change exits 0 with no bump.
+ * Unit-tests the pure decideBump() core, locks CONTENT_PREFIXES against the
+ * install-version.mjs artifact enumerator (the installed-surface oracle —
+ * codex R1 F3), then drives the REAL scripts/check-plugin-version-bump.mjs
+ * against isolated fixture git repos OUTSIDE the checkout, covering the
+ * codex R1 fail-open axes: push-tip self-compare, ambient-cwd authority,
+ * corrupt-base-as-introduction, quoted pathnames, lax semver.
  */
 import fs from 'node:fs'
 import os from 'node:os'
@@ -13,7 +15,8 @@ import path from 'node:path'
 import { execFileSync, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { decideBump, parseSemver, semverGreater } from '../scripts/check-plugin-version-bump.mjs'
+import { decideBump, isContentPath, parseSemver, semverGreater } from '../scripts/check-plugin-version-bump.mjs'
+import { perProjectArtifactPairs } from '../scripts/lib/install-version.mjs'
 
 const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
 const GATE = path.join(REPO_ROOT, 'scripts/check-plugin-version-bump.mjs')
@@ -22,44 +25,90 @@ let pass = 0, fail = 0
 const failures = []
 const assert = (c, n, d) => { if (c) pass++; else { fail++; failures.push(`${n}${d ? ' - ' + d : ''}`) } }
 
+const present = (v) => ({ state: 'present', version: v })
+
 // --- decideBump unit axes ---------------------------------------------------
 
 {
-  const r = decideBump({ changedPaths: ['docs/rfcs/rfc-999.md', 'tests/test-x.mjs'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  const r = decideBump({ changedPaths: ['docs/rfcs/rfc-999.md', 'tests/test-x.mjs'], base: present('0.1.0'), headVersion: '0.1.0' })
   assert(r.ok === true && r.bump_required === false, 'docs+tests only: no bump required', r.reason)
 }
 {
-  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], base: present('0.1.0'), headVersion: '0.1.0' })
   assert(r.ok === false && r.bump_required === true, 'content change + same version: fail', r.reason)
 }
 {
-  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], baseVersion: '0.1.0', headVersion: '0.2.0' })
+  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], base: present('0.1.0'), headVersion: '0.2.0' })
   assert(r.ok === true, 'content change + greater version: pass', r.reason)
 }
 {
-  const r = decideBump({ changedPaths: ['skills/episodic-memory/SKILL.md'], baseVersion: '0.2.0', headVersion: '0.1.9' })
+  const r = decideBump({ changedPaths: ['skills/episodic-memory/SKILL.md'], base: present('0.2.0'), headVersion: '0.1.9' })
   assert(r.ok === false, 'content change + downgrade: fail', r.reason)
 }
 {
-  const r = decideBump({ changedPaths: ['.claude-plugin/plugin.json'], baseVersion: '0.1.0', headVersion: '0.2.0-rc1' })
+  const r = decideBump({ changedPaths: ['.claude-plugin/plugin.json'], base: present('0.1.0'), headVersion: '0.2.0-rc1' })
   assert(r.ok === false, 'prerelease/non-X.Y.Z head version: fail closed', r.reason)
 }
 {
-  const r = decideBump({ changedPaths: ['install.mjs'], baseVersion: null, headVersion: '0.1.0' })
-  assert(r.ok === true, 'manifest absent at merge-base: pass', r.reason)
+  const r = decideBump({ changedPaths: ['install.mjs'], base: { state: 'absent' }, headVersion: '0.1.0' })
+  assert(r.ok === true, 'manifest proven absent at merge-base: pass', r.reason)
+}
+{
+  // codex R1 F4: an existing-but-corrupt base manifest is NOT an introduction.
+  const r = decideBump({ changedPaths: ['scripts/a.mjs'], base: present(undefined), headVersion: '0.2.0' })
+  assert(r.ok === false, 'base manifest missing version field: fail closed', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['scripts/a.mjs'], base: present('<unreadable: bad json>'), headVersion: '0.2.0' })
+  assert(r.ok === false, 'base manifest unparsable: fail closed', r.reason)
 }
 {
   // Prefix must bind on path boundaries: install.mjs is an exact file entry,
   // not a prefix — install.mjs.bak must not trip the gate.
-  const r = decideBump({ changedPaths: ['install.mjs.bak'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  const r = decideBump({ changedPaths: ['install.mjs.bak'], base: present('0.1.0'), headVersion: '0.1.0' })
   assert(r.ok === true && r.bump_required === false, 'exact-file entry does not prefix-match siblings', r.reason)
 }
 {
-  assert(parseSemver('1.2.3') !== null && parseSemver('v1.2.3') === null && parseSemver('1.2') === null, 'parseSemver shape')
-  assert(semverGreater([0, 2, 0], [0, 1, 9]) && !semverGreater([0, 1, 0], [0, 1, 0]), 'semverGreater ordering')
+  // codex R1 F3: the runtime data surface is content.
+  for (const p of ['patterns/taxonomy.json', 'categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md', '.claude/hooks/bp1-approval-check.sh']) {
+    const r = decideBump({ changedPaths: [p], base: present('0.1.0'), headVersion: '0.1.0' })
+    assert(r.ok === false, `runtime surface path requires bump: ${p}`, r.reason)
+  }
+}
+{
+  // codex R1 F6: strict semver — leading zeros rejected, big components exact.
+  assert(parseSemver('00.2.0') === null && parseSemver('0.01.0') === null && parseSemver('0.0') === null && parseSemver('v1.2.3') === null, 'parseSemver rejects leading zeros and malformed shapes')
+  assert(parseSemver('0.0.0') !== null && parseSemver('10.0.3') !== null, 'parseSemver accepts canonical zero and multi-digit')
+  const big = decideBump({ changedPaths: ['scripts/a.mjs'], base: present('0.0.9007199254740992'), headVersion: '0.0.9007199254740993' })
+  assert(big.ok === true, 'BigInt compare: above MAX_SAFE_INTEGER still strictly ordered', big.reason)
+  const zeros = decideBump({ changedPaths: ['scripts/a.mjs'], base: present('0.1.0'), headVersion: '00.2.0' })
+  assert(zeros.ok === false, 'leading-zero head version: fail closed', zeros.reason)
+  assert(semverGreater([0n, 2n, 0n], [0n, 1n, 9n]) && !semverGreater([0n, 1n, 0n], [0n, 1n, 0n]), 'semverGreater ordering')
 }
 
-// --- E2E against the real script in an isolated fixture repo ----------------
+// --- conformance: CONTENT_PREFIXES covers the installed-artifact oracle -----
+
+{
+  // Every per-project artifact SOURCE the installer enumerates must be gate
+  // content — the enumerator grows automatically, so this locks against the
+  // hand-list drifting stale (codex R1 F3). Plus the named global-substrate
+  // data files install.mjs copies directly.
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pvb-conf-'))
+  let sources = []
+  try {
+    sources = perProjectArtifactPairs(REPO_ROOT, tmp).map((p) => p.sourceRel)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+  assert(sources.length > 0, 'artifact enumerator returned sources')
+  const uncovered = sources.filter((s) => !isContentPath(s))
+  assert(uncovered.length === 0, 'every enumerated install source is gate content', uncovered.join(', '))
+  for (const g of ['categories.json', 'activation-classes.json', 'docs/EM_SCRIPTS_GUIDE.md']) {
+    assert(isContentPath(g), `global substrate data file is gate content: ${g}`)
+  }
+}
+
+// --- E2E against the real script in isolated fixture repos ------------------
 
 const _tmpDirs = []
 process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
@@ -82,17 +131,17 @@ function mkRepo() {
   fs.writeFileSync(path.join(dir, 'docs/readme.md'), 'v1\n')
   git(dir, 'add', '-A')
   git(dir, 'commit', '-q', '-m', 'base')
-  // The gate diffs against a base ref; point origin/main at the base commit
+  // The gate diffs against a baseline; point origin/main at the base commit
   // without needing a network remote.
   git(dir, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
   return dir
 }
 
-function runGate(cwd) {
-  const r = spawnSync(process.execPath, [GATE], { cwd, encoding: 'utf8' })
+function runGate(cwd, ...extra) {
+  const r = spawnSync(process.execPath, [GATE, ...extra], { cwd, encoding: 'utf8' })
   let json = null
   try { json = JSON.parse(r.stdout) } catch {}
-  return { status: r.status, json, stderr: r.stderr }
+  return { status: r.status, json, stdout: r.stdout, stderr: r.stderr }
 }
 
 {
@@ -118,17 +167,102 @@ function runGate(cwd) {
   assert(r.status === 0 && r.json?.bump_required === false, 'E2E docs-only: no bump required', JSON.stringify(r.json))
 }
 {
-  // No commits past merge-base (push-to-main shape): exit 0
+  // codex R1 F1: push-event shape. The remote-tracking ref has advanced to the
+  // pushed tip (self-compare would see an empty diff); the workflow instead
+  // passes the immutable pre-push sha, which must still catch the missing bump.
   const repo = mkRepo()
-  const r = runGate(repo)
-  assert(r.status === 0 && r.json?.ok === true, 'E2E no delta vs base ref: pass', JSON.stringify(r.json))
+  const beforeSha = git(repo, 'rev-parse', 'HEAD')
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'pushed content change, no bump')
+  git(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD') // ref now useless as baseline
+  const r = runGate(repo, '--base-ref', beforeSha)
+  assert(r.status === 1 && r.json?.ok === false, 'E2E push baseline: explicit before-sha catches missing bump', JSON.stringify(r.json))
+  const zero = runGate(repo, '--base-ref', '0'.repeat(40))
+  assert(zero.status === 0 && zero.json?.ok === true, 'E2E push baseline: all-zeros before sha (branch creation) passes', JSON.stringify(zero.json))
 }
 {
-  // Missing base ref -> fail closed
+  // codex R1 F2: --project binds authority; ambient cwd must not.
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'change script')
+  const elsewhere = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'pvb-elsewhere-')))
+  _tmpDirs.push(elsewhere)
+  const r = runGate(elsewhere, '--project', repo)
+  assert(r.status === 1 && r.json?.ok === false && r.json?.project_root === repo,
+    'E2E --project: audits the declared root from a foreign cwd and reports it', JSON.stringify(r.json))
+}
+{
+  // codex R1 F4: base manifest present but corrupt is NOT "introduced".
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), '{not json')
+  git(repo, 'commit', '-aqm', 'corrupt manifest')
+  git(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '0.2.0' }))
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'repair + content change')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.ok === false, 'E2E corrupt base manifest: fail closed, not introduction', JSON.stringify(r.json))
+}
+{
+  // codex R1 F4: base manifest missing its version field.
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture' }))
+  git(repo, 'commit', '-aqm', 'versionless manifest')
+  git(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '0.2.0' }))
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'add version + content change')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.ok === false, 'E2E versionless base manifest: fail closed', JSON.stringify(r.json))
+}
+{
+  // True introduction: manifest path absent at base -> pass.
+  const repo = mkRepo()
+  git(repo, 'rm', '-q', '.claude-plugin/plugin.json')
+  git(repo, 'commit', '-qm', 'no manifest yet')
+  git(repo, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+  fs.mkdirSync(path.join(repo, '.claude-plugin'), { recursive: true }) // git rm pruned the empty dir
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '0.1.0' }))
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'add', '-A')
+  git(repo, 'commit', '-qm', 'introduce manifest + content change')
+  const r = runGate(repo)
+  assert(r.status === 0 && r.json?.ok === true && r.json?.base_manifest?.state === 'absent',
+    'E2E proven-absent base manifest: introduction passes', JSON.stringify(r.json))
+}
+{
+  // codex R1 F5: non-ASCII path under default core.quotePath must still match.
+  const repo = mkRepo()
+  git(repo, 'config', 'core.quotePath', 'true')
+  fs.writeFileSync(path.join(repo, 'scripts/é.mjs'), '// unicode\n')
+  git(repo, 'add', '-A')
+  git(repo, 'commit', '-qm', 'unicode script')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.ok === false && r.json?.content_paths?.some((p) => p.includes('é')),
+    'E2E quoted pathname: NUL-delimited diff sees the raw unicode path', JSON.stringify(r.json))
+}
+{
+  // No commits past baseline (nothing to gate): exit 0
+  const repo = mkRepo()
+  const r = runGate(repo)
+  assert(r.status === 0 && r.json?.ok === true, 'E2E no delta vs baseline: pass', JSON.stringify(r.json))
+}
+{
+  // Missing baseline ref -> fail closed, and the one-JSON contract holds on
+  // every error path (codex free-hunt 2).
   const repo = mkRepo()
   git(repo, 'update-ref', '-d', 'refs/remotes/origin/main')
   const r = runGate(repo)
-  assert(r.status === 1 && r.json?.ok === false, 'E2E missing base ref: fail closed', JSON.stringify(r.json))
+  assert(r.status === 1 && r.json?.ok === false, 'E2E missing baseline ref: fail closed with JSON report', JSON.stringify(r.json ?? r.stdout))
+}
+{
+  // Head manifest unreadable -> JSON error, not a raw stack.
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'rm', '-q', '--cached', '.claude-plugin/plugin.json')
+  git(repo, 'commit', '-aqm', 'drop manifest from HEAD')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.status === 'error', 'E2E unreadable HEAD manifest: one-JSON error contract', JSON.stringify(r.json ?? r.stdout))
 }
 
 console.log(`test-plugin-version-bump: ${pass}/${pass + fail} pass`)

--- a/tests/test-plugin-version-bump.mjs
+++ b/tests/test-plugin-version-bump.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * test-plugin-version-bump.mjs - #644: the plugin version-bump CI gate.
+ *
+ * Unit-tests the pure decideBump() core, then drives the REAL
+ * scripts/check-plugin-version-bump.mjs against an isolated fixture git repo
+ * OUTSIDE the checkout (red-then-green): content change without a bump must
+ * exit 1, with a bump exit 0, docs-only change exits 0 with no bump.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { decideBump, parseSemver, semverGreater } from '../scripts/check-plugin-version-bump.mjs'
+
+const REPO_ROOT = fs.realpathSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..'))
+const GATE = path.join(REPO_ROOT, 'scripts/check-plugin-version-bump.mjs')
+
+let pass = 0, fail = 0
+const failures = []
+const assert = (c, n, d) => { if (c) pass++; else { fail++; failures.push(`${n}${d ? ' - ' + d : ''}`) } }
+
+// --- decideBump unit axes ---------------------------------------------------
+
+{
+  const r = decideBump({ changedPaths: ['docs/rfcs/rfc-999.md', 'tests/test-x.mjs'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  assert(r.ok === true && r.bump_required === false, 'docs+tests only: no bump required', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  assert(r.ok === false && r.bump_required === true, 'content change + same version: fail', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['scripts/em-store.mjs'], baseVersion: '0.1.0', headVersion: '0.2.0' })
+  assert(r.ok === true, 'content change + greater version: pass', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['skills/episodic-memory/SKILL.md'], baseVersion: '0.2.0', headVersion: '0.1.9' })
+  assert(r.ok === false, 'content change + downgrade: fail', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['.claude-plugin/plugin.json'], baseVersion: '0.1.0', headVersion: '0.2.0-rc1' })
+  assert(r.ok === false, 'prerelease/non-X.Y.Z head version: fail closed', r.reason)
+}
+{
+  const r = decideBump({ changedPaths: ['install.mjs'], baseVersion: null, headVersion: '0.1.0' })
+  assert(r.ok === true, 'manifest absent at merge-base: pass', r.reason)
+}
+{
+  // Prefix must bind on path boundaries: install.mjs is an exact file entry,
+  // not a prefix — install.mjs.bak must not trip the gate.
+  const r = decideBump({ changedPaths: ['install.mjs.bak'], baseVersion: '0.1.0', headVersion: '0.1.0' })
+  assert(r.ok === true && r.bump_required === false, 'exact-file entry does not prefix-match siblings', r.reason)
+}
+{
+  assert(parseSemver('1.2.3') !== null && parseSemver('v1.2.3') === null && parseSemver('1.2') === null, 'parseSemver shape')
+  assert(semverGreater([0, 2, 0], [0, 1, 9]) && !semverGreater([0, 1, 0], [0, 1, 0]), 'semverGreater ordering')
+}
+
+// --- E2E against the real script in an isolated fixture repo ----------------
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function mkRepo() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'pvb-gate-')))
+  _tmpDirs.push(dir)
+  git(dir, 'init', '-q', '-b', 'main')
+  git(dir, 'config', 'user.email', 't@t')
+  git(dir, 'config', 'user.name', 't')
+  fs.mkdirSync(path.join(dir, '.claude-plugin'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true })
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true })
+  fs.writeFileSync(path.join(dir, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '0.1.0' }))
+  fs.writeFileSync(path.join(dir, 'scripts/a.mjs'), '// v1\n')
+  fs.writeFileSync(path.join(dir, 'docs/readme.md'), 'v1\n')
+  git(dir, 'add', '-A')
+  git(dir, 'commit', '-q', '-m', 'base')
+  // The gate diffs against a base ref; point origin/main at the base commit
+  // without needing a network remote.
+  git(dir, 'update-ref', 'refs/remotes/origin/main', 'HEAD')
+  return dir
+}
+
+function runGate(cwd) {
+  const r = spawnSync(process.execPath, [GATE], { cwd, encoding: 'utf8' })
+  let json = null
+  try { json = JSON.parse(r.stdout) } catch {}
+  return { status: r.status, json, stderr: r.stderr }
+}
+
+{
+  // RED: content change, no bump -> exit 1
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, 'scripts/a.mjs'), '// v2\n')
+  git(repo, 'commit', '-aqm', 'change script')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.ok === false, 'E2E red: content change without bump exits 1', JSON.stringify(r.json))
+
+  // GREEN: bump the version on top -> exit 0
+  fs.writeFileSync(path.join(repo, '.claude-plugin/plugin.json'), JSON.stringify({ name: 'fixture', version: '0.2.0' }))
+  git(repo, 'commit', '-aqm', 'bump version')
+  const g = runGate(repo)
+  assert(g.status === 0 && g.json?.ok === true && g.json?.bump_required === true, 'E2E green: bump satisfies gate', JSON.stringify(g.json))
+}
+{
+  // Docs-only change -> exit 0, no bump required
+  const repo = mkRepo()
+  fs.writeFileSync(path.join(repo, 'docs/readme.md'), 'v2\n')
+  git(repo, 'commit', '-aqm', 'docs only')
+  const r = runGate(repo)
+  assert(r.status === 0 && r.json?.bump_required === false, 'E2E docs-only: no bump required', JSON.stringify(r.json))
+}
+{
+  // No commits past merge-base (push-to-main shape): exit 0
+  const repo = mkRepo()
+  const r = runGate(repo)
+  assert(r.status === 0 && r.json?.ok === true, 'E2E no delta vs base ref: pass', JSON.stringify(r.json))
+}
+{
+  // Missing base ref -> fail closed
+  const repo = mkRepo()
+  git(repo, 'update-ref', '-d', 'refs/remotes/origin/main')
+  const r = runGate(repo)
+  assert(r.status === 1 && r.json?.ok === false, 'E2E missing base ref: fail closed', JSON.stringify(r.json))
+}
+
+console.log(`test-plugin-version-bump: ${pass}/${pass + fail} pass`)
+if (fail > 0) { console.error(failures.map(f => `FAIL ${f}`).join('\n')); process.exit(1) }


### PR DESCRIPTION
## Problem

`claude plugin update` is version-gated on `.claude-plugin/plugin.json`, which has carried `0.1.0` since inception. Every content merge since then has been invisible to installed plugins: the cache sat at `97a4309` while main advanced to `6964ea0`, and only a manual uninstall+reinstall refreshed it (workplan v285 leg-2 audit).

## Fix

- **`scripts/check-plugin-version-bump.mjs`** — CI gate. Diffs HEAD against the merge-base with the base ref; if any install-surface path changed (`.claude-plugin/`, `scripts/`, `skills/`, `plugins/`, `instructions/`, `install.mjs`), `plugin.json` must carry a strictly greater plain-`X.Y.Z` semver. Fails closed on missing base ref or malformed version (matching the validate-bp-contract stable-ID precedent). Docs/tests/workflow-only changes don't require a bump — they change the marketplace clone sha but not installed behavior.
- **`tests/test-plugin-version-bump.mjs`** — unit axes on the pure `decideBump` core + red-then-green E2E driving the real script against isolated fixture git repos outside the checkout. Observed: **14/14 pass**.
- **`plugin-validate.yml`** — gate step (`--base-ref origin/${{ github.base_ref || 'main' }}`; empty `base_ref` on push events falls back to `main`, where merge-base == HEAD → no delta → pass) + suite registration (test-ci-suite-registration: 16 passed). YAML parse verified (#614 class).
- **`plugin.json` `0.1.0` → `0.2.0`** — this PR changes the install surface, so the gate dogfoods itself. Observed gate output on this branch: `ok:true, reason: "version advanced 0.1.0 -> 0.2.0"`.

Release ceremony from here: any PR touching the install surface bumps the version or CI fails — no doc-only discipline to remember.

Second-opinion (codex) review dispatched via the harness; findings will be applied to this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2T1qkZLrFVePHPEEHUmfG