### PR TITLE
FIX-666/667: safe-body-read class pass + em-store write-leg typed envelopes (fixes #666, fixes #667)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/docs/EM_SCRIPTS_GUIDE.md
+++ b/docs/EM_SCRIPTS_GUIDE.md
@@ -145,6 +145,31 @@ default.
    in `docs/plans/fix-649-653.md` (as `docs/plans/issue-651-index-existence-contract.md`
    bound the original #651 classification table).
 
+   Body/write-block envelope families (issues #666, #667): three additive
+   `code` families beside `index-unreadable:<CODE>` above, same envelope
+   shape (`{"status":"error","message":"...","code":"<family>:<CODE>"}`,
+   exit 1, stdout-only, never a raw stack). `episode-unreadable:<CODE>` — an
+   AUTHORITATIVE single-target episode-body read (`em-search --read`,
+   `em-revise`'s category-inherit preflight and in-lock supersede rewrite)
+   found the body unreadable or absent; message `"<tool>: episode body
+   unreadable (<CODE>) (<path>)"` (`<tool>` is `em-search` or `em-revise` —
+   the message is NOT byte-frozen the way `index-unreadable`'s is, since
+   both emitters prefix their own tool name). Query-tier per-row body reads
+   (`em-search`, `em-graph`, `em-semantic`, `em-embed`) never abort this way
+   — an unreadable body is skipped with a warning (absent bodies stay
+   silent, matching the existing dangling-row convention) and the
+   row/episode is simply excluded from that field. `episode-write-failed:<CODE>`
+   — `em-store` hit a raw filesystem error on one of its four write legs
+   (`index-commit`, `episodes-dir`, `episode-file`, `derived-index`) after
+   its lock was already held; message names the failing leg: `"em-store:
+   episode write failed (<CODE>) at <leg> (<path>)"`; the lock is released
+   explicitly before exiting, exactly like the `index-unreadable` in-lock
+   branch above. `store-lock-failed:<CODE>` — `em-store` could not even
+   ACQUIRE its store-write lock in the first place (e.g. an EACCES data
+   directory); message `"em-store: lock acquire failed (<CODE>) (<path>)"`.
+   There is no lock to release on this path — the failure happens before
+   `acquireStoreWriteLocksSync` ever returns a handle.
+
 ---
 
 ## Read-only manifest (checkpoint-gate integration, E4)

--- a/docs/plans/fix-666-667.md
+++ b/docs/plans/fix-666-667.md
@@ -1,0 +1,287 @@
+# Plan: fix #666 (episode-body FIFO reads in query paths) + #667 (em-store write-leg typed envelopes)
+
+Status: **FROZEN** 2026-08-11. Audit round 1 HOLD (ep
+`20260811-002135-hold-5-small-edits-fix-666-667-plan-audi-727b`) → all
+findings dispositioned (§8) → round 2 delta re-walk PROCEED-TO-FREEZE (ep
+`20260811-002854-proceed-to-freeze-round-2-delta-fix-666--46aa`) with three
+editorial amendments, folded. Builder implements THIS text; deviations are
+flagged, never improvised.
+Arc: playbook-v15 gate-free run, 2026-08-11. Scout evidence: 2× Sonnet seats, all
+file:line claims ground-truthed by orchestrator; runtime probes on isolated
+fixture stores (exit 142 = SIGALRM = hang confirmed).
+
+## 0. Evidence-corrected scope
+
+Scout findings that reshape the issues as filed:
+
+- **#666 premise correction**: em-recall reads NO episode bodies (only
+  `index.jsonl` rows + JSON config; runtime-confirmed no-hang against a
+  FIFO-shaped episode). It leaves the named set. em-revise has THREE raw
+  original-body reads (`em-revise.mjs:211`, `:387`, `:495`), not two.
+- **Class is larger than filed**: em-semantic `--full` (`em-semantic.mjs:218`)
+  and em-embed (`lib/embeddings.mjs:185`) are runtime-confirmed hangs; a
+  curation/audit tier (em-consolidate, em-promote, em-move, em-pin, em-backup,
+  em-restore, em-review-request, em-workflow-validate, topic-tracks/engine) has
+  the same static shape; the BP-1 subsystem reads the same `episodes/` dir via
+  independent code (runtime-confirmed hang in `lib/bp1-atomic.mjs:115`); the
+  vendored `plugins/episodic-memory/scripts/` fork hangs too (em-revise `:184`,
+  em-search `--full`). This slice fixes the QUERY tier + em-revise + one
+  static SessionStart exposure; the rest is DEFERRED with follow-up issues (§4).
+- **Worse than filed**: `lib/bp001-advisory.mjs:70` (`loadActiveEntries`) is a
+  **static** hang (not TOCTOU-only) on the SessionStart hook path
+  (`enforce-contract.mjs:475`) — first-and-only touch of `index.jsonl` in its
+  call chain, no `index-state.mjs` import, `try/catch` cannot stop a block.
+- **#667 class-completion**: four raw-throw sites in canonical `em-store.mjs`,
+  not one: lock-acquire `:371` (BEFORE the try at `:379`; `lib/lock.mjs:28`
+  rethrows non-EEXIST), index-commit `:544`, `mkdirSync` `:551`, episode-commit
+  `:554` (via `store-write-lock.mjs:259`). EEXIST and EACCES shapes
+  runtime-confirmed raw. Lock is NOT leaked on raw throw (finally works —
+  probe-confirmed); the dangling-index-row fail shape is BY DESIGN and MUST NOT
+  change.
+
+## 1. Slice S1 — shared safe-body-read helper (`scripts/lib/index-state.mjs`)
+
+Two new exports beside the proven fd-based primitives (same
+open(O_RDONLY|O_NONBLOCK) + fstat(fd) + read(fd) pattern as
+`openReadableIndex`, which `store-identity.mjs:114` already proves generic):
+
+- `readBodyOrSkip(fsMod, filePath)` → `{ ok: true, raw }` |
+  `{ ok: false, code }` — never throws, never blocks. For per-row iteration in
+  query tools and advisory reads. `absent` and `unreadable` both map to
+  `ok:false` with the classify code (`ENOENT` | `EISDIR` | `ENOTREG` | …);
+  the CALLER decides warn-vs-silent per code (§2 F5 rule).
+- `openReadableBody(fsMod, filePath)` → raw string | **null on absent**
+  (mirrors `openReadableIndex`'s absent contract), throws
+  `BodyUnreadableError` on unreadable (new class, fields `.code`/`.file`,
+  message `"episode body unreadable (<CODE>) (<path>)"`). For single-target
+  reads where the caller asked for THAT episode. Callers MUST handle the null
+  return explicitly (per-site mapping in §2/§3). Wire code convention:
+  `episode-unreadable:<CODE>` (mirrors `index-unreadable:<CODE>`;
+  `roleForFile`'s basename map does not generalize to `<id>.md`, so the body
+  family carries its own message text, no role lookup).
+
+→ verify: unit legs in `tests/test-651-index-existence.mjs` (mkfifo tooling
+already there): FIFO/dir/absent shapes for both helpers, no hang under alarm.
+
+## 2. Slice S2 — query-tier adoption (per-row skip + warning; single-target typed)
+
+| Tool | Sites | Behavior after fix |
+|---|---|---|
+| em-search | `:166` (materializeChain), `:452` (history --full), `:583`/`:621` (scoring), `:712` (--full) | per-row `readBodyOrSkip`; on non-regular skip, row emitted WITHOUT body + entry appended to the existing joined `result.warning` shape (`em-search.mjs:727-735` convention) |
+| em-search `--read <id>` | `:261` **AND `:335` — audit F1: the file is read TWICE today; read ONCE at `:261` via `openReadableBody` and reuse that content for the body extraction at `:335` (second read deleted — closing the same classify-then-read TOCTOU S6 closes in store-identity)** | single-target: unreadable → typed error envelope `{status:'error', code:'episode-unreadable:<CODE>'}`, exit 1; **null (absent) → the existing load-bearing `body_missing` exit-0 path (`em-search.mjs:326-333`) UNCHANGED** |
+| em-graph | `:211` (bodyCitations), `:236` (ruleBody) | per-row skip + warning in em-graph's existing diagnostics shape; a skipped body contributes zero cites edges |
+| em-semantic | `:218` | per-row skip + same warning convention as em-search |
+| em-embed | `lib/embeddings.mjs:185` | per-row skip + warning; skipped episode gets no embedding row (re-embeddable after heal) |
+
+Warning-shape unification across the three existing conventions is OUT of
+scope (D-4): each tool keeps its own established shape.
+
+**F5 rule (per-code disposition, all S2 sites):** non-ENOENT codes (`EISDIR`,
+`ENOTREG`, `EACCES`, …) → skip + warning, message
+`"episode body skipped <id>: unreadable (<CODE>)"` (or the tool's
+diagnostics equivalent — round-2 amendment (c): an EACCES body IS a regular
+file, so "not a regular file" wording is forbidden here too). `ENOENT` (absent/dangling row) → **preserve each
+site's current behavior exactly** — `:583`/`:712` swallow silently today and
+stay silent (a dangling-row store must not start spamming warnings on every
+search); `--read` keeps its `body_missing` contract. "not a regular file
+(ENOENT)" wording is forbidden — absent is not a shape defect.
+
+→ verify: fixture probes (FIFO episode; alarm wrapper): each tool exits 0 with
+warning + skip where specified, typed abort for `--read`; healthy-store control
+unchanged output.
+
+## 3. Slice S3 — em-revise writer guard + S4 bp001 + S5 em-store envelopes + S6 carried P3s
+
+**S3 em-revise** — audit F2: the three reads are ROLE-DIVERGENT; a uniform
+typed abort would false-reject. Per-site semantics:
+
+| Site | Role | Fix |
+|---|---|---|
+| `:211` (category-inherit preflight, pre-lock) | authoritative | `openReadableBody`; unreadable → typed abort `episode-unreadable:<CODE>` exit 1; null (absent) → typed abort `episode-unreadable:ENOENT` (today: raw ENOENT crash — envelope is additive) |
+| `:387` (`snapshotOriginalState`) | **advisory** TOCTOU snapshot (`catch { null }` today, feeds the pre/in-lock stability comparison at `:431`/`:467`) | `readBodyOrSkip`; ANY `ok:false` → `fileStatus = null` — degrade semantics preserved exactly, NO abort. A FIFO original cannot reach a write through this path: `:211` gates before it, `:495` gates after |
+| `:495` (in-lock supersede rewrite) | authoritative | `openReadableBody`; unreadable throws `BodyUnreadableError` into the existing catch → typed envelope + explicit lock release + exit 1 (extend the catch's typed branch to cover `BodyUnreadableError` beside `IndexUnreadableError`); null (absent) → same typed abort as `:211` |
+
+Round-2 note on `:495` reachability: the `:387`-degrade + stability gate
+(`fileAndIndexAgree`, `em-revise.mjs:475-489`) aborts `stale-original` with
+ZERO writes for every black-box-constructible swap timing; the `:495`
+`BodyUnreadableError` branch is the residual-window backstop
+(`:467`→`:495` only) — mirror of em-store's in-lock `IndexUnreadableError`
+branch. **Accepted-TOCTOU backstop: NO race test attempted** (reachable-by-race
+is not the F4 unreachable class; a race test would be flaky by construction).
+
+**S4 bp001-advisory** (`lib/bp001-advisory.mjs:70`): replace raw
+`fs.readFileSync(indexFile)` with `readSidecarOrDegrade` (existing helper:
+fd-based, absent/unreadable → null) → `continue`. Advisory degrades, never
+blocks SessionStart.
+
+**S5 em-store write-block envelope class** (canonical `scripts/em-store.mjs`
+ONLY; vendored fork untouched → D-3):
+
+1. Lock-acquire `:371`: wrap in try/catch → fs errors (F3 predicate below)
+   emit `{status:'error', message, code:'store-lock-failed:<CODE>'}`,
+   exit 1. (`ok:false` typed path at `:372-376` unchanged.)
+2. Extend the catch at `:629`: after the `IndexUnreadableError` branch, add an
+   fs-error branch — **F3 predicate, pinned:
+   `typeof e.errno === 'number' && typeof e.code === 'string'`** (real fs
+   errors carry numeric `.errno`; `ERR_INVALID_ARG_TYPE`-class programming
+   errors have string `.code` but `errno: undefined` and must keep the raw
+   stack; `IndexUnreadableError` has no `.errno`, so the predicate excludes it
+   order-independently) — **and F4 leg-sentinel gate: `let leg = null`,
+   assigned immediately before each write leg
+   (`index-commit` | `episodes-dir` | `episode-file` | `derived-index`),
+   branch fires only when `leg !== null`; anything else rethrows bare.** Emit
+   `{status:'error', message:'em-store: episode write failed (<CODE>) at <leg> (<path>)', code:'episode-write-failed:<CODE>'}`,
+   release locks explicitly (process.exit skips finally — same discipline as
+   the existing branch), exit 1. Naming precedent: `<verb>-failed:<CODE>`
+   (`bp1-marker-validate.mjs:160,177`).
+3. Non-errno errors (programming bugs) keep the bare rethrow — raw stack
+   stays CORRECT for genuine bugs.
+4. ~~Pre-lock preflight `store-preflight-failed`~~ **DROPPED (audit F4): the
+   branch is unreachable — `classifyIndexFile` wraps every lstat/stat errno
+   into `IndexUnreadableError` (`index-state.mjs:32-79`), so no test could
+   ever exercise it (vacuous by the #665-F6 standard). The existing bare
+   rethrow at `:363` stays.**
+5. INVARIANTS: dangling-index-row fail shape unchanged (no rollback); write
+   order unchanged; lock-release discipline unchanged; success payload
+   unchanged; stdout-only envelopes (`console.log`), never stderr.
+
+**S6 carried P3s (from #666 body, in-slice because trivial and same family):**
+- `em-restore.mjs:2632`: drop the `stack` field from the error payload (keeps
+  `message` + conditional `code`) — Family A "never a stack".
+- `em-rebuild-index.mjs:94-98` (`--check`): emit a `warnings` array entry for
+  each skipped non-regular episode file (same string convention as the rebuild
+  path `:238-243`); drift semantics unchanged. **F6b: this deliberately
+  SUPERSEDES #653 F1c's "drift only, no warnings field" decision (comment at
+  `em-rebuild-index.mjs:92-94`) — update that comment to name #666 as the
+  superseding decision.**
+- `lib/store-identity.mjs:108-114`: close the classify-then-read TOCTOU window
+  by switching the episode read to the fd-based helper (skip-on-unreadable
+  behavior unchanged).
+- **F6a: add doc rows to `docs/EM_SCRIPTS_GUIDE.md` (beside the
+  `index-unreadable:<CODE>` row at `:102`) for the three new code families:
+  `episode-unreadable:<CODE>`, `episode-write-failed:<CODE>`,
+  `store-lock-failed:<CODE>`.**
+
+## 4. Exclusions / DEFERs (5-field)
+
+- **D-1 curation/audit tier** (em-consolidate ×6, em-promote ×6, em-move ×2,
+  em-pin, em-backup ×3, em-restore restore-import `:595`,
+  em-review-request ×2, em-workflow-validate ×3, topic-tracks/engine `:245`).
+  what: same static hang shape on body reads. why deferrable: operator-invoked
+  curation surfaces, not query/session paths; adversarial-local trust domain
+  (same acceptance as #628 DEFER-1/#653 D1). risk: hang in a curation run;
+  recovery = remove FIFO + rebuild. trigger: any curation-hang report, or
+  scheduling of the follow-up. owner: follow-up issue (filed at #E).
+- **D-2 BP-1 subsystem** (`bp1-orchestrator.mjs:607,:721`,
+  `lib/bp1-atomic.mjs:115` (probe-confirmed), `lib/bp1-episode-verify.mjs:85`,
+  `bp1-crash-classify.mjs:466`, `lib/bp1-manifest.mjs:549`). what: independent
+  reader of the same `episodes/` dir, never imports index-state. why
+  deferrable: separate subsystem with its own HMAC/verify semantics — adopting
+  the helper needs BP-1-aware review, wrong to rush inside this slice. risk:
+  BP-1 run hangs; same trust domain. trigger: BP-1 hang report or follow-up
+  scheduling. owner: follow-up issue (filed at #E).
+- **D-3 vendored plugin fork** (`plugins/episodic-memory/scripts/`: em-revise
+  `:184` + em-search `--full` probe-confirmed hangs; em-revise `:192`
+  post-preflight TOCTOU raw-throw (P3-i HOLDS); em-store PRE-DEFER-3
+  episode-first write order (orphan-producing on mid-write failure), no lock,
+  bare write block). what: the fork is a self-contained old snapshot missing
+  DEFER-3/#546/#667 classes wholesale. why deferrable: piecemeal patching a
+  stale fork entrenches drift — it needs a regenerate-or-retire decision
+  (operator-level, per CAPABILITIES/consumer-sync discipline). risk: plugin
+  consumers hit orphan/hang shapes canonical scripts no longer have. trigger:
+  operator decision on fork strategy. owner: follow-up issue (filed at #E)
+  flagging the regenerate-vs-retire question explicitly.
+- **D-4 warning-shape unification** (three live conventions: rebuild string
+  array / search joined string / recall typed objects). why deferrable: cosmetic
+  contract churn across many consumers; not needed for the hang fix. trigger:
+  next contract-shaping RFC. owner: noted here, no issue.
+- **D-5 relevance.mjs:204 writeBackAccessTracking** — TOCTOU-only (guarded
+  loadIndex precedes it in every invocation; Scout A confirmed). Accepted, same
+  trust-domain rationale; name-checked so it is not rediscovered.
+
+## 5. Tests (into EXISTING registered suites only — no new files, no .github edits)
+
+- `tests/test-651-index-existence.mjs`:
+  - helper unit legs (S1): FIFO/dir/absent × both helpers.
+  - T8d: EEXIST episode-leg → `lastJson(stdout)` asserts
+    `status:'error'` + `code:'episode-write-failed:EEXIST'` + leg name in
+    message + **explicit `r.status !== 0` assert (audit Q6: kills the
+    "envelope + exit 0" mutation; T8b precedent `:712-713`)** + existing T8b
+    side-effect invariants re-checked (dangling row, no orphan, derived JSONs
+    untouched). T8b itself UNTOUCHED.
+  - T8e: EACCES episode-leg (chmod 0000 episodes/) →
+    `episode-write-failed:EACCES` + `r.status !== 0` + **`IS_ROOT` skip
+    (suite's existing convention at `:39` — root bypasses permission checks
+    on CI edge cases)**.
+  - T8f: lock-acquire EACCES (chmod 0555 data dir) →
+    `store-lock-failed:EACCES`, index byte-unchanged, `r.status !== 0`,
+    `IS_ROOT` skip.
+  - em-revise typed-abort leg (FIFO original → `episode-unreadable:<CODE>`,
+    no supersede written, no lock leak: follow-up healthy revise succeeds).
+  - `--check` warnings leg (P3-iii): FIFO episode → warnings entry present,
+    drift semantics unchanged.
+- `tests/test-em-search-read.mjs`: `--read` FIFO → typed abort; `--full` query
+  with FIFO row → exit 0 + skip + warning; `--materialize` chain with FIFO
+  member → skip + warning; healthy controls.
+- `tests/test-em-graph.mjs`: `--hubs` with FIFO episode → exit 0, zero cites
+  from skipped body, diagnostics entry; healthy control.
+- em-semantic/em-embed legs: into `tests/test-em-stats-semantic.mjs` (the
+  registered semantic suite) — FIFO row → skip + warning, no hang.
+- All new legs alarm-wrapped where a regression would hang (suite must fail,
+  not freeze, on regression). Platform note: tests must use Node child spawn
+  timeouts (`spawnSync` `timeout` option), NOT the `timeout` binary (absent on
+  macOS).
+
+## 6. Verification (run at #E, all against fixture stores + full suites)
+
+```
+node tests/test-651-index-existence.mjs        # all legs incl. new
+node tests/test-em-search-read.mjs
+node tests/test-em-graph.mjs
+node tests/test-em-stats-semantic.mjs
+node tests/test-store-write-concurrency.mjs    # lock discipline unregressed
+node tests/test-plugin-version-bump.mjs
+node scripts/check-plugin-version-bump.mjs --project .   # expects bump ok
+```
+Plus live probes replicating scout probes (a)–(f): FIFO fixture per tool,
+alarm-wrapped, cited JSON in the PR body. Gate #644: `plugin.json` 0.2.8 →
+0.2.9 in the same diff.
+
+## 7. Constraints (write-back content screen + arc discipline)
+
+- NO `.github/` edits. NO new `tests/test-*` files. Builder makes NO commits.
+- Vendored `plugins/` fork NOT touched (D-3) — keeps the diff out of the
+  fork-drift question entirely; `plugins/` content is untouched so the #644
+  bump is driven by `scripts/` changes alone.
+- Episode IDs immutable; no store-format changes; success payloads unchanged.
+- Builder flags any spec deviation, never improvises.
+
+## 8. Negative-scenario audit round 1 — dispositions (HOLD → revised)
+
+Audit episode: `20260811-002135-hold-5-small-edits-fix-666-667-plan-audi-727b`.
+All file:line claims re-ground-truthed by orchestrator before acceptance.
+
+| Finding | Class | Disposition | Where applied |
+|---|---|---|---|
+| F1 `--read` double-read (`:261`+`:335`) | GAP-MAJOR | ACCEPT (source-confirmed: two `readFileSync` calls, `body_missing` path between them) | §2 `--read` row |
+| F2 em-revise `:387` role-divergent | GAP-MAJOR | ACCEPT (source-confirmed: `catch { /* missing file → null status */ }` advisory snapshot) | §3 S3 role table |
+| F3 errno predicate underspecified | GAP-MINOR | ACCEPT | §3 S5.2 |
+| F4 `store-preflight-failed` unreachable + leg sentinel | GAP-MINOR | ACCEPT (branch dropped entirely — untestable code fails the #665-F6 vacuous standard) | §3 S5.2/S5.4 |
+| F5 ENOENT wording/noise | GAP-MINOR | ACCEPT-WITH-MOD: per-site ENOENT behavior preserved exactly rather than a new uniform rule — the surgical option | §2 F5 rule |
+| F6 doc rows + F1c supersession | GAP-MINOR | ACCEPT | §3 S6 F6a/F6b |
+| Q6 `status !== 0` + IS_ROOT | GAP-MINOR | ACCEPT | §5 T8d/e/f |
+| D-1..D-5 | — | Auditor ACCEPTed all five DEFERs as justified | §4 |
+
+### New surfaces introduced by the fixes (audit #17 matrix)
+
+| New surface | Scope | Persistence / terminal state | Cross-process | Rollback | Negative test |
+|---|---|---|---|---|---|
+| `openReadableBody` null-on-absent return | 2 callers (em-search `--read`, em-revise `:211`/`:495`); compile-time surface only | none (pure read) | none | n/a | absent-file legs per caller (§5): `--read` absent → `body_missing` exit 0; revise absent → `episode-unreadable:ENOENT` exit 1 |
+| `readBodyOrSkip` (round-2 (a): the widest surface — em-search per-row ×4 regions, em-graph ×2, em-semantic, embeddings, em-revise `:387`) | 5 tools + 1 advisory site | none (pure read) | none | n/a | §1 unit legs (FIFO/dir/absent), §2 per-tool FIFO probes, §2 ENOENT-silence dangling-row control |
+| `BodyUnreadableError` class | thrown only by `openReadableBody`; caught by named per-site handlers | none | none | n/a | FIFO legs assert typed envelope, not raw stack |
+| `leg` sentinel in em-store | single function-scope `let` in a run-once script; reset per process; no state file | none | none — process-local | n/a | T8f asserts `store-lock-failed` (leg never set → lock branch, not write branch); T8d/e assert leg name in message |
+| Three new `code` families | stdout wire contract, additive (no existing field changes) | documented in EM_SCRIPTS_GUIDE (F6a) | consumers parse stdout JSON — additive field on paths that today hang or crash raw, so no consumer regression possible | revert = restore raw behavior | envelope-shape asserts in every new leg |
+| Per-code skip-warning strings | joined into existing per-tool warning shapes | none | none | n/a | FIFO legs assert warning presence; dangling-row control asserts ENOENT silence at `:583`/`:712` |
+
+No `--project`-flag or subprocess-shell-out surface introduced (audit #20: no
+cwd fixture required).

--- a/scripts/em-embed.mjs
+++ b/scripts/em-embed.mjs
@@ -85,8 +85,18 @@ function embedDir(dataDir, label) {
 
   const keep = new Map()
   const todo = []
+  const warnings = []
   for (const row of rows) {
-    const text = episodeEmbedText(row, dataDir)
+    // #666 S2 lib/embeddings.mjs:185: a body-read skip (non-ENOENT — F5)
+    // means episodeEmbedText could not compute a trustworthy content hash;
+    // skip the WHOLE episode this run (no keep, no todo) rather than
+    // embedding from impoverished text. No row for this id until the shape
+    // heals and a re-run picks it back up.
+    const { text, skipped, skipCode } = episodeEmbedText(row, dataDir)
+    if (skipped) {
+      warnings.push(`episode body skipped ${row.id}: unreadable (${skipCode})`)
+      continue
+    }
     const h = contentHash(text)
     const prior = existing.rows.get(row.id)
     if (prior && prior.h === h && prior.model === model) {
@@ -112,9 +122,16 @@ function embedDir(dataDir, label) {
     }
   }
 
-  if (todo.length > 0 || dropped > 0 || rebuild) writeEmbeddings(dataDir, keep)
+  // warnings.length joins the write-trigger set: a body-skip can drop a
+  // previously-embedded id from `keep` (unreadable now, was fine before) —
+  // that must be persisted even when todo/dropped/rebuild are all otherwise
+  // empty, or the sidecar would keep a stale row for a since-corrupted body.
+  if (todo.length > 0 || dropped > 0 || rebuild || warnings.length > 0) writeEmbeddings(dataDir, keep)
 
-  return { scope: label, embedded: todo.length, reused: keep.size - todo.length, dropped, total: keep.size, model }
+  return {
+    scope: label, embedded: todo.length, reused: keep.size - todo.length, dropped, total: keep.size, model,
+    ...(warnings.length ? { warnings } : {}),
+  }
 }
 
 const scopes = []

--- a/scripts/em-graph.mjs
+++ b/scripts/em-graph.mjs
@@ -46,7 +46,7 @@ import os from 'os'
 import { resolveLocalDir, resolveRepoRoot } from './lib/local-dir.mjs'
 import { loadIndex } from './lib/relevance.mjs'
 import { resolveRuleDir, scanRuleNodes, scanRfcNodes, slugify } from './lib/rule-nodes.mjs'
-import { IndexUnreadableError } from './lib/index-state.mjs'
+import { IndexUnreadableError, readBodyOrSkip } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -173,6 +173,13 @@ if (nodeTypes.includes('rfc')) {
 const nodeDiag = () => (nodesRaw === undefined ? {} : { skipped_nodes: skippedNodes })
 const danglingOut = () => (edgeTypes.some(e => RULE_EDGE_TYPES.includes(e)) ? { dangling } : {})
 
+// #666 S2: body-read skip warnings for bodyCitations/ruleBody below (F5:
+// non-ENOENT codes only — ENOENT/absent stays silent, zero cites edges from
+// that row, same as today). Spread conditionally into every output shape,
+// mirroring nodeDiag/danglingOut's additive-field convention.
+const bodyWarnings = []
+const bodyWarningsOut = () => (bodyWarnings.length ? { body_warnings: bodyWarnings } : {})
+
 // ---------------------------------------------------------------------------
 // Edge projection. adjacency: id -> [{from,to,type}] (edge listed under BOTH
 // endpoints for undirected traversal; emitted once via a key set).
@@ -207,16 +214,21 @@ const strings = v => (Array.isArray(v) ? v.filter(x => typeof x === 'string') : 
 // example ids in code samples don't fabricate lineage (RFC-007 cites rule).
 const ID_RE = /\d{8}-\d{6}-[a-z0-9-]+-[a-f0-9]{4}/g
 function bodyCitations(row, dataDir) {
-  try {
-    const content = fs.readFileSync(path.join(dataDir, 'episodes', `${row.id}.md`), 'utf8')
-    // BODY only: frontmatter ids (supersedes:, superseded_by:, consolidates:)
-    // are already first-class edges — rescanning them as cites would emit
-    // duplicate parallel edges for every chain link.
-    const parts = content.split('---')
-    const body = parts.length >= 3 ? parts.slice(2).join('---') : content
-    const cleaned = body.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '')
-    return [...new Set(cleaned.match(ID_RE) || [])].filter(id => id !== row.id && byId.has(id))
-  } catch { return [] }
+  // #666 S2 :211: readBodyOrSkip replaces the swallowing try/catch — a
+  // FIFO-shaped body skips (zero cites edges, unchanged) and, for a
+  // non-ENOENT defect, warns (F5); an absent body stays silent.
+  const r = readBodyOrSkip(fs, path.join(dataDir, 'episodes', `${row.id}.md`))
+  if (!r.ok) {
+    if (r.code !== 'ENOENT') bodyWarnings.push(`episode body skipped ${row.id}: unreadable (${r.code})`)
+    return []
+  }
+  // BODY only: frontmatter ids (supersedes:, superseded_by:, consolidates:)
+  // are already first-class edges — rescanning them as cites would emit
+  // duplicate parallel edges for every chain link.
+  const parts = r.raw.split('---')
+  const body = parts.length >= 3 ? parts.slice(2).join('---') : r.raw
+  const cleaned = body.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]*`/g, '')
+  return [...new Set(cleaned.match(ID_RE) || [])].filter(id => id !== row.id && byId.has(id))
 }
 
 // --- Phase 3: rule-body edge extraction (RFC-007 wiki-link + composes-with) ---
@@ -232,11 +244,18 @@ const stripFenced = s => s.replace(/```[\s\S]*?```/g, '').replace(/~~~[\s\S]*?~~
 const stripInline = s => s.replace(/`[^`\n]*`/g, '')
 
 function ruleBody(file) {
-  try {
-    const content = fs.readFileSync(file, 'utf8')
-    const parts = content.split('---')
-    return parts.length >= 3 ? parts.slice(2).join('---') : content
-  } catch { return '' }
+  // #666 S2 :236: readBodyOrSkip replaces the swallowing try/catch — same
+  // skip+warn contract as bodyCitations above, applied to a rule/RFC file
+  // instead of an episode body (the fd-based primitive is body-shape
+  // agnostic; only the message wording differs, since there is no episode
+  // id to name here).
+  const r = readBodyOrSkip(fs, file)
+  if (!r.ok) {
+    if (r.code !== 'ENOENT') bodyWarnings.push(`rule body skipped ${path.basename(file)}: unreadable (${r.code})`)
+    return ''
+  }
+  const parts = r.raw.split('---')
+  return parts.length >= 3 ? parts.slice(2).join('---') : r.raw
 }
 
 // Secondary index for TARGET resolution only. Node ids stay frontmatter-name
@@ -396,12 +415,12 @@ if (orphans || hubs) {
     // otherwise, so the default result set is unchanged (REQ-8).
     for (const id of ruleById.keys()) if ((degree.get(id) || 0) === 0) out.push(nodeOut(id, 0))
     for (const id of rfcById.keys()) out.push(nodeOut(id, 0))
-    console.log(JSON.stringify({ status: 'ok', mode: 'orphans', count: out.length, nodes: out, ...nodeDiag(), ...danglingOut() }))
+    console.log(JSON.stringify({ status: 'ok', mode: 'orphans', count: out.length, nodes: out, ...nodeDiag(), ...danglingOut(), ...bodyWarningsOut() }))
   } else {
     const ranked = [...degree.entries()].filter(([id, d]) => d > 0 && reportable(byId.get(id)))
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, top)
       .map(([id, d]) => ({ ...nodeOut(id, 0), degree: d }))
-    console.log(JSON.stringify({ status: 'ok', mode: 'hubs', count: ranked.length, nodes: ranked }))
+    console.log(JSON.stringify({ status: 'ok', mode: 'hubs', count: ranked.length, nodes: ranked, ...bodyWarningsOut() }))
   }
   process.exit(0)
 }
@@ -423,6 +442,7 @@ if (!byId.has(from)) {
         edges: [],
         ...nodeDiag(),
         ...danglingOut(),
+        ...bodyWarningsOut(),
       }))
       process.exit(0)
     }
@@ -482,4 +502,5 @@ console.log(JSON.stringify({
   ...(truncated ? { truncated: true } : {}),
   ...nodeDiag(),
   ...danglingOut(),
+  ...bodyWarningsOut(),
 }))

--- a/scripts/em-rebuild-index.mjs
+++ b/scripts/em-rebuild-index.mjs
@@ -79,6 +79,7 @@ if (checkMode) {
   let vocabLoaded = true
   try { loadCategories() } catch { vocabLoaded = false }
   const drift = []
+  const warnings = []
   if (vocabLoaded) {
     const dirs = []
     if (scope === 'local' || scope === 'all') dirs.push(LOCAL_DIR)
@@ -90,10 +91,19 @@ if (checkMode) {
       for (const file of files) {
         // #653 (F1c): lstat-classify before read — a FIFO-shaped episode
         // file must never hang the drift scan; a non-regular shape is not a
-        // parseable episode, so it is silently skipped (this mode reports
-        // drift only, no warnings field).
+        // parseable episode, so it is skipped. #653's original F1c decision
+        // was "drift only, no warnings field" — #666 SUPERSEDES that: a
+        // skip now surfaces via the warnings array below (same string
+        // convention as the rebuild path, :238-243), so a --check run
+        // silently losing FIFO/dir episodes to the classify gate is
+        // visible, not invisible. Drift semantics (the `drift` array + its
+        // exit-code contract) are UNCHANGED.
         const filePath = path.join(episodesDir, file)
-        if (classifyIndexFile(fs, filePath).state !== 'ok') continue
+        const shape = classifyIndexFile(fs, filePath)
+        if (shape.state !== 'ok') {
+          warnings.push(`skipped ${file}: not a regular file (${shape.state === 'unreadable' ? shape.code : 'vanished'})`)
+          continue
+        }
         let fm
         try { fm = parseFrontmatter(fs.readFileSync(filePath, 'utf8')) } catch (e) {
           console.log(JSON.stringify({ status: 'error', error: 'structured-frontmatter-invalid', field: e.field, id: e.id || null }))
@@ -109,7 +119,7 @@ if (checkMode) {
     // reader surface must never be fatal (B1): degrade to an empty, clean report + a stderr warn
     process.stderr.write('em-rebuild-index --check: categories.json unloadable; drift not classified\n')
   }
-  console.log(JSON.stringify({ status: 'ok', drift }))
+  console.log(JSON.stringify({ status: 'ok', drift, ...(warnings.length ? { warnings } : {}) }))
   process.exit(drift.length ? 1 : 0)
 }
 

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -2629,7 +2629,9 @@ try {
   // F3 (code review): if applyDocWrites partially applied before failing,
   // surface which files made it so the user has a clear inventory rather
   // than discovering the partial state via filesystem walk.
-  const errPayload = { status: 'error', message: String(e.message || e), stack: e.stack }
+  // S6 (#666 carried P3): never a stack — Family A envelope contract (keeps
+  // message + conditional code, drops the raw stack).
+  const errPayload = { status: 'error', message: String(e.message || e) }
   if (e instanceof IndexUnreadableError) errPayload.code = `index-unreadable:${e.code}`
   if (Array.isArray(e.applied_before_failure)) errPayload.applied_before_failure = e.applied_before_failure
   if (e.staging_dir) errPayload.staging_dir = e.staging_dir

--- a/scripts/em-revise.mjs
+++ b/scripts/em-revise.mjs
@@ -37,7 +37,7 @@ import { loadMergedTriggerIndex } from './em-trigger-index.mjs'
 import { episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalizePromotionSources, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { assertReadableIndex, openReadableIndex, IndexUnreadableError, unreadableMessage, roleForFile } from './lib/index-state.mjs'
+import { assertReadableIndex, openReadableIndex, IndexUnreadableError, unreadableMessage, roleForFile, readBodyOrSkip, openReadableBody, BodyUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -198,6 +198,18 @@ if (!original) {
   process.exit(1)
 }
 
+// S3 (#666): shared typed-abort emitter for em-revise's two AUTHORITATIVE
+// body reads (:211 preflight below, :495 in-lock supersede — see the role
+// table in docs/plans/fix-666-667.md §3). Absent (openReadableBody's null
+// return) gets the SAME typed abort as unreadable, built via
+// `new BodyUnreadableError(path, 'ENOENT')` even though nothing threw —
+// today this is a raw ENOENT crash (TOCTOU-only: findEpisode's existsSync
+// already confirmed the file moments earlier), so the envelope is additive.
+function abortBodyUnreadable(err) {
+  console.log(JSON.stringify({ status: 'error', message: `em-revise: ${err.message}`, code: `episode-unreadable:${err.code}` }))
+  process.exit(1)
+}
+
 // ---------------------------------------------------------------------------
 // Validate the inherited category BEFORE any write (I4 / EC6 — a rejected revise
 // must leave the store byte-unchanged; the original is marked superseded just below,
@@ -208,7 +220,16 @@ let inheritedLessons = [] // violation-side forward-links, inherited verbatim (F
 let inheritedViolatedPattern // T6 typed scalar, inherited verbatim (F3)
 let promotionSources
 {
-  const origRaw = fs.readFileSync(original.filePath, 'utf8')
+  // #666 S3 :211 — AUTHORITATIVE preflight read: openReadableBody aborts
+  // typed on unreadable; null (absent) aborts typed too (see helper above).
+  let origRaw
+  try {
+    origRaw = openReadableBody(fs, original.filePath)
+  } catch (e) {
+    if (e instanceof BodyUnreadableError) abortBodyUnreadable(e)
+    throw e
+  }
+  if (origRaw === null) abortBodyUnreadable(new BodyUnreadableError(original.filePath, 'ENOENT'))
   const fm = origRaw.match(/^---\n([\s\S]*?)\n---/)
   let cat = 'decision'
   if (fm) {
@@ -383,11 +404,15 @@ for (const dir of preflightDirs) {
 // ---------------------------------------------------------------------------
 function snapshotOriginalState(filePath, statusDir, successorDirs, id) {
   let fileStatus = null
-  try {
-    const content = fs.readFileSync(filePath, 'utf8')
-    const m = content.match(/^status:\s*(\S+)$/m)
+  // #666 S3 :387 — ADVISORY TOCTOU snapshot: readBodyOrSkip never throws, so
+  // ANY unreadable/absent shape degrades to fileStatus=null exactly like the
+  // old catch-all did. NO abort here — a FIFO original cannot reach a write
+  // through this path: :211 above gates before it, :495 below gates after.
+  const bodyRead = readBodyOrSkip(fs, filePath)
+  if (bodyRead.ok) {
+    const m = bodyRead.raw.match(/^status:\s*(\S+)$/m)
     if (m) fileStatus = m[1]
-  } catch { /* missing file → null status */ }
+  }
   let indexStatus = null
   const statusIndexPath = path.join(statusDir, 'index.jsonl')
   const statusIndexRaw = openReadableIndex(fs, statusIndexPath)
@@ -492,7 +517,13 @@ try {
   // ---------------------------------------------------------------------------
   // Mark original as superseded
   // ---------------------------------------------------------------------------
-  const currentOriginalContent = fs.readFileSync(original.filePath, 'utf8')
+  // #666 S3 :495 — AUTHORITATIVE in-lock read: openReadableBody throws
+  // BodyUnreadableError OUT of this locked try on unreadable, straight into
+  // the catch below (mirrors every openReadableIndex call in this same try —
+  // F6 discipline). null (absent) is thrown explicitly here so it reaches
+  // the SAME typed-abort branch as :211 above.
+  const currentOriginalContent = openReadableBody(fs, original.filePath)
+  if (currentOriginalContent === null) throw new BodyUnreadableError(original.filePath, 'ENOENT')
   const supersededContent = currentOriginalContent.replace(/^status: active$/m, 'status: superseded')
   atomicReplaceFileSync(original.filePath, supersededContent)
 
@@ -761,6 +792,15 @@ try {
     // "episode index unreadable" regardless of which file failed; derive
     // the role from e.file's basename instead.
     console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-revise', roleForFile(e.file), e), code: `index-unreadable:${e.code}` }))
+    releaseStoreWriteLocks(lockHandles)
+    process.exit(1)
+  }
+  // S3 (#666): the :495 in-lock supersede-rewrite branch (BodyUnreadableError,
+  // beside IndexUnreadableError above) — roleForFile/unreadableMessage do NOT
+  // apply here (roleForFile's basename map does not generalize to `<id>.md`;
+  // the body family carries its own message text, no role lookup).
+  if (e instanceof BodyUnreadableError) {
+    console.log(JSON.stringify({ status: 'error', message: `em-revise: ${e.message}`, code: `episode-unreadable:${e.code}` }))
     releaseStoreWriteLocks(lockHandles)
     process.exit(1)
   }

--- a/scripts/em-search.mjs
+++ b/scripts/em-search.mjs
@@ -29,7 +29,7 @@ import {
   computeScore, writeBackAccessTracking, scoreTextMatch,
   tokenizeQuery, loadTokensIndex, tokenCandidates, scorePartialMatch
 } from './lib/relevance.mjs'
-import { IndexUnreadableError } from './lib/index-state.mjs'
+import { IndexUnreadableError, readBodyOrSkip, openReadableBody, BodyUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -136,6 +136,25 @@ function collectChainEntries(baseResults, seenIds) {
   return allEntries
 }
 
+// F5 rule (issues #666/#667, every body-read site in this file): non-ENOENT
+// codes (EISDIR/ENOTREG/EACCES/...) are a shape defect — skip + warn.
+// ENOENT (absent body / dangling row) preserves each site's CURRENT silent
+// behavior exactly — a dangling-row store must not start spamming warnings
+// on every search. Deduped per id:code so a body that fails BOTH the
+// scoring read and the --full output re-read warns only once. Returns
+// nothing; the caller passes the array its own output shape will surface
+// the joined warning through (materializeChain/--history have their own
+// output objects; the default search path shares the bottom `warnings`
+// array via searchBodyWarnings).
+const bodyWarnSeen = new Set()
+function noteBodySkip(target, id, code) {
+  if (code === 'ENOENT') return
+  const key = `${id}:${code}`
+  if (bodyWarnSeen.has(key)) return
+  bodyWarnSeen.add(key)
+  target.push(`episode body skipped ${id}: unreadable (${code})`)
+}
+
 // --materialize (#634a): walk backward via the scalar `supersedes` edge from the
 // anchor to root (archived-aware via collectChainEntries — same live+archived
 // merge as --history), reverse to root->terminal order, and concatenate full
@@ -158,14 +177,19 @@ function materializeChain(anchorRow) {
     node = parent
   }
   spine.reverse() // root -> anchor (terminal)
+  const chainWarnings = []
   const members = spine.map(e => {
     const archived = !!e._archived
     const filePath = path.join(e._dataDir, archived ? 'archived' : 'episodes', `${e.id}.md`)
     let bodyText = ''
-    if (fs.existsSync(filePath)) {
-      const content = fs.readFileSync(filePath, 'utf8')
-      const parts = content.split('---')
+    // #666 S2 :166: readBodyOrSkip replaces existsSync+readFileSync — a
+    // FIFO-shaped member must skip+warn (F5), not hang the whole chain.
+    const bodyRead = readBodyOrSkip(fs, filePath)
+    if (bodyRead.ok) {
+      const parts = bodyRead.raw.split('---')
       bodyText = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
+    } else {
+      noteBodySkip(chainWarnings, e.id, bodyRead.code)
     }
     const meta = { id: e.id, date: e.date, summary: e.summary, body_len: bodyText.length }
     if (archived) meta.archived = true
@@ -180,6 +204,7 @@ function materializeChain(anchorRow) {
     count: members.length,
     members: members.map(m => m.meta),
     body,
+    ...(chainWarnings.length ? { warning: chainWarnings.join(' | ') } : {}),
   }
 }
 
@@ -248,7 +273,21 @@ if (readId !== undefined) {
   // mirrors --history body resolution).
   const subDir = archived ? 'archived' : 'episodes'
   const filePath = path.join(row._dataDir, subDir, `${row.id}.md`)
-  const fileExists = fs.existsSync(filePath)
+  // #666 S2 --read row: single-target AUTHORITATIVE read — openReadableBody
+  // reads the file ONCE (audit F1: this used to be TWO separate readFileSync
+  // calls, here and again at the body-extraction site below); unreadable
+  // (non-absent) aborts typed, absent (null) preserves the existing
+  // load-bearing body_missing exit-0 path UNCHANGED.
+  let fileContent
+  try {
+    fileContent = openReadableBody(fs, filePath)
+  } catch (e) {
+    if (!(e instanceof BodyUnreadableError)) throw e
+    const out = JSON.stringify({ status: 'error', message: `em-search: ${e.message}`, code: `episode-unreadable:${e.code}` })
+    await new Promise((resolve) => process.stdout.write(out + '\n', resolve))
+    process.exit(1)
+  }
+  const fileExists = fileContent !== null
 
   // F-codex: parse the episode FILE's frontmatter and merge OVER the index row
   // (file wins for frontmatter fields). The index row supplies the operational
@@ -258,8 +297,7 @@ if (readId !== undefined) {
   // inline arrays, quoted scalars) — keeps custom/foreign frontmatter keys.
   const entry = {}
   if (fileExists) {
-    const content = fs.readFileSync(filePath, 'utf8')
-    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
+    const fmMatch = fileContent.match(/^---\n([\s\S]*?)\n---/)
     if (fmMatch) {
       for (const line of fmMatch[1].split('\n')) {
         const m = line.match(/^(\w+):\s*(.*)$/)
@@ -331,9 +369,9 @@ if (readId !== undefined) {
     process.exit(0)
   }
 
-  // Body is everything after the second `---`.
-  const content = fs.readFileSync(filePath, 'utf8')
-  const parts = content.split('---')
+  // Body is everything after the second `---`. Reuses fileContent read ONCE
+  // above (F1: no second readFileSync).
+  const parts = fileContent.split('---')
   const body = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
 
   // The body is returned IN FULL. There is deliberately no size bound here.
@@ -442,18 +480,22 @@ if (historyId) {
     }
   }
 
-  // Include full body if requested (archived members read from archived/)
+  // Include full body if requested (archived members read from archived/).
+  // #666 S2 :452: readBodyOrSkip replaces existsSync+readFileSync — a
+  // FIFO-shaped member skips+warns (F5) instead of hanging the whole walk.
+  const historyWarnings = []
   const output = chain.map(e => {
     const { _dataDir, _archived, ...rest } = e
     const row = _archived ? { ...rest, archived: true } : rest
     if (full) {
       const filePath = path.join(_dataDir, _archived ? 'archived' : 'episodes', `${e.id}.md`)
-      if (fs.existsSync(filePath)) {
-        const content = fs.readFileSync(filePath, 'utf8')
-        const parts = content.split('---')
+      const bodyRead = readBodyOrSkip(fs, filePath)
+      if (bodyRead.ok) {
+        const parts = bodyRead.raw.split('---')
         const body = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
         return { ...row, body }
       }
+      noteBodySkip(historyWarnings, e.id, bodyRead.code)
     }
     return row
   })
@@ -463,7 +505,10 @@ if (historyId) {
   // buffer, and process.exit() discards unflushed writes — piped consumers
   // (em-console, execFile callers) received exactly 65536 truncated bytes.
   await new Promise((resolve) => process.stdout.write(
-    JSON.stringify({ status: 'ok', count: output.length, chain: output }) + '\n', resolve))
+    JSON.stringify({
+      status: 'ok', count: output.length, chain: output,
+      ...(historyWarnings.length ? { warning: historyWarnings.join(' | ') } : {}),
+    }) + '\n', resolve))
   process.exit(0)
 }
 
@@ -477,6 +522,9 @@ if (project) {
   results = results.filter(e => e.project === project)
 }
 let searchWarning = null
+// #666 S2 :583/:621/:712: per-row body-read skip warnings for the scoring +
+// --full output sites below, joined into the final `warnings` array (F5).
+const searchBodyWarnings = []
 if (tag) {
   const normalizedTag = normalizeTags(tag)[0]
   if (normalizedTag) {
@@ -578,9 +626,15 @@ if (query) {
     ? results.filter(e => candidateInfo.all.has(e.id) || !candidateInfo.covered.has(e.id))
     : results
   const matched = pool.filter(e => {
+    // #666 S2 :583: readBodyOrSkip replaces the swallowing try/catch —
+    // scoreTextMatch's readBody contract (string|null) is unchanged, so this
+    // is transparent to lib/relevance.mjs; a non-ENOENT skip now warns (F5).
     const readBody = () => {
       const filePath = path.join(e._dataDir, 'episodes', `${e.id}.md`)
-      try { return fs.readFileSync(filePath, 'utf8') } catch { return null }
+      const r = readBodyOrSkip(fs, filePath)
+      if (r.ok) return r.raw
+      noteBodySkip(searchBodyWarnings, e.id, r.code)
+      return null
     }
     const { matched: isMatch, textMatch, body } = scoreTextMatch(e, query, readBody)
     if (!isMatch) return false
@@ -615,11 +669,16 @@ if (query) {
       .filter(e => !matchedIds.has(e.id))
     for (const e of partialPool) {
       let bodyLower // lazy, read at most once per episode
+      // #666 S2 :621: readBodyOrSkip replaces the swallowing try/catch.
       const readBodyLower = () => {
         if (bodyLower === undefined) {
-          try {
-            bodyLower = fs.readFileSync(path.join(e._dataDir, 'episodes', `${e.id}.md`), 'utf8').toLowerCase()
-          } catch { bodyLower = null }
+          const r = readBodyOrSkip(fs, path.join(e._dataDir, 'episodes', `${e.id}.md`))
+          if (r.ok) {
+            bodyLower = r.raw.toLowerCase()
+          } else {
+            noteBodySkip(searchBodyWarnings, e.id, r.code)
+            bodyLower = null
+          }
         }
         return bodyLower
       }
@@ -707,9 +766,15 @@ const output = results.map(e => {
     entry.score = Math.round(_score * 1000) / 1000
   }
   if (full) {
+    // #666 S2 :712: readBodyOrSkip replaces the swallowing try/catch — a
+    // non-ENOENT skip warns (F5); ENOENT stays silent (row emitted without
+    // a body field, exactly as an absent file did before).
     const content = _body || (() => {
       const filePath = path.join(_dataDir, 'episodes', `${e.id}.md`)
-      try { return fs.readFileSync(filePath, 'utf8') } catch { return null }
+      const r = readBodyOrSkip(fs, filePath)
+      if (r.ok) return r.raw
+      noteBodySkip(searchBodyWarnings, e.id, r.code)
+      return null
     })()
     if (content) {
       const parts = content.split('---')
@@ -726,6 +791,7 @@ const result = { status: 'ok', count: output.length, episodes: output }
 const elapsed = Date.now() - searchStart
 const warnings = []
 if (searchWarning) warnings.push(searchWarning)
+for (const w of searchBodyWarnings) warnings.push(w)
 if (elapsed > warnTimeMs) {
   warnings.push(`Search took ${elapsed}ms across ${totalEpisodeCount} episodes. Consider running em-prune.mjs to archive stale episodes.`)
 }

--- a/scripts/em-semantic.mjs
+++ b/scripts/em-semantic.mjs
@@ -34,7 +34,7 @@ import {
   HASH_MODEL, hashEmbed, buildIdf, cmdEmbed, cosine, loadEmbeddings, contentHash,
   loadEmbedConfig, resolveEmbedSettings
 } from './lib/embeddings.mjs'
-import { IndexUnreadableError } from './lib/index-state.mjs'
+import { IndexUnreadableError, readBodyOrSkip } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -205,6 +205,9 @@ if (!noTrack && results.length > 0) {
   writeBackAccessTracking(results.map(r => r.entry))
 }
 
+// #666 S2 :218: per-row body-read skip warnings, same F5 rule + same joined-
+// string convention as em-search (non-ENOENT codes only).
+const semanticBodyWarnings = []
 const episodes = results.map(({ entry, similarity, score }) => {
   const { _dataDir, _source, ...rest } = entry
   const out = {
@@ -214,20 +217,26 @@ const episodes = results.map(({ entry, similarity, score }) => {
     score: Math.round(score * 1000) / 1000,
   }
   if (full) {
-    try {
-      const content = fs.readFileSync(path.join(_dataDir, 'episodes', `${entry.id}.md`), 'utf8')
-      const parts = content.split('---')
+    const r = readBodyOrSkip(fs, path.join(_dataDir, 'episodes', `${entry.id}.md`))
+    if (r.ok) {
+      const parts = r.raw.split('---')
       out.body = parts.length >= 3 ? parts.slice(2).join('---').trim() : ''
-    } catch {}
+    } else if (r.code !== 'ENOENT') {
+      semanticBodyWarnings.push(`episode body skipped ${entry.id}: unreadable (${r.code})`)
+    }
   }
   return out
 })
+
+const semanticWarnings = []
+if (rerankWarning) semanticWarnings.push(rerankWarning)
+for (const w of semanticBodyWarnings) semanticWarnings.push(w)
 
 console.log(JSON.stringify({
   status: 'ok',
   count: episodes.length,
   model: queryModel,
   ...(reranked ? { reranked: true } : {}),
-  ...(rerankWarning ? { warning: rerankWarning } : {}),
+  ...(semanticWarnings.length ? { warning: semanticWarnings.join(' | ') } : {}),
   episodes,
 }))

--- a/scripts/em-store.mjs
+++ b/scripts/em-store.mjs
@@ -368,7 +368,23 @@ for (const [role, file] of [
 // persistence and every derived-index update. Validation above stays before
 // the first durable write; the collision report and final JSON emit only
 // after the lock is released.
-const lockResult = acquireStoreWriteLocksSync(dataDir)
+//
+// S5.1 (#667): lock-acquire raw fs errors. lib/lock.mjs:28 rethrows any
+// non-EEXIST errno (e.g. EACCES creating clerk-apply.lock under a
+// write-protected data dir); canonicalizeAndSort's own mkdirSync/realpathSync
+// can also throw raw. F3 predicate (pinned): real fs errors carry a numeric
+// .errno; a programming error has a string .code but errno:undefined and
+// must keep its raw stack — rethrown bare.
+let lockResult
+try {
+  lockResult = acquireStoreWriteLocksSync(dataDir)
+} catch (e) {
+  if (typeof e.errno === 'number' && typeof e.code === 'string') {
+    console.log(JSON.stringify({ status: 'error', message: `em-store: lock acquire failed (${e.code}) (${dataDir})`, code: `store-lock-failed:${e.code}` }))
+    process.exit(1)
+  }
+  throw e
+}
 if (!lockResult.ok) {
   console.log(JSON.stringify({ status: 'error', code: lockResult.code, heldBy: lockResult.heldBy }))
   process.exit(1)
@@ -376,6 +392,12 @@ if (!lockResult.ok) {
 const lockHandles = lockResult.handles
 let successPayload
 let storedId
+// S5.2 leg sentinel (#667): assigned immediately before each of em-store's
+// FOUR write legs so the catch below can (a) name the failing leg in its
+// envelope and (b) gate the fs-error branch to fire only when a leg was
+// actually in flight (leg !== null) — anything else rethrows bare.
+let leg = null
+let legPath = null
 try {
 // Issue 546 (S3c ID-collision retry): under the lock, re-read the index
 // ids and generate an ID absent from both the index and episode path.
@@ -541,6 +563,7 @@ const indexEntry = JSON.stringify({
 //     (genuinely-absent store), priorIndexContent is "" and this
 //     creates a fresh file via atomicReplaceFileSync's temp+rename.
 //     A populated store appends exactly one line under the lock.
+leg = 'index-commit'; legPath = indexFile
 atomicReplaceFileSync(indexFile, priorIndexContent + indexEntry + '\n')
 
 // (2) Episode file commit SECOND. mkdirSync(episodesDir, recursive)
@@ -548,16 +571,24 @@ atomicReplaceFileSync(indexFile, priorIndexContent + indexEntry + '\n')
 //     that path THROWS EEXIST and aborts the writer — leaving the
 //     index with a dangling row, but no orphan .md. em-rebuild-index
 //     heals on the next run (see block comment above).
+leg = 'episodes-dir'; legPath = episodesDir
 fs.mkdirSync(episodesDir, { recursive: true })
 
 const filePath = path.join(episodesDir, `${id}.md`)
+leg = 'episode-file'; legPath = filePath
 atomicReplaceFileSync(filePath, episodeContent)
 
+leg = 'derived-index'; legPath = dataDir
 updateTagsIndex(dataDir, id, tags)
 updateCategoryIndex(dataDir, id, category)
 // Token source is the FULL FILE content (frontmatter + body): the search
 // body tier greps the whole file, so pruning must see the same text.
 updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeContent }))
+// S5.2 leg sentinel: past the raw-fs-risk window. The playbook import/
+// registration code below has its own self-contained try/catch (never lets
+// an exception escape this outer try) and must never be misattributed to a
+// write leg if that assumption ever changes.
+leg = null
 
   storedId = id
   successPayload = { status: 'ok', id, file: filePath, scope }
@@ -644,6 +675,18 @@ updateTokensIndex(dataDir, id, episodeTokens({ summary, tags, body: episodeConte
     // — e.message is byte-frozen to "episode index unreadable" regardless of
     // which file failed; derive the role from e.file's basename instead.
     console.log(JSON.stringify({ status: 'error', message: unreadableMessage('em-store', roleForFile(e.file), e), code: `index-unreadable:${e.code}` }))
+    releaseStoreWriteLocks(lockHandles)
+    process.exit(1)
+  }
+  // S5.2 (#667): a raw fs errno from one of the FOUR write legs (leg
+  // sentinel above). F3 predicate, pinned: real fs errors carry a numeric
+  // .errno; a programming error has a string .code but errno:undefined and
+  // must keep its raw stack — IndexUnreadableError has no .errno at all, so
+  // this predicate excludes it order-independently even if branch order ever
+  // changes. leg !== null gates the branch to only fire when the throw
+  // genuinely originated inside a leg; anything else rethrows bare.
+  if (leg !== null && typeof e.errno === 'number' && typeof e.code === 'string') {
+    console.log(JSON.stringify({ status: 'error', message: `em-store: episode write failed (${e.code}) at ${leg} (${legPath})`, code: `episode-write-failed:${e.code}` }))
     releaseStoreWriteLocks(lockHandles)
     process.exit(1)
   }

--- a/scripts/lib/bp001-advisory.mjs
+++ b/scripts/lib/bp001-advisory.mjs
@@ -23,6 +23,7 @@ import fs from 'fs'
 import path from 'node:path'
 import os from 'node:os'
 import { resolveLocalDir } from './local-dir.mjs'
+import { readSidecarOrDegrade } from './index-state.mjs'
 
 export const BP1_ADVISORY_MESSAGE =
   '__BP1_ADVISORY__ A recent bp-001-implementation-workflow violation exists in this project. ' +
@@ -66,8 +67,14 @@ function loadActiveEntries() {
   const all = []
   for (const dir of dirs) {
     const indexFile = path.join(dir, 'index.jsonl')
-    let raw
-    try { raw = fs.readFileSync(indexFile, 'utf8') } catch { continue }
+    // S4 (#666): a raw fs.readFileSync BLOCKS on a FIFO-shaped index.jsonl —
+    // this is the first-and-only touch of index.jsonl in the SessionStart
+    // hook's call chain, no try/catch can stop a hang mid-read.
+    // readSidecarOrDegrade is fd-based (open O_NONBLOCK + fstat + read from
+    // the same fd) and collapses absent/unreadable to null uniformly —
+    // advisory degrades, never blocks SessionStart.
+    const raw = readSidecarOrDegrade(fs, indexFile)
+    if (raw === null) continue
     for (const line of raw.trim().split('\n')) {
       if (!line) continue
       try { all.push(JSON.parse(line)) } catch {}

--- a/scripts/lib/embeddings.mjs
+++ b/scripts/lib/embeddings.mjs
@@ -28,7 +28,7 @@ import os from 'os'
 import crypto from 'crypto'
 import { spawnSync } from 'child_process'
 import { tokenizeQuery, TOKENS_DROPPED_KEY } from './relevance.mjs'
-import { readSidecarOrDegrade } from './index-state.mjs'
+import { readSidecarOrDegrade, readBodyOrSkip } from './index-state.mjs'
 
 export const HASH_DIM = 256
 export const HASH_MODEL = `hash-v1-${HASH_DIM}`
@@ -179,13 +179,28 @@ export function writeEmbeddings(dataDir, rows) {
 
 // Text an episode is embedded from: summary + tags + body (file content
 // after frontmatter; falls back to full content when unparseable).
+//
+// #666 S2 :185: readBodyOrSkip replaces the swallowing try/catch. ENOENT
+// (absent body) preserves the prior behavior exactly — body stays '', the
+// episode still embeds from summary+tags alone. A non-ENOENT defect
+// (EISDIR/ENOTREG/EACCES/...) is a shape defect, not an absent body: the
+// caller (em-embed.mjs's embedDir) cannot compute a trustworthy content hash
+// without the body text, so it skips the WHOLE episode this run rather than
+// embedding from impoverished text — { skipped:true, skipCode } tells it to
+// do that and warn (F5), leaving the episode with no embedding row until the
+// shape heals.
 export function episodeEmbedText(row, dataDir) {
+  const r = readBodyOrSkip(fs, path.join(dataDir, 'episodes', `${row.id}.md`))
   let body = ''
-  try {
-    const content = fs.readFileSync(path.join(dataDir, 'episodes', `${row.id}.md`), 'utf8')
-    const parts = content.split('---')
-    body = parts.length >= 3 ? parts.slice(2).join('---') : content
-  } catch {}
+  let skipped = false
+  let skipCode = null
+  if (r.ok) {
+    const parts = r.raw.split('---')
+    body = parts.length >= 3 ? parts.slice(2).join('---') : r.raw
+  } else if (r.code !== 'ENOENT') {
+    skipped = true
+    skipCode = r.code
+  }
   const tags = Array.isArray(row.tags) ? row.tags.join(' ') : ''
-  return `${row.summary || ''}\n${tags}\n${body}`.trim()
+  return { text: `${row.summary || ''}\n${tags}\n${body}`.trim(), skipped, skipCode }
 }

--- a/scripts/lib/index-state.mjs
+++ b/scripts/lib/index-state.mjs
@@ -210,3 +210,71 @@ const FILE_ROLE_BY_BASENAME = {
 export function roleForFile(filePath) {
   return FILE_ROLE_BY_BASENAME[path.basename(filePath)] || 'episode index'
 }
+
+// ---------------------------------------------------------------------------
+// Episode-body fd-based read helpers (issues #666/#667). Same fd-based
+// classify-and-read pattern as openReadableIndex above (ONE open(O_RDONLY|
+// O_NONBLOCK) + fstat(fd) + read from that SAME fd) — store-identity.mjs:114
+// already proves the pattern generalizes to any store-dir file, not just
+// index.jsonl. Body files get their OWN error class (BodyUnreadableError)
+// and their own wire-code family (`episode-unreadable:<CODE>`) rather than
+// reusing IndexUnreadableError/roleForFile: roleForFile's basename map does
+// not generalize to `<id>.md` filenames, and the two families are
+// semantically distinct (an unreadable BODY is not an unreadable INDEX).
+// ---------------------------------------------------------------------------
+
+// BodyUnreadableError — typed abort for a single-target body read
+// (openReadableBody). Fields mirror IndexUnreadableError: .code/.file.
+export class BodyUnreadableError extends Error {
+  constructor(filePath, code) {
+    super(`episode body unreadable (${code}) (${filePath})`)
+    this.code = code
+    this.file = filePath
+  }
+}
+
+// readBodyOrSkip(fsMod, filePath) -> { ok:true, raw } | { ok:false, code } —
+// never throws, never blocks. For per-row iteration in query tools and
+// advisory reads: 'absent' and 'unreadable' both collapse to ok:false with
+// the classify code (ENOENT | EISDIR | ENOTREG | ...); the CALLER decides
+// warn-vs-silent per code (F5 rule: non-ENOENT warns, ENOENT stays silent).
+export function readBodyOrSkip(fsMod, filePath) {
+  const O_NONBLOCK_READ = fsMod.constants.O_RDONLY | fsMod.constants.O_NONBLOCK
+  let fd
+  try {
+    fd = fsMod.openSync(filePath, O_NONBLOCK_READ)
+  } catch (e) {
+    return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+  }
+  try {
+    let st
+    try {
+      st = fsMod.fstatSync(fd)
+    } catch (e) {
+      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+    }
+    if (st.isDirectory()) return { ok: false, code: 'EISDIR' }
+    if (!st.isFile()) return { ok: false, code: 'ENOTREG' }
+    try {
+      return { ok: true, raw: fsMod.readFileSync(fd, 'utf8') }
+    } catch (e) {
+      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+    }
+  } finally {
+    fsMod.closeSync(fd)
+  }
+}
+
+// openReadableBody(fsMod, filePath) -> raw string | null on absent (mirrors
+// openReadableIndex's absent contract); throws BodyUnreadableError on
+// unreadable. For single-target reads where the caller asked for THAT
+// episode. Callers MUST handle the null return explicitly. Built on top of
+// readBodyOrSkip rather than duplicating the fd-based pattern — the two
+// helpers share ONE primitive, differing only in how they surface a defect
+// (return vs throw).
+export function openReadableBody(fsMod, filePath) {
+  const r = readBodyOrSkip(fsMod, filePath)
+  if (r.ok) return r.raw
+  if (r.code === 'ENOENT') return null
+  throw new BodyUnreadableError(filePath, r.code)
+}

--- a/scripts/lib/store-identity.mjs
+++ b/scripts/lib/store-identity.mjs
@@ -7,7 +7,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { tryAcquire, release } from './lock.mjs'
-import { classifyIndexFile } from './index-state.mjs'
+import { readBodyOrSkip } from './index-state.mjs'
 
 // §A.5-S1 constants (verbatim)
 export const STORE_IDENTITY_RECORD_TYPE = 'store-identity'
@@ -106,13 +106,18 @@ function listIdentityEpisodes(storeDir) {
     // #653 (discovered via em-rebuild-index's S7 FIFO-episode battery leg):
     // resolveStoreIdentity is called BY em-rebuild-index — the remediation
     // tool the #649/#653 contract requires to never hang on a FIFO-shaped
-    // episode file — so this scan needs the same lstat-classify-skip guard
+    // episode file — so this scan needs the same skip-on-unreadable guard
     // as em-rebuild-index's own episode loop, not the deferred query-path
     // body-read class (§4 D2 is about read-tool --full/--materialize paths).
+    // #666 S6: switched from a separate classify-then-read pair (a TOCTOU
+    // window between the lstat-classify and the readFileSync) to the
+    // fd-based readBodyOrSkip — ONE open()+fstat()+read(), same fd
+    // throughout, closing that window. Skip-on-unreadable behavior
+    // (including absent) is unchanged.
     const filePath = path.join(episodesDir, file)
-    if (classifyIndexFile(fs, filePath).state !== 'ok') continue
-    const content = fs.readFileSync(filePath, 'utf8')
-    const parsed = parseIdentityFrontmatter(content)
+    const bodyRead = readBodyOrSkip(fs, filePath)
+    if (!bodyRead.ok) continue
+    const parsed = parseIdentityFrontmatter(bodyRead.raw)
     if (parsed) {
       parsed.filename = file
       out.push(parsed)

--- a/tests/test-651-index-existence.mjs
+++ b/tests/test-651-index-existence.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url'
 
 import {
   classifyIndexFile, assertReadableIndex, readIndexFileOrThrow, openReadableIndex, IndexUnreadableError,
+  readBodyOrSkip, openReadableBody, BodyUnreadableError,
 } from '../scripts/lib/index-state.mjs'
 
 // EM651_TEST_REPO_OVERRIDE: points spawned scripts at an alternate repo root
@@ -327,6 +328,132 @@ function cleanup(world) {
     assert(readIndexFileOrThrow(fs, okPath) === 'hello\n', 'ok -> content')
     fs.unlinkSync(okPath)
   })
+
+  fs.rmSync(dir, { recursive: true, force: true })
+})()
+
+// =============================================================================
+// S1 — body-read helper unit legs (issues #666/#667): readBodyOrSkip /
+// openReadableBody against FIFO/dir/absent shapes.
+//
+// Review fix-round item 1 (both lenses, mutation-proven): the FIFO legs are
+// spawned into a CHILD process with a hard timeout, NOT called in-process.
+// A same-process call is safe TODAY because O_NONBLOCK makes open() return
+// immediately — but that is exactly the property a regression could break
+// (e.g. a mutant that drops O_NONBLOCK or swaps in a blocking read). Called
+// in-process, that mutant would FREEZE this entire suite forever (no
+// external alarm to kill it), violating spec §5's fail-not-freeze
+// requirement — the suite must observe the regression as a FAILURE, not
+// hang until an operator notices. Dir/absent shapes stay in-process: no
+// blocking-read mutant can hang an lstat/fstat-only path, so a spawn there
+// buys nothing and only adds process overhead.
+// =============================================================================
+;(function S1_bodyHelpers() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em666-s1-'))
+  const INDEX_STATE_PATH = path.join(SCRIPTS, 'lib', 'index-state.mjs')
+
+  // spawnBodyHelperChild(childSrcLines) — writes a throwaway .mjs file that
+  // imports index-state.mjs fresh (same pattern as the D1 interleave child
+  // below) and spawns it with timeout:10000 + SIGKILL. A regression that
+  // reintroduces a blocking read is killed and reported as a signal, not a
+  // frozen suite.
+  function spawnBodyHelperChild(name, childSrcLines) {
+    const childPath = path.join(dir, `child-${name}.mjs`)
+    fs.writeFileSync(childPath, childSrcLines.join('\n'))
+    const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+    fs.rmSync(childPath, { force: true })
+    return r
+  }
+
+  t('S1 readBodyOrSkip — absent (ENOENT), never throws', () => {
+    const p = path.join(dir, 'absent.md')
+    const r = readBodyOrSkip(fs, p)
+    assert(r.ok === false && r.code === 'ENOENT', JSON.stringify(r))
+  })
+
+  t('S1 readBodyOrSkip — directory (EISDIR)', () => {
+    const p = path.join(dir, 'adir.md')
+    fs.mkdirSync(p)
+    const r = readBodyOrSkip(fs, p)
+    assert(r.ok === false && r.code === 'EISDIR', JSON.stringify(r))
+    fs.rmdirSync(p)
+  })
+
+  t('S1 readBodyOrSkip — ok on a regular file, returns raw content', () => {
+    const p = path.join(dir, 'ok.md')
+    fs.writeFileSync(p, 'hello body\n')
+    const r = readBodyOrSkip(fs, p)
+    assert(r.ok === true && r.raw === 'hello body\n', JSON.stringify(r))
+    fs.unlinkSync(p)
+  })
+
+  if (!IS_WIN) {
+    t('S1 readBodyOrSkip — FIFO (ENOTREG), no hang (spawned, alarm-wrapped)', () => {
+      const p = path.join(dir, 'fifo.md')
+      const mk = spawnSync('mkfifo', [p])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      const r = spawnBodyHelperChild('readBodyOrSkip-fifo', [
+        `import fs from 'node:fs'`,
+        `import { readBodyOrSkip } from ${JSON.stringify(INDEX_STATE_PATH)}`,
+        `const r = readBodyOrSkip(fs, ${JSON.stringify(p)})`,
+        `console.log(JSON.stringify(r))`,
+      ])
+      fs.unlinkSync(p)
+      assert(r.signal === null, `S1 readBodyOrSkip FIFO: no signal (timeout/kill) — got ${r.signal} (this is the fail-not-freeze regression signature)`)
+      assert(r.status === 0, `S1 readBodyOrSkip FIFO: child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+      const j = JSON.parse((r.stdout || '').trim())
+      assert(j.ok === false && j.code === 'ENOTREG', JSON.stringify(j))
+    })
+  } else {
+    skip('S1 readBodyOrSkip — FIFO (ENOTREG)', 'mkfifo unavailable on win32')
+  }
+
+  t('S1 openReadableBody — absent returns null', () => {
+    const p = path.join(dir, 'absent2.md')
+    assert(openReadableBody(fs, p) === null, 'absent -> null')
+  })
+
+  t('S1 openReadableBody — ok returns content', () => {
+    const p = path.join(dir, 'ok2.md')
+    fs.writeFileSync(p, 'content\n')
+    assert(openReadableBody(fs, p) === 'content\n', 'ok -> content')
+    fs.unlinkSync(p)
+  })
+
+  t('S1 openReadableBody — directory throws BodyUnreadableError(EISDIR)', () => {
+    const p = path.join(dir, 'adir2.md')
+    fs.mkdirSync(p)
+    let threw = null
+    try { openReadableBody(fs, p) } catch (e) { threw = e }
+    assert(threw instanceof BodyUnreadableError && threw.code === 'EISDIR', JSON.stringify(threw))
+    assert(/episode body unreadable \(EISDIR\)/.test(threw.message), threw.message)
+    fs.rmdirSync(p)
+  })
+
+  if (!IS_WIN) {
+    t('S1 openReadableBody — FIFO throws BodyUnreadableError(ENOTREG), no hang (spawned, alarm-wrapped)', () => {
+      const p = path.join(dir, 'fifo2.md')
+      const mk = spawnSync('mkfifo', [p])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      const r = spawnBodyHelperChild('openReadableBody-fifo', [
+        `import fs from 'node:fs'`,
+        `import { openReadableBody, BodyUnreadableError } from ${JSON.stringify(INDEX_STATE_PATH)}`,
+        `try {`,
+        `  const raw = openReadableBody(fs, ${JSON.stringify(p)})`,
+        `  console.log(JSON.stringify({ step: 'unexpected-ok', raw }))`,
+        `} catch (e) {`,
+        `  console.log(JSON.stringify({ step: 'typed-abort', isBodyUnreadable: e instanceof BodyUnreadableError, code: e.code, message: e.message }))`,
+        `}`,
+      ])
+      fs.unlinkSync(p)
+      assert(r.signal === null, `S1 openReadableBody FIFO: no signal (timeout/kill) — got ${r.signal} (this is the fail-not-freeze regression signature)`)
+      assert(r.status === 0, `S1 openReadableBody FIFO: child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+      const j = JSON.parse((r.stdout || '').trim())
+      assert(j.step === 'typed-abort' && j.isBodyUnreadable && j.code === 'ENOTREG', JSON.stringify(j))
+    })
+  } else {
+    skip('S1 openReadableBody — FIFO (ENOTREG)', 'mkfifo unavailable on win32')
+  }
 
   fs.rmSync(dir, { recursive: true, force: true })
 })()
@@ -830,6 +957,192 @@ t('T8c — em-rebuild-index heals dangling index row left by aborted em-store (s
     const rawAfterHeal = fs.readFileSync(indexPath, 'utf8')
     assert(rawAfterHeal.trim() === '' || afterHeal.length === 0, `em-rebuild-index (T8c): empty index (no FS-backed rows), got raw=${JSON.stringify(rawAfterHeal.slice(0, 200))} entries=${afterHeal.length}`)
   } finally { cleanup(world) }
+})
+
+// =============================================================================
+// T8d/T8e/T8f (issues #666/#667 S5, audit Q6): em-store's write-block
+// envelope class. T8d/T8e reuse T8b's fixture shapes (episodes/ as a regular
+// file / chmod 0000) but assert the NEW typed episode-write-failed envelope
+// on top of T8b's untouched side-effect invariants. T8f exercises the
+// lock-acquire branch (store-lock-failed) via a chmod 0555 data dir.
+// =============================================================================
+
+t('T8d — em-store with episodes/ as a regular file: typed episode-write-failed:EEXIST envelope, T8b invariants hold', () => {
+  const world = mkStore()
+  try {
+    const indexPath = path.join(world.localDir, 'index.jsonl')
+    const episodesDir = path.join(world.localDir, 'episodes')
+    const beforeEntries = readIndexEntries(indexPath)
+    const tagsFile = path.join(world.localDir, 'tags.json')
+    const beforeTags = fs.existsSync(tagsFile) ? fs.readFileSync(tagsFile, 'utf8') : null
+    fs.rmSync(episodesDir, { recursive: true, force: true })
+    fs.writeFileSync(episodesDir, '')
+
+    const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+      '--project', 'p651', '--category', 'decision',
+      '--summary', 'write-order-t8d', '--body', 'defer3 t8d body',
+      '--scope', 'local',
+    ], { cwd: world.proj, home: world.root })
+
+    assert(r.signal === null, `em-store (T8d): no signal, got ${r.signal}: ${r.stderr}`)
+    // Q6 (audit): explicit non-zero-status assert kills the "envelope + exit 0" mutation (T8b precedent).
+    assert(r.status !== 0, `em-store (T8d): non-zero exit, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'error', `em-store (T8d): typed envelope, got ${r.stdout}`)
+    assert(j.code === 'episode-write-failed:EEXIST', `em-store (T8d): code episode-write-failed:EEXIST, got ${JSON.stringify(j)}`)
+    assert(/episodes-dir/.test(r.stdout), `em-store (T8d): leg name in message, got ${r.stdout.slice(0, 300)}`)
+    assert(/EEXIST/.test(r.stdout), `em-store (T8d): CODE in message, got ${r.stdout.slice(0, 300)}`)
+
+    // T8b invariants, re-checked: episodes/ still the regular file (no
+    // promotion), dangling row (exactly one new row), no orphan .md, derived
+    // JSONs untouched.
+    const st = fs.lstatSync(episodesDir)
+    assert(st.isFile(), 'em-store (T8d): episodes/ still a regular file (mkdirSync did NOT promote)')
+    const afterEntries = readIndexEntries(indexPath)
+    assert(afterEntries.length === beforeEntries.length + 1, `em-store (T8d): index gained exactly one dangling row, before=${beforeEntries.length} after=${afterEntries.length}`)
+    const dangling = afterEntries.find(e => !beforeEntries.some(b => b.id === e.id))
+    assert(dangling && dangling.summary === 'write-order-t8d', `em-store (T8d): dangling row summary matches, got ${JSON.stringify(dangling)}`)
+    const afterTags = fs.existsSync(tagsFile) ? fs.readFileSync(tagsFile, 'utf8') : null
+    assert(afterTags === beforeTags, `em-store (T8d): tags.json unchanged (derived indexes never reached), before=${beforeTags} after=${afterTags}`)
+  } finally { cleanup(world) }
+})
+
+{
+  const name = 'T8e — em-store with episodes/ chmod 0000: typed episode-write-failed:EACCES envelope'
+  if (IS_ROOT) { skip(name, 'root bypasses permission checks') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        const episodesDir = path.join(world.localDir, 'episodes')
+        const beforeEntries = readIndexEntries(indexPath)
+        fs.chmodSync(episodesDir, 0o000)
+        const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'decision',
+          '--summary', 'write-order-t8e', '--body', 'defer3 t8e body',
+          '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        fs.chmodSync(episodesDir, 0o755)
+        assert(r.signal === null, `em-store (T8e): no signal, got ${r.signal}: ${r.stderr}`)
+        assert(r.status !== 0, `em-store (T8e): non-zero exit, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-store (T8e): typed envelope, got ${r.stdout}`)
+        assert(j.code === 'episode-write-failed:EACCES', `em-store (T8e): code episode-write-failed:EACCES, got ${JSON.stringify(j)}`)
+        assert(/episode-file/.test(r.stdout), `em-store (T8e): leg name in message, got ${r.stdout.slice(0, 300)}`)
+        const afterEntries = readIndexEntries(indexPath)
+        assert(afterEntries.length === beforeEntries.length + 1, `em-store (T8e): index gained exactly one dangling row, before=${beforeEntries.length} after=${afterEntries.length}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+{
+  const name = 'T8f — em-store with data dir chmod 0555: typed store-lock-failed:EACCES envelope, index byte-unchanged'
+  if (IS_ROOT) { skip(name, 'root bypasses permission checks') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        const beforeIndex = fs.readFileSync(indexPath, 'utf8')
+        fs.chmodSync(world.localDir, 0o555)
+        const r = run(path.join(SCRIPTS, 'em-store.mjs'), [
+          '--project', 'p651', '--category', 'decision',
+          '--summary', 'write-order-t8f', '--body', 'defer3 t8f body',
+          '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        fs.chmodSync(world.localDir, 0o755)
+        assert(r.signal === null, `em-store (T8f): no signal, got ${r.signal}: ${r.stderr}`)
+        assert(r.status !== 0, `em-store (T8f): non-zero exit, got status=${r.status} stdout=${(r.stdout || '').slice(0, 200)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-store (T8f): typed envelope, got ${r.stdout}`)
+        assert(j.code === 'store-lock-failed:EACCES', `em-store (T8f): code store-lock-failed:EACCES, got ${JSON.stringify(j)}`)
+        const afterIndex = fs.readFileSync(indexPath, 'utf8')
+        assert(afterIndex === beforeIndex, 'em-store (T8f): index.jsonl byte-unchanged (aborted before lock/any write)')
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- em-revise typed-abort leg (FIFO original body) ---
+{
+  const name = 'em-revise x FIFO original body -> typed episode-unreadable abort, no supersede written, follow-up revise succeeds'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const episodePath = path.join(world.localDir, 'episodes', `${world.seedId}.md`)
+        const indexPath = path.join(world.localDir, 'index.jsonl')
+        const beforeIndex = fs.readFileSync(indexPath, 'utf8')
+        fs.renameSync(episodePath, `${episodePath}.bak`)
+        const mk = spawnSync('mkfifo', [episodePath])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-revise.mjs'), [
+          '--original', world.seedId, '--project', 'p651', '--summary', 'fifo-original-revise', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        fs.unlinkSync(episodePath)
+        fs.renameSync(`${episodePath}.bak`, episodePath)
+        assert(r.signal === null, `em-revise: no signal, got ${r.signal}: ${r.stderr}`)
+        assert(r.status === 1, `em-revise: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'error', `em-revise: typed envelope, got ${r.stdout}`)
+        assert(/^episode-unreadable:/.test(j.code || ''), `em-revise: code episode-unreadable:<CODE>, got ${JSON.stringify(j)}`)
+        const afterIndex = fs.readFileSync(indexPath, 'utf8')
+        assert(afterIndex === beforeIndex, 'em-revise: index.jsonl byte-unchanged (no supersede written)')
+        // Follow-up healthy revise succeeds — no lock leak, no lingering damage.
+        const retry = run(path.join(SCRIPTS, 'em-revise.mjs'), [
+          '--original', world.seedId, '--project', 'p651', '--summary', 'follow-up-revise', '--body', 'body', '--scope', 'local',
+        ], { cwd: world.proj, home: world.root })
+        assert(retry.status === 0, `em-revise retry: exit 0, got ${retry.status}: stdout=${(retry.stdout || '').slice(0, 300)}`)
+        const rj = lastJson(retry.stdout)
+        assert(rj && rj.status === 'ok', `em-revise retry: status ok, got ${retry.stdout}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- em-rebuild-index --check warnings leg (P3-iii) ---
+{
+  const name = 'em-rebuild-index --check x FIFO episode -> warnings entry present, drift semantics unchanged'
+  if (IS_WIN) { skip(name, 'mkfifo unavailable on win32') } else {
+    t(name, () => {
+      const world = mkStore()
+      try {
+        const fifoEpisode = path.join(world.localDir, 'episodes', 'fifo-check-episode.md')
+        const mk = spawnSync('mkfifo', [fifoEpisode])
+        assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+        const r = run(path.join(SCRIPTS, 'em-rebuild-index.mjs'), ['--check', '--scope', 'local'], { cwd: world.proj, home: world.root })
+        fs.rmSync(fifoEpisode, { force: true })
+        assert(r.signal === null, `em-rebuild-index --check: no signal, got ${r.signal}`)
+        assert(r.status === 0, `em-rebuild-index --check: exit 0 (seed episode has no drift), got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+        const j = lastJson(r.stdout)
+        assert(j && j.status === 'ok', `em-rebuild-index --check: status ok, got ${r.stdout}`)
+        assert(Array.isArray(j.drift) && j.drift.length === 0, `em-rebuild-index --check: drift semantics unchanged (empty), got ${JSON.stringify(j.drift)}`)
+        // Exactly one warning (the FIFO episode) — kills a warn-on-every-file
+        // mutation; the fixture's ONLY other file is the healthy seed episode.
+        assert(Array.isArray(j.warnings) && j.warnings.length === 1, `em-rebuild-index --check: exactly one warning, got ${JSON.stringify(j.warnings)}`)
+        assert(j.warnings.some(w => w.includes('fifo-check-episode.md')), `em-rebuild-index --check: warnings names the skipped FIFO episode, got ${JSON.stringify(j.warnings)}`)
+      } finally { cleanup(world) }
+    })
+  }
+}
+
+// --- em-restore stack-field regression leg (review fix-round item 6) ---
+// Cheap construction: a nonexistent --from backup dir fails preflight()
+// (plain Error, not IndexUnreadableError) BEFORE any store touch — dry-run
+// is the default mode, no --apply/fixture backup needed.
+t('em-restore error envelope: nonexistent --from backup dir -> message present, no stack key', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'em651-restore-nostack-'))
+  try {
+    const r = run(path.join(SCRIPTS, 'em-restore.mjs'), ['--from', path.join(root, 'does-not-exist')], { cwd: root, home: root })
+    assert(r.signal === null, `em-restore: no signal, got ${r.signal}`)
+    assert(r.status === 1, `em-restore: exit 1, got ${r.status}: stdout=${(r.stdout || '').slice(0, 300)}`)
+    const j = lastJson(r.stdout)
+    assert(j && j.status === 'error', `em-restore: typed envelope, got ${r.stdout}`)
+    assert(typeof j.message === 'string' && j.message.length > 0, `em-restore: message present, got ${JSON.stringify(j)}`)
+    assert(!('stack' in j), `em-restore: no stack key on the error payload (S6 Family A), got keys=${JSON.stringify(Object.keys(j))}`)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
 })
 
 // =============================================================================

--- a/tests/test-em-graph.mjs
+++ b/tests/test-em-graph.mjs
@@ -164,6 +164,83 @@ t('non-numeric / out-of-range bounds are rejected with exit 2 (RFC-007 depth/cap
   assert.equal(d0.json.count, 1, 'depth 0 = root only');
 });
 
+// ---------------------------------------------------------------------------
+// Issue #666/#667 S2: FIFO-shaped episode body in the cites-edge read
+// (bodyCitations, em-graph.mjs body-citation scan). Isolated fixture (own
+// cwd/home) so the FIFO swap cannot bleed into the shared fixture above.
+// ---------------------------------------------------------------------------
+t('--hubs with a FIFO-shaped episode body: exit 0, cites edge from the skipped body never materializes, diagnostics entry present', () => {
+  const gcwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgraph-fifo-')));
+  const ghome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgraph-fifo-home-')));
+  function grun(script, args) {
+    const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd: gcwd, encoding: 'utf8', timeout: 10000, env: { ...process.env, HOME: ghome } });
+    let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+    return { code: r.status, json, stdout: r.stdout, signal: r.signal };
+  }
+  function gst(args) {
+    const r = grun('em-store.mjs', ['--project', 'fx', '--scope', 'local', ...args]);
+    assert.equal(r.json.status, 'ok', r.stdout);
+    return r.json.id;
+  }
+  const Y = gst(['--category', 'decision', '--summary', 'fifo target Y', '--body', 'plain body']);
+  const X = gst(['--category', 'lesson', '--summary', 'fifo citer X', '--body', `cites ${Y} in its body`]);
+
+  // Healthy control: before any corruption, X's cite of Y makes Y a degree-1 hub.
+  const before = grun('em-graph.mjs', ['--hubs', '--scope', 'local', '--top', '5']);
+  assert.equal(before.code, 0, `healthy control exit 0, got ${before.code}: ${before.stdout}`);
+  assert.ok(before.json.nodes.some((n) => n.id === Y && n.degree === 1), `healthy control: cites edge makes Y a hub, got ${before.stdout}`);
+  assert.equal(before.json.body_warnings, undefined, 'healthy control: no diagnostics entry');
+
+  const xPath = path.join(gcwd, '.episodic-memory', 'episodes', `${X}.md`);
+  fs.unlinkSync(xPath);
+  const mk = spawnSync('mkfifo', [xPath]);
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+  const r = grun('em-graph.mjs', ['--hubs', '--scope', 'local', '--top', '5']);
+  fs.unlinkSync(xPath);
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`);
+  assert.equal(r.code, 0, `exit 0, got ${r.code}: ${r.stdout}`);
+  assert.equal(r.json.status, 'ok');
+  assert.ok(!r.json.nodes.some((n) => n.id === Y), 'cites edge from the skipped body never materialized (Y no longer a hub)');
+  assert.ok(
+    Array.isArray(r.json.body_warnings) && r.json.body_warnings.some((w) => w.includes(X) && w.includes('ENOTREG')),
+    `diagnostics entry present, got ${JSON.stringify(r.json.body_warnings)}`
+  );
+
+  fs.rmSync(gcwd, { recursive: true, force: true });
+  fs.rmSync(ghome, { recursive: true, force: true });
+});
+
+// Review fix-round item 3 (§8 matrix control): a dangling row (ENOENT —
+// absent, not a shape defect) must stay silent per F5 — no body_warnings
+// field at all. Kills removal of the ENOENT guard in bodyCitations.
+t('--hubs with a dangling row (body file absent): NO body_warnings field (ENOENT stays silent, F5)', () => {
+  const dcwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgraph-dangle-')));
+  const dhome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emgraph-dangle-home-')));
+  function drun(script, args) {
+    const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd: dcwd, encoding: 'utf8', timeout: 10000, env: { ...process.env, HOME: dhome } });
+    let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
+    return { code: r.status, json, stdout: r.stdout, signal: r.signal };
+  }
+  function dst(args) {
+    const r = drun('em-store.mjs', ['--project', 'fx', '--scope', 'local', ...args]);
+    assert.equal(r.json.status, 'ok', r.stdout);
+    return r.json.id;
+  }
+  const Y = dst(['--category', 'decision', '--summary', 'dangle target Y', '--body', 'plain body']);
+  const X = dst(['--category', 'lesson', '--summary', 'dangle citer X', '--body', `cites ${Y} in its body`]);
+  const xPath = path.join(dcwd, '.episodic-memory', 'episodes', `${X}.md`);
+  fs.unlinkSync(xPath); // dangling row: index still has X, the body file is gone entirely (ENOENT)
+
+  const r = drun('em-graph.mjs', ['--hubs', '--scope', 'local', '--top', '5']);
+  assert.equal(r.signal, null, `no signal, got ${r.signal}`);
+  assert.equal(r.code, 0, `exit 0, got ${r.code}: ${r.stdout}`);
+  assert.equal(r.json.status, 'ok');
+  assert.equal(r.json.body_warnings, undefined, 'ENOENT (dangling row) stays silent — no body_warnings field (F5)');
+
+  fs.rmSync(dcwd, { recursive: true, force: true });
+  fs.rmSync(dhome, { recursive: true, force: true });
+});
+
 fs.rmSync(cwd, { recursive: true, force: true });
 fs.rmSync(home, { recursive: true, force: true });
 console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/test-em-recall-session-start-early-exit.mjs
+++ b/tests/test-em-recall-session-start-early-exit.mjs
@@ -438,7 +438,9 @@ test('T10: direct --session-start from nested cwd writes artifacts at repo root,
 // out of em-recall). Per feedback_fixture_transitive_imports.md, stage
 // enforce-contract.mjs PLUS its full transitive lib closure:
 //   local-dir, marker-paths, marker-state, session-id, bp001-advisory,
-//   json-instance-validate, effective-tier.
+//   json-instance-validate, effective-tier, index-state (#666 S4: bp001-advisory
+//   imports readSidecarOrDegrade for its SessionStart-hang fix; index-state.mjs
+//   itself imports only node:path, so staging it is closure-complete).
 // (--session-start needs no patterns/ files — contract/tier loading is the
 // --gate stop path; the advisory reads the episode index, the sweeps/baseline
 // read only the marker libs.)
@@ -457,6 +459,7 @@ function buildTempHome(homeRoot) {
     'bp001-advisory.mjs',
     'json-instance-validate.mjs',
     'effective-tier.mjs',
+    'index-state.mjs',
   ]) {
     fs.copyFileSync(path.join(SCRIPTS, 'lib', lib), path.join(installedLib, lib))
   }

--- a/tests/test-em-recall-sessionstart.sh
+++ b/tests/test-em-recall-sessionstart.sh
@@ -305,7 +305,10 @@ E2E_HOME=$(mktemp -d)
 E2E_REPO=$(mktemp -d)
 mkdir -p "$E2E_HOME/.episodic-memory/scripts/lib"
 cp "$REPO_ROOT/scripts/enforce-contract.mjs" "$E2E_HOME/.episodic-memory/scripts/enforce-contract.mjs"
-for lib in local-dir marker-paths marker-state session-id bp001-advisory json-instance-validate effective-tier; do
+# index-state: bp001-advisory imports readSidecarOrDegrade for its #666 S4
+# SessionStart-hang fix; index-state.mjs itself imports only node:path, so
+# staging it is closure-complete.
+for lib in local-dir marker-paths marker-state session-id bp001-advisory json-instance-validate effective-tier index-state; do
   cp "$REPO_ROOT/scripts/lib/$lib.mjs" "$E2E_HOME/.episodic-memory/scripts/lib/$lib.mjs"
 done
 ( cd "$E2E_REPO" && git init -q -b main && git config user.email t@t && git config user.name t && echo x > README.md && git add . && git commit -q -m init ) >/dev/null 2>&1

--- a/tests/test-em-search-read.mjs
+++ b/tests/test-em-search-read.mjs
@@ -137,9 +137,11 @@ function writeEpisode(cwd, opts) {
   return id;
 }
 
+const IS_WIN = process.platform === 'win32';
+
 function run(cwd, home, args) {
   const r = spawnSync('node', [EM_SEARCH, ...args], {
-    cwd, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024,
+    cwd, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, timeout: 10000,
     env: { ...process.env, HOME: home, USERPROFILE: home },
   });
   let json = null;
@@ -597,6 +599,98 @@ t('readLockstepCoercesPriorityPinnedTypesViaRealEmStore', () => {
   assert.equal(ep.priority, 5, 'priority value preserved (5)');
   assert.equal(ep.pinned, true, 'pinned is boolean true (LOCKSTEP coercion, not string "true")');
 });
+
+// ===========================================================================
+// Issue #666/#667 S2 additions: FIFO-shaped episode bodies in the query
+// tier. --read is a single-target authoritative read (typed abort); --full
+// query and --materialize are per-row skip+warning (F5: non-ENOENT codes
+// only — ENOENT/absent preserves each site's existing silent behavior).
+// ===========================================================================
+
+if (!IS_WIN) {
+  t('readFifoBodyReturnsTypedAbort', () => {
+    const { cwd, home } = mkStore();
+    const id = writeEpisode(cwd, { id: 'ep-fifo', summary: 'fifo target', body: 'b' });
+    const filePath = path.join(storeDir(cwd), 'episodes', `${id}.md`);
+    fs.unlinkSync(filePath);
+    const mk = spawnSync('mkfifo', [filePath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+    const r = readOne(cwd, home, id);
+    fs.unlinkSync(filePath);
+    assert.equal(r.code, 1, `exit 1; stdout=${r.stdout}`);
+    assert.equal(r.json.status, 'error');
+    assert.equal(r.json.code, 'episode-unreadable:ENOTREG', `typed code, got ${JSON.stringify(r.json)}`);
+    assert.ok(/episode body unreadable/.test(r.json.message || ''), `message names the defect, got ${JSON.stringify(r.json)}`);
+  });
+
+  t('searchFullWithFifoBodySkipsRowWithWarning', () => {
+    const { cwd, home } = mkStore();
+    writeEpisode(cwd, { id: 'ep-healthy', summary: 'healthy episode', body: 'healthy body text' });
+    const fifoId = writeEpisode(cwd, { id: 'ep-fifobody', summary: 'fifo episode', body: 'will be replaced' });
+    const fifoPath = path.join(storeDir(cwd), 'episodes', `${fifoId}.md`);
+    fs.unlinkSync(fifoPath);
+    const mk = spawnSync('mkfifo', [fifoPath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+    const r = run(cwd, home, ['--full', '--scope', 'local', '--no-track']);
+    fs.unlinkSync(fifoPath);
+    assert.equal(r.code, 0, `exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.equal(r.json.status, 'ok');
+    const healthy = r.json.episodes.find((e) => e.id === 'ep-healthy');
+    const fifoEp = r.json.episodes.find((e) => e.id === fifoId);
+    assert.ok(healthy && healthy.body, 'healthy episode body present');
+    assert.ok(fifoEp, 'FIFO-shaped episode row still present (skip, not drop)');
+    assert.equal(fifoEp.body, undefined, 'FIFO-shaped episode row emitted WITHOUT body');
+    assert.ok(
+      typeof r.json.warning === 'string' && r.json.warning.includes('ep-fifobody') && r.json.warning.includes('ENOTREG'),
+      `warning names the skipped episode + code, got ${JSON.stringify(r.json.warning)}`
+    );
+  });
+
+  // Review fix-round item 3 (§8 matrix control): a dangling row (ENOENT —
+  // absent, not a shape defect) must stay silent per F5 — no warning field
+  // at all, not even an empty one. Kills removal of the ENOENT guard in
+  // em-search's noteBodySkip.
+  t('searchFullWithDanglingRowStaysSilentControl', () => {
+    const { cwd, home } = mkStore();
+    fs.appendFileSync(indexPath(cwd), JSON.stringify({
+      id: 'ep-dangle-full', date: '2026-07-10', time: '00:00', project: 't',
+      category: 'lesson', status: 'active', supersedes: null, tags: [],
+      summary: 'dangle full', access_count: 0, last_accessed: null,
+    }) + '\n');
+    const r = run(cwd, home, ['--full', '--scope', 'local', '--no-track']);
+    assert.equal(r.code, 0, `exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.equal(r.json.status, 'ok');
+    const row = r.json.episodes.find((e) => e.id === 'ep-dangle-full');
+    assert.ok(row, 'dangling row still present in results');
+    assert.equal(row.body, undefined, 'dangling row emitted WITHOUT body');
+    assert.equal(r.json.warning, undefined, 'ENOENT (dangling row) stays silent — no warning field (F5)');
+  });
+
+  t('materializeChainWithFifoMemberSkipsWithWarning', () => {
+    const { cwd, home } = mkStore();
+    writeEpisode(cwd, { id: 'mat-root', summary: 'materialize root', body: 'root body text' });
+    const midId = writeEpisode(cwd, { id: 'mat-mid', summary: 'materialize mid', body: 'to be fifo', supersedes: 'mat-root' });
+    const midPath = path.join(storeDir(cwd), 'episodes', `${midId}.md`);
+    fs.unlinkSync(midPath);
+    const mk = spawnSync('mkfifo', [midPath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+    const r = run(cwd, home, ['--read', 'mat-mid', '--materialize', '--scope', 'local']);
+    fs.unlinkSync(midPath);
+    assert.equal(r.code, 0, `exit 0; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.equal(r.json.status, 'ok');
+    assert.equal(r.json.terminal_id, 'mat-mid');
+    assert.equal(r.json.count, 2, 'both chain members present (skip, not drop)');
+    const midMember = r.json.members.find((m) => m.id === 'mat-mid');
+    assert.equal(midMember.body_len, 0, 'FIFO member contributes zero-length body');
+    assert.ok(!r.json.body.includes('to be fifo'), 'skipped body text absent from the concatenated materialize body');
+    assert.ok(
+      typeof r.json.warning === 'string' && r.json.warning.includes('mat-mid') && r.json.warning.includes('ENOTREG'),
+      `warning names the skipped member + code, got ${JSON.stringify(r.json.warning)}`
+    );
+  });
+} else {
+  console.log('  skip  FIFO legs (mkfifo unavailable on win32)');
+}
 
 console.log(`\n${pass}/${pass + fail} pass`);
 process.exit(fail ? 1 : 0);

--- a/tests/test-em-stats-semantic.mjs
+++ b/tests/test-em-stats-semantic.mjs
@@ -35,9 +35,9 @@ function t(name, fn) {
 }
 
 function run(script, args, cwd, env) {
-  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', timeout: 10000, env: { ...process.env, ...env } });
   let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
-  return { code: r.status, json, stdout: r.stdout };
+  return { code: r.status, json, stdout: r.stdout, signal: r.signal };
 }
 
 function snapshot(dir) {
@@ -300,6 +300,123 @@ print(json.dumps({'order': list(reversed(ids))}))
   assert.equal(rr.reranked, true, JSON.stringify(rr));
   assert.deepEqual(rr.episodes.map(e => e.id), [...base.episodes.map(e => e.id)].reverse());
 });
+
+// ---------------------------------------------------------------------------
+// Issue #666/#667 S2: FIFO-shaped episode bodies in em-embed / em-semantic
+// --full. Isolated fixtures (own cwd/home) so the FIFO swap cannot bleed
+// into the shared fixture above.
+// ---------------------------------------------------------------------------
+const IS_WIN = process.platform === 'win32';
+
+if (!IS_WIN) {
+  t('embed: episode body FIFO -> skipped (no embedding row for that id), warning present, no hang', () => {
+    const ecwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emembed-fifo-')));
+    const ehome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emembed-fifo-home-')));
+    const eenv = { HOME: ehome };
+    const healthyId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'healthy embed target', '--body', 'plain body text'], ecwd, eenv).json.id;
+    const fifoId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'fifo embed target', '--body', 'will become fifo'], ecwd, eenv).json.id;
+    const estore = path.join(ecwd, '.episodic-memory');
+    const fifoEpisodePath = path.join(estore, 'episodes', `${fifoId}.md`);
+    fs.unlinkSync(fifoEpisodePath);
+    const mk = spawnSync('mkfifo', [fifoEpisodePath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+    const r = run('em-embed.mjs', ['--scope', 'local'], ecwd, eenv);
+    fs.unlinkSync(fifoEpisodePath);
+    assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`);
+    assert.equal(r.code, 0, `exit 0, got ${r.code}: ${r.stdout}`);
+    assert.equal(r.json.status, 'ok');
+    const scopeResult = r.json.scopes.find((s) => s.scope === 'local');
+    assert.ok(scopeResult, 'local scope present');
+    assert.ok(
+      Array.isArray(scopeResult.warnings) && scopeResult.warnings.some((w) => w.includes(fifoId) && w.includes('ENOTREG')),
+      `warnings names the skipped episode + code, got ${JSON.stringify(scopeResult.warnings)}`
+    );
+    const side = fs.readFileSync(path.join(estore, 'embeddings.jsonl'), 'utf8');
+    assert.ok(side.includes(healthyId), 'healthy episode got an embedding row');
+    assert.ok(!side.includes(fifoId), 'FIFO-shaped episode got NO embedding row (skipped, re-embeddable after heal)');
+    fs.rmSync(ecwd, { recursive: true, force: true });
+    fs.rmSync(ehome, { recursive: true, force: true });
+  });
+
+  // Review fix-round item 2: proves em-embed.mjs's `warnings.length > 0`
+  // write trigger is load-bearing (kills the mutation "delete
+  // `|| warnings.length > 0` from em-embed.mjs's write condition"). Both
+  // episodes embed cleanly on the FIRST run; the second run's content hashes
+  // are unchanged for BOTH ids (victim now unreadable, healthy untouched),
+  // so todo=0/dropped=0/rebuild=false — ONLY the warnings-triggered write
+  // can evict the victim's now-stale sidecar row.
+  t('embed: second run after a body FIFO-swap evicts the stale row (warnings.length triggers the write with zero todo/dropped/rebuild)', () => {
+    const vcwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emembed-evict-')));
+    const vhome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emembed-evict-home-')));
+    const venv = { HOME: vhome };
+    const healthyId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'healthy evict target', '--body', 'plain body text'], vcwd, venv).json.id;
+    const victimId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'victim evict target', '--body', 'will become fifo after first embed'], vcwd, venv).json.id;
+    const vstore = path.join(vcwd, '.episodic-memory');
+
+    const first = run('em-embed.mjs', ['--scope', 'local'], vcwd, venv);
+    assert.equal(first.code, 0, `first embed exit 0, got ${first.code}: ${first.stdout}`);
+    assert.equal(first.json.scopes[0].embedded, 2, 'both episodes embedded on the first run');
+    let side = fs.readFileSync(path.join(vstore, 'embeddings.jsonl'), 'utf8');
+    assert.ok(side.includes(healthyId) && side.includes(victimId), 'both rows present after the first embed');
+
+    const victimPath = path.join(vstore, 'episodes', `${victimId}.md`);
+    fs.unlinkSync(victimPath);
+    const mk = spawnSync('mkfifo', [victimPath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+
+    const second = run('em-embed.mjs', ['--scope', 'local'], vcwd, venv);
+    fs.unlinkSync(victimPath);
+    assert.equal(second.signal, null, `no signal (hang), got ${second.signal}`);
+    assert.equal(second.code, 0, `second embed exit 0, got ${second.code}: ${second.stdout}`);
+    assert.equal(second.json.status, 'ok');
+    const scopeResult = second.json.scopes.find((s) => s.scope === 'local');
+    assert.ok(scopeResult, 'local scope present');
+    assert.equal(scopeResult.embedded, 0, 'nothing NEW to embed (healthy row reused unchanged, victim skipped)');
+    assert.ok(
+      Array.isArray(scopeResult.warnings) && scopeResult.warnings.some((w) => w.includes(victimId) && w.includes('ENOTREG')),
+      `warnings names the victim id + code, got ${JSON.stringify(scopeResult.warnings)}`
+    );
+    side = fs.readFileSync(path.join(vstore, 'embeddings.jsonl'), 'utf8');
+    assert.ok(!side.includes(victimId), 'victim row EVICTED from the sidecar after the second (warnings-only) run');
+    assert.ok(side.includes(healthyId), 'healthy row still present');
+
+    fs.rmSync(vcwd, { recursive: true, force: true });
+    fs.rmSync(vhome, { recursive: true, force: true });
+  });
+
+  t('semantic --full: episode body FIFO -> skipped (no body field), warning present, no hang', () => {
+    const scwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emsem-fifo-')));
+    const shome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emsem-fifo-home-')));
+    const senv = { HOME: shome };
+    const healthyId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'healthy semantic target', '--body', 'shared vocabulary term alpha'], scwd, senv).json.id;
+    const fifoId = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'fifo semantic target', '--body', 'shared vocabulary term alpha too'], scwd, senv).json.id;
+    const embedR = run('em-embed.mjs', ['--scope', 'local'], scwd, senv);
+    assert.equal(embedR.code, 0, `embed seed exit 0, got ${embedR.code}: ${embedR.stdout}`);
+    const sstore = path.join(scwd, '.episodic-memory');
+    const fifoEpisodePath = path.join(sstore, 'episodes', `${fifoId}.md`);
+    fs.unlinkSync(fifoEpisodePath);
+    const mk = spawnSync('mkfifo', [fifoEpisodePath]);
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+    const r = run('em-semantic.mjs', ['--query', 'shared vocabulary term', '--scope', 'local', '--no-track', '--full', '--min-sim', '0'], scwd, senv);
+    fs.unlinkSync(fifoEpisodePath);
+    assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`);
+    assert.equal(r.code, 0, `exit 0, got ${r.code}: ${r.stdout}`);
+    assert.equal(r.json.status, 'ok');
+    const healthyEp = r.json.episodes.find((e) => e.id === healthyId);
+    const fifoEp = r.json.episodes.find((e) => e.id === fifoId);
+    assert.ok(healthyEp && healthyEp.body, `healthy episode body present, got ${JSON.stringify(healthyEp)}`);
+    assert.ok(fifoEp, 'FIFO episode still present in results (skip, not drop)');
+    assert.equal(fifoEp.body, undefined, 'FIFO episode emitted WITHOUT body');
+    assert.ok(
+      typeof r.json.warning === 'string' && r.json.warning.includes(fifoId) && r.json.warning.includes('ENOTREG'),
+      `warning names the skipped episode + code, got ${JSON.stringify(r.json.warning)}`
+    );
+    fs.rmSync(scwd, { recursive: true, force: true });
+    fs.rmSync(shome, { recursive: true, force: true });
+  });
+} else {
+  console.log('  skip  FIFO legs (mkfifo unavailable on win32)');
+}
 
 fs.rmSync(cwd, { recursive: true, force: true });
 fs.rmSync(home, { recursive: true, force: true });

--- a/tests/test-enforce-contract.mjs
+++ b/tests/test-enforce-contract.mjs
@@ -323,7 +323,10 @@ function armedRepo() {
 function stageModule(scriptsDir) {
   fs.mkdirSync(path.join(scriptsDir, 'lib'), { recursive: true })
   fs.copyFileSync(path.join(REPO, 'scripts', 'enforce-contract.mjs'), path.join(scriptsDir, 'enforce-contract.mjs'))
-  for (const lib of ['local-dir', 'marker-paths', 'marker-state', 'session-id', 'json-instance-validate', 'effective-tier', 'bp001-advisory']) {
+  // index-state: bp001-advisory imports readSidecarOrDegrade for its #666 S4
+  // SessionStart-hang fix; index-state.mjs itself imports only node:path, so
+  // staging it is closure-complete.
+  for (const lib of ['local-dir', 'marker-paths', 'marker-state', 'session-id', 'json-instance-validate', 'effective-tier', 'bp001-advisory', 'index-state']) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', `${lib}.mjs`), path.join(scriptsDir, 'lib', `${lib}.mjs`))
   }
 }

--- a/tests/test-issue-146.mjs
+++ b/tests/test-issue-146.mjs
@@ -554,9 +554,12 @@ function mkE2EHome() {
   //   session-id (2026-05-18 concurrent-session fix)
   //   effective-tier + json-instance-validate (P3b-2 tier/clamp layer)
   //   bp001-advisory (P3d, relocated bp-001 advisory)
+  //   index-state (#666 S4: bp001-advisory imports readSidecarOrDegrade for
+  //   its SessionStart-hang fix; index-state.mjs itself imports only
+  //   node:path, so staging it is closure-complete)
   // Omit any and enforce-contract fails to load → hook falls back to loud-fail.
   fs.copyFileSync(ENFORCE, path.join(scripts, 'enforce-contract.mjs'))
-  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'marker-state.mjs', 'session-id.mjs', 'effective-tier.mjs', 'json-instance-validate.mjs', 'bp001-advisory.mjs']) {
+  for (const lib of ['local-dir.mjs', 'marker-paths.mjs', 'marker-state.mjs', 'session-id.mjs', 'effective-tier.mjs', 'json-instance-validate.mjs', 'bp001-advisory.mjs', 'index-state.mjs']) {
     const libSrc = path.join(REPO_ROOT, 'scripts', 'lib', lib)
     fs.copyFileSync(libSrc, path.join(scripts, 'lib', lib))
   }

--- a/tests/test-stop-gate.sh
+++ b/tests/test-stop-gate.sh
@@ -107,6 +107,10 @@ mk_fake_home() {
   # (the relocated --session-start bp-001 advisory). Load-time dep regardless of
   # whether the stop gate calls it; omit it and the module fails to load.
   cp "$REPO_ROOT/scripts/lib/bp001-advisory.mjs" "$fake_home/.episodic-memory/scripts/lib/bp001-advisory.mjs"
+  # #666 S4: bp001-advisory.mjs imports readSidecarOrDegrade from index-state.mjs
+  # for its SessionStart-hang fix. index-state.mjs itself imports only
+  # node:path, so staging it is closure-complete.
+  cp "$REPO_ROOT/scripts/lib/index-state.mjs" "$fake_home/.episodic-memory/scripts/lib/index-state.mjs"
 }
 
 TMP_ROOT="$(mktemp -d -t em-stopgate-XXXXXX)"


### PR DESCRIPTION
## Summary

Closes the #653 D2 residual (**#666**) and the #661-close residual (**#667**) in one class-neighborhood slice, built via the playbook-v15 gate-free arc (2 scouts → twice-audited frozen spec → test-first builder → 2-lens review + fix round → independent verification).

**#666 — FIFO-shaped `episodes/*.md` no longer hangs body-loading paths.** Shared fd-based `O_NONBLOCK` helpers in `lib/index-state.mjs` (`readBodyOrSkip` never-throw per-row skip, `openReadableBody` null-on-absent / typed `BodyUnreadableError`), adopted by em-search (including the `--read` double-read fix), em-graph, em-semantic, em-embed, em-revise (role-split: `:211`/`:495` authoritative typed abort, `:387` advisory degrade), and `bp001-advisory` (a **static** SessionStart-path hang the scouts found — worse than the issue's TOCTOU-only framing). New code family `episode-unreadable:<CODE>`; ENOENT behavior preserved per-site exactly (`body_missing` exit-0 contract untouched, no new warnings on dangling-row stores).

**#667 — em-store write-block failures emit typed envelopes, not raw stacks.** Four sites covered: bare pre-try lock acquire → `store-lock-failed:<CODE>`; index-commit / episodes-dir / episode-file / derived-index legs → `episode-write-failed:<CODE>` with a leg sentinel naming the failing leg. Errno predicate (`typeof e.errno === 'number' && typeof e.code === 'string'`) keeps programming errors on the raw stack deliberately. The dangling-index-row fail shape (self-healing via `em-rebuild-index`) is unchanged by design, and asserted so.

Carried P3s from the #665 round: em-restore drops `stack` from error payloads; `em-rebuild-index --check` gains skip warnings (explicitly supersedes the #653 F1c "drift only" scope); store-identity's classify-then-read TOCTOU closed; `EM_SCRIPTS_GUIDE` documents all three new code families.

## Out of scope (deferred with follow-up issues)

Curation/audit-tier body reads, the BP-1 subsystem's independent `episodes/` readers, and the vendored `plugins/` fork (which still carries the pre-DEFER-3 orphan-producing write order — regenerate-vs-retire decision flagged) — follow-up issues filed alongside this PR with 5-field justifications in the spec §4.

## Evidence

- Spec: `docs/plans/fix-666-667.md`, frozen after 2 negative-scenario audit rounds (round 1 HOLD with 2 majors both confirmed in source and fixed in-spec; round 2 PROCEED-TO-FREEZE).
- Test-first: every new leg observed RED before implementation (hang legs via spawn timeouts — suite fails, never freezes).
- 2-lens review on the frozen diff (md5-pinned): claude-subagent runtime lens (4/4 mutations caught, all invariants probe-verified) and kimi-k3 static lens — both ACCEPT-WITH-FINDINGS, zero MAJOR; the one convergent finding (fail-not-freeze on in-process FIFO legs) plus 5 accepted findings applied in the fix round, including a mutation-kill-proven em-embed eviction leg.
- Independent orchestrator verification on the final tree: 164/164 (4 platform skips), 22/22, 12/12, 16/16, 46/46, 60/60, 16/16; live fixture probes: `episode-write-failed:EEXIST at episodes-dir` envelope, `--full` FIFO skip + warning, `--read` FIFO `episode-unreadable:ENOTREG` abort — all byte-matching the spec.
- Gate #644: plugin 0.2.8 → 0.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)