### PR TITLE
FIX-632/633/634: anchored history walk + --materialize + agent-loader class fix + activation-log schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.claude/agents/bp1-rfc-classifier.md
+++ b/.claude/agents/bp1-rfc-classifier.md
@@ -8,18 +8,59 @@ tools: Read, Grep, Bash
 
 Canonical-prompt-as-episode pattern (per `feedback_canonical_prompt_as_episode.md`):
 the prompt body lives as a global episode that is revisable via `em-revise`.
-This loader is a thin reference; reload via:
+This loader is a thin reference.
 
+## Step 0 — Inlined canonical prompt (preferred)
+
+If the dispatch message contains a `<canonical-prompt source-episode="<id>">…</canonical-prompt>`
+block, the orchestrator has already materialized and inlined the canonical prompt (#633/#634).
+That block IS your operational prompt body — read it carefully and treat it as authoritative. Do
+NOT run the loader below. ECHO the `source-episode` id in your output (drift detection, Principle 8).
+
+## Step 1 — Loader (only when Step 0 found no inlined block)
+
+Only run this when Step 0 found no `<canonical-prompt>` block AND `em-search.mjs` is permitted in
+this runtime — two steps:
+
+1. Resolve the terminal episode id:
 ```bash
 node scripts/em-search.mjs \
-  --tag canonical-prompt --tag bp1-rfc-classifier \
-  --scope global --limit 1 --full --no-score --no-track
+  --tag bp1-rfc-classifier \
+  --scope global --limit 1 --no-score --no-track
 ```
+   Note: single `--tag` filter (no `--category`). Multi-tag query (`--tag X --tag Y`) is silently
+   ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one
+   disambiguating tag instead.
+   The terminal revision in the supersedes chain is the active prompt.
 
-The terminal revision in the supersedes chain is the active prompt.
+2. Materialize the full chain from that id:
+```bash
+node scripts/em-search.mjs --read <id> --materialize --no-track --scope global
+```
+   The result's `body` field is the operational prompt (root→terminal concatenation, not just the
+   terminal delta).
+
+**Known ceiling:** step 1 inherits today's recency-pick exposure — `--limit 1` can resolve to a
+retired-fork tombstone or forked episode that also matches this tag/scope filter, silently picking
+the wrong branch. `--materialize`'s ambiguity check is strict and PRE-`--limit` precisely because
+`--limit 1` alone can mask this multiplicity — but it cannot detect a wrong id already resolved by
+step 1's tag query. Probed reality: this filter (`tag: bp1-rfc-classifier`, `scope: global`)
+currently has exactly 1 pre-limit match in the live store — nil exposure today — but the class of
+risk stands should a fork/tombstone ever come to share the tag. Known, documented gap (relates
+#621).
 
 **v1 seed:** episode `20260513-053454-bp1-rfc-classifier-canonical-prompt-v1-s-a0c0`
 (global scope). Subsequent revisions via `em-revise --original <id> ...`.
+
+## Fallback (loader failure)
+
+If step 1's tag-query resolution returns 0 hits or errors, `--materialize` returns
+`{"status":"error", ...}` (including `code:"materialize-ambiguous"`), or the resolved body doesn't
+appear to be a system prompt:
+
+1. STOP. Do not produce classifier output from memory.
+2. Emit JSON: `{"status": "error", "message": "Canonical prompt episode missing. Tags: canonical-prompt, bp1-rfc-classifier, scope: global. Run em-rebuild-index --scope global, or restore the canonical prompt episode."}`
+3. Exit.
 
 ## RFC-004 reference
 

--- a/.claude/agents/negative-scenario-planner.md
+++ b/.claude/agents/negative-scenario-planner.md
@@ -7,18 +7,40 @@ tools: Read, Bash, Grep, Glob, WebFetch
 # Loader — canonical prompt lives in episodic memory
 
 Your full system prompt lives in a global episode (revisable via `em-revise`).
-Load it as your FIRST action.
+Resolve it as your FIRST action.
 
-## Step 1 — Load canonical prompt
+## Step 0 — Inlined canonical prompt (preferred)
 
-Run:
+If the dispatch message contains a `<canonical-prompt source-episode="<id>">…</canonical-prompt>`
+block, the orchestrator has already materialized and inlined the canonical prompt (#633/#634).
+That block IS your operational system prompt — read it carefully and treat it as authoritative. Do
+NOT run the loader below. ECHO the `source-episode` id somewhere in your output (drift detection,
+Principle 8) so a stale inline can be caught against the episode store.
+
+## Step 1 — Loader (only when Step 0 found no inlined block)
+
+Only run this when Step 0 found no `<canonical-prompt>` block AND `em-search.mjs` is permitted in
+this runtime — two steps:
+
+1. Resolve the terminal episode id:
 ```bash
-node scripts/em-search.mjs --tag negative-scenario-planner --category context --scope global --limit 1 --full --no-track --no-score
+node scripts/em-search.mjs --tag negative-scenario-planner --category context --scope global --limit 1 --no-track --no-score
 ```
+   Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
 
-Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
+2. Materialize the full chain from that id:
+```bash
+node scripts/em-search.mjs --read <id> --materialize --no-track --scope global
+```
+   The result's `body` field IS your operational system prompt (root→terminal concatenation across
+   the whole chain, not just the terminal delta). Read it carefully. Treat it as the authoritative
+   rules for this task.
 
-The result body IS your operational system prompt. Read it carefully. Treat it as the authoritative rules for this task.
+**Known ceiling:** step 1 inherits today's recency-pick exposure — `--limit 1` can resolve to a
+retired-fork tombstone episode that also matches the tag/category filter (2 such tombstones exist
+in the live store alongside the real terminal). `--materialize`'s ambiguity check is strict and
+PRE-`--limit`, so it cannot detect this on its own — a wrong id resolved here still materializes
+(silently) down the wrong branch. Known, documented gap (relates #621).
 
 ## Step 2 — Follow the loaded prompt
 
@@ -26,7 +48,9 @@ Apply every instruction in the loaded prompt body — required reading, audit ch
 
 ## Fallback (loader failure)
 
-If the em-search returns 0 hits, errors out, or returns a body that doesn't appear to be a system prompt:
+If step 1's tag-query resolution returns 0 hits or errors, `--materialize` returns
+`{"status":"error", ...}` (including `code:"materialize-ambiguous"`), or the resolved body doesn't
+appear to be a system prompt:
 
 1. STOP. Do not produce analytical output from memory.
 2. Emit JSON: `{"status": "error", "message": "Canonical prompt episode missing. Tag: negative-scenario-planner, category: context, scope: global. Run em-rebuild-index --scope global, or restore the canonical prompt episode."}`

--- a/.claude/agents/negative-scenario-reviewer.md
+++ b/.claude/agents/negative-scenario-reviewer.md
@@ -7,18 +7,43 @@ tools: Read, Grep, Glob, Bash
 # Loader — canonical prompt lives in episodic memory
 
 Your full system prompt lives in a global episode (revisable via `em-revise`).
-Load it as your FIRST action.
+Resolve it as your FIRST action.
 
-## Step 1 — Load canonical prompt
+## Step 0 — Inlined canonical prompt (preferred)
 
-Run:
+If the dispatch message contains a `<canonical-prompt source-episode="<id>">…</canonical-prompt>`
+block, the orchestrator has already materialized and inlined the canonical prompt (#633/#634).
+That block IS your operational system prompt — read it carefully and treat it as authoritative. Do
+NOT run the loader below. ECHO the `source-episode` id somewhere in your output (drift detection,
+Principle 8) so a stale inline can be caught against the episode store.
+
+## Step 1 — Loader (only when Step 0 found no inlined block)
+
+Only run this when Step 0 found no `<canonical-prompt>` block AND `em-search.mjs` is permitted in
+this runtime — two steps:
+
+1. Resolve the terminal episode id:
 ```bash
-node scripts/em-search.mjs --tag negative-scenario-reviewer --category context --scope global --limit 1 --full --no-track --no-score
+node scripts/em-search.mjs --tag negative-scenario-reviewer --category context --scope global --limit 1 --no-track --no-score
 ```
+   Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
 
-Note: single `--tag` + `--category` filter. Multi-tag query (`--tag X --tag Y`) is silently ignored per [#123](https://github.com/lantisprime/episodic-memory/issues/123); use one disambiguating tag + category instead.
+2. Materialize the full chain from that id:
+```bash
+node scripts/em-search.mjs --read <id> --materialize --no-track --scope global
+```
+   The result's `body` field IS your operational system prompt (root→terminal concatenation across
+   the whole chain, not just the terminal delta). Read it carefully. Treat it as the authoritative
+   rules for this task.
 
-The result body IS your operational system prompt. Read it carefully. Treat it as the authoritative rules for this task.
+**Known ceiling:** step 1 inherits today's recency-pick exposure — `--limit 1` can resolve to a
+retired-fork tombstone or forked episode that also matches the tag/category filter, silently
+picking the wrong branch. `--materialize`'s ambiguity check is strict and PRE-`--limit` precisely
+because `--limit 1` alone can mask this multiplicity — but it cannot detect a wrong id already
+resolved by step 1's tag query. Probed reality: this filter (`tag: negative-scenario-reviewer`,
+`category: context`, `scope: global`) currently has exactly 1 pre-limit match in the live store —
+nil exposure today — but the class of risk stands should a fork/tombstone ever come to share the
+tag. Known, documented gap (relates #621).
 
 ## Step 2 — Follow the loaded prompt
 
@@ -26,7 +51,9 @@ Apply every instruction in the loaded prompt body — required reading, audit ch
 
 ## Fallback (loader failure)
 
-If the em-search returns 0 hits, errors out, or returns a body that doesn't appear to be a system prompt:
+If step 1's tag-query resolution returns 0 hits or errors, `--materialize` returns
+`{"status":"error", ...}` (including `code:"materialize-ambiguous"`), or the resolved body doesn't
+appear to be a system prompt:
 
 1. STOP. Do not produce analytical output from memory.
 2. Emit JSON: `{"status": "error", "message": "Canonical prompt episode missing. Tag: negative-scenario-reviewer, category: context, scope: global. Run em-rebuild-index --scope global, or restore the canonical prompt episode."}`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,6 +332,9 @@ jobs:
       - name: Run RFC-009 P4-S1 telemetry suite (#505 / REQ-22)
         run: node tests/test-rfc-009-p4-telemetry.mjs
 
+      - name: Run activation-log schema suite (#632 residual 2)
+        run: node tests/test-activation-log-schema.mjs
+
       - name: Run RFC-009 P4-S3 clerk report suite (REQ-1,2,3,4,5,21,23)
         run: node tests/test-rfc-009-p4-report.mjs
 
@@ -382,6 +385,9 @@ jobs:
 
       - name: Run RFC-009 P1a --history multi-parent walk tests
         run: node tests/test-history-walk.mjs
+
+      - name: Run em-search --materialize suite (#634a)
+        run: node tests/test-materialize.mjs
 
       - name: Run RFC-009 P1a per-category prune lifecycle tests
         run: node tests/test-prune-lifecycle.mjs

--- a/docs/PLAN_TEMPLATE.md
+++ b/docs/PLAN_TEMPLATE.md
@@ -161,7 +161,10 @@ only by a skippable smoke is tagged **`UNGUARDED-IN-CI`** with the covering manu
 **Dispatch the canonical planner first (do not self-walk).** For any schema / validator /
 security / multi-actor change, dispatch `negative-scenario-planner` on the design **before**
 writing this section — it walks the 8-axis attack matrix and reliably surfaces the level-2
-(one-branch-only) gaps a solo walk misses. Self-walk is the fallback when no agent matches.
+(one-branch-only) gaps a solo walk misses. Self-walk is the fallback when no agent matches. The
+orchestrator materializes (`em-search --read <terminal-id> --materialize`) and inlines the
+canonical prompt with a provenance-stamped `<canonical-prompt source-episode="<id>">` block at
+dispatch; the in-agent loader is fallback-only (#633/#634).
 
 **Path-authority predicates** (`realpath`, `pwd -P`, `resolveRepoRoot`, `lstat`,
 `O_NOFOLLOW`, `import.meta.url`/isMain, "is this repo/safe-class"): enumerate the **8-axis

--- a/docs/plans/fix-632-633-634.md
+++ b/docs/plans/fix-632-633-634.md
@@ -1,0 +1,68 @@
+# Frozen build spec: #632 + #633 + #634 (history anchoring, --materialize, agent loader class fix, activation-log schema)
+
+Status: FROZEN at dispatch (2026-08-08, HEAD = main 0d5ec7d). Scope changes require updating this doc AND restart-or-resync of the builder seat.
+
+## Evidence base (scouted + orchestrator-ground-truthed + negative-scenario audit)
+
+- **#634 reproduced on the real store**: `--history` on the live planner-prompt terminal (`...ff81`, v6.7) returns v1→v2→v3→retired-fork; the requested id is absent from its own history and the retired-fork tombstone reads as the active terminal. Root cause: `em-search.mjs:304-309` walks backward to root discarding the path, then `:317-338` walks forward from root; `bySupersedes` (`:319-326`) is built in array order — fork selection is last-writer-wins by index position ("characterized not fixed, §17-E" comment at `:313`; pinned by `tests/test-history-walk.mjs:70-79`).
+- **Chains mix full revisions and deltas** with no machine-readable marker (planner line: v1–v6.5 self-contained, v6.6/v6.7 deltas; 13 episodes, ~150K chars total). A mechanical materializer must concatenate the whole line; semantic trimming is the consumer's judgment.
+- **#633 loader class = all 3 agents** in `.claude/agents/` (`negative-scenario-planner.md:12-17`, `negative-scenario-reviewer.md` identical shape, `bp1-rfc-classifier.md:9-22`). `docs/PLAN_TEMPLATE.md:161-164,419` names the planner canonical. Seat rule forbidding em-* is external operator policy; the loader is the only mandated action, so the agents cannot start.
+- **D3-fallback ambiguity is real on the real store**: the filter `--tag negative-scenario-planner --category context --scope global` matches **3 active episodes** pre-limit — the live terminal plus TWO retired-fork tombstones (`...-68a2`, `...-78f2`; both carry the tag, both active since nothing supersedes them). Today's loaders survive only because recency ordering + `--limit 1` mask this. Tag cleanup is blocked by #506 (revise unions tags; no removal path) — out of scope, noted as follow-up.
+- **#632**: all five residuals present at HEAD, line drift only (issue's `em-consolidate.mjs:1932`→`:1982`, `:2023`→`:2073`, via cab6a3d). Residual 2 (schema) is cheaply fixable in-idiom: `scripts/lib/json-instance-validate.mjs` (zero-dep closed-subset instance validator) + `scripts/lib/mini-jsonschema.mjs` (schema-doc linter) + `validate-schemas.mjs` auto-discovery over `schemas/` with `MIN_SCHEMA_DOCS` floor (currently 22 at `:51`; 31 schema docs on disk — the constant is a non-vacuity FLOOR, not a tally).
+- **Negative-scenario audit verdict** (canonical prompt v6.5+v6.6+v6.7, materialized+inlined per the #633 workaround this slice makes permanent): HOLD with F1/F3 blocking, F2/F4/F5 must-address, F6 defer — ALL dispositioned in this spec (ledger in §Findings). No architecture change required.
+
+## In scope (writable file set — exhaustive)
+
+1. `scripts/em-search.mjs` — TWO changes:
+   - **History anchoring (#634b)**: during the backward walk (`:304-309`), collect the spine `[requested … root]`. Chain = reversed spine (root→requested; fork-immune, `supersedes` is scalar) + forward continuation FROM the requested id using the existing 3-edge priority (inverted supersedes, superseded_by, consolidates). **Seed the forward visited-set with the ENTIRE spine** (audit F1: prevents duplicate ids / splice re-entry; a cyclic fixture must terminate). Linear chains stay byte-identical: `testHistoryFollowsSupersededBy`, `testHistorySurfacesConsolidatesSuccessor`, `testHistorySingleSupersedesUnchanged` (`tests/test-history-walk.mjs:48-68`) must pass UNMODIFIED. Update the `:311-315` comment block (§17-E fork loss is fixed AT the anchor spine; beyond-anchor forward fork selection stays last-writer-wins, documented, tiebreak-by-id deferred — relates #621).
+   - **`--materialize` flag (#634a)**: composes with `--read <id>` (never ambiguous), or with a filter query **iff the PRE-`--limit` filtered result set has exactly 1 member** (audit F3) — otherwise emit a typed error envelope `{status:'error', code:'materialize-ambiguous', matches:[{id, summary}, …]}` so the caller re-runs with an explicit id. On success: walk backward via scalar `supersedes` from the anchor to root (archived-aware — same live+archived row merge as history mode), reverse, read full bodies (archived members from `archived/`), emit `{status:'ok', terminal_id, count, members:[{id, date, summary, body_len, archived?}], body}` where `body` = root→terminal concatenation with `<!-- <id> | <summary> -->` delimiters. A `consolidates`-bearing root terminates the walk naturally. Drain stdout before exit (`:358-361` precedent — bodies exceed the 64KB pipe buffer). Update the usage string.
+2. `tests/test-history-walk.mjs` — flip `testHistorySupersedesForkCharacterized` (`:70-79`) from asserting branch LOSS to asserting: querying from a member of either fork branch returns that member's own line (invariant: chain contains the requested id). Add: no-duplicate-ids invariant on every history assertion; a cyclic/contradictory-frontmatter fixture that terminates (visited-set seeded with spine). Do NOT touch the three linear-chain tests.
+3. `tests/test-materialize.mjs` — NEW, fixture-store pattern copied from `test-history-walk.mjs`. Cases: (a) full+delta chain materializes root→terminal, `body` contains both bodies in order, `members` metadata correct; (b) fork fixture — anchored via `--read` on branch-A member returns ONLY A's spine (tombstone branch absent); (c) archived intermediate member resolves body from `archived/` and is flagged; (d) ambiguity — 2 active matches + `--limit 1` still errors `materialize-ambiguous` listing both ids (pins the PRE-limit check); (e) filter query with exactly 1 match succeeds; (f) single-episode chain (count=1) is normal, not an error.
+4. `.claude/agents/negative-scenario-planner.md`, `.claude/agents/negative-scenario-reviewer.md`, `.claude/agents/bp1-rfc-classifier.md` — loader rewrite, same shape all three:
+   - NEW Step 0: if the dispatch message contains a `<canonical-prompt source-episode="<id>">…</canonical-prompt>` block, that is the operational prompt (orchestrator materialized it); ECHO the `source-episode` id in output for drift detection (audit F2, Principle 8). Do not run any loader.
+   - Step 1 fallback (no inlined block AND em-search permitted in the runtime): two-step — (i) existing tag query with `--limit 1` to resolve the terminal id, (ii) `node scripts/em-search.mjs --read <id> --materialize --no-track --scope global`. Known ceiling (state it in the file): step (i) inherits today's recency-pick exposure to tombstone episodes matching the filter; the strict materialize ambiguity check exists precisely because `--limit 1` masks multiplicity.
+   - Fallback-failure STOP behavior unchanged (typed error JSON, no output-from-memory).
+5. `docs/PLAN_TEMPLATE.md` — in the §7 canonical-planner paragraph (`:161-164`): one added sentence — the orchestrator materializes (`em-search --read <terminal-id> --materialize`) and inlines the canonical prompt with a provenance-stamped block at dispatch; the in-agent loader is fallback. Note (audit #20): the fallback subprocess is homedir-anchored (`em-search.mjs:31`), not cwd-derived — no cwd-binding fixture required.
+6. `schemas/activation-log.schema.json` — NEW. Row schema for `activation-log.jsonl` (JSONL: one instance per line — document this in a top-of-schema `description`). Fields ground-truthed from the sole writer `appendActivationLine` (`scripts/lib/activation-log.mjs:35`, call site `activation-hook-run.mjs:645-654`) (audit F4: the writer is `appendActivationLine`, not "appendActivationLog"). Required = fields the writer always emits (including `v`); reader-ignored fields are still required if always written (writer-regression detection is the goal — single writer, so this is regression pinning, not cross-writer symmetry). Keywords restricted to `json-instance-validate.mjs`'s modeled closed subset (it hard-errors on unmodeled keywords — verify with the validator, not by eye).
+7. `tests/test-activation-log-schema.mjs` — NEW: drive the REAL writer on an isolated fixture store, parse every emitted JSONL line, `validateInstance` each against the schema (fail-closed import from `scripts/lib/json-instance-validate.mjs`); include one negative case (mutated row fails).
+8. `scripts/validate-schemas.mjs` — `MIN_SCHEMA_DOCS` 22→23 at `:51`, comment extended "+ activation-log.schema.json (#632 r2)". This is a non-vacuity floor bump, not a doc tally (audit F5; 31 docs on disk today).
+9. `.github/workflows/tests.yml` — wire `test-materialize.mjs` and `test-activation-log-schema.mjs` as explicit bare `run:` steps beside the existing suite entries. Do NOT add to `KNOWN_UNWIRED`.
+10. `.claude-plugin/plugin.json` — version `0.2.6` → `0.2.7` (CI gate #644; em-search.mjs is installer-shipped).
+
+## Explicitly OUT of scope (do not touch)
+
+- NO fork tiebreak-by-id beyond the anchor spine (relates #621, open — record in PR body).
+- NO contract-mirror script for the materialize output shape (audit contract-density BLOCKER taken ACCEPT-WITH-MOD: em-search.mjs has zero exports — same idiom constraint as em-consolidate — so the invariants are pinned as tests (items 2–3), which is the enforcement tier the sibling pins use; rationale goes in the PR body).
+- NO delimiter escaping in `body` (audit F6 DEFER, 5 fields recorded in PR body; JSON envelope safety verified — `JSON.stringify` escapes all C0).
+- NO tombstone data surgery and NO retired-fork storage convention (blocked by #506; follow-up note in PR body).
+- NO `revision_kind` frontmatter field, NO em-consolidate/em-revise changes, NO runtime per-line log validation in `loadInjectState`/`_parseLogForConversion` (hot fail-open readers), NO changes to count pin / tail constants / `RESURFACE_TAIL_MAX_BYTES`.
+- NO edits to #632 residuals 1/3/4/5 code paths — they are re-affirmed DEFERs (dispositions + drift-corrected citations in PR body only).
+- NO commits, pushes, memory writes, or edits outside the writable set.
+
+## Per-step verification (builder runs each; orchestrator re-runs independently)
+
+- V1: `node tests/test-history-walk.mjs` → all pass; the three linear-chain tests unmodified.
+- V2: `node tests/test-materialize.mjs` → all pass (cases a–f).
+- V3: `node tests/test-activation-log-schema.mjs` → all pass incl. negative case.
+- V4: `node scripts/validate-schemas.mjs` → clean at floor 23.
+- V5: `node tests/test-ci-suite-registration.mjs` → new suites detected as wired.
+- V6: `node tests/test-rfc-015-p1-s3a-resurfacing.mjs` → still green (adjacent surface, must not disturb).
+- V7: `node scripts/validate-rfc-009-contract-mirror.mjs` → count pin 6+3 unchanged.
+- V8: `node tests/test-trigger-index-playbooks.mjs` + `node tests/test-activation-match.mjs` → sibling schema consumers undisturbed.
+- Orchestrator-only (real store, read-only, post-build): `--history` on `...ff81` returns the 13-member live line including the requested id; `--read ...ff81 --materialize` body length ≈ 150K with 13 members; D3 two-step fallback command sequence succeeds end-to-end.
+
+## Findings ledger (negative-scenario audit → disposition)
+
+| Finding | Verdict | Disposition |
+|---|---|---|
+| F1 forward walk can re-splice/duplicate spine members | ACCEPT | Spine-seeded visited-set + cyclic fixture + no-dup invariant (items 1–2) |
+| F3 ambiguity check vs `--limit` ordering | ACCEPT-WITH-MOD | Strict PRE-limit check + candidates in error envelope; D3 fallback becomes two-step because the real store has 3 pre-limit matches (2 tombstones) — strict-only would hard-break the fallback |
+| F2 inlined block lacks provenance | ACCEPT | `source-episode` attribute + agent echo (item 4) |
+| F4 writer name `appendActivationLine` | ACCEPT | Corrected throughout (items 6–7) |
+| F5 MIN_SCHEMA_DOCS framing | ACCEPT | Floor-bump framing (item 8) |
+| F6 delimiter escaping in `body` | DEFER | 5-field justification to PR body; trigger = first structured `body` consumer |
+| Contract-density: mirror for new shapes | ACCEPT-WITH-MOD | Test-tier pins, no mirror script (zero-export idiom); rationale to PR body |
+
+## Builder hard rules
+
+Implement ONLY what this spec lists. No commits. No `git add`. No em-* invocations against real stores (~/.episodic-memory or any repo-local store) — fixture stores in temp dirs only, per the test-file precedents. Report a per-file diff summary + verbatim verification outputs (V1–V8). Style anchors: `tests/test-history-walk.mjs` (fixture-store pattern), `schemas/playbooks.schema.json` + `scripts/lib/playbook-registration.mjs:24-43` (schema + validateInstance idiom), `tests.yml` existing suite steps, `docs/plans/fix-516-512-residuals.md` (this spec's format precedent).

--- a/schemas/activation-log.schema.json
+++ b/schemas/activation-log.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://episodic-memory/schemas/activation-log.schema.json",
+  "title": "One row of <project>/.episodic-memory/activation-log.jsonl (RFC-009 P4-S1 R6)",
+  "description": "activation-log.jsonl is JSONL — one JSON object per line, newline-delimited, NOT a JSON array. This schema validates a single PARSED line/instance, not the whole file. The sole writer is appendActivationLine (scripts/lib/activation-log.mjs), called from exactly one call site (plugins/claude-code-activation/hooks/activation-hook-run.mjs, ~:640-654) which always passes event:'inject' literally. Required = every field the writer always emits (writer-regression pinning, not cross-writer symmetry — there is one writer). `surface` and `entries[].rendered` enums mirror this module's own exported INJECTION_SURFACES / RENDERED_FORMS constants (activation-log.mjs:8-9).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["v", "ts", "project", "event", "surface", "entries"],
+  "properties": {
+    "v": {
+      "type": "integer",
+      "const": 1,
+      "description": "LOG_FORMAT_VERSION (activation-log.mjs:5), stamped by appendActivationLine on every line. The reader (loadInjectState) discards any row whose v does not match its own constant (activation-log.mjs:159) — the version dimension cannot drift between writer and reader by construction."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "new Date().toISOString() at injection time (the call site's `ts` field)."
+    },
+    "project": {
+      "type": "string",
+      "minLength": 1,
+      "description": "identity.slug. resolveIdentity() guarantees a non-empty string before this call site is ever reached."
+    },
+    "event": {
+      "type": "string",
+      "const": "inject",
+      "description": "The sole writer call site passes event:'inject' literally; no other event value is ever written."
+    },
+    "surface": {
+      "enum": ["session_start", "per_prompt", "tool", "dispatcher"],
+      "description": "Mirrors INJECTION_SURFACES. The writer's EVENT_NAME ternary currently only ever emits 'tool' | 'session_start' | 'per_prompt'; 'dispatcher' is a reserved value from the same domain constant, not yet emitted by any call site."
+    },
+    "entries": {
+      "type": "array",
+      "description": "One entry per rendered injection line (REQ-16: entries[] cannot diverge from the rendered lines[]). May be empty in principle; in practice the writer is only reached after a non-empty lines[] check.",
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "effective_priority", "rendered", "source_scope", "access_count_at_inject"],
+      "description": "The call site rebuilds each entry as exactly these 5 keys (activation-hook-run.mjs's entries.map), discarding anything else matchActivation's entry carried.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Episode id of the injected entry."
+        },
+        "effective_priority": {
+          "type": ["integer", "null"],
+          "description": "Tier-1 / playbook entries carry an integer (playbooks default 0 via `?? 0`); tier-2 (static-blend) entries carry null by REQ-18/§8.2 — plain-only, no priority (activation-match.mjs)."
+        },
+        "rendered": {
+          "enum": ["imperative", "plain"],
+          "description": "Mirrors RENDERED_FORMS."
+        },
+        "source_scope": {
+          "type": ["string", "null"],
+          "description": "Stamped by mergeIndexes in the hook (typically 'local' or 'global'); null when the upstream entry carried none (`?? null`)."
+        },
+        "access_count_at_inject": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Defaults to 0 via `?? 0` when the upstream row carried no integer access_count."
+        }
+      }
+    }
+  }
+}

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -6,9 +6,12 @@
  *   node em-search.mjs [--project <name>] [--tag <tag>] [--category <cat>]
  *                      [--query <text>] [--since <YYYY-MM-DD>] [--limit <n>]
  *                      [--scope local|global|all] [--include-superseded]
- *                      [--read <id>] [--history <id>] [--full]
+ *                      [--read <id>] [--history <id>] [--full] [--materialize]
  *                      [--no-score] [--no-track]
- *                      (if both --read and --history are passed, --read wins)
+ *                      (if both --read and --history are passed, --read wins;
+ *                      --materialize composes with --read (never ambiguous), or
+ *                      with a filter query iff the pre-limit match count is 1 —
+ *                      otherwise a materialize-ambiguous error)
  *                      [--warn-time-ms <n>] [--warn-count <n>]
  *
  * By default, searches local then global (scope=all), hides superseded episodes,
@@ -37,7 +40,7 @@ const LOCAL_DIR = resolveLocalDir()
 const argv = process.argv.slice(2)
 
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-search.mjs', usage: 'node em-search.mjs [--project <name>] [--tag <tag>] [--category <cat>] [--query <text>] [--since <YYYY-MM-DD>] [--limit <n>] [--scope local|global|all] [--include-superseded] [--read <id>] [--history <id>] [--full] [--no-score] [--no-track] (if both --read and --history are passed, --read wins) [--warn-time-ms <n>] [--warn-count <n>]' }))
+  console.log(JSON.stringify({ status: 'help', script: 'em-search.mjs', usage: 'node em-search.mjs [--project <name>] [--tag <tag>] [--category <cat>] [--query <text>] [--since <YYYY-MM-DD>] [--limit <n>] [--scope local|global|all] [--include-superseded] [--read <id>] [--history <id>] [--full] [--materialize] [--no-score] [--no-track] (if both --read and --history are passed, --read wins; --materialize composes with --read (never ambiguous), or with a filter query iff the pre-limit match count is 1 — otherwise a materialize-ambiguous error) [--warn-time-ms <n>] [--warn-count <n>]' }))
   process.exit(0)
 }
 
@@ -58,6 +61,7 @@ const full = argv.includes('--full')
 const includeSuperseded = argv.includes('--include-superseded')
 const historyId = flag('--history')
 const readId = flag('--read')
+const materialize = argv.includes('--materialize')
 const noScore = argv.includes('--no-score')
 const noTrack = argv.includes('--no-track')
 const warnTimeMs = parseInt(flag('--warn-time-ms') || '500', 10)
@@ -104,6 +108,80 @@ results = results.filter(e => {
   seen.add(e.id)
   return true
 })
+
+// Preserved BEFORE any mode branch/filter narrows `results`: --history and
+// --materialize's backward chain walk need EVERY live row, including ones the
+// search filters below (e.g. `status !== 'superseded'`) would exclude — an
+// ancestor revision is superseded by definition and would otherwise vanish
+// from `results` before the walk could ever reach it.
+const allLiveResults = results.slice()
+
+// Shared by --history and --materialize: live rows (already scope-filtered +
+// deduped) plus archived rows for the active scope(s) — em-prune and
+// em-consolidate --fold-superseded move an episode's file to archived/ and its
+// row to archived-index.jsonl, so a chain with archived members would
+// otherwise silently truncate. Live rows win on id collision (`seenIds`
+// already carries every live id from the dedup above); archived rows carry
+// `_archived: true` (stamped by loadArchivedIndex).
+function collectChainEntries(baseResults, seenIds) {
+  const allEntries = [...baseResults]
+  for (const [dir, label] of [[LOCAL_DIR, 'local'], [GLOBAL_DIR, 'global']]) {
+    if (scope !== 'all' && scope !== label) continue
+    for (const row of loadArchivedIndex(dir, label)) {
+      if (seenIds.has(row.id)) continue
+      seenIds.add(row.id)
+      allEntries.push(row)
+    }
+  }
+  return allEntries
+}
+
+// --materialize (#634a): walk backward via the scalar `supersedes` edge from the
+// anchor to root (archived-aware via collectChainEntries — same live+archived
+// merge as --history), reverse to root->terminal order, and concatenate full
+// bodies with a provenance delimiter. A `consolidates`-bearing root terminates
+// the walk naturally: `consolidates` is a forward-only successor edge this
+// backward walk never follows.
+function materializeChain(anchorRow) {
+  const allEntries = collectChainEntries(allLiveResults, seen)
+  const byId = new Map(allEntries.map(e => [e.id, e]))
+  const spine = []
+  const spineVisited = new Set()
+  let node = byId.get(anchorRow.id) || anchorRow
+  while (node) {
+    if (spineVisited.has(node.id)) break // cyclic supersedes: truncate, do not loop forever
+    spineVisited.add(node.id)
+    spine.push(node)
+    if (!node.supersedes) break
+    const parent = byId.get(node.supersedes)
+    if (!parent) break
+    node = parent
+  }
+  spine.reverse() // root -> anchor (terminal)
+  const members = spine.map(e => {
+    const archived = !!e._archived
+    const filePath = path.join(e._dataDir, archived ? 'archived' : 'episodes', `${e.id}.md`)
+    let bodyText = ''
+    if (fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, 'utf8')
+      const parts = content.split('---')
+      bodyText = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
+    }
+    const meta = { id: e.id, date: e.date, summary: e.summary, body_len: bodyText.length }
+    if (archived) meta.archived = true
+    return { meta, bodyText }
+  })
+  // Delimiter escaping is deliberately DEFERRED (audit F6) — id/summary are
+  // store-controlled strings, not yet exposed to a structured `body` consumer.
+  const body = members.map(m => `<!-- ${m.meta.id} | ${m.meta.summary} -->\n${m.bodyText}`).join('\n\n')
+  return {
+    status: 'ok',
+    terminal_id: anchorRow.id,
+    count: members.length,
+    members: members.map(m => m.meta),
+    body,
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Read mode (RFC-011 R7 / REQ-14 — amended): fetch exactly ONE episode by exact
@@ -152,6 +230,18 @@ if (readId !== undefined) {
     const out = JSON.stringify({ status: 'error', message: `Episode "${readId}" not found` })
     await new Promise((resolve) => process.stdout.write(out + '\n', resolve))
     process.exit(1)
+  }
+
+  // --materialize composes with --read (#634a): the anchor is already resolved
+  // unambiguously by exact id, so no ambiguity check is needed here (that check
+  // is filter-query-only, below). Short-circuits before the single-episode read
+  // path (frontmatter merge, coercions, tracking) — materialize is a chain-wide
+  // retrieval, not a single-episode read. No access tracking, mirroring
+  // --history's investigative-query posture.
+  if (materialize) {
+    const out = materializeChain(row)
+    await new Promise((resolve) => process.stdout.write(JSON.stringify(out) + '\n', resolve))
+    process.exit(0)
   }
 
   // Episode file path (episodes/ for active rows, archived/ for archived rows —
@@ -276,46 +366,60 @@ if (readId !== undefined) {
 // History mode: show full revision chain for an episode
 // ---------------------------------------------------------------------------
 if (historyId) {
-  const chain = []
   // Find all episodes in the revision chain
   let currentId = historyId
 
-  // Walk backwards: find what this episode supersedes
-  //
-  // The walk sees index rows PLUS archived metadata: em-prune and
-  // em-consolidate --fold-superseded move an episode's file to archived/ and
-  // its row to archived-index.jsonl, so a chain with archived members would
-  // otherwise silently truncate (runtime-probed: archiving one intermediate
-  // cut a 4-link chain to 2 from the terminal and 1 from the root). Live
-  // rows win on id collision; archived rows are marked `archived: true` in
+  // The walk sees index rows PLUS archived metadata (collectChainEntries): em-prune and
+  // em-consolidate --fold-superseded move an episode's file to archived/ and its row to
+  // archived-index.jsonl, so a chain with archived members would otherwise silently truncate
+  // (runtime-probed: archiving one intermediate cut a 4-link chain to 2 from the terminal and 1
+  // from the root). Live rows win on id collision; archived rows are marked `archived: true` in
   // the output and their bodies resolve from archived/.
-  const allEntries = [...results]
-  for (const [dir, label] of [[LOCAL_DIR, 'local'], [GLOBAL_DIR, 'global']]) {
-    if (scope !== 'all' && scope !== label) continue
-    for (const row of loadArchivedIndex(dir, label)) {
-      if (seen.has(row.id)) continue
-      seen.add(row.id)
-      allEntries.push(row)
-    }
-  }
+  const allEntries = collectChainEntries(allLiveResults, seen)
   const byId = new Map(allEntries.map(e => [e.id, e]))
 
-  // Find the root of the chain
-  let root = byId.get(currentId)
-  while (root && root.supersedes) {
-    const parent = byId.get(root.supersedes)
+  // Walk backward via the scalar `supersedes` edge, collecting the SPINE
+  // [requested id ... root] as we go (#634b anchor fix). The requested id is
+  // ALWAYS spine[0], so it is guaranteed present in its own history — previously
+  // only `root` was kept and the forward walk resumed FROM root, so a supersedes
+  // FORK between root and the requested id could walk past it entirely (§17-E:
+  // `bySupersedes` below is last-writer-wins by Map insertion order, so the
+  // fork's OTHER branch could be the one forward-from-root actually surfaced,
+  // silently dropping the requested id from its own --history output).
+  const spine = []
+  const spineVisited = new Set()
+  let node = byId.get(currentId)
+  while (node) {
+    if (spineVisited.has(node.id)) break // cyclic supersedes: truncate, do not loop forever
+    spineVisited.add(node.id)
+    spine.push(node)
+    if (!node.supersedes) break
+    const parent = byId.get(node.supersedes)
     if (!parent) break
-    root = parent
+    node = parent
   }
 
-  // Walk forward from root along the many-to-one edges R9 (P4) will write (REQ-14):
-  //   1. inverted supersedes (existing behavior — kept first so single-supersedes chains are
-  //      byte-identical; a supersedes FORK stays last-writer-wins, characterized not fixed, §17-E),
-  //   2. the scalar superseded_by edge,
-  //   3. a consolidates successor (an active episode whose consolidates array names current).
-  // A visited Set makes a cyclic consolidates/superseded_by fixture terminate (EC7).
-  if (root) {
-    chain.push(root)
+  let chain = []
+  if (spine.length) {
+    chain = [...spine].reverse() // root -> requested
+
+    // Walk forward from the REQUESTED id (not root — the anchor fix above) along
+    // the many-to-one edges R9 (P4) will write (REQ-14):
+    //   1. inverted supersedes (existing behavior — kept first so single-supersedes chains are
+    //      byte-identical),
+    //   2. the scalar superseded_by edge,
+    //   3. a consolidates successor (an active episode whose consolidates array names current).
+    // The requested id is now the walk's anchor: §17-E fork loss is FIXED at the anchor spine
+    // (querying any spine member is guaranteed to see itself in its own history). Fork selection
+    // BEYOND the anchor (what supersedes/succeeds a node forward of the requested id) is
+    // UNCHANGED — still last-writer-wins by Map insertion order, characterized not fixed,
+    // tiebreak-by-id deferred (relates #621).
+    //
+    // The visited Set is seeded with the ENTIRE spine, not just root (audit F1): seeding only
+    // root left every OTHER spine member free to be re-discovered and re-pushed by the forward
+    // walk (a contradictory/cyclic superseded_by or consolidates edge pointing back into the
+    // spine would duplicate it in `chain`); seeding the whole spine also bounds a cyclic fixture
+    // to a single pass (EC7).
     const bySupersedes = new Map()
     const byConsolidates = new Map()
     for (const e of allEntries) {
@@ -324,8 +428,8 @@ if (historyId) {
         for (const cid of e.consolidates) byConsolidates.set(cid, e)
       }
     }
-    const visited = new Set([root.id])
-    let current = root
+    const visited = new Set(spine.map(e => e.id))
+    let current = spine[0] // the requested episode
     while (true) {
       let next = null
       if (bySupersedes.has(current.id)) next = bySupersedes.get(current.id)
@@ -537,6 +641,28 @@ if (query) {
   }
 
   results = [...matched, ...partials]
+}
+
+// ---------------------------------------------------------------------------
+// --materialize (filter-anchored, #634a): only reached when --read was not
+// given (the --read branch above already exited). Requires the PRE-`--limit`
+// filtered result set to have EXACTLY ONE member (audit F3) — `--limit` masks
+// multiplicity (the real store's 2-tombstone-plus-terminal case is exactly why
+// the D3 loader fallback is a two-step: resolve-id-then-materialize, not a
+// single filtered read), so this check runs BEFORE the `--limit` slice below
+// ever narrows `results`. A count other than 1 (0 or many) is reported the
+// same way — the caller re-runs with an explicit id via --read.
+// ---------------------------------------------------------------------------
+if (materialize) {
+  if (results.length !== 1) {
+    const matches = results.map(e => ({ id: e.id, summary: e.summary }))
+    const out = JSON.stringify({ status: 'error', code: 'materialize-ambiguous', matches })
+    await new Promise((resolve) => process.stdout.write(out + '\n', resolve))
+    process.exit(1)
+  }
+  const out = materializeChain(results[0])
+  await new Promise((resolve) => process.stdout.write(JSON.stringify(out) + '\n', resolve))
+  process.exit(0)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -48,7 +48,7 @@ import { UsageError } from "./lib/path-contain.mjs";
 
 const SCAN_ROOTS = ["patterns", "plugins", "schemas"];
 const CORPUS_REL = "tests/fixtures/schema-negative-corpus.json";
-const MIN_SCHEMA_DOCS = 22; // 21 (through activation-classes.schema.json P1b) + playbooks.schema.json (RFC-011 R1) = 22
+const MIN_SCHEMA_DOCS = 23; // 21 (through activation-classes.schema.json P1b) + playbooks.schema.json (RFC-011 R1) = 22 + activation-log.schema.json (#632 r2) = 23
 const MIN_CORPUS_ENTRIES = 14; // #368 non-vacuity floor (the 14 P0 negatives)
 
 function isSchemaDocName(name) {

--- a/tests/test-activation-log-schema.mjs
+++ b/tests/test-activation-log-schema.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * test-activation-log-schema.mjs — schemas/activation-log.schema.json vs the REAL writer
+ * (#632 residual 2).
+ *
+ * Drives the real appendActivationLine (scripts/lib/activation-log.mjs) on an isolated tmp dir —
+ * the same direct-import pattern as tests/test-rfc-009-p4-telemetry.mjs — parses every emitted
+ * JSONL line, and validateInstance()s each against the schema (fail-closed import from
+ * scripts/lib/json-instance-validate.mjs, matching the schema + validateInstance idiom in
+ * tests/test-trigger-index-playbooks.mjs / scripts/lib/playbook-registration.mjs). Includes one
+ * negative case: a mutated row must fail validation.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { appendActivationLine, ACTIVATION_LOG_NAME } from '../scripts/lib/activation-log.mjs'
+import { validateInstance } from '../scripts/lib/json-instance-validate.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(REPO, 'schemas', 'activation-log.schema.json'), 'utf8'))
+
+let pass = 0, fail = 0
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`) }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`) }
+}
+
+const _tmpDirs = []
+process.on('exit', () => { for (const d of _tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }) } catch {} } })
+function mkTmp(label) {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `actlog-schema-${label}-`)))
+  _tmpDirs.push(dir)
+  return dir
+}
+
+function readLines(dir) {
+  return fs.readFileSync(path.join(dir, ACTIVATION_LOG_NAME), 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l))
+}
+
+// (1) tier-1 entry (integer effective_priority, non-null source_scope), surface: per_prompt.
+t('schema::tier1EntryValid', () => {
+  const dir = mkTmp('tier1')
+  appendActivationLine(dir, {
+    ts: '2026-07-12T05:44:37.000Z', project: 'p632', event: 'inject', surface: 'per_prompt',
+    entries: [{ id: 'ep-tier1', effective_priority: 8, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 3 }],
+  })
+  const [row] = readLines(dir)
+  const { valid, errors } = validateInstance(row, SCHEMA)
+  assert.ok(valid, `tier-1 row must validate: ${JSON.stringify(errors)}`)
+})
+
+// (2) tier-2 entry (null effective_priority, null source_scope), surface: session_start —
+// exercises the array-valued `type: ["integer","null"]` / `["string","null"]` branches.
+t('schema::tier2NullFieldsValid', () => {
+  const dir = mkTmp('tier2')
+  appendActivationLine(dir, {
+    ts: '2026-07-12T05:44:38.000Z', project: 'p632', event: 'inject', surface: 'session_start',
+    entries: [{ id: 'ep-tier2', effective_priority: null, rendered: 'plain', source_scope: null, access_count_at_inject: 0 }],
+  })
+  const [row] = readLines(dir)
+  const { valid, errors } = validateInstance(row, SCHEMA)
+  assert.ok(valid, `tier-2 row (null effective_priority/source_scope) must validate: ${JSON.stringify(errors)}`)
+})
+
+// (3) surface: tool, multi-entry line (playbook-style entry mixed with a tier-1 entry).
+t('schema::toolSurfaceMultiEntryValid', () => {
+  const dir = mkTmp('tool')
+  appendActivationLine(dir, {
+    ts: '2026-07-12T05:44:39.000Z', project: 'p632', event: 'inject', surface: 'tool',
+    entries: [
+      { id: 'ep-a', effective_priority: 5, rendered: 'plain', source_scope: 'global', access_count_at_inject: 17 },
+      { id: 'ep-playbook', effective_priority: 0, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 },
+    ],
+  })
+  const [row] = readLines(dir)
+  assert.equal(row.entries.length, 2, 'both entries persisted')
+  const { valid, errors } = validateInstance(row, SCHEMA)
+  assert.ok(valid, `tool-surface multi-entry row must validate: ${JSON.stringify(errors)}`)
+})
+
+// (4) empty entries[] (writer permits it structurally; schema must not reject it — entries is
+// `required` but not `minItems`-bounded).
+t('schema::emptyEntriesArrayValid', () => {
+  const dir = mkTmp('empty')
+  appendActivationLine(dir, {
+    ts: '2026-07-12T05:44:40.000Z', project: 'p632', event: 'inject', surface: 'per_prompt',
+    entries: [],
+  })
+  const [row] = readLines(dir)
+  const { valid, errors } = validateInstance(row, SCHEMA)
+  assert.ok(valid, `empty-entries row must validate: ${JSON.stringify(errors)}`)
+})
+
+// (5) negative case: a captured VALID row, mutated, must FAIL validation. Multiple mutation axes
+// in one test — each independently must flip `valid` to false (fail-closed teeth, not a vacuous
+// single check).
+t('schema::mutatedRowFailsValidation', () => {
+  const dir = mkTmp('negative')
+  appendActivationLine(dir, {
+    ts: '2026-07-12T05:44:41.000Z', project: 'p632', event: 'inject', surface: 'per_prompt',
+    entries: [{ id: 'ep-neg', effective_priority: 5, rendered: 'imperative', source_scope: 'local', access_count_at_inject: 0 }],
+  })
+  const [row] = readLines(dir)
+  assert.ok(validateInstance(row, SCHEMA).valid, 'sanity: the captured row itself is valid before mutation')
+
+  const wrongVersion = { ...row, v: 2 }
+  assert.equal(validateInstance(wrongVersion, SCHEMA).valid, false, 'v !== 1 (const violation) must fail')
+
+  const wrongEvent = { ...row, event: 'other' }
+  assert.equal(validateInstance(wrongEvent, SCHEMA).valid, false, 'event !== "inject" (const violation) must fail')
+
+  const missingProject = { ...row }
+  delete missingProject.project
+  assert.equal(validateInstance(missingProject, SCHEMA).valid, false, 'missing required `project` must fail')
+
+  const badSurface = { ...row, surface: 'not-a-real-surface' }
+  assert.equal(validateInstance(badSurface, SCHEMA).valid, false, 'surface outside the enum must fail')
+
+  const badEntryPriorityType = {
+    ...row,
+    entries: [{ ...row.entries[0], effective_priority: 'eight' }],
+  }
+  assert.equal(validateInstance(badEntryPriorityType, SCHEMA).valid, false, 'string effective_priority (not integer|null) must fail')
+
+  const extraProperty = { ...row, unexpected_field: 'nope' }
+  assert.equal(validateInstance(extraProperty, SCHEMA).valid, false, 'additionalProperties:false must reject an unmodeled top-level key')
+})
+
+console.log(`\n${pass}/${pass + fail} pass`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-history-walk.mjs
+++ b/tests/test-history-walk.mjs
@@ -2,8 +2,14 @@
  * test-history-walk.mjs — RFC-009 P1a S5: em-search --history multi-parent walk (REQ-14).
  *
  * The walk follows inverted `supersedes` (existing), the scalar `superseded_by`, and a
- * `consolidates` successor, cycle-safe. Single-supersedes chains stay byte-identical; a supersedes
- * FORK is CHARACTERIZED (last-writer-wins, the pre-existing loss deferred in §17-E, not fixed).
+ * `consolidates` successor, cycle-safe. Single-supersedes chains stay byte-identical.
+ *
+ * #634b anchor fix: the backward walk collects the whole SPINE (requested id ... root), not just
+ * root, and the forward walk resumes FROM the requested id with `visited` seeded by the entire
+ * spine. This guarantees the requested id is always present in its own history and that a
+ * cyclic/contradictory back-edge into the spine cannot re-splice a duplicate (audit F1). A
+ * supersedes FORK *beyond* the anchor (what supersedes/succeeds a node forward of the requested
+ * id) stays CHARACTERIZED — last-writer-wins, deferred, relates #621.
  */
 
 import assert from 'node:assert/strict';
@@ -22,6 +28,13 @@ let pass = 0, fail = 0;
 function t(name, fn) {
   try { fn(); pass++; console.log(`  ok  ${name}`); }
   catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// No-duplicate-ids invariant (audit F1): a chain must never repeat an id — the
+// spine-seeded visited-set is what guarantees this once the forward walk can
+// resume from a non-root anchor.
+function assertNoDupIds(ids, label) {
+  assert.equal(new Set(ids).size, ids.length, `${label}: chain has duplicate ids ${JSON.stringify(ids)}`);
 }
 
 // episodes: [{id, supersedes?, superseded_by?, consolidates?:[ids]}]
@@ -68,14 +81,37 @@ t('testHistorySingleSupersedesUnchanged', () => {
 });
 
 t('testHistorySupersedesForkCharacterized', () => {
-  // root superseded by BOTH b and c (fork). The Map is last-writer-wins, so exactly one child
-  // surfaces — the pre-existing loss (§17-E), pinned here so the multi-parent walk does not
-  // silently change which child is dropped.
+  // root superseded by BOTH b and c (fork immediately below root). #634b anchors the walk at the
+  // REQUESTED id: querying either fork branch member returns THAT member's own line — the
+  // requested id is always present in its own history (previously it could be entirely absent
+  // when the forward-from-root walk happened to surface the OTHER branch). Fork selection BEYOND
+  // the anchor stays characterized (last-writer-wins, deferred, relates #621) — not asserted here.
   const cwd = mkStore([{ id: 'root' }, { id: 'b', supersedes: 'root' }, { id: 'c', supersedes: 'root' }]);
-  const r = history(cwd, 'root');
-  assert.equal(r.chain.length, 2, 'root + exactly one child (fork loss characterized)');
-  assert.equal(r.chain[0].id, 'root');
-  assert.ok(['b', 'c'].includes(r.chain[1].id), 'the surviving child is one of the fork branches');
+  for (const branch of ['b', 'c']) {
+    const r = history(cwd, branch);
+    const ids = r.chain.map((e) => e.id);
+    assert.ok(ids.includes(branch), `history(${branch}) contains the requested id itself (#634b invariant)`);
+    assert.equal(ids[0], 'root', `history(${branch}) is anchored at root`);
+    assertNoDupIds(ids, `history(${branch})`);
+  }
+});
+
+t('testHistorySpineSeededVisitedPreventsDuplicate', () => {
+  // root <- c1 <- c2 via supersedes, PLUS a contradictory c2.superseded_by = 'c1' back-edge (c2's
+  // own parent, already on the spine). Queried from the MIDDLE of the spine ('c1'): the forward
+  // walk starts at c1 (not root), discovers c2 via supersedes, then hits the contradictory
+  // back-edge to c1. Seeding `visited` with the WHOLE spine (not just root, audit F1) is what
+  // stops this from re-pushing c1 and duplicating it in `chain` — seeding root only would have
+  // let this contradiction re-splice c1.
+  const cwd = mkStore([
+    { id: 'root' },
+    { id: 'c1', supersedes: 'root' },
+    { id: 'c2', supersedes: 'c1', superseded_by: 'c1' },
+  ]);
+  const r = history(cwd, 'c1');
+  const ids = r.chain.map((e) => e.id);
+  assert.deepEqual(ids, ['root', 'c1', 'c2'], 'spine + forward discovery, no re-splice');
+  assertNoDupIds(ids, 'history(c1) with contradictory back-edge');
 });
 
 t('testHistoryCycleSafe', () => {
@@ -84,6 +120,19 @@ t('testHistoryCycleSafe', () => {
   const r = history(cwd, 'A');
   assert.ok(r.chain.length <= 2, 'cycle terminates without repeating');
   assert.equal(r.chain[0].id, 'A');
+});
+
+t('testHistoryMutualSupersedesCycleTerminates', () => {
+  // Corrupt store: a supersedes b, b supersedes a (mutual cycle on the BACKWARD supersedes edge —
+  // no root exists). Pre-fix the spine-collection walk had no visited-set and would re-visit a/b
+  // forever; the fix seeds a spineVisited Set so it breaks gracefully (truncation, matching the
+  // forward walk's posture) instead of hanging.
+  const cwd = mkStore([{ id: 'a', supersedes: 'b' }, { id: 'b', supersedes: 'a' }]);
+  const r = history(cwd, 'a');
+  assert.equal(r.status, 'ok');
+  const ids = r.chain.map((e) => e.id);
+  assertNoDupIds(ids, 'history(a) with mutual supersedes cycle');
+  assert.ok(ids.length <= 2, 'cycle terminates without unbounded growth');
 });
 
 console.log(`\n${pass}/${pass + fail} pass`);

--- a/tests/test-materialize.mjs
+++ b/tests/test-materialize.mjs
@@ -1,0 +1,182 @@
+/**
+ * test-materialize.mjs — em-search --materialize (#634a).
+ *
+ * --materialize composes with --read <id> (never ambiguous — the anchor is resolved by exact id)
+ * or with a filter query IFF the PRE-`--limit` filtered result set has exactly one member (audit
+ * F3) — otherwise a typed `materialize-ambiguous` error envelope lists every pre-limit candidate.
+ * On success it walks backward via the scalar `supersedes` edge from the anchor to root
+ * (archived-aware, same live+archived merge as --history), reverses to root->terminal order, and
+ * concatenates full bodies with a `<!-- id | summary -->` provenance delimiter.
+ */
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+const EM_SEARCH = path.join(REPO, 'scripts/em-search.mjs');
+const EM_REBUILD = path.join(REPO, 'scripts/em-rebuild-index.mjs');
+
+let pass = 0, fail = 0;
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`); }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
+}
+
+// Mirrors the exact frontmatter+body construction em-search reads back (split on
+// '---', slice(2).join('---').trim()) so expected body_len/content can be computed
+// from the fixture spec directly, without re-parsing the written file.
+function renderBody(ep) {
+  return `# ${ep.id}\n\n${ep.body ?? `body-${ep.id}`}`;
+}
+
+// episodes: [{id, supersedes?, superseded_by?, summary?, body?, status?, archived?}]
+// `archived: true` writes the episode to archived/ + archived-index.jsonl instead of
+// episodes/ + index.jsonl (the em-prune / em-consolidate --fold-superseded shape).
+function mkStore(episodes) {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'catmat-')));
+  const dataDir = path.join(cwd, '.episodic-memory');
+  const epDir = path.join(dataDir, 'episodes');
+  fs.mkdirSync(epDir, { recursive: true });
+  const archivedRows = [];
+  for (const ep of episodes) {
+    const summary = ep.summary ?? ep.id;
+    const lines = ['---', `id: ${ep.id}`, 'date: 2026-07-06', 'time: "00:00"', 'project: fx', 'category: lesson', `status: ${ep.status ?? 'active'}`];
+    if (ep.supersedes) lines.push(`supersedes: ${ep.supersedes}`);
+    if (ep.superseded_by) lines.push(`superseded_by: ${ep.superseded_by}`);
+    lines.push('tags: []', `summary: ${summary}`, '---', '', renderBody(ep), '');
+    const targetDir = ep.archived ? path.join(dataDir, 'archived') : epDir;
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(path.join(targetDir, `${ep.id}.md`), lines.join('\n'));
+    if (ep.archived) {
+      archivedRows.push({
+        id: ep.id, date: '2026-07-06', time: '00:00', project: 'fx', category: 'lesson',
+        status: ep.status ?? 'active',
+        ...(ep.supersedes ? { supersedes: ep.supersedes } : {}),
+        ...(ep.superseded_by ? { superseded_by: ep.superseded_by } : {}),
+        tags: [], summary, access_count: 0,
+      });
+    }
+  }
+  spawnSync('node', [EM_REBUILD, '--scope', 'local'], { cwd, encoding: 'utf8' });
+  if (archivedRows.length) {
+    fs.writeFileSync(path.join(dataDir, 'archived-index.jsonl'), archivedRows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  }
+  return cwd;
+}
+
+function materialize(cwd, args) {
+  const r = spawnSync('node', [EM_SEARCH, ...args, '--scope', 'local'], { cwd, encoding: 'utf8' });
+  if (!r.stdout || !r.stdout.trim()) throw new Error(`no stdout (status ${r.status}); stderr: ${r.stderr}`);
+  return JSON.parse(r.stdout.trim());
+}
+
+// (a) full+delta chain materializes root->terminal; body contains both bodies in order; members
+// metadata correct (body_len matches the exact rendered body text).
+t('materialize::readAnchorFullPlusDeltaChain', () => {
+  const specs = [
+    { id: 'v1', body: 'ROOT-BODY-TEXT' },
+    { id: 'v2', supersedes: 'v1', body: 'DELTA-BODY-TEXT' },
+  ];
+  const cwd = mkStore(specs);
+  const r = materialize(cwd, ['--read', 'v2', '--materialize']);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.terminal_id, 'v2');
+  assert.equal(r.count, 2);
+  assert.deepEqual(r.members.map((m) => m.id), ['v1', 'v2']);
+  assert.equal(r.members[0].body_len, renderBody(specs[0]).length, 'v1 body_len matches rendered body');
+  assert.equal(r.members[1].body_len, renderBody(specs[1]).length, 'v2 body_len matches rendered body');
+  const iRoot = r.body.indexOf('ROOT-BODY-TEXT');
+  const iDelta = r.body.indexOf('DELTA-BODY-TEXT');
+  assert.ok(iRoot >= 0 && iDelta >= 0 && iRoot < iDelta, 'body contains both bodies, root before terminal');
+});
+
+// (b) fork fixture — anchored via --read on branch-A member returns ONLY A's spine (the
+// tombstone branch is absent, both from members and from body).
+t('materialize::forkAnchorReturnsOnlyOwnBranch', () => {
+  const cwd = mkStore([
+    { id: 'root', body: 'ROOT-BODY' },
+    { id: 'a', supersedes: 'root', body: 'BRANCH-A-BODY' },
+    { id: 'tombstone', supersedes: 'root', body: 'BRANCH-B-TOMBSTONE-BODY' },
+  ]);
+  const r = materialize(cwd, ['--read', 'a', '--materialize']);
+  assert.equal(r.status, 'ok');
+  assert.deepEqual(r.members.map((m) => m.id), ['root', 'a'], 'only the A branch spine, tombstone absent');
+  assert.ok(!r.body.includes('BRANCH-B-TOMBSTONE-BODY'), 'tombstone branch body never appears');
+});
+
+// (c) archived intermediate member resolves body from archived/ and is flagged; the live root and
+// live terminal are not.
+t('materialize::archivedIntermediateResolvesFromArchivedDir', () => {
+  const cwd = mkStore([
+    { id: 'root', body: 'ROOT-LIVE-BODY' },
+    { id: 'mid', supersedes: 'root', body: 'MID-ARCHIVED-BODY', archived: true },
+    { id: 'term', supersedes: 'mid', body: 'TERM-LIVE-BODY' },
+  ]);
+  const r = materialize(cwd, ['--read', 'term', '--materialize']);
+  assert.equal(r.status, 'ok');
+  assert.deepEqual(r.members.map((m) => m.id), ['root', 'mid', 'term']);
+  assert.equal(r.members[1].archived, true, 'archived member flagged');
+  assert.ok(!('archived' in r.members[0]), 'live root not flagged archived');
+  assert.ok(!('archived' in r.members[2]), 'live terminal not flagged archived');
+  assert.ok(r.body.includes('MID-ARCHIVED-BODY'), 'archived body resolved from archived/ into the concatenation');
+});
+
+// (d) ambiguity — 2 active matches + --limit 1 STILL errors materialize-ambiguous listing both
+// ids (pins the PRE-limit check: --limit must not mask the true candidate count).
+t('materialize::ambiguousFilterPreLimitEvenWithLimit1', () => {
+  const cwd = mkStore([
+    { id: 'alpha', body: 'ALPHA-BODY' },
+    { id: 'beta', body: 'BETA-BODY' },
+  ]);
+  const r = materialize(cwd, ['--category', 'lesson', '--materialize', '--limit', '1']);
+  assert.equal(r.status, 'error');
+  assert.equal(r.code, 'materialize-ambiguous');
+  assert.deepEqual(r.matches.map((m) => m.id).sort(), ['alpha', 'beta']);
+});
+
+// (e) filter query with exactly 1 match succeeds.
+t('materialize::filterQueryExactlyOneMatchSucceeds', () => {
+  const cwd = mkStore([
+    { id: 'solo', summary: 'unique-solo-summary', body: 'SOLO-BODY' },
+    { id: 'other', summary: 'other-summary', body: 'OTHER-BODY' },
+  ]);
+  const r = materialize(cwd, ['--query', 'unique-solo-summary', '--materialize']);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.terminal_id, 'solo');
+  assert.equal(r.count, 1);
+});
+
+// (f) single-episode chain (count=1) is normal, not an error — via --read (distinct from case e's
+// filter anchor).
+t('materialize::singleEpisodeChainViaReadNotAnError', () => {
+  const cwd = mkStore([{ id: 'lonely', body: 'LONELY-BODY' }]);
+  const r = materialize(cwd, ['--read', 'lonely', '--materialize']);
+  assert.equal(r.status, 'ok');
+  assert.equal(r.count, 1);
+  assert.deepEqual(r.members.map((m) => m.id), ['lonely']);
+  assert.ok(r.body.includes('LONELY-BODY'));
+});
+
+// (g) cyclic corrupt store — mutual supersedes (a<->b, no root) on the BACKWARD spine walk. Pre-fix
+// materializeChain's backward walk had no visited-set and would re-visit a/b forever; the fix seeds
+// a spineVisited Set so it terminates gracefully instead of hanging, returning a finite,
+// duplicate-free member list.
+t('materialize::mutualSupersedesCycleTerminates', () => {
+  const cwd = mkStore([
+    { id: 'a', supersedes: 'b', body: 'A-BODY' },
+    { id: 'b', supersedes: 'a', body: 'B-BODY' },
+  ]);
+  const r = materialize(cwd, ['--read', 'a', '--materialize']);
+  assert.equal(r.status, 'ok');
+  const ids = r.members.map((m) => m.id);
+  assert.equal(new Set(ids).size, ids.length, 'no duplicate ids in members');
+  assert.ok(ids.length <= 2, 'cycle terminates without unbounded growth');
+});
+
+console.log(`\n${pass}/${pass + fail} pass`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes three queue-head issues via the playbook-v15 tiered arc (2 scouts → negative-scenario audit → frozen spec → builder → 2-lens review → fix round → independent verification). Frozen spec committed at `docs/plans/fix-632-633-634.md`.

## What ships

**#634 — history resolution + delta-only chains (`scripts/em-search.mjs`)**
- `--history` is now ANCHORED on the requested id: the backward walk collects the spine `[requested…root]`, the chain is the reversed spine plus forward continuation from the requested id, and the forward visited-set is seeded with the entire spine. Reproduced defect (live store): `--history` on the planner-prompt terminal returned a 4-member wrong branch ending in a retired-fork tombstone, with the requested id absent from its own history. Post-fix: the full 13-member live line, requested id present, no duplicates, no tombstone. Beyond-anchor fork selection stays last-writer-wins (characterized; tiebreak-by-id deferred, relates #621).
- New `--materialize` flag: one command reconstructs a full supersedes chain (root→terminal concatenated bodies with provenance delimiters, archived-aware, fork-immune backward-only walk). Live store: the complete 152,818-char planner prompt from one command — previously required a hand-driven multi-step walk. Filter-anchored form requires exactly one PRE-`--limit` match, else a typed `materialize-ambiguous` envelope listing candidates (the live store's planner filter matches 3 episodes — the terminal plus two retired-fork tombstones — which `--limit 1` was silently masking).
- Both backward walks carry a visited-set: a corrupt store with a mutual `supersedes` cycle now truncates gracefully with valid JSON (HEAD's old code infinite-loops on the same input; the pre-fix-round slice crashed with RangeError).

**#633 — agent loaders unusable under seat rules (`.claude/agents/` ×3, `docs/PLAN_TEMPLATE.md`)**
- All three episode-as-prompt agents (planner, reviewer, bp1-rfc-classifier — the full class) get Step 0: an orchestrator-inlined `<canonical-prompt source-episode="…">` block is the operational prompt (provenance echoed for drift detection, Principle 8); the em-search loader becomes a fallback, now a two-step resolve-id-then-`--materialize` sequence so fallback loads are complete, not delta-only. PLAN_TEMPLATE §7 documents the materialize-and-inline dispatch pattern.
- Review-convergent P1 fixed en route: bp1's fallback used a double `--tag` query; `flag()` reads only the first occurrence (#123), so it deterministically resolved the negative-scenario-REVIEWER's prompt instead of the bp1 seed (live-store-proven). Now single-tag; resolves `20260513-053454-…-a0c0` correctly.

**#632 — RFC-015 P1-S3a residuals: 1 fixed, 4 re-affirmed DEFER**
- Residual 2 FIXED: `schemas/activation-log.schema.json` (JSONL row schema, fields ground-truthed from the sole writer `appendActivationLine`; `event` pinned `const:"inject"`; enums mirror `INJECTION_SURFACES`/`RENDERED_FORMS`) + `tests/test-activation-log-schema.mjs` (real-writer fixture rows validated via the zero-dep `json-instance-validate.mjs`, negative case included) + `MIN_SCHEMA_DOCS` floor 22→23. Test-tier validation by design — no runtime per-line validation in the hot fail-open readers.
- Residuals re-affirmed DEFER with line-drift corrections (issue's `em-consolidate.mjs:1932`→`:1982`, `:2023`→`:2073`, via cab6a3d):
  - r1 Windows rename-while-open: NEEDS-EVIDENCE (Windows runner); fail-open worst case unchanged. Re-opens on evidence.
  - r3 reader divergence: stays; #628's closure doesn't alter `em-consolidate.mjs`'s zero-export posture, which is what blocks a parity test.
  - r4 64 KiB tail: needs real log-density measurement; one-constant change (`RESURFACE_TAIL_MAX_BYTES`) when justified.
  - r5 count-pin evasion: stays with stated ceiling; no zero-dep AST tooling precedent exists (Node stdlib has no JS-AST API); regex-widening interim rejected as changing the pin's claim without closing the set.

Plus: CI wiring for both new suites (`tests.yml`), plugin `0.2.6`→`0.2.7` (#644 gate).

## Review (2 provider-diverse lenses, codex CLI dead)

- **qwen3.8-max (pi print-mode)**: ACCEPT-WITH-FINDINGS — 1 P1 (bp1 double-tag, fixed), 0 P2, 5 P3. Mutation-tested (anchor seeding, schema required-field), both killed; restoration proven by SHA-256; battery + real-store probes green.
- **claude-subagent (second-opinion harness)**: ACCEPT-WITH-FINDINGS — 0 P1, 2 P2 (bp1 double-tag → convergent with qwen's P1, fixed; backward-cycle crash, fixed), 4 P3. Same two mutations independently run and killed; tree restored byte-identical.
- Fix round covered: bp1 single-tag + #123 note; `spineVisited` in both backward walks + 2 cycle-fixture tests; known-ceiling text corrected in reviewer/classifier files (the "2 tombstones" count is a planner-filter fact; reviewer and bp1 filters each have exactly 1 pre-limit match today, probed).

## DEFERs on record (this slice)

- **F6 delimiter escaping in `--materialize` `body`**: (1) scope: `<!-- id | summary -->` delimiters vs free-text summaries; (2) residual risk: confuses a *structured* parser of `body` — the JSON envelope itself is safe (`JSON.stringify` escapes all C0); (3) trigger: first machine consumer that parses `body` sub-structure; (4) owner: that consumer's PR; (5) ceiling: expires when such a PR opens.
- **Contract-mirror for the new output shapes**: taken ACCEPT-WITH-MOD — `em-search.mjs` has zero exports (same idiom constraint as `em-consolidate.mjs`), so the invariants (requested-id-present, no-duplicates, materialize shape) are pinned as tests rather than a mirror script.
- **Beyond-anchor fork tiebreak** stays last-writer-wins (characterized); an id-based tiebreak may also settle #621 — deferred to that issue.

## P3 observations recorded, no code change

- `materialize-ambiguous` `matches[]` is unbounded on broad filters (consider cap + `matches_count` later).
- `--history` + `--materialize` combo silently ignores `--materialize` (history exits first); usage documents `--read`/filter composition only.
- A spine member with a missing body file yields `body_len:0` with no `body_missing` flag (contrast `--read`'s typed flag) — follow-up candidate.
- `tests/test-p3-fixes.mjs` fails identically at base 0d5ec7d (pre-existing, em-revise scope message, unrelated — proven via `git archive HEAD` extraction).

## Follow-ups (not this slice)

- Retired-fork tombstones permanently match canonical-prompt filters (2 in the planner's filter today) — data hygiene is blocked by #506 (em-revise unions tags; no removal path). A fork-retire storage convention needs #506 or a new mechanism.
- Prompt-chain consolidation cadence for `category: context` (cluster-mode digests are already self-contained and context is eligible; similarity clustering may not sweep an evolving chain end-to-end).

## Verification

Builder battery V1–V8 green; two reviewer re-runs green (each independently mutation-tested); orchestrator re-ran the full battery post-fix-round: history-walk 7/7, materialize 7/7, activation-log-schema 5/5, ci-suite-registration 16/16 PASS, rfc-015 resurfacing 29/29, em-search-read 18/18, em-help-flags 32/32, trigger-index-playbooks 32/32, activation-match 84/84, validate-schemas OK (32 docs, floor 23), rfc-009 contract-mirror ok. Real-store (read-only): history on the live terminal = 13 members, requested id present, no duplicates; one-command materialize = 152,818 chars; bp1 fallback resolves the correct seed.

fixes #632, fixes #633, fixes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
