### PR TITLE
FIX-516/512 residuals: CLAUDE_SCHEDULED_TASK marker on gemini/opencode dispatch + effective-timeout reporting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,6 +224,12 @@ jobs:
       - name: Run codex env-propagation suite (#636 — CLAUDE_SCHEDULED_TASK marker on codex dispatch)
         run: node tests/test-codex-env-propagation.mjs
 
+      - name: Run gemini env-propagation suite (#516 — CLAUDE_SCHEDULED_TASK marker on gemini dispatch)
+        run: node tests/test-gemini-env-propagation.mjs
+
+      - name: Run opencode env-propagation suite (#516 — CLAUDE_SCHEDULED_TASK marker on opencode dispatch)
+        run: node tests/test-opencode-env-propagation.mjs
+
       - name: Run second-opinion preamble suite (#573 wiring sweep — composer + registry validator)
         run: node tests/test-second-opinion-preamble.mjs
 

--- a/docs/plans/fix-516-512-residuals.md
+++ b/docs/plans/fix-516-512-residuals.md
@@ -1,0 +1,43 @@
+# Frozen build spec: #516 + #512 residuals (env-marker class completion + timeout message accuracy)
+
+Status: FROZEN at dispatch (2026-08-08). Scope changes require updating this doc AND restart-or-resync of the builder seat.
+
+## Evidence base (scouted + orchestrator-ground-truthed)
+
+- **#516 core is already fixed**: `scripts/second-opinion/providers/codex.mjs:89` sets `env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' }` (commit `6e82fee`, "fixes #636", merged 2026-07-30; #636 CLOSED, #516 left open). `claude-subagent.mjs:72` has the same fix (#232). Regression suite `tests/test-codex-env-propagation.mjs` passes locally (1/1, run 2026-08-08).
+- **Unfixed same-class siblings**: `scripts/second-opinion/providers/gemini.mjs:54-60` and `scripts/second-opinion/providers/opencode.mjs:84-90` spawn with NO `env:` key — they inherit `process.env` without the marker, so a hook-bearing repo breaks their dispatches identically.
+- **#512 core is already fixed**: `--timeout` parsing (`scripts/second-opinion.mjs:220-224`), dispatch plumbing (`:388`), typed `provider-timeout` envelope + forensics (`:393-406`) shipped in `766ed3c` (PR #520). Runtime-verified this session on an isolated fixture: stub + `--timeout 1500` + `SO_STUB_SLEEP_MS=3000` → `{"code":"provider-timeout","message":"Provider stub timed out after 1500ms (round 1)",...}` with forensics file; fast path clean.
+- **#512 residual defect**: when `--timeout` is omitted, `timeoutMs` is `undefined`; the provider's internal 600000 default fires but the error message at `scripts/second-opinion.mjs:404` renders "timed out after undefinedms" and the envelope carries `timeoutMs: undefined`.
+
+## In scope (writable file set — exhaustive)
+
+1. `scripts/second-opinion/providers/gemini.mjs` — add the one-line env override to the `dispatch()` spawnSync options, mirroring `codex.mjs:89` exactly, including a short comment citing #516/#636 class.
+2. `scripts/second-opinion/providers/opencode.mjs` — same one-line env override + comment.
+3. `scripts/second-opinion.mjs` — timeout message accuracy: introduce `const DEFAULT_DISPATCH_TIMEOUT_MS = 600000` near the top of the request path; always pass `timeout: timeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS` to `providerModule.dispatch(...)` (replacing the conditional spread at `:388`); use the same effective value in the `provider-timeout` message and envelope (`:403-405`). No behavior change when `--timeout` is passed; when omitted, behavior is identical (600000) but the error now names the real number.
+4. `tests/test-gemini-env-propagation.mjs` — NEW. Copy `tests/test-codex-env-propagation.mjs`, retarget the provider path and shim binary name (`gemini`, argv shape `[prompt]`); assert the marker, cwd binding, no side-effect leaks (I-516a/b/c naming).
+5. `tests/test-opencode-env-propagation.mjs` — NEW. Same twin, retargeted (`opencode`, argv shape `['run','-m',<model>,prompt]`).
+6. `.github/workflows/tests.yml` — wire BOTH new suites as explicit bare `run:` steps next to the codex entry (lines 224-225). Do NOT add them to `KNOWN_UNWIRED` in `tests/test-ci-suite-registration.mjs`.
+7. `.claude-plugin/plugin.json` — version `0.2.5` → `0.2.6` (CI gate #644; this manifest, NOT `plugins/episodic-memory/.claude-plugin/plugin.json`).
+
+## Explicitly OUT of scope (do not touch)
+
+- NO CLI-side floor-clamp of `--timeout` to 600000 (issue #512's "floor-clamped" clause): DEFERRED — the floor is enforced at the outer layer by the so-gate hook (`plugins/claude-code/hooks/lib/so-timeout-floor.mjs`, `TIMEOUT_FLOOR_MS`, stub carve-out); a CLI clamp would break `tests/test-so-timeout.mjs` (stub + `--timeout 1500`) and duplicate gate logic. Rationale goes in the PR body, not code.
+- NO request-record failure annotation for orphaned requests: DEFERRED to #649-class envelope work (forensics capture already persists evidence).
+- NO changes to `session-handoff-prompt.sh`, no `EM_NONINTERACTIVE` marker (zero repo precedent; `CLAUDE_SCHEDULED_TASK` is the established convention used by launchd callers).
+- NO edits to `codex.mjs` / `claude-subagent.mjs` / `stub.mjs`, no shared spawn-helper refactor (per-provider option objects are the established pattern).
+- NO commits, pushes, memory writes, or edits outside the writable set.
+
+## Per-step verification (builder runs each; orchestrator re-runs independently)
+
+- V1: `node tests/test-gemini-env-propagation.mjs` → all pass.
+- V2: `node tests/test-opencode-env-propagation.mjs` → all pass.
+- V3: `node tests/test-codex-env-propagation.mjs` → still 1/1 (no regression).
+- V4: `node tests/test-so-timeout.mjs` → all pass (message fix must not disturb explicit-timeout paths).
+- V5: `node tests/test-second-opinion-providers.mjs` → provider contract intact.
+- V6: `node tests/test-ci-suite-registration.mjs` → new suites detected as wired.
+- V7: `node scripts/check-plugin-version-bump.mjs` semantics honored (bump present; CI validates on PR).
+- V8: `node tests/test-second-opinion-dispatch.mjs` and `node tests/test-second-opinion-consensus.mjs` → dispatch-path suites green after the `:388` change.
+
+## Builder hard rules
+
+Implement ONLY what this spec lists. No commits. No `git add`. Report a per-file diff summary + verbatim verification outputs. Style anchors: `codex.mjs:82-89` (env override + comment), `tests/test-codex-env-propagation.mjs` (twin test), `tests.yml:224-225` (CI step shape).

--- a/scripts/second-opinion.mjs
+++ b/scripts/second-opinion.mjs
@@ -189,6 +189,11 @@ function checkRegistryFreshness() {
 }
 
 async function cmdRequest() {
+  // #512 residual: providers default their internal timeout to 600000ms when
+  // the harness omits `timeout`; naming that same value here lets the
+  // provider-timeout message/envelope report the real effective timeout
+  // instead of "undefinedms" when --timeout is not passed.
+  const DEFAULT_DISPATCH_TIMEOUT_MS = 600000
   const provider = flag('--provider')
   if (!provider) emitErr('missing-flag', '--provider is required')
 
@@ -383,9 +388,10 @@ async function cmdRequest() {
   }
 
   function runDispatch(promptText, roundN = 1, requestId = null) {
+    const effectiveTimeoutMs = timeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS
     let r
     try {
-      r = providerModule.dispatch({ prompt: promptText, projectRoot, ...(timeoutMs === undefined ? {} : { timeout: timeoutMs }) })
+      r = providerModule.dispatch({ prompt: promptText, projectRoot, timeout: effectiveTimeoutMs })
     } catch (e) {
       emitErr('provider-dispatch-failed',
         `Provider ${provider} dispatch threw: ${e.message}`, { provider })
@@ -401,8 +407,8 @@ async function cmdRequest() {
         } catch { forensicsPath = null }
       }
       emitErr('provider-timeout',
-        `Provider ${provider} timed out after ${timeoutMs}ms (round ${roundN})`,
-        { provider, round: roundN, timeoutMs, forensics: forensicsPath })
+        `Provider ${provider} timed out after ${effectiveTimeoutMs}ms (round ${roundN})`,
+        { provider, round: roundN, timeoutMs: effectiveTimeoutMs, forensics: forensicsPath })
     }
     if (!r.ok) {
       emitErr('provider-dispatch-nonzero',

--- a/scripts/second-opinion/providers/gemini.mjs
+++ b/scripts/second-opinion/providers/gemini.mjs
@@ -57,6 +57,10 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout,
     maxBuffer: MAX_BUFFER_BYTES,
+    // CLAUDE_SCHEDULED_TASK=1 (#516/#636 class — mirrors codex.mjs): a
+    // project's session-start hooks skip non-interactive routines on this
+    // marker; without it a headless dispatch can hang on a blocking prompt.
+    env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' },
   })
 
   return {

--- a/scripts/second-opinion/providers/opencode.mjs
+++ b/scripts/second-opinion/providers/opencode.mjs
@@ -87,6 +87,10 @@ export function dispatch({ prompt, projectRoot, timeout = 600000 }) {
     stdio: ['ignore', 'pipe', 'pipe'],   // stdin: ignore → no hang waiting on input
     timeout,
     maxBuffer: MAX_BUFFER_BYTES,
+    // CLAUDE_SCHEDULED_TASK=1 (#516/#636 class — mirrors codex.mjs): a
+    // project's session-start hooks skip non-interactive routines on this
+    // marker; without it a headless dispatch can hang on a blocking prompt.
+    env: { ...process.env, CLAUDE_SCHEDULED_TASK: '1' },
   })
 
   return {

--- a/tests/test-gemini-env-propagation.mjs
+++ b/tests/test-gemini-env-propagation.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * test-gemini-env-propagation.mjs — Issue #516 regression test.
+ *
+ * Mirrors tests/test-codex-env-propagation.mjs (#636) for the gemini
+ * provider. gemini.mjs was one of the unfixed same-class siblings identified
+ * in #516: it spawned with NO `env:` key, so it silently inherited
+ * process.env without the CLAUDE_SCHEDULED_TASK marker — a headless `gemini`
+ * seat spawned that way obeys a project's blocking session-start hook and
+ * replies with the first y/n question instead of a review.
+ *
+ * Invariants:
+ *   I-516a: dispatch() forces CLAUDE_SCHEDULED_TASK=1 into child env
+ *           regardless of parent state.
+ *   I-516b: dispatch() preserves inherited env (PATH/HOME/auth).
+ *   I-516c: child runs with PWD === projectRoot even when caller cwd
+ *           differs; no side-effect dirs leak under caller cwd.
+ *
+ * Strategy: install a `gemini` shim in a test-controlled PATH dir, point
+ * dispatch at a different `projectRoot`, run it from a third `callerDir`,
+ * and verify the shim's stdout matches the invariants.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PROVIDER_PATH = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers', 'gemini.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+async function asyncTest(name, fn) {
+  try {
+    await fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+console.log('# test-gemini-env-propagation (issue #516)')
+
+await asyncTest('dispatch propagates CLAUDE_SCHEDULED_TASK=1 + cwd binding + no side-effect leaks', async () => {
+  // mkdtemp three dirs; realpath each immediately (macOS /var ↔ /private/var).
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-gemini-bin-')))
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-gemini-proj-')))
+  const callerDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-gemini-caller-')))
+
+  const originalPath = process.env.PATH
+  const originalScheduled = process.env.CLAUDE_SCHEDULED_TASK
+  const originalCwd = process.cwd()
+
+  try {
+    // Narrow shim: 3 echoes only — no full `env` dump (avoids secret leak in
+    // CI failure logs, same rule as the #636/#232 tests). Ignores its argv
+    // (the single prompt positional).
+    const shimPath = path.join(binDir, 'gemini')
+    fs.writeFileSync(
+      shimPath,
+      '#!/bin/sh\n' +
+      'echo "CLAUDE_SCHEDULED_TASK=${CLAUDE_SCHEDULED_TASK}"\n' +
+      'echo "PWD=$(pwd)"\n' +
+      'echo "PATH=${PATH}"\n',
+      { mode: 0o755 }
+    )
+
+    // Caller cwd ≠ projectRoot.
+    process.chdir(callerDir)
+
+    // Regression-state parent env: shim on PATH, marker explicitly unset so
+    // the test starts from the bug's actual parent-env shape.
+    process.env.PATH = binDir + path.delimiter + originalPath
+    delete process.env.CLAUDE_SCHEDULED_TASK
+
+    // Pre-condition negative spawn: direct shim spawn (no dispatch) must show
+    // the marker empty in the parent env — guards a vacuous pass.
+    const preCheck = spawnSync('gemini', [], {
+      env: process.env,
+      cwd: callerDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    assert.strictEqual(preCheck.status, 0,
+      `pre-check shim failed: ${preCheck.stderr?.toString()}`)
+    assert.match(preCheck.stdout.toString(), /^CLAUDE_SCHEDULED_TASK=\s*$/m,
+      `pre-condition vacuous-pass guard: expected empty CLAUDE_SCHEDULED_TASK in parent env, ` +
+      `got stdout=${JSON.stringify(preCheck.stdout.toString())}`)
+
+    // Import provider + dispatch.
+    const mod = await import(`${pathToFileURL(PROVIDER_PATH).href}?cb=${Date.now()}`)
+    const result = mod.dispatch({ prompt: 'x', projectRoot: projectDir })
+    assert.strictEqual(result.exitCode, 0,
+      `dispatch exit code: expected 0, got ${result.exitCode} stderr=${result.stderr}`)
+
+    // I-516a — env override.
+    assert.match(result.stdout, /^CLAUDE_SCHEDULED_TASK=1$/m,
+      `I-516a: expected CLAUDE_SCHEDULED_TASK=1 in child env, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // I-516c — cwd binding via realpath comparison.
+    const pwdMatch = result.stdout.match(/^PWD=(.+)$/m)
+    assert.ok(pwdMatch, `I-516c: expected PWD=<value> line in stdout`)
+    const childPwdReal = fs.realpathSync(pwdMatch[1])
+    const projectDirReal = fs.realpathSync(projectDir)
+    assert.strictEqual(childPwdReal, projectDirReal,
+      `I-516c: child PWD must equal projectRoot (realpath). ` +
+      `child=${childPwdReal} expected=${projectDirReal}`)
+
+    // I-516b — PATH propagation.
+    assert.match(result.stdout, new RegExp(`^PATH=.*${escapeRegex(binDir)}`, 'm'),
+      `I-516b: expected binDir on child PATH, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // Side-effect leak: no artifact dirs under callerDir.
+    const leakNames = ['.review-store', '.episodic-memory', '.checkpoints']
+    const callerContents = fs.readdirSync(callerDir)
+    const leaked = callerContents.filter((n) => leakNames.includes(n))
+    assert.deepStrictEqual(leaked, [],
+      `I-516c: expected no side-effect dirs under callerDir, found ${JSON.stringify(leaked)}`)
+  } finally {
+    process.chdir(originalCwd)
+    process.env.PATH = originalPath
+    if (originalScheduled === undefined) {
+      delete process.env.CLAUDE_SCHEDULED_TASK
+    } else {
+      process.env.CLAUDE_SCHEDULED_TASK = originalScheduled
+    }
+    try { fs.rmSync(binDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(projectDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(callerDir, { recursive: true, force: true }) } catch {}
+  }
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}

--- a/tests/test-opencode-env-propagation.mjs
+++ b/tests/test-opencode-env-propagation.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * test-opencode-env-propagation.mjs — Issue #516 regression test.
+ *
+ * Mirrors tests/test-codex-env-propagation.mjs (#636) for the opencode
+ * provider. opencode.mjs was one of the unfixed same-class siblings
+ * identified in #516: it spawned with NO `env:` key, so it silently
+ * inherited process.env without the CLAUDE_SCHEDULED_TASK marker — a
+ * headless `opencode run` seat spawned that way obeys a project's blocking
+ * session-start hook and replies with the first y/n question instead of a
+ * review.
+ *
+ * Invariants:
+ *   I-516a: dispatch() forces CLAUDE_SCHEDULED_TASK=1 into child env
+ *           regardless of parent state.
+ *   I-516b: dispatch() preserves inherited env (PATH/HOME/auth).
+ *   I-516c: child runs with PWD === projectRoot even when caller cwd
+ *           differs; no side-effect dirs leak under caller cwd.
+ *
+ * Strategy: install an `opencode` shim in a test-controlled PATH dir, point
+ * dispatch at a different `projectRoot`, run it from a third `callerDir`,
+ * and verify the shim's stdout matches the invariants. The shim ignores its
+ * argv (`run -m <model> <prompt>`), same as the codex twin ignores
+ * `exec --skip-git-repo-check <prompt>`.
+ *
+ * Zero deps. Node stdlib only.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const PROVIDER_PATH = path.join(REPO_ROOT, 'scripts', 'second-opinion', 'providers', 'opencode.mjs')
+
+let passed = 0
+let failed = 0
+const failures = []
+
+async function asyncTest(name, fn) {
+  try {
+    await fn()
+    passed++
+    console.log(`  ✓ ${name}`)
+  } catch (e) {
+    failed++
+    failures.push({ name, error: e.stack || e.message })
+    console.log(`  ✗ ${name}: ${e.message}`)
+  }
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+console.log('# test-opencode-env-propagation (issue #516)')
+
+await asyncTest('dispatch propagates CLAUDE_SCHEDULED_TASK=1 + cwd binding + no side-effect leaks', async () => {
+  // mkdtemp three dirs; realpath each immediately (macOS /var ↔ /private/var).
+  const binDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-opencode-bin-')))
+  const projectDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-opencode-proj-')))
+  const callerDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'so-516-opencode-caller-')))
+
+  const originalPath = process.env.PATH
+  const originalScheduled = process.env.CLAUDE_SCHEDULED_TASK
+  const originalCwd = process.cwd()
+
+  try {
+    // Narrow shim: 3 echoes only — no full `env` dump (avoids secret leak in
+    // CI failure logs, same rule as the #636/#232 tests). Ignores its argv
+    // (`run -m <model> <prompt>`).
+    const shimPath = path.join(binDir, 'opencode')
+    fs.writeFileSync(
+      shimPath,
+      '#!/bin/sh\n' +
+      'echo "CLAUDE_SCHEDULED_TASK=${CLAUDE_SCHEDULED_TASK}"\n' +
+      'echo "PWD=$(pwd)"\n' +
+      'echo "PATH=${PATH}"\n',
+      { mode: 0o755 }
+    )
+
+    // Caller cwd ≠ projectRoot.
+    process.chdir(callerDir)
+
+    // Regression-state parent env: shim on PATH, marker explicitly unset so
+    // the test starts from the bug's actual parent-env shape.
+    process.env.PATH = binDir + path.delimiter + originalPath
+    delete process.env.CLAUDE_SCHEDULED_TASK
+
+    // Pre-condition negative spawn: direct shim spawn (no dispatch) must show
+    // the marker empty in the parent env — guards a vacuous pass.
+    const preCheck = spawnSync('opencode', [], {
+      env: process.env,
+      cwd: callerDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    assert.strictEqual(preCheck.status, 0,
+      `pre-check shim failed: ${preCheck.stderr?.toString()}`)
+    assert.match(preCheck.stdout.toString(), /^CLAUDE_SCHEDULED_TASK=\s*$/m,
+      `pre-condition vacuous-pass guard: expected empty CLAUDE_SCHEDULED_TASK in parent env, ` +
+      `got stdout=${JSON.stringify(preCheck.stdout.toString())}`)
+
+    // Import provider + dispatch.
+    const mod = await import(`${pathToFileURL(PROVIDER_PATH).href}?cb=${Date.now()}`)
+    const result = mod.dispatch({ prompt: 'x', projectRoot: projectDir })
+    assert.strictEqual(result.exitCode, 0,
+      `dispatch exit code: expected 0, got ${result.exitCode} stderr=${result.stderr}`)
+
+    // I-516a — env override.
+    assert.match(result.stdout, /^CLAUDE_SCHEDULED_TASK=1$/m,
+      `I-516a: expected CLAUDE_SCHEDULED_TASK=1 in child env, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // I-516c — cwd binding via realpath comparison.
+    const pwdMatch = result.stdout.match(/^PWD=(.+)$/m)
+    assert.ok(pwdMatch, `I-516c: expected PWD=<value> line in stdout`)
+    const childPwdReal = fs.realpathSync(pwdMatch[1])
+    const projectDirReal = fs.realpathSync(projectDir)
+    assert.strictEqual(childPwdReal, projectDirReal,
+      `I-516c: child PWD must equal projectRoot (realpath). ` +
+      `child=${childPwdReal} expected=${projectDirReal}`)
+
+    // I-516b — PATH propagation.
+    assert.match(result.stdout, new RegExp(`^PATH=.*${escapeRegex(binDir)}`, 'm'),
+      `I-516b: expected binDir on child PATH, ` +
+      `got stdout=${JSON.stringify(result.stdout)}`)
+
+    // Side-effect leak: no artifact dirs under callerDir.
+    const leakNames = ['.review-store', '.episodic-memory', '.checkpoints']
+    const callerContents = fs.readdirSync(callerDir)
+    const leaked = callerContents.filter((n) => leakNames.includes(n))
+    assert.deepStrictEqual(leaked, [],
+      `I-516c: expected no side-effect dirs under callerDir, found ${JSON.stringify(leaked)}`)
+  } finally {
+    process.chdir(originalCwd)
+    process.env.PATH = originalPath
+    if (originalScheduled === undefined) {
+      delete process.env.CLAUDE_SCHEDULED_TASK
+    } else {
+      process.env.CLAUDE_SCHEDULED_TASK = originalScheduled
+    }
+    try { fs.rmSync(binDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(projectDir, { recursive: true, force: true }) } catch {}
+    try { fs.rmSync(callerDir, { recursive: true, force: true }) } catch {}
+  }
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  for (const f of failures) console.error(`\n${f.name}\n${f.error}`)
+  process.exit(1)
+}


### PR DESCRIPTION
Fixes #516, fixes #512.

Both issues' core asks already shipped but were never closed (bot-merge-gap class). This PR runtime-verifies the shipped cores, completes the residual class gaps, and closes both with evidence.

## #516 — non-interactive marker on provider dispatch
- **Already shipped**: codex provider forces `CLAUDE_SCHEDULED_TASK=1` since `6e82fee` (fixes #636, merged 2026-07-30); claude-subagent since #232. Regression suite `test-codex-env-propagation.mjs` green.
- **This PR**: extends the marker to the two unfixed same-class siblings — `gemini.mjs` and `opencode.mjs` dispatch spawns — with twin regression suites (`test-gemini-env-propagation.mjs`, `test-opencode-env-propagation.mjs`, both mutation-kill-verified: deleting the env line fails I-516a) wired as explicit CI steps.
- Class inventory (2 independent reviewer sweeps): all four agent-CLI dispatch spawns now marked; remaining spawn sites are intra-repo `node` scripts or test stubs, out of class. `available()` `--help` probes are marker-less uniformly (incl. the shipped codex anchor) — out of class, future issue only if observed.

## #512 — --timeout plumbing
- **Already shipped**: `--timeout` parse/validate, dispatch plumbing, typed `provider-timeout` envelope + forensics capture landed in `766ed3c` (PR #520), CI-wired E2E (`test-so-timeout.mjs`). Runtime-verified on an isolated fixture this session: stub + `--timeout 1500` + 3000ms sleep → `{"code":"provider-timeout","message":"Provider stub timed out after 1500ms (round 1)",...}` with forensics file persisted; fast path clean.
- **This PR**: the harness now always passes an explicit effective timeout (`timeoutMs ?? 600000`) to dispatch, so the timeout message/envelope name the real value instead of rendering "timed out after undefinedms" when the flag is omitted. Reviewer-probed: with the default mutated to 2000ms and no `--timeout`, single and consensus round-2 dispatches both emit the named effective value.
- **DEFER — CLI floor-clamp** (issue's "floor-clamped" clause): the 600000ms floor is enforced at the outer layer by the so-gate hook (`so-timeout-floor.mjs`, `TIMEOUT_FLOOR_MS`, stub carve-out). A CLI-side clamp would break `test-so-timeout.mjs`'s stub short-timeout assertions and duplicate gate logic in a second layer.
- **DEFER — orphaned-request annotation**: forensics capture already persists timeout evidence; request-record status markers are #649-class read-side envelope work.

## Verification
- Full battery green locally (builder run + orchestrator re-run + 2 reviewer re-runs): env-propagation twins 1/1 each, codex 1/1, so-timeout 31/31, providers 24/24, ci-suite-registration PASS, dispatch 9/9, consensus 18/18.
- Behavior delta assessed: stub provider previously received no timeout key when `--timeout` was omitted (uncapped sleeper); now capped at 600000 — matches the documented contract, no consumer relies on uncapped behavior.
- Review: two independent lenses (qwen3.8-max via pi print-mode; claude-subagent via the harness), both ACCEPT, zero P1/P2 findings; frozen spec at `docs/plans/fix-516-512-residuals.md`.
- Plugin version 0.2.5 → 0.2.6 (gate #644).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
