### PR TITLE
FIX-649/653: typed error-envelope contract (code field) + fd-based index classification (D1) + static FIFO-hang class closure

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -91,24 +91,59 @@ default.
    default behavior, including a real `em-prune` pass; if `--help` returns
    anything other than `status: "help"`, refresh the install before probing
    further, and read the flag lists in this guide instead.
-6. Index existence contract (issue #651): `index.jsonl` presence is classified
-   `lstat`-first, not by `existsSync`. **Absent** (no file, and the parent store
-   dir is itself absent or a clean symlink) keeps today's behavior — `[]` /
-   skip / create-on-first-use. **Unreadable** (a symlink loop or dangling
-   symlink, an EACCES/broken parent directory, a FIFO/socket/device, a
-   directory where the index should be, or a file that fails to read) is a
-   defect, never treated as an empty store: every reader aborts with
-   `{"status":"error","message":"...episode index unreadable (<CODE>)
-   (<path>)..."}` and exit 1, instead of fabricating an empty result or (for a
-   FIFO) blocking forever. `em-doctor` is the one non-abort adopter — it
-   REPORTS `index: "unreadable (<CODE>)"` as a problem entry so the health
-   tool never dies on the disease it diagnoses. `em-rebuild-index` classifies
-   before acquiring its store lock and never truncates/replaces a corrupt
-   `index.jsonl`; its abort envelope adds a `remediation` hint (remove the
-   corrupt file and re-run). Recovery for any of the above: remove the
-   offending `index.jsonl` (or fix the symlink/permission) and run
-   `em-rebuild-index`, which rebuilds it from `episodes/*.md` (the source of
-   truth).
+6. Index existence contract (issues #651, #649, #653): `index.jsonl` presence
+   is classified `lstat`-first, not by `existsSync`. **Absent** (no file, and
+   the parent store dir is itself absent or a clean symlink) keeps today's
+   behavior — `[]` / skip / create-on-first-use. **Unreadable** (a symlink
+   loop or dangling symlink, an EACCES/broken parent directory, a
+   FIFO/socket/device, a directory where the index should be, or a file that
+   fails to read) is a defect, never treated as an empty store: every reader
+   aborts with `{"status":"error","message":"...episode index unreadable
+   (<CODE>) (<path>)...","code":"index-unreadable:<CODE>"}` and exit 1,
+   instead of fabricating an empty result or (for a FIFO) blocking forever.
+   `<CODE>` is the classifier's errno-shaped code (`ENOENT`, `EISDIR`,
+   `ENOTREG`, `EACCES`, `ELOOP`, `UNKNOWN`, or a raw errno). The `code` field
+   is additive on top of the pre-existing `message` wording, which stays
+   byte-unchanged for tooling that already parses it. A writer (`em-store`,
+   `em-revise`) that finds a corrupt DERIVED sidecar (`tags.json`,
+   `category-index.json`, `tokens.json`) before it ever writes names that
+   file's role in the message instead of `episode index` (e.g. `"tags index
+   unreadable (<CODE>) (<path>)"`) — same envelope shape, same `code` field.
+   `em-doctor` is the one non-abort adopter — it REPORTS `index: "unreadable
+   (<CODE>)"` (and a matching `code` on the check row) as a problem entry so
+   the health tool never dies on the disease it diagnoses. `em-rebuild-index`
+   classifies before acquiring its store lock and never truncates/replaces a
+   corrupt `index.jsonl`; its abort envelope adds a `remediation` hint (remove
+   the corrupt file and re-run), and a FIFO/socket-shaped `episodes/*.md` file
+   is skipped with a `warnings` entry rather than aborting the whole rebuild.
+   Recovery for any of the above: remove the offending file (or fix the
+   symlink/permission) and run `em-rebuild-index`, which rebuilds the index
+   from `episodes/*.md` (the source of truth).
+
+   Advisory-degrade rule: the derived/optional surfaces — `tags.json`,
+   `category-index.json`, `tokens.json`, `archived-index.jsonl`, the
+   `embeddings.jsonl` sidecar, and the `~/.episodic-memory/installs.json`
+   consumer registry — never abort and never hang on an unreadable shape;
+   they classify first and degrade (empty/`null`, a linear-scan fallback, or
+   an advisory warning) exactly as if the file were absent. `em-doctor` is the
+   one place this degrade is still surfaced as a diagnostic: an unreadable
+   registry or sidecar reports a `warn` row with `code` rather than reading as
+   healthy.
+
+   Implementation note (issue #653, D1): the classifier never opens a file —
+   it only `lstat`s/`stat`s. The reader closes the "classify, then separately
+   open the path" race by doing ONE `open(O_NONBLOCK)` + `fstat` on the
+   resulting file descriptor, reading (only for a confirmed regular file) from
+   that SAME fd. This means the read observes whatever inode the fd was bound
+   to at open time — if the path is atomically replaced *after* the open
+   succeeds, the read still returns the ORIGINAL file's bytes; that stale
+   snapshot is the classified object, by design, not a bug. A regular file
+   swapped to a FIFO *before* the open (e.g. an actively racing writer) is
+   caught: the FIFO's own `open(O_NONBLOCK)` returns immediately (no writer
+   needed) and `fstat` reports it non-regular, so the reader aborts typed
+   instead of blocking. No RFC formalizes this contract; it is bound here and
+   in `docs/plans/fix-649-653.md` (as `docs/plans/issue-651-index-existence-contract.md`
+   bound the original #651 classification table).
 
 ---
 

--- a/docs/plans/fix-649-653.md
+++ b/docs/plans/fix-649-653.md
@@ -1,0 +1,195 @@
+# FIX-649/653 — error-envelope contract (typed `code`) + fd-based index classification (D1) + static FIFO-hang class closure
+
+Status: FROZEN (Revision 1, 2026-08-08). One PR, `fixes #649, fixes #653`. Base: main `b16f353`.
+Provenance: 2 scout digests + orchestrator ground-truth probes + negative-scenario plan audit
+(HOLD → 9 findings F1–F9 dispositioned below, F1/F2/F3 folded as scope/spec changes).
+
+## §1 Premise (evidence-corrected)
+
+- #649's raw-crash premise is stale: PR #652 (`cab6a3d`) guarded all 8 read/diagnostic tools
+  (probe-verified: uniform typed envelopes on 7 tools, inline report on em-doctor, 4 corruption
+  shapes, zero stacks). Remaining #649 work = bind the contract + ship the typed `code` field.
+- #653 D1 is real on HEAD: `readIndexFileOrThrow` classifies (`index-state.mjs:90`) then
+  path-reads (`:93`). Repro: regular→FIFO swap between the calls hangs to SIGKILL; reclassify
+  control aborts `ENOTREG` in ~50ms. fd semantics validated on Darwin 25.5.0: nonblock open of
+  writer-less FIFO returns fd immediately; `fstatSync(fd)` classifies; fd read returns 0 bytes
+  (no hang); `O_NONBLOCK` no-op on regular files; `readFileSync(fd)` never re-opens the path.
+- Static FIFO-hang class (no race needed), probe-confirmed hangs on HEAD:
+  em-search × FIFO tags.json / tokens.json; em-store × FIFO tags.json (dies mid-write, partial
+  store: episode file committed, sidecars not); em-revise × FIFO tags.json (partial: episode +
+  index committed) and × FIFO index.jsonl (`em-revise.mjs:359/:442` raw, NO index-state import);
+  em-rebuild-index × FIFO episodes/*.md (`:91/:222` — the remediation tool the contract points
+  users at); em-semantic × FIFO embeddings.jsonl (`lib/embeddings.mjs:151-155` existsSync+read);
+  em-doctor × FIFO `~/.episodic-memory/installs.json` (`em-doctor.mjs:572-578` readJson).
+  try/catch does not stop a blocking open — classification (or an fd) must come first.
+- Vendored plugin copies: only 3/6 carry the inlined classifier (em-search:52, em-list:37,
+  em-check-stale:38). Vendored em-store/em-rebuild-index/em-revise have NONE — vendored
+  em-store × FIFO index.jsonl hangs today (probe, alarm-kill). S6 ADDS guards there.
+
+## §2 Contract (the #649 deliverable — bound in docs/EM_SCRIPTS_GUIDE.md)
+
+No new RFC (issue-651 precedent: plan doc + guide binding; the RFC gap is noted in the guide).
+
+- **Family A — store-abort envelope** (read tools on unreadable index; writers on unreadable
+  index/sidecar): `{"status":"error","code":"index-unreadable:<CODE>","message":"<tool>: <file
+  role> unreadable (<CODE>) (<path>)"}` on stdout, exit 1, never a stack. `<CODE>` = classifier
+  code (`ENOENT|EISDIR|ENOTREG|EACCES|ELOOP|UNKNOWN|<errno>`). Message strings are UNCHANGED
+  where they exist today (pinned by tests); `code` is ADDITIVE. Namespace mirrors
+  `protection-abort:<kind>`; extends the existing repo-wide code-field convention.
+  Consumers verified tolerant (em-routines.mjs:361-366, em-manage.mjs:83-100,
+  em-console.mjs:216-228; no exact-key pins anywhere in tests/ or schemas/ — audit F7).
+- **Family B** — em-consolidate `protection-abort:<kind>`: unchanged, documented.
+- **Family C — em-doctor report**: never aborts; `summary` + `checks[]` ALWAYS present
+  (install-wizard.mjs:383-385 is load-bearing). Shape-unreadable rows gain
+  `code:"index-unreadable:<CODE>"`; malformed-content rows stay message-only. Exit 0/1/2 as is.
+- **Advisory degrade rule**: no tool opens an unclassified store-dir or registry path. Advisory
+  surfaces (tags/category/tokens/archived-index/embeddings sidecar/installs.json registry) on
+  unreadable SHAPE → degrade (null/[] + existing warning path), never hang, never abort.
+- **Writer rule**: em-store/em-revise classify index + sidecars (tags/category/tokens) BEFORE
+  lock acquisition and any durable write → typed abort exit 1, zero partial state. Post-preflight
+  swap (TOCTOU) → fd-based read aborts typed mid-run; partial state then possible only under an
+  active same-trust-domain race (documented, same acceptance as #628 DEFER-1).
+- **fd snapshot semantics** (audit F8): a read from a classified fd returns that inode's bytes
+  even if the path is atomically replaced mid-read — the stale snapshot IS the classified object;
+  documented in the guide.
+- **Absent store**: ok/empty, exit 0 (unchanged). em-promote unregistered-cwd-local (#628 P5):
+  pre-existing design, documented (probe: exit 0, "needs >=2 registered stores").
+- **em-topic-tracks** `error:'episode-index-unreadable'`: legacy variant kept (test-651:989);
+  `code` added alongside.
+
+## §3 Implementation slices
+
+- **S1 `lib/index-state.mjs` — `openReadableIndex(fsMod, filePath)`** (fd-based, closes D1):
+  `openSync(path, O_RDONLY|O_NONBLOCK)` → `fstatSync(fd)`:
+  regular → read from the SAME fd → return content; non-regular → throw
+  `IndexUnreadableError` (code from fstat: FIFO/socket/device→ENOTREG, dir→EISDIR).
+  Open-error legs: ENOENT → delegate to `classifyIndexFile` (3-way, audit F4: dangling symlink →
+  throw ENOENT; broken parent → its classifier verdict; absent → null; if the classifier now says
+  `ok` — created between open and classify — retry the open ONCE, a second ENOENT returns null);
+  EACCES/ELOOP/other → typed throw. FD HYGIENE (audit F5): every fd closed via try/finally
+  `closeSync`, exactly once, on all paths (`readFileSync(fd)` does NOT close; an fstat throw must
+  not leak). `readIndexFileOrThrow` rewires to `openReadableIndex` — public contract unchanged
+  (null | content | IndexUnreadableError) → D1 closed for all ~20 transitive users.
+  `assertReadableIndex`/`classifyIndexFile` unchanged.
+- **S2 `lib/relevance.mjs` + sidecar/advisory loaders**: `loadArchivedIndex` (:133→:139 gap) →
+  `openReadableIndex`, degrade to []. `loadTagsIndex`/`loadCategoryIndex`/`loadTokensIndex` →
+  shared fd-based read-or-degrade (unreadable shape → null + existing warning/linear fallback).
+  `lib/embeddings.mjs` `loadEmbeddings` → classify-or-fd, non-regular → return null (F1d).
+  Registry readers (F1e): `install-version.mjs` `readRegistry` + `em-doctor.mjs:572-578` readJson
+  (for installs.json/install-manifest.json) → classify before read, degrade to null (posture per
+  registered-stores.mjs:23-27 "degrade-not-throw"); em-doctor reports a warn/error row instead of
+  hanging; em-promote inherits via `resolveRegisteredStores`.
+- **S3 `em-store.mjs`**: (a) extend the `:333` preflight to classify tags.json,
+  category-index.json, tokens.json — typed abort (Family A, message names the file role+path)
+  BEFORE lock/any write; (b) `:373` priorIndexContent read → `openReadableIndex`; (c)
+  updateTagsIndex/category/tokens read sites → fd-based. ABORT-INSIDE-LOCK MECHANISM (audit F6):
+  throw `IndexUnreadableError` out of the locked try — the existing `finally` (em-store.mjs:594-596)
+  releases the lock — outer catch emits the Family-A envelope and exits 1. NEVER `process.exit`
+  inside the try (em-consolidate.mjs:177-178 documents why).
+- **S3R `em-revise.mjs`** (audit F1a/F1b — mirrors S3): add index-state import; pre-lock
+  preflight classify of index.jsonl + tags/category/tokens for BOTH store dirs it touches
+  (locks `[original.dir, dataDir]` at :379 — preflight runs before :379); index reads
+  :359/:347/:442 → `readIndexFileOrThrow`/`openReadableIndex`; sidecar reads :504/:521 →
+  fd-based; in-lock aborts use the same throw-out-of-try mechanism (verify em-revise's
+  finally releases; add one if absent). Episode-BODY reads (:210/:434) are NOT in scope —
+  they belong to the DEFER'd body-read class (§4 D2) to keep one code namespace.
+- **S4 remaining inline sites**: `em-doctor.mjs:190` → `readIndexFileOrThrow` in try/catch →
+  report row (never abort); `em-feedback.mjs:191/:260` → `readIndexFileOrThrow` (current failure
+  semantics preserved); `em-consolidate.mjs:478` → `readIndexFileOrThrow` (existing :509 backstop
+  catches → protection abort). `em-rebuild-index.mjs:91/:222` (F1c): lstat-classify each
+  episodes/*.md before read; non-regular → skip + entry in the output's warnings (degrade —
+  a FIFO is not a parseable episode; the remediation tool must never hang).
+- **S5 `code` field + docs**: add `code:'index-unreadable:'+e.code` at EVERY Family-A emission
+  site — grep-derived sweep (em-search.mjs:96, em-recall.mjs:262, em-list.mjs:58,
+  em-check-stale.mjs:59, em-graph.mjs:135, em-semantic.mjs:147, em-stats.mjs:201 + archived site
+  :137-142, em-store.mjs:336, em-promote loadIndexOrAbort:137-145, em-topic-tracks:175 additive,
+  em-rebuild-index, em-revise, em-prune, em-restore, em-seed-patterns, + all further grep hits of
+  the family message). em-doctor rows :165/:183/:211/:729/:743 gain `code`.
+  EM_SCRIPTS_GUIDE.md: contract section per §2 (incl. F8 fd-snapshot note + RFC-gap note).
+  This plan committed as docs/plans/fix-649-653.md.
+- **S6 vendored plugin copies** (audit F2 — inventory corrected): em-search/em-list/
+  em-check-stale: upgrade inlined classifier to fd-based + add `code`. em-store/
+  em-rebuild-index/em-revise: ADD the inlined classifier + preflight + guarded reads (new
+  behavior — vendored em-store hangs on FIFO index today). Inline blocks byte-consistent across
+  the 6 copies. `plugin.json` 0.2.7 → 0.2.8.
+- **S7 tests** (extend tests/test-651-index-existence.mjs, CI-wired at tests.yml:324; split a new
+  wired file only if it grows unwieldy):
+  - D1 interleave: classify-ok → swap-FIFO → helper read → typed ENOTREG, under spawn timeout.
+  - Static-FIFO legs: em-search × FIFO tags/tokens/category → ok+warning, no hang; em-store ×
+    FIFO tags → typed abort, episode count unchanged (zero partial state); em-revise × FIFO
+    tags AND × FIFO index → typed abort, original episode + index untouched; em-rebuild-index ×
+    FIFO episodes/*.md → completes with warning; em-semantic × FIFO embeddings.jsonl → degrade;
+    em-doctor × FIFO installs.json (fake HOME) → report row, exit != hang.
+  - PARITY leg (audit F3 — end-to-end, not classify-vs-open): for every applyShape shape
+    (+ file000, symlink→FIFO, symlink→dir, parent-dangling), OLD `readIndexFileOrThrow` outcome
+    (captured pre-change or via reference vector) == NEW outcome — both e.g. unreadable:EACCES
+    on file000 (probe-pinned: classify alone says ok there; end-to-end wraps EACCES).
+  - Envelope sweep (audit F9): runtime legs for the 8 read tools + em-store + em-revise +
+    em-rebuild-index (dir-shaped index → `code==='index-unreadable:EISDIR'` + message regex +
+    exit 1); static grep-pin that every Family-A emission site carries `code`.
+  - Lock-release leg (audit F6): induced unreadable mid-lock → envelope emitted, lock file
+    absent afterward, immediate retry em-store succeeds.
+  - Vendored-writer legs (audit F2): vendored em-store/em-revise/em-rebuild-index × FIFO
+    index.jsonl → typed abort, no hang (T7 pattern, spawn timeout).
+  - Fixture discipline: mkdtemp fixture stores, explicit cwd + fake HOME, `--scope local`,
+    spawn timeout 10000 (macOS has NO `timeout` binary — spawn timeouts / perl alarm only).
+
+## §4 Exclusions / DEFERs
+
+- **D2 (NEW, audit F1c/f residual) — episode-body FIFO reads in query paths**: (what) FIFO-shaped
+  episodes/*.md hangs body-loading reads (em-search --full/--materialize, em-recall, em-graph,
+  em-revise:210/:434, others); (why deferrable) advisory display surface; requires store-dir
+  write access — same trust domain as #628 DEFER-1/#653 D1 acceptance; the sweep spans many
+  sites across many tools and deserves one class pass with a shared safe-body-read helper;
+  em-rebuild-index (the remediation path) IS fixed in this slice; (risk) hang on read paths,
+  adversarial-local only, recovery = remove the FIFO + em-rebuild-index (which no longer hangs);
+  (trigger) any body-read hang report, or scheduling of the follow-up; (owner) follow-up issue
+  filed from the PR (like #653 was from #651).
+- em-promote.mjs:668/:686/:810 raw TOCTOU sites — #628 DEFER-1 accepted trust domain
+  (issue-651 plan §4), re-affirmed, unchanged.
+- em-promote unregistered-cwd-local (#628 P5) — pre-existing design, documented only.
+- Content corruption (malformed lines dropped per-row) — #447/#448 class, unchanged.
+- em-topic-tracks `error:` field shape — legacy, kept; `code` additive only.
+- No new RFC; no consumer changes.
+
+## §5 Verification battery (falsifiable; run by builder, reviewers, and orchestrator)
+
+- V1 `node tests/test-651-index-existence.mjs` — all legs green; NEW hang legs must FAIL
+  (timeout-kill or wrong envelope) against unpatched b16f353 (falsifiability proof).
+- V2 static probes (perl-alarm): FIFO tags/tokens × em-search → instant ok+warning; FIFO tags ×
+  em-store AND em-revise → instant typed abort, store byte-identical after.
+- V3 envelope legs incl. sweep + em-doctor `summary`/`checks` presence + row `code`.
+- V4 full battery: ci-suite-registration, em-search-read, em-help-flags, trigger-index-playbooks,
+  activation-match, validate-schemas (floor 23), rfc-009 contract-mirror, rfc-015 resurfacing,
+  test-history-walk, test-materialize, test-activation-log-schema, store-write-concurrency.
+- V5 real-store read-only smoke: `em-search --limit 1 --no-track` output unchanged pre/post.
+- V6 vendored parity: inline classifier blocks identical across 6 copies; vendored-writer FIFO
+  legs green.
+- V7 fd-hygiene: new helper paths leak no fd (leg: loop openReadableIndex over unreadable shapes
+  1000×, assert no EMFILE).
+- V8 `git diff` inspection: only files named in §3; no drive-by edits.
+
+## §6 Risks
+
+- fd semantics on non-local filesystems — stdlib-only; degrade paths documented.
+- Lock-release-before-exit — mechanism specified (F6), tested (S7 leg).
+- Vendored inline drift — S6 + V6.
+- code-field consumer breakage — F7-verified additive.
+- Classification behavior drift — end-to-end parity leg (F3-corrected definition).
+- New-surface integration (audit re-walk targets): em-revise preflight × its two-dir lock
+  ordering (preflight strictly pre-lock); vendored writer guards × plugin cwd resolution
+  (T7-pattern spawn tests); registry classify × em-doctor non-abort posture (report row).
+
+## §7 Audit disposition table (F1–F9)
+
+| F | Sev | Disposition | Where folded |
+|---|---|---|---|
+| F1 | MAJOR | ACCEPT-WITH-MOD: em-revise index+sidecars, rebuild-index bodies, embeddings, registry IN; query-path bodies → D2 DEFER (5-field) | S3R, S4, S2, §4 D2 |
+| F2 | MAJOR | ACCEPT: vendored inventory corrected; writers get guards ADDED + legs | S6, S7 |
+| F3 | MAJOR | ACCEPT: parity leg redefined end-to-end (file000 probe-pinned) | S7 |
+| F4 | MINOR | ACCEPT: 3-way ENOENT delegation + retry-open-once | S1 |
+| F5 | MINOR | ACCEPT: try/finally closeSync, single-close | S1, V7 |
+| F6 | MINOR | ACCEPT: throw-out-of-try mechanism + lock-release leg | S3, S7 |
+| F7 | INFO | verified additive, no change | §2 |
+| F8 | INFO | fd-snapshot semantics documented | §2, S5 |
+| F9 | MINOR | ACCEPT: envelope sweep leg (runtime + grep-pin) | S7 |

--- a/plugins/episodic-memory/scripts/em-check-stale.mjs
+++ b/plugins/episodic-memory/scripts/em-check-stale.mjs
@@ -30,11 +30,16 @@ const maxDays = parseInt(flag('--days') || '30', 10)
 const project = flag('--project')
 const scope = flag('--scope') || 'all'
 
-// #651: lstat-based index existence classifier, inlined (no lib/ in this
-// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
-// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
-// failure) -> throws with .code, so the caller aborts typed instead of
-// silently degrading or blocking forever on an unguarded FIFO read.
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
 function classifyIndexFile(filePath) {
   let st
   try { st = fs.lstatSync(filePath) } catch (e) {
@@ -59,18 +64,50 @@ function classifyIndexFile(filePath) {
   return { state: 'ok' }
 }
 
-function readIndexOrThrow(filePath) {
-  const c = classifyIndexFile(filePath)
-  if (c.state === 'absent') return null
-  if (c.state === 'unreadable') {
-    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
-    err.code = c.code
-    throw err
-  }
-  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
     const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
     err.code = (e && e.code) || 'UNKNOWN'
     throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
   }
 }
 
@@ -92,7 +129,7 @@ try {
   if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
   if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
 } catch (e) {
-  console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}` }))
+  console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}`, code: `index-unreadable:${e.code}` }))
   process.exit(1)
 }
 

--- a/plugins/episodic-memory/scripts/em-list.mjs
+++ b/plugins/episodic-memory/scripts/em-list.mjs
@@ -29,11 +29,16 @@ const limit = parseInt(flag('--limit') || '10', 10)
 const scope = flag('--scope') || 'all'
 const includeSuperseded = argv.includes('--include-superseded')
 
-// #651: lstat-based index existence classifier, inlined (no lib/ in this
-// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
-// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
-// failure) -> throws with .code, so the caller aborts typed instead of
-// silently degrading or blocking forever on an unguarded FIFO read.
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
 function classifyIndexFile(filePath) {
   let st
   try { st = fs.lstatSync(filePath) } catch (e) {
@@ -58,18 +63,50 @@ function classifyIndexFile(filePath) {
   return { state: 'ok' }
 }
 
-function readIndexOrThrow(filePath) {
-  const c = classifyIndexFile(filePath)
-  if (c.state === 'absent') return null
-  if (c.state === 'unreadable') {
-    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
-    err.code = c.code
-    throw err
-  }
-  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
     const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
     err.code = (e && e.code) || 'UNKNOWN'
     throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
   }
 }
 
@@ -91,7 +128,7 @@ try {
   if (scope === 'local' || scope === 'all') results.push(...loadIndex(LOCAL_DIR, 'local'))
   if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
 } catch (e) {
-  console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}` }))
+  console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}`, code: `index-unreadable:${e.code}` }))
   process.exit(1)
 }
 

--- a/plugins/episodic-memory/scripts/em-rebuild-index.mjs
+++ b/plugins/episodic-memory/scripts/em-rebuild-index.mjs
@@ -25,6 +25,87 @@ function flag(name) {
 
 const scope = flag('--scope') || 'all'
 
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
 /**
  * Parse YAML frontmatter from a markdown string.
  * Handles the simple subset we produce: scalar values and inline arrays.
@@ -54,6 +135,14 @@ function rebuildDir(dataDir, label) {
   const episodesDir = path.join(dataDir, 'episodes')
   const indexFile = path.join(dataDir, 'index.jsonl')
 
+  // #653: classify index.jsonl BEFORE any write — the absent-episodesDir
+  // branch below writes indexFile DIRECTLY (not via tmp+rename), so a
+  // FIFO-shaped index.jsonl there would otherwise block forever.
+  const shape = classifyIndexFile(indexFile)
+  if (shape.state === 'unreadable') {
+    throw Object.assign(new Error(`episode index unreadable (${shape.code}) (${indexFile})`), { code: shape.code, scope: label })
+  }
+
   if (!fs.existsSync(episodesDir)) {
     fs.mkdirSync(episodesDir, { recursive: true })
     fs.writeFileSync(indexFile, '', 'utf8')
@@ -62,9 +151,17 @@ function rebuildDir(dataDir, label) {
 
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []
+  const warnings = []
 
   for (const file of files) {
-    const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
+    // #653: lstat-classify before read — a FIFO-shaped episode file is not
+    // a parseable episode; skip + warn instead of hanging the rebuild.
+    const filePath = path.join(episodesDir, file)
+    if (classifyIndexFile(filePath).state !== 'ok') {
+      warnings.push(`skipped ${file}: not a regular file`)
+      continue
+    }
+    const content = fs.readFileSync(filePath, 'utf8')
     const fm = parseFrontmatter(content)
     if (!fm || !fm.id) continue
     entries.push(JSON.stringify({
@@ -85,11 +182,15 @@ function rebuildDir(dataDir, label) {
   fs.writeFileSync(tmpFile, entries.join('\n') + (entries.length ? '\n' : ''), 'utf8')
   fs.renameSync(tmpFile, indexFile)
 
-  return { scope: label, count: entries.length }
+  return { scope: label, count: entries.length, ...(warnings.length ? { warnings } : {}) }
 }
 
 const rebuilt = []
-if (scope === 'local' || scope === 'all') rebuilt.push(rebuildDir(LOCAL_DIR, 'local'))
-if (scope === 'global' || scope === 'all') rebuilt.push(rebuildDir(GLOBAL_DIR, 'global'))
-
-console.log(JSON.stringify({ status: 'ok', rebuilt }))
+try {
+  if (scope === 'local' || scope === 'all') rebuilt.push(rebuildDir(LOCAL_DIR, 'local'))
+  if (scope === 'global' || scope === 'all') rebuilt.push(rebuildDir(GLOBAL_DIR, 'global'))
+  console.log(JSON.stringify({ status: 'ok', rebuilt }))
+} catch (e) {
+  console.log(JSON.stringify({ status: 'error', scope: e.scope, message: `em-rebuild-index: ${e.message}`, ...(e.code ? { code: `index-unreadable:${e.code}` } : {}) }))
+  process.exit(1)
+}

--- a/plugins/episodic-memory/scripts/em-revise.mjs
+++ b/plugins/episodic-memory/scripts/em-revise.mjs
@@ -54,6 +54,87 @@ if (!originalId || !summary || !body) {
   process.exit(1)
 }
 
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Resolve data directory — find the original episode
 // ---------------------------------------------------------------------------
@@ -74,6 +155,29 @@ if (!original) {
   process.exit(1)
 }
 
+// dataDir/indexFile are resolved here (rather than after the mark-superseded
+// write below) so the #653 preflight can classify BOTH store dirs this
+// revision touches — original.dir (supersession target) and dataDir
+// (successor target; may be the same dir) — before ANY write.
+const dataDir = scope === 'inherit'
+  ? original.dir
+  : (scope === 'global' ? GLOBAL_DIR : LOCAL_DIR)
+const episodesDir = path.join(dataDir, 'episodes')
+const indexFile = path.join(dataDir, 'index.jsonl')
+const originalIndexFile = path.join(original.dir, 'index.jsonl')
+
+// #653: classify index.jsonl for both dirs BEFORE any read/write so a
+// FIFO-shaped index aborts typed, exit 1, instead of blocking forever
+// (this vendored copy has no store-write lock — the only write hazard is
+// index.jsonl itself).
+for (const file of new Set([originalIndexFile, indexFile])) {
+  const shape = classifyIndexFile(file)
+  if (shape.state === 'unreadable') {
+    console.log(JSON.stringify({ status: 'error', message: `em-revise: episode index unreadable (${shape.code}) (${file})`, code: `index-unreadable:${shape.code}` }))
+    process.exit(1)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Mark original as superseded
 // ---------------------------------------------------------------------------
@@ -81,10 +185,13 @@ let originalContent = fs.readFileSync(original.filePath, 'utf8')
 originalContent = originalContent.replace(/^status: active$/m, 'status: superseded')
 fs.writeFileSync(original.filePath, originalContent, 'utf8')
 
-// Update the index entry for the original
-const originalIndexFile = path.join(original.dir, 'index.jsonl')
-if (fs.existsSync(originalIndexFile)) {
-  const lines = fs.readFileSync(originalIndexFile, 'utf8').trim().split('\n').filter(Boolean)
+// Update the index entry for the original. #653: fd-based read
+// (readIndexOrThrow) instead of existsSync+readFileSync; only write back
+// when the index was actually present (preserves the pre-#653 behavior of
+// leaving a genuinely absent index.jsonl untouched).
+const originalIndexRaw = readIndexOrThrow(originalIndexFile)
+if (originalIndexRaw !== null) {
+  const lines = originalIndexRaw.trim().split('\n').filter(Boolean)
   const updated = lines.map(line => {
     try {
       const entry = JSON.parse(line)
@@ -116,13 +223,9 @@ if (origFmMatch) {
 
 // ---------------------------------------------------------------------------
 // Create the revision episode in the same store as the original
+// (dataDir/episodesDir/indexFile were resolved earlier, above the #653
+// preflight, so they are already in scope here.)
 // ---------------------------------------------------------------------------
-const dataDir = scope === 'inherit'
-  ? original.dir
-  : (scope === 'global' ? GLOBAL_DIR : LOCAL_DIR)
-const episodesDir = path.join(dataDir, 'episodes')
-const indexFile = path.join(dataDir, 'index.jsonl')
-
 const now = new Date()
 const dateStr = now.toISOString().slice(0, 10)
 const timeStr = now.toISOString().slice(11, 16)

--- a/plugins/episodic-memory/scripts/em-search.mjs
+++ b/plugins/episodic-memory/scripts/em-search.mjs
@@ -44,11 +44,16 @@ const historyId = flag('--history')
 // ---------------------------------------------------------------------------
 // Load index entries from a data directory
 // ---------------------------------------------------------------------------
-// #651: lstat-based index existence classifier, inlined (no lib/ in this
-// vendored copy). absent -> null (loadIndex returns []); unreadable (symlink
-// loop/dangling, EACCES parent, FIFO/socket/device, EISDIR, or a read
-// failure) -> throws with .code, so the caller aborts typed instead of
-// silently degrading or blocking forever on an unguarded FIFO read.
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
 function classifyIndexFile(filePath) {
   let st
   try { st = fs.lstatSync(filePath) } catch (e) {
@@ -73,18 +78,50 @@ function classifyIndexFile(filePath) {
   return { state: 'ok' }
 }
 
-function readIndexOrThrow(filePath) {
-  const c = classifyIndexFile(filePath)
-  if (c.state === 'absent') return null
-  if (c.state === 'unreadable') {
-    const err = new Error(`episode index unreadable (${c.code}) (${filePath})`)
-    err.code = c.code
-    throw err
-  }
-  try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
     const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
     err.code = (e && e.code) || 'UNKNOWN'
     throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
   }
 }
 
@@ -115,7 +152,7 @@ try {
     results.push(...loadIndex(GLOBAL_DIR, 'global'))
   }
 } catch (e) {
-  console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}` }))
+  console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}`, code: `index-unreadable:${e.code}` }))
   process.exit(1)
 }
 

--- a/plugins/episodic-memory/scripts/em-store.mjs
+++ b/plugins/episodic-memory/scripts/em-store.mjs
@@ -37,6 +37,87 @@ const body = flag('--body')
 const url = flag('--url')
 const scope = flag('--scope') || 'global'
 
+// #651/#653: fd-based index existence classifier + reader, inlined (no lib/
+// in this vendored copy) — mirrors scripts/lib/index-state.mjs. A single
+// open() + fstat() on ONE fd (never a separate classify-then-path-read pair)
+// closes the D1 TOCTOU window: even a regular file swapped to a FIFO/dir
+// between calls cannot re-open a hang, because the read below reuses the
+// SAME fd the fstat just classified. absent -> null (loadIndex returns []);
+// unreadable (symlink loop/dangling, EACCES parent, FIFO/socket/device,
+// EISDIR, or a read failure) -> throws with .code, so the caller aborts
+// typed instead of silently degrading or blocking forever on an unguarded
+// open.
+function classifyIndexFile(filePath) {
+  let st
+  try { st = fs.lstatSync(filePath) } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const dir = path.dirname(filePath)
+      let dirStat
+      try { dirStat = fs.lstatSync(dir) } catch (e2) {
+        return (e2 && e2.code === 'ENOENT') ? { state: 'absent' } : { state: 'unreadable', code: (e2 && e2.code) || 'UNKNOWN' }
+      }
+      if (dirStat.isSymbolicLink()) {
+        try { fs.statSync(dir) } catch (e3) { return { state: 'unreadable', code: (e3 && e3.code) || 'UNKNOWN' } }
+      }
+      return { state: 'absent' }
+    }
+    return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' }
+  }
+  if (st.isSymbolicLink()) {
+    try { st = fs.statSync(filePath) } catch (e) { return { state: 'unreadable', code: (e && e.code) || 'UNKNOWN' } }
+  }
+  if (st.isDirectory()) return { state: 'unreadable', code: 'EISDIR' }
+  if (!st.isFile()) return { state: 'unreadable', code: 'ENOTREG' }
+  return { state: 'ok' }
+}
+
+function readIndexOrThrow(filePath, retried = false) {
+  let fd
+  try {
+    fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
+  } catch (e) {
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null
+        return readIndexOrThrow(filePath, true)
+      }
+      const err = new Error(`episode index unreadable (${verdict.code}) (${filePath})`)
+      err.code = verdict.code
+      throw err
+    }
+    const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+    err.code = (e && e.code) || 'UNKNOWN'
+    throw err
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+    if (!st.isFile()) {
+      const code = st.isDirectory() ? 'EISDIR' : 'ENOTREG'
+      const err = new Error(`episode index unreadable (${code}) (${filePath})`)
+      err.code = code
+      throw err
+    }
+    try {
+      return fs.readFileSync(fd, 'utf8')
+    } catch (e) {
+      const err = new Error(`episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${filePath})`)
+      err.code = (e && e.code) || 'UNKNOWN'
+      throw err
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
 if (!project || !category || !summary || !body) {
   console.log(JSON.stringify({
     status: 'error',
@@ -60,6 +141,17 @@ if (!VALID_CATEGORIES.includes(category)) {
 const dataDir = scope === 'global' ? GLOBAL_DIR : LOCAL_DIR
 const episodesDir = path.join(dataDir, 'episodes')
 const indexFile = path.join(dataDir, 'index.jsonl')
+
+// #653: classify index.jsonl BEFORE any read/append so a FIFO-shaped index
+// aborts typed, exit 1, instead of blocking forever (this vendored copy has
+// no store-write lock — the only write hazard is index.jsonl itself).
+{
+  const shape = classifyIndexFile(indexFile)
+  if (shape.state === 'unreadable') {
+    console.log(JSON.stringify({ status: 'error', message: `em-store: episode index unreadable (${shape.code}) (${indexFile})`, code: `index-unreadable:${shape.code}` }))
+    process.exit(1)
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Generate episode

--- a/scripts/em-check-stale.mjs
+++ b/scripts/em-check-stale.mjs
@@ -56,7 +56,7 @@ try {
   if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-check-stale: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -475,7 +475,16 @@ if (foldSuperseded) {
 
       // index.jsonl: keep only non-folded rows (atomic rewrite); folded rows
       // move to archived-index.jsonl with reader-internal fields stripped.
-      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+      // #653 S4: this read was fully unguarded (raw fs.readFileSync, no
+      // classify at all) — the widest D1 window in foldStore. Same
+      // protection-abort pattern as the archived-index preflight above.
+      let rawPrimaryIndex
+      try {
+        rawPrimaryIndex = readIndexFileOrThrow(fs, indexFile) || ''
+      } catch (e) {
+        emitProtectionAbort(indexUnreadableAbort(dataDir, e), 'fold-superseded')
+      }
+      const lines = rawPrimaryIndex.trim().split('\n').filter(Boolean)
       const keptLines = []
       const archivedLines = []
       for (const line of lines) {
@@ -1412,8 +1421,26 @@ try {
     // 4. tags.json: read, append digest id to each tag's posting, atomic-replace.
     // Null-proto (#469/#470): a tag literally named "constructor"/"__proto__"
     // must not resolve to an inherited Object.prototype member.
+    // #653 (FIX-F, review P2-2 + same-pattern extension): unlike index.jsonl
+    // (classified once via loadIndex above — TOCTOU-only from here), tags.json
+    // has NO upstream classify anywhere in this flow — a static FIFO/dir shape
+    // would hang. fd-guard it, matching this flow's existing protection-abort
+    // idiom (indexUnreadableAbort + emitProtectionAbort, mode 'consolidate-
+    // apply' — same as the index-load site above and --fold-superseded's
+    // sidecar preflight); emitProtectionAbort exits, which skips any pending
+    // finally, so the held lock is released explicitly first.
+    let tagsRaw
+    try {
+      tagsRaw = readIndexFileOrThrow(fs, tagsFile)
+    } catch (e) {
+      releaseStoreWriteLocks(_csLockHandles)
+      _csLockHandles = null
+      emitProtectionAbort(indexUnreadableAbort(DATA_DIR, e, tagsFile), 'consolidate-apply')
+    }
     let tagsIndex = Object.create(null)
-    try { tagsIndex = JSON.parse(fs.readFileSync(tagsFile, 'utf8')) } catch {}
+    if (tagsRaw !== null) {
+      try { tagsIndex = JSON.parse(tagsRaw) } catch {}
+    }
     if (Object.getPrototypeOf(tagsIndex) !== null) tagsIndex = Object.assign(Object.create(null), tagsIndex)
     for (const tag of tags) {
       if (!tagsIndex[tag]) tagsIndex[tag] = []
@@ -1422,8 +1449,20 @@ try {
     atomicReplaceFileSync(tagsFile, JSON.stringify(tagsIndex, null, 2))
 
     // 5. category-index.json: read, append digest id under canonical category.
+    // #653 (FIX-F, review P2-2): same guard as tags.json above — no upstream
+    // classify, static FIFO hang reachable.
+    let catRaw
+    try {
+      catRaw = readIndexFileOrThrow(fs, categoryIndexFile)
+    } catch (e) {
+      releaseStoreWriteLocks(_csLockHandles)
+      _csLockHandles = null
+      emitProtectionAbort(indexUnreadableAbort(DATA_DIR, e, categoryIndexFile), 'consolidate-apply')
+    }
     let catIndex = Object.create(null)
-    try { catIndex = JSON.parse(fs.readFileSync(categoryIndexFile, 'utf8')) } catch {}
+    if (catRaw !== null) {
+      try { catIndex = JSON.parse(catRaw) } catch {}
+    }
     if (Object.getPrototypeOf(catIndex) !== null) catIndex = Object.assign(Object.create(null), catIndex)
     if (!catIndex[category]) catIndex[category] = []
     if (!catIndex[category].includes(digestId)) catIndex[category].push(digestId)

--- a/scripts/em-doctor.mjs
+++ b/scripts/em-doctor.mjs
@@ -61,7 +61,7 @@ import { loadIndex, TOKENS_DROPPED_KEY } from './lib/relevance.mjs'
 import { findContradictionCandidates, SUMMARY_JACCARD_MIN } from './lib/contradiction.mjs'
 import { resolveRegisteredStores, realpathSafe } from './lib/registered-stores.mjs'
 import { parsePlaybooksConfig, terminalOf, buildChainMaps, mergeIndexRowsForChain } from './em-trigger-index.mjs'
-import { assertReadableIndex } from './lib/index-state.mjs'
+import { assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -163,7 +163,7 @@ function checkStore(dataDir, scopeName) {
     report('archived-index', scopeName, 'ok', archivedState === 'ok' ? 'archived-index.jsonl readable' : 'archived-index.jsonl absent')
   } catch (e) {
     report('archived-index', scopeName, 'error', `archived-index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'})`,
-      { fix: 'remove the corrupt archived-index.jsonl and re-run em-rebuild-index' })
+      { fix: 'remove the corrupt archived-index.jsonl and re-run em-rebuild-index', code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` })
   }
 
   if (!hasIndex && !indexUnreadableCode && episodeIds.size === 0) {
@@ -181,21 +181,37 @@ function checkStore(dataDir, scopeName) {
     // unindexed"), so they are skipped. tmp-litter/stale-locks are
     // directory-level and still run below.
     report('index-parse', scopeName, 'error', `index.jsonl unreadable (${indexUnreadableCode})`,
-      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index', code: `index-unreadable:${indexUnreadableCode}` })
   } else {
     // --- index-parse: count rows that fail to parse -------------------------
+    // #653: readIndexFileOrThrow (fd-based) instead of a raw fs.readFileSync
+    // — hasIndex was classified 'ok' above, but a TOCTOU swap between that
+    // classify and this read must never crash em-doctor. On a hit, skip
+    // silently: the loadIndex() call just below reads the same file and is
+    // the single site that reports the defect (never double-report).
     let rawLines = []
     let badLines = 0
+    let indexReadFailed = false
     if (hasIndex) {
-      rawLines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
-      for (const line of rawLines) {
-        try { JSON.parse(line) } catch { badLines++ }
+      let rawIndexContent
+      try {
+        rawIndexContent = readIndexFileOrThrow(fs, indexFile)
+      } catch {
+        indexReadFailed = true
+      }
+      if (!indexReadFailed) {
+        rawLines = (rawIndexContent || '').trim().split('\n').filter(Boolean)
+        for (const line of rawLines) {
+          try { JSON.parse(line) } catch { badLines++ }
+        }
       }
     }
-    if (badLines > 0) {
-      report('index-parse', scopeName, 'error', `${badLines} malformed line(s) in index.jsonl`, { fix: 'em-rebuild-index' })
-    } else {
-      report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
+    if (!indexReadFailed) {
+      if (badLines > 0) {
+        report('index-parse', scopeName, 'error', `${badLines} malformed line(s) in index.jsonl`, { fix: 'em-rebuild-index' })
+      } else {
+        report('index-parse', scopeName, 'ok', hasIndex ? `index.jsonl: ${rawLines.length} row(s), all parse` : 'index.jsonl absent')
+      }
     }
 
     // --- row-shape: schema-deviant rows (#448 class) -------------------------
@@ -209,7 +225,7 @@ function checkStore(dataDir, scopeName) {
     } catch (e) {
       // TOCTOU: readable at classify time, swapped to unreadable by read time.
       report('index-parse', scopeName, 'error', `index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'})`,
-        { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+        { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index', code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` })
       entriesForShape = []
       indexUnreadableCode = (e && e.code) || 'UNKNOWN'
     }
@@ -569,19 +585,43 @@ function checkGateFriction() {
 // section touched.
 // ---------------------------------------------------------------------------
 function checkInstallsDrift() {
-  const readJson = (p) => {
+  // #653 (F1e / review FIX-D, P2-1): classify before read (readIndexFileOrThrow)
+  // so a FIFO-shaped installs.json/install-manifest.json/.episodic-memory-
+  // install.json can never hang a raw readFileSync — em-doctor never aborts.
+  // BUT an unreadable SHAPE (FIFO/dir/EACCES/...) is a real defect and must
+  // stay DISTINGUISHABLE from "genuinely absent" (which legitimately degrades
+  // to "nothing recorded yet, ok"): the caller-supplied `onUnreadable`
+  // callback fires only for IndexUnreadableError, carrying the .code, so the
+  // two global-registry files can be reported as warn rows instead of being
+  // silently indistinguishable from an empty/absent registry.
+  const readJson = (p, onUnreadable) => {
+    let raw
     try {
-      const v = JSON.parse(fs.readFileSync(p, 'utf8'))
+      raw = readIndexFileOrThrow(fs, p)
+    } catch (e) {
+      if (e instanceof IndexUnreadableError && onUnreadable) onUnreadable(e.code)
+      return null
+    }
+    if (raw === null) return null
+    try {
+      const v = JSON.parse(raw)
       return v && typeof v === 'object' && !Array.isArray(v) ? v : null
     } catch { return null }
   }
-  const registry = readJson(path.join(GLOBAL_DIR, 'installs.json'))
+  let installsUnreadableCode = null
+  let manifestUnreadableCode = null
+  const registry = readJson(path.join(GLOBAL_DIR, 'installs.json'), (code) => { installsUnreadableCode = code })
+  if (installsUnreadableCode) {
+    report('installs-drift', 'global', 'warn', `installs.json unreadable (${installsUnreadableCode}) — consumer registry cannot be read`,
+      { code: `index-unreadable:${installsUnreadableCode}` })
+    return
+  }
   const entries = registry && Array.isArray(registry.entries) ? registry.entries : []
   if (entries.length === 0) {
     report('installs-drift', 'global', 'ok', 'no consumer registry entries (no per-project installs recorded yet)')
     return
   }
-  const globalManifest = readJson(path.join(GLOBAL_DIR, 'install-manifest.json'))
+  const globalManifest = readJson(path.join(GLOBAL_DIR, 'install-manifest.json'), (code) => { manifestUnreadableCode = code })
   const globalVersion = globalManifest && typeof globalManifest.source_version === 'string'
     ? globalManifest.source_version : null
   const sha256 = (p) => crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex')
@@ -621,7 +661,14 @@ function checkInstallsDrift() {
       details.push(`${projectPath}: ${isBehind ? `behind global (${String(m.source_version).slice(0, 12)} vs ${globalVersion.slice(0, 12)})` : 'at global version'}${modified > 0 ? `, ${modified} locally modified artifact(s)` : ''}`)
     }
   }
-  if (behind + withModified + vanished + noManifest === 0) {
+  if (manifestUnreadableCode) {
+    // install-manifest.json unreadable degrades globalVersion to null (every
+    // project reads as "not behind" — a real defect, not a healthy "current"
+    // state), so this can never reach the ok branch below.
+    report('installs-drift', 'global', 'warn',
+      `install-manifest.json unreadable (${manifestUnreadableCode}) — cannot compare ${projects.length} consumer project(s) against the global version`,
+      { code: `index-unreadable:${manifestUnreadableCode}` })
+  } else if (behind + withModified + vanished + noManifest === 0) {
     report('installs-drift', 'global', 'ok', `${projects.length} consumer project(s) current with global${globalVersion ? ` (${globalVersion.slice(0, 12)})` : ''}`)
   } else {
     report('installs-drift', 'global', 'warn',
@@ -727,7 +774,7 @@ function checkPlaybookRegistration(dataDir, scopeName) {
     scannedRows = loadIndex(dataDir, scopeName)
   } catch (e) {
     report('playbook-registration', scopeName, 'error', `index.jsonl unreadable (${(e && e.code) || 'UNKNOWN'}) — cannot check playbook registration`,
-      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index', code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` })
     return
   }
   // NF4 (review r2): merge = (scanned store rows) + GLOBAL_DIR rows.
@@ -741,7 +788,7 @@ function checkPlaybookRegistration(dataDir, scopeName) {
     mergedRows = mergeIndexRowsForChain(loadIndex(dataDir, scopeName), loadIndex(GLOBAL_DIR, 'global'))
   } catch (e) {
     report('playbook-registration', scopeName, 'error', `index unreadable (${(e && e.code) || 'UNKNOWN'}) — cannot check playbook registration`,
-      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index' })
+      { fix: 'remove the corrupt index.jsonl and re-run em-rebuild-index', code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` })
     return
   }
   const { byId, successorOf } = buildChainMaps(mergedRows)

--- a/scripts/em-feedback.mjs
+++ b/scripts/em-feedback.mjs
@@ -50,7 +50,7 @@ function filterReadableStoreDirs(dirs) {
     try {
       state = assertReadableIndex(fs, indexFile)
     } catch (e) {
-      console.log(JSON.stringify({ status: 'error', message: `em-feedback: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${indexFile})` }))
+      console.log(JSON.stringify({ status: 'error', message: `em-feedback: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${indexFile})`, code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` }))
       process.exit(1)
     }
     if (state === 'ok') kept.push(dir)
@@ -165,7 +165,7 @@ if (scanTextFile !== undefined) {
       ({ resolved, skipped } = resolveIds())
     } catch (e) {
       if (e instanceof IndexUnreadableError) {
-        console.log(JSON.stringify({ status: 'error', message: `em-feedback: ${e.message}` }))
+        console.log(JSON.stringify({ status: 'error', message: `em-feedback: ${e.message}`, code: `index-unreadable:${e.code}` }))
         process.exit(1)
       }
       throw e
@@ -188,7 +188,11 @@ if (scanTextFile !== undefined) {
         const targetIds = idsByDir.get(name)
         if (targetIds.size === 0) continue
         const indexFile = path.join(dir, 'index.jsonl')
-        const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+        // #653 S4: fd-based read (readIndexFileOrThrow) instead of a raw
+        // readFileSync — never opens a FIFO. Current failure semantics
+        // preserved: any thrown error (incl. IndexUnreadableError) is
+        // caught by the surrounding try/catch below exactly as before.
+        const lines = (readIndexFileOrThrow(fs, indexFile) || '').trim().split('\n').filter(Boolean)
         const updated = lines.map(line => {
           try {
             const entry = JSON.parse(line)
@@ -257,7 +261,10 @@ try {
   // command began, especially when several useful/noise votes overlap.
   for (const dir of candidateDirs) {
     const indexFile = path.join(dir, 'index.jsonl')
-    const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    // #653 S4: fd-based read; current failure semantics preserved (any
+    // thrown error, incl. IndexUnreadableError, is caught below at the
+    // existing generic writeError handler).
+    const lines = (readIndexFileOrThrow(fs, indexFile) || '').trim().split('\n').filter(Boolean)
     let found = false
     const updated = lines.map(line => {
       try {

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -132,7 +132,7 @@ try {
   if (scope === 'global' || scope === 'all') rows.push(...loadIndex(GLOBAL_DIR, 'global'))
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-graph: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-graph: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-list.mjs
+++ b/scripts/em-list.mjs
@@ -55,7 +55,7 @@ try {
   if (scope === 'global' || scope === 'all') results.push(...loadIndex(GLOBAL_DIR, 'global'))
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-list: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -196,7 +196,7 @@ else {
     }
   } catch (e) {
     if (e instanceof IndexUnreadableError) {
-      console.log(JSON.stringify({ status: 'error', message: `em-move: ${e.message}` }))
+      console.log(JSON.stringify({ status: 'error', message: `em-move: ${e.message}`, code: `index-unreadable:${e.code}` }))
       process.exit(1)
     }
     throw e

--- a/scripts/em-pattern-health.mjs
+++ b/scripts/em-pattern-health.mjs
@@ -178,7 +178,7 @@ try {
   for (const s of SCOPE_DIRS) allEntries.push(...loadIndex(s.dir, s.source))
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-pattern-health: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-pattern-health: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-pin.mjs
+++ b/scripts/em-pin.mjs
@@ -24,6 +24,7 @@ import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { openReadableIndex, IndexUnreadableError, unreadableMessage } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -85,12 +86,18 @@ try {
     const newContent = content.replace(fmMatch[0], `---\n${fmLines.join('\n')}\n---`)
 
     // Read and prepare the index snapshot before the first durable write.
-    // Missing/corrupt index behavior remains unchanged: frontmatter is the
-    // durable source and a later rebuild can regenerate its row.
+    // #653 (FIX-E, review P2-2): fd-based read (openReadableIndex) — a
+    // genuinely ABSENT index keeps the historical best-effort behavior
+    // (frontmatter is the durable source; a later rebuild regenerates the
+    // row), but an UNREADABLE shape (FIFO/dir/EACCES/...) now aborts typed
+    // BEFORE any write (Family A writer rule) instead of silently opening a
+    // FIFO (hang) or swallowing a real defect into "skip the index update".
+    // Malformed per-line CONTENT (not shape) still degrades below, unchanged.
     const indexFile = path.join(dataDir, 'index.jsonl')
     let indexReplacement = null
-    try {
-      const lines = fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean)
+    const rawIndex = openReadableIndex(fs, indexFile)
+    if (rawIndex !== null) {
+      const lines = rawIndex.trim().split('\n').filter(Boolean)
       const updated = lines.map(line => {
         try {
           const entry = JSON.parse(line)
@@ -102,8 +109,6 @@ try {
         } catch { return line }
       })
       indexReplacement = { indexFile, data: updated.join('\n') + '\n' }
-    } catch {
-      // Keep the historical best-effort index behavior.
     }
 
     atomicReplaceFileSync(filePath, newContent)
@@ -114,7 +119,11 @@ try {
     }
   }
 } catch (e) {
-  result = { status: 'error', message: `Pin write failed: ${e.message}` }
+  if (e instanceof IndexUnreadableError) {
+    result = { status: 'error', message: unreadableMessage('em-pin', 'episode index', e), code: `index-unreadable:${e.code}` }
+  } else {
+    result = { status: 'error', message: `Pin write failed: ${e.message}` }
+  }
   exitCode = 1
 } finally {
   releaseStoreWriteLocks(lockResult.handles)

--- a/scripts/em-promote.mjs
+++ b/scripts/em-promote.mjs
@@ -139,7 +139,7 @@ function loadIndexOrAbort(dataDir, source) {
     return loadIndex(dataDir, source)
   } catch (e) {
     const file = path.join(dataDir, 'index.jsonl')
-    console.log(JSON.stringify({ status: 'error', message: `em-promote: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${file})` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-promote: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${file})`, ...(e && e.code ? { code: `index-unreadable:${e.code}` } : {}) }))
     process.exit(1)
   }
 }

--- a/scripts/em-prune.mjs
+++ b/scripts/em-prune.mjs
@@ -93,7 +93,7 @@ function loadIndexRowsOrAbort(dataDir, storeLabel) {
     return loadIndexRows(dataDir, storeLabel)
   } catch (e) {
     const file = path.join(dataDir, 'index.jsonl')
-    console.log(JSON.stringify({ status: 'error', message: `em-prune: aborting archival — episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${file})` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-prune: aborting archival — episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${file})`, ...(e && e.code ? { code: `index-unreadable:${e.code}` } : {}) }))
     process.exit(1)
   }
 }
@@ -317,7 +317,7 @@ try {
     process.exit(1)
   }
   if (error instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-prune: aborting archival — episode index unreadable (${error.code}) (${error.file})` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-prune: aborting archival — episode index unreadable (${error.code}) (${error.file})`, code: `index-unreadable:${error.code}` }))
     process.exit(1)
   }
   throw error

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -19,7 +19,7 @@ import { episodeTokens, DF_DROP_RATIO, TOKENS_DROPPED_KEY } from './lib/relevanc
 import { resolveStoreIdentity } from './lib/store-identity.mjs'
 import { STRUCTURED_FIELDS } from './lib/promotion-sources.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { assertReadableIndex, readIndexFileOrThrow } from './lib/index-state.mjs'
+import { assertReadableIndex, readIndexFileOrThrow, classifyIndexFile } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -68,6 +68,7 @@ function unreadableIndexFailure(indexFile, label, e) {
     status: 'error',
     scope: label,
     message: `em-rebuild-index: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${indexFile})`,
+    code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}`,
     remediation: 'remove the corrupt index.jsonl and re-run em-rebuild-index',
   })
 }
@@ -87,8 +88,14 @@ if (checkMode) {
       let files = []
       try { files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort() } catch { continue }
       for (const file of files) {
+        // #653 (F1c): lstat-classify before read — a FIFO-shaped episode
+        // file must never hang the drift scan; a non-regular shape is not a
+        // parseable episode, so it is silently skipped (this mode reports
+        // drift only, no warnings field).
+        const filePath = path.join(episodesDir, file)
+        if (classifyIndexFile(fs, filePath).state !== 'ok') continue
         let fm
-        try { fm = parseFrontmatter(fs.readFileSync(path.join(episodesDir, file), 'utf8')) } catch (e) {
+        try { fm = parseFrontmatter(fs.readFileSync(filePath, 'utf8')) } catch (e) {
           console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null }))
           process.exit(1)
         }
@@ -204,6 +211,7 @@ function rebuildDir(dataDir, label) {
 
   const files = fs.readdirSync(episodesDir).filter(f => f.endsWith('.md')).sort()
   const entries = []
+  const warnings = []
 
   // Null-proto maps: keys come from episode content (tags, tokens, category
   // names), and "constructor" on a plain {} resolves to Object.prototype's
@@ -219,7 +227,18 @@ function rebuildDir(dataDir, label) {
   try { loadCategories() } catch { vocabLoaded = false }
 
   for (const file of files) {
-    const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
+    // #653 (F1c): lstat-classify before read — em-rebuild-index is the
+    // remediation tool the envelope contract points users at, so it must
+    // never hang on a FIFO-shaped episode file. A non-regular shape is not a
+    // parseable episode: skip it and record a warning instead of aborting
+    // the whole rebuild or opening the file.
+    const filePath = path.join(episodesDir, file)
+    const shape = classifyIndexFile(fs, filePath)
+    if (shape.state !== 'ok') {
+      warnings.push(`skipped ${file}: not a regular file (${shape.state === 'unreadable' ? shape.code : 'vanished'})`)
+      continue
+    }
+    const content = fs.readFileSync(filePath, 'utf8')
     let fm
     try { fm = parseFrontmatter(content) } catch (e) {
       throw new RebuildFailure({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null, scope: label })
@@ -364,7 +383,11 @@ function rebuildDir(dataDir, label) {
     process.stderr.write(`em-rebuild-index: categories.json unloadable; ${label} category-index.json skipped (index.jsonl + tags.json built normally)\n`)
   }
 
-  return { scope: label, count: entries.length, category_drift: { unknown: driftUnknown, deprecated: driftDeprecated } }
+  return {
+    scope: label, count: entries.length,
+    category_drift: { unknown: driftUnknown, deprecated: driftDeprecated },
+    ...(warnings.length ? { warnings } : {}),
+  }
   } finally {
     releaseStoreWriteLocks(lockHandles)
   }

--- a/scripts/em-recall.mjs
+++ b/scripts/em-recall.mjs
@@ -259,7 +259,7 @@ try {
   }
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-recall: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-recall: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -41,7 +41,7 @@ import { nullProtoIndex } from './lib/relevance.mjs'
 // derived-index merge so two restore targets cannot diverge before both
 // locks are held.
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -2630,6 +2630,7 @@ try {
   // surface which files made it so the user has a clear inventory rather
   // than discovering the partial state via filesystem walk.
   const errPayload = { status: 'error', message: String(e.message || e), stack: e.stack }
+  if (e instanceof IndexUnreadableError) errPayload.code = `index-unreadable:${e.code}`
   if (Array.isArray(e.applied_before_failure)) errPayload.applied_before_failure = e.applied_before_failure
   if (e.staging_dir) errPayload.staging_dir = e.staging_dir
   out(errPayload)

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -83,8 +83,8 @@ function flagAll(name) {
 }
 function hasFlag(name) { return argv.includes(name) }
 
-function fail(code, message, errors = []) {
-  console.log(JSON.stringify({ status: 'error', message, errors }))
+function fail(code, message, errors = [], extra) {
+  console.log(JSON.stringify({ status: 'error', message, errors, ...(extra || {}) }))
   process.exit(code)
 }
 
@@ -218,7 +218,7 @@ function loadIndexOrAbort(dataDir, source) {
   try {
     return loadIndex(dataDir, source)
   } catch (e) {
-    fail(1, `em-review-request: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${path.join(dataDir, 'index.jsonl')})`)
+    fail(1, `em-review-request: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${path.join(dataDir, 'index.jsonl')})`, [], e && e.code ? { code: `index-unreadable:${e.code}` } : undefined)
   }
 }
 
@@ -517,7 +517,7 @@ try {
       // fail() calls process.exit, which skips this try's finally — release
       // the lock explicitly first (mirrors em-consolidate's emitProtectionAbort).
       releaseStoreWriteLocks(lockResult.handles)
-      fail(1, `em-review-request: ${e.message}`)
+      fail(1, `em-review-request: ${e.message}`, [], { code: `index-unreadable:${e.code}` })
     }
     throw e
   }

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -37,6 +37,7 @@ import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
+import { assertReadableIndex, openReadableIndex, IndexUnreadableError, unreadableMessage, roleForFile } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -285,7 +286,19 @@ let promotionSources
   // verbatim (a linked violation may have been legitimately retracted since;
   // the band derivation, not the write gate, is what discounts it).
   if (evidence.length) {
-    const lv = resolveLinkage(evidence, { requireCategory: 'violation', index: loadMergedIndex() })
+    // FIX-A (#649/#653 review P1-1): loadMergedIndex throws IndexUnreadableError
+    // on an unreadable (not absent) store index; this runs BEFORE any write.
+    let mergedIndex
+    try {
+      mergedIndex = loadMergedIndex()
+    } catch (e) {
+      if (e instanceof IndexUnreadableError) {
+        console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-revise', 'episode index', e), code: `index-unreadable:${e.code}` }))
+        process.exit(1)
+      }
+      throw e
+    }
+    const lv = resolveLinkage(evidence, { requireCategory: 'violation', index: mergedIndex })
     if (!lv.ok) {
       console.log(JSON.stringify({
         status: 'error',
@@ -324,6 +337,34 @@ if (hasRegisterPlaybookFlag && dataDir === GLOBAL_DIR) {
 }
 
 // ---------------------------------------------------------------------------
+// #653 S3R: classify index.jsonl AND every derived sidecar (tags/category/
+// tokens) for BOTH store dirs this revision touches — original.dir (the
+// supersession target) and dataDir (the successor target; may be the same
+// dir) — BEFORE any read, lock, or write. Mirrors em-store's S3(a) preflight;
+// placed strictly before the pre-lock snapshot below (which itself reads
+// index.jsonl) and before acquireStoreWriteLocksSync.
+// ---------------------------------------------------------------------------
+const preflightDirs = original.dir === dataDir ? [original.dir] : [original.dir, dataDir]
+for (const dir of preflightDirs) {
+  for (const [role, file] of [
+    ['episode index', path.join(dir, 'index.jsonl')],
+    ['tags index', path.join(dir, 'tags.json')],
+    ['category index', path.join(dir, 'category-index.json')],
+    ['token index', path.join(dir, 'tokens.json')],
+  ]) {
+    try {
+      assertReadableIndex(fs, file)
+    } catch (e) {
+      if (e instanceof IndexUnreadableError) {
+        console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-revise', role, e), code: `index-unreadable:${e.code}` }))
+        process.exit(1)
+      }
+      throw e
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // PR-562 snapshot helper (§8.2 in-lock reread, file/index coherence, and the
 // direct-successor set): captures (fileStatus, indexStatus, successors) so
 // the in-lock state can be compared to the pre-lock snapshot. A change in
@@ -333,6 +374,12 @@ if (hasRegisterPlaybookFlag && dataDir === GLOBAL_DIR) {
 // accepted clerk merge-Revive path) while still serializing an actually
 // concurrent revision. The helper tolerates missing files and missing index
 // rows (status=null in both cases) so the snapshot shape is stable.
+//
+// fileStatus reads the episode BODY file — out of #653 scope (§4 D2 DEFER,
+// the query-path body-read class); indexStatus/successors read index.jsonl
+// and use the fd-based openReadableIndex (#653), which THROWS
+// IndexUnreadableError on a defect instead of existsSync's silent
+// false-negative (which would misreport "no index row" instead of aborting).
 // ---------------------------------------------------------------------------
 function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
   let fileStatus = null
@@ -343,8 +390,9 @@ function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
   } catch { /* missing file → null status */ }
   let indexStatus = null
   const statusIndexPath = path.join(statusDir, 'index.jsonl')
-  if (fs.existsSync(statusIndexPath)) {
-    for (const line of fs.readFileSync(statusIndexPath, 'utf8').split('\n')) {
+  const statusIndexRaw = openReadableIndex(fs, statusIndexPath)
+  if (statusIndexRaw !== null) {
+    for (const line of statusIndexRaw.split('\n')) {
       if (!line.trim()) continue
       try {
         const entry = JSON.parse(line)
@@ -355,8 +403,9 @@ function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
   const successors = []
   for (const storeDir of successorDirs) {
     const indexFilePath = path.join(storeDir, 'index.jsonl')
-    if (!fs.existsSync(indexFilePath)) continue
-    for (const line of fs.readFileSync(indexFilePath, 'utf8').split('\n')) {
+    const raw = openReadableIndex(fs, indexFilePath)
+    if (raw === null) continue
+    for (const line of raw.split('\n')) {
       if (!line.trim()) continue
       try {
         const entry = JSON.parse(line)
@@ -374,7 +423,19 @@ function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
 // direct-successor set is unioned across both locked stores
 // ([original.dir, dataDir]) so a cross-scope revision detects a successor
 // appended in either the original's store or the successor's store.
-const preLock = snapshotOriginalState(original.filePath, original.dir, [original.dir, dataDir], originalId)
+// No lock is held yet, so a TOCTOU-raced IndexUnreadableError here (the
+// preflight above already passed) gets its own catch rather than the F6
+// in-lock mechanism below.
+let preLock
+try {
+  preLock = snapshotOriginalState(original.filePath, original.dir, [original.dir, dataDir], originalId)
+} catch (e) {
+  if (e instanceof IndexUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-revise: ${e.message}`, code: `index-unreadable:${e.code}` }))
+    process.exit(1)
+  }
+  throw e
+}
 
 const lockResult = acquireStoreWriteLocksSync([original.dir, dataDir])
 if (!lockResult.ok) {
@@ -436,10 +497,12 @@ try {
   atomicReplaceFileSync(original.filePath, supersededContent)
 
   // Update the index entry for the original + capture origTags in one pass
+  // #653 S3R: fd-based read (openReadableIndex) — a TOCTOU throw propagates
+  // out of this locked try (F6) instead of a raw readFileSync crash.
   let origTagsFromIndex = []
   let origPinned = false
   let origPlaybook = false
-  const lines = fs.readFileSync(originalIndexFile, 'utf8').trim().split('\n').filter(Boolean)
+  const lines = (openReadableIndex(fs, originalIndexFile) || '').trim().split('\n').filter(Boolean)
   const updated = lines.map(line => {
     try {
       const entry = JSON.parse(line)
@@ -499,10 +562,13 @@ try {
   function updateTagsIndex(dataDir, episodeId, tags) {
     const tagsFile = path.join(dataDir, 'tags.json')
     // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+    // #653 S3R: fd-based read; a TOCTOU throw propagates out of this locked
+    // try (F6) instead of being swallowed. Malformed CONTENT still degrades.
     let index = Object.create(null)
-    try {
-      index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
-    } catch {}
+    const raw = openReadableIndex(fs, tagsFile)
+    if (raw !== null) {
+      try { index = nullProtoIndex(JSON.parse(raw)) } catch {}
+    }
     for (const tag of tags) {
       if (!index[tag]) index[tag] = []
       if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
@@ -516,10 +582,13 @@ try {
     const catFile = path.join(dataDir, 'category-index.json')
     // Null-proto: unknown categories index under their literal key, which could
     // collide with Object.prototype names (issue #469)
+    // #653 S3R: fd-based read; a TOCTOU throw propagates (F6) instead of
+    // being swallowed. Malformed CONTENT still degrades.
     let index = Object.create(null)
-    try {
-      index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
-    } catch {}
+    const raw = openReadableIndex(fs, catFile)
+    if (raw !== null) {
+      try { index = nullProtoIndex(JSON.parse(raw)) } catch {}
+    }
     const key = canonicalCategory(category)
     if (!index[key]) index[key] = []
     if (!index[key].includes(episodeId)) index[key].push(episodeId)
@@ -675,6 +744,27 @@ try {
       }
     }
   }
+} catch (e) {
+  // ABORT-INSIDE-LOCK (audit F6): a post-preflight TOCTOU swap throws
+  // IndexUnreadableError OUT of this locked try, straight into this catch —
+  // NEVER process.exit inside the TRY itself. But process.exit() called
+  // from HERE, in the catch, ALSO skips the paired finally below (it is not
+  // a normal JS return/throw — Node exits immediately without unwinding
+  // pending finally blocks), so both locks are released EXPLICITLY right
+  // here before exiting; the finally's own release is a no-op repeat for
+  // this path (releaseStoreWriteLocks is idempotent) and the only one that
+  // runs for the `throw e` (unexpected-error) path below.
+  if (e instanceof IndexUnreadableError) {
+    // FIX-C (#649/#653 review P3-1): this catch funnels throws from EVERY
+    // in-lock read (index.jsonl in either store dir, tags.json,
+    // category-index.json, tokens.json) — e.message is byte-frozen to
+    // "episode index unreadable" regardless of which file failed; derive
+    // the role from e.file's basename instead.
+    console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-revise', roleForFile(e.file), e), code: `index-unreadable:${e.code}` }))
+    releaseStoreWriteLocks(lockHandles)
+    process.exit(1)
+  }
+  throw e
 } finally {
   releaseStoreWriteLocks(lockHandles)
 }
@@ -694,6 +784,14 @@ if (result.status === 'ok' && activation && Array.isArray(activation.triggers) &
       if (reported.has(key)) continue
       reported.add(key)
       process.stderr.write(`collision: trigger "${e.value}" also on ${e.episode_id}: ${e.summary}\n`)
+    }
+    // FIX-A (#649/#653 review P1-1): the write already succeeded (this block
+    // runs post-lock-release) — an unreadable local/global index must never
+    // misreport that as a failure. loadMergedTriggerIndex degrades instead of
+    // throwing; surface the degrade on the (already-successful) stdout
+    // payload so the caller knows the collision check was incomplete.
+    if (merged.degraded && merged.degraded.length && result.status === 'ok') {
+      result.warning = `trigger collision check incomplete: ${merged.degraded.join(', ')} index unreadable`
     }
   } catch {}
 }

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -93,7 +93,7 @@ try {
   }
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-search: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-seed-patterns.mjs
+++ b/scripts/em-seed-patterns.mjs
@@ -249,7 +249,7 @@ try {
   } catch (e) {
     if (e instanceof IndexUnreadableError) {
       releaseStoreWriteLocks(lockResult.handles)
-      console.log(JSON.stringify({ status: 'error', message: `em-seed-patterns: ${e.message}` }))
+      console.log(JSON.stringify({ status: 'error', message: `em-seed-patterns: ${e.message}`, code: `index-unreadable:${e.code}` }))
       process.exit(1)
     }
     throw e

--- a/scripts/em-semantic.mjs
+++ b/scripts/em-semantic.mjs
@@ -144,7 +144,7 @@ try {
   for (const [dir, label] of dirs) entries.push(...loadIndex(dir, label))
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-semantic: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-semantic: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-stats.mjs
+++ b/scripts/em-stats.mjs
@@ -198,7 +198,7 @@ try {
   }
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-stats: ${e.message}` }))
+    console.log(JSON.stringify({ status: 'error', message: `em-stats: ${e.message}`, code: `index-unreadable:${e.code}` }))
     process.exit(1)
   }
   throw e

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -38,7 +38,7 @@ import { episodeTokens, updateTokensIndex, nullProtoIndex, loadIndex } from './l
 import { findContradictionsFor } from './lib/contradiction.mjs'
 import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { assertReadableIndex, IndexUnreadableError } from './lib/index-state.mjs'
+import { assertReadableIndex, openReadableIndex, IndexUnreadableError, unreadableMessage, roleForFile } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -263,10 +263,26 @@ if (!av.ok) {
 }
 const activation = av.fields // null for freeform writes
 
+// FIX-A (#649/#653 review P1-1): loadMergedIndex now throws IndexUnreadableError
+// on a genuinely unreadable store index (as opposed to absent) — both call
+// sites below run BEFORE any write, so an unreadable local/global index.jsonl
+// must abort typed (Family A), never silently under-resolve linkage.
+function loadMergedIndexOrAbort() {
+  try {
+    return loadMergedIndex()
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-store', 'episode index', e), code: `index-unreadable:${e.code}` }))
+      process.exit(1)
+    }
+    throw e
+  }
+}
+
 // REQ-6 (S3): each --evidence id must resolve to an EXISTING category:violation
 // episode in the MERGED (local+global) index — never per-active-scope (F1).
 if (activation && Array.isArray(activation.evidence) && activation.evidence.length) {
-  const lv = resolveLinkage(activation.evidence, { requireCategory: 'violation', index: loadMergedIndex() })
+  const lv = resolveLinkage(activation.evidence, { requireCategory: 'violation', index: loadMergedIndexOrAbort() })
   if (!lv.ok) {
     console.log(JSON.stringify({
       status: 'error',
@@ -303,7 +319,7 @@ if (lessonLinks.length) {
     console.log(JSON.stringify({ status: 'error', message: `--lesson is a violation-side linkage field, valid only with --category violation (got "${category}")` }))
     process.exit(1)
   }
-  const lv = resolveLinkage(lessonLinks, { requireCategory: 'lesson', index: loadMergedIndex() })
+  const lv = resolveLinkage(lessonLinks, { requireCategory: 'lesson', index: loadMergedIndexOrAbort() })
   if (!lv.ok) {
     console.log(JSON.stringify({
       status: 'error',
@@ -320,23 +336,32 @@ if (lessonLinks.length) {
 const dataDir = scope === 'global' ? GLOBAL_DIR : LOCAL_DIR
 const episodesDir = path.join(dataDir, 'episodes')
 const indexFile = path.join(dataDir, 'index.jsonl')
+const tagsFile = path.join(dataDir, 'tags.json')
+const categoryIndexFile = path.join(dataDir, 'category-index.json')
+const tokensFile = path.join(dataDir, 'tokens.json')
 
-// F3 (issue #653 follow-up — #651 §4 DEFER): classify index.jsonl BEFORE any
-// read OR append so a FIFO-shaped index aborts typed, exit 1, instead of
-// blocking forever (opening a FIFO for append blocks exactly like a read —
-// see docs/plans/issue-651-index-existence-contract.md §4 review F3 note).
-// Classify-before-open mirrors em-rebuild-index's REQ-8 pattern; em-store's
-// append path was outside #651's loader scope. Placed BEFORE the lock so
-// lock acquisition (which writes into dataDir) never races a corrupt store,
-// and BEFORE the indexIdSet read so the FIFO never opens.
-try {
-  assertReadableIndex(fs, indexFile)
-} catch (e) {
-  if (e instanceof IndexUnreadableError) {
-    console.log(JSON.stringify({ status: 'error', message: `em-store: ${e.message}` }))
-    process.exit(1)
+// F3 (issue #653 follow-up — #651 §4 DEFER) + #653 S3(a): classify
+// index.jsonl AND every derived sidecar (tags/category/tokens) BEFORE any
+// read, lock, OR write so a FIFO-shaped file aborts typed, exit 1, instead
+// of blocking forever (opening a FIFO for append blocks exactly like a
+// read). Classify-before-open mirrors em-rebuild-index's REQ-8 pattern.
+// Placed BEFORE the lock so lock acquisition (which writes into dataDir)
+// never races a corrupt store, and BEFORE any of the reads below.
+for (const [role, file] of [
+  ['episode index', indexFile],
+  ['tags index', tagsFile],
+  ['category index', categoryIndexFile],
+  ['token index', tokensFile],
+]) {
+  try {
+    assertReadableIndex(fs, file)
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-store', role, e), code: `index-unreadable:${e.code}` }))
+      process.exit(1)
+    }
+    throw e
   }
-  throw e
 }
 
 // Issue 546 / REQ-4: hold the canonical store-write lock across episode
@@ -366,16 +391,22 @@ const slug = summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g,
 // "" and atomic-replace creates a fresh file; populated stores append
 // exactly one line. Captured outside the IIFE so the write block can
 // reference it without a closure capture.
+// #653 S3(c): fd-based read (openReadableIndex), not a swallowing try/catch —
+// the preflight above already confirmed 'ok'/'absent'; a TOCTOU swap to a
+// non-regular shape between preflight and here must ABORT (F6: throw out of
+// this locked try), never silently fall back to an empty prior index (that
+// would risk overwriting an existing store's rows with a fresh, one-line file).
 let priorIndexContent = ''
 const indexIdSet = (() => {
   const set = new Set()
-  try {
-    priorIndexContent = fs.readFileSync(indexFile, 'utf8')
+  const raw = openReadableIndex(fs, indexFile)
+  if (raw !== null) {
+    priorIndexContent = raw
     for (const line of priorIndexContent.split('\n')) {
       if (!line.trim()) continue
       try { const e = JSON.parse(line); if (e && typeof e.id === 'string') set.add(e.id) } catch {}
     }
-  } catch { priorIndexContent = '' }
+  }
   return set
 })()
 let id
@@ -394,10 +425,14 @@ function normalizeTags(raw, repeats = []) {
 function updateTagsIndex(dataDir, episodeId, tags) {
   const tagsFile = path.join(dataDir, 'tags.json')
   // Null-proto: a tag named "constructor" must not resolve to Object.prototype (issue #469)
+  // #653 S3(c): fd-based read; a TOCTOU throw propagates out of this locked
+  // try (F6) instead of being swallowed into a silently-fresh index. Malformed
+  // CONTENT (not shape) still degrades — that is the pre-existing #447/#448 class.
   let index = Object.create(null)
-  try {
-    index = nullProtoIndex(JSON.parse(fs.readFileSync(tagsFile, 'utf8')))
-  } catch {}
+  const raw = openReadableIndex(fs, tagsFile)
+  if (raw !== null) {
+    try { index = nullProtoIndex(JSON.parse(raw)) } catch {}
+  }
   for (const tag of tags) {
     if (!index[tag]) index[tag] = []
     if (!index[tag].includes(episodeId)) index[tag].push(episodeId)
@@ -591,6 +626,28 @@ updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeConte
       }
     }
   }
+} catch (e) {
+  // ABORT-INSIDE-LOCK (audit F6): a post-preflight TOCTOU swap (e.g. a
+  // sidecar replaced with a FIFO between the preflight above and one of the
+  // fd-based reads inside this try) throws IndexUnreadableError OUT of this
+  // locked try, straight into this catch — NEVER process.exit inside the
+  // TRY itself (em-consolidate.mjs:177-178 documents why). But process.exit()
+  // called from HERE, in the catch, ALSO skips the paired finally below (it
+  // is not a normal JS return/throw — Node exits immediately without
+  // unwinding pending finally blocks), so the lock is released EXPLICITLY
+  // right here before exiting; the finally's own release is a no-op repeat
+  // for this path (releaseStoreWriteLocks is idempotent) and the only one
+  // that runs for the `throw e` (unexpected-error) path below.
+  if (e instanceof IndexUnreadableError) {
+    // FIX-C (#649/#653 review P3-1): this catch funnels throws from EVERY
+    // in-lock read (index.jsonl, tags.json, category-index.json, tokens.json)
+    // — e.message is byte-frozen to "episode index unreadable" regardless of
+    // which file failed; derive the role from e.file's basename instead.
+    console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-store', roleForFile(e.file), e), code: `index-unreadable:${e.code}` }))
+    releaseStoreWriteLocks(lockHandles)
+    process.exit(1)
+  }
+  throw e
 } finally {
   releaseStoreWriteLocks(lockHandles)
 }
@@ -612,6 +669,15 @@ if (activation && Array.isArray(activation.triggers) && activation.triggers.leng
       if (reported.has(key)) continue
       reported.add(key)
       process.stderr.write(`collision: trigger "${e.value}" also on ${e.episode_id}: ${e.summary}\n`)
+    }
+    // FIX-A (#649/#653 review P1-1): the write already succeeded (this block
+    // runs post-lock-release) — an unreadable local/global index must never
+    // misreport that as a failure. loadMergedTriggerIndex degrades instead of
+    // throwing; surface the degrade on the (already-successful) stdout
+    // payload so the caller knows the collision check was incomplete,
+    // instead of silently under-reporting collisions.
+    if (merged.degraded && merged.degraded.length && successPayload.status === 'ok') {
+      successPayload.warning = `trigger collision check incomplete: ${merged.degraded.join(', ')} index unreadable`
     }
   } catch {}
 }
@@ -650,10 +716,13 @@ export function updateCategoryIndex(dataDir, episodeId, category) {
   const catFile = path.join(dataDir, 'category-index.json')
   // Null-proto: unknown categories index under their literal key, which could
   // collide with Object.prototype names (issue #469)
+  // #653 S3(c): fd-based read; a TOCTOU throw propagates (F6) instead of
+  // being swallowed. Malformed CONTENT (not shape) still degrades.
   let index = Object.create(null)
-  try {
-    index = nullProtoIndex(JSON.parse(fs.readFileSync(catFile, 'utf8')))
-  } catch {}
+  const raw = openReadableIndex(fs, catFile)
+  if (raw !== null) {
+    try { index = nullProtoIndex(JSON.parse(raw)) } catch {}
+  }
   const key = canonicalCategory(category)
   if (!index[key]) index[key] = []
   if (!index[key].includes(episodeId)) index[key].push(episodeId)

--- a/scripts/em-topic-tracks.mjs
+++ b/scripts/em-topic-tracks.mjs
@@ -33,9 +33,10 @@ const SCRIPT_NAME = 'em-topic-tracks.mjs'
 
 const VALID_VALUE_FLAGS = new Set(['--max-episodes', '--confirm'])
 
-function emitError(errorCode, detail, exitCode) {
+function emitError(errorCode, detail, exitCode, extra) {
   const obj = { status: 'error', error: errorCode }
   if (detail !== undefined) obj.detail = detail
+  if (extra) Object.assign(obj, extra)
   console.log(JSON.stringify(obj))
   process.exit(exitCode)
 }
@@ -173,7 +174,9 @@ try {
   // #651 F4 (revision 3, step 7e): a corrupt index.jsonl is a distinct
   // failure class from a malformed config.json — don't misattribute it.
   if (err instanceof IndexUnreadableError) {
-    emitError('episode-index-unreadable', err.message, 1)
+    // #653 (§2): 'error' stays the legacy field (test-651:989 pins it);
+    // 'code' is additive alongside it.
+    emitError('episode-index-unreadable', err.message, 1, { code: `index-unreadable:${err.code}` })
   }
   emitError('topic-tracks-config-invalid', err && err.message, 1)
 }

--- a/scripts/em-trigger-index.mjs
+++ b/scripts/em-trigger-index.mjs
@@ -45,6 +45,7 @@ import { spawnSync } from 'node:child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadActivationClasses, parseTriggerKind } from './lib/activation.mjs'
 import { computeCadence } from './lib/activation-log.mjs'
+import { openReadableIndex, readSidecarOrDegrade, classifyIndexFile } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 
@@ -92,21 +93,37 @@ function sha256(buf) {
  * Read a store's index.jsonl with a TOCTOU-safe fingerprint: stat, read,
  * re-stat; on a stat mismatch re-read ONCE and fingerprint the bytes actually
  * read (REQ-14/EC9). A missing index file fingerprints as the empty store.
+ *
+ * #653 (FIX-A): this is a BUILD INPUT for the trigger-index cache, reached
+ * from loadMergedTriggerIndex()'s POST-durable-write collision-report path
+ * (em-store/em-revise call it AFTER the episode + index row are already
+ * committed) as well as this script's own standalone CLI build — neither
+ * context is a validation gate, so a non-regular (FIFO/socket/device/dir)
+ * index.jsonl must DEGRADE to the empty-store fingerprint, never abort and
+ * never hang. `stat` (unlike `open`+read) never blocks on a FIFO, so the
+ * `isFile()` checks below run before either read attempt.
  */
 function readIndexWithFingerprint(storeDir) {
   const indexPath = path.join(storeDir, 'index.jsonl')
+  const empty = { raw: '', fingerprint: { index_mtime_ms: 0, index_size: 0, index_sha256: sha256('') } }
   let st1 = null
   try { st1 = fs.statSync(indexPath) } catch {}
-  if (!st1) {
-    return { raw: '', fingerprint: { index_mtime_ms: 0, index_size: 0, index_sha256: sha256('') } }
+  if (!st1 || !st1.isFile()) {
+    return empty
   }
   let raw = fs.readFileSync(indexPath, 'utf8')
   let st2 = null
   try { st2 = fs.statSync(indexPath) } catch {}
-  if (!st2 || st2.mtimeMs !== st1.mtimeMs || st2.size !== st1.size) {
-    // mid-read rewrite: one re-read, fingerprint what we actually consumed (EC9)
-    try { raw = fs.readFileSync(indexPath, 'utf8') } catch { raw = '' }
-    try { st2 = fs.statSync(indexPath) } catch { st2 = null }
+  if (!st2 || !st2.isFile() || st2.mtimeMs !== st1.mtimeMs || st2.size !== st1.size) {
+    // mid-read rewrite: one re-read, fingerprint what we actually consumed
+    // (EC9) — UNLESS the rewrite swapped it to a non-regular shape, in which
+    // case degrade rather than reopen.
+    if (st2 && st2.isFile()) {
+      try { raw = fs.readFileSync(indexPath, 'utf8') } catch { raw = '' }
+      try { st2 = fs.statSync(indexPath) } catch { st2 = null }
+    } else {
+      return empty
+    }
   }
   const bytes = Buffer.byteLength(raw, 'utf8')
   return {
@@ -648,7 +665,19 @@ export function buildTriggerIndex({ project, scope = 'local', now = new Date(), 
   // invalidate; a cached v2 index mismatches on schema_version and rebuilds (T12).
   let priorPatternHealth = null
   try {
-    const cached = JSON.parse(fs.readFileSync(indexPath, 'utf8'))
+    // #653 (FIX-A): fd-based read (openReadableIndex) — trigger-index.json is
+    // a cache file inside the store dir; a non-regular shape (FIFO/dir) must
+    // never hang the build. null (absent) synthesizes the same ENOENT the
+    // pre-existing catch below already treats as a silent cache miss;
+    // anything else routes through the same "unreadable" stderr note a
+    // malformed cache already got.
+    const cachedRaw = openReadableIndex(fs, indexPath)
+    if (cachedRaw === null) {
+      const absent = new Error('trigger-index cache absent')
+      absent.code = 'ENOENT'
+      throw absent
+    }
+    const cached = JSON.parse(cachedRaw)
     if (scope === 'local' && cached && cached.session_start &&
         typeof cached.session_start.pattern_health === 'object' && cached.session_start.pattern_health !== null) {
       priorPatternHealth = cached.session_start.pattern_health
@@ -923,6 +952,18 @@ export function buildSessionStart(rows, now = new Date()) {
  * rebuilt from the merged rows for the same reason.
  */
 export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
+  // #653 (FIX-A): cheap lstat-only classify (never opens, never hangs) up
+  // front, purely to REPORT which scope(s) are unreadable (distinct from
+  // genuinely absent) — the actual reads below already degrade safely
+  // either way; this is observability for a caller that wants to know its
+  // collision check ran against an incomplete view (e.g. em-store/em-revise's
+  // POST-durable-write R9a report, which must never misreport the write that
+  // already succeeded, but should surface that the check was degraded).
+  const degraded = []
+  for (const scope of ['local', 'global']) {
+    const dir = resolveStoreDir({ project, scope })
+    if (classifyIndexFile(fs, path.join(dir, 'index.jsonl')).state === 'unreadable') degraded.push(scope)
+  }
   let local = null
   let global = null
   try { local = buildTriggerIndex({ project, scope: 'local', now }).index } catch (e) {
@@ -938,11 +979,13 @@ export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
   const mergedRows = []
   const seenRows = new Set()
   for (const scope of ['local', 'global']) {
-    let raw = ''
-    try {
-      const dir = resolveStoreDir({ project, scope })
-      raw = fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8')
-    } catch { continue }
+    // #653 (FIX-A): fd-based degrade (readSidecarOrDegrade) — this merge runs
+    // from the same POST-durable-write collision-report path as
+    // readIndexWithFingerprint above; a non-regular index.jsonl must degrade
+    // to "skip this scope", never hang, never abort.
+    const dir = resolveStoreDir({ project, scope })
+    const raw = readSidecarOrDegrade(fs, path.join(dir, 'index.jsonl'))
+    if (raw === null) continue
     for (const row of parseRows(raw)) {
       if (!row || typeof row.id !== 'string' || seenRows.has(row.id)) continue
       seenRows.add(row.id)
@@ -998,7 +1041,7 @@ export function loadMergedTriggerIndex({ project, now = new Date() } = {}) {
   if (lp && Object.prototype.hasOwnProperty.call(lp, 'cadence')) {
     session_start.cadence = lp.cadence
   }
-  return { entries, session_start, local, global }
+  return { entries, session_start, local, global, ...(degraded.length ? { degraded } : {}) }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/em-violation.mjs
+++ b/scripts/em-violation.mjs
@@ -29,6 +29,7 @@ import os from 'os'
 import { execFileSync } from 'child_process'
 import { readBodyFile } from './lib/body-file.mjs'
 import { loadMergedIndex, resolveLinkage } from './lib/activation.mjs'
+import { IndexUnreadableError, unreadableMessage } from './lib/index-state.mjs'
 
 const SCRIPTS_DIR = path.dirname(new URL(import.meta.url).pathname)
 const STORE_SCRIPT = path.join(SCRIPTS_DIR, 'em-store.mjs')
@@ -149,7 +150,19 @@ if (!patterns) {
 // path (§7): fail closed, no partial write.
 // ---------------------------------------------------------------------------
 if (lessons.length) {
-  const lv = resolveLinkage(lessons, { requireCategory: 'lesson', index: loadMergedIndex() })
+  // FIX-A (#649/#653 review P1-1): loadMergedIndex throws IndexUnreadableError
+  // on an unreadable (not absent) store index; this runs BEFORE any write.
+  let mergedIndex
+  try {
+    mergedIndex = loadMergedIndex()
+  } catch (e) {
+    if (e instanceof IndexUnreadableError) {
+      console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-violation', 'episode index', e), code: `index-unreadable:${e.code}` }))
+      process.exit(1)
+    }
+    throw e
+  }
+  const lv = resolveLinkage(lessons, { requireCategory: 'lesson', index: mergedIndex })
   if (!lv.ok) {
     console.log(JSON.stringify({
       status: 'error',

--- a/scripts/em-watch-codex.mjs
+++ b/scripts/em-watch-codex.mjs
@@ -51,8 +51,8 @@ function flag(name) {
   return v
 }
 
-function fail(message, code = 2) {
-  console.log(JSON.stringify({ status: 'error', message }))
+function fail(message, code = 2, extra) {
+  console.log(JSON.stringify({ status: 'error', message, ...(extra || {}) }))
   process.exit(code)
 }
 
@@ -98,7 +98,7 @@ function findLocalStore(startDir) {
     try {
       state = assertReadableIndex(fs, candidate)
     } catch (e) {
-      fail(`em-watch-codex: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${candidate})`, 1)
+      fail(`em-watch-codex: episode index unreadable (${(e && e.code) || 'UNKNOWN'}) (${candidate})`, 1, { code: `index-unreadable:${(e && e.code) || 'UNKNOWN'}` })
     }
     if (state === 'ok') return path.join(dir, '.episodic-memory')
     const parent = path.dirname(dir)
@@ -285,7 +285,7 @@ try {
   }
 } catch (e) {
   if (e instanceof IndexUnreadableError) {
-    fail(`em-watch-codex: ${e.message}`, 1)
+    fail(`em-watch-codex: ${e.message}`, 1, { code: `index-unreadable:${e.code}` })
   }
   throw e
 }

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -103,8 +103,8 @@ const TERMINAL_FOR_GATE = {
   'push-allowed': 'push-allowed'
 }
 
-function fail(msg, code = 2) {
-  console.log(JSON.stringify({ status: 'error', message: msg }))
+function fail(msg, code = 2, extra) {
+  console.log(JSON.stringify({ status: 'error', message: msg, ...(extra || {}) }))
   process.exit(code)
 }
 
@@ -145,7 +145,7 @@ function loadIndexOrAbort(dataDir, source) {
   try {
     return loadIndex(dataDir, source)
   } catch (e) {
-    fail(`em-workflow-validate: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${path.join(dataDir, 'index.jsonl')})`, 1)
+    fail(`em-workflow-validate: episode index unreadable (${e && e.code ? e.code : (e && e.message) || 'unknown'}) (${path.join(dataDir, 'index.jsonl')})`, 1, e && e.code ? { code: `index-unreadable:${e.code}` } : undefined)
   }
 }
 

--- a/scripts/lib/activation.mjs
+++ b/scripts/lib/activation.mjs
@@ -17,6 +17,7 @@ import path from 'node:path'
 import os from 'node:os'
 import { resolveLocalDir } from './local-dir.mjs'
 import { STRUCTURED_FIELDS } from './promotion-sources.mjs'
+import { openReadableIndex } from './index-state.mjs'
 export { STRUCTURED_FIELDS } from './promotion-sources.mjs'
 
 // Resolved relative to this file so the path is symmetric in-repo
@@ -309,6 +310,12 @@ export function parseActivationFromFrontmatter(content) {
  * @param {{localDir?:string, globalDir?:string}} [opts] test injection points;
  *   defaults resolve the same way the em-* writers do.
  * @returns {Array<object>}
+ * @throws {IndexUnreadableError} PRE-write linkage-validation caller (see
+ *   FIX-A/#649-653 review): a store's index.jsonl being a defect (FIFO/dir/
+ *   EACCES/...) is never treated as "no rows" here — the em-store/em-revise/
+ *   em-violation callers all invoke this BEFORE any write, so the right
+ *   failure mode is the typed Family-A abort, not silently under-resolving
+ *   linkage and letting a forged/incomplete evidence check through.
  */
 export function loadMergedIndex({ localDir, globalDir } = {}) {
   const dirs = [
@@ -318,12 +325,8 @@ export function loadMergedIndex({ localDir, globalDir } = {}) {
   const rows = []
   for (const dir of dirs) {
     if (!dir) continue
-    let raw
-    try {
-      raw = fs.readFileSync(path.join(dir, 'index.jsonl'), 'utf8')
-    } catch {
-      continue
-    }
+    const raw = openReadableIndex(fs, path.join(dir, 'index.jsonl')) // throws IndexUnreadableError; null = absent
+    if (raw === null) continue
     for (const line of raw.split('\n')) {
       if (!line.trim()) continue
       try {

--- a/scripts/lib/embeddings.mjs
+++ b/scripts/lib/embeddings.mjs
@@ -28,6 +28,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { spawnSync } from 'child_process'
 import { tokenizeQuery, TOKENS_DROPPED_KEY } from './relevance.mjs'
+import { readSidecarOrDegrade } from './index-state.mjs'
 
 export const HASH_DIM = 256
 export const HASH_MODEL = `hash-v1-${HASH_DIM}`
@@ -150,10 +151,14 @@ export function cmdEmbed(cmd, items) {
 // ---------------------------------------------------------------------------
 export function loadEmbeddings(dataDir) {
   const p = path.join(dataDir, 'embeddings.jsonl')
-  if (!fs.existsSync(p)) return null
+  // #653: fd-based classify-and-read — a FIFO-shaped embeddings.jsonl must
+  // degrade (F1d), never open/hang. existsSync's own false-negative on a
+  // broken shape is moot here since readSidecarOrDegrade classifies first.
+  const raw = readSidecarOrDegrade(fs, p)
+  if (raw === null) return null
   const rows = new Map()
   let model = null
-  for (const line of fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean)) {
+  for (const line of raw.trim().split('\n').filter(Boolean)) {
     try {
       const row = JSON.parse(line)
       if (typeof row.id === 'string' && Array.isArray(row.v)) {

--- a/scripts/lib/index-state.mjs
+++ b/scripts/lib/index-state.mjs
@@ -1,4 +1,5 @@
-// index-state.mjs — lstat-based index.jsonl existence classifier (issue #651).
+// index-state.mjs — lstat-based index.jsonl existence classifier (issue #651)
+// + fd-based classify-and-read (issue #653 D1).
 //
 // existsSync(index.jsonl) is not a reliable existence check: it returns false
 // for a symlink loop, a dangling symlink, or an index under an EACCES parent
@@ -7,6 +8,17 @@
 // blocks forever). classifyIndexFile draws the distinction loaders actually
 // need — 'absent' (genuinely no store, keep today's [] / skip / create) vs
 // 'unreadable' (a defect: abort typed, never silently degrade, never open).
+//
+// D1 (issue #653): classifyIndexFile/assertReadableIndex are lstat-only and
+// NEVER open the file, by design (safe to call on a FIFO). The historical
+// readIndexFileOrThrow paired a classify() with a SEPARATE path-based read()
+// — two syscalls with a race window between them. A regular->FIFO swap inside
+// that window re-opens the hang the classifier exists to prevent.
+// openReadableIndex closes that window: ONE open() (O_NONBLOCK, so a
+// writer-less FIFO returns immediately instead of blocking) + fstat() on the
+// resulting fd, and — only when fstat confirms a regular file — a read from
+// that SAME fd. The object fstat classified is the object read; there is no
+// second syscall for a swap to land between.
 //
 // Zero external dependencies — Node.js stdlib only. fsMod injection mirrors
 // protection.mjs's existing injected-fs signature.
@@ -37,7 +49,9 @@ function classifyParent(fsMod, filePath) {
 }
 
 // classifyIndexFile(fsMod, filePath) — the §2 contract table, lstat-based so a
-// symlink is inspected before being followed. Never opens the file.
+// symlink is inspected before being followed. Never opens the file. UNCHANGED
+// by #653 — this stays the classification-only primitive; openReadableIndex
+// below is the new fd-based read path that closes D1.
 export function classifyIndexFile(fsMod, filePath) {
   let st
   try {
@@ -63,7 +77,7 @@ export function classifyIndexFile(fsMod, filePath) {
 // 'unreadable' classification (or a read failure after an 'ok' classification
 // — the file-mode-000 / post-classify swap-to-dir race, §2 last row). Message
 // shape matches the #628 envelope family the existing tests regex against
-// (/episode index unreadable/, /index\.jsonl/).
+// (/episode index unreadable/, /index\.jsonl/). UNCHANGED — byte-frozen.
 export class IndexUnreadableError extends Error {
   constructor(filePath, code, detail) {
     super(`episode index unreadable (${code}) (${filePath})`)
@@ -75,6 +89,7 @@ export class IndexUnreadableError extends Error {
 
 // assertReadableIndex(fsMod, filePath) — returns 'absent' | 'ok'; throws
 // IndexUnreadableError on 'unreadable'. Classification only — never reads.
+// UNCHANGED.
 export function assertReadableIndex(fsMod, filePath) {
   const result = classifyIndexFile(fsMod, filePath)
   if (result.state === 'absent') return 'absent'
@@ -82,16 +97,116 @@ export function assertReadableIndex(fsMod, filePath) {
   throw new IndexUnreadableError(filePath, result.code, result.detail)
 }
 
-// readIndexFileOrThrow(fsMod, filePath) — classify, then read. 'absent' ->
-// null (caller's missing-store branch); 'ok' -> file contents, with any read
-// failure (file-mode-000 EACCES, or a post-classify swap to directory) wrapped
-// into IndexUnreadableError so no raw fs stack ever reaches a caller.
-export function readIndexFileOrThrow(fsMod, filePath) {
-  const state = assertReadableIndex(fsMod, filePath)
-  if (state === 'absent') return null
+// openReadableIndex(fsMod, filePath) — fd-based classify-and-read (closes D1).
+// ONE open(O_RDONLY|O_NONBLOCK) + fstat(fd); only a regular file is read, and
+// the read reuses the SAME fd fstat just classified — no second syscall, so
+// no window for a regular->non-regular swap to land in. Contract identical to
+// the pre-#653 readIndexFileOrThrow: null (absent) | string content (ok) |
+// throws IndexUnreadableError (unreadable, incl. a read failure on a fd that
+// fstat confirmed regular — file-mode-000 EACCES, or an fstat/read errno).
+//
+// Open-error handling (audit F4): O_NONBLOCK makes a writer-less FIFO open
+// return immediately rather than block, but the FILE MAY NOT EXIST AT ALL —
+// open() then fails ENOENT, which classify() alone would resolve more
+// precisely (absent vs. dangling-symlink vs. broken-parent) than a bare
+// open() errno can. So an ENOENT from open() delegates to classifyIndexFile:
+// its 'absent' -> null; its 'unreadable' (dangling symlink, broken parent)
+// -> typed throw with the classifier's own code/detail; its 'ok' means the
+// file was CREATED between our open() and this classify() — retry the open
+// ONCE (a second ENOENT then returns null rather than looping). Any other
+// open() errno (EACCES, ELOOP, ...) throws typed directly — classification
+// would not tell us more than the open() errno already does.
+//
+// FD hygiene (audit F5): once open() succeeds, every path below closes the
+// fd via try/finally, exactly once. readFileSync(fd) does NOT close the fd
+// (unlike readFileSync(path)) — an early throw from fstat must not leak it.
+export function openReadableIndex(fsMod, filePath) {
+  return openReadableIndexAttempt(fsMod, filePath, false)
+}
+
+function openReadableIndexAttempt(fsMod, filePath, retried) {
+  const O_NONBLOCK_READ = fsMod.constants.O_RDONLY | fsMod.constants.O_NONBLOCK
+  let fd
   try {
-    return fsMod.readFileSync(filePath, 'utf8')
+    fd = fsMod.openSync(filePath, O_NONBLOCK_READ)
   } catch (e) {
-    throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'read failed')
+    if (e && e.code === 'ENOENT') {
+      const verdict = classifyIndexFile(fsMod, filePath)
+      if (verdict.state === 'absent') return null
+      if (verdict.state === 'ok') {
+        if (retried) return null // gone again on the second try — treat as absent
+        return openReadableIndexAttempt(fsMod, filePath, true)
+      }
+      throw new IndexUnreadableError(filePath, verdict.code, verdict.detail)
+    }
+    throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'open failed')
   }
+  try {
+    let st
+    try {
+      st = fsMod.fstatSync(fd)
+    } catch (e) {
+      throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'fstat failed')
+    }
+    if (st.isDirectory()) throw new IndexUnreadableError(filePath, 'EISDIR', 'index is a directory')
+    if (!st.isFile()) throw new IndexUnreadableError(filePath, 'ENOTREG', 'index is not a regular file')
+    try {
+      return fsMod.readFileSync(fd, 'utf8')
+    } catch (e) {
+      throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'read failed')
+    }
+  } finally {
+    fsMod.closeSync(fd)
+  }
+}
+
+// readIndexFileOrThrow — the pre-#653 public name, kept for the ~20 existing
+// call sites (relevance.mjs, protection.mjs, topic-tracks/engine.mjs, and
+// every script that imports it directly). Same function: fd-based
+// classify-and-read closes D1 for every transitive caller without any call
+// site needing to change.
+export const readIndexFileOrThrow = openReadableIndex
+
+// readSidecarOrDegrade(fsMod, filePath) — for ADVISORY sidecar/registry
+// readers that must never open a non-regular file and must never abort:
+// fd-based classify-and-read, collapsing BOTH 'absent' and 'unreadable' to
+// null so callers degrade uniformly (existing warning/linear-fallback path).
+// Used by lib/relevance.mjs's tags/category/tokens loaders, lib/embeddings.mjs,
+// and install-version.mjs's consumer-registry reader.
+export function readSidecarOrDegrade(fsMod, filePath) {
+  try {
+    return openReadableIndex(fsMod, filePath)
+  } catch (e) {
+    // #653 review FIX-H: narrow the catch to the expected error class — a
+    // programming error inside openReadableIndex (not a store defect) must
+    // still surface, not be silently swallowed into "advisory degrade".
+    if (e instanceof IndexUnreadableError) return null
+    throw e
+  }
+}
+
+// unreadableMessage(tool, role, err) — Family A abort message builder for a
+// writer-preflight classify site. IndexUnreadableError's own .message is
+// byte-frozen to the literal "episode index unreadable" wording for the
+// primary index.jsonl call sites tests regex against; a sidecar file (tags.json,
+// category-index.json, tokens.json, ...) needs its own role in the sentence,
+// so callers build the message from err.code/err.file instead of err.message.
+// For role 'episode index' this reproduces the pinned wording exactly.
+export function unreadableMessage(tool, role, err) {
+  return `${tool}: ${role} unreadable (${err.code}) (${err.file})`
+}
+
+// roleForFile(filePath) — derive unreadableMessage's `role` argument from a
+// store-dir file's basename (#653 review FIX-C). Used by in-lock TOCTOU
+// catches that funnel throws from MULTIPLE possible files (index.jsonl,
+// tags.json, category-index.json, tokens.json) through ONE catch block, so
+// the role can't be hardcoded per call site the way the preflight loops do.
+const FILE_ROLE_BY_BASENAME = {
+  'index.jsonl': 'episode index',
+  'tags.json': 'tags index',
+  'category-index.json': 'category index',
+  'tokens.json': 'token index',
+}
+export function roleForFile(filePath) {
+  return FILE_ROLE_BY_BASENAME[path.basename(filePath)] || 'episode index'
 }

--- a/scripts/lib/install-version.mjs
+++ b/scripts/lib/install-version.mjs
@@ -47,6 +47,7 @@ import fs from 'fs'
 import path from 'path'
 import crypto from 'crypto'
 import { execFileSync } from 'child_process'
+import { openReadableIndex } from './index-state.mjs'
 import {
   HOOK_SPECS, SESSION_END_SCRIPT,
   enforcementHookLibBasenames, enforcementEntryScripts, enforcementBundleLibs,
@@ -334,10 +335,19 @@ export function normalizeProjectPath(p) {
 }
 
 // Degrade-not-throw: malformed/alien registry shape → rebuild from scratch
-// with a stderr note; never block the install.
+// with a stderr note; never block the install. #653 (F1e): classify before
+// read (openReadableIndex) so a FIFO/dir-shaped installs.json can never hang
+// a raw readFileSync — an unreadable SHAPE degrades the same way unparseable
+// CONTENT already did below (rebuilt from scratch, old content ignored).
 export function readRegistry(regPath) {
   let raw
-  try { raw = fs.readFileSync(regPath, 'utf8') } catch { return { entries: [], rebuilt: false } }
+  try {
+    raw = openReadableIndex(fs, regPath)
+  } catch {
+    console.error(`episodic-memory: consumer registry at ${regPath} is unreadable; rebuilding from scratch (old content ignored).`)
+    return { entries: [], rebuilt: true }
+  }
+  if (raw === null) return { entries: [], rebuilt: false } // genuinely absent
   let parsed
   try { parsed = JSON.parse(raw) } catch { parsed = null }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !Array.isArray(parsed.entries)) {

--- a/scripts/lib/relevance.mjs
+++ b/scripts/lib/relevance.mjs
@@ -24,7 +24,7 @@
 import fs from 'fs'
 import path from 'path'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './store-write-lock.mjs'
-import { assertReadableIndex, readIndexFileOrThrow } from './index-state.mjs'
+import { readIndexFileOrThrow, openReadableIndex, readSidecarOrDegrade } from './index-state.mjs'
 
 // Per-token field weights for the multi-term tier. Summary tokens count just
 // under a contiguous summary substring (0.7); tags sit between summary and
@@ -75,20 +75,20 @@ export function nullProtoIndex(parsed) {
   return Object.assign(Object.create(null), parsed)
 }
 
+// #653: fd-based classify-and-read (readSidecarOrDegrade) — never opens a
+// non-regular tags.json (a FIFO would otherwise block a raw readFileSync
+// forever); absent/unreadable/malformed all degrade to null uniformly, same
+// as before.
 export function loadTagsIndex(dataDir) {
-  try {
-    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'tags.json'), 'utf8')))
-  } catch {
-    return null
-  }
+  const raw = readSidecarOrDegrade(fs, path.join(dataDir, 'tags.json'))
+  if (raw === null) return null
+  try { return nullProtoIndex(JSON.parse(raw)) } catch { return null }
 }
 
 export function loadCategoryIndex(dataDir) {
-  try {
-    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'category-index.json'), 'utf8')))
-  } catch {
-    return null
-  }
+  const raw = readSidecarOrDegrade(fs, path.join(dataDir, 'category-index.json'))
+  if (raw === null) return null
+  try { return nullProtoIndex(JSON.parse(raw)) } catch { return null }
 }
 
 // ---------------------------------------------------------------------------
@@ -128,24 +128,22 @@ export function loadIndex(dataDir, source) {
 // ---------------------------------------------------------------------------
 export function loadArchivedIndex(dataDir, source) {
   const indexFile = path.join(dataDir, 'archived-index.jsonl')
-  let state
-  try {
-    state = assertReadableIndex(fs, indexFile)
-  } catch {
-    return [] // unreadable (incl. non-regular): classify-before-read, never open, degrade
-  }
-  if (state !== 'ok') return [] // absent
-  try {
-    return fs.readFileSync(indexFile, 'utf8').trim().split('\n').filter(Boolean).map(line => {
-      try {
-        const entry = JSON.parse(line)
-        entry._source = source
-        entry._dataDir = dataDir
-        entry._archived = true
-        return entry
-      } catch { return null }
-    }).filter(Boolean)
-  } catch { return [] } // read failure (e.g. TOCTOU swap) also degrades
+  // #653: fd-based classify-and-read closes the D1 gap the old two-step
+  // (classify-then-separately-read) shape had here — a regular->FIFO swap in
+  // that gap would have re-opened the hang even though this function
+  // degrades on failure, because the OLD read blocked before its catch could
+  // ever run.
+  const raw = readSidecarOrDegrade(fs, indexFile)
+  if (raw === null) return [] // absent or unreadable (incl. non-regular): degrade
+  return raw.trim().split('\n').filter(Boolean).map(line => {
+    try {
+      const entry = JSON.parse(line)
+      entry._source = source
+      entry._dataDir = dataDir
+      entry._archived = true
+      return entry
+    } catch { return null }
+  }).filter(Boolean)
 }
 
 // ---------------------------------------------------------------------------
@@ -338,11 +336,9 @@ export const DF_DROP_RATIO = 0.4
 export const TOKENS_DROPPED_KEY = '_dropped'
 
 export function loadTokensIndex(dataDir) {
-  try {
-    return nullProtoIndex(JSON.parse(fs.readFileSync(path.join(dataDir, 'tokens.json'), 'utf8')))
-  } catch {
-    return null
-  }
+  const raw = readSidecarOrDegrade(fs, path.join(dataDir, 'tokens.json'))
+  if (raw === null) return null
+  try { return nullProtoIndex(JSON.parse(raw)) } catch { return null }
 }
 
 // Incremental writer, structurally mirroring em-store's updateTagsIndex.
@@ -364,10 +360,18 @@ export function updateTokensIndex(dataDir, episodeId, tokens) {
     // The nested acquire is inherited when em-store/em-revise already hold
     // the canonical store lock. This keeps direct callers safe without
     // introducing a second lock protocol or a self-deadlock.
+    //
+    // #653: fd-based read (openReadableIndex) rather than the degrading
+    // readSidecarOrDegrade — this is a WRITE path under the store lock, so a
+    // post-preflight TOCTOU swap must throw IndexUnreadableError out of this
+    // try (never silently treat a defect as an empty index and keep
+    // writing); the finally below still releases this function's own lock,
+    // and the throw propagates to the caller's F6 abort-inside-lock catch.
     let index = Object.create(null)
-    try {
-      index = nullProtoIndex(JSON.parse(fs.readFileSync(tokensFile, 'utf8')))
-    } catch {}
+    const raw = openReadableIndex(fs, tokensFile)
+    if (raw !== null) {
+      try { index = nullProtoIndex(JSON.parse(raw)) } catch {} // malformed CONTENT still tolerant-degrades
+    }
     const dropped = new Set(Array.isArray(index[TOKENS_DROPPED_KEY]) ? index[TOKENS_DROPPED_KEY] : [])
     for (const tok of tokens) {
       if (dropped.has(tok)) continue

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -7,6 +7,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { tryAcquire, release } from './lock.mjs'
+import { classifyIndexFile } from './index-state.mjs'
 
 // §A.5-S1 constants (verbatim)
 export const STORE_IDENTITY_RECORD_TYPE = 'store-identity'
@@ -102,7 +103,15 @@ function listIdentityEpisodes(storeDir) {
   }
   const out = []
   for (const file of files) {
-    const content = fs.readFileSync(path.join(episodesDir, file), 'utf8')
+    // #653 (discovered via em-rebuild-index's S7 FIFO-episode battery leg):
+    // resolveStoreIdentity is called BY em-rebuild-index — the remediation
+    // tool the #649/#653 contract requires to never hang on a FIFO-shaped
+    // episode file — so this scan needs the same lstat-classify-skip guard
+    // as em-rebuild-index's own episode loop, not the deferred query-path
+    // body-read class (§4 D2 is about read-tool --full/--materialize paths).
+    const filePath = path.join(episodesDir, file)
+    if (classifyIndexFile(fs, filePath).state !== 'ok') continue
+    const content = fs.readFileSync(filePath, 'utf8')
     const parsed = parseIdentityFrontmatter(content)
     if (parsed) {
       parsed.filename = file

--- a/tests/test-651-index-existence.mjs
+++ b/tests/test-651-index-existence.mjs
@@ -9,11 +9,11 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { spawnSync } from 'node:child_process'
+import { spawnSync, spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 import {
-  classifyIndexFile, assertReadableIndex, readIndexFileOrThrow, IndexUnreadableError,
+  classifyIndexFile, assertReadableIndex, readIndexFileOrThrow, openReadableIndex, IndexUnreadableError,
 } from '../scripts/lib/index-state.mjs'
 
 // EM651_TEST_REPO_OVERRIDE: points spawned scripts at an alternate repo root
@@ -48,6 +48,22 @@ function run(scriptPath, args, { cwd, home }) {
     cwd, encoding: 'utf8', timeout: 10000,
     env: { ...process.env, HOME: home, USERPROFILE: home },
   })
+}
+
+// sleepSync(ms) / waitForFileSync(path, timeoutMs) — issue #653 S7 lock-
+// release leg needs a synchronous wait (the whole suite is spawnSync-based,
+// no async/await): Atomics.wait on a throwaway SharedArrayBuffer blocks the
+// calling thread without special worker setup on Node's main thread.
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+function waitForFileSync(p, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  while (!fs.existsSync(p)) {
+    if (Date.now() > deadline) return false
+    sleepSync(20)
+  }
+  return true
 }
 
 // Most scripts print one compact JSON line; em-restore.mjs pretty-prints
@@ -1052,6 +1068,848 @@ function mkChainStore() {
         assert(fs.existsSync(oldEpisodePath), 'chain-old episode file must still exist — nothing moved before the abort')
         const archivedDir = path.join(world.localDir, 'archived')
         assert(!fs.existsSync(archivedDir), `archived/ must not exist (abort precedes its creation), got present: ${fs.existsSync(archivedDir)}`)
+      } finally {
+        try { fs.rmSync(world.root, { recursive: true, force: true }) } catch {}
+      }
+    })
+  }
+}
+
+// =============================================================================
+// Issue #649/#653 additions (docs/plans/fix-649-653.md §7 S7). Reuses the
+// fixtures/helpers above (mkStore, applyShape, run, lastJson, checkTyped).
+// =============================================================================
+
+// -----------------------------------------------------------------------
+// D1 interleave (§7 S7 bullet 1): classify-ok -> swap-to-FIFO -> the NEW
+// fd-based reader must still typed-abort ENOTREG, never hang. Mirrors the
+// toctou-child.mjs harness used to prove D1 pre-fix: a throwaway child
+// process imports the CURRENT working tree's index-state.mjs, classifies
+// while the file is REGULAR (sanity precondition), swaps it to a FIFO, then
+// calls openReadableIndex — under a spawnSync hard-kill timeout so a
+// regression fails as a timeout-kill, never a stuck test run. Because
+// openReadableIndex does ONE open()+fstat() on a single fd (no separate
+// classify-then-path-read pair), this is strictly harder than the pre-fix
+// race: the swap is already complete before the reader is even called, yet
+// it still resolves instantly.
+// -----------------------------------------------------------------------
+{
+  const name = 'D1 interleave: classify-ok -> swap-FIFO -> openReadableIndex -> typed ENOTREG (not a hang)'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em653-d1-'))
+      const indexPath = path.join(dir, 'index.jsonl')
+      fs.writeFileSync(indexPath, '{"id":"x"}\n')
+      const indexStatePath = path.join(SCRIPTS, 'lib', 'index-state.mjs')
+      const childPath = path.join(dir, 'child.mjs')
+      fs.writeFileSync(childPath, [
+        `import fs from 'node:fs'`,
+        `import { spawnSync } from 'node:child_process'`,
+        `import { classifyIndexFile, openReadableIndex } from ${JSON.stringify(indexStatePath)}`,
+        `const p = ${JSON.stringify(indexPath)}`,
+        `const cls = classifyIndexFile(fs, p)`,
+        `if (cls.state !== 'ok') { console.log(JSON.stringify({ step: 'abort', reason: 'precondition failed', cls })); process.exit(2) }`,
+        `fs.rmSync(p, { force: true })`,
+        `const mk = spawnSync('mkfifo', [p])`,
+        `if (mk.status !== 0) { console.log(JSON.stringify({ step: 'abort', reason: 'mkfifo failed' })); process.exit(2) }`,
+        `try {`,
+        `  const raw = openReadableIndex(fs, p)`,
+        `  console.log(JSON.stringify({ step: 'unexpected-ok', raw }))`,
+        `} catch (e) {`,
+        `  console.log(JSON.stringify({ step: 'typed-abort', code: e.code, message: e.message }))`,
+        `}`,
+      ].join('\n'))
+      const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 5000, killSignal: 'SIGKILL' })
+      fs.rmSync(dir, { recursive: true, force: true })
+      assert(r.signal === null, `D1 interleave: no signal (timeout/kill) — got ${r.signal} (this is the falsifiability failure mode against an unfixed two-step classify-then-read)`)
+      assert(r.status === 0, `D1 interleave: child exit 0, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)} stderr=${(r.stderr || '').slice(0, 300)}`)
+      const j = JSON.parse((r.stdout || '').trim().split('\n').pop())
+      assert(j.step === 'typed-abort', `D1 interleave: expected typed-abort, got ${JSON.stringify(j)}`)
+      assert(j.code === 'ENOTREG', `D1 interleave: expected code ENOTREG, got ${JSON.stringify(j)}`)
+    })
+  }
+}
+
+// -----------------------------------------------------------------------
+// Static-FIFO legs (§7 S7 bullet 2 / §5 V2). No race needed — these hang
+// (or misbehave) on unpatched HEAD because the read sites were either fully
+// unguarded (em-store/em-revise's sidecar writers, em-rebuild-index's
+// episode-file reads, em-semantic's embeddings loader) or had the D1
+// classify-then-separately-read gap (relevance.mjs's advisory loaders).
+// -----------------------------------------------------------------------
+
+// em-search x FIFO tags.json/tokens.json/category-index.json -> ok+warning,
+// no hang (advisory degrade surface; #653 S2).
+{
+  const cases = [
+    { file: 'tags.json', args: ['--tag', 'x'] },
+    { file: 'category-index.json', args: ['--category', 'decision'] },
+    { file: 'tokens.json', args: ['--query', 'seed'] },
+  ]
+  for (const { file, args } of cases) {
+    const name = `em-search x FIFO ${file} -> ok+warning, no hang`
+    if (IS_WIN) { skip(name, 'mkfifo unavailable on win32'); continue }
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const sidecarPath = path.join(world.localDir, file)
+        fs.rmSync(sidecarPath, { force: true })
+        const mk = spawnSync('mkfifo', [sidecarPath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-search.mjs'), ['--scope', 'local', '--no-track', ...args], { cwd: world.proj, home: world.root })
+        assert(r.signal === null, `em-search: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 0, `em-search: exit 0, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)} stderr=${(r.stderr || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'ok', `em-search: status ok, got ${r.stdout}`)
+        assert(typeof j.warning === 'string' && j.warning.length > 0, `em-search: degrade warning present, got ${r.stdout}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// em-store x FIFO tags.json -> typed abort, episode count unchanged (zero
+// partial state — #653 S3 preflight, before lock/any write).
+{
+  const name = 'em-store x FIFO tags.json -> typed abort, zero partial state'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const tagsFile = path.join(world.localDir, 'tags.json')
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        const beforeIndex = fs.readFileSync(indexPath, 'utf8')
+        const beforeEpisodeCount = fs.readdirSync(path.join(world.localDir, 'episodes')).length
+        fs.rmSync(tagsFile, { force: true })
+        const mk = spawnSync('mkfifo', [tagsFile])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'decision', '--summary', 'fifo-tags', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        fs.rmSync(tagsFile, { force: true })
+        assert(r.signal === null, `em-store: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-store: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-store: typed envelope, got ${r.stdout}`)
+        assert(/tags index unreadable/.test(r.stdout), `em-store: names tags index, got ${r.stdout.slice(0, 300)}`)
+        assert(j.code === 'index-unreadable:ENOTREG', `em-store: code index-unreadable:ENOTREG, got ${JSON.stringify(j)}`)
+        const afterEpisodeCount = fs.readdirSync(path.join(world.localDir, 'episodes')).length
+        assert(afterEpisodeCount === beforeEpisodeCount, `em-store: no episode file written, before=${beforeEpisodeCount} after=${afterEpisodeCount}`)
+        const afterIndex = fs.readFileSync(indexPath, 'utf8')
+        assert(afterIndex === beforeIndex, 'em-store: index.jsonl byte-unchanged (preflight aborted before lock/any write)')
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// em-revise x FIFO tags.json AND x FIFO index.jsonl -> typed abort, original
+// episode + index untouched (#653 S3R preflight, before lock/any write).
+{
+  const reviseCases = [
+    { label: 'tags.json', file: 'tags.json', roleRe: /tags index unreadable/ },
+    { label: 'index.jsonl', file: 'index.jsonl', roleRe: /episode index unreadable/ },
+  ]
+  for (const { label, file, roleRe } of reviseCases) {
+    const name = `em-revise x FIFO ${label} -> typed abort, original untouched`
+    if (IS_WIN) { skip(name, 'mkfifo unavailable on win32'); continue }
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const target = path.join(world.localDir, file)
+        const episodePath = path.join(world.localDir, 'episodes', `${world.seedId}.md`)
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        const beforeEpisode = fs.readFileSync(episodePath, 'utf8')
+        const beforeIndex = fs.readFileSync(indexPath, 'utf8')
+        fs.rmSync(target, { force: true })
+        const mk = spawnSync('mkfifo', [target])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-revise.mjs'), [
+          '--original', world.seedId, '--project', 'p651', '--summary', 'fifo-revise', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        fs.rmSync(target, { force: true })
+        assert(r.signal === null, `em-revise: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-revise: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-revise: typed envelope, got ${r.stdout}`)
+        assert(roleRe.test(r.stdout), `em-revise: names ${label}, got ${r.stdout.slice(0, 300)}`)
+        assert(j.code === 'index-unreadable:ENOTREG', `em-revise: code index-unreadable:ENOTREG, got ${JSON.stringify(j)}`)
+        const afterEpisode = fs.readFileSync(episodePath, 'utf8')
+        assert(afterEpisode === beforeEpisode, `em-revise (${label}): original episode file byte-unchanged`)
+        const afterIndex = file === 'index.jsonl' ? null : fs.readFileSync(indexPath, 'utf8')
+        if (afterIndex !== null) assert(afterIndex === beforeIndex, `em-revise (${label}): index.jsonl byte-unchanged`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// em-rebuild-index x FIFO episodes/*.md -> completes with a warning, never
+// hangs (#653 S4: the remediation tool must never hang on the disease it
+// repairs).
+{
+  const name = 'em-rebuild-index x FIFO episodes/*.md -> completes with warning, no hang'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const fifoEpisode = path.join(world.localDir, 'episodes', 'fifo-episode.md')
+        const mk = spawnSync('mkfifo', [fifoEpisode])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-rebuild-index.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+        assert(r.signal === null, `em-rebuild-index: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 0, `em-rebuild-index: exit 0, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)} stderr=${(r.stderr || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'ok', `em-rebuild-index: status ok, got ${r.stdout}`)
+        const localScope = j.rebuilt.find(x => x.scope === 'local')
+        assert(localScope && Array.isArray(localScope.warnings) && localScope.warnings.some(w => w.includes('fifo-episode.md')), `em-rebuild-index: warnings names the skipped FIFO episode, got ${JSON.stringify(localScope)}`)
+        assert(localScope.count === 1, `em-rebuild-index: the FIFO episode is excluded from count (only the seed episode), got ${JSON.stringify(localScope)}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// em-semantic x FIFO embeddings.jsonl -> degrade (advisory sidecar, #653
+// S2), no hang, no index-unreadable envelope — loadEmbeddings treats a
+// non-regular sidecar exactly like an absent one.
+{
+  const name = 'em-semantic x FIFO embeddings.jsonl -> degrade (no sidecar), no hang'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const embed = run(path.join(SCRIPTS, 'em-embed.mjs'), ['--scope', 'local', '--provider', 'hash'], { cwd: world.proj, home: world.root })
+        assert(embed.status === 0, `em-embed seed failed: ${embed.stderr}`)
+        const sidecar = path.join(world.localDir, 'embeddings.jsonl')
+        assert(fs.existsSync(sidecar), 'precondition: embeddings sidecar exists')
+        fs.rmSync(sidecar, { force: true })
+        const mk = spawnSync('mkfifo', [sidecar])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-semantic.mjs'), ['--query', 'seed', '--scope', 'local', '--no-track'], { cwd: world.proj, home: world.root })
+        fs.rmSync(sidecar, { force: true })
+        assert(r.signal === null, `em-semantic: no signal (timeout/kill), got ${r.signal}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-semantic: typed JSON, got ${r.stdout}`)
+        assert(/No embeddings sidecar found/.test(j.message || ''), `em-semantic: degrades to "no sidecar", NOT an index-unreadable abort, got ${r.stdout}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// em-doctor x FIFO installs.json (fake HOME) -> report row, exit != hang
+// (#653 S2: registry readers classify before read; em-doctor never aborts).
+// #649/#653 review FIX-D (P2-1): tightened past "no hang, no crash" — the
+// installs-drift row must be a WARN carrying a typed code, not indistinguishable
+// from a genuinely absent/empty registry ("ok" — the pre-fix defect).
+{
+  const name = 'em-doctor x FIFO installs.json -> warn row with code (not "ok")'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em653-doctor-'))
+      const proj = path.join(root, 'proj')
+      fs.mkdirSync(proj)
+      const globalDir = path.join(root, '.episodic-memory')
+      fs.mkdirSync(globalDir, { recursive: true })
+      const installsFile = path.join(globalDir, 'installs.json')
+      const mk = spawnSync('mkfifo', [installsFile])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      try {
+        // --scope global (not local): checkInstallsDrift, which reads
+        // installs.json, only runs for scope global|all — a local-scope
+        // run would never touch the FIFO at all and pass trivially.
+        const r = run(path.join(SCRIPTS, 'em-doctor.mjs'), ['--scope', 'global'], { cwd: proj, home: root })
+        assert(r.signal === null, `em-doctor: no signal (timeout/kill), got ${r.signal}`)
+        assert([0, 1, 2].includes(r.status), `em-doctor: a real exit code (no crash), got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && Array.isArray(j.checks) && j.summary, `em-doctor: report shape present (never aborts), got ${(r.stdout || '').slice(0, 300)}`)
+        assert(!/at .*\.mjs/.test(r.stderr || ''), `em-doctor: no raw stack frames on stderr, got ${(r.stderr || '').slice(0, 300)}`)
+        const row = j.checks.find(c => c.id === 'installs-drift')
+        assert(row, `em-doctor: installs-drift row present, got ${JSON.stringify(j.checks.map(c => c.id))}`)
+        assert(row.level === 'warn', `em-doctor: installs-drift is warn (a defect, not indistinguishable from an absent/empty registry), got ${JSON.stringify(row)}`)
+        assert(row.code === 'index-unreadable:ENOTREG', `em-doctor: installs-drift carries code index-unreadable:ENOTREG, got ${JSON.stringify(row)}`)
+      } finally {
+        try { fs.rmSync(installsFile, { force: true }) } catch {}
+        try { fs.rmSync(root, { recursive: true, force: true }) } catch {}
+      }
+    })
+  }
+}
+
+// -----------------------------------------------------------------------
+// PARITY leg (§7 S7 bullet 3, audit F3 — end-to-end, not classify-vs-open):
+// for every shape, the OLD contract's outcome (assertReadableIndex classify,
+// then a separate read) and the NEW contract's outcome (openReadableIndex,
+// one fd) agree — both degrade the same way, and both type the same .code.
+// file000 is the probe-pinned case: classify alone says 'ok' there (chmod
+// doesn't change st.isFile()), but BOTH the old separate-read and the new
+// fd-based read must surface EACCES end-to-end.
+// -----------------------------------------------------------------------
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em653-parity-'))
+
+  function oldStyleRead(filePath) {
+    // Reference "old" contract: classify (lstat-only), then a SEPARATE
+    // path-based read — exactly index-state.mjs's pre-#653 shape.
+    const state = assertReadableIndex(fs, filePath) // throws IndexUnreadableError on 'unreadable'
+    if (state === 'absent') return null
+    try { return fs.readFileSync(filePath, 'utf8') } catch (e) {
+      throw new IndexUnreadableError(filePath, (e && e.code) || 'UNKNOWN', 'read failed')
+    }
+  }
+
+  function outcomeOf(fn, filePath) {
+    try { return { ok: true, value: fn(filePath) } } catch (e) {
+      if (e instanceof IndexUnreadableError) return { ok: false, code: e.code }
+      throw e
+    }
+  }
+
+  const PARITY_SHAPES = [...ALL_SHAPES, 'symlink-to-fifo', 'symlink-to-dir']
+  for (const shape of PARITY_SHAPES) {
+    const skipReason = (shape === 'eaccess' || shape === 'symlink-to-fifo') && IS_ROOT ? 'root bypasses permission checks'
+      : (shape === 'fifo' || shape === 'symlink-to-fifo') && IS_WIN ? 'mkfifo unavailable on win32'
+      : null
+    const name = `PARITY ${shape}: old classify+read outcome === new fd-based outcome`
+    if (skipReason) { skip(name, skipReason); continue }
+    t(name, () => {
+      // Each shape gets its OWN isolated subdirectory — 'parent-dangling'
+      // rmSync's + replaces storeDir itself, which must never be the shared
+      // parity root (that would corrupt every other shape sharing it).
+      const shapeDir = path.join(dir, shape)
+      fs.rmSync(shapeDir, { recursive: true, force: true })
+      fs.mkdirSync(shapeDir, { recursive: true })
+      const p = path.join(shapeDir, 'index.jsonl')
+      const targetDir = path.join(shapeDir, 'target-dir')
+      try {
+        if (shape === 'symlink-to-fifo') {
+          const fifoTarget = path.join(shapeDir, 'fifo-target')
+          const mk = spawnSync('mkfifo', [fifoTarget])
+          assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+          fs.symlinkSync(fifoTarget, p)
+        } else if (shape === 'symlink-to-dir') {
+          fs.mkdirSync(targetDir)
+          fs.symlinkSync(targetDir, p)
+        } else {
+          applyShape(shape, p, shapeDir)
+        }
+        const oldOutcome = outcomeOf(oldStyleRead, p)
+        const newOutcome = outcomeOf((fp) => openReadableIndex(fs, fp), p)
+        assert(oldOutcome.ok === newOutcome.ok, `PARITY ${shape}: ok-ness matches, old=${JSON.stringify(oldOutcome)} new=${JSON.stringify(newOutcome)}`)
+        if (!oldOutcome.ok) {
+          assert(oldOutcome.code === newOutcome.code, `PARITY ${shape}: .code matches, old=${oldOutcome.code} new=${newOutcome.code}`)
+        } else {
+          assert(oldOutcome.value === newOutcome.value, `PARITY ${shape}: content matches`)
+        }
+      } finally {
+        try { restoreShape(shape, p, shapeDir) } catch {}
+        try { fs.chmodSync(p, 0o644) } catch {}
+        try { fs.rmSync(shapeDir, { recursive: true, force: true }) } catch {}
+      }
+    })
+  }
+
+  // file000 probe-pin: classify ALONE says 'ok' (chmod doesn't change
+  // st.isFile()); both end-to-end paths must surface EACCES.
+  t('PARITY file000: classify alone says ok; both end-to-end paths yield EACCES', () => {
+    if (IS_ROOT) { skip('PARITY file000 probe-pin', 'root bypasses permission checks'); return }
+    const p = path.join(dir, 'parity-file000-probe.jsonl')
+    fs.writeFileSync(p, FILE000_FIXTURE_CONTENT)
+    fs.chmodSync(p, 0o000)
+    try {
+      const cls = classifyIndexFile(fs, p)
+      assert(cls.state === 'ok', `classify alone says ok (permission bits are invisible to lstat type checks), got ${JSON.stringify(cls)}`)
+      const oldOutcome = outcomeOf(oldStyleRead, p)
+      const newOutcome = outcomeOf((fp) => openReadableIndex(fs, fp), p)
+      assert(!oldOutcome.ok && oldOutcome.code === 'EACCES', `old end-to-end: EACCES, got ${JSON.stringify(oldOutcome)}`)
+      assert(!newOutcome.ok && newOutcome.code === 'EACCES', `new end-to-end: EACCES, got ${JSON.stringify(newOutcome)}`)
+    } finally {
+      try { fs.chmodSync(p, 0o644) } catch {}
+      try { fs.rmSync(p, { force: true }) } catch {}
+    }
+  })
+
+  fs.rmSync(dir, { recursive: true, force: true })
+}
+
+// -----------------------------------------------------------------------
+// Envelope sweep (§7 S7 bullet 4, audit F9): runtime legs — a directory-
+// shaped index.jsonl -> code === 'index-unreadable:EISDIR' + message regex
+// + exit 1, for every reader plus the two writers plus em-rebuild-index.
+// Static grep-pin: every known Family-A emission site's source carries the
+// `code` field.
+// -----------------------------------------------------------------------
+const ENVELOPE_SWEEP_TOOLS = [
+  { name: 'em-search', script: 'em-search.mjs', args: ['--scope', 'local', '--no-track'] },
+  { name: 'em-recall', script: 'em-recall.mjs', args: ['--scope', 'local', '--no-track'] },
+  { name: 'em-list', script: 'em-list.mjs', args: ['--scope', 'local'] },
+  { name: 'em-check-stale', script: 'em-check-stale.mjs', args: ['--scope', 'local'] },
+  { name: 'em-graph', script: 'em-graph.mjs', args: ['--orphans', '--scope', 'local'] },
+  { name: 'em-stats', script: 'em-stats.mjs', args: ['--scope', 'local'] },
+  { name: 'em-rebuild-index', script: 'em-rebuild-index.mjs', args: ['--scope', 'local'] },
+]
+for (const { name, script, args } of ENVELOPE_SWEEP_TOOLS) {
+  t(`envelope sweep: ${name} x EISDIR index -> code index-unreadable:EISDIR`, () => {
+    const world = mkStore()
+    try {
+      const indexPath = path.join(world.localDir, 'index.jsonl')
+      fs.rmSync(indexPath, { force: true })
+      fs.mkdirSync(indexPath)
+      const r = run(path.join(SCRIPTS, script), args, { cwd: world.proj, home: world.root })
+      fs.rmdirSync(indexPath)
+      assert(r.signal === null, `${name}: no signal, got ${r.signal}`)
+      assert(r.status === 1, `${name}: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+      const j = lastJson(r.stdout)
+      assert(j && j.status === 'error', `${name}: typed envelope, got ${r.stdout}`)
+      assert(/unreadable \(EISDIR\)/.test(r.stdout), `${name}: message names EISDIR, got ${r.stdout.slice(0, 300)}`)
+      assert(j.code === 'index-unreadable:EISDIR', `${name}: code index-unreadable:EISDIR, got ${JSON.stringify(j)}`)
+    } finally { cleanup(world) }
+  })
+}
+// em-semantic needs a query + sidecar to reach the index read at all.
+t('envelope sweep: em-semantic x EISDIR index -> code index-unreadable:EISDIR', () => {
+  const world = mkStore()
+  try {
+    const embed = run(path.join(SCRIPTS, 'em-embed.mjs'), ['--scope', 'local', '--provider', 'hash'], { cwd: world.proj, home: world.root })
+    assert(embed.status === 0, `em-embed seed failed: ${embed.stderr}`)
+    const indexPath = path.join(world.localDir, 'index.jsonl')
+    fs.rmSync(indexPath, { force: true })
+    fs.mkdirSync(indexPath)
+    const r = run(path.join(SCRIPTS, 'em-semantic.mjs'), ['--query', 'seed', '--scope', 'local', '--no-track'], { cwd: world.proj, home: world.root })
+    fs.rmdirSync(indexPath)
+    assert(r.signal === null, `em-semantic: no signal, got ${r.signal}`)
+    assert(r.status === 1, `em-semantic: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'error' && j.code === 'index-unreadable:EISDIR', `em-semantic: code index-unreadable:EISDIR, got ${JSON.stringify(j)}`)
+  } finally { cleanup(world) }
+})
+// em-store / em-revise: EISDIR index -> preflight abort, code carried.
+t('envelope sweep: em-store x EISDIR index -> code index-unreadable:EISDIR', () => {
+  const world = mkStore()
+  try {
+    const indexPath = path.join(world.localDir, 'index.jsonl')
+    fs.rmSync(indexPath, { force: true })
+    fs.mkdirSync(indexPath)
+    const r = run(path.join(SCRIPTS, 'em-store.mjs'), ['--project', 'p651', '--category', 'decision', '--summary', 'x', '--body', 'x', '--scope', 'local'], { cwd: world.proj, home: world.root })
+    fs.rmdirSync(indexPath)
+    assert(r.status === 1 && r.signal === null, `em-store: exit 1 no signal, got status=${r.status} signal=${r.signal}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.code === 'index-unreadable:EISDIR', `em-store: code index-unreadable:EISDIR, got ${JSON.stringify(j)}`)
+  } finally { cleanup(world) }
+})
+t('envelope sweep: em-revise x EISDIR index -> code index-unreadable:EISDIR', () => {
+  const world = mkStore()
+  try {
+    const indexPath = path.join(world.localDir, 'index.jsonl')
+    fs.rmSync(indexPath, { force: true })
+    fs.mkdirSync(indexPath)
+    const r = run(path.join(SCRIPTS, 'em-revise.mjs'), ['--original', world.seedId, '--project', 'p651', '--summary', 'x', '--body', 'x', '--scope', 'local'], { cwd: world.proj, home: world.root })
+    fs.rmdirSync(indexPath)
+    assert(r.status === 1 && r.signal === null, `em-revise: exit 1 no signal, got status=${r.status} signal=${r.signal}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.code === 'index-unreadable:EISDIR', `em-revise: code index-unreadable:EISDIR, got ${JSON.stringify(j)}`)
+  } finally { cleanup(world) }
+})
+
+// Static grep-pin: every known Family-A emission site's source carries the
+// `code` field (regression guard against a future edit silently dropping
+// it). One occurrence of the literal marker per file is sufficient — this
+// pins the KNOWN S5 sweep set, not a live re-discovery of new sites.
+t('static grep-pin: every known Family-A emission site carries `code`', () => {
+  const CODE_BEARING_FILES = [
+    'em-search.mjs', 'em-recall.mjs', 'em-list.mjs', 'em-check-stale.mjs', 'em-graph.mjs',
+    'em-semantic.mjs', 'em-stats.mjs', 'em-store.mjs', 'em-revise.mjs', 'em-promote.mjs',
+    'em-topic-tracks.mjs', 'em-rebuild-index.mjs', 'em-prune.mjs', 'em-restore.mjs',
+    'em-seed-patterns.mjs', 'em-watch-codex.mjs', 'em-workflow-validate.mjs',
+    'em-review-request.mjs', 'em-pattern-health.mjs', 'em-move.mjs', 'em-feedback.mjs', 'em-doctor.mjs',
+    'em-pin.mjs', 'em-violation.mjs', // FIX-E/FIX-A (fix round 2)
+  ]
+  const missing = []
+  for (const f of CODE_BEARING_FILES) {
+    const src = fs.readFileSync(path.join(SCRIPTS, f), 'utf8')
+    if (!/code:?\s*[=]?\s*`index-unreadable:/.test(src)) missing.push(f)
+  }
+  assert(missing.length === 0, `every Family-A site carries code, missing from: ${missing.join(', ')}`)
+  for (const f of ['em-search.mjs', 'em-list.mjs', 'em-check-stale.mjs']) {
+    const src = fs.readFileSync(path.join(PLUGIN_SCRIPTS, f), 'utf8')
+    assert(/code:\s*`index-unreadable:/.test(src), `vendored ${f} carries code`)
+  }
+})
+
+// -----------------------------------------------------------------------
+// Lock-release leg (§7 S7 bullet 5, audit F6): a TOCTOU swap DURING the
+// held lock (not caught by the preflight, which already passed while the
+// file was still regular) still emits the typed envelope, releases the
+// lock (no stale lock file left behind), and an immediate retry succeeds.
+// Deterministic construction (no real race): a background holder process
+// owns the lock first; em-store is spawned WHILE tags.json is still regular
+// (so its preflight passes and it blocks waiting for the held lock) — ONLY
+// THEN does the test swap tags.json to a FIFO and release the holder, so the
+// swap lands strictly after preflight and strictly before the in-lock read
+// (#649/#653 review FIX-B: the original leg swapped BEFORE spawning em-store,
+// which only re-exercised the pre-lock preflight — a mutation deleting the
+// in-lock catch's explicit lock release survived the whole suite under that
+// ordering; this leg is the fix, see the mutation-kill proof in the report).
+// -----------------------------------------------------------------------
+{
+  const name = 'F6 lock-release: TOCTOU swap of tags.json mid-lock (post-spawn) aborts typed; lock released; immediate retry succeeds'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const dataDir = world.localDir
+        const tagsFile = path.join(dataDir, 'tags.json')
+        fs.writeFileSync(tagsFile, JSON.stringify({}))
+        // store-write-lock.mjs realpaths dataDir before placing the lock
+        // file (canonicalizeAndSort) — macOS's os.tmpdir() is itself a
+        // symlink (/tmp -> /private/tmp), so the lock's actual location can
+        // differ from the literal world.localDir spelling.
+        const lockPath = path.join(fs.realpathSync(dataDir), 'clerk-apply.lock')
+
+        const holderPath = path.join(world.root, 'lock-holder.mjs')
+        const lockLibPath = path.join(SCRIPTS, 'lib', 'store-write-lock.mjs')
+        const readySignal = path.join(world.root, 'ready.signal')
+        const releaseSignal = path.join(world.root, 'release.signal')
+        fs.writeFileSync(holderPath, [
+          `import fs from 'node:fs'`,
+          `import { acquireStoreWriteLocksSync, releaseStoreWriteLocks } from ${JSON.stringify(lockLibPath)}`,
+          `const dataDir = ${JSON.stringify(dataDir)}`,
+          `const r = acquireStoreWriteLocksSync(dataDir)`,
+          `if (!r.ok) { fs.writeFileSync(${JSON.stringify(readySignal)}, 'FAILED'); process.exit(1) }`,
+          `fs.writeFileSync(${JSON.stringify(readySignal)}, 'HELD')`,
+          `const deadline = Date.now() + 10000`,
+          `while (!fs.existsSync(${JSON.stringify(releaseSignal)}) && Date.now() < deadline) {`,
+          `  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20)`,
+          `}`,
+          `releaseStoreWriteLocks(r.handles)`,
+          `process.exit(0)`,
+        ].join('\n'))
+
+        const holder = spawn(process.execPath, [holderPath], { stdio: 'ignore' })
+        holder.unref()
+        const gotLock = waitForFileSync(readySignal, 5000)
+        assert(gotLock, 'lock holder signaled within 5s')
+        assert(fs.readFileSync(readySignal, 'utf8') === 'HELD', 'lock holder actually acquired the lock (not FAILED)')
+        assert(fs.existsSync(lockPath), 'lock file present while held')
+
+        // Spawn em-store NOW, while tags.json is STILL a regular file — its
+        // preflight (classify index+tags+category+tokens, all still
+        // healthy) passes, and it then blocks inside
+        // acquireStoreWriteLocksSync waiting for the holder above to
+        // release. Run via a shell wrapper that redirects stdout/stderr to
+        // FILES and writes the exit code to a marker file — progress is
+        // polled via fs.existsSync, NOT via 'exit'/'data' event listeners:
+        // sleepSync's Atomics.wait blocks this thread's event loop
+        // synchronously, so an event-driven wait would deadlock (the 'exit'
+        // callback could never fire while we are inside the busy loop
+        // waiting for it).
+        const outPath = path.join(world.root, 'em-store.stdout')
+        const errPath = path.join(world.root, 'em-store.stderr')
+        const exitPath = path.join(world.root, 'em-store.exitcode')
+        const shQuote = (s) => `'${String(s).replace(/'/g, `'\\''`)}'`
+        const emStoreArgs = [
+          path.join(SCRIPTS, 'em-store.mjs'), '--project', 'p651', '--category', 'decision',
+          '--summary', 'f6-lock-release', '--body', 'body', '--scope', 'local',
+        ]
+        const shellCmd = `${shQuote(process.execPath)} ${emStoreArgs.map(shQuote).join(' ')} > ${shQuote(outPath)} 2> ${shQuote(errPath)}; echo $? > ${shQuote(exitPath)}`
+        const storeProc = spawn('/bin/sh', ['-c', shellCmd], {
+          cwd: world.proj, env: { ...process.env, HOME: world.root, USERPROFILE: world.root }, stdio: 'ignore',
+        })
+        storeProc.unref()
+
+        // Give em-store a moment to run its (fast, lstat-only) preflight and
+        // reach the lock-wait poll loop — well before the holder's own 10s
+        // deadline, and well before we release it below. Poll-verify it is
+        // actually still alive (still blocked) rather than trusting a fixed
+        // sleep: if it already exited, the ordering assumption failed and
+        // the leg must not silently pass on the WRONG code path.
+        sleepSync(300)
+        function isAlive(pid) { try { process.kill(pid, 0); return true } catch { return false } }
+        assert(isAlive(storeProc.pid), 'em-store is still blocked on the held lock 300ms after spawn (preflight passed, has not aborted yet)')
+        assert(!fs.existsSync(exitPath), 'em-store has not exited yet — still waiting on the lock, not already aborted at the preflight')
+
+        // NOW swap tags.json -> FIFO. This lands strictly after em-store's
+        // preflight (already passed, or it would have exited above) and
+        // strictly before the in-lock read (blocked on the lock, has not
+        // acquired it yet) — the exact interleave F6 exists to cover.
+        fs.rmSync(tagsFile, { force: true })
+        const mk = spawnSync('mkfifo', [tagsFile])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+
+        // Release the holder — em-store acquires the lock immediately after
+        // and hits the FIFO on its in-lock updateTagsIndex read.
+        fs.writeFileSync(releaseSignal, '1')
+
+        const finished = waitForFileSync(exitPath, 10000)
+        assert(finished, `em-store exited within 10s (no signal/timeout-kill)`)
+        const exitCode = Number(fs.readFileSync(exitPath, 'utf8').trim())
+        const stdout = fs.readFileSync(outPath, 'utf8')
+        const stderr = fs.readFileSync(errPath, 'utf8')
+        assert(exitCode === 1, `em-store: exit 1, got ${exitCode}: stdout=${stdout.slice(0, 300)} stderr=${stderr.slice(0, 300)}`)
+        const j = lastJson(stdout)
+        // Post-FIX-C: the in-lock catch derives the role from e.file's
+        // basename, so this now correctly says "tags index unreadable" (not
+        // the byte-frozen-for-index.jsonl "episode index unreadable").
+        assert(j && j.status === 'error' && /tags index unreadable/.test(stdout), `em-store: typed tags-index envelope (in-lock F6 path, role-correct wording), got stdout=${stdout} stderr=${stderr.slice(0, 300)}`)
+        assert(j.code === 'index-unreadable:ENOTREG', `em-store: code index-unreadable:ENOTREG, got ${JSON.stringify(j)}`)
+
+        // The lock must be released — no stale lock file left behind.
+        // Polled (not a single immediate check): em-store's own acquisition
+        // can briefly show a just-recreated lock file at the moment its
+        // process is tearing down; the assertion that matters is "not
+        // leaked forever", not "vanished within the same microsecond".
+        let lockGone = !fs.existsSync(lockPath)
+        const lockDeadline = Date.now() + 2000
+        while (!lockGone && Date.now() < lockDeadline) {
+          sleepSync(20)
+          lockGone = !fs.existsSync(lockPath)
+        }
+        assert(lockGone, 'lock file absent within 2s of the abort (finally/explicit release ran, not leaked)')
+
+        // Restore tags.json (remove the FIFO — a fresh index-write recreates
+        // it) and confirm an immediate retry succeeds.
+        fs.rmSync(tagsFile, { force: true })
+        const retry = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'decision', '--summary', 'f6-retry', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        assert(retry.status === 0, `retry em-store: exit 0, got ${retry.status}: stdout=${(retry.stdout || '').slice(0, 300)} stderr=${(retry.stderr || '').slice(0, 300)}`)
+        const rj = lastJson(retry.stdout)
+        assert(rj && rj.status === 'ok', `retry em-store: status ok, got ${retry.stdout}`)
+      } finally {
+        try { fs.rmSync(path.join(world.localDir, 'tags.json'), { force: true }) } catch {}
+        cleanup(world)
+      }
+    })
+  }
+}
+
+// -----------------------------------------------------------------------
+// Vendored-writer legs (§7 S7 bullet 6, audit F2): vendored em-store/
+// em-revise/em-rebuild-index x FIFO index.jsonl -> typed abort, no hang
+// (T7 pattern, spawn timeout). New behavior — these had NO guard at all
+// pre-#653 (em-store's vendored copy hangs on a FIFO index today).
+// -----------------------------------------------------------------------
+{
+  const vendoredWriterCases = [
+    {
+      name: 'plugin em-store', script: 'em-store.mjs',
+      args: ['--project', 'p651', '--category', 'decision', '--tags', 'x', '--summary', 'v', '--body', 'v', '--scope', 'local'],
+    },
+    {
+      name: 'plugin em-rebuild-index', script: 'em-rebuild-index.mjs', args: ['--scope', 'local'],
+    },
+  ]
+  for (const { name: caseName, script, args } of vendoredWriterCases) {
+    const name = `T7 vendored ${caseName} x FIFO index.jsonl -> typed abort, no hang`
+    if (IS_WIN) { skip(name, 'mkfifo unavailable on win32'); continue }
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        fs.rmSync(indexPath, { force: true })
+        const mk = spawnSync('mkfifo', [indexPath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(PLUGIN_SCRIPTS, script), args, { cwd: world.proj, home: world.root })
+        fs.rmSync(indexPath, { force: true })
+        checkTyped(r, caseName)
+      } finally { cleanup(world) }
+    })
+  }
+
+  // plugin em-revise needs an existing episode to revise; mkStore's seed
+  // already provides one via the VENDORED em-list contract (id shape is
+  // identical — the vendored writer just wrote it with the real em-store
+  // above in other legs, but here we seed via the real em-store for a
+  // deterministic id and then FIFO the vendored copy's index target).
+  {
+    const name = 'T7 vendored plugin em-revise x FIFO index.jsonl -> typed abort, no hang'
+    if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+      t(name, () => {
+        const world = mkStore()
+        try {
+          const indexPath = path.join(world.localDir, 'index.jsonl')
+          fs.rmSync(indexPath, { force: true })
+          const mk = spawnSync('mkfifo', [indexPath])
+          assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+          const r = run(path.join(PLUGIN_SCRIPTS, 'em-revise.mjs'), [
+            '--original', world.seedId, '--project', 'p651', '--tags', 'x', '--summary', 'v', '--body', 'v', '--scope', 'local',
+          ], { cwd: world.proj, home: world.root })
+          fs.rmSync(indexPath, { force: true })
+          checkTyped(r, 'plugin em-revise')
+        } finally { cleanup(world) }
+      })
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
+// FD hygiene (§5 V7, audit F5): looping openReadableIndex over unreadable
+// shapes must never leak a file descriptor — 1000 iterations over a FIFO
+// and a directory shape, then confirm the process can still open ordinary
+// files (no EMFILE).
+// -----------------------------------------------------------------------
+{
+  const name = 'V7 FD hygiene: 1000x openReadableIndex over unreadable shapes leaks no fd'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em653-fdhygiene-'))
+      const fifoPath = path.join(dir, 'fifo.jsonl')
+      const dirPath = path.join(dir, 'adir.jsonl')
+      const mk = spawnSync('mkfifo', [fifoPath])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      fs.mkdirSync(dirPath)
+      try {
+        for (let i = 0; i < 1000; i++) {
+          try { openReadableIndex(fs, i % 2 === 0 ? fifoPath : dirPath) } catch (e) {
+            assert(e instanceof IndexUnreadableError, `iteration ${i}: throws IndexUnreadableError, got ${e}`)
+          }
+        }
+        // No EMFILE: confirm we can still open a batch of ordinary fds.
+        const probeFiles = []
+        for (let i = 0; i < 50; i++) {
+          const p = path.join(dir, `probe-${i}.txt`)
+          fs.writeFileSync(p, 'x')
+          probeFiles.push(p)
+        }
+        for (const p of probeFiles) {
+          const content = fs.readFileSync(p, 'utf8')
+          assert(content === 'x', `probe file ${p} still readable (no fd exhaustion)`)
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  }
+}
+
+// =============================================================================
+// #649/#653 second-opinion fix round (2026-08-08) — new regression legs for
+// FIX-A, FIX-E, FIX-F. (FIX-B/FIX-C/FIX-D/FIX-H are covered by tightening the
+// existing legs above, in place; FIX-G is docs-only.)
+// =============================================================================
+
+// --- FIX-A: static FIFO hangs inside touched writers (activation.mjs
+// loadMergedIndex, reached from em-store --lesson/--evidence PRE-write
+// validation) now abort typed instead of hanging. ---
+{
+  const name = 'FIX-A: em-store --lesson x FIFO local index (PRE-write linkage validation) -> typed abort'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const seedViol = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'violation', '--summary', 'seed-violation', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        assert(seedViol.status === 0, `seed violation failed: ${seedViol.stderr}`)
+        const violId = (lastJson(seedViol.stdout) || {}).id
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        fs.rmSync(indexPath, { force: true })
+        const mk = spawnSync('mkfifo', [indexPath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'violation', '--summary', 'x1', '--body', 'body', '--scope', 'local', '--lesson', violId,
+        ], { cwd: world.proj, home: world.root })
+        restoreShape('fifo', indexPath, world.localDir)
+        assert(r.signal === null, `em-store: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-store: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-store: typed envelope, got ${r.stdout}`)
+        assert(j.code === 'index-unreadable:ENOTREG', `em-store: code index-unreadable:ENOTREG, got ${JSON.stringify(j)}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- FIX-A: POST-durable-write trigger-merge reads (em-trigger-index.mjs)
+// degrade instead of hanging, and the already-successful write surfaces a
+// warning instead of silently misreporting. ---
+{
+  const name = 'FIX-A: em-store --category lesson --trigger x FIFO GLOBAL index (POST-write collision merge) -> ok + warning, no hang, no double-store'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const globalIndexPath = path.join(world.globalDir, 'index.jsonl')
+        fs.rmSync(globalIndexPath, { force: true })
+        const mk = spawnSync('mkfifo', [globalIndexPath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'lesson', '--summary', 'x2', '--body', 'body', '--scope', 'local', '--trigger', 'a distinctive trigger phrase',
+        ], { cwd: world.proj, home: world.root })
+        restoreShape('fifo', globalIndexPath, world.globalDir)
+        assert(r.signal === null, `em-store: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 0, `em-store: exit 0 (the write already succeeded — a degraded post-write check must never misreport it), got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'ok', `em-store: status ok, got ${r.stdout}`)
+        assert(typeof j.warning === 'string' && /global index unreadable/.test(j.warning), `em-store: warning field names the degraded scope, got ${JSON.stringify(j)}`)
+        const list = run(path.join(SCRIPTS, 'em-list.mjs'), ['--scope', 'local'], { cwd: world.proj, home: world.root })
+        const lj = lastJson(list.stdout)
+        assert(lj.count === 2, `em-store: episode committed exactly once (seed + x2), no double-store, got count=${lj.count}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- FIX-E: em-pin's primary-index read now aborts typed on a static FIFO
+// instead of hanging. ---
+{
+  const name = 'FIX-E: em-pin x FIFO local index -> typed abort, no hang'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        fs.rmSync(indexPath, { force: true })
+        const mk = spawnSync('mkfifo', [indexPath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-pin.mjs'), ['--id', world.seedId], { cwd: world.proj, home: world.root })
+        restoreShape('fifo', indexPath, world.localDir)
+        assert(r.signal === null, `em-pin: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-pin: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-pin: typed envelope, got ${r.stdout}`)
+        assert(/episode index unreadable/.test(r.stdout), `em-pin: names the defect, got ${r.stdout.slice(0, 300)}`)
+        assert(j.code === 'index-unreadable:ENOTREG', `em-pin: code index-unreadable:ENOTREG, got ${JSON.stringify(j)}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- FIX-F: em-consolidate's clerk-apply-family digest write (tags.json /
+// category-index.json) now fd-guards its sidecar reads instead of hanging.
+// Needs a near-duplicate cluster to reach the digest-write path.
+// -----------------------------------------------------------------------
+function mkConsolidateClusterStore() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em653-consolidate-'))
+  const proj = path.join(root, 'proj')
+  fs.mkdirSync(proj)
+  const summary = 'duplicate cluster candidate alpha beta gamma delta epsilon'
+  const a = spawnSync(process.execPath, [
+    path.join(SCRIPTS, 'em-store.mjs'), '--project', 'p651', '--category', 'decision',
+    '--tags', 'foo', '--summary', summary, '--body', 'body one detail', '--scope', 'local',
+  ], { cwd: proj, encoding: 'utf8', env: { ...process.env, HOME: root, USERPROFILE: root } })
+  assert(a.status === 0, `seed member A failed: ${a.stderr}`)
+  const b = spawnSync(process.execPath, [
+    path.join(SCRIPTS, 'em-store.mjs'), '--project', 'p651', '--category', 'decision',
+    '--tags', 'bar', '--summary', summary, '--body', 'body two detail', '--scope', 'local',
+  ], { cwd: proj, encoding: 'utf8', env: { ...process.env, HOME: root, USERPROFILE: root } })
+  assert(b.status === 0, `seed member B failed: ${b.stderr}`)
+  return { root, proj, localDir: path.join(proj, '.episodic-memory') }
+}
+for (const { name: fileLabel, file } of [{ name: 'tags.json', file: 'tags.json' }, { name: 'category-index.json', file: 'category-index.json' }]) {
+  const name = `FIX-F: em-consolidate --apply x FIFO ${fileLabel} (digest write) -> typed protection-abort, no hang`
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkConsolidateClusterStore()
+      try {
+        const sidecarFile = path.join(world.localDir, file)
+        fs.rmSync(sidecarFile, { force: true })
+        const mk = spawnSync('mkfifo', [sidecarFile])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-consolidate.mjs'), ['--scope', 'local', '--min-cluster', '2', '--apply', '--confirm'], { cwd: world.proj, home: world.root })
+        restoreShape('fifo', sidecarFile, world.localDir)
+        assert(r.signal === null, `em-consolidate: no signal (timeout/kill), got ${r.signal}`)
+        assert(r.status === 1, `em-consolidate: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error' && j.mode === 'consolidate-apply', `em-consolidate: typed protection-abort envelope, got ${r.stdout}`)
+        assert(j.code === 'protection-abort:protection', `em-consolidate: code protection-abort:protection, got ${JSON.stringify(j)}`)
+        assert(r.stdout.includes(sidecarFile), `em-consolidate: names ${fileLabel} by path, got ${r.stdout.slice(0, 300)}`)
       } finally {
         try { fs.rmSync(world.root, { recursive: true, force: true }) } catch {}
       }

--- a/tests/test-activation-write.mjs
+++ b/tests/test-activation-write.mjs
@@ -364,18 +364,32 @@ t('testNoCollisionNoReport', () => {
   assert.ok(!/collision:/.test(b.stderr), 'disjoint triggers -> no report');
 });
 
-t('testCollisionWriteProceeds', () => {
-  // EC13: the collision READ fails (index.jsonl write-only -> the lazy build
-  // cannot read it) -> NO report, write proceeds, exit unchanged, stdout normal.
+t('testUnreadableIndexAbortsWriteTyped', () => {
+  // EC13 (superseded by issue #653): a write-only (0o200) index.jsonl used
+  // to make ONLY the lazy collision-report read fail (silently, best-effort)
+  // while the write itself "proceeded" — because em-store's OWN prior-index
+  // read (for the atomic index replace) ALSO silently swallowed that same
+  // EACCES into an empty prior-content fallback, which in fact meant the
+  // write would have truncated index.jsonl down to just the new row,
+  // destroying every existing entry (a real bug, not a feature). Issue #653
+  // closes that swallow: em-store's prior-index read is now fd-based
+  // (openReadableIndex) and a read failure throws typed instead of
+  // degrading to "" — so this same fixture now correctly ABORTS the whole
+  // write before anything is touched, rather than silently proceeding.
   const { cwd, home } = mkStore();
   run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
   const idxPath = path.join(storeDir(cwd), 'index.jsonl');
-  fs.chmodSync(idxPath, 0o200); // append still works; reads fail
+  const beforeIndex = fs.readFileSync(idxPath, 'utf8');
+  fs.chmodSync(idxPath, 0o200); // append still worked pre-#653; reads always failed
   try {
     const b = run(EM_STORE, [...LESSON, '--trigger', 'shared phrase'], { cwd, home });
-    assert.equal(b.code, 0, `write proceeds when the collision read fails: ${b.stdout}`);
-    assert.equal(b.json.status, 'ok');
-    assert.ok(!/collision:/.test(b.stderr), 'unreadable index -> no report, never fatal');
+    assert.equal(b.code, 1, `unreadable index.jsonl aborts the write typed: ${b.stdout}`);
+    assert.equal(b.json.status, 'error');
+    assert.match(b.json.message, /episode index unreadable \(EACCES\)/);
+    assert.equal(b.json.code, 'index-unreadable:EACCES');
+    assert.ok(!/collision:/.test(b.stderr), 'aborted before the write — no collision report either');
+    fs.chmodSync(idxPath, 0o644);
+    assert.equal(fs.readFileSync(idxPath, 'utf8'), beforeIndex, 'index.jsonl byte-unchanged — zero partial state');
   } finally {
     fs.chmodSync(idxPath, 0o644);
   }

--- a/tests/test-store-write-concurrency.mjs
+++ b/tests/test-store-write-concurrency.mjs
@@ -1228,23 +1228,41 @@ async function testReviseCrossScopeStaleOriginalSnapshotDrift() {
   const otherStoreDir = canonical[1]
   const markerFile = path.join(fixture.root, 'prelock-marker')
 
-  // CJS preload: intercept the first fs.readFileSync of the successor-store
-  // index (dataDir), write a marker, and patch the builtin ESM exports so
-  // the em-revise ESM import sees the wrapped function.
+  // CJS preload: intercept the first read of the successor-store index
+  // (dataDir), write a marker, and patch the builtin ESM exports so the
+  // em-revise ESM import sees the wrapped functions.
+  //
+  // #653: em-revise's pre-lock snapshot now reads index.jsonl via the
+  // fd-based openReadableIndex (scripts/lib/index-state.mjs) — ONE
+  // openSync(path) + fstat + readFileSync(fd), never a path-based
+  // readFileSync(path) — closing the exact D1 TOCTOU window this test
+  // injects a race into. The marker must therefore fire on the openSync
+  // syscall boundary (args[0] === targetIndex, a path string), not on
+  // readFileSync (which the new code calls with a numeric fd, never
+  // matching a path-string comparison). Both are intercepted for
+  // resilience against either read shape.
   const preloadPath = path.join(fixture.root, 'snapshot-drift-preload.cjs')
   fs.writeFileSync(preloadPath, `
     const fs = require('fs');
     const moduleObj = require('module');
     const origReadFileSync = fs.readFileSync;
+    const origOpenSync = fs.openSync;
     const markerFile = ${JSON.stringify(markerFile)};
     const targetIndex = ${JSON.stringify(path.join(dataDir, 'index.jsonl'))};
     let marked = false;
+    function markOnce() {
+      if (marked) return;
+      fs.writeFileSync(markerFile, 'prelock-complete');
+      marked = true;
+    }
     fs.readFileSync = function (...args) {
       const result = origReadFileSync.apply(fs, args);
-      if (!marked && args[0] === targetIndex) {
-        fs.writeFileSync(markerFile, 'prelock-complete');
-        marked = true;
-      }
+      if (args[0] === targetIndex) markOnce();
+      return result;
+    };
+    fs.openSync = function (...args) {
+      const result = origOpenSync.apply(fs, args);
+      if (args[0] === targetIndex) markOnce();
       return result;
     };
     moduleObj.syncBuiltinESMExports();


### PR DESCRIPTION
Fixes #649, fixes #653.

## What shipped

**#649 — the contract (premise corrected).** The issue's raw-crash premise was stale: PR #652 already guarded all 8 read/diagnostic tools (probe-verified this arc). The remaining deliverable was the contract itself, now bound in `docs/EM_SCRIPTS_GUIDE.md`:
- **Family A**: `{"status":"error","code":"index-unreadable:<CODE>","message":"<tool>: <file role> unreadable (<CODE>) (<path>)"}`, exit 1, never a stack. `code` added at every Family-A emission site across 22 scripts — **additive** (messages byte-frozen; consumers probe-verified tolerant; no exact-key pins in tests/ or schemas/).
- **Family C**: em-doctor never aborts; `summary`+`checks[]` always present (`install-wizard` load-bearing); shape-unreadable rows carry `code`; unreadable registry now a **warn** row instead of masquerading as healthy.
- Advisory-degrade rule (sidecars/registry: degrade, never hang, never abort), writer preflight rule (zero partial state), fd-snapshot semantics, and the #628 P5 em-promote row documented as design.

**#653 D1 — fd-based classification.** New `openReadableIndex` in `lib/index-state.mjs`: one `openSync(O_RDONLY|O_NONBLOCK)` + `fstatSync(fd)` + read from the **same fd** — no second syscall for a regular→FIFO swap to land between. ENOENT 3-way delegation (+ retry-once), try/finally single-close. `readIndexFileOrThrow` aliases it → D1 closed for ~20 transitive callers.

**Static FIFO-hang class closure** (orchestrator probes found these hang on base with NO race): read-tool sidecar loaders, em-store/em-revise (writer preflights + in-lock fd reads + explicit lock release in the abort catch — `process.exit` in a `catch` skips the paired `finally`, repro-proven), em-pin, `activation.mjs` linkage merge, em-trigger-index build/cache/merge reads (post-durable-write path degrades with a `warning` on the success payload — never misreports a committed write), em-consolidate clerk-apply digest loop, em-rebuild-index + store-identity episode scans. Vendored copies: 3 upgraded, 3 gained the classifier fresh (vendored em-store hung on a FIFO index pre-fix). Plugin 0.2.7 → 0.2.8.

## Process + review

Playbook-v15 arc: 2 scouts → negative-scenario plan audit (HOLD → 9 findings, all dispositioned in `docs/plans/fix-649-653.md` §7) → frozen spec → builder → **2-lens frozen-diff review** (claude-subagent via second-opinion harness + kimi-k3 via pi; codex CLI dead, GLM down) → 8-fix convergent round → independent orchestrator verification.

Both lenses: **ACCEPT-WITH-FINDINGS**, all three builder spec-deviations adjudicated ACCEPT with runtime proof. **Convergent highlight**: both lenses independently ran the same release-deletion mutation and both saw it survive — the original F6 test leg swapped the FIFO before spawning em-store, so it only re-tested the preflight. The reordered leg now kills that mutant (144/145 under mutation). Both lenses restored byte-identical to the frozen diff SHA (`af09a0dc…`), proofs in their reports.

## Verification

- `tests/test-651-index-existence.mjs` **150/150** (4 win32/root skips). Falsifiability: 24 legs fail on unpatched base (SIGTERM on every FIFO leg; vendored em-rebuild-index pre-fix silently **overwrote** the FIFO with status 0).
- Full battery green: ci-suite-registration 16/16, em-search-read 18/18, em-help-flags 32/32, trigger-index-playbooks 32/32, activation-match 84/84, validate-schemas 40/40 (floor 23), contract-mirror-009 5/5, rfc-015 29/29, history-walk 7/7, materialize 7/7, activation-log-schema 5/5, store-write-concurrency 46/46, activation-write 22/22.
- Orchestrator re-probes of every pre-fix hang: all now resolve in ~50 ms with correct typed envelopes/degrade + zero partial state. Real-store read-only smoke unchanged.
- Two pre-existing test rewrites adjudicated by both lenses: the old activation-write leg pinned **silent index truncation** (0o200 index → whole index rewritten to one row on base — probe-proven); the concurrency suite's path-string interception could never see fd reads (interception moved to the `openSync` boundary).

## DEFERs (re-affirmed / new)

- **D2 (new, 5-field in plan §4)**: episode-body FIFO reads in query paths (em-search `--full`/`--materialize`, em-recall, em-graph, em-revise body reads) — advisory display surface, same trust domain as #628 DEFER-1; the remediation path (em-rebuild-index) IS fixed here. Follow-up issue filed and linked below. Also carries: vendored em-revise TOCTOU raw-throw, em-restore `stack` field tension, em-rebuild-index `--check` silent skip, `relevance.mjs:204` + `bp001-advisory.mjs:70` TOCTOU-only notes.
- em-promote `:668/:686/:810` raw TOCTOU sites — #628 DEFER-1 accepted trust domain, unchanged.
- em-promote unregistered-cwd-local (#628 P5) — pre-existing design, now documented in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)