### PR TITLE
FIX-651: lstat-based index existence contract — typed aborts on unreadable index shapes (fixes #651)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -314,6 +314,9 @@ jobs:
       - name: "Run #628 sibling-init-guard tests"
         run: node tests/test-628-sibling-init-guard.mjs
 
+      - name: "Run #651 index existence-contract tests"
+        run: node tests/test-651-index-existence.mjs
+
       - name: Run em-consolidate suite
         run: node tests/test-em-consolidate.mjs
 

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -91,6 +91,24 @@ default.
    default behavior, including a real `em-prune` pass; if `--help` returns
    anything other than `status: "help"`, refresh the install before probing
    further, and read the flag lists in this guide instead.
+6. Index existence contract (issue #651): `index.jsonl` presence is classified
+   `lstat`-first, not by `existsSync`. **Absent** (no file, and the parent store
+   dir is itself absent or a clean symlink) keeps today's behavior — `[]` /
+   skip / create-on-first-use. **Unreadable** (a symlink loop or dangling
+   symlink, an EACCES/broken parent directory, a FIFO/socket/device, a
+   directory where the index should be, or a file that fails to read) is a
+   defect, never treated as an empty store: every reader aborts with
+   `{"status":"error","message":"...episode index unreadable (<CODE>)
+   (<path>)..."}` and exit 1, instead of fabricating an empty result or (for a
+   FIFO) blocking forever. `em-doctor` is the one non-abort adopter — it
+   REPORTS `index: "unreadable (<CODE>)"` as a problem entry so the health
+   tool never dies on the disease it diagnoses. `em-rebuild-index` classifies
+   before acquiring its store lock and never truncates/replaces a corrupt
+   `index.jsonl`; its abort envelope adds a `remediation` hint (remove the
+   corrupt file and re-run). Recovery for any of the above: remove the
+   offending `index.jsonl` (or fix the symlink/permission) and run
+   `em-rebuild-index`, which rebuilds it from `episodes/*.md` (the source of
+   truth).
 
 ---
 

--- a/docs/plans/issue-651-index-existence-contract.md
+++ b/docs/plans/issue-651-index-existence-contract.md
@@ -1,0 +1,349 @@
+# Plan: issue #651 — index existence-semantics contract (lstat-based), silent-[] fail-open + FIFO hang
+
+Status: REVISED (Revision 1 — negative-scenario audit gaps folded in; pending second-opinion review)
+Issue: #651 (split from #628 plan §17 DEFER-4; pre-declared at
+`docs/plans/issue-628-sibling-init-guard.md:48`)
+Branch: `fix-651-index-existence-contract`
+Executor: low-capability builder subagent (fresh context) — the §7 site table is the
+mechanical build path.
+
+## §1 Problem
+
+`existsSync(index.jsonl)` returns **false** for a symlink loop, a dangling symlink, or an
+index under an EACCES parent, so every loader takes its missing-store branch and returns
+`[]`. Scripts then exit 0 `status:ok` with the store's evidence silently gone — for
+`em-prune` that is R5(b) protection evidence loss (FAIL-OPEN, strictly worse than the
+EISDIR crash #628 fixed). `existsSync` returns **true** for a FIFO, and the unguarded
+`readFileSync` blocks forever.
+
+Runtime evidence (main @ 792ca0e, isolated fixture store, 2026-08-03):
+
+- symloop / dangling / eaccess-parent: `em-search` → `{"status":"ok","count":0}` exit 0;
+  `em-prune --scope local --dry-run` → `{"status":"ok","results":[{"scope":"local","pruned":0,"remaining":0,"protected":0,...}]}`
+  exit 0 (control store shows `remaining:1`).
+- fifo: `em-list`, `em-search`, `em-prune` all killed by a 5 s alarm (exit 142) — indefinite hang.
+- Audit probes (same commit): chmod-000 on the index **file** itself → raw `node:fs:539`
+  stack, exit 1, empty stdout on `em-list`/`em-recall`. Dangling **parent** symlink
+  (`.episodic-memory` → missing) → lstat(index) ENOENT → silent-[] exit 0.
+  `em-rebuild-index` under eaccess parent dies raw at lock acquisition
+  (`store-write-lock.mjs:142-146`) **before** reaching its loader.
+
+## §2 Contract decision
+
+New shared classifier (lstat-based) defines index-file existence semantics for every
+loader:
+
+| observed shape | classification | rationale |
+|---|---|---|
+| `lstatSync(index)` throws ENOENT AND parent probe (below) is clean | **absent** | genuinely missing store — keep today's `[]` / skip / create-on-first-use |
+| `lstatSync(index)` throws ENOENT, parent probe finds `.episodic-memory` is a symlink whose `statSync` fails (dangling/loop) or parent `lstatSync` throws non-ENOENT (EACCES/EIO/ELOOP) | **unreadable** (broken parent) | audit P2: a dangling-parent symlink is a defect, not an absent store |
+| `lstatSync(index)` throws anything else (EACCES, ENOTDIR, EIO, ELOOP mid-path) | **unreadable** | inspection failed — fail closed |
+| final component is a symlink, `statSync` resolves to a regular file | **ok** | healthy symlinked index stays supported (works today; audit P4: relative targets are cwd-independent) |
+| symlink, `statSync` throws ENOENT | **unreadable** (dangling) | a dangling link is a defect, not an absent store |
+| symlink, `statSync` throws ELOOP/other | **unreadable** (loop) | |
+| resolves to directory | **unreadable**, code `EISDIR` | preserves #628 message compat (`(EISDIR)` in envelope) |
+| resolves to FIFO/socket/device (incl. via symlink) | **unreadable**, code `ENOTREG` | classified BEFORE any open — this is the hang fix |
+| regular file, classification `ok`, but the subsequent read throws (file-mode-000 EACCES, or a post-classify swap to dir) | **unreadable** — read errors inside the shared loaders are wrapped into `IndexUnreadableError` | audit Gap 2 (probe P1): classification alone cannot see file-mode-000; wrapping the read also types the swap-to-dir race. Residual: a post-classify swap to FIFO re-opens the hang — DEFER D1 (§4), same trust domain as #628 DEFER-1 |
+
+Fail-direction doctrine (RFC-011 `docs/rfcs/RFC-011-playbook-activation-preferences.md:58,:122,:138`):
+retention/mutation consumers fail closed (typed abort, exit 1); the enumerated advisory
+degrade surfaces (§4 list) keep degrading on unreadable but MUST classify before read so
+a FIFO can never be opened and MUST surface observability where a reporter exists
+(doctor/stats — §7 steps 18, 22). Everything else — including read/query tools — aborts
+typed: a recall surface returning fabricated-empty is still evidence loss (issue text:
+"affects ALL loaders uniformly").
+
+Known collision, decided here: no RFC binds an error-envelope contract for read-only
+query tools (#628 plan `:44`). This plan extends the de-facto envelope
+(`{status:'error', message}` + exit 1, `docs/EM_SCRIPTS_GUIDE.md:26-28`) to them for the
+unreadable-index case only. That is a deliberate, documented contract extension, recorded
+in EM_SCRIPTS_GUIDE (§7 step 24).
+
+## §3 Requirements
+
+| REQ | Statement | Test |
+|---|---|---|
+| REQ-1 | Shared classifier `classifyIndexFile(fsMod, filePath)` + `IndexUnreadableError` + `assertReadableIndex` in new `scripts/lib/index-state.mjs`; semantics exactly the §2 table incl. parent probe | T1 unit legs |
+| REQ-2 | `relevance.mjs` `loadIndex`: absent → `[]`, unreadable → throw `IndexUnreadableError`, read errors wrapped into `IndexUnreadableError`; `loadArchivedIndex`: classify-then-degrade (no open on non-regular) | T2, T3 fifo/file-000 columns |
+| REQ-3 | Every §7 in-scope loader/call-site adopts the contract; unreadable reaches the user as a typed envelope `{status:'error', message:/episode index unreadable/}` + exit 1, last stdout line, no stack frames on stderr — verified by the §7 step-28 importer sweep (baseline: 36 `loadIndex(` call sites in 20 files on main) with every site typed-abort / doctor-report / documented-degrade | T3 matrix + sweep |
+| REQ-4 | FIFO-shaped index: no in-scope script blocks; each exits 1 typed within the spawn timeout | T3 fifo column |
+| REQ-5 | Genuinely-missing index (ENOENT, clean parent): behavior byte-compatible with today (exit 0, same JSON) | T4 controls |
+| REQ-6 | Healthy symlink → regular file keeps loading rows | T4 symlink-ok |
+| REQ-7 | `em-prune` unreadable: exit 1, nothing archived, episode files + index untouched | T5 |
+| REQ-8 | `em-rebuild-index`: classification runs BEFORE store-write-lock acquisition; never truncates/replaces the index when unreadable; envelope carries remediation hint ("remove the corrupt index.jsonl and re-run") | T6 |
+| REQ-9 | Vendored copies `plugins/episodic-memory/scripts/{em-search,em-list,em-check-stale}.mjs` get the same semantics (inlined classifier — no lib/ in plugin dir; behavioral parity via T7, no byte-parity mechanism exists — accepted, repo vendoring precedent) | T7 |
+| REQ-10 | #628 + #626 suites stay green: `test-628-sibling-init-guard` 5/5, `test-prune-protection` 32/32, `test-rfc-015-p1-s2-consolidation` green | §8 gate |
+| REQ-11 | New suite CI-wired exactly as `node tests/test-651-index-existence.mjs` (registration lint `tests/test-ci-suite-registration.mjs:8-24`); `.claude-plugin/plugin.json` bumped 0.2.2 → 0.2.3 (#644 gate) | §8 gate |
+
+## §4 Non-goals / exclusions / DEFERs (each deliberate, not an omission)
+
+Exclusions:
+- `em-promote.mjs:668,:686,:810` TOCTOU-only raw sites — #628 DEFER-1 stands.
+- `em-consolidate.mjs:1604,:1637` silent-degrade catches — pre-existing #628-era decision.
+- `tags.json` / `category-index.json` / `tokens.json` loaders — tolerant-JSON, rebuildable,
+  non-authoritative; different class.
+- `episodes/<id>.md` per-file existence checks (`em-search.mjs:152,:338`,
+  `em-move.mjs:224,:279`) — row-level body resolution, not index integrity.
+- `em-search.mjs:444` tokens-index gating — optimization gate; main load covered via
+  relevance.mjs.
+- `em-trigger-index.mjs` statSync fingerprint and activation-hook statSync zero-states —
+  different (cache-freshness) contract.
+- `em-revise.mjs:346,:358` — already fail-closed direction (unknown → revision rejected).
+- Windows-specific symlink/FIFO/EACCES semantics — CI is ubuntu; T-legs guard
+  `process.platform` / root-uid and skip-with-note.
+
+Documented advisory degrade surfaces (classify-before-read; unreadable → degrade, never
+open non-regular):
+- `relevance.mjs loadArchivedIndex` (history walk) — degrade `[]`; observability via
+  doctor/stats (§7 steps 18, 22).
+- `em-store.mjs:563` post-write contradiction advisory (inside `catch{}`, stderr-only) —
+  degrade automatic once loadIndex classifies. NOTE (review F3, Revision 3): the append
+  path itself DOES block on a FIFO-shaped index (opening a FIFO for append blocks like a
+  read) — pre-existing, outside this issue's loader scope; follow-up issue filed at PR
+  time (classify-before-append), folded into the D1 revisit trigger.
+- `em-mine-transcripts.mjs:98` dedupe corpus — unreadable store skipped (worst case: a
+  duplicate episode, not evidence loss).
+- `em-consolidate.mjs:1898` F4 last-accessed lower-bound scan (inside `try{}`,
+  conservative on failure) — classify-before-read, keep conservative degrade.
+
+DEFER D1 — FIFO-swap TOCTOU: (what) a regular→FIFO swap between classify and read
+re-opens the hang; (why deferrable) requires a racing writer inside the store dir — same
+trust domain #628 DEFER-1 accepted for path-TOCTOU; closed form is fd-based
+classification (`openSync` O_NONBLOCK + `fstatSync`); (risk) hang recurrence,
+adversarial-local only; (trigger) any post-fix hang report or #628 DEFER-1 revisit;
+(owner) follow-up issue linked from the #651 PR.
+
+DEFER D2 — real-socket/device test legs: (what) no live-socket fixture leg; (why
+deferrable) same `!isFile()` branch as FIFO; cheap `symlink → /dev/null` T1 leg covers
+the device path; (risk) negligible; (trigger) classifier refactor; (owner) none.
+
+## §5 Blast radius / token budget (Rule 12)
+
+26 script files + docs + tests. `wc -l` (2026-08-03): relevance.mjs 454, protection.mjs
+322, em-prune 308, em-list 80, em-check-stale 91, em-workflow-validate 1018,
+em-review-request 544, em-pattern-health 420, em-watch-codex 315, em-move 406, em-restore
+2635, em-consolidate 2439, em-search 602, em-feedback 260, em-doctor 911, em-seed-patterns
+324, em-rebuild-index 349, topic-tracks/engine.mjs 756, em-stats 195, em-recall / em-graph
+/ em-semantic / em-embed (importer wraps only), plugin copies 184+67+85. Edits are
+surgical per site (§7); large files get only their loader/call-sites touched.
+
+`lib/relevance.mjs` was held byte-unchanged by #628 REQ-6. That was a scoping invariant
+of THAT plan, and #628 §17 DEFER-4 / plan `:48` explicitly pre-authorized this follow-up
+to change existence semantics "in ALL loaders including lib/relevance.mjs". This plan
+supersedes that invariant.
+
+## §6 Design notes
+
+New `scripts/lib/index-state.mjs` (zero-dep ESM, ~80 lines):
+
+```js
+export function classifyIndexFile(fsMod, filePath) {
+  let st
+  try { st = fsMod.lstatSync(filePath) }
+  catch (e) {
+    if (e && e.code === 'ENOENT') return classifyParent(fsMod, filePath) // absent vs broken-parent
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'lstat failed' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fsMod.statSync(filePath) }
+    catch (e) {
+      if (e && e.code === 'ENOENT') return { state: 'unreadable', code: 'ENOENT', detail: 'dangling symlink' }
+      return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'symlink resolution failed' }
+    }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR', detail: 'index is a directory' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG', detail: 'index is not a regular file' }
+  return { state: 'ok' }
+}
+
+// classifyParent: lstat(dirname). ENOENT → {state:'absent'} (no store).
+// lstat throws non-ENOENT → unreadable (parent inspection failed).
+// parent is a symlink whose statSync fails → unreadable (broken parent, audit P2).
+// otherwise → {state:'absent'} (store dir exists, index genuinely missing).
+
+export class IndexUnreadableError extends Error {
+  constructor(filePath, code, detail) {
+    super(`episode index unreadable (${code}) (${filePath})`)
+    this.code = code; this.file = filePath; this.detail = detail
+  }
+}
+
+// returns 'absent' | 'ok'; throws IndexUnreadableError on unreadable
+export function assertReadableIndex(fsMod, filePath) { ... }
+
+// readIndexFileOrThrow(fsMod, filePath): assertReadableIndex; 'absent' → null;
+// 'ok' → try readFileSync, catch e → throw IndexUnreadableError(filePath, e.code, 'read failed')
+// (types file-mode-000 EACCES and the swap-to-dir race — §2 last row)
+```
+
+- `fsMod` injection mirrors `protection.mjs`'s existing injected-fs signature.
+- Envelope for scripts without an existing #628 wrapper:
+  `{status:'error', message:'<script>: episode index unreadable (<CODE>) (<file>)'}` +
+  `process.exit(1)` — same family the #628 tests regex (`/episode index unreadable/`,
+  `/index\.jsonl/`). Scripts WITH wrappers (`em-prune` `loadIndexRowsOrAbort:89`,
+  `em-promote:137`, `em-review-request fail:85`, `em-workflow-validate fail:105`,
+  `em-consolidate emitProtectionAbort:176`) keep their exact message shapes — the new
+  throw simply flows into them.
+- `em-rebuild-index` envelope appends: `remediation: 'remove the corrupt index.jsonl and re-run em-rebuild-index'`
+  (episodes/*.md is the source of truth; ENOENT-after-removal takes the normal rebuild path).
+- `em-doctor` is the non-abort adopter: it REPORTS `index: 'unreadable (<CODE>)'` as a
+  problem entry instead of `'index.jsonl absent'` at ALL its loadIndex call sites
+  (`em-doctor.mjs:135,:170,:674,:681`), and additionally classifies
+  `archived-index.jsonl` (a health tool must not die on the disease it diagnoses, and
+  must not report fail-open `ok`).
+
+## §7 Site table (mechanical build path — execute top to bottom)
+
+| step | file:site | action |
+|---|---|---|
+| 1 | new `scripts/lib/index-state.mjs` | write module per §6 |
+| 2 | `scripts/lib/relevance.mjs:99` (`loadIndex`) | use `readIndexFileOrThrow`: absent → `[]`; unreadable (incl. wrapped read error) → throw |
+| 3 | `scripts/lib/relevance.mjs:120` (`loadArchivedIndex`) | classify first: absent/unreadable → `[]` (documented advisory degrade), `ok` → existing read path; delete the `existsSync` line |
+| 4 | `scripts/lib/protection.mjs:30` (`loadProtectionRows`) | classify with injected fs + wrapped read: absent → `[]`, unreadable → throw `IndexUnreadableError` |
+| 5 | `scripts/em-prune.mjs:72` (`loadIndexRows`) | classify + wrapped read: absent → `[]`, unreadable → throw; confirm EVERY caller routes via `loadIndexRowsOrAbort:89` (incl. `partitionPrunable:109`) — reroute any that don't |
+| 6 | `scripts/em-consolidate.mjs:150` (`loadProtectionRows` caller) | catch `IndexUnreadableError` → `emitProtectionAbort` with `kind:'protection'`, file = the store's index.jsonl |
+| 7 | `scripts/em-consolidate.mjs:528` (skip-store site) | classify: absent → keep `skipped_store:'no-index'`; unreadable → typed abort (never skip) |
+| 7b | `scripts/em-consolidate.mjs:577` (single-store `--fold-superseded` `foldStore(DATA_DIR, ...)` call) | catch `IndexUnreadableError` → `emitProtectionAbort`-family typed abort, exit 1, archive nothing (builder-found NEW-SITE, Revision 2) |
+| 7c | `scripts/em-prune.mjs:251` + `scripts/em-consolidate.mjs:485` (archived-index.jsonl mutation-path reads) | classify `archived-index.jsonl` BEFORE any episode file is moved (pre-flight, alongside the main-index classification); unreadable → typed abort with nothing moved; also wrap the in-place read (review F2, Revision 3) |
+| 7d | `scripts/em-feedback.mjs:129` (`resolveIds` raw read, `--scan-text` both modes) | route through `readIndexFileOrThrow` → typed envelope + exit 1 (review F1 BLOCKER, Revision 3) |
+| 7e | `scripts/em-topic-tracks.mjs:172` (CLI catch fallthrough) | map `IndexUnreadableError` to a distinct error code (`episode-index-unreadable`), not `topic-tracks-config-invalid` (review F4, Revision 3) |
+| 7f | `scripts/em-stats.mjs` archived field | emit `archived_unreadable` only when true (review F5, Revision 3) |
+| 8 | `scripts/em-list.mjs:40` | classify + wrapped read: absent → `[]`; unreadable → envelope + exit 1 |
+| 9 | `scripts/em-check-stale.mjs:41` | same as step 8 |
+| 10 | `scripts/em-search.mjs` (loadIndex call sites via relevance import) | wrap in try/catch `IndexUnreadableError` → envelope + exit 1 |
+| 11 | `scripts/em-recall.mjs:253,:256` | wrap loadIndex calls → envelope + exit 1 (audit Gap 1 — THE recall surface) |
+| 12 | `scripts/em-graph.mjs:129-130` | same wrap |
+| 13 | `scripts/em-semantic.mjs:142` | same wrap |
+| 14 | `scripts/em-embed.mjs:81` | same wrap |
+| 15 | `scripts/em-stats.mjs:78` (main load) | same wrap; `:131` archived read → classify-before-read, unreadable → `archived_unreadable: true` in output (degrade, observable) |
+| 16 | `scripts/em-doctor.mjs:135,:170,:674,:681` | report-not-abort per §6; also classify `archived-index.jsonl` |
+| 17 | `scripts/em-workflow-validate.mjs:128` | classify + wrapped read; unreadable → existing `fail(msg, 1)` (`:105`) |
+| 18 | `scripts/em-review-request.mjs:202,:510` | classify + wrapped read; unreadable → existing `fail(1, msg)` (`:85`) |
+| 19 | `scripts/em-pattern-health.mjs:153` | classify + wrapped read: absent → `[]`; unreadable → envelope + exit 1 |
+| 20 | `scripts/em-watch-codex.mjs:92,:155,:247` | `:92` discovery predicate: absent → continue walk, unreadable → envelope abort (never bind parent store); `:155` loader per contract; `:247` unchanged if unreachable post-abort, else report state |
+| 21 | `scripts/em-move.mjs:98` (`readIndexRows`) | classify + wrapped read: absent → `[]`, unreadable → envelope + exit 1 (mutation path) |
+| 22 | `scripts/em-restore.mjs:411` (`loadIndexJsonl`) | classify + wrapped read: absent → empty Map, unreadable → envelope + exit 1 |
+| 23 | `scripts/em-feedback.mjs:138,:208` (store-selection filters) | absent → drop store from set (today's behavior), unreadable → envelope + exit 1 (never silently drop a lock/write target) |
+| 24 | `scripts/em-seed-patterns.mjs:44` | classify; absent → today's behavior, unreadable → envelope + exit 1 |
+| 25 | `scripts/em-rebuild-index.mjs` | classification of index + episodesDir runs BEFORE `acquireStoreWriteLocksSync` (`:154`, audit Gap 4 — lock open dies raw under eaccess); any unreadable → envelope + remediation hint + exit 1 BEFORE any write/truncate; absent episodesDir with readable parent → today's create path; `loadOldIndex:134` classify + wrapped read |
+| 26 | `scripts/topic-tracks/engine.mjs:160` | classify before read: absent → `[]`, unreadable → throw; route script entry to envelope |
+| 27 | `scripts/em-mine-transcripts.mjs:98` + `scripts/em-consolidate.mjs:1898` + `scripts/em-store.mjs:563` | advisory dispositions per §4: classify-before-read, degrade on unreadable, never open non-regular |
+| 28 | importer sweep (verify) | `grep -rn "loadIndex(" scripts/ plugins/` — baseline 36 sites / 20 files on main; post-build, table every site as typed-abort / doctor-report / documented-degrade (§4 list); any new site found = STOP and add a row |
+| 29 | `plugins/episodic-memory/scripts/em-search.mjs:49`, `em-list.mjs:34`, `em-check-stale.mjs:35` | inline classifier + wrapped read (copy §6 functions into each file's local helpers, matching vendored style); same absent/unreadable behavior as steps 8–10 |
+| 30 | `docs/EM_SCRIPTS_GUIDE.md` | add short "index existence contract" note (absent vs unreadable, envelope, exit 1, rebuild remediation) |
+| 31 | new `tests/test-651-index-existence.mjs` | per §8 |
+| 32 | `.github/workflows/tests.yml` | add step `node tests/test-651-index-existence.mjs` in the clerk-consolidation shard (exact-form rule, registration lint) |
+| 33 | `.claude-plugin/plugin.json:3` | version 0.2.2 → 0.2.3 |
+
+## §8 Test plan (`tests/test-651-index-existence.mjs`)
+
+Harness pattern = `tests/test-628-sibling-init-guard.mjs` (mkdtemp + real `em-store` seed
++ spawnSync with `cwd` + pinned `HOME`/`USERPROFILE`; `lastJson()`; no-stack assert), with
+`spawnSync` `timeout: 10000` on every leg so a FIFO regression FAILS (spawnSync returns
+`status: null` + `signal: 'SIGTERM'` on timeout — assert `status === 1` catches it)
+instead of hanging the suite.
+
+Fixture shapes: `symloop` (index.jsonl → loop-b → index.jsonl), `dangling`
+(→ does-not-exist), `eaccess` (chmod 000 on `.episodic-memory`; restore in finally; skip
+when `process.getuid() === 0`), `fifo` (`mkfifo` via child_process; skip on win32),
+`file000` (chmod 000 on index.jsonl itself; audit Gap 2), `parent-dangling`
+(`.episodic-memory` → missing target; audit Gap 3).
+
+- **T1** unit: import `classifyIndexFile`, assert every §2 table row directly, incl.
+  healthy-symlink `ok`, directory `EISDIR`, `symlink → /dev/null` `ENOTREG` (DEFER D2
+  cheap leg), parent-probe rows.
+- **T3 matrix**: shapes {symloop, dangling, eaccess, fifo, file000, parent-dangling} ×
+  scripts {`em-list`, `em-search --project p651 --no-track`, `em-recall`,
+  `em-check-stale`, `em-prune --scope local --dry-run`, `em-pattern-health`,
+  `em-rebuild-index --scope local`, `em-watch-codex` (status/read mode),
+  `em-feedback` (read-then-write mode per script help), `em-restore` (dry/list mode)} →
+  exit 1; last stdout line JSON `status:'error'`; `/episode index unreadable/`;
+  `/index\.jsonl/`; no `at *.mjs` frames on stderr. Skip legs a given script cannot
+  reach (document each skip inline with the reason).
+- **T4 controls**: genuinely-missing index (clean parent) → `em-list`/`em-search`/`em-prune
+  --dry-run` exit 0, `status:'ok'` (REQ-5); healthy symlink to a real index → `em-list`
+  shows the seeded episode (REQ-6).
+- **T5** protection: seeded store + each silent shape → `em-prune --scope local` (real,
+  not dry-run) exits 1 and `episodes/<id>.md` still exists (REQ-7).
+- **T6** rebuild guard: eaccess + symloop + file000 → `em-rebuild-index` exits 1 typed
+  (envelope incl. remediation hint) AND `index.jsonl` shape is unchanged (REQ-8).
+- **T7** vendored: shapes × {plugin em-search, em-list, em-check-stale} → typed abort
+  (REQ-9).
+
+Falsifiability gate (per #628 plan `:132`): before the fix lands, run the new suite
+against pre-fix HEAD — every T3/T5/T6/T7 leg MUST fail (observed today: exit 0
+`status:ok`, raw-stack exit 1, or timeout-kill `status:null`; expected post-fix: exit 1
+typed). Record both runs in the PR.
+
+Regression gates (absolute counts): `test-628-sibling-init-guard` → `5/5 pass`;
+`test-prune-protection` → `32/32 pass`; `test-rfc-015-p1-s2-consolidation` → exit 0;
+`test-ci-suite-registration` → exit 0; `test-plugin-version-bump` → exit 0;
+`check-plugin-version-bump.mjs --base-ref origin/main` → exit 0.
+
+## §9 Verification commands (orchestrator, post-build)
+
+```
+node tests/test-651-index-existence.mjs
+node tests/test-628-sibling-init-guard.mjs
+node tests/test-prune-protection.mjs
+node tests/test-rfc-015-p1-s2-consolidation.mjs
+node tests/test-ci-suite-registration.mjs
+node tests/test-plugin-version-bump.mjs
+node scripts/check-plugin-version-bump.mjs --base-ref origin/main
+```
+
+Plus independent behavior probes (not repo tests): re-run the §1 fixture probes on the
+branch — symloop/dangling/eaccess/fifo/file000/parent-dangling must produce typed exit-1
+envelopes on `em-list`, `em-search`, `em-recall`, `em-prune --dry-run`; control store
+unchanged `status:ok`.
+
+## §10 Review & handoff
+
+Builder does not commit. Frozen diff goes to second-opinion review via
+`scripts/second-opinion.mjs` (provider `claude-subagent`; GLM down 2026-08-02, codex
+liveness unproven). Findings dispositioned ACCEPT/ACCEPT-WITH-MOD/REJECT/DEFER/
+NEEDS-EVIDENCE in §11 below (appended at review time). Orchestrator commits the intended
+slice only, opens PR "FIX-651: lstat-based index existence contract — typed aborts on
+unreadable index shapes (fixes #651)", watches CI to green. Merge = operator.
+
+## §11 Revision log
+
+Revision 4 (2026-08-03, review round 2, reply 20260803-103806): F1-F5 all CLOSED by
+independent runtime probe. New F2b MAJOR ACCEPT: `em-consolidate.mjs:459,:505` pass
+archived-index failures to `indexUnreadableAbort(dataDir, e)` (`:194`), which hardcodes
+`file: index.jsonl` — envelope names a healthy file. Fix: add an optional explicit
+file param (default preserves main-index callers), pass `archivedIndexFile` at both
+step-7c sites; new test leg asserts the fold abort envelope names
+`archived-index.jsonl`, not `index.jsonl` (falsifiable: names the wrong file today).
+
+Revision 3 (2026-08-03, second-opinion review round 1 REQUEST-CHANGES, reply
+20260803-101837): F1 BLOCKER ACCEPT → step 7d (em-feedback scan-text FIFO hang);
+F2 MAJOR ACCEPT → step 7c (archived-index mutation-path reads, classify pre-move);
+F3 MAJOR ACCEPT-WITH-MOD → §4 sentence corrected, follow-up issue at PR time
+(em-store append blocks on FIFO — pre-existing, out of scope); F4 MINOR ACCEPT →
+step 7e (distinct error code); F5 NIT ACCEPT-WITH-MOD → step 7f (conditional field).
+New test legs: T3 em-feedback --scan-text --dry-run × fifo; T5 archived-index fifo ×
+em-prune real run with prunable row (falsifiable: SIGTERM-hang before, typed abort
+nothing-moved after); em-topic-tracks error-code assert.
+
+Revision 2 (2026-08-03, builder step-28 sweep NEW-SITE): added §7 step 7b —
+`em-consolidate.mjs:366` `foldStore()` calls `loadIndex` and the single-store fold path
+(`:577`) had no unreadable handling; post-step-2 it raw-crashed (fail-closed but
+untyped, REQ-3 violation). Fix: typed abort at the single-store call site; new T3 leg
+`em-consolidate --fold-superseded --dry-run` × silent shapes (falsifiable: raw
+IndexUnreadableError stack before, typed envelope + no stack after). No other new
+integration surface — the `--all-projects` loop already classifies pre-call (step 7).
+
+Revision 1 (2026-08-03, negative-scenario audit HOLD → revised): (1) statement — folded
+all 6 audit gaps + 2 DEFERs. (2) New things: parent-probe classifier branch
+(`classifyParent`), read-error wrapping (`readIndexFileOrThrow`), `file000` +
+`parent-dangling` fixture shapes, `archived_unreadable` stats field, rebuild lock
+reorder + remediation envelope field, doctor archived-index report, §7 steps 11–16
+(unswept importers), step 28 sweep verify, T3 legs for em-watch-codex/em-feedback/
+em-restore/em-recall. (3) Each new branch has a §2 row (scope), no persistence beyond
+process lifetime, terminal state = envelope/degrade per row, rollback = revert commit,
+negative test = T1/T3 legs named above. (4) 8-axis re-walk on new surfaces: parent-probe
+lstat EACCES → unreadable (§2 row 2); read-wrap changes the throw surface for all
+importers at once → closed by step-28 sweep; remediation field is output-only. (5) New
+integration surface: `index-state.mjs` is imported by relevance/protection/per-script
+loaders; vendored copies remain inline (REQ-9 parity note).

--- a/plugins/episodic-memory/scripts/em-check-stale.mjs
+++ b/plugins/episodic-memory/scripts/em-check-stale.mjs
@@ -30,10 +30,55 @@ const maxDays = parseInt(flag('--days') || '30', 10)
 const project = flag('--project')
 const scope = flag('--scope') || 'all'
 
+// #651: lstat-based index existence classifier, inlined (no lib/ in this
+// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
+// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
+// failure) -> throws with .code, so the caller aborts typed instead of
+// silently degrading or blocking forever on an unguarded FIFO read.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath) {
+  const c = classifyIndexFile(filePath)
+  if (c.state === 'absent') return null
+  if (c.state === 'unreadable') {
+    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
+    err.code = c.code
+    throw err
+  }
+  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+}
+
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexOrThrow(indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -43,8 +88,13 @@ function loadIndex(dataDir, source) {
 }
 
 let results = []
-if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+} catch (e) {
+  console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}` }))
+  process.exit(1)
+}
 
 // Dedupe
 const seen = new Set()

--- a/plugins/episodic-memory/scripts/em-list.mjs
+++ b/plugins/episodic-memory/scripts/em-list.mjs
@@ -29,10 +29,55 @@ const limit = parseInt(flag('--limit') || '10', 10)
 const scope = flag('--scope') || 'all'
 const includeSuperseded = argv.includes('--include-superseded')
 
+// #651: lstat-based index existence classifier, inlined (no lib/ in this
+// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
+// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
+// failure) -> throws with .code, so the caller aborts typed instead of
+// silently degrading or blocking forever on an unguarded FIFO read.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath) {
+  const c = classifyIndexFile(filePath)
+  if (c.state === 'absent') return null
+  if (c.state === 'unreadable') {
+    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
+    err.code = c.code
+    throw err
+  }
+  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+}
+
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexOrThrow(indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -42,8 +87,13 @@ function loadIndex(dataDir, source) {
 }
 
 let results = []
-if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+} catch (e) {
+  console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}` }))
+  process.exit(1)
+}
 
 // Dedupe by id (local takes priority)
 const seen = new Set()

--- a/plugins/episodic-memory/scripts/em-search.mjs
+++ b/plugins/episodic-memory/scripts/em-search.mjs
@@ -44,10 +44,55 @@ const historyId = flag('--history')
 // ---------------------------------------------------------------------------
 // Load index entries from a data directory
 // ---------------------------------------------------------------------------
+// #651: lstat-based index existence classifier, inlined (no lib/ in this
+// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
+// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
+// failure) -> throws with .code, so the caller aborts typed instead of
+// silently degrading or blocking forever on an unguarded FIFO read.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath) {
+  const c = classifyIndexFile(filePath)
+  if (c.state === 'absent') return null
+  if (c.state === 'unreadable') {
+    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
+    err.code = c.code
+    throw err
+  }
+  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+}
+
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexOrThrow(indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -62,11 +107,16 @@ function loadIndex(dataDir, source) {
 // ---------------------------------------------------------------------------
 let results = []
 
-if (scope === 'local' || scope === 'all') {
-  results.push(...loadIndex(LOCAL_DIR, 'local'))
-}
-if (scope === 'global' || scope === 'all') {
-  results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') {
+    results.push(...loadIndex(LOCAL_DIR, 'local'))
+  }
+  if (scope === 'global' || scope === 'all') {
+    results.push(...loadIndex(GLOBAL_DIR, 'global'))
+  }
+} catch (e) {
+  console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}` }))
+  process.exit(1)
 }
 
 // Dedupe by id (local takes priority)

--- a/scripts/em-check-stale.mjs
+++ b/scripts/em-check-stale.mjs
@@ -15,6 +15,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -38,8 +39,9 @@ const scope = flag('--scope') || 'all'
 
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -49,8 +51,16 @@ function loadIndex(dataDir, source) {
 }
 
 let results = []
-if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
+}
 
 // Dedupe
 const seen = new Set()

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -63,6 +63,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensIndex, tokenizeQuery } from './lib/relevance.mjs'
 import { loadCategories, canonicalCategory, machineConsumedCategories, validateCategory } from './lib/categories.mjs'
 import { loadProtectionRows, computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
+import { assertReadableIndex, readIndexFileOrThrow } from './lib/index-state.mjs'
 import {
   buildConsolidationAdvisory,
   PLAYBOOK_PROTECTION_CLASS,
@@ -190,11 +191,17 @@ function emitProtectionAbort(abort, mode) {
 // mode's primary-store load routes through loadIndexOrAbort. The one in-lock
 // reload (consolidate-apply) instead inlines indexUnreadableAbort after
 // releasing its lock: emitProtectionAbort exits, and exit skips finally.
-function indexUnreadableAbort(dataDir, e) {
+// #651 F2b (revision 4): file defaults to the primary index.jsonl (every
+// existing caller stays byte-identical) but the two archived-index.jsonl
+// preflight/backstop sites in foldStore (below) pass it explicitly — the
+// caught error is real (fail-closed, correct) but was misnaming the file,
+// pointing an operator at a healthy index.jsonl instead of the broken
+// archived-index.jsonl.
+function indexUnreadableAbort(dataDir, e, file = path.join(dataDir, 'index.jsonl')) {
   return {
     kind: PROTECTION_ABORT_PROTECTION,
     reason: `episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'})`,
-    file: path.join(dataDir, 'index.jsonl'),
+    file,
   }
 }
 
@@ -444,6 +451,20 @@ if (foldSuperseded) {
       const archivedDir = path.join(dataDir, 'archived')
       const indexFile = path.join(dataDir, 'index.jsonl')
       const archivedIndexFile = path.join(dataDir, 'archived-index.jsonl')
+
+      // #651 F2 (revision 3, step 7c): classify archived-index.jsonl BEFORE
+      // any file move — the read-merge-replace at the end of this block
+      // (below) previously discovered a FIFO/broken archived-index only
+      // AFTER episode files were already renamed and index.jsonl/tags.json
+      // already rewritten. Self-contained (calls emitProtectionAbort
+      // directly) so it aborts correctly regardless of which caller
+      // (--all-projects loop or single-store path) invoked foldStore.
+      try {
+        assertReadableIndex(fs, archivedIndexFile)
+      } catch (e) {
+        emitProtectionAbort(indexUnreadableAbort(dataDir, e, archivedIndexFile), 'fold-superseded')
+      }
+
       fs.mkdirSync(archivedDir, { recursive: true })
 
       for (const id of allFoldIds) {
@@ -481,7 +502,14 @@ if (foldSuperseded) {
       fs.writeFileSync(tagsTmp, JSON.stringify(tagsIndex, null, 2), 'utf8')
       fs.renameSync(tagsTmp, tagsFile)
 
-      const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
+      // Backstop wrap (TOCTOU against the preflight classify above, same
+      // trust domain as DEFER D1) — classify-before-read even here.
+      let existingArchived
+      try {
+        existingArchived = readIndexFileOrThrow(fs, archivedIndexFile) || ''
+      } catch (e) {
+        emitProtectionAbort(indexUnreadableAbort(dataDir, e, archivedIndexFile), 'fold-superseded')
+      }
       const archivedTmp = archivedIndexFile + '.tmp'
       fs.writeFileSync(archivedTmp, existingArchived + archivedLines.join('\n') + '\n', 'utf8')
       fs.renameSync(archivedTmp, archivedIndexFile)
@@ -525,7 +553,17 @@ if (foldSuperseded) {
         stores.push({ project_path: st.project_path, data_dir: st.data_dir, label: st.label, skipped_store: 'non-root-store' })
         continue
       }
-      if (!fs.existsSync(path.join(st.data_dir, 'index.jsonl'))) {
+      // #651: classify before deciding skip-vs-abort — existsSync's false
+      // negative on a broken/EACCES-parent store would silently skip a
+      // defect the same way it would a genuinely absent one. absent -> keep
+      // the skip; unreadable -> typed abort (never skip a real defect).
+      let idxState
+      try {
+        idxState = assertReadableIndex(fs, path.join(st.data_dir, 'index.jsonl'))
+      } catch (e) {
+        emitProtectionAbort(indexUnreadableAbort(st.data_dir, e), 'fold-superseded')
+      }
+      if (idxState === 'absent') {
         stores.push({ project_path: st.project_path, data_dir: st.data_dir, label: st.label, skipped_store: 'no-index' })
         continue
       }
@@ -563,7 +601,15 @@ if (foldSuperseded) {
     abortOnLocalPlaybooks: true,
   })
   if (pbAbort) emitProtectionAbort(pbAbort, 'fold-superseded')
-  const res = foldStore(DATA_DIR, scope, protectedIds)
+  // #651 NEW-SITE (revision 2, §7 step 7b): foldStore's own loadIndex read
+  // (unlike the --all-projects loop above, which classifies before calling
+  // foldStore) has no precondition check — mirrors loadIndexOrAbort's shape.
+  let res
+  try {
+    res = foldStore(DATA_DIR, scope, protectedIds)
+  } catch (e) {
+    emitProtectionAbort(indexUnreadableAbort(DATA_DIR, e), 'fold-superseded')
+  }
 
   console.log(JSON.stringify({
     status: 'ok',
@@ -1895,9 +1941,13 @@ function _parseLogForConversion(filePath, now, windowMs, opts) {
         // earliest access that could have converted). Row-order independent.
         try {
           const indexFile = path.join(sourceDataDir, 'index.jsonl')
-          if (fs.existsSync(indexFile)) {
+          // #651: classify-before-read (readIndexFileOrThrow) so a FIFO/loop-
+          // shaped index can never be opened; unreadable falls into the
+          // catch below and this scan stays conservative (§4 advisory).
+          const raw = readIndexFileOrThrow(fs, indexFile)
+          if (raw !== null) {
             let minLa = null
-            for (const ln of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+            for (const ln of raw.split('\n')) {
               if (!ln.trim()) continue
               try {
                 const row = JSON.parse(ln)

--- a/scripts/em-doctor.mjs
+++ b/scripts/em-doctor.mjs
@@ -61,6 +61,7 @@ import { loadIndex, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
 import { findContradictionCandidates, SUMMARY_JACCARD_MIN } from './lib/contradiction.mjs'
 import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
 import { parsePlaybooksConfig, terminalOf, buildChainMaps, mergeIndexRowsForChain } from './em-trigger-index.mjs'
+import { assertReadableIndex } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -132,7 +133,20 @@ function checkStore(dataDir, scopeName) {
   const episodesDir = path.join(dataDir, 'episodes')
   const indexFile = path.join(dataDir, 'index.jsonl')
   const hasEpisodes = fs.existsSync(episodesDir)
-  const hasIndex = fs.existsSync(indexFile)
+
+  // #651: classify (lstat-based) instead of existsSync — existsSync's false
+  // negative on a symlink loop/dangling link/EACCES parent would report a
+  // healthy-looking "absent" index instead of the defect it actually is.
+  // em-doctor is the non-abort adopter: REPORT 'unreadable (<CODE>)', never
+  // crash on the disease it diagnoses, and never silently report 'ok'.
+  let hasIndex
+  let indexUnreadableCode = null
+  try {
+    hasIndex = assertReadableIndex(fs, indexFile) === 'ok'
+  } catch (e) {
+    hasIndex = false
+    indexUnreadableCode = (e && e.code) || 'UNKNOWN'
+  }
 
   // Episode files on disk (source of truth for drift checks).
   const episodeIds = new Set(
@@ -141,141 +155,175 @@ function checkStore(dataDir, scopeName) {
       : []
   )
 
-  if (!hasIndex && episodeIds.size === 0) {
+  // #651: also classify archived-index.jsonl — a health tool must not die on
+  // the disease it diagnoses, and must not report fail-open 'ok' the way
+  // existsSync-based absence-detection would on a broken/looping link.
+  try {
+    const archivedState = assertReadableIndex(fs, path.join(dataDir, 'archived-index.jsonl'))
+    report('archived-index', scopeName, 'ok', archivedState === 'ok' ? 'archived-index.jsonl readable' : 'archived-index.jsonl absent')
+  } catch (e) {
+    report('archived-index', scopeName, 'error', `archived-index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'})`,
+      { fix: 'remove the corrupt archived-index.jsonl and re-run em-rebuild-index' })
+  }
+
+  if (!hasIndex && !indexUnreadableCode && episodeIds.size === 0) {
     report('store', scopeName, 'ok', `Empty store at ${dataDir}`)
     return
   }
   report('store', scopeName, 'ok', `Store at ${dataDir}: ${episodeIds.size} episode file(s)`)
 
-  // --- index-parse: count rows that fail to parse -------------------------
-  let rawLines = []
-  let badLines = 0
-  if (hasIndex) {
-    rawLines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-    for (const line of rawLines) {
-      try { JSON.parse(line) } catch { badLines++ }
-    }
-  }
-  if (badLines > 0) {
-    report('index-parse', scopeName, 'error', `${badLines} malformed line(s) in index.jsonl`, { fix: 'em-rebuild-index' })
+  if (indexUnreadableCode) {
+    // The index-row-dependent checks below (row-shape, index-drift,
+    // tags/category/tokens dangling-ref, supersedes-links, contradiction
+    // candidates) all need to read index.jsonl rows: with no readable rows
+    // there is nothing honest to report for them (reporting index-drift
+    // against an empty row set would fabricate "every episode file
+    // unindexed"), so they are skipped. tmp-litter/stale-locks are
+    // directory-level and still run below.
+    report('index-parse', scopeName, 'error', `index.jsonl unreadable (${indexUnreadableCode})`,
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
   } else {
-    report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
-  }
-
-  // --- row-shape: schema-deviant rows (#448 class) -------------------------
-  // Hand-appended rows missing string date/time/summary (or with non-array
-  // tags) no longer crash readers (#447) but sort last and degrade filters.
-  // em-rebuild-index backfills date/time from the id prefix, so the fix hint
-  // is a real repair, not just a report.
-  const entriesForShape = loadIndex(dataDir, scopeName)
-  const deviant = entriesForShape.filter(e =>
-    typeof e.id !== 'string' || typeof e.date !== 'string' ||
-    typeof e.time !== 'string' || typeof e.summary !== 'string' ||
-    !Array.isArray(e.tags)
-  )
-  if (deviant.length) {
-    report('row-shape', scopeName, 'warn',
-      `${deviant.length} index row(s) missing typed id/date/time/summary/tags (hand-appended?). Rebuild backfills date/time from the episode id.`,
-      { fix: 'em-rebuild-index', ...(verbose ? { rows: deviant.map(e => e.id).filter(Boolean) } : {}) })
-  } else if (entriesForShape.length) {
-    report('row-shape', scopeName, 'ok', 'all index rows carry typed id/date/time/summary/tags')
-  }
-
-  // --- index-drift: index rows ↔ episode files ----------------------------
-  const entries = entriesForShape
-  const indexedIds = new Set(entries.map(e => e.id))
-  const missingFiles = [...indexedIds].filter(id => !episodeIds.has(id))
-  const unindexed = [...episodeIds].filter(id => !indexedIds.has(id))
-  if (missingFiles.length || unindexed.length) {
-    report('index-drift', scopeName, 'error',
-      `${missingFiles.length} indexed id(s) with no episode file; ${unindexed.length} episode file(s) not in index`,
-      { fix: 'em-rebuild-index', ...(verbose ? { missing_files: missingFiles, unindexed_files: unindexed } : {}) })
-  } else {
-    report('index-drift', scopeName, 'ok', 'index.jsonl and episodes/ agree')
-  }
-
-  // --- tags-index / category-index / tokens-index ---------------------------
-  for (const [checkId, fileName] of [['tags-index', 'tags.json'], ['category-index', 'category-index.json'], ['tokens-index', 'tokens.json']]) {
-    const p = path.join(dataDir, fileName)
-    if (!fs.existsSync(p)) {
-      if (indexedIds.size > 0) {
-        report(checkId, scopeName, 'warn', `${fileName} missing — searches fall back to slow linear scan`, { fix: 'em-rebuild-index' })
-      } else {
-        report(checkId, scopeName, 'ok', `${fileName} absent (empty store)`)
+    // --- index-parse: count rows that fail to parse -------------------------
+    let rawLines = []
+    let badLines = 0
+    if (hasIndex) {
+      rawLines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      for (const line of rawLines) {
+        try { JSON.parse(line) } catch { badLines++ }
       }
-      continue
     }
-    let idx
-    try {
-      idx = JSON.parse(fs.readFileSync(p, 'utf8'))
-    } catch {
-      report(checkId, scopeName, 'error', `${fileName} is corrupt (invalid JSON)`, { fix: 'em-rebuild-index' })
-      continue
-    }
-    const danglers = []
-    for (const [key, ids] of Object.entries(idx)) {
-      // tokens.json df-diet marker: value is dropped TOKEN strings, not ids.
-      if (fileName === 'tokens.json' && key === TOKENS_DROPPED_KEY) continue
-      if (!Array.isArray(ids)) continue
-      for (const id of ids) if (!indexedIds.has(id)) danglers.push(id)
-    }
-    if (danglers.length) {
-      report(checkId, scopeName, 'warn', `${fileName} references ${danglers.length} id(s) not in index.jsonl`, { fix: 'em-rebuild-index', ...(verbose ? { dangling: [...new Set(danglers)] } : {}) })
+    if (badLines > 0) {
+      report('index-parse', scopeName, 'error', `${badLines} malformed line(s) in index.jsonl`, { fix: 'em-rebuild-index' })
     } else {
-      report(checkId, scopeName, 'ok', `${fileName} consistent`)
+      report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
     }
-  }
 
-  // --- tokens-bloat ---------------------------------------------------------
-  // tokens.json is derived from the same episodes index.jsonl describes; a
-  // byte ratio above TOKENS_BLOAT_RATIO means the vocabulary is dominated by
-  // non-discriminating posting lists (common tokens). A rebuild applies the
-  // df diet (em-rebuild-index drops >40%-df posting lists) and shrinks it.
-  try {
-    const idxBytes = fs.statSync(indexFile).size
-    const tokBytes = fs.statSync(path.join(dataDir, 'tokens.json')).size
-    if (idxBytes > 0) {
-      const ratio = tokBytes / idxBytes
-      if (ratio > TOKENS_BLOAT_RATIO) {
-        report('tokens-bloat', scopeName, 'warn',
-          `tokens.json is ${Math.round(ratio)}x the size of index.jsonl (threshold ${TOKENS_BLOAT_RATIO}x) — rebuild to apply the df diet`,
-          { fix: 'em-rebuild-index' })
+    // --- row-shape: schema-deviant rows (#448 class) -------------------------
+    // Hand-appended rows missing string date/time/summary (or with non-array
+    // tags) no longer crash readers (#447) but sort last and degrade filters.
+    // em-rebuild-index backfills date/time from the id prefix, so the fix hint
+    // is a real repair, not just a report.
+    let entriesForShape
+    try {
+      entriesForShape = loadIndex(dataDir, scopeName)
+    } catch (e) {
+      // TOCTOU: readable at classify time, swapped to unreadable by read time.
+      report('index-parse', scopeName, 'error', `index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'})`,
+        { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+      entriesForShape = []
+      indexUnreadableCode = (e && e.code) || 'UNKNOWN'
+    }
+    const deviant = entriesForShape.filter(e =>
+      typeof e.id !== 'string' || typeof e.date !== 'string' ||
+      typeof e.time !== 'string' || typeof e.summary !== 'string' ||
+      !Array.isArray(e.tags)
+    )
+    if (deviant.length) {
+      report('row-shape', scopeName, 'warn',
+        `${deviant.length} index row(s) missing typed id/date/time/summary/tags (hand-appended?). Rebuild backfills date/time from the episode id.`,
+        { fix: 'em-rebuild-index', ...(verbose ? { rows: deviant.map(e => e.id).filter(Boolean) } : {}) })
+    } else if (entriesForShape.length) {
+      report('row-shape', scopeName, 'ok', 'all index rows carry typed id/date/time/summary/tags')
+    }
+
+    if (!indexUnreadableCode) {
+      // --- index-drift: index rows ↔ episode files ----------------------------
+      const entries = entriesForShape
+      const indexedIds = new Set(entries.map(e => e.id))
+      const missingFiles = [...indexedIds].filter(id => !episodeIds.has(id))
+      const unindexed = [...episodeIds].filter(id => !indexedIds.has(id))
+      if (missingFiles.length || unindexed.length) {
+        report('index-drift', scopeName, 'error',
+          `${missingFiles.length} indexed id(s) with no episode file; ${unindexed.length} episode file(s) not in index`,
+          { fix: 'em-rebuild-index', ...(verbose ? { missing_files: missingFiles, unindexed_files: unindexed } : {}) })
       } else {
-        report('tokens-bloat', scopeName, 'ok', `tokens.json/index.jsonl ratio ${Math.round(ratio * 10) / 10}x`)
+        report('index-drift', scopeName, 'ok', 'index.jsonl and episodes/ agree')
+      }
+
+      // --- tags-index / category-index / tokens-index ---------------------------
+      for (const [checkId, fileName] of [['tags-index', 'tags.json'], ['category-index', 'category-index.json'], ['tokens-index', 'tokens.json']]) {
+        const p = path.join(dataDir, fileName)
+        if (!fs.existsSync(p)) {
+          if (indexedIds.size > 0) {
+            report(checkId, scopeName, 'warn', `${fileName} missing — searches fall back to slow linear scan`, { fix: 'em-rebuild-index' })
+          } else {
+            report(checkId, scopeName, 'ok', `${fileName} absent (empty store)`)
+          }
+          continue
+        }
+        let idx
+        try {
+          idx = JSON.parse(fs.readFileSync(p, 'utf8'))
+        } catch {
+          report(checkId, scopeName, 'error', `${fileName} is corrupt (invalid JSON)`, { fix: 'em-rebuild-index' })
+          continue
+        }
+        const danglers = []
+        for (const [key, ids] of Object.entries(idx)) {
+          // tokens.json df-diet marker: value is dropped TOKEN strings, not ids.
+          if (fileName === 'tokens.json' && key === TOKENS_DROPPED_KEY) continue
+          if (!Array.isArray(ids)) continue
+          for (const id of ids) if (!indexedIds.has(id)) danglers.push(id)
+        }
+        if (danglers.length) {
+          report(checkId, scopeName, 'warn', `${fileName} references ${danglers.length} id(s) not in index.jsonl`, { fix: 'em-rebuild-index', ...(verbose ? { dangling: [...new Set(danglers)] } : {}) })
+        } else {
+          report(checkId, scopeName, 'ok', `${fileName} consistent`)
+        }
+      }
+
+      // --- tokens-bloat ---------------------------------------------------------
+      // tokens.json is derived from the same episodes index.jsonl describes; a
+      // byte ratio above TOKENS_BLOAT_RATIO means the vocabulary is dominated by
+      // non-discriminating posting lists (common tokens). A rebuild applies the
+      // df diet (em-rebuild-index drops >40%-df posting lists) and shrinks it.
+      try {
+        const idxBytes = fs.statSync(indexFile).size
+        const tokBytes = fs.statSync(path.join(dataDir, 'tokens.json')).size
+        if (idxBytes > 0) {
+          const ratio = tokBytes / idxBytes
+          if (ratio > TOKENS_BLOAT_RATIO) {
+            report('tokens-bloat', scopeName, 'warn',
+              `tokens.json is ${Math.round(ratio)}x the size of index.jsonl (threshold ${TOKENS_BLOAT_RATIO}x) — rebuild to apply the df diet`,
+              { fix: 'em-rebuild-index' })
+          } else {
+            report('tokens-bloat', scopeName, 'ok', `tokens.json/index.jsonl ratio ${Math.round(ratio * 10) / 10}x`)
+          }
+        }
+      } catch { /* either file absent — covered by the presence checks above */ }
+
+      // --- supersedes-links ----------------------------------------------------
+      const dangling = entries.filter(e => e.supersedes && !indexedIds.has(e.supersedes)).map(e => e.id)
+      if (dangling.length) {
+        // Dangling supersedes can be legitimate (chain crosses scopes, or the
+        // original was pruned) — surface, don't fail.
+        report('supersedes-links', scopeName, 'warn', `${dangling.length} episode(s) supersede id(s) not present in this scope`, verbose ? { episodes: dangling } : undefined)
+      } else {
+        report('supersedes-links', scopeName, 'ok', 'all supersedes pointers resolve')
+      }
+
+      // --- contradiction-candidates (#537) --------------------------------------
+      // Two ACTIVE decision episodes in one project with near-identical summaries
+      // are very likely the same decision stored twice — the correction written
+      // with em-store instead of em-revise, so nothing links them and both stay
+      // searchable. Advisory only: warn, no fix hint (the repair is human judgment,
+      // em-rebuild-index cannot do it), and never an error.
+      const contradiction = findContradictionCandidates(entries)
+      if (contradiction.pairs.length) {
+        report('contradiction-candidates', scopeName, 'warn',
+          `${contradiction.pairs.length} pair(s) of active decision episodes share >= ${SUMMARY_JACCARD_MIN} summary-token similarity — one may be an unlinked correction; link them with em-revise --original <id>`,
+          {
+            ...(verbose ? { pairs: contradiction.pairs } : {}),
+            ...(contradiction.skipped.length ? { skipped_projects: contradiction.skipped } : {})
+          })
+      } else if (contradiction.skipped.length) {
+        report('contradiction-candidates', scopeName, 'warn',
+          `${contradiction.skipped.length} project group(s) above the pairwise scan cap were not checked for contradictions`,
+          { skipped_projects: contradiction.skipped })
+      } else {
+        report('contradiction-candidates', scopeName, 'ok', 'no active decision episodes with near-identical summaries')
       }
     }
-  } catch { /* either file absent — covered by the presence checks above */ }
-
-  // --- supersedes-links ----------------------------------------------------
-  const dangling = entries.filter(e => e.supersedes && !indexedIds.has(e.supersedes)).map(e => e.id)
-  if (dangling.length) {
-    // Dangling supersedes can be legitimate (chain crosses scopes, or the
-    // original was pruned) — surface, don't fail.
-    report('supersedes-links', scopeName, 'warn', `${dangling.length} episode(s) supersede id(s) not present in this scope`, verbose ? { episodes: dangling } : undefined)
-  } else {
-    report('supersedes-links', scopeName, 'ok', 'all supersedes pointers resolve')
-  }
-
-  // --- contradiction-candidates (#537) --------------------------------------
-  // Two ACTIVE decision episodes in one project with near-identical summaries
-  // are very likely the same decision stored twice — the correction written
-  // with em-store instead of em-revise, so nothing links them and both stay
-  // searchable. Advisory only: warn, no fix hint (the repair is human judgment,
-  // em-rebuild-index cannot do it), and never an error.
-  const contradiction = findContradictionCandidates(entries)
-  if (contradiction.pairs.length) {
-    report('contradiction-candidates', scopeName, 'warn',
-      `${contradiction.pairs.length} pair(s) of active decision episodes share >= ${SUMMARY_JACCARD_MIN} summary-token similarity — one may be an unlinked correction; link them with em-revise --original <id>`,
-      {
-        ...(verbose ? { pairs: contradiction.pairs } : {}),
-        ...(contradiction.skipped.length ? { skipped_projects: contradiction.skipped } : {})
-      })
-  } else if (contradiction.skipped.length) {
-    report('contradiction-candidates', scopeName, 'warn',
-      `${contradiction.skipped.length} project group(s) above the pairwise scan cap were not checked for contradictions`,
-      { skipped_projects: contradiction.skipped })
-  } else {
-    report('contradiction-candidates', scopeName, 'ok', 'no active decision episodes with near-identical summaries')
   }
 
   // --- tmp-litter -----------------------------------------------------------
@@ -671,14 +719,31 @@ function checkPlaybookRegistration(dataDir, scopeName) {
   // checkPlaybookRegistration call. No module-scope memoization. The chain
   // maps are threaded into collectDeclarationTerminalSet so the declaration
   // pass and the marker scan share one construction.
-  const scannedRows = loadIndex(dataDir, scopeName)
+  // #651: em-doctor is the non-abort adopter — a corrupt index REPORTS
+  // 'unreadable (<CODE>)' and this check is skipped (nothing honest to scan
+  // for playbook registration without readable rows), it never crashes.
+  let scannedRows
+  try {
+    scannedRows = loadIndex(dataDir, scopeName)
+  } catch (e) {
+    report('playbook-registration', scopeName, 'error', `index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'}) — cannot check playbook registration`,
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+    return
+  }
   // NF4 (review r2): merge = (scanned store rows) + GLOBAL_DIR rows.
   // Resolution must include the scanned store's own rows — a marker in the
   // scanned store cannot resolve through terminalOf unless its id is in
   // byId, and byId is built from the merged rows. For cwd-local this
   // collapses to (LOCAL_DIR + GLOBAL_DIR); for a registered-store scan
   // this is (registeredStore + GLOBAL_DIR), so cross-store chains resolve.
-  const mergedRows = mergeIndexRowsForChain(loadIndex(dataDir, scopeName), loadIndex(GLOBAL_DIR, 'global'))
+  let mergedRows
+  try {
+    mergedRows = mergeIndexRowsForChain(loadIndex(dataDir, scopeName), loadIndex(GLOBAL_DIR, 'global'))
+  } catch (e) {
+    report('playbook-registration', scopeName, 'error', `index unreadable (${(e && e.code) || 'UNKNOWN'}) — cannot check playbook registration`,
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+    return
+  }
   const { byId, successorOf } = buildChainMaps(mergedRows)
   const declSet = collectDeclarationTerminalSet(byId, successorOf)
 

--- a/scripts/em-feedback.mjs
+++ b/scripts/em-feedback.mjs
@@ -34,6 +34,29 @@ import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
+
+// #651: store-selection filter for the write-lock candidate set. A store is
+// a WRITE target here (feedback counters are mutated), so an unreadable
+// index.jsonl must never be silently dropped the way existsSync's false
+// negative would drop it — that would skip locking/writing a store that
+// actually needs the write. absent -> drop (today's behavior, nothing to
+// write); unreadable -> typed abort, exit 1.
+function filterReadableStoreDirs(dirs) {
+  const kept = []
+  for (const dir of dirs) {
+    const indexFile = path.join(dir, 'index.jsonl')
+    let state
+    try {
+      state = assertReadableIndex(fs, indexFile)
+    } catch (e) {
+      console.log(JSON.stringify({ status: 'error', message: `em-feedback: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${indexFile})` }))
+      process.exit(1)
+    }
+    if (state === 'ok') kept.push(dir)
+  }
+  return kept
+}
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -98,19 +121,26 @@ if (scanTextFile !== undefined) {
   // preserves the historical report exactly. The real write path acquires
   // every existing selected store before rereading its index, so resolving an
   // id and incrementing its counter are one serialized read-modify-write.
+  // #651 F1 (revision 3, step 7d): classify-before-read — a raw readFileSync
+  // wrapped in a swallowing catch degraded an unreadable store to "no ids"
+  // AND could block forever opening a FIFO (this ran in BOTH dry-run and
+  // write mode). readIndexFileOrThrow classifies first (never opens a FIFO)
+  // and throws IndexUnreadableError instead of silently degrading; callers
+  // below type it into an envelope for both modes.
   const resolveIds = () => {
     const idsByDir = new Map(dirs.map(([name]) => [name, new Set()]))
     const dirIndexIds = dirs.map(([name, dir]) => {
       const ids = new Set()
-      try {
-        for (const line of fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8').split('\n')) {
+      const raw = readIndexFileOrThrow(fs, path.join(dir, 'index.jsonl'))
+      if (raw !== null) {
+        for (const line of raw.split('\n')) {
           if (!line.trim()) continue
           try {
             const e = JSON.parse(line)
             if (typeof e.id === 'string') ids.add(e.id)
           } catch {}
         }
-      } catch {}
+      }
       return [name, ids]
     })
     const resolved = []
@@ -131,11 +161,17 @@ if (scanTextFile !== undefined) {
   let skipped
   let recorded = 0
   if (dryRun) {
-    ({ resolved, skipped } = resolveIds())
+    try {
+      ({ resolved, skipped } = resolveIds())
+    } catch (e) {
+      if (e instanceof IndexUnreadableError) {
+        console.log(JSON.stringify({ status: 'error', message: `em-feedback: ${e.message}` }))
+        process.exit(1)
+      }
+      throw e
+    }
   } else {
-    const lockDirs = dirs
-      .map(([, dir]) => dir)
-      .filter(dir => fs.existsSync(path.join(dir, 'index.jsonl')))
+    const lockDirs = filterReadableStoreDirs(dirs.map(([, dir]) => dir))
     const lockResult = lockDirs.length
       ? acquireStoreWriteLocksSync(lockDirs)
       : { ok: true, handles: [] }
@@ -204,8 +240,7 @@ const delta = useful ? 1 : -1
 // Lock every existing candidate store before reading the mutable rows. Local
 // remains first in the scan, so the historical local-priority resolution is
 // unchanged while two feedback writers now serialize the whole counter RMW.
-const candidateDirs = [LOCAL_DIR, GLOBAL_DIR]
-  .filter(dir => fs.existsSync(path.join(dir, 'index.jsonl')))
+const candidateDirs = filterReadableStoreDirs([LOCAL_DIR, GLOBAL_DIR])
 const lockResult = candidateDirs.length
   ? acquireStoreWriteLocksSync(candidateDirs)
   : { ok: true, handles: [] }

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -46,6 +46,7 @@ import os from 'os'
 import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 import { loadIndex } from './lib/relevance.mjs'
 import { resolveRuleDir, scanRuleNodes, scanRfcNodes, slugify } from './lib/rule-nodes.mjs'
+import { IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -126,8 +127,16 @@ if ([from !== undefined, orphans, hubs].filter(Boolean).length !== 1) {
 // Load rows (local shadows global on id collision, matching the readers)
 // ---------------------------------------------------------------------------
 let rows = []
-if (scope === 'local' || scope === 'all') rows.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') rows.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') rows.push(...loadIndex(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') rows.push(...loadIndex(GLOBAL_DIR, 'global'))
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-graph: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
+}
 const seen = new Set()
 rows = rows.filter(r => {
   if (typeof r.id !== 'string' || seen.has(r.id)) return false

--- a/scripts/em-list.mjs
+++ b/scripts/em-list.mjs
@@ -13,6 +13,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -37,8 +38,9 @@ const includeSuperseded = argv.includes('--include-superseded')
 
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -48,8 +50,16 @@ function loadIndex(dataDir, source) {
 }
 
 let results = []
-if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
+}
 
 // Dedupe by id (local takes priority)
 const seen = new Set()

--- a/scripts/em-mine-transcripts.mjs
+++ b/scripts/em-mine-transcripts.mjs
@@ -35,6 +35,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { walkTranscripts } from './lib/transcript-walker.mjs'
 import { resolveRepoRoot } from './lib/local-dir.mjs'
+import { readIndexFileOrThrow } from './lib/index-state.mjs'
 
 // ---------------------------------------------------------------------------
 // Trigger config
@@ -117,9 +118,13 @@ function loadDedupeCorpus() {
   return corpus
 }
 
+// #651: classify before reading — dedupe is best-effort (worst case: a
+// duplicate episode, not evidence loss), but the read must still be
+// classified before opening so an index-shaped FIFO can never be blocked on.
 function addIndexToCorpus(file, corpus) {
   let raw
-  try { raw = fs.readFileSync(file, 'utf8') } catch { return }
+  try { raw = readIndexFileOrThrow(fs, file) } catch { return }
+  if (raw === null) return
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     try {

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -46,6 +46,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { normalizeTags, episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -95,8 +96,9 @@ const SRC_SCOPE_OF = dir => (dir === GLOBAL_DIR ? 'global' : 'local')
 // ---------------------------------------------------------------------------
 function readIndexRows(dataDir) {
   const p = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(p)) return []
-  return fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean).map(l => {
+  const raw = readIndexFileOrThrow(fs, p)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(l => {
     try { return JSON.parse(l) } catch { return null }
   }).filter(Boolean)
 }
@@ -182,14 +184,22 @@ else {
   const tag = normalizeTags(filterTag)[0]
   if (!tag) usageError('--filter-tag requires a non-empty tag.')
   const seen = new Set()
-  for (const dir of [LOCAL_DIR, GLOBAL_DIR]) {
-    for (const row of readIndexRows(dir)) {
-      if (typeof row.id !== 'string' || seen.has(row.id)) continue
-      if (Array.isArray(row.tags) && row.tags.map(t => String(t).toLowerCase().trim()).includes(tag)) {
-        seen.add(row.id)
-        ids.push(row.id)
+  try {
+    for (const dir of [LOCAL_DIR, GLOBAL_DIR]) {
+      for (const row of readIndexRows(dir)) {
+        if (typeof row.id !== 'string' || seen.has(row.id)) continue
+        if (Array.isArray(row.tags) && row.tags.map(t => String(t).toLowerCase().trim()).includes(tag)) {
+          seen.add(row.id)
+          ids.push(row.id)
+        }
       }
     }
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      console.log(JSON.stringify({ status: 'error', message: `em-move: ${e.message}` }))
+      process.exit(1)
+    }
+    throw e
   }
 }
 

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -20,6 +20,7 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const HOME = os.homedir()
 const CWD = process.cwd()
@@ -150,9 +151,10 @@ if (effectiveScope === 'global' || effectiveScope === 'all') SCOPE_DIRS.push({ d
 // invocation picks up the now-complete entry.
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
   const out = []
-  for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+  for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     try {
       const e = JSON.parse(line)
@@ -172,7 +174,15 @@ function loadTagsIndex(dataDir) {
 }
 
 const allEntries = []
-for (const s of SCOPE_DIRS) allEntries.push(...loadIndex(s.dir, s.source))
+try {
+  for (const s of SCOPE_DIRS) allEntries.push(...loadIndex(s.dir, s.source))
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-pattern-health: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
+}
 
 // Dedupe by id (local takes priority over global) — mirrors em-search.mjs:159-164
 const seen = new Set()

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -29,6 +29,7 @@ import { categoryLifecycle, canonicalCategory } from './lib/categories.mjs'
 import { computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
 import { resolveRegisteredStoresWithStatus } from './lib/registered-stores.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -69,9 +70,10 @@ const TODAY = new Date().toISOString().slice(0, 10)
 
 function loadIndexRows(dataDir, storeLabel) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
   const out = []
-  for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+  for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     try {
       const e = JSON.parse(line)
@@ -107,11 +109,18 @@ function loadInvertedIndex(dataDir, fileName) {
 
 function partitionPrunable(dataDir, protectedIds) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) {
+  // #651: routes through the shared classify+wrapped-read helper (like
+  // loadIndexRows/loadIndexRowsOrAbort above) instead of a raw existsSync
+  // check — absent keeps today's "missing" shortcut; unreadable throws
+  // IndexUnreadableError, caught by the results.push(pruneDir(...)) try/catch
+  // below so a corrupt index aborts typed instead of fabricating an empty
+  // preview or a raw stack.
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) {
     return { missing: true, entries: [], toPrune: [], toKeep: [], protectedEntries: [] }
   }
 
-  const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+  const lines = raw.trim().split('\n').filter(Boolean)
   const entries = lines.map(line => {
     try { return JSON.parse(line) } catch { return null }
   }).filter(Boolean)
@@ -202,6 +211,16 @@ function pruneDir(dataDir, label, protectedIds) {
       return { scope: label, pruned: 0, remaining: toKeep.length, freed_bytes: 0, protected: protectedEntries.length }
     }
 
+    // #651 F2 (revision 3, step 7c): classify archived-index.jsonl BEFORE any
+    // file move — a FIFO/broken archived-index discovered only at the
+    // read-merge-replace step below (after episode files are already
+    // renamed into archived/ and index.jsonl already replaced) leaves a
+    // killed process with moved files unrecorded in archived-index. absent/ok
+    // are both fine to continue; unreadable throws IndexUnreadableError,
+    // caught by the top-level results.push(pruneDir(...)) handler below —
+    // nothing has moved yet.
+    assertReadableIndex(fs, archivedIndexFile)
+
     fs.mkdirSync(archivedDir, { recursive: true })
 
     let freedBytes = 0
@@ -239,7 +258,9 @@ function pruneDir(dataDir, label, protectedIds) {
     }
 
     // Read-merge-replace archived-index while still holding the same lock.
-    const existingArchived = fs.existsSync(archivedIndexFile) ? fs.readFileSync(archivedIndexFile, 'utf8') : ''
+    // Backstop wrap (TOCTOU against the preflight classify above, same trust
+    // domain as DEFER D1) — classify-before-read even here, never a raw open.
+    const existingArchived = readIndexFileOrThrow(fs, archivedIndexFile) || ''
     atomicReplaceFileSync(archivedIndexFile, existingArchived + archivedEntries.join('\n') + '\n')
 
     return { scope: label, pruned: toPrune.length, remaining: toKeep.length, freed_bytes: freedBytes, protected: protectedEntries.length }
@@ -293,6 +314,10 @@ try {
 } catch (error) {
   if (error?.code === 'store-write-lock-timeout') {
     console.log(JSON.stringify({ status: 'error', code: error.code, heldBy: error.heldBy, message: error.message }))
+    process.exit(1)
+  }
+  if (error instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-prune: aborting archival — episode index unreadable (${error.code}) (${error.file})` }))
     process.exit(1)
   }
   throw error

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -19,6 +19,7 @@ import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevanc
 import { resolveStoreIdentity } from './lib/store-identity.mjs'
 import { STRUCTURED_FIELDS } from './lib/promotion-sources.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { assertReadableIndex, readIndexFileOrThrow } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -57,6 +58,18 @@ class RebuildFailure extends Error {
     super(payload.error || 'rebuild failed')
     this.payload = payload
   }
+}
+
+// #651 (audit Gap 4 / REQ-8): a corrupt index.jsonl aborts typed, with a
+// remediation hint, BEFORE any write — the same envelope shape whether the
+// defect is caught before lock acquisition or on the in-lock re-read.
+function unreadableIndexFailure(indexFile, label, e) {
+  return new RebuildFailure({
+    status: 'error',
+    scope: label,
+    message: `em-rebuild-index: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${indexFile})`,
+    remediation: 'remove the corrupt index.jsonl and re-run em-rebuild-index',
+  })
 }
 
 // --check: drift DETECTION only (R10f). Lists every episode whose stored category is unknown or
@@ -131,22 +144,46 @@ function parseFrontmatter(content) {
  * Load old index.jsonl into a map keyed by episode ID.
  * Used to carry forward access_count and last_accessed during rebuild.
  */
-function loadOldIndex(dataDir) {
+function loadOldIndex(dataDir, label) {
   const indexFile = path.join(dataDir, 'index.jsonl')
   const map = new Map()
+  let raw
   try {
-    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line)
-        if (entry.id) map.set(entry.id, entry)
-      } catch {}
-    }
-  } catch {}
+    raw = readIndexFileOrThrow(fs, indexFile)
+  } catch (e) {
+    // In-lock re-read found a defect (TOCTOU against the pre-lock classify
+    // below, or the pre-lock classify's absent->created-since race) — abort
+    // rather than silently losing access_count carry-forward and proceeding
+    // to truncate/replace a corrupt index (REQ-8).
+    throw unreadableIndexFailure(indexFile, label, e)
+  }
+  if (raw === null) return map
+  for (const line of raw.trim().split('\n').filter(Boolean)) {
+    try {
+      const entry = JSON.parse(line)
+      if (entry.id) map.set(entry.id, entry)
+    } catch {}
+  }
   return map
 }
 
 function rebuildDir(dataDir, label) {
+  // Scans episodes/ only — archived/ is intentionally ignored
+  const episodesDir = path.join(dataDir, 'episodes')
+  const indexFile = path.join(dataDir, 'index.jsonl')
+
+  // #651 (audit Gap 4): classify index.jsonl AND check episodesDir BEFORE
+  // acquiring the store lock. acquireStoreWriteLocksSync itself writes into
+  // dataDir and dies with a raw stack under an eaccess/broken store; an
+  // unreadable index must abort typed, with a remediation hint, before any
+  // lock is taken or any write happens — never truncated/replaced (REQ-8).
+  try {
+    assertReadableIndex(fs, indexFile)
+  } catch (e) {
+    throw unreadableIndexFailure(indexFile, label, e)
+  }
+  const hasEpisodesDir = fs.existsSync(episodesDir)
+
   // Hold the per-store lock from the episode scan through every derived
   // replacement. Rebuild is a full snapshot transaction, not four unrelated
   // renames that can interleave with a writer.
@@ -154,18 +191,16 @@ function rebuildDir(dataDir, label) {
   if (!lockResult.ok) throw new RebuildFailure({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy, scope: label })
   const lockHandles = lockResult.handles
   try {
-  // Scans episodes/ only — archived/ is intentionally ignored
-  const episodesDir = path.join(dataDir, 'episodes')
-  const indexFile = path.join(dataDir, 'index.jsonl')
-
-  if (!fs.existsSync(episodesDir)) {
+  if (!hasEpisodesDir) {
+    // absent episodesDir with a readable (or genuinely absent) index parent
+    // still takes today's create path.
     fs.mkdirSync(episodesDir, { recursive: true })
     atomicReplaceFileSync(indexFile, '')
     return { scope: label, count: 0 }
   }
 
   // Load old index to preserve access metadata
-  const oldIndex = loadOldIndex(dataDir)
+  const oldIndex = loadOldIndex(dataDir, label)
 
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -24,6 +24,7 @@ import {
   normalizeTags, loadTagsIndex, loadIndex,
   computeScore, writeBackAccessTracking
 } from './lib/relevance.mjs'
+import { IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -249,11 +250,19 @@ function inferContext() {
 // ---------------------------------------------------------------------------
 let allEntries = []
 
-if (scope === 'local' || scope === 'all') {
-  allEntries.push(...loadIndex(LOCAL_DIR, 'local'))
-}
-if (scope === 'global' || scope === 'all') {
-  allEntries.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') {
+    allEntries.push(...loadIndex(LOCAL_DIR, 'local'))
+  }
+  if (scope === 'global' || scope === 'all') {
+    allEntries.push(...loadIndex(GLOBAL_DIR, 'global'))
+  }
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-recall: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
 }
 
 const totalEpisodeCount = allEntries.length

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -41,6 +41,7 @@ import { nullProtoIndex } from './lib/relevance.mjs'
 // derived-index merge so two restore targets cannot diverge before both
 // locks are held.
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { readIndexFileOrThrow } from './lib/index-state.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -408,8 +409,9 @@ function writeJSONAtomic(filePath, obj) {
 // ---------------------------------------------------------------------------
 function loadIndexJsonl(filePath) {
   const map = new Map()
-  if (!fs.existsSync(filePath)) return map
-  const content = fs.readFileSync(filePath, 'utf8').trim()
+  const raw = readIndexFileOrThrow(fs, filePath)
+  if (raw === null) return map
+  const content = raw.trim()
   if (!content) return map
   for (const line of content.split('\n')) {
     if (!line.trim()) continue

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -49,6 +49,7 @@ import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { nullProtoIndex, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -199,8 +200,9 @@ function refTarget(ref) {
 
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -507,8 +509,20 @@ try {
   // Re-read both collision surfaces under lock rather than silently
   // overwriting an episode or duplicating its index row.
   let idInIndex = false
-  if (fs.existsSync(indexFile)) {
-    for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+  let collisionRaw
+  try {
+    collisionRaw = readIndexFileOrThrow(fs, indexFile)
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      // fail() calls process.exit, which skips this try's finally — release
+      // the lock explicitly first (mirrors em-consolidate's emitProtectionAbort).
+      releaseStoreWriteLocks(lockResult.handles)
+      fail(1, `em-review-request: ${e.message}`)
+    }
+    throw e
+  }
+  if (collisionRaw !== null) {
+    for (const line of collisionRaw.split('\n')) {
       if (!line.trim()) continue
       try {
         if (JSON.parse(line).id === id) { idInIndex = true; break }

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -26,6 +26,7 @@ import {
   computeScore, writeBackAccessTracking, scoreTextMatch,
   tokenizeQuery, loadTokensIndex, tokenCandidates, scorePartialMatch
 } from './lib/relevance.mjs'
+import { IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -79,11 +80,19 @@ const searchStart = Date.now()
 // ---------------------------------------------------------------------------
 let results = []
 
-if (scope === 'local' || scope === 'all') {
-  results.push(...loadIndex(LOCAL_DIR, 'local'))
-}
-if (scope === 'global' || scope === 'all') {
-  results.push(...loadIndex(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') {
+    results.push(...loadIndex(LOCAL_DIR, 'local'))
+  }
+  if (scope === 'global' || scope === 'all') {
+    results.push(...loadIndex(GLOBAL_DIR, 'global'))
+  }
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
 }
 
 const totalEpisodeCount = results.length

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -18,6 +18,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { nullProtoIndex, episodeTokens, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 
@@ -238,7 +239,21 @@ try {
   } catch {
     tagsIndex = Object.create(null)
   }
-  const existingIndex = fs.existsSync(globalIndexFile) ? fs.readFileSync(globalIndexFile, 'utf8') : ''
+  // #651: classify + wrapped read; unreadable is a real defect on a store
+  // this run is about to write into — release the held lock and abort typed
+  // instead of silently treating the store as empty (existsSync's false
+  // negative on a broken index) or reading past a defect.
+  let existingIndex
+  try {
+    existingIndex = readIndexFileOrThrow(fs, globalIndexFile) || ''
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      releaseStoreWriteLocks(lockResult.handles)
+      console.log(JSON.stringify({ status: 'error', message: `em-seed-patterns: ${e.message}` }))
+      process.exit(1)
+    }
+    throw e
+  }
   const existingIds = new Set(existingIndex.split('\n').filter(Boolean).map(line => {
     try { return JSON.parse(line).id } catch { return null }
   }).filter(Boolean))

--- a/scripts/em-semantic.mjs
+++ b/scripts/em-semantic.mjs
@@ -34,6 +34,7 @@ import {
   HASH_MODEL, hashEmbed, buildIdf, cmdEmbed, cosine, loadEmbeddings, contentHash,
   loadEmbedConfig, resolveEmbedSettings
 } from './lib/embeddings.mjs'
+import { IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -139,7 +140,15 @@ if (provider === 'hash') {
 // Rank
 // ---------------------------------------------------------------------------
 let entries = []
-for (const [dir, label] of dirs) entries.push(...loadIndex(dir, label))
+try {
+  for (const [dir, label] of dirs) entries.push(...loadIndex(dir, label))
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-semantic: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
+}
 const seen = new Set()
 entries = entries.filter(e => {
   if (seen.has(e.id)) return false

--- a/scripts/em-stats.mjs
+++ b/scripts/em-stats.mjs
@@ -22,6 +22,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, computeScore } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -127,10 +128,18 @@ function statsFor(dataDir, label) {
     if (r.pinned !== true && computeScore(r, 1.0) < PRUNE_THRESHOLD) prunable++
   }
 
+  // #651: archived-index.jsonl is a documented advisory degrade surface —
+  // classify-before-read (never open a FIFO), and an unreadable shape
+  // degrades `archived` to 0 while surfacing the defect via
+  // archived_unreadable (a health/analytics tool must not silently hide it).
   let archived = 0
+  let archivedUnreadable = false
   try {
-    archived = fs.readFileSync(path.join(dataDir, 'archived-index.jsonl'), 'utf8').trim().split('\n').filter(Boolean).length
-  } catch {}
+    const raw = readIndexFileOrThrow(fs, path.join(dataDir, 'archived-index.jsonl'))
+    if (raw !== null) archived = raw.trim().split('\n').filter(Boolean).length
+  } catch {
+    archivedUnreadable = true
+  }
 
   // Derived-index bloat: tokens.json is DERIVED from the same episodes
   // index.jsonl describes, so their byte ratio is a health signal — a ratio
@@ -148,6 +157,9 @@ function statsFor(dataDir, label) {
     dir: dataDir,
     episodes: { total: rows.length, active: active.length, superseded: rows.length - active.length, pinned },
     archived,
+    // #651 F5 (revision 3, step 7f): surface only on the unreadable case
+    // (a healthy store's schema stays exactly as it was pre-#651).
+    ...(archivedUnreadable ? { archived_unreadable: true } : {}),
     by_category: byCategory,
     top_projects: topN(byProject, top),
     top_tags: topN(byTag, top),
@@ -167,21 +179,29 @@ function statsFor(dataDir, label) {
 }
 
 const scopes = []
-if (scope === 'local' || scope === 'all') scopes.push(statsFor(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') scopes.push(statsFor(GLOBAL_DIR, 'global'))
+try {
+  if (scope === 'local' || scope === 'all') scopes.push(statsFor(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') scopes.push(statsFor(GLOBAL_DIR, 'global'))
 
-// --all-projects: one block per consumer-registry store not already covered.
-// Identity is realpath on BOTH comparison operands (the dir field a block
-// carries is the unresolved spelling; a cwd-local store symlinked to a
-// registered store must not double-count).
-if (argv.includes('--all-projects')) {
-  const included = new Set(scopes.map(s => realpathSafe(s.dir)))
-  for (const st of resolveRegisteredStores()) {
-    const key = realpathSafe(st.data_dir)
-    if (included.has(key)) continue
-    included.add(key)
-    scopes.push(statsFor(st.data_dir, st.label))
+  // --all-projects: one block per consumer-registry store not already covered.
+  // Identity is realpath on BOTH comparison operands (the dir field a block
+  // carries is the unresolved spelling; a cwd-local store symlinked to a
+  // registered store must not double-count).
+  if (argv.includes('--all-projects')) {
+    const included = new Set(scopes.map(s => realpathSafe(s.dir)))
+    for (const st of resolveRegisteredStores()) {
+      const key = realpathSafe(st.data_dir)
+      if (included.has(key)) continue
+      included.add(key)
+      scopes.push(statsFor(st.data_dir, st.label))
+    }
   }
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-stats: ${e.message}` }))
+    process.exit(1)
+  }
+  throw e
 }
 
 const totals = {

--- a/scripts/em-topic-tracks.mjs
+++ b/scripts/em-topic-tracks.mjs
@@ -26,6 +26,7 @@ import {
   scanTopicTracks,
   applyTopicTracks,
 } from './topic-tracks/engine.mjs'
+import { IndexUnreadableError } from './lib/index-state.mjs'
 
 const argv = process.argv.slice(2)
 const SCRIPT_NAME = 'em-topic-tracks.mjs'
@@ -168,6 +169,11 @@ try {
         ? `members=${err.observed} > cap=${err.max_episodes}`
         : 'members exceeded committed hard cap',
       2)
+  }
+  // #651 F4 (revision 3, step 7e): a corrupt index.jsonl is a distinct
+  // failure class from a malformed config.json — don't misattribute it.
+  if (err instanceof IndexUnreadableError) {
+    emitError('episode-index-unreadable', err.message, 1)
   }
   emitError('topic-tracks-config-invalid', err && err.message, 1)
 }

--- a/scripts/em-watch-codex.mjs
+++ b/scripts/em-watch-codex.mjs
@@ -29,6 +29,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
+import { assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const TAG_ALIASES = ['codex', 'codex-review', 'codex-reply']
 const VALID_SCOPES = ['local', 'global', 'all']
@@ -90,7 +91,16 @@ function findLocalStore(startDir) {
   while (true) {
     if (dir === home) return null
     const candidate = path.join(dir, '.episodic-memory', 'index.jsonl')
-    if (fs.existsSync(candidate)) return path.join(dir, '.episodic-memory')
+    // #651: classify, don't existsSync — a broken (unreadable) ancestor store
+    // must abort here, never be silently skipped as "absent" and let the walk
+    // bind a DIFFERENT, unrelated ancestor's store instead.
+    let state
+    try {
+      state = assertReadableIndex(fs, candidate)
+    } catch (e) {
+      fail(`em-watch-codex: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${candidate})`, 1)
+    }
+    if (state === 'ok') return path.join(dir, '.episodic-memory')
     const parent = path.dirname(dir)
     if (parent === dir) return null
     dir = parent
@@ -153,9 +163,9 @@ function saveCursor(cursor) {
 // ---------------------------------------------------------------------------
 function loadIndex(dataDir) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
   const out = []
-  const raw = fs.readFileSync(indexFile, 'utf8')
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     try {
@@ -257,20 +267,27 @@ const newCursor = { local: cursorBefore.local, global: cursorBefore.global }
 const allMatches = []
 let warning = null
 
-for (const s of SCOPES_QUERIED) {
-  const sinceForScope = since !== undefined ? since : cursorBefore[s]
-  const { matches, usedFallback, hasIndexFile } = queryScope(s, sinceForScope)
-  if (usedFallback && hasIndexFile) {
-    warning = `tags.json missing for ${s}; used linear scan. Run em-rebuild-index.mjs to regenerate.`
-  }
-  for (const m of matches) allMatches.push(m)
+try {
+  for (const s of SCOPES_QUERIED) {
+    const sinceForScope = since !== undefined ? since : cursorBefore[s]
+    const { matches, usedFallback, hasIndexFile } = queryScope(s, sinceForScope)
+    if (usedFallback && hasIndexFile) {
+      warning = `tags.json missing for ${s}; used linear scan. Run em-rebuild-index.mjs to regenerate.`
+    }
+    for (const m of matches) allMatches.push(m)
 
-  // Advance cursor only to max id of *returned* episodes for this scope.
-  // Zero-result → no-advance (preserves cursor against partial writes / races).
-  if (matches.length > 0) {
-    const maxId = matches[matches.length - 1].id
-    newCursor[s] = maxId
+    // Advance cursor only to max id of *returned* episodes for this scope.
+    // Zero-result → no-advance (preserves cursor against partial writes / races).
+    if (matches.length > 0) {
+      const maxId = matches[matches.length - 1].id
+      newCursor[s] = maxId
+    }
   }
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    fail(`em-watch-codex: ${e.message}`, 1)
+  }
+  throw e
 }
 
 // Dedup across scopes by id (in case of cross-scope copies — local takes priority,

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -31,6 +31,7 @@ import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
+import { readIndexFileOrThrow } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -125,8 +126,9 @@ if ((gate === 'push-allowed' || gate === 'review-request') && !head) {
 // ---------------------------------------------------------------------------
 function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source

--- a/scripts/lib/index-state.mjs
+++ b/scripts/lib/index-state.mjs
@@ -1,0 +1,97 @@
+// index-state.mjs — lstat-based index.jsonl existence classifier (issue #651).
+//
+// existsSync(index.jsonl) is not a reliable existence check: it returns false
+// for a symlink loop, a dangling symlink, or an index under an EACCES parent
+// (silent fail-open — the loader takes its missing-store branch and evidence
+// silently disappears), and true for a FIFO (an unguarded readFileSync then
+// blocks forever). classifyIndexFile draws the distinction loaders actually
+// need — 'absent' (genuinely no store, keep today's [] / skip / create) vs
+// 'unreadable' (a defect: abort typed, never silently degrade, never open).
+//
+// Zero external dependencies — Node.js stdlib only. fsMod injection mirrors
+// protection.mjs's existing injected-fs signature.
+
+import path from 'node:path'
+
+// classifyParent(fsMod, filePath) — invoked only when lstat(filePath) itself
+// threw ENOENT, to distinguish "no store at all" from "store dir is a broken
+// symlink" (a dangling/looping .episodic-memory is a defect, not an absent
+// store — audit P2).
+function classifyParent(fsMod, filePath) {
+  const dir = path.dirname(filePath)
+  let dirStat
+  try {
+    dirStat = fsMod.lstatSync(dir)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return { state: 'absent' } // no store dir either — genuinely missing
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'parent inspection failed' }
+  }
+  if (dirStat.isSymbolicLink()) {
+    try {
+      fsMod.statSync(dir)
+    } catch (e) {
+      return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'broken parent (dangling/loop)' }
+    }
+  }
+  return { state: 'absent' } // store dir exists (or resolves cleanly), index genuinely missing
+}
+
+// classifyIndexFile(fsMod, filePath) — the §2 contract table, lstat-based so a
+// symlink is inspected before being followed. Never opens the file.
+export function classifyIndexFile(fsMod, filePath) {
+  let st
+  try {
+    st = fsMod.lstatSync(filePath)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return classifyParent(fsMod, filePath) // absent vs broken-parent
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'lstat failed' }
+  }
+  if (st.isSymbolicLink()) {
+    try {
+      st = fsMod.statSync(filePath)
+    } catch (e) {
+      if (e && e.code === 'ENOENT') return { state: 'unreadable', code: 'ENOENT', detail: 'dangling symlink' }
+      return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN', detail: 'symlink resolution failed' }
+    }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR', detail: 'index is a directory' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG', detail: 'index is not a regular file' }
+  return { state: 'ok' }
+}
+
+// IndexUnreadableError — the typed abort every loader throws for an
+// 'unreadable' classification (or a read failure after an 'ok' classification
+// — the file-mode-000 / post-classify swap-to-dir race, §2 last row). Message
+// shape matches the #628 envelope family the existing tests regex against
+// (/episode index unreadable/, /index\.jsonl/).
+export class IndexUnreadableError extends Error {
+  constructor(filePath, code, detail) {
+    super(`episode index unreadable (${code}) (${filePath})`)
+    this.code = code
+    this.file = filePath
+    this.detail = detail
+  }
+}
+
+// assertReadableIndex(fsMod, filePath) — returns 'absent' | 'ok'; throws
+// IndexUnreadableError on 'unreadable'. Classification only — never reads.
+export function assertReadableIndex(fsMod, filePath) {
+  const result = classifyIndexFile(fsMod, filePath)
+  if (result.state === 'absent') return 'absent'
+  if (result.state === 'ok') return 'ok'
+  throw new IndexUnreadableError(filePath, result.code, result.detail)
+}
+
+// readIndexFileOrThrow(fsMod, filePath) — classify, then read. 'absent' ->
+// null (caller's missing-store branch); 'ok' -> file contents, with any read
+// failure (file-mode-000 EACCES, or a post-classify swap to directory) wrapped
+// into IndexUnreadableError so no raw fs stack ever reaches a caller.
+export function readIndexFileOrThrow(fsMod, filePath) {
+  const state = assertReadableIndex(fsMod, filePath)
+  if (state === 'absent') return null
+  try {
+    return fsMod.readFileSync(filePath, 'utf8')
+  } catch (e) {
+    throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'read failed')
+  }
+}

--- a/scripts/lib/protection.mjs
+++ b/scripts/lib/protection.mjs
@@ -20,16 +20,23 @@
 
 import path from 'node:path'
 import { parsePlaybooksConfig } from '../em-trigger-index.mjs'
+import { readIndexFileOrThrow } from './index-state.mjs'
 
 // index.jsonl rows for one store, tagged with a store label. UNION both stores'
 // output before computeProtectedIds: a global lesson's evidence can name a local
 // violation, so protection is cross-store. Deliberately NO id-dedupe — a stale
 // superseded copy in one store must not shadow an active referencer in the other.
+//
+// #651: absent index.jsonl -> []; unreadable (symlink loop/dangling, EACCES
+// parent, FIFO/socket/device, EISDIR, or a read failure) -> throws
+// IndexUnreadableError — a retention consumer must never treat a defect as an
+// empty (unprotected) store.
 export function loadProtectionRows(fs, path, dataDir, storeLabel) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
   const out = []
-  for (const line of fs.readFileSync(indexFile, 'utf8').split('\n')) {
+  for (const line of raw.split('\n')) {
     if (!line.trim()) continue
     try {
       const e = JSON.parse(line)

--- a/scripts/lib/relevance.mjs
+++ b/scripts/lib/relevance.mjs
@@ -24,6 +24,7 @@
 import fs from 'fs'
 import path from 'path'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './store-write-lock.mjs'
+import { assertReadableIndex, readIndexFileOrThrow } from './index-state.mjs'
 
 // Per-token field weights for the multi-term tier. Summary tokens count just
 // under a contiguous summary substring (0.7); tags sit between summary and
@@ -93,11 +94,18 @@ export function loadCategoryIndex(dataDir) {
 // ---------------------------------------------------------------------------
 // loadIndex(dataDir, source) — read index.jsonl rows, tagging each with the
 // scope it came from. Malformed lines are skipped, not fatal.
+//
+// Existence semantics (#651): absent (genuinely no store) -> []; unreadable
+// (symlink loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a
+// read failure such as file-mode-000) -> throws IndexUnreadableError. Callers
+// that must never fabricate empty results on a real defect catch this; see
+// scripts/lib/index-state.mjs for the full classification table.
 // ---------------------------------------------------------------------------
 export function loadIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
-  return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
+  const raw = readIndexFileOrThrow(fs, indexFile)
+  if (raw === null) return []
+  return raw.trim().split('\n').filter(Boolean).map(line => {
     try {
       const entry = JSON.parse(line)
       entry._source = source
@@ -113,11 +121,20 @@ export function loadIndex(dataDir, source) {
 // move an episode file to archived/). Same tolerant shape as loadIndex, plus
 // _archived: true so callers resolve bodies from archived/ instead of
 // episodes/. Used by the em-search --history walk so folded/pruned chain
-// members stay resolvable. Missing/corrupt file degrades to [].
+// members stay resolvable. Documented advisory degrade surface (#651 §4):
+// classify before any read (never open a FIFO), and degrade to [] on BOTH
+// absent and unreadable — this is a history-walk convenience index, not
+// index.jsonl's authoritative store.
 // ---------------------------------------------------------------------------
 export function loadArchivedIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'archived-index.jsonl')
-  if (!fs.existsSync(indexFile)) return []
+  let state
+  try {
+    state = assertReadableIndex(fs, indexFile)
+  } catch {
+    return [] // unreadable (incl. non-regular): classify-before-read, never open, degrade
+  }
+  if (state !== 'ok') return [] // absent
   try {
     return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
       try {
@@ -128,7 +145,7 @@ export function loadArchivedIndex(dataDir, source) {
         return entry
       } catch { return null }
     }).filter(Boolean)
-  } catch { return [] }
+  } catch { return [] } // read failure (e.g. TOCTOU swap) also degrades
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/topic-tracks/engine.mjs
+++ b/scripts/topic-tracks/engine.mjs
@@ -24,6 +24,7 @@ import {
   acquireStoreWriteLocksSync,
   releaseStoreWriteLocks,
 } from '../lib/store-write-lock.mjs'
+import { readIndexFileOrThrow } from '../lib/index-state.mjs'
 
 // --- §A.5 frozen constants ---
 export const TOPIC_TRACK_TAG = 'topic-track'
@@ -156,11 +157,14 @@ export function loadTopicTracksConfig(pathOverride) {
   })
 }
 
-// --- Minimal JSONL index reader. Tolerates missing files (returns []). ---
+// --- Minimal JSONL index reader. Absent -> []; unreadable (#651: classified
+// BEFORE read — a symlink loop/FIFO/EACCES-parent index.jsonl is a defect,
+// not an empty store) -> throws IndexUnreadableError, which the CLI entry
+// (em-topic-tracks.mjs) already routes to its generic error envelope. ---
 function loadIndexRows(dataDir) {
   const indexFile = path.join(dataDir, 'index.jsonl')
-  let text
-  try { text = fs.readFileSync(indexFile, 'utf8') } catch { return [] }
+  const text = readIndexFileOrThrow(fs, indexFile)
+  if (text === null) return []
   const out = []
   for (const line of text.split('\n')) {
     const trimmed = line.trim()

--- a/tests/test-651-index-existence.mjs
+++ b/tests/test-651-index-existence.mjs
@@ -1,0 +1,821 @@
+#!/usr/bin/env node
+// test-651-index-existence.mjs — issue #651 lstat-based index existence-semantics
+// contract (see docs/plans/issue-651-index-existence-contract.md §8). Harness
+// pattern mirrors tests/test-628-sibling-init-guard.mjs: mkdtemp + real em-store
+// seed + spawnSync with explicit cwd + pinned HOME/USERPROFILE; lastJson(); no
+// raw-stack assert. Every spawnSync call carries timeout: 10000 so a FIFO
+// regression FAILS the assertion (status:null/signal) instead of hanging the
+// suite.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import {
+  classifyIndexFile, assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError,
+} from '../scripts/lib/index-state.mjs'
+
+// EM651_TEST_REPO_OVERRIDE: points spawned scripts at an alternate repo root
+// (used ONLY to re-run this suite against a pre-fix snapshot for the §8
+// falsifiability gate — see docs/plans/issue-651-index-existence-contract.md
+// build order step 2). Unset in normal use; T1 always imports the CURRENT
+// working tree's scripts/lib/index-state.mjs via the static import above,
+// regardless of this override.
+const REPO = process.env.EM651_TEST_REPO_OVERRIDE
+  ? path.resolve(process.env.EM651_TEST_REPO_OVERRIDE)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const SCRIPTS = path.join(REPO, 'scripts')
+const PLUGIN_SCRIPTS = path.join(REPO, 'plugins', 'episodic-memory', 'scripts')
+
+let pass = 0, fail = 0, skipped = 0
+function assert(cond, msg) { if (!cond) throw new Error(msg) }
+function t(name, fn) {
+  try { fn(); pass++; console.log(`ok - ${name}`) }
+  catch (e) { fail++; console.log(`not ok - ${name}: ${e.message}`) }
+}
+function skip(name, reason) { skipped++; console.log(`ok - ${name} # SKIP ${reason}`) }
+
+const IS_ROOT = typeof process.getuid === 'function' && process.getuid() === 0
+const IS_WIN = process.platform === 'win32'
+
+// ---------------------------------------------------------------------------
+// spawn helper — real script, explicit cwd, pinned HOME/USERPROFILE, bounded
+// timeout so a FIFO regression fails loud instead of hanging the suite.
+// ---------------------------------------------------------------------------
+function run(scriptPath, args, { cwd, home }) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd, encoding: 'utf8', timeout: 10000,
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  })
+}
+
+// Most scripts print one compact JSON line; em-restore.mjs pretty-prints
+// (JSON.stringify(o, null, 2)) so the LAST line alone ("}") is not valid JSON
+// on its own — try the whole trimmed stdout first, fall back to the last
+// non-empty line for the compact-single-line scripts.
+function lastJson(stdout) {
+  const trimmed = (stdout || '').trim()
+  try { return JSON.parse(trimmed) } catch {}
+  try { return JSON.parse(trimmed.split('\n').filter(Boolean).pop()) } catch { return null }
+}
+
+// Generic typed-abort assertion (REQ-3/REQ-4): exit 1, last stdout line is a
+// {status:'error'} JSON object, message names the defect + the file, and
+// stderr carries no raw stack frames (a FIFO regression instead reports
+// status:null/signal via the timeout).
+function checkTyped(r, who) {
+  assert(r.signal === null, `${who}: no signal (timeout/kill) — got ${r.signal}`)
+  assert(r.status === 1, `${who}: exit 1, got status=${r.status} signal=${r.signal} stdout=${(r.stdout || '').slice(0, 200)} stderr=${(r.stderr || '').slice(0, 200)}`)
+  const j = lastJson(r.stdout)
+  assert(j && j.status === 'error', `${who}: typed envelope on stdout, got: ${(r.stdout || '').slice(0, 200)}`)
+  const raw = r.stdout
+  assert(/episode index unreadable/.test(raw), `${who}: message names 'episode index unreadable', got: ${raw.slice(0, 300)}`)
+  assert(/index\.jsonl/.test(raw), `${who}: message names index.jsonl, got: ${raw.slice(0, 300)}`)
+  assert(!/at .*\.mjs/.test(r.stderr || ''), `${who}: no raw stack frames on stderr, got: ${(r.stderr || '').slice(0, 300)}`)
+  return j
+}
+
+// ---------------------------------------------------------------------------
+// Fixture shapes (§8): symloop, dangling, eaccess, fifo, file000, parent-dangling.
+// Applied to an already-seeded store's LOCAL index.jsonl (or, for
+// parent-dangling, the store dir itself).
+// ---------------------------------------------------------------------------
+const ALL_SHAPES = ['symloop', 'dangling', 'eaccess', 'fifo', 'file000', 'parent-dangling']
+
+function shapeSkipReason(shape) {
+  if (shape === 'eaccess' && IS_ROOT) return 'root bypasses permission checks'
+  if (shape === 'fifo' && IS_WIN) return 'mkfifo unavailable on win32'
+  return null
+}
+
+// file000's fixture content — named so callers that need to assert
+// "index.jsonl unchanged after an aborted run" can compare against the
+// POST-corruption content directly instead of racing a chmod-000 read.
+const FILE000_FIXTURE_CONTENT = JSON.stringify({ id: 'x', date: '2020-01-01', time: '00:00', project: 'p', category: 'decision', status: 'active', supersedes: null, tags: [], summary: 'x' }) + '\n'
+
+// indexPath = <storeDir>/index.jsonl. storeDir must already exist (with
+// episodes/ etc) except for 'parent-dangling', which replaces storeDir itself.
+function applyShape(shape, indexPath, storeDir) {
+  const dir = path.dirname(indexPath)
+  switch (shape) {
+    case 'symloop': {
+      fs.rmSync(indexPath, { force: true })
+      const loopB = path.join(dir, 'loop-b')
+      fs.rmSync(loopB, { force: true })
+      fs.symlinkSync('loop-b', indexPath)
+      fs.symlinkSync('index.jsonl', loopB)
+      return
+    }
+    case 'dangling': {
+      fs.rmSync(indexPath, { force: true })
+      fs.symlinkSync('does-not-exist-target', indexPath)
+      return
+    }
+    case 'eaccess': {
+      fs.chmodSync(storeDir, 0o000)
+      return
+    }
+    case 'fifo': {
+      fs.rmSync(indexPath, { force: true })
+      const r = spawnSync('mkfifo', [indexPath])
+      if (r.status !== 0) throw new Error(`mkfifo failed: ${r.stderr}`)
+      return
+    }
+    case 'file000': {
+      fs.writeFileSync(indexPath, FILE000_FIXTURE_CONTENT)
+      fs.chmodSync(indexPath, 0o000)
+      return
+    }
+    case 'parent-dangling': {
+      fs.rmSync(storeDir, { recursive: true, force: true })
+      fs.symlinkSync('does-not-exist-parent-target', storeDir)
+      return
+    }
+    default:
+      throw new Error(`unknown shape ${shape}`)
+  }
+}
+
+// Best-effort restore so a chmod-000 fixture doesn't break cleanup / later
+// shape comparison.
+function restoreShape(shape, indexPath, storeDir) {
+  if (shape === 'eaccess') { try { fs.chmodSync(storeDir, 0o755) } catch {} }
+  if (shape === 'file000') { try { fs.chmodSync(indexPath, 0o644) } catch {} }
+}
+
+// ---------------------------------------------------------------------------
+// Store fixtures
+// ---------------------------------------------------------------------------
+function mkStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-'))
+  const proj = path.join(root, 'proj')
+  fs.mkdirSync(proj)
+  const seed = spawnSync(process.execPath, [
+    path.join(SCRIPTS, 'em-store.mjs'), '--project', 'p651', '--category', 'decision',
+    '--summary', 'seed', '--body', 'seed body', '--scope', 'local',
+  ], { cwd: proj, encoding: 'utf8', env: { ...process.env, HOME: root, USERPROFILE: root } })
+  assert(seed.status === 0, `seed store failed: ${seed.stderr}`)
+  const seedId = (lastJson(seed.stdout) || {}).id
+  const localDir = path.join(proj, '.episodic-memory')
+  const globalDir = path.join(root, '.episodic-memory')
+  // Valid (empty) global store so cross-store abort attribution is unambiguous.
+  fs.mkdirSync(path.join(globalDir, 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(globalDir, 'index.jsonl'), '')
+  // em-pattern-health refuses before it ever reaches the episode index unless
+  // a patterns/_index.json is reachable (CWD or ~/.episodic-memory) — an
+  // empty registry is sufficient to clear that precondition.
+  fs.mkdirSync(path.join(proj, 'patterns'), { recursive: true })
+  fs.writeFileSync(path.join(proj, 'patterns', '_index.json'), JSON.stringify({ patterns: [] }))
+  return { root, proj, localDir, globalDir, seedId }
+}
+
+function mkEmptyWorld() {
+  // Genuinely-missing index, clean parent all the way up: no .episodic-memory
+  // anywhere reachable (fresh proj, fresh HOME).
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-empty-'))
+  const proj = path.join(root, 'proj')
+  fs.mkdirSync(proj)
+  return { root, proj }
+}
+
+function cleanup(world) {
+  try {
+    if (world.localDir) restoreShape('eaccess', path.join(world.localDir, 'index.jsonl'), world.localDir)
+    if (world.localDir) restoreShape('file000', path.join(world.localDir, 'index.jsonl'), world.localDir)
+  } catch {}
+  try { fs.rmSync(world.root, { recursive: true, force: true }) } catch {}
+}
+
+// =============================================================================
+// T1 — unit: classifyIndexFile direct assertions against the §2 table.
+// =============================================================================
+;(function T1() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-t1-'))
+
+  t('T1 absent — ENOENT + clean parent', () => {
+    const p = path.join(dir, 'sub1', 'index.jsonl')
+    fs.mkdirSync(path.dirname(p))
+    const r = classifyIndexFile(fs, p)
+    assert(r.state === 'absent', JSON.stringify(r))
+  })
+
+  t('T1 absent — parent also ENOENT (no store dir at all)', () => {
+    const p = path.join(dir, 'does-not-exist-at-all', 'index.jsonl')
+    const r = classifyIndexFile(fs, p)
+    assert(r.state === 'absent', JSON.stringify(r))
+  })
+
+  t('T1 unreadable — parent-dangling symlink (broken parent)', () => {
+    const parent = path.join(dir, 'sub2')
+    fs.symlinkSync('nope', parent)
+    const p = path.join(parent, 'index.jsonl')
+    const r = classifyIndexFile(fs, p)
+    assert(r.state === 'unreadable', JSON.stringify(r))
+    fs.unlinkSync(parent)
+  })
+
+  t('T1 unreadable — symlink, dangling target', () => {
+    const p = path.join(dir, 'dangling.jsonl')
+    fs.symlinkSync('does-not-exist', p)
+    const r = classifyIndexFile(fs, p)
+    assert(r.state === 'unreadable' && r.code === 'ENOENT', JSON.stringify(r))
+    fs.unlinkSync(p)
+  })
+
+  t('T1 unreadable — symlink loop (ELOOP)', () => {
+    const a = path.join(dir, 'loopa.jsonl')
+    const b = path.join(dir, 'loopb.jsonl')
+    fs.symlinkSync('loopb.jsonl', a)
+    fs.symlinkSync('loopa.jsonl', b)
+    const r = classifyIndexFile(fs, a)
+    assert(r.state === 'unreadable', JSON.stringify(r))
+    fs.unlinkSync(a); fs.unlinkSync(b)
+  })
+
+  t('T1 ok — healthy symlink to a regular file', () => {
+    const real = path.join(dir, 'real.jsonl')
+    fs.writeFileSync(real, '')
+    const link = path.join(dir, 'link.jsonl')
+    fs.symlinkSync('real.jsonl', link)
+    const r = classifyIndexFile(fs, link)
+    assert(r.state === 'ok', JSON.stringify(r))
+    fs.unlinkSync(link); fs.unlinkSync(real)
+  })
+
+  t('T1 unreadable — resolves to a directory (EISDIR)', () => {
+    const p = path.join(dir, 'isadir.jsonl')
+    fs.mkdirSync(p)
+    const r = classifyIndexFile(fs, p)
+    assert(r.state === 'unreadable' && r.code === 'EISDIR', JSON.stringify(r))
+    fs.rmdirSync(p)
+  })
+
+  if (!IS_WIN) {
+    t('T1 unreadable — FIFO (ENOTREG), classified without opening', () => {
+      const p = path.join(dir, 'fifo.jsonl')
+      const mk = spawnSync('mkfifo', [p])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      const r = classifyIndexFile(fs, p)
+      assert(r.state === 'unreadable' && r.code === 'ENOTREG', JSON.stringify(r))
+      fs.unlinkSync(p)
+    })
+
+    t('T1 unreadable — symlink to /dev/null (ENOTREG, DEFER D2 cheap leg)', () => {
+      if (!fs.existsSync('/dev/null')) { skip('T1 unreadable — symlink to /dev/null', 'no /dev/null on this platform'); return }
+      const p = path.join(dir, 'devnull.jsonl')
+      fs.symlinkSync('/dev/null', p)
+      const r = classifyIndexFile(fs, p)
+      assert(r.state === 'unreadable' && r.code === 'ENOTREG', JSON.stringify(r))
+      fs.unlinkSync(p)
+    })
+  } else {
+    skip('T1 unreadable — FIFO (ENOTREG)', 'mkfifo unavailable on win32')
+    skip('T1 unreadable — symlink to /dev/null', 'no /dev/null on win32')
+  }
+
+  if (!IS_ROOT) {
+    t('T1 unreadable — EACCES parent (direct lstat failure)', () => {
+      const parent = path.join(dir, 'sub3')
+      fs.mkdirSync(parent)
+      const p = path.join(parent, 'index.jsonl')
+      fs.writeFileSync(p, '')
+      fs.chmodSync(parent, 0o000)
+      const r = classifyIndexFile(fs, p)
+      fs.chmodSync(parent, 0o755)
+      assert(r.state === 'unreadable', JSON.stringify(r))
+      fs.rmSync(parent, { recursive: true, force: true })
+    })
+  } else {
+    skip('T1 unreadable — EACCES parent', 'root bypasses permission checks')
+  }
+
+  t('assertReadableIndex — absent returns "absent", ok returns "ok", unreadable throws', () => {
+    const absentPath = path.join(dir, 'sub4', 'index.jsonl')
+    assert(assertReadableIndex(fs, absentPath) === 'absent', 'absent case')
+    const okPath = path.join(dir, 'ok.jsonl')
+    fs.writeFileSync(okPath, '')
+    assert(assertReadableIndex(fs, okPath) === 'ok', 'ok case')
+    fs.mkdirSync(path.join(dir, 'baddir.jsonl'))
+    let threw = false
+    try { assertReadableIndex(fs, path.join(dir, 'baddir.jsonl')) } catch (e) { threw = e instanceof IndexUnreadableError }
+    assert(threw, 'unreadable case must throw IndexUnreadableError')
+    fs.unlinkSync(okPath); fs.rmdirSync(path.join(dir, 'baddir.jsonl'))
+  })
+
+  t('readIndexFileOrThrow — absent null, ok returns content, read failure wraps', () => {
+    const absentPath = path.join(dir, 'sub5', 'index.jsonl')
+    assert(readIndexFileOrThrow(fs, absentPath) === null, 'absent -> null')
+    const okPath = path.join(dir, 'ok2.jsonl')
+    fs.writeFileSync(okPath, 'hello\n')
+    assert(readIndexFileOrThrow(fs, okPath) === 'hello\n', 'ok -> content')
+    fs.unlinkSync(okPath)
+  })
+
+  fs.rmSync(dir, { recursive: true, force: true })
+})()
+
+// =============================================================================
+// T3 — matrix: fixture shapes x scripts -> typed abort.
+//
+// Falsifiability note (build order step 2): (shape=file000, script=em-prune)
+// and its T5 twin PASS pre-fix — em-prune's #628 loadIndexRowsOrAbort already
+// wraps ANY exception from a raw fs.readFileSync (not just EISDIR) into the
+// "episode index unreadable" envelope, so a chmod-000 index.jsonl was already
+// typed-aborted before this plan existed. Not falsifiable evidence of #651
+// for THIS (shape, script) pair specifically — verified in pre-fix.txt — but
+// still kept as valid regression coverage post-fix.
+// =============================================================================
+const T3_SCRIPTS = [
+  { name: 'em-list', script: 'em-list.mjs', args: ['--scope', 'local'] },
+  { name: 'em-search', script: 'em-search.mjs', args: ['--project', 'p651', '--no-track', '--scope', 'local'] },
+  { name: 'em-recall', script: 'em-recall.mjs', args: ['--scope', 'local', '--no-track'] },
+  { name: 'em-check-stale', script: 'em-check-stale.mjs', args: ['--scope', 'local'] },
+  { name: 'em-prune', script: 'em-prune.mjs', args: ['--scope', 'local', '--dry-run'] },
+  { name: 'em-pattern-health', script: 'em-pattern-health.mjs', args: ['--scope', 'local'] },
+  { name: 'em-rebuild-index', script: 'em-rebuild-index.mjs', args: ['--scope', 'local'] },
+  { name: 'em-watch-codex', script: 'em-watch-codex.mjs', args: [] },
+  {
+    name: 'em-feedback', script: 'em-feedback.mjs', args: ['--id', 'does-not-exist-651', '--useful'],
+    // Step-23 scope note: em-feedback's #651 fix covers the STORE-SELECTION
+    // filter only (existsSync's false-negative silently dropping a broken
+    // store from the lock/write set — plan §7 step 23, lines :138/:208). A
+    // regular file that classifies 'ok' but fails to OPEN (file000) is not
+    // one of those two named sites: it is still caught, but by the
+    // pre-existing generic write-path catch (a different, also-typed
+    // "Feedback write failed: ..." envelope, exit 1, no raw stack) rather
+    // than the shared "episode index unreadable" wording. Out of this step's
+    // literal scope, not a #651 gap.
+    skipShapes: { file000: 'outside step-23 scope: caught by the pre-existing generic write-path catch, different envelope wording' },
+  },
+]
+
+for (const shape of ALL_SHAPES) {
+  const skipReason = shapeSkipReason(shape)
+  for (const s of T3_SCRIPTS) {
+    const name = `T3 ${shape} x ${s.name} -> typed abort`
+    const perScriptSkip = s.skipShapes && s.skipShapes[shape]
+    if (skipReason) { skip(name, skipReason); continue }
+    if (perScriptSkip) { skip(name, perScriptSkip); continue }
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        applyShape(shape, indexPath, world.localDir)
+        const r = run(path.join(SCRIPTS, s.script), s.args, { cwd: world.proj, home: world.root })
+        restoreShape(shape, indexPath, world.localDir)
+        checkTyped(r, s.name)
+      } finally {
+        cleanup(world)
+      }
+    })
+  }
+}
+
+// =============================================================================
+// T3 (em-consolidate --fold-superseded --dry-run) — revision 2, §7 step 7b.
+//
+// Reachability finding (verified empirically with a throwaway probe against
+// BOTH the current tree and a scratch copy with the step-7b hunk reverted,
+// via explicit-cwd/env spawnSync — never shell cd/HOME juggling): for EVERY
+// one of these shapes, the single-store fold path's typed abort comes from
+// resolveProtectionOrAbort's PRE-EXISTING protection scan (SCOPE-INDEPENDENT:
+// SINGLE_SCOPE_PROTECTION_STORES always reads BOTH LOCAL_DIR and GLOBAL_DIR
+// via loadProtectionRows, i.e. exactly the two values DATA_DIR can ever be),
+// which intercepts BEFORE foldStore is ever called — identically with and
+// without the step-7b foldStore try/catch. The step-7b catch is real and
+// correctly implemented (mirrors loadIndexOrAbort's shape) but is reachable
+// ONLY via a TOCTOU race between the protection scan's read and foldStore's
+// own read (same class as em-promote's DEFER-1 TOCTOU sites, §4) — not via
+// any static, deterministic fixture. These legs are therefore NOT
+// falsifiable evidence of the step-7b change specifically (verified: they
+// pass identically pre- and post-7b) but ARE valid end-to-end regression
+// coverage that `--fold-superseded --dry-run` aborts typed (archives
+// nothing) on a corrupted store, which is the externally-observable
+// guarantee that matters.
+//
+// Message-wording note: resolveProtectionOrAbort's own catch (pre-existing,
+// scripts/em-consolidate.mjs indexUnreadableAbort/emitProtectionAbort family)
+// produces "protection index unreadable (<CODE>) (<path>)", not "episode
+// index unreadable" — a deliberately distinct reason string for a
+// protection-scan failure vs. a primary-index read failure. Asserting the
+// generic project-wide "episode index unreadable" wording here would be
+// asserting something that has never been true for this code path; the
+// checks below match the ACTUAL (correct) wording instead.
+// =============================================================================
+const CONSOLIDATE_SHAPES = ['symloop', 'dangling', 'eaccess', 'fifo']
+for (const shape of CONSOLIDATE_SHAPES) {
+  const skipReason = shapeSkipReason(shape)
+  const name = `T3 ${shape} x em-consolidate --fold-superseded --dry-run -> typed abort`
+  if (skipReason) { skip(name, skipReason); continue }
+  t(name, () => {
+    const world = mkStore()
+    try {
+      const indexPath = path.join(world.localDir, 'index.jsonl')
+      applyShape(shape, indexPath, world.localDir)
+      const r = run(path.join(SCRIPTS, 'em-consolidate.mjs'), ['--fold-superseded', '--dry-run', '--scope', 'local'], { cwd: world.proj, home: world.root })
+      restoreShape(shape, indexPath, world.localDir)
+      assert(r.signal === null, `em-consolidate: no signal (timeout/kill), got ${r.signal}`)
+      assert(r.status === 1, `em-consolidate: exit 1, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)} stderr=${(r.stderr || '').slice(0, 200)}`)
+      const j = lastJson(r.stdout)
+      assert(j && j.status === 'error' && j.mode === 'fold-superseded', `em-consolidate: typed envelope, got ${r.stdout}`)
+      assert(/index unreadable/.test(r.stdout), `em-consolidate: names an index-unreadable defect, got ${r.stdout.slice(0, 300)}`)
+      assert(/index\.jsonl/.test(r.stdout), `em-consolidate: names index.jsonl, got ${r.stdout.slice(0, 300)}`)
+      assert(!/at .*\.mjs/.test(r.stderr || ''), `em-consolidate: no raw stack frames on stderr, got ${(r.stderr || '').slice(0, 300)}`)
+    } finally { cleanup(world) }
+  })
+}
+
+// =============================================================================
+// T4 — controls: genuinely-missing index stays byte-compatible; healthy
+// symlink keeps loading rows.
+// =============================================================================
+t('T4 control — genuinely-missing index: em-list exit 0 ok', () => {
+  const world = mkEmptyWorld()
+  try {
+    const r = run(path.join(SCRIPTS, 'em-list.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+    assert(r.status === 0, `expected exit 0, got ${r.status}: ${r.stderr}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'ok' && j.count === 0, `expected status:ok count:0, got ${r.stdout}`)
+  } finally { fs.rmSync(world.root, { recursive: true, force: true }) }
+})
+
+t('T4 control — genuinely-missing index: em-search exit 0 ok', () => {
+  const world = mkEmptyWorld()
+  try {
+    const r = run(path.join(SCRIPTS, 'em-search.mjs'), ['--scope', 'local', '--no-track'], { cwd: world.proj, home: world.root })
+    assert(r.status === 0, `expected exit 0, got ${r.status}: ${r.stderr}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'ok', `expected status:ok, got ${r.stdout}`)
+  } finally { fs.rmSync(world.root, { recursive: true, force: true }) }
+})
+
+t('T4 control — genuinely-missing index: em-prune --dry-run exit 0 ok', () => {
+  const world = mkEmptyWorld()
+  try {
+    const r = run(path.join(SCRIPTS, 'em-prune.mjs'), ['--scope', 'local', '--dry-run'], { cwd: world.proj, home: world.root })
+    assert(r.status === 0, `expected exit 0, got ${r.status}: ${r.stderr}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'ok', `expected status:ok, got ${r.stdout}`)
+  } finally { fs.rmSync(world.root, { recursive: true, force: true }) }
+})
+
+t('T4 control — healthy symlink to real index.jsonl: em-list shows the seeded episode', () => {
+  const world = mkStore()
+  try {
+    const indexPath = path.join(world.localDir, 'index.jsonl')
+    const realPath = path.join(world.localDir, 'index.real.jsonl')
+    fs.renameSync(indexPath, realPath)
+    fs.symlinkSync('index.real.jsonl', indexPath)
+    const r = run(path.join(SCRIPTS, 'em-list.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+    assert(r.status === 0, `expected exit 0, got ${r.status}: ${r.stderr}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'ok' && j.count === 1, `expected one episode via the healthy symlink, got ${r.stdout}`)
+  } finally { cleanup(world) }
+})
+
+// =============================================================================
+// T5 — protection: em-prune --scope local (REAL, not dry-run) exits 1 and the
+// seeded episode file is untouched, for every silent-pre-fix shape.
+//
+// 'parent-dangling' is excluded: constructing it requires rmSync'ing the
+// WHOLE .episodic-memory dir (episodes/ included) and replacing it with a
+// dangling symlink — the fixture setup itself destroys the seeded episode
+// file before em-prune ever runs, so "file still exists" cannot be asserted
+// meaningfully here. Its typed-abort behavior is already covered by T3.
+// =============================================================================
+for (const shape of ALL_SHAPES) {
+  const skipReason = shapeSkipReason(shape) || (shape === 'parent-dangling' ? 'fixture setup itself removes episodes/ (see comment above); typed-abort already covered by T3' : null)
+  const name = `T5 ${shape} — em-prune real run aborts, episode file untouched`
+  if (skipReason) { skip(name, skipReason); continue }
+  t(name, () => {
+    const world = mkStore()
+    try {
+      const indexPath = path.join(world.localDir, 'index.jsonl')
+      const episodePath = path.join(world.localDir, 'episodes', `${world.seedId}.md`)
+      assert(fs.existsSync(episodePath), 'precondition: seeded episode file exists')
+      applyShape(shape, indexPath, world.localDir)
+      const r = run(path.join(SCRIPTS, 'em-prune.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+      restoreShape(shape, indexPath, world.localDir)
+      checkTyped(r, 'em-prune')
+      assert(fs.existsSync(episodePath), 'episode file must still exist after aborted prune')
+      const archivedDir = path.join(world.localDir, 'archived')
+      const archivedCount = fs.existsSync(archivedDir) ? fs.readdirSync(archivedDir).filter(f => f.endsWith('.md')).length : 0
+      assert(archivedCount === 0, `nothing archived, got ${archivedCount}`)
+    } finally { cleanup(world) }
+  })
+}
+
+// =============================================================================
+// T6 — rebuild guard: em-rebuild-index exits 1 typed (envelope incl.
+// remediation hint) AND index.jsonl's shape is unchanged.
+// =============================================================================
+const T6_SHAPES = ['eaccess', 'symloop', 'file000']
+for (const shape of T6_SHAPES) {
+  const skipReason = shapeSkipReason(shape)
+  const name = `T6 ${shape} — em-rebuild-index aborts before any write, index.jsonl unchanged`
+  if (skipReason) { skip(name, skipReason); continue }
+  t(name, () => {
+    const world = mkStore()
+    try {
+      const indexPath = path.join(world.localDir, 'index.jsonl')
+      const before = fs.readFileSync(indexPath, 'utf8')
+      applyShape(shape, indexPath, world.localDir)
+      const r = run(path.join(SCRIPTS, 'em-rebuild-index.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+      const j = checkTyped(r, 'em-rebuild-index')
+      assert(typeof j.remediation === 'string' && /em-rebuild-index/.test(j.remediation), `remediation hint present, got ${JSON.stringify(j)}`)
+      restoreShape(shape, indexPath, world.localDir)
+      // Shape-unchanged: for eaccess (whole store dir chmod, file content
+      // never touched) compare against the pre-corruption snapshot; for
+      // file000 the corruption itself REPLACES content before chmod, so
+      // compare against that fixed fixture content instead.
+      if (shape === 'eaccess') {
+        const after = fs.readFileSync(indexPath, 'utf8')
+        assert(after === before, 'index.jsonl content unchanged after aborted rebuild')
+      } else if (shape === 'file000') {
+        const after = fs.readFileSync(indexPath, 'utf8')
+        assert(after === FILE000_FIXTURE_CONTENT, 'index.jsonl content unchanged (still the file000 fixture) after aborted rebuild')
+      } else {
+        // symloop's index.jsonl is a symlink pointing at loop-b; confirm it is
+        // still the same loop, not replaced by a regular file.
+        const st = fs.lstatSync(indexPath)
+        assert(st.isSymbolicLink(), 'index.jsonl symlink shape unchanged after aborted rebuild')
+      }
+    } finally { cleanup(world) }
+  })
+}
+
+// =============================================================================
+// T7 — vendored plugin copies: same absent/unreadable behavior as T3's
+// em-search/em-list/em-check-stale, via the inlined classifier.
+// =============================================================================
+const T7_SCRIPTS = [
+  { name: 'plugin em-list', script: 'em-list.mjs', args: ['--scope', 'local'] },
+  { name: 'plugin em-search', script: 'em-search.mjs', args: ['--scope', 'local'] },
+  { name: 'plugin em-check-stale', script: 'em-check-stale.mjs', args: ['--scope', 'local'] },
+]
+for (const shape of ALL_SHAPES) {
+  const skipReason = shapeSkipReason(shape)
+  for (const s of T7_SCRIPTS) {
+    const name = `T7 ${shape} x ${s.name} -> typed abort`
+    if (skipReason) { skip(name, skipReason); continue }
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        applyShape(shape, indexPath, world.localDir)
+        // The vendored copies resolve LOCAL_DIR from process.cwd() directly
+        // (no resolveLocalDir walk), so cwd must equal proj exactly.
+        const r = run(path.join(PLUGIN_SCRIPTS, s.script), s.args, { cwd: world.proj, home: world.root })
+        restoreShape(shape, indexPath, world.localDir)
+        checkTyped(r, s.name.replace('plugin ', ''))
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// =============================================================================
+// em-restore leg: dry-run never reads the target's index.jsonl (mergeIndexes
+// only runs on --apply), so a "dry/list mode" leg would be vacuous (identical
+// pre-fix/post-fix — nothing to falsify). Substituting an --apply leg against
+// a pre-existing, corrupted TARGET index.jsonl, which is the only path that
+// reaches loadIndexJsonl. Only shapes that corrupt index.jsonl ITSELF (not the
+// whole target dir) are usable: em-restore's preflight independently refuses
+// a symlinked target dir (unrelated "is a symlink; refusing" error) and a
+// whole-dir-eaccess target still passes preflight's existsSync/isDirectory
+// check, then fails later on episode-write EACCES — neither exercises this
+// contract, so 'eaccess' and 'parent-dangling' are skipped here with reason.
+// =============================================================================
+function mkRestoreBackup() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-restore-'))
+  const backupDir = path.join(root, 'backup')
+  fs.mkdirSync(backupDir, { recursive: true })
+  const git = (args) => spawnSync('git', args, { cwd: backupDir, encoding: 'utf8' })
+  assert(git(['init', '-b', 'main']).status === 0, 'git init failed')
+  assert(git(['config', 'user.email', 'test@example.com']).status === 0, 'git config email failed')
+  assert(git(['config', 'user.name', 'test']).status === 0, 'git config name failed')
+  fs.mkdirSync(path.join(backupDir, 'lab', 'episodes'), { recursive: true })
+  const fm = ['---', 'id: id-651-1', 'date: 2026-05-01', 'time: "10:00"', 'project: t', 'category: decision',
+    'status: active', 'supersedes: null', 'tags: [x]', 'summary: one', '---', '', '# one', '', 'body\n'].join('\n')
+  fs.writeFileSync(path.join(backupDir, 'lab', 'episodes', 'id-651-1.md'), fm)
+  assert(git(['add', '-A']).status === 0, 'git add failed')
+  assert(git(['commit', '-m', 'test']).status === 0, 'git commit failed')
+  return { root, backupDir }
+}
+
+const RESTORE_SHAPES = ['symloop', 'dangling', 'fifo', 'file000']
+for (const shape of ALL_SHAPES) {
+  const restoreOk = RESTORE_SHAPES.includes(shape)
+  const name = `T3 ${shape} x em-restore --apply -> typed abort`
+  const skipReason = shapeSkipReason(shape) || (!restoreOk ? 'target-dir-level shape does not exercise the index.jsonl contract (em-restore preflight refuses/mis-attributes it independently)' : null)
+  if (skipReason) { skip(name, skipReason); continue }
+  t(name, () => {
+    const { root, backupDir } = mkRestoreBackup()
+    const target = path.join(root, 'target')
+    fs.mkdirSync(target, { recursive: true })
+    const indexPath = path.join(target, 'index.jsonl')
+    fs.writeFileSync(indexPath, '')
+    try {
+      applyShape(shape, indexPath, target)
+      const r = run(path.join(SCRIPTS, 'em-restore.mjs'),
+        ['--from', backupDir, '--source-map', `lab=${target}`, '--apply'],
+        { cwd: root, home: root })
+      restoreShape(shape, indexPath, target)
+      assert(r.signal === null, `em-restore: no signal, got ${r.signal}`)
+      assert(r.status === 1, `em-restore: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 200)}`)
+      const j = lastJson(r.stdout)
+      assert(j && j.status === 'error', `em-restore: typed envelope, got ${r.stdout}`)
+      assert(/episode index unreadable/.test(r.stdout), `em-restore: names the defect, got ${r.stdout.slice(0, 300)}`)
+      assert(/index\.jsonl/.test(r.stdout), `em-restore: names index.jsonl, got ${r.stdout.slice(0, 300)}`)
+    } finally {
+      try { fs.rmSync(root, { recursive: true, force: true }) } catch {}
+    }
+  })
+}
+
+// =============================================================================
+// Second-opinion review round 1 (2026-08-03, verdict REQUEST-CHANGES) —
+// revision 3, §7 steps 7c-7f.
+// =============================================================================
+
+// --- F1 (step 7d, BLOCKER): em-feedback --scan-text --dry-run raw-read hang ---
+{
+  const name = 'F1 em-feedback --scan-text --dry-run x fifo -> typed abort (not a hang)'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        applyShape('fifo', indexPath, world.localDir)
+        const scanFile = path.join(world.root, 'scan.txt')
+        fs.writeFileSync(scanFile, `handoff mentions ${world.seedId} in passing\n`)
+        const r = run(path.join(SCRIPTS, 'em-feedback.mjs'), ['--scan-text', scanFile, '--scope', 'local', '--dry-run'], { cwd: world.proj, home: world.root })
+        restoreShape('fifo', indexPath, world.localDir)
+        checkTyped(r, 'em-feedback')
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- F2 (step 7c, MAJOR): FIFO archived-index.jsonl hangs mid-transaction ---
+function mkPrunableStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-prunable-'))
+  const proj = path.join(root, 'proj')
+  fs.mkdirSync(proj)
+  const localDir = path.join(proj, '.episodic-memory')
+  fs.mkdirSync(path.join(localDir, 'episodes'), { recursive: true })
+  // Score = max(0.1, 1 - daysSince/365); daysSince > ~311 days puts score
+  // below the default 0.15 prune threshold with access_count 0. A fixed
+  // 2025-01-01 date is comfortably past that (roughly 19 months before the
+  // 2026-08-03 fixture date this suite otherwise assumes).
+  const id = '20250101-000000-prunable-fixture-a1b1'
+  const row = { id, date: '2025-01-01', time: '00:00', project: 'p651', category: 'decision', status: 'active', supersedes: null, tags: [], summary: 'prunable fixture', access_count: 0, last_accessed: null }
+  fs.writeFileSync(path.join(localDir, 'index.jsonl'), JSON.stringify(row) + '\n')
+  fs.writeFileSync(path.join(localDir, 'episodes', `${id}.md`), [
+    '---', `id: ${id}`, 'date: 2025-01-01', 'time: "00:00"', 'project: p651', 'category: decision',
+    'status: active', 'supersedes: null', 'tags: []', 'summary: prunable fixture', '---', '',
+    '# prunable fixture', '', 'body', '',
+  ].join('\n'))
+  const globalDir = path.join(root, '.episodic-memory')
+  fs.mkdirSync(path.join(globalDir, 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(globalDir, 'index.jsonl'), '')
+  return { root, proj, localDir, globalDir, id }
+}
+
+{
+  const name = 'F2 em-prune real run: FIFO archived-index.jsonl aborts before any file move'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkPrunableStore()
+      try {
+        const archivedIndexFile = path.join(world.localDir, 'archived-index.jsonl')
+        const mk = spawnSync('mkfifo', [archivedIndexFile])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const episodePath = path.join(world.localDir, 'episodes', `${world.id}.md`)
+        assert(fs.existsSync(episodePath), 'precondition: prunable episode file exists')
+        const r = run(path.join(SCRIPTS, 'em-prune.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+        assert(r.signal === null, `em-prune: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-prune: exit 1, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)} stderr=${(r.stderr || '').slice(0, 200)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-prune: typed envelope, got ${r.stdout}`)
+        assert(/episode index unreadable/.test(r.stdout), `em-prune: names the defect, got ${r.stdout.slice(0, 300)}`)
+        assert(/archived-index\.jsonl/.test(r.stdout), `em-prune: names archived-index.jsonl, got ${r.stdout.slice(0, 300)}`)
+        assert(!/at .*\.mjs/.test(r.stderr || ''), `em-prune: no raw stack frames on stderr, got ${(r.stderr || '').slice(0, 300)}`)
+        assert(fs.existsSync(episodePath), 'episode file must still exist — nothing moved before the abort')
+        const archivedDir = path.join(world.localDir, 'archived')
+        const archivedCount = fs.existsSync(archivedDir) ? fs.readdirSync(archivedDir).filter(f => f.endsWith('.md')).length : 0
+        assert(archivedCount === 0, `archived/ must be empty, got ${archivedCount}`)
+      } finally {
+        try { fs.rmSync(world.root, { recursive: true, force: true }) } catch {}
+      }
+    })
+  }
+}
+
+// --- F4 (step 7e, MINOR): em-topic-tracks misattributes unreadable index ---
+{
+  const name = 'F4 em-topic-tracks: corrupt GLOBAL index maps to episode-index-unreadable'
+  t(name, () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-topictracks-'))
+    const proj = path.join(root, 'proj')
+    fs.mkdirSync(proj)
+    const globalDir = path.join(root, '.episodic-memory')
+    fs.mkdirSync(globalDir, { recursive: true })
+    const indexPath = path.join(globalDir, 'index.jsonl')
+    // symloop — the engine's loadIndexRows classifies before reading, same
+    // as every other #651 site; any unreadable shape reaches the same catch.
+    applyShape('symloop', indexPath, globalDir)
+    const configPath = path.join(root, 'topic-tracks-config.json')
+    fs.writeFileSync(configPath, JSON.stringify({
+      version: '1.0.0', tag_jaccard_min: 0.3, summary_jaccard_min: 0.2, min_cluster: 3,
+      warn_episodes: 1000, max_episodes: 2000, common_tag_support: 0.5,
+      source_categories: ['decision', 'lesson', 'research'],
+    }))
+    try {
+      // engine only scans global + registered stores (no cwd-local store is
+      // registered here), so a corrupt cwd-local index would be unreachable —
+      // the corruption must be on GLOBAL_DIR specifically.
+      const r = spawnSync(process.execPath, [path.join(SCRIPTS, 'em-topic-tracks.mjs')], {
+        cwd: proj, encoding: 'utf8', timeout: 10000,
+        env: { ...process.env, HOME: root, USERPROFILE: root, EM_TOPIC_TRACKS_CONFIG_PATH: configPath },
+      })
+      restoreShape('symloop', indexPath, globalDir)
+      assert(r.signal === null, `em-topic-tracks: no signal, got ${r.signal}`)
+      assert(r.status === 1, `em-topic-tracks: exit 1, got ${r.status}: stdout=${r.stdout} stderr=${r.stderr}`)
+      const j = lastJson(r.stdout)
+      assert(j && j.status === 'error', `typed envelope, got ${r.stdout}`)
+      assert(j.error === 'episode-index-unreadable', `expected error code "episode-index-unreadable", got ${JSON.stringify(j)}`)
+      assert(typeof j.detail === 'string' && /episode index unreadable/.test(j.detail), `detail names the defect, got ${JSON.stringify(j)}`)
+    } finally {
+      try { fs.rmSync(root, { recursive: true, force: true }) } catch {}
+    }
+  })
+}
+
+// =============================================================================
+// Second-opinion review round 2 (2026-08-03, verdict REQUEST-CHANGES ->
+// ACCEPT after fix) — revision 4, §11 F2b.
+// =============================================================================
+
+// --- F2b: em-consolidate archived-index abort misnamed index.jsonl ---
+function mkChainStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-chain-'))
+  const proj = path.join(root, 'proj')
+  fs.mkdirSync(proj)
+  const localDir = path.join(proj, '.episodic-memory')
+  fs.mkdirSync(path.join(localDir, 'episodes'), { recursive: true })
+  // Linear 2-member supersedes chain (min-chain 2): idOld is superseded by
+  // idNew, which is the chain terminal (no successor) — foldStore folds
+  // idOld (status:superseded, unprotected) and keeps idNew.
+  const idOld = '20250101-000000-chain-old-a1a1'
+  const idNew = '20250102-000000-chain-new-b2b2'
+  const rowOld = { id: idOld, date: '2025-01-01', time: '00:00', project: 'p651', category: 'decision', status: 'superseded', supersedes: null, superseded_by: idNew, tags: [], summary: 'chain old' }
+  const rowNew = { id: idNew, date: '2025-01-02', time: '00:00', project: 'p651', category: 'decision', status: 'active', supersedes: idOld, tags: [], summary: 'chain new' }
+  fs.writeFileSync(path.join(localDir, 'index.jsonl'), JSON.stringify(rowOld) + '\n' + JSON.stringify(rowNew) + '\n')
+  for (const [id, fm] of [[idOld, rowOld], [idNew, rowNew]]) {
+    fs.writeFileSync(path.join(localDir, 'episodes', `${id}.md`), [
+      '---', `id: ${id}`, `date: ${fm.date}`, `time: "${fm.time}"`, `project: ${fm.project}`, `category: ${fm.category}`,
+      `status: ${fm.status}`, `supersedes: ${fm.supersedes || 'null'}`,
+      ...(fm.superseded_by ? [`superseded_by: ${fm.superseded_by}`] : []),
+      'tags: []', `summary: ${fm.summary}`, '---', '', `# ${fm.summary}`, '', 'body', '',
+    ].join('\n'))
+  }
+  const globalDir = path.join(root, '.episodic-memory')
+  fs.mkdirSync(path.join(globalDir, 'episodes'), { recursive: true })
+  fs.writeFileSync(path.join(globalDir, 'index.jsonl'), '')
+  return { root, proj, localDir, globalDir, idOld, idNew }
+}
+
+{
+  const name = 'F2b em-consolidate --fold-superseded real run: FIFO archived-index.jsonl abort names archived-index.jsonl, not index.jsonl'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkChainStore()
+      try {
+        const archivedIndexFile = path.join(world.localDir, 'archived-index.jsonl')
+        const primaryIndexFile = path.join(world.localDir, 'index.jsonl')
+        const mk = spawnSync('mkfifo', [archivedIndexFile])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const oldEpisodePath = path.join(world.localDir, 'episodes', `${world.idOld}.md`)
+        assert(fs.existsSync(oldEpisodePath), 'precondition: chain-old episode file exists')
+        const r = run(path.join(SCRIPTS, 'em-consolidate.mjs'), ['--fold-superseded', '--min-chain', '2', '--scope', 'local'], { cwd: world.proj, home: world.root })
+        assert(r.signal === null, `em-consolidate: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-consolidate: exit 1, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)} stderr=${(r.stderr || '').slice(0, 200)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-consolidate: typed envelope, got ${r.stdout}`)
+        assert(/archived-index\.jsonl/.test(r.stdout), `em-consolidate: names archived-index.jsonl, got ${r.stdout.slice(0, 300)}`)
+        assert(!r.stdout.includes(primaryIndexFile), `em-consolidate: must NOT name the primary index.jsonl as the broken file, got ${r.stdout.slice(0, 300)}`)
+        assert(r.stdout.includes(archivedIndexFile), `em-consolidate: must name archived-index.jsonl by full path, got ${r.stdout.slice(0, 300)}`)
+        assert(!/at .*\.mjs/.test(r.stderr || ''), `em-consolidate: no raw stack frames on stderr, got ${(r.stderr || '').slice(0, 300)}`)
+        assert(fs.existsSync(oldEpisodePath), 'chain-old episode file must still exist — nothing moved before the abort')
+        const archivedDir = path.join(world.localDir, 'archived')
+        assert(!fs.existsSync(archivedDir), `archived/ must not exist (abort precedes its creation), got present: ${fs.existsSync(archivedDir)}`)
+      } finally {
+        try { fs.rmSync(world.root, { recursive: true, force: true }) } catch {}
+      }
+    })
+  }
+}
+
+console.log(`${pass}/${pass + fail} pass (${skipped} skipped)`)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Fixes #651 (split from #628 plan §17 DEFER-4).

## Problem

`existsSync(index.jsonl)` returns **false** for a symlink loop, dangling symlink, or an index under an EACCES parent — so every loader took its missing-store branch and returned `[]`, and scripts exited 0 `status:ok` with the store's evidence silently gone. For `em-prune` that is R5(b) protection-evidence loss (FAIL-OPEN, strictly worse than the EISDIR crash #628 fixed). `existsSync` returns **true** for a FIFO, and the unguarded `readFileSync` blocked forever.

Runtime evidence on main @ 792ca0e (isolated fixture store): `em-prune --scope local --dry-run` → `{"status":"ok",...,"remaining":0,"protected":0}` exit 0 on all three silent shapes (control store shows `remaining:1`); `em-list`/`em-search`/`em-prune` hang indefinitely on a FIFO index.

## Fix

New shared lstat-based classifier `scripts/lib/index-state.mjs` defines a uniform existence contract for every index loader (plan: `docs/plans/issue-651-index-existence-contract.md`, Revisions 1–3):

- **absent** (clean ENOENT, clean parent) → today's `[]` / skip / create-on-first-use, byte-compatible
- **unreadable** (symlink loop, dangling link, dangling *parent* link, EACCES, EISDIR, FIFO/socket/device, or a read failure like file-mode-000) → typed `{"status":"error","message":"<script>: episode index unreadable (<CODE>) (<file>)"}` + exit 1, no stack; classification happens **before any open**, so a FIFO can never hang a loader
- healthy symlink → regular file keeps working
- mutation paths (`em-prune`, `em-consolidate` fold) additionally classify `archived-index.jsonl` **pre-flight**, before any episode file moves
- `em-doctor` reports `unreadable (<CODE>)` instead of dying or reporting fail-open `ok`; documented advisory surfaces (`loadArchivedIndex`, `em-stats` archived counter, `em-store` post-write advisory, `em-mine-transcripts` dedupe corpus) degrade but never open a non-regular file

Applied across the shared loader (`lib/relevance.mjs`), every per-script loader copy, and the vendored `plugins/episodic-memory/scripts/` copies (inlined — no lib/ there). 36 `loadIndex(` call sites in 20 files swept and dispositioned (typed-abort / doctor-report / documented-degrade).

## Process

Full tiered arc per playbook v15: scouts → runtime repro → falsifiable plan → negative-scenario audit (HOLD verdict, 6 gaps folded in as Revision 1) → builder → **second-opinion review round 1 REQUEST-CHANGES** (5 findings, all runtime-confirmed: em-feedback scan-text FIFO hang BLOCKER; archived-index mid-transaction hang MAJOR; plan-claim refutation MAJOR; error-code misattribution MINOR; schema nit) → fixes as Revision 3 → round 2 verdict below. Review artifacts in `.review-store/` (requests/replies `20260803-*`).

## Verification

- `tests/test-651-index-existence.mjs`: **106/106 pass** (4 documented platform skips). Falsifiability recorded: 85/103 legs fail against pre-fix main; the 3 review-round legs verified failing (SIGTERM hang ×2, misattributed code) on a pre-Revision-3 snapshot.
- Regression gates: `test-628-sibling-init-guard` 5/5 · `test-prune-protection` 32/32 · `test-rfc-015-p1-s2-consolidation` 34/34 · `test-ci-suite-registration` 16/16 · `test-plugin-version-bump` 60/60.
- Missing-index byte-compat vs main verified (identical JSON on empty fixtures).
- Plugin version bumped 0.2.2 → 0.2.3 (#644 gate); suite CI-wired in the clerk-consolidation shard.

## Deliberate DEFERs (plan §4)

- **D1** FIFO-swap TOCTOU between classify and read (same trust domain as #628 DEFER-1; closed form is fd-based classification) — follow-up issue.
- **F3** `em-store` append to a FIFO index blocks (pre-existing, outside loader scope) — follow-up issue.
- `em-promote` TOCTOU-only sites (#628 DEFER-1) and `em-consolidate` legacy degrade catches unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
