### PR TITLE
FIX-669: curation/audit-tier guarded body-read class pass (fixes #669)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -413,6 +413,15 @@ jobs:
       - name: Run em-move suite (RFC-005)
         run: node tests/test-em-move.mjs
 
+      - name: Run em-pin body-read suite (#669)
+        run: node tests/test-em-pin-body-read.mjs
+
+      - name: Run em-backup body-read suite (#669)
+        run: node tests/test-em-backup-body-read.mjs
+
+      - name: Run em-review-request body-read suite (#669)
+        run: node tests/test-em-review-request-body-read.mjs
+
       - name: Run em-stats + semantic recall suite
         run: node tests/test-em-stats-semantic.mjs
 

--- a/docs/plans/fix-669.md
+++ b/docs/plans/fix-669.md
@@ -1,0 +1,202 @@
+# Plan: fix #669 (curation/audit-tier episode-body FIFO reads + rule-node scan reads)
+
+Status: **FROZEN** 2026-08-14. Audit round 1 HOLD (4 MAJORs) → all seven
+required edits folded → round 2 delta re-walk **PROCEED-TO-FREEZE** with two
+one-line MINOR pins (folded: classifyConflict per-code/force mapping,
+classify unreadable→'binary') and the site-count convention fix. Builder
+implements THIS text; deviations are flagged, never improvised.
+Arc: playbook-v15 gate-free run, 2026-08-14. Evidence: scout seat digest +
+NSP round-1 probes, all file:line claims ground-truthed at main 2c2c7f4
+(orchestrator spot-verified the six load-bearing round-1 citations in-tree).
+Exit 142 = SIGALRM = hang confirmed under probe wrapper.
+
+## 0. Evidence scope
+
+- Scout: every #669-listed site verified at HEAD; line drifts
+  `em-promote.mjs:365`→`:367`, `em-workflow-validate.mjs:568`→`:570`. Zero
+  prior work on any site. Runtime-confirmed hangs: `em-pin.mjs:78` (>6s block
+  **holding the store write lock**; force-kill leaves stale
+  `clerk-apply.lock`) and `lib/rule-nodes.mjs` `scanRuleNodes` (FIFO named
+  `MEMORY.md`). Control: `em-graph --orphans` (fixed in #668) exits 0 <1s
+  with `body_warnings … unreadable (ENOTREG)`.
+- NSP round 1 (HOLD): `em-restore --dry-run` with a FIFO at a **target-store**
+  episode path → exit 142 (planning-time `classifyConflict` reads at
+  `em-restore.mjs:333-334` — lstat symlink guard passes a FIFO, then raw
+  read blocks). `em-backup --audit` with a planted at-rest FIFO exits 0
+  TODAY — `walk()` (`em-backup.mjs:402`) pushes `isFile()` dirents only, so
+  at-rest FIFOs never reach the reads; those rows are race-window hardening,
+  not at-rest-hang fixes.
+- Helper of record (shipped #668): `scripts/lib/index-state.mjs:236-280` —
+  `readBodyOrSkip(fsMod, filePath)` → `{ok:true, raw:string} |
+  {ok:false, code}` (never throws, never blocks; single-fd
+  open(O_RDONLY|O_NONBLOCK)+fstat+read, finally-close — NSP-verified sound);
+  `openReadableBody` → string | null(absent) | throws `BodyUnreadableError`
+  (`.code`/`.file`); wire family `episode-unreadable:<CODE>`.
+  `lib/body-file.mjs` is a different helper (operator `--body-file` arg), not
+  touched.
+
+## 1. Slice S1 — guarded-read adoption (30 read sites, 9 files)
+
+Count convention: every raw read the table enumerates counts as one site —
+27 episode-body reads + the `:352` classify sibling + the `:164` doc-domain
+scan + the `:145` hash helper (call sites `:293-294`). S2 adds 2 rule-node
+sites.
+
+Per-site rules:
+
+- **R-A** Replace the raw `fs.readFileSync` (and any ambient try/catch whose
+  only job was that read) with `readBodyOrSkip(fs, path)`; `ok:false` takes
+  the site's EXISTING failure disposition (skip row / return value /
+  continue), converting hang → skip. Never a raw throw, never a block.
+- **R-B (F5 rule, carried)** `ENOENT` stays silent everywhere. Non-ENOENT
+  (`ENOTREG`, `EISDIR`, `EACCES`, …): if the tool's JSON output already
+  carries a warnings/errors channel, report there in that tool's OWN shape;
+  a silent-by-design catch-and-continue MAY stay silent **except at
+  validation/verification-gate sites — see R-D**. Warning-shape unification
+  stays out of scope (D-4). em-backup additionally gains an
+  `unreadable_skipped` count in its EXISTING report shape (round-1 Q2: its
+  silent exclusion of non-regular files is pre-existing, but must stop being
+  invisible).
+- **R-C** Single-target reads (caller asked for THAT file) use
+  `openReadableBody` with explicit null/throw mapping; loop scans use
+  `readBodyOrSkip`. **Exception — em-pin.mjs:78 keeps `readBodyOrSkip`**: a
+  thrown `BodyUnreadableError` would be swallowed by the generic catch at
+  `em-pin.mjs:121-126` into a code-less message, losing the typed envelope.
+  Mechanism pinned: on `ok:false`, set `result`/`exitCode` inside the try
+  (pattern of `:80-82`) and fall through — NEVER `process.exit` inside the
+  try — so the `finally` (`:128-129`) releases the write lock
+  (`store-write-lock.mjs:177-184` is null-safe/idempotent). The error path
+  precedes the first write (`:114`): a failed pin changes nothing on disk,
+  releases the lock, exits 1.
+- **R-D (validation gates fail closed — round-1 MAJOR-2)** At
+  `em-review-request.mjs:324,:371` and `em-workflow-validate.mjs:194,:570`,
+  non-ENOENT unreadable is a GATE FAILURE reported through the tool's
+  existing errors channel — never a silent skip (a planted FIFO must not
+  dodge a cross-task/provenance check). Absent (`ENOENT`) keeps each site's
+  existing absent semantics. At `:194` (`extractPayload`), the existing
+  failure mode is throw → caught at `:957` → `errors.push`: preserve that
+  fail-closed shape (convert `ok:false` non-ENOENT into the same
+  errors-channel outcome, e.g. by rethrowing a typed error for `:957` to
+  catch).
+
+| File | Sites | Role | Disposition after fix |
+|---|---|---|---|
+| em-consolidate.mjs | :832 :920 :1676 | loop-scan advisory | `readBodyOrSkip`, existing skip/null semantics |
+| em-consolidate.mjs | :1609 | read-modify-write | `readBodyOrSkip`; skip = index/file divergence identical to today's catch{} — accepted, note in code only if a comment exists today |
+| em-consolidate.mjs | :1821 :2471 | fold/migrate source | `readBodyOrSkip`; prefer SKIP-THE-MEMBER over empty-body proceed where the surrounding loop allows it cheaply (round-1 MINOR-4); else keep existing empty-body behavior and name it in the §4 follow-up issue |
+| em-promote.mjs | :161 :277 :367 :459 :462 :644 | loop-scan / hash-identity | `readBodyOrSkip`; skip row on `ok:false`. (:459/:462 sit inside the `try{}` at `:458` with `catch {}` at `:465` — round-1 corrected the draft's "no try/catch" claim; disposition unchanged.) Hash sites are digest-stable: `computeContentSha256` utf8-normalizes Buffer input first (`lib/promotion-sources.mjs:57-60`), so the Buffer→string swap cannot change any content_sha256 |
+| em-move.mjs | :266 :316 | single-target authoritative | `openReadableBody`; unreadable → per-id error entry + continue (match the `:268-271` errors.push pattern — `:266` is PRE-lock and outside any try today, so the builder wraps it; a bare throw there crashes the whole run). Typed error BEFORE any move side-effect. `:399`'s catch currently drops `e.code` — carry the code into the error entry |
+| em-move.mjs | :145 (`sha256`, called `:293-294`) | hash-identity | guarded read; the both-scopes divergence check runs **under both store locks** — on `ok:false`, emit the existing per-id error entry (same severity class as em-pin's lock-hold) and continue; never block holding two locks |
+| em-move.mjs | :164 | doc-domain anchor scan (MEMORY.md) | `readBodyOrSkip`, skip + existing warn channel |
+| em-pin.mjs | :78 | single-target authoritative (locked) | per R-C exception above; typed envelope `episode-unreadable:<CODE>`, exit 1, lock released |
+| em-backup.mjs | :549 :651 :1483 | loop-scan (race-window hardening — at-rest FIFOs never reach these reads, see §0) | `readBodyOrSkip`; skipped body must NOT abort the run; counted in `unreadable_skipped` (R-B) |
+| em-backup.mjs | :352 (`classifyFileBytes`) | classify (race-window) | same-class sibling: blocking `openSync` without O_NONBLOCK sitting BEFORE `:549`/`:623` — swap to the fd-based non-blocking classify pattern (helper family), preserving its existing classification return shape. **Pinned (round-2 MINOR-R2-2):** fd-classify failures keep today's catch mapping (`em-backup.mjs:360-361`) → `'binary'`, so `:547`/`:623` consumers and counts are untouched |
+| em-restore.mjs | :333 :334 (`classifyConflict`) | conflict-classify (TARGET store, planning-time — round-1 MAJOR-1, probe-confirmed dry-run hang) | `readBodyOrSkip` on BOTH src and dst reads; `ok:false` → new conflict class `unreadable` carried in restore's existing per-item report shape (consumer-visible; wire note in PR); dry-run must terminate and report it. **Pinned (round-2 MINOR-R2-1):** per-code mapping — dst-side `ENOENT` (vanished after the `:329` existsSync) → `'clean'` (absent = no conflict); src-side `ENOENT` → skip + per-item report; all other codes → `'unreadable'`. `unreadable` stays default-skip under ALL modes **including `--force`** (restore never writes through an unclassifiable target; operator removes the poison manually) — documented in restore's help/PR, not remapped |
+| em-restore.mjs | :595 | loop-scan (import) | `readBodyOrSkip` + skip-and-report (never import a half-read body) |
+| em-restore.mjs | :977 | apply-time re-read of walked sourcePath (F1-class double-read) | prefer REUSING the planning-phase read where the data is already in hand; if the two phases are structurally separate, guard the re-read with `readBodyOrSkip` + per-item error entry (builder picks the smaller diff, flags which) |
+| em-review-request.mjs | :324 :371 | validation gate | R-D fail-closed via existing errors channel |
+| em-workflow-validate.mjs | :194 :570 | validation gate | R-D; `:570` also replaces the `existsSync`+read TOCTOU pair with ONE guarded read |
+| topic-tracks/engine.mjs | :245 | loop-scan / hash-identity | **settled (round-1 MINOR-5): no genuine Buffer dependency** — `bodyOf` decodes (`engine.mjs:184-185`) and `computeContentSha256` utf8-normalizes; adopt `readBodyOrSkip` directly, digests provably unchanged |
+
+## 2. Slice S2 — rule/RFC node scans (`lib/rule-nodes.mjs:111,166`)
+
+`scanRuleNodes`/`scanRfcNodes`: swap the raw read inside the directory-scan
+loop for `readBodyOrSkip`; `ok:false` → increment the EXISTING `skipped`
+counter (return shape `{ruleById, collisions, skipped}` unchanged; #603 stays
+untouched). No wire-shape change to em-graph output.
+
+## 3. Tests (test-first)
+
+- FIFO legs in existing dedicated suites (pattern
+  `tests/test-em-graph.mjs:168-205`: `spawnSync('mkfifo',…)`, isolated tmp
+  fixture, alarm wrapper, assert clean exit + skip semantics):
+  em-consolidate, em-promote, em-move, em-restore, em-workflow-validate,
+  topic-tracks, and a rule-node FIFO leg in `test-em-graph-nodes.mjs` (zero
+  FIFO coverage today, grep-confirmed).
+- **Probe shapes must reach the read (round-1 MAJOR-4):** em-restore legs
+  plant the FIFO in the TARGET store and assert BOTH `--dry-run` and apply
+  paths terminate with the `unreadable` conflict class; em-backup legs use
+  direct-unit calls (or race shapes) on `classifyFileBytes`/the read helpers
+  plus an `unreadable_skipped` count assertion — an at-rest-FIFO
+  end-to-end em-backup probe is VACUOUS (passes on unfixed HEAD) and must not
+  be counted as coverage.
+- Net-new minimal suites (no dedicated file today): `test-em-pin-body-read.mjs`
+  (FIFO under lock → typed `episode-unreadable:<CODE>` envelope, exit 1,
+  **on-disk `clerk-apply.lock` ABSENT afterward** — assert the file, not just
+  JSON), `test-em-backup-body-read.mjs`, `test-em-review-request-body-read.mjs`.
+- Every net-new suite step-wired into CI per `test-ci-suite-registration.mjs`.
+- **R1 resolved-NO (round 1):** no §1/§2 file appears in any of the five
+  hand-enumerated hook-fixture closures, and `index-state.mjs` is already
+  staged in all five since 1213bcf. Builder re-runs the closure grep as a
+  cheap guard; hook-E2E battery joins acceptance ONLY if that re-check flips.
+
+## 4. Non-scope (explicit)
+
+- D-4 warning-shape unification (carried deferral).
+- **DEFER-A (round 1, residual TOCTOU re-reads):** `em-move.mjs:335`
+  (`copyFileSync` EXDEV branch re-open), em-backup classify-then-read
+  double-open — attacker-race windows, not at-rest; #653 D1 precedent;
+  recovery = kill + stale-lock ESRCH reclaim (`lib/lock.mjs:38-46`).
+  Accepted residual, recorded in the PR body.
+- ONE follow-up issue filed at PR time enumerating the adjacent
+  same-trust-domain reads NOT in #669's title scope: `em-doctor.mjs:372`
+  (lock PID file), `:555` (classifier cache), `em-consolidate.mjs:1943,2107`
+  (conversion-log rotation), the sidecar-index family
+  (`em-prune.mjs:104`, `em-promote.mjs:524,:535`, `em-move.mjs:116,:136`,
+  `em-consolidate.mjs:1225,:1400,:1595,:1667`,
+  `em-review-request.mjs:484,:495`), the pre-existing em-backup silent
+  exclusion + prune-of-prior-dest-copy behavior
+  (`em-backup.mjs:640-658`), and the fold/migrate empty-body-proceed
+  residue if §1 keeps it anywhere.
+- #670 (BP-1 subsystem) — next arc; owns the Buffer-vs-string helper-API
+  decision (`parseBp1Frontmatter` strict-decode bypass risk). This slice
+  makes NO helper API change.
+- Vendored `plugins/episodic-memory` fork — #671, operator decision pending.
+
+## 5. Acceptance
+
+- Runtime probe battery on isolated fixture stores, probe shapes per §3
+  (target-store FIFO for restore incl. dry-run; unit/race legs for backup;
+  planted at-rest FIFO for the rest): every §1/§2 tool exits cleanly (no
+  exit 142) with the specified skip/typed-error/fail-closed semantics; em-pin
+  leaves no stale on-disk lock; em-move never blocks holding two locks.
+- New consumer-visible surfaces called out in the PR body: restore's
+  `unreadable` conflict class, the validators' new errors-channel entries,
+  em-backup's `unreadable_skipped` count.
+- Full local battery green (new + extended suites, test-651, search-read,
+  graph, stats-semantic, ci-registration, version-bump; hook-E2E only if the
+  §3 R1 re-check flips).
+- Plugin version bump 0.2.9 → 0.2.10 (scripts changed).
+- PR carries `fixes #669`, the §4 follow-up issue link, the em-pin/em-move
+  lock-hold severity note, and the DEFER-A record.
+
+## 6. Review-round amendments (2-lens, 2026-08-14)
+
+Lens 1 (codex, REJECT → fix round) + lens 2 (claude-subagent,
+ACCEPT-WITH-FINDINGS). Convergent MAJORs: (A1) em-move `sha256` hashed
+utf8-DECODED text — byte-divergent invalid-UTF-8 bodies collapsed to
+"identical" and the both-scopes branch unlinked one copy (both lenses
+runtime-confirmed) → fixed with a LOCAL fd-based raw-Buffer guarded read in
+em-move (no shared-helper API change; §4 stands); (A2) em-backup's
+entry-point guard `import.meta.url === file://argv[1]` silently no-ops the
+CLI via symlink/space paths (FU #390 regression) → realpath-both idiom.
+Codex-only MAJORs: (A3) restore `docWrites` — planning-time-unreadable docs
+must become TERMINAL skips and the apply-time raw `copyFileSync`
+(em-restore.mjs:947) is replaced by an fd-guarded byte-faithful read+write
+with per-item skip on `ok:false` (extends the :977 row; "guard the re-read
+alone" REJECTED); (A4) em-promote migration rows — ANY source-read
+`ok:false` skips the WHOLE row (reason `source-unreadable`), no partial
+`sources`, no placeholder successor (both branches; "partial retention"
+REJECTED as fail-open provenance). Adjudications: `source-missing` conflict
+string KEPT but promoted to a declared wire surface; restore help documents
+the `unreadable` class + default-skip-under-`--force` (the §1 pin's
+documentation leg); `readSkipManifest` surfaces the new manifest class;
+`syncToBackup` return key renamed `skippedUnreadable` (manifest key stays
+`skipped_unreadable`). Declared additive wire surfaces now: restore
+`unreadable` + `source-missing` conflict classes, `ref_integrity[].unreadable/.code`,
+promote `skipped[].reason:'source-unreadable'`, backup `skippedUnreadable`
+(return) / `skipped_unreadable` (manifest), validator error entries. Test
+amendments: em-move divergent-invalid-byte leg; backup symlink-invocation
+leg; backup FIFO-classify leg moved to a spawned child with external
+timeout; `scanRfcNodes` FIFO leg; promote migration-branch legs; restore
+planning-regular→apply-FIFO docWrites leg.

--- a/scripts/em-backup.mjs
+++ b/scripts/em-backup.mjs
@@ -20,6 +20,8 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 import { execSync, execFileSync } from 'child_process'
+import { fileURLToPath } from 'url'
+import { readBodyOrSkip } from './lib/index-state.mjs'
 
 const HOME = os.homedir()
 
@@ -347,10 +349,18 @@ function classifyFileBytes(filePath) {
   // Fast-path: known text extensions skip the probe and are always text.
   if (KNOWN_TEXT_EXTENSIONS.has(ext)) return 'text'
   // Probe the head of the file for binary markers.
+  // #669: fd-based non-blocking classify (same-class sibling of the
+  // index-state.mjs helper family) — a blocking openSync('r') on a FIFO
+  // with no writer would hang forever; O_NONBLOCK + fstat rejects any
+  // non-regular file before ever attempting the read. Pinned (round-2
+  // MINOR-R2-2): any classify failure — open error, non-regular fstat, or
+  // read error — keeps today's catch mapping to 'binary', unchanged.
   let buf
   try {
-    const fd = fs.openSync(filePath, 'r')
+    const fd = fs.openSync(filePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK)
     try {
+      const st = fs.fstatSync(fd)
+      if (!st.isFile()) return 'binary' // non-regular (FIFO/dir/device/...) → unreadable-as-text
       const probe = Buffer.alloc(BINARY_PROBE_BYTES)
       const n = fs.readSync(fd, probe, 0, BINARY_PROBE_BYTES, 0)
       buf = probe.subarray(0, n)
@@ -528,7 +538,7 @@ function redactConfigForDisplay(cfg) {
 function auditSources({ sample = 0 } = {}) {
   const report = {
     sources: [],
-    totals: { files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, redaction_findings: 0 },
+    totals: { files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, unreadable_skipped: 0, redaction_findings: 0 },
     samples: [],
     findings_by_pattern: {},
   }
@@ -536,7 +546,7 @@ function auditSources({ sample = 0 } = {}) {
     const exists = fs.existsSync(s.src)
     // Codex PR-#137 round-1: `src` leaks raw source paths.
     // Codex PR-#137 round-2 F1: `label` also leaks. Apply redaction to both.
-    const entry = { label: redactArtifactString(s.label), src: redactArtifactString(s.src), exists, files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, redactions: 0 }
+    const entry = { label: redactArtifactString(s.label), src: redactArtifactString(s.src), exists, files: 0, text_files: 0, binary_files: 0, oversized_skipped: 0, unreadable_skipped: 0, redactions: 0 }
     if (!exists) { report.sources.push(entry); continue }
     const files = walk(s.src)
     for (const f of files) {
@@ -545,8 +555,16 @@ function auditSources({ sample = 0 } = {}) {
       entry.files++
       report.totals.files++
       if (classifyFileBytes(f) === 'binary') { entry.binary_files++; report.totals.binary_files++; continue }
+      // #669: readBodyOrSkip — a race-window non-regular file (at-rest FIFOs
+      // never reach here; walk() only pushes isFile() dirents, see §0)
+      // becomes a counted skip instead of a hang. F5: ENOENT stays silent.
+      const bodyRead = readBodyOrSkip(fs, f)
+      if (!bodyRead.ok) {
+        if (bodyRead.code !== 'ENOENT') { entry.unreadable_skipped++; report.totals.unreadable_skipped++ }
+        continue
+      }
       entry.text_files++; report.totals.text_files++
-      const content = fs.readFileSync(f, 'utf8')
+      const content = bodyRead.raw
       const { redacted, findings } = applyRedactions(content)
       if (findings.length > 0) {
         const totalForFile = findings.reduce((a, b) => a + b.count, 0)
@@ -592,6 +610,7 @@ function syncToBackup({ verbose = false } = {}) {
   const skippedOversized = []
   const skippedBinary = [] // Codex F3: track skipped binaries explicitly.
   const skippedDerived = [] // #495: derived indexes excluded from backup.
+  const skippedUnreadable = [] // #669: race-window/non-regular reads at write time.
   for (const s of SOURCES) {
     if (!fs.existsSync(s.src)) continue
     // Codex round-3: use the pre-validated absDest from resolveConfig. This
@@ -647,9 +666,18 @@ function syncToBackup({ verbose = false } = {}) {
         skippedBinary.push({ source: safeLabel, path: redactArtifactString(p.source), size: p.size })
         continue
       }
+      // #669: readBodyOrSkip — a classify-then-read TOCTOU (source raced
+      // from regular to non-regular between the pre-walk classify above and
+      // this write pass) is accepted residual (DEFER-A, plan §4); the FIX
+      // here is only to never hang on it. Skipped body is counted and does
+      // NOT abort the run.
+      const bodyRead = readBodyOrSkip(fs, p.source)
+      if (!bodyRead.ok) {
+        if (bodyRead.code !== 'ENOENT') skippedUnreadable.push({ source: safeLabel, path: redactArtifactString(p.source) })
+        continue
+      }
       ensureDir(path.dirname(p.destPath))
-      const content = fs.readFileSync(p.source, 'utf8')
-      const { redacted, findings } = applyRedactions(content)
+      const { redacted, findings } = applyRedactions(bodyRead.raw)
       fs.writeFileSync(p.destPath, redacted)
       totalRedacted += findings.reduce((a, b) => a + b.count, 0)
       totalCopied++
@@ -668,6 +696,7 @@ function syncToBackup({ verbose = false } = {}) {
     skipped_oversized: skippedOversized.map(x => ({ ...x, max_bytes: MAX_FILE_BYTES })),
     skipped_binary: skippedBinary,
     skipped_derived_index: skippedDerived, // #495
+    skipped_unreadable: skippedUnreadable, // #669
   }
   fs.writeFileSync(path.join(BACKUP_DIR, '.skipped-files.json'), JSON.stringify(manifest, null, 2) + '\n')
   return {
@@ -677,6 +706,11 @@ function syncToBackup({ verbose = false } = {}) {
     skippedOversized: skippedOversized.length,
     skippedBinary: skippedBinary.length,
     skippedDerived: skippedDerived.length,
+    // #669 review-round lens-2 MINOR-2: camelCase to match every sibling in
+    // THIS return object (skippedSymlinks/skippedOversized/skippedBinary/
+    // skippedDerived) — the manifest's OWN skipped_unreadable key (snake,
+    // matching ITS snake-case siblings) is unaffected.
+    skippedUnreadable: skippedUnreadable.length,
   }
 }
 
@@ -1479,10 +1513,13 @@ function selfTest() {
     for (const bf of backupFiles) {
       const relInBackup = path.relative(tmpBackup, bf)
       if (relInBackup.includes(literal)) backupPathMatches++
-      try {
-        const content = fs.readFileSync(bf, 'utf8')
-        if (content.includes(literal)) backupContentMatches++
-      } catch { /* binary or unreadable */ }
+      // #669: readBodyOrSkip — the existing try/catch already treats any
+      // failure as "binary or unreadable" (silent skip); a raw readFileSync
+      // could still HANG on a non-regular file even inside try/catch (a
+      // blocking syscall never throws), so the guard is needed even though
+      // the disposition itself is unchanged.
+      const bodyRead = readBodyOrSkip(fs, bf)
+      if (bodyRead.ok && bodyRead.raw.includes(literal)) backupContentMatches++
     }
 
     // Grep captured outputs for literal + collision pair
@@ -1780,6 +1817,49 @@ function selfTest() {
     results.push({ name: 'issue495_derived_indexes_excluded_from_backup', pass: false, why: `test infrastructure error: ${e.message}` })
   }
 
+  // #669 review-round lens-2 MINOR-2: syncToBackup's RETURN object renamed
+  // unreadable_skipped -> skippedUnreadable (matches camelCase siblings
+  // skippedSymlinks/skippedOversized/skippedBinary/skippedDerived in THIS
+  // SAME object). Plant a genuinely-unreadable-but-present regular file
+  // (chmod 0o000) so the count is non-zero and deterministic (no race).
+  try {
+    if (process.getuid && process.getuid() === 0) {
+      results.push({ name: 'issue669_sync_result_skipped_unreadable_camel_key', skipped: true, why: 'running as root, chmod 0o000 does not block reads' })
+    } else {
+      const tmpBackup = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-unreadable-'))
+      execFileSync('git', ['init', '-b', 'main'], { cwd: tmpBackup, stdio: ['ignore', 'pipe', 'pipe'] })
+      const tmpSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'em-backup-unreadable-src-'))
+      fs.writeFileSync(path.join(tmpSrc, 'ok.txt'), 'readable\n')
+      const blockedPath = path.join(tmpSrc, 'blocked.txt')
+      fs.writeFileSync(blockedPath, 'unreadable\n')
+      fs.chmodSync(blockedPath, 0o000)
+
+      const savedBackupDir = BACKUP_DIR
+      const savedSources = [...SOURCES]
+      BACKUP_DIR = tmpBackup
+      SOURCES.length = 0
+      SOURCES.push({ src: tmpSrc, dest: 'u', absDest: path.join(tmpBackup, 'u'), label: 'u' })
+
+      const res = syncToBackup({})
+
+      BACKUP_DIR = savedBackupDir
+      SOURCES.length = 0
+      for (const s of savedSources) SOURCES.push(s)
+      fs.chmodSync(blockedPath, 0o644)
+      fs.rmSync(tmpBackup, { recursive: true, force: true })
+      fs.rmSync(tmpSrc, { recursive: true, force: true })
+
+      const hasCamelKey = res && res.skippedUnreadable === 1
+      const noSnakeKey = res && !('unreadable_skipped' in res)
+      const ok669 = hasCamelKey && noSnakeKey
+      if (ok669) pass++; else fail++
+      results.push({ name: 'issue669_sync_result_skipped_unreadable_camel_key', pass: ok669, ...(ok669 ? {} : { why: `hasCamelKey=${hasCamelKey} noSnakeKey=${noSnakeKey} res=${JSON.stringify(res)}` }) })
+    }
+  } catch (e) {
+    fail++
+    results.push({ name: 'issue669_sync_result_skipped_unreadable_camel_key', pass: false, why: `test infrastructure error: ${e.message}` })
+  }
+
   // #495 review finding (GLM lens): a store whose episodes/ is a SYMLINK must
   // NOT end up with a silently-EMPTY backup. walk() rejects the symlinked
   // episodes/ (no episodes copied); if isDerivedIndexPath followed the symlink
@@ -1834,12 +1914,12 @@ function selfTest() {
 // ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
-const argv = process.argv.slice(2)
-
-if (argv.includes('--help') || argv.includes('-h')) {
-  console.log(JSON.stringify({ status: 'help', script: 'em-backup.mjs', usage: 'node em-backup.mjs (--audit | --init | --sync | --self-test | --show-config) [--sample <n>]' }))
-  process.exit(0)
-}
+// #669: exported for tests/test-em-backup-body-read.mjs's direct-unit calls
+// on classifyFileBytes/auditSources (plan §3 — an at-rest-FIFO end-to-end
+// CLI probe is VACUOUS, since walk() already excludes non-regular dirents
+// before either function runs; the real exposure is a race-window, tested
+// by direct call instead).
+export { classifyFileBytes, auditSources, SOURCES }
 
 // Codex PR-#137 round-5: every CLI JSON output (success OR error) must pass
 // through artifact redaction at the output boundary. Patching individual
@@ -1912,6 +1992,36 @@ function runInit() {
   return { init, sync, commit }
 }
 
+// #669: entry-point guard. Every branch below ends in process.exit(), so
+// importing this module unconditionally would exit as a side effect of the
+// import (breaking the exports above for a test-file consumer). Running the
+// script normally (`node em-backup.mjs ...`) is unaffected — import.meta.url
+// equals the invoked file's path in that case. Function declarations above
+// this point (out, applyConfig, runSync, runInit, ...) stay unguarded since
+// selfTest() calls them directly.
+// review-round A2 (MAJOR, convergent — silent no-op CLI): a plain
+// `import.meta.url === file://${argv[1]}` string compare FAILS when the
+// invocation path has a symlink component or contains a space (the file://
+// URL percent-encodes spaces; argv[1] doesn't) — the CLI would then exit 0
+// with NO output instead of running (FU #390 regression class). Realpath-
+// both idiom (scripts/lib/structured-alert-probe.mjs:65-72 / N2): resolve
+// BOTH sides to their real filesystem path before comparing.
+const isMain = (() => {
+  if (!process.argv[1]) return false
+  try {
+    return fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+})()
+if (isMain) {
+const argv = process.argv.slice(2)
+
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(JSON.stringify({ status: 'help', script: 'em-backup.mjs', usage: 'node em-backup.mjs (--audit | --init | --sync | --self-test | --show-config) [--sample <n>]' }))
+  process.exit(0)
+}
+
 try {
   if (argv.includes('--self-test')) {
     // Self-test runs without config; uses isolated tmp dirs.
@@ -1963,3 +2073,4 @@ try {
   out({ status: 'error', message: String(e.message || e), stack: e.stack })
   process.exit(1)
 }
+} // #669 entry-point guard close

--- a/scripts/em-consolidate.mjs
+++ b/scripts/em-consolidate.mjs
@@ -63,7 +63,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { loadIndex, loadTagsIndex, normalizeTags, episodeTokens, updateTokensIndex, tokenizeQuery } from './lib/relevance.mjs'
 import { loadCategories, canonicalCategory, machineConsumedCategories, validateCategory } from './lib/categories.mjs'
 import { loadProtectionRows, computeProtectedIds, resolvePlaybookProtection } from './lib/protection.mjs'
-import { assertReadableIndex, readIndexFileOrThrow } from './lib/index-state.mjs'
+import { assertReadableIndex, readIndexFileOrThrow, readBodyOrSkip } from './lib/index-state.mjs'
 import {
   buildConsolidationAdvisory,
   PLAYBOOK_PROTECTION_CLASS,
@@ -829,7 +829,14 @@ if (clerk && !apply && !enrich) {
         .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')) || String(b.id || '').localeCompare(String(a.id || '')))
       for (const rr of rrRows) {
         let payload = null
-        try { payload = JSON.parse((fs.readFileSync(path.join(EPISODES_DIR, `${rr.id}.md`), 'utf8').split('\n\n').slice(1).join('\n\n') || '{}').replace(/^[^{]*/, '').match(/\{[\s\S]*\}/)?.[0] || 'null') } catch {}
+        // #669: readBodyOrSkip — a run-record body can be a race-window
+        // non-regular file; ok:false falls through to the existing
+        // "malformed/missing → skip" disposition below, same as a parse
+        // failure always has.
+        const bodyRead = readBodyOrSkip(fs, path.join(EPISODES_DIR, `${rr.id}.md`))
+        if (bodyRead.ok) {
+          try { payload = JSON.parse((bodyRead.raw.split('\n\n').slice(1).join('\n\n') || '{}').replace(/^[^{]*/, '').match(/\{[\s\S]*\}/)?.[0] || 'null') } catch {}
+        }
         if (!payload || !payload.conversion || !Array.isArray(payload.conversion.per_lesson)) continue
         for (const le of payload.conversion.per_lesson) {
           if (!le || typeof le.id !== 'string') continue
@@ -917,7 +924,11 @@ const rows = loadIndexOrAbort(DATA_DIR, scope, apply ? 'consolidate-apply' : 'co
 )
 
 function readEpisode(id) {
-  try { return fs.readFileSync(path.join(EPISODES_DIR, `${id}.md`), 'utf8') } catch { return null }
+  // #669: readBodyOrSkip — converts a FIFO/non-regular member body from a
+  // hang into the existing null (skip) disposition every caller already
+  // handles ("Episodes whose file is missing are skipped, not fatal").
+  const r = readBodyOrSkip(fs, path.join(EPISODES_DIR, `${id}.md`))
+  return r.ok ? r.raw : null
 }
 
 function bodyOf(content) {
@@ -1606,7 +1617,9 @@ function clerkWrite(kind, frontmatter, dataDir) {
     // Flip the episode file frontmatter too so a rebuild stays consistent.
     try {
       const fp = path.join(episodesDir, `${memberId}.md`)
-      const content = fs.readFileSync(fp, 'utf8')
+      const bodyRead = readBodyOrSkip(fs, fp)
+      if (!bodyRead.ok) throw new Error(`unreadable (${bodyRead.code})`)
+      const content = bodyRead.raw
       let updated = content.replace(/^status: active$/m, `status: superseded\nsuperseded_by: ${supersededBy}`)
       if (updated === content) updated = content.replace(/^---\n/, `---\nsuperseded_by: ${supersededBy}\n`)
       const ftmp = fp + '.tmp'
@@ -1673,7 +1686,9 @@ function clerkReadIndexRows(dataDir) {
 // Parse a run-record episode's JSON payload (stored as the last {-line of body).
 function clerkReadRunRecordPayload(dataDir, id) {
   try {
-    const content = fs.readFileSync(path.join(dataDir, 'episodes', `${id}.md`), 'utf8')
+    const bodyRead = readBodyOrSkip(fs, path.join(dataDir, 'episodes', `${id}.md`))
+    if (!bodyRead.ok) return null
+    const content = bodyRead.raw
     const lines = content.split('\n')
     for (let i = lines.length - 1; i >= 0; i--) {
       const s = lines[i].trim()
@@ -1818,7 +1833,13 @@ function clerkBuildMergeFrontmatter(members) {
   const reviewBys = members.map(m => m.review_by).filter(r => typeof r === 'string')
   const bodySections = members.map(m => {
     let body = ''
-    try { body = bodyOf(fs.readFileSync(path.join(EPISODES_DIR, `${m.id}.md`), 'utf8')) } catch {}
+    // #669 round-1 MINOR-4: consolidates[] above (memberIds) already lists
+    // every member regardless of body readability, so skip-the-member here
+    // would desync consolidates[] from the sections that actually landed —
+    // not cheap through a .map(). Existing empty-body-proceed fallback kept
+    // (residual named in the PR's follow-up issue, plan §4).
+    const bodyRead = readBodyOrSkip(fs, path.join(EPISODES_DIR, `${m.id}.md`))
+    if (bodyRead.ok) body = bodyOf(bodyRead.raw)
     return `## ${m.summary}\n\n(id: \`${m.id}\`, ${m.date})\n\n${body}`
   })
   const digestBody = [`Digest of ${members.length} related episodes (clerk merge, ${dateStr}).`, '', ...bodySections].join('\n\n')
@@ -2467,8 +2488,13 @@ async function clerkEnrichMain() {
       const row = activeRaw.find(r => r.id === p.id)
       if (!row) continue
       // Read the original body from the episode file.
-      let body = ''
-      try { body = bodyOf(fs.readFileSync(path.join(EPISODES_DIR, `${p.id}.md`), 'utf8')) } catch {}
+      // #669 round-1 MINOR-4: skip-the-member is cheap here (a real
+      // for-loop with continue) — reuse the existing reject channel so an
+      // unreadable body surfaces in the run's own report shape rather than
+      // silently proceeding with an empty body.
+      const bodyRead = readBodyOrSkip(fs, path.join(EPISODES_DIR, `${p.id}.md`))
+      if (!bodyRead.ok) { rejectedThisRun.push(p.id); continue }
+      const body = bodyOf(bodyRead.raw)
       // Build em-revise args (REQ-14: provenance-only triggers/applies).
       const args = [
         _revisePath,

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -46,7 +46,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { normalizeTags, episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip, openReadableBody, BodyUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -141,15 +141,70 @@ function addToInverted(dataDir, fileName, id, keys, pretty) {
   atomicReplaceFileSync(p, JSON.stringify(idx, ...(pretty ? [null, 2] : [])))
 }
 
+// #669: readEpisodeBodyOrThrow — fd-based guarded read for the pre-lock/
+// post-lock frontmatter-id content reads below (text use: regex + later
+// tokenization, not byte-identity — see readEpisodeBodyRawOrThrow below for
+// sha256's separate raw-Buffer need, review-round A1). openReadableBody
+// never blocks on a non-regular file (FIFO/dir/EACCES/...); a genuinely-
+// vanished (ENOENT) file is also converted to a throw here (plain Error, so
+// the existing catch(e) => errors.push(e.message) shape needs no new
+// branch) since every caller of this helper already confirmed presence
+// moments earlier and a race-vanish is exceptional either way.
+function readEpisodeBodyOrThrow(filePath) {
+  const body = openReadableBody(fs, filePath)
+  if (body === null) throw new Error(`Episode file vanished: ${filePath}`)
+  return body
+}
+
+// #669 review-round A1 (MAJOR, convergent — data loss): sha256() must hash
+// RAW BYTES, not the utf8-DECODED string readEpisodeBodyOrThrow returns.
+// Two byte-divergent invalid-UTF-8 bodies (e.g. a trailing 0xFF vs 0xFE) both
+// decode to the same string (lone surrogates become U+FFFD), so hashing the
+// decoded text collapsed them to "identical" — the found-in-both-scopes
+// divergence check then unlinked one copy as a false duplicate (data loss,
+// reviewer-confirmed: exit 0, moved, local deleted). LOCAL fd-based
+// raw-Buffer read — NOT a shared-helper change (plan §4 stands): open
+// O_NONBLOCK so a FIFO/no-writer never blocks, fstat rejects any
+// non-regular file BEFORE the read, readFileSync(fd) with NO encoding
+// returns the exact bytes. Reuses the already-exported BodyUnreadableError
+// class (index-state.mjs) purely for typed-error shape parity with
+// readEpisodeBodyOrThrow's callers — not a helper-contract change.
+function readEpisodeBodyRawOrThrow(filePath) {
+  const O_NONBLOCK_READ = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
+  let fd
+  try {
+    fd = fs.openSync(filePath, O_NONBLOCK_READ)
+  } catch (e) {
+    throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
+    }
+    if (st.isDirectory()) throw new BodyUnreadableError(filePath, 'EISDIR')
+    if (!st.isFile()) throw new BodyUnreadableError(filePath, 'ENOTREG')
+    try {
+      return fs.readFileSync(fd)
+    } catch (e) {
+      throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
 function sha256(p) {
-  return crypto.createHash('sha256').update(fs.readFileSync(p)).digest('hex')
+  return crypto.createHash('sha256').update(readEpisodeBodyRawOrThrow(p)).digest('hex')
 }
 
 // ---------------------------------------------------------------------------
 // Anchor pre-flight (RFC-005 F6): IDs hardcoded in MEMORY.md files have a
 // documented-anchor semantic role; moving them silently invalidates the path.
 // ---------------------------------------------------------------------------
-function findAnchoredIds(ids) {
+function findAnchoredIds(ids, warnings) {
   const anchored = new Map()
   const projectsDir = path.join(os.homedir(), '.claude', 'projects')
   let memoryFiles = []
@@ -160,8 +215,15 @@ function findAnchoredIds(ids) {
     }
   } catch {}
   for (const mf of memoryFiles) {
-    let content = ''
-    try { content = fs.readFileSync(mf, 'utf8') } catch { continue }
+    // #669: readBodyOrSkip — converts a FIFO/non-regular MEMORY.md from a
+    // hang into a skip. F5: ENOENT stays silent; non-ENOENT reports through
+    // this file's existing warnings channel (surfaced in the final JSON).
+    const r = readBodyOrSkip(fs, mf)
+    if (!r.ok) {
+      if (r.code !== 'ENOENT') warnings.push(`MEMORY.md anchor scan: ${mf} unreadable (${r.code}) — skipped`)
+      continue
+    }
+    const content = r.raw
     for (const id of ids) {
       if (content.includes(`episodes/${id}.md`)) {
         if (!anchored.has(id)) anchored.set(id, [])
@@ -211,7 +273,11 @@ if (ids.length > 10 && !confirm && !dryRun) {
   usageError(`${ids.length} episodes selected (> 10). Re-run with --confirm (or --dry-run to preview).`)
 }
 
-const anchoredIds = findAnchoredIds(ids)
+// warnings declared before findAnchoredIds (#669) so its MEMORY.md
+// unreadable-scan reports use the SAME channel the move loop below appends
+// to (single warnings surface in the final JSON).
+const warnings = []
+const anchoredIds = findAnchoredIds(ids, warnings)
 
 // ---------------------------------------------------------------------------
 // Per-episode move
@@ -219,7 +285,6 @@ const anchoredIds = findAnchoredIds(ids)
 const moved = []
 const noop = []
 const errors = []
-const warnings = []
 
 for (const id of ids) {
   if (!/^\d{8}-\d{6}-/.test(id)) {
@@ -239,8 +304,21 @@ for (const id of ids) {
   if (inLocal && inGlobal) {
     // F3 recovery: identical → an earlier move copied but never unlinked;
     // finish the cleanup. Different → hard error, touch nothing.
-    const hLocal = sha256(path.join(LOCAL_DIR, 'episodes', `${id}.md`))
-    const hGlobal = sha256(path.join(GLOBAL_DIR, 'episodes', `${id}.md`))
+    // #669: PRE-lock, outside any try — sha256() now reads via the guarded
+    // helper and can throw; wrap locally so an unreadable body becomes a
+    // per-id error + continue instead of crashing the whole run.
+    let hLocal, hGlobal
+    try {
+      hLocal = sha256(path.join(LOCAL_DIR, 'episodes', `${id}.md`))
+      hGlobal = sha256(path.join(GLOBAL_DIR, 'episodes', `${id}.md`))
+    } catch (e) {
+      errors.push({
+        id,
+        error: e instanceof BodyUnreadableError ? `episode body unreadable (${e.code}) (${e.file})` : e.message,
+        ...(e instanceof BodyUnreadableError ? { code: `episode-unreadable:${e.code}` } : {}),
+      })
+      continue
+    }
     if (hLocal !== hGlobal) {
       errors.push({ id, error: 'Present in BOTH scopes with DIFFERENT content — manual reconciliation required (compare the two files, delete the stale one, run em-rebuild-index --scope all).' })
       continue
@@ -263,7 +341,21 @@ for (const id of ids) {
   let srcFile = path.join(srcDir, 'episodes', `${id}.md`)
 
   // Defensive: frontmatter id must match the filename.
-  let content = fs.readFileSync(srcFile, 'utf8')
+  // #669: PRE-lock (this runs before acquireStoreWriteLocksSync below) and
+  // outside any try today — a bare throw here would crash the whole run.
+  // Wrap locally, matching the :292 errors.push pattern, so an unreadable
+  // body becomes a per-id error + continue instead of a hang or a crash.
+  let content
+  try {
+    content = readEpisodeBodyOrThrow(srcFile)
+  } catch (e) {
+    errors.push({
+      id,
+      error: e instanceof BodyUnreadableError ? `episode body unreadable (${e.code}) (${e.file})` : e.message,
+      ...(e instanceof BodyUnreadableError ? { code: `episode-unreadable:${e.code}` } : {}),
+    })
+    continue
+  }
   let fmId = (content.match(/^id:\s*(.+)$/m) || [])[1]
   if (fmId && fmId.trim() !== id) {
     errors.push({ id, error: `Frontmatter id "${fmId.trim()}" does not match filename — refusing to move.` })
@@ -313,7 +405,10 @@ for (const id of ids) {
     const currentFrom = SRC_SCOPE_OF(srcDir)
     srcFile = path.join(srcDir, 'episodes', `${id}.md`)
     const dstFile = path.join(DEST_DIR, 'episodes', `${id}.md`)
-    content = fs.readFileSync(srcFile, 'utf8')
+    // #669: already inside the lock-held try (catch below now carries
+    // e.code for a BodyUnreadableError) — a natural throw here is caught,
+    // reported per-id, and the finally still releases both locks.
+    content = readEpisodeBodyOrThrow(srcFile)
     fmId = (content.match(/^id:\s*(.+)$/m) || [])[1]
     if (fmId && fmId.trim() !== id) {
       errors.push({ id, error: `Frontmatter id "${fmId.trim()}" does not match filename — refusing to move.` })
@@ -397,7 +492,16 @@ for (const id of ids) {
 
     moved.push({ id, from: currentFrom, to, ...(auditId ? { audit_id: auditId } : {}) })
   } catch (e) {
-    errors.push({ id, error: e.message, ...(steps ? { steps_succeeded: steps } : {}), recovery: 'run em-rebuild-index --scope all after resolving the reported paths' })
+    // #669: e.code was previously dropped for a BodyUnreadableError thrown
+    // from the guarded reads above (sha256 / readEpisodeBodyOrThrow) —
+    // carry it so the per-id error entry names the typed wire code.
+    errors.push({
+      id,
+      error: e instanceof BodyUnreadableError ? `episode body unreadable (${e.code}) (${e.file})` : e.message,
+      ...(e instanceof BodyUnreadableError ? { code: `episode-unreadable:${e.code}` } : {}),
+      ...(steps ? { steps_succeeded: steps } : {}),
+      recovery: 'run em-rebuild-index --scope all after resolving the reported paths',
+    })
     continue
   } finally {
     releaseStoreWriteLocks(lockResult.handles)

--- a/scripts/em-pin.mjs
+++ b/scripts/em-pin.mjs
@@ -24,7 +24,7 @@ import path from 'path'
 import os from 'os'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { openReadableIndex, IndexUnreadableError, unreadableMessage } from './lib/index-state.mjs'
+import { openReadableIndex, IndexUnreadableError, unreadableMessage, readBodyOrSkip } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -75,7 +75,18 @@ let result
 let exitCode = 0
 try {
   // --- frontmatter: insert or remove the `pinned: true` line -------------
-  const content = fs.readFileSync(filePath, 'utf8')
+  // #669 R-C exception: readBodyOrSkip (not openReadableBody) — a thrown
+  // BodyUnreadableError would be swallowed by the generic catch below into
+  // a code-less message, losing the typed envelope. Set result/exitCode
+  // here and fall through (NEVER process.exit inside the try) so `finally`
+  // still releases the write lock. This read precedes the first write
+  // (atomicReplaceFileSync below): a failed pin changes nothing on disk.
+  const bodyRead = readBodyOrSkip(fs, filePath)
+  if (!bodyRead.ok) {
+    result = { status: 'error', message: `episode body unreadable (${bodyRead.code}) (${filePath})`, code: `episode-unreadable:${bodyRead.code}` }
+    exitCode = 1
+  } else {
+  const content = bodyRead.raw
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
   if (!fmMatch) {
     result = { status: 'error', message: `Episode "${id}" has no parseable frontmatter.` }
@@ -117,6 +128,7 @@ try {
       status: 'ok', id, pinned: !unpin,
       scope: dataDir === GLOBAL_DIR ? 'global' : 'local'
     }
+  }
   }
 } catch (e) {
   if (e instanceof IndexUnreadableError) {

--- a/scripts/em-promote.mjs
+++ b/scripts/em-promote.mjs
@@ -54,6 +54,7 @@ import { illegalScalarChar } from './lib/activation.mjs'
 import { resolveRegisteredStores } from './lib/registered-stores.mjs'
 import { canonicalizePromotionSources, computeContentSha256, resolveSourceRefs, serializePromotionSources, validatePromotionSources } from './lib/promotion-sources.mjs'
 import { tryAcquire, release } from './lib/lock.mjs'
+import { readBodyOrSkip } from './lib/index-state.mjs'
 
 export const PROMOTE_RUN_RECORD_TYPE = 'promote-run'
 import { RUN_RECORD_CATEGORY } from './lib/activation-log.mjs'
@@ -157,11 +158,12 @@ for (const st of stores) {
     if (r.status === 'superseded') continue
     if (typeof r.id !== 'string' || typeof r.summary !== 'string') continue
     if (canonicalCategory(r.category) !== 'lesson') continue
-    let content
-    try { content = fs.readFileSync(path.join(st.data_dir, 'episodes', `${r.id}.md`)) } catch {
+    const bodyRead = readBodyOrSkip(fs, path.join(st.data_dir, 'episodes', `${r.id}.md`))
+    if (!bodyRead.ok) {
       warnings.push({ episode: r.id, store: st.label, problem: 'episode file missing' })
       continue
     }
+    const content = bodyRead.raw
     const contentSha256 = computeContentSha256(content)
     const key = `${r.id}#${contentSha256}`
     const source = { store_id: st.store_id, episode_id: r.id, content_sha256: contentSha256 }
@@ -274,7 +276,8 @@ for (const r of globalRows) {
   }
   if (hashTags.length === 0) warnings.push({ episode: r.id, problem: 'promoted-lesson episode without a promoted:<sha8> tag' })
   let content = null
-  try { content = fs.readFileSync(path.join(GLOBAL_DIR, 'episodes', `${r.id}.md`), 'utf8') } catch {}
+  const bodyReadA = readBodyOrSkip(fs, path.join(GLOBAL_DIR, 'episodes', `${r.id}.md`))
+  if (bodyReadA.ok) content = bodyReadA.raw
   if (content === null) {
     warnings.push({ episode: r.id, problem: 'episode file missing' })
     continue
@@ -363,8 +366,9 @@ function recomputeSources(c) {
     const store = byStore.get(ref.store_id)
     if (!store) return null
     const file = path.join(store.data_dir, 'episodes', `${ref.episode_id}.md`)
-    let content
-    try { content = fs.readFileSync(file) } catch { return null }
+    const bodyReadB = readBodyOrSkip(fs, file)
+    if (!bodyReadB.ok) return null
+    const content = bodyReadB.raw
     const hash = computeContentSha256(content)
     if (hash !== ref.content_sha256) return null
     refs.push({ store_id: ref.store_id, episode_id: ref.episode_id, content_sha256: hash })
@@ -454,15 +458,34 @@ export function selectMigrationCandidates(rows) {
     if (row.status !== 'active') { skipped.push({ hash: row.id, reason: 'superseded' }); continue }
     // (6) parseable `## Sources` — state B. Only reached for global+active
     // legacy-shaped rows.
+    // #669 review-round A4 (codex MAJOR — fail-open provenance): the prior
+    // shape accumulated `sources` incrementally and let a mid-loop
+    // per-source hash-read failure fall into an EMPTY outer catch, so
+    // entries pushed by EARLIER-successful matches survived — a candidate
+    // could reach `candidates.push` with PARTIAL provenance (silently
+    // dropped evidence) instead of being skipped whole. Frozen disposition:
+    // ANY source-read ok:false (the row's own Sources-listing read, or any
+    // referenced episode's hash read) discards the row's `sources` entirely
+    // — explicit `sourceUnreadable` flag replaces throw-into-empty-catch so
+    // no partial array can escape this block.
+    const bodyReadC = readBodyOrSkip(fs, path.join(GLOBAL_DIR, 'episodes', `${row.id}.md`))
+    if (!bodyReadC.ok) { skipped.push({ hash: row.id, reason: 'source-unreadable' }); continue }
+    const text = bodyReadC.raw
+    if (!text.includes('## Sources')) { skipped.push({ hash: row.id, reason: 'no-parseable-sources' }); continue }
     let sources = []
-    try {
-      const text = fs.readFileSync(path.join(GLOBAL_DIR, 'episodes', `${row.id}.md`), 'utf8')
-      if (!text.includes('## Sources')) { skipped.push({ hash: row.id, reason: 'no-parseable-sources' }); continue }
-      for (const match of text.matchAll(/^- (\S+) \(([^,]+),/gm)) {
-        const source = stores.flatMap(st => loadIndexOrAbort(st.data_dir, st.label).filter(r => r.id === match[1]).map(r => ({ store_id: st.store_id, episode_id: r.id, content_sha256: computeContentSha256(fs.readFileSync(path.join(st.data_dir, 'episodes', `${r.id}.md`))) })))
-        sources.push(...source)
+    let sourceUnreadable = false
+    outer:
+    for (const match of text.matchAll(/^- (\S+) \(([^,]+),/gm)) {
+      for (const st of stores) {
+        for (const r of loadIndexOrAbort(st.data_dir, st.label)) {
+          if (r.id !== match[1]) continue
+          const hashRead = readBodyOrSkip(fs, path.join(st.data_dir, 'episodes', `${r.id}.md`))
+          if (!hashRead.ok) { sourceUnreadable = true; break outer }
+          sources.push({ store_id: st.store_id, episode_id: r.id, content_sha256: computeContentSha256(hashRead.raw) })
+        }
       }
-    } catch {}
+    }
+    if (sourceUnreadable) { skipped.push({ hash: row.id, reason: 'source-unreadable' }); continue }
     if (sources.length === 0) { skipped.push({ hash: row.id, reason: 'no-parseable-sources' }); continue }
     // (7) §12 state A: full match.
     candidates.push({ row, promotion_sources: canonicalizePromotionSources(sources), fingerprint: computeSourceFingerprint(sources) })
@@ -639,12 +662,28 @@ if (migrate) {
       // search hides superseded predecessors, so a sentinel-preserved body
       // here is the active-recall surface.
       const bodyFileMig = path.join(tmpDirMig, `${cand.row.id}.md`)
+      // #669 round-3 (codex MAJOR-2 residual, runtime-confirmed): this read
+      // previously ignored ok:false and silently substituted a placeholder
+      // body — the successor would still be written (with a
+      // "(no legacy body available)" placeholder) and the legacy row
+      // superseded, even though the source was genuinely unreadable at
+      // apply time (probe: targeted EACCES on exactly this read → exit 0,
+      // successor written with placeholder, legacy superseded). Plan §6 A4:
+      // ANY source-read ok:false skips the WHOLE row — no placeholder
+      // successor, no supersede, no em-revise spawn. Terminal skip via the
+      // SAME migSkipped array selectMigrationCandidates' state B/C/D
+      // skips already use; the post-loop sweep below converts it into the
+      // unified migItems list automatically.
+      const bodyReadD = readBodyOrSkip(fs, path.join(GLOBAL_DIR, 'episodes', `${cand.row.id}.md`))
+      if (!bodyReadD.ok) {
+        migSkipped.push({ hash: cand.row.id, reason: 'source-unreadable' })
+        continue
+      }
       let legacyBodyMig = ''
-      try {
-        const legacyText = fs.readFileSync(path.join(GLOBAL_DIR, 'episodes', `${cand.row.id}.md`), 'utf8')
-        const parts = legacyText.split('---')
+      {
+        const parts = bodyReadD.raw.split('---')
         if (parts.length >= 3) legacyBodyMig = parts.slice(2).join('---').trim()
-      } catch {}
+      }
       const successorBodyMig = [
         `Migration successor: typed promotion_sources + corrected project for ${cand.row.id}.`,
         '',

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -41,7 +41,7 @@ import { nullProtoIndex } from './lib/relevance.mjs'
 // derived-index merge so two restore targets cannot diverge before both
 // locks are held.
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip } from './lib/index-state.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -318,21 +318,35 @@ function expandSupersedesChain(selected, byId) {
 // Conflict classification (P1-8: 4 buckets, normalized-equal as 3rd)
 // ---------------------------------------------------------------------------
 function normalizeText(buf) {
-  let s = buf.toString('utf8')
+  let s = typeof buf === 'string' ? buf : buf.toString('utf8')
   if (s.charCodeAt(0) === 0xFEFF) s = s.slice(1) // strip BOM
   s = s.replace(/\r\n/g, '\n') // CRLF → LF
   s = s.replace(/\n+$/, '') + '\n' // single trailing newline
   return s
 }
 
+// #669 round-1 MAJOR-1 (probe-confirmed dry-run hang): both reads guarded
+// via readBodyOrSkip — planning-time, so classifyConflict must never block
+// on a target-store FIFO. Pinned (round-2 MINOR-R2-1) per-code mapping:
+//   - dst-side ENOENT here means the file vanished between the :fs.existsSync
+//     check above and this read (TOCTOU) — absent = no conflict → 'clean'.
+//   - src-side ENOENT means there is nothing to restore from → 'source-missing'
+//     (distinct from 'unreadable' for report clarity; both default-skip via
+//     decideAction's fallthrough, under EVERY conflictMode including --force
+//     — restore never writes through an unclassifiable source/target).
+//   - any other code (either side) → 'unreadable'.
 function classifyConflict(srcPath, dstPath) {
   if (!fs.existsSync(dstPath)) return 'clean'
   // P1-7: lstat dst; if symlink, special-case so we never write through it.
   const lst = fs.lstatSync(dstPath)
   if (lst.isSymbolicLink()) return 'target-symlink'
-  const a = fs.readFileSync(srcPath)
-  const b = fs.readFileSync(dstPath)
-  if (a.equals(b)) return 'identical'
+  const srcRead = readBodyOrSkip(fs, srcPath)
+  if (!srcRead.ok) return srcRead.code === 'ENOENT' ? 'source-missing' : 'unreadable'
+  const dstRead = readBodyOrSkip(fs, dstPath)
+  if (!dstRead.ok) return dstRead.code === 'ENOENT' ? 'clean' : 'unreadable'
+  const a = srcRead.raw
+  const b = dstRead.raw
+  if (a === b) return 'identical'
   if (normalizeText(a) === normalizeText(b)) return 'normalized-equal'
   return 'overwrite'
 }
@@ -592,7 +606,16 @@ function discoverEpisodes(backupDir, sourceLabels, sourceMap, sourceFilter) {
     let hadEpisodeForLabel = false
     for (const f of files) {
       if (!f.endsWith('.md')) continue
-      const content = fs.readFileSync(f, 'utf8')
+      // #669: readBodyOrSkip + skip-and-report — never import a half-read
+      // body. F5: ENOENT stays silent; non-ENOENT reuses the existing
+      // symlinkRejects report channel (already reused for "unsafe-id:" —
+      // see below).
+      const bodyRead = readBodyOrSkip(fs, f)
+      if (!bodyRead.ok) {
+        if (bodyRead.code !== 'ENOENT') symlinkRejects.push(`unreadable:${bodyRead.code}:${f}`)
+        continue
+      }
+      const content = bodyRead.raw
       const fm = parseFrontmatter(content)
       if (!fm || !fm.id) continue
       hadEpisodeForLabel = true
@@ -889,6 +912,42 @@ function applyEpisodeWrites(plan) {
 }
 
 // --include-docs atomic write via staging dir + per-file rename (P1-10)
+// #669 review-round A3(b) (codex MAJOR): a doc regular at planning time can
+// still race to non-regular (FIFO) before this staging copy runs — a raw
+// fs.copyFileSync blocks forever opening a FIFO with no writer (reviewer
+// probe: SIGKILL required to recover). fd-guarded RAW-BYTE read closes that:
+// O_NONBLOCK open (never blocks) + fstat().isFile() guard (rejects any
+// non-regular file BEFORE the read) + readFileSync(fd) with NO encoding
+// (byte-faithful — a doc copy must never decode/re-encode). Local to
+// em-restore.mjs, mirroring em-move.mjs's readEpisodeBodyRawOrThrow — no
+// shared-helper API change (plan §4 stands).
+function readDocBytesOrSkip(filePath) {
+  const O_NONBLOCK_READ = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
+  let fd
+  try {
+    fd = fs.openSync(filePath, O_NONBLOCK_READ)
+  } catch (e) {
+    return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+  }
+  try {
+    let st
+    try {
+      st = fs.fstatSync(fd)
+    } catch (e) {
+      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+    }
+    if (st.isDirectory()) return { ok: false, code: 'EISDIR' }
+    if (!st.isFile()) return { ok: false, code: 'ENOTREG' }
+    try {
+      return { ok: true, raw: fs.readFileSync(fd) }
+    } catch (e) {
+      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
+
 function applyDocWrites(plan, sourceMap) {
   const written = []
   const skipped = []
@@ -920,8 +979,16 @@ function applyDocWrites(plan, sourceMap) {
       for (const w of writes) {
         const rel = path.relative(targetDir, w.targetPath)
         const stagePath = path.join(stagingDir, rel)
+        // #669 review-round A3(b): guarded byte-faithful read replaces the
+        // raw copyFileSync — ok:false (incl. a race to non-regular since
+        // planning) is a per-item TERMINAL skip, never a hang.
+        const bodyRead = readDocBytesOrSkip(w.sourcePath)
+        if (!bodyRead.ok) {
+          skipped.push({ ...w, action: 'skip', apply_skip_reason: 'unreadable', code: bodyRead.code })
+          continue
+        }
         fs.mkdirSync(path.dirname(stagePath), { recursive: true })
-        fs.copyFileSync(w.sourcePath, stagePath)
+        fs.writeFileSync(stagePath, bodyRead.raw)
         staged.push({ w, stagePath })
       }
       // Rename phase: per-file atomic moves into final position.
@@ -974,7 +1041,28 @@ function buildRefIntegrityReport(plan, sourceMap, docs) {
   for (const [label, mems] of docsByLabel) {
     const targetDir = sourceMap.get(label)
     for (const mem of mems) {
-      const content = fs.readFileSync(mem.sourcePath, 'utf8')
+      // #669 (F1-class double-read — this same sourcePath is already read
+      // once by classifyConflict during buildWritePlan): the two phases are
+      // structurally separate (buildWritePlan iterates plan.docWrites,
+      // buildRefIntegrityReport iterates the raw `docs` list independently),
+      // so the smaller diff is to guard THIS re-read rather than thread the
+      // planning-phase content through; flagged in the PR body per plan §1.
+      const bodyRead = readBodyOrSkip(fs, mem.sourcePath)
+      if (!bodyRead.ok) {
+        if (bodyRead.code !== 'ENOENT') {
+          reports.push({ label, relPath: mem.relPath, present: true, unreadable: true, code: bodyRead.code, refs: [], dangling: [] })
+          // #669 review-round A3(a): a doc found unreadable HERE (before
+          // apply) must not carry a live action into apply — force the
+          // matching docWrites entry to a TERMINAL skip so applyDocWrites
+          // never attempts to stage/copy it. The ref_integrity entry above
+          // is the per-item report; this just stops the write.
+          for (const w of plan.docWrites) {
+            if (w.label === label && w.relPath === mem.relPath) w.action = 'skip'
+          }
+        }
+        continue
+      }
+      const content = bodyRead.raw
       // Build set of basenames in the restore set for THIS label
       const restoreBasenames = new Set()
       for (const w of plan.docWrites) if (w.label === label && w.action !== 'skip') restoreBasenames.add(path.basename(w.relPath))
@@ -1271,7 +1359,11 @@ function readSkipManifest(backupDir) {
       counts: {
         symlinks: (m.skipped_symlinks || []).length,
         oversized: (m.skipped_oversized || []).length,
-        binary: (m.skipped_binary || []).length
+        binary: (m.skipped_binary || []).length,
+        // #669 review-round lens-2 MINOR-1: em-backup's manifest gained a
+        // skipped_unreadable class (round-1 R-B); restore's summary of that
+        // SAME manifest silently omitted it — surface the count here too.
+        unreadable: (m.skipped_unreadable || []).length
       }
     }
   } catch (e) {
@@ -1466,6 +1558,175 @@ function selfTest() {
     assert('target_symlink_detected', classifyConflict(src, linkDst) === 'target-symlink')
     fs.rmSync(tmp, { recursive: true, force: true })
   } catch (e) { bad('target_symlink_detect', e.message) }
+
+  // T669: issue #669 round-1 MAJOR-1 (probe-confirmed dry-run hang) — a
+  // FIFO-shaped TARGET-store episode body previously hung classifyConflict
+  // forever (fs.readFileSync on both srcPath/dstPath, unguarded). The fix
+  // (readBodyOrSkip on both reads) must terminate the classify call itself,
+  // AND both --dry-run and --apply run() paths must terminate with the new
+  // 'unreadable' conflict class (round-2 MINOR-R2-1 pin), never a hang.
+  try {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'em-restore-t669-'))
+    const src = path.join(tmp, 'src.md')
+    const dstFifo = path.join(tmp, 'dst-fifo.md')
+    const srcFifo = path.join(tmp, 'src-fifo.md')
+    const dst = path.join(tmp, 'dst.md')
+    fs.writeFileSync(src, 'content\n')
+    fs.writeFileSync(dst, 'content\n')
+    execFileSync('mkfifo', [dstFifo])
+    execFileSync('mkfifo', [srcFifo])
+    assert('t669_dst_fifo_unreadable', classifyConflict(src, dstFifo) === 'unreadable',
+      `got ${classifyConflict(src, dstFifo)}`)
+    assert('t669_src_fifo_unreadable', classifyConflict(srcFifo, dst) === 'unreadable',
+      `got ${classifyConflict(srcFifo, dst)}`)
+    // Pinned (round-2 MINOR-R2-1): src-side ENOENT (vanished, not a FIFO) is
+    // its own class, distinct from 'unreadable' — decideAction still
+    // default-skips it, but the report distinguishes source-missing from a
+    // genuinely broken target/source.
+    assert('t669_src_enoent_is_source_missing', classifyConflict(path.join(tmp, 'does-not-exist.md'), dst) === 'source-missing')
+    // Pinned: 'unreadable'/'source-missing' stay default-skip under EVERY
+    // conflictMode, INCLUDING 'force' — decideAction's force branch is
+    // scoped to conflict==='overwrite' only; restore never writes through
+    // an unclassifiable target even with --force.
+    assert('t669_unreadable_stays_skip_under_force', decideAction('unreadable', 'force') === 'skip')
+    assert('t669_source_missing_stays_skip_under_force', decideAction('source-missing', 'force') === 'skip')
+    assert('t669_unreadable_stays_skip_under_sidecar', decideAction('unreadable', 'sidecar') === 'skip')
+    fs.unlinkSync(dstFifo); fs.unlinkSync(srcFifo)
+    fs.rmSync(tmp, { recursive: true, force: true })
+  } catch (e) { bad('t669_classify_conflict_fifo', e.message) }
+
+  try {
+    const { root, backupDir } = makeFakeBackup()
+    const epId = 'id-669'
+    const ep = makeEpisode(epId, { id: epId, date: '2026-05-01', time: '"10:00"', project: 't', category: 'decision', status: 'active', tags: [], summary: 'fifo target' })
+    const epDir = path.join(backupDir, 'lab', 'episodes')
+    fs.mkdirSync(epDir, { recursive: true })
+    fs.writeFileSync(path.join(epDir, `${epId}.md`), ep)
+    commitBackup(backupDir)
+
+    const target = path.join(root, 'target')
+    fs.mkdirSync(path.join(target, 'episodes'), { recursive: true })
+    const targetEpPath = path.join(target, 'episodes', `${epId}.md`)
+    execFileSync('mkfifo', [targetEpPath])
+
+    const dryOpts = {
+      backupDir, sourceMap: new Map([['lab', target]]),
+      fromDate: undefined, toDate: undefined, tags: [], categories: [], sources: [],
+      apply: false, conflictMode: 'skip', force: false, includeDocs: false,
+      restoreClaudeMd: false, skipMemoryMd: false, allowSymlinkOverwrite: false,
+      allowDuplicateId: false, rebuildIndex: false
+    }
+    const dryStart = Date.now()
+    const dry = run(dryOpts)
+    assert('t669_dry_run_terminates', Date.now() - dryStart < 5000, `took ${Date.now() - dryStart}ms`)
+    assert('t669_dry_run_ok', dry.status === 'ok', JSON.stringify(dry))
+    assert('t669_dry_run_unreadable_class', dry.summary.conflicts.unreadable === 1, JSON.stringify(dry.summary.conflicts))
+    assert('t669_dry_run_target_untouched', fs.lstatSync(targetEpPath).isFIFO(), 'dry-run must never touch the target FIFO')
+
+    const applyStart = Date.now()
+    const applied = run({ ...dryOpts, apply: true, rebuildIndex: true })
+    assert('t669_apply_terminates', Date.now() - applyStart < 5000, `took ${Date.now() - applyStart}ms`)
+    assert('t669_apply_ok', applied.status === 'ok', JSON.stringify(applied))
+    assert('t669_apply_conflicts_unreadable', applied.summary.conflicts.unreadable === 1, JSON.stringify(applied.summary.conflicts))
+    assert('t669_apply_skipped_episode', applied.skipped.episodes === 1 && applied.written.episodes === 0,
+      `expected the unreadable target skipped (never written through), got written=${JSON.stringify(applied.written)} skipped=${JSON.stringify(applied.skipped)}`)
+    assert('t669_apply_never_wrote_through_fifo', fs.lstatSync(targetEpPath).isFIFO(), 'apply must never write through the unclassifiable target')
+
+    fs.unlinkSync(targetEpPath)
+    fs.rmSync(root, { recursive: true, force: true })
+  } catch (e) { bad('t669_run_dry_and_apply_terminate', e.message) }
+
+  // T669-A3: review-round codex MAJOR — a DOC (not episode) regular at
+  // planning-time but raced to a FIFO before apply used to hang forever at
+  // the raw copyFileSync in applyDocWrites' staging loop (reviewer probe:
+  // SIGKILL required). Uses a non-MEMORY.md doc so buildRefIntegrityReport
+  // (A3(a)'s flip-to-skip) never even looks at it — isolating A3(b)'s
+  // apply-time fd-guarded read as the ONLY thing standing between this and
+  // a hang.
+  //
+  // The real CLI's preflight() re-validates `git status --porcelain` clean
+  // on EVERY invocation (run() is called once per process) — a FIFO in the
+  // working tree is always untracked, so a genuine two-invocation
+  // (dry-run, swap, apply) sequence would be rejected by preflight before
+  // ever reaching the code this test targets; the actual hang window is
+  // WITHIN one run() call, between the planning read and the apply-time
+  // copy. Calling the pipeline's internal functions directly (same
+  // technique as the em-backup classify-then-read race test) reproduces
+  // that intra-call window deterministically: plan built while the doc is
+  // still regular (confirms a LIVE 'create' action), THEN the file is
+  // swapped to a FIFO, THEN applyDocWrites runs — exactly the sequence a
+  // single `--apply` call performs internally.
+  try {
+    const { root, backupDir } = makeFakeBackup()
+    const docPath = path.join(backupDir, 'lab', 'notes.md')
+    fs.mkdirSync(path.dirname(docPath), { recursive: true })
+    fs.writeFileSync(docPath, 'regular doc content\n')
+    commitBackup(backupDir)
+
+    const target = path.join(root, 'target')
+    fs.mkdirSync(target, { recursive: true })
+    const sourceMap = new Map([['lab', target]])
+    const sourceLabels = discoverSourceLabels(backupDir)
+    const { docs } = discoverDocFiles(backupDir, sourceLabels, sourceMap, [])
+
+    const plan = buildWritePlan({
+      selected: new Map(), extraEntries: [], sourceMap, sourceLabelByEpisode: new Map(),
+      conflictMode: 'skip', allowSymlinkOverwrite: false, allowDuplicateId: false,
+      includeDocs: true, docs, restoreClaudeMd: false, skipMemoryMd: false, sidecarRefuseExisting: true
+    })
+    const docWritePlanned = plan.docWrites.find(w => w.relPath === 'notes.md')
+    assert('t669a3_plan_doc_is_live_create', docWritePlanned && docWritePlanned.action === 'create' && docWritePlanned.conflict === 'clean',
+      `doc must be planned as a live 'create' action while regular: ${JSON.stringify(docWritePlanned)}`)
+    buildRefIntegrityReport(plan, sourceMap, docs) // mirrors run()'s call order; no-op for a non-MEMORY.md doc
+
+    // Race: swap the regular doc for a FIFO — mid-call, between plan-build
+    // and apply, exactly the window the reviewer probed.
+    fs.unlinkSync(docPath)
+    execFileSync('mkfifo', [docPath])
+
+    preflightTargetDirs(plan, sourceMap)
+    const applyStart = Date.now()
+    const docResult = applyDocWrites(plan, sourceMap)
+    const elapsed = Date.now() - applyStart
+    assert('t669a3_apply_terminates', elapsed < 5000, `took ${elapsed}ms`)
+    assert('t669a3_apply_skipped_doc', docResult.skipped.length === 1 && docResult.written.length === 0,
+      `expected the raced doc skipped (never written through), got written=${JSON.stringify(docResult.written)} skipped=${JSON.stringify(docResult.skipped)}`)
+    assert('t669a3_skip_entry_names_reason', docResult.skipped[0].apply_skip_reason === 'unreadable' && docResult.skipped[0].code === 'ENOTREG',
+      `skip entry must carry the reason/code, got: ${JSON.stringify(docResult.skipped[0])}`)
+    assert('t669a3_nothing_written_to_target', !fs.existsSync(path.join(target, 'notes.md')),
+      'apply must never write through the raced-to-FIFO doc')
+
+    fs.unlinkSync(docPath)
+    fs.rmSync(root, { recursive: true, force: true })
+  } catch (e) { bad('t669a3_docwrites_apply_race_no_hang', e.message) }
+
+  // T669-item5 (review-round lens-2 MINOR-1): readSkipManifest must surface
+  // the unreadable count em-backup's manifest carries (skipped_unreadable,
+  // manifest key stays snake_case per item 6's naming split).
+  try {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'em-restore-t669item5-'))
+    fs.writeFileSync(path.join(tmp, '.skipped-files.json'), JSON.stringify({
+      generated_at: '2026-08-14T00:00:00Z',
+      skipped_symlinks: [{ source: 'a', path: 'x' }],
+      skipped_oversized: [],
+      skipped_binary: [{ source: 'a', path: 'y' }, { source: 'a', path: 'z' }],
+      skipped_unreadable: [{ source: 'a', path: 'w' }],
+    }))
+    const m = readSkipManifest(tmp)
+    assert('t669item5_manifest_present', m.present === true)
+    assert('t669item5_unreadable_count', m.counts.unreadable === 1, JSON.stringify(m.counts))
+    assert('t669item5_other_counts_unaffected', m.counts.symlinks === 1 && m.counts.binary === 2, JSON.stringify(m.counts))
+    fs.rmSync(tmp, { recursive: true, force: true })
+  } catch (e) { bad('t669item5_readskipmanifest_unreadable_count', e.message) }
+
+  // T669-item5: --help documents the 'unreadable' conflict class and its
+  // default-skip-under---force behavior (the §1 pin's documentation leg the
+  // original build missed).
+  try {
+    const helpText = usage()
+    assert('t669item5_help_mentions_unreadable_class', /\bunreadable\b/.test(helpText), helpText)
+    assert('t669item5_help_mentions_force_default_skip', /--force/.test(helpText) && /default-skip/.test(helpText), helpText)
+  } catch (e) { bad('t669item5_help_documents_unreadable', e.message) }
 
   // T8: backup-side symlink rejection
   try {
@@ -2570,7 +2831,13 @@ function usage() {
                  [--self-test]
 
 Default mode is --dry-run. --apply required for any disk write.
-Lossy-data note: backup is content+path-redacted; restore CANNOT undo redaction.`
+Lossy-data note: backup is content+path-redacted; restore CANNOT undo redaction.
+Conflict classes (summary.conflicts): clean, identical, normalized-equal,
+overwrite, target-symlink, source-missing (source file vanished — nothing to
+restore), unreadable (source or target is present but not a regular file —
+e.g. a FIFO or a permission defect). 'unreadable' ALWAYS default-skips,
+under EVERY --conflict-mode INCLUDING --force: restore never writes through
+an unclassifiable source or target. Remove the poison manually and re-run.`
 }
 
 try {

--- a/scripts/em-review-request.mjs
+++ b/scripts/em-review-request.mjs
@@ -49,7 +49,7 @@ import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
 import { nullProtoIndex, episodeTokens, updateTokensIndex } from './lib/relevance.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow, IndexUnreadableError } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -321,7 +321,16 @@ function checkChainRef(label, value, expectedEvent) {
     errors.push(`${label}: episode:${r.entry.id} indexed but file missing at ${filePath}; cannot verify event/task for chain link`)
     return null
   }
-  const text = fs.readFileSync(filePath, 'utf8')
+  // #669 R-D: this gate's existing absent (missing-file) semantics is
+  // already an errors.push above, not a silent skip — so ANY read failure
+  // here (including a post-existsSync ENOENT race) is a GATE FAILURE via
+  // the same errors channel; a planted FIFO must not dodge this check.
+  const bodyRead = readBodyOrSkip(fs, filePath)
+  if (!bodyRead.ok) {
+    errors.push(`${label}: episode:${r.entry.id} body unreadable (${bodyRead.code}); cannot verify event/task for chain link`)
+    return null
+  }
+  const text = bodyRead.raw
   const m = text.match(/```json\s*\n([\s\S]*?)\n```/)
   if (!m) {
     errors.push(`${label}: episode:${r.entry.id} body has no \`\`\`json fenced block; cannot verify event/task for chain link`)
@@ -367,8 +376,18 @@ if (triggeredBy) {
     // Read body to extract task field. Non-lifecycle episodes have no task in
     // body → null/undefined → provenance-only (no task assertion).
     const filePath = path.join(triggeredByEntry._dataDir, 'episodes', `${triggeredByEntry.id}.md`)
-    if (fs.existsSync(filePath)) {
-      const text = fs.readFileSync(filePath, 'utf8')
+    // #669 R-D: ONE guarded read replaces the existsSync+read TOCTOU pair.
+    // A planted FIFO must not dodge this cross-task provenance check — a
+    // non-ENOENT unreadable body is a GATE FAILURE via the errors channel.
+    // Absent (ENOENT) keeps this site's existing absent semantics: silent,
+    // provenance-only (no `else` branch existed here before either).
+    const bodyRead = readBodyOrSkip(fs, filePath)
+    if (!bodyRead.ok) {
+      if (bodyRead.code !== 'ENOENT') {
+        errors.push(`--triggered-by: episode:${triggeredByEntry.id} body unreadable (${bodyRead.code}); cannot verify cross-task provenance`)
+      }
+    } else {
+      const text = bodyRead.raw
       const m = text.match(/```json\s*\n([\s\S]*?)\n```/)
       if (m) {
         try {

--- a/scripts/em-workflow-validate.mjs
+++ b/scripts/em-workflow-validate.mjs
@@ -31,7 +31,7 @@ import path from 'path'
 import os from 'os'
 import { execFileSync } from 'child_process'
 import { resolveLocalDir } from './lib/local-dir.mjs'
-import { readIndexFileOrThrow } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, readBodyOrSkip } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -191,7 +191,13 @@ function frontmatterScalar(text, key) {
 // JSON contracts and exit codes are preserved.
 // ---------------------------------------------------------------------------
 function extractPayload(filePath) {
-  const text = fs.readFileSync(filePath, 'utf8')
+  // #669 R-D: the existing failure mode is throw → caught at the call site
+  // → errors.push (fail-closed gate) — preserve that shape by rethrowing a
+  // typed error on ANY read failure (readBodyOrSkip never blocks, so a
+  // planted FIFO can no longer dodge this gate by hanging it instead).
+  const bodyRead = readBodyOrSkip(fs, filePath)
+  if (!bodyRead.ok) throw new Error(`episode body unreadable (${bodyRead.code}) (${filePath})`)
+  const text = bodyRead.raw
   const t = frontmatterScalar(text, 'type')
   if (t !== null && NON_WORKFLOW_EVENT_TYPES.has(t)) {
     return { kind: 'non-event', payload: null }
@@ -566,8 +572,18 @@ function validatePayload(payload, entry, errors, warnings, indexById) {
             errors.push(`${fp}: triggered_by ${tbR.error}`)
           } else {
             const tbFilePath = path.join(tbR.entry._dataDir, 'episodes', `${tbR.entry.id}.md`)
-            if (fs.existsSync(tbFilePath)) {
-              const tbText = fs.readFileSync(tbFilePath, 'utf8')
+            // #669 R-D: ONE guarded read replaces the existsSync+read TOCTOU
+            // pair. A planted FIFO must not dodge this cross-task provenance
+            // check — non-ENOENT unreadable is a GATE FAILURE via errors[].
+            // Absent (ENOENT) keeps this site's existing absent semantics:
+            // silent, provenance-only (no `else` branch existed before).
+            const tbRead = readBodyOrSkip(fs, tbFilePath)
+            if (!tbRead.ok) {
+              if (tbRead.code !== 'ENOENT') {
+                errors.push(`${fp}: triggered_by episode:${tbR.entry.id} body unreadable (${tbRead.code}); cannot verify cross-task provenance`)
+              }
+            } else {
+              const tbText = tbRead.raw
               const tbM = tbText.match(/```json\s*\n([\s\S]*?)\n```/)
               if (tbM) {
                 try {

--- a/scripts/lib/rule-nodes.mjs
+++ b/scripts/lib/rule-nodes.mjs
@@ -17,6 +17,7 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { resolveRepoRoot } from './local-dir.mjs'
+import { readBodyOrSkip } from './index-state.mjs'
 
 const RULE_GLOB_RE = /^(feedback_.+\.md|reference_.+\.md|MEMORY\.md|MEMORY_.+\.md)$/
 const RFC_FILE_RE = /^RFC-.+\.md$/
@@ -106,13 +107,15 @@ export function scanRuleNodes(dir) {
   for (const entry of entries.slice().sort()) {
     if (!RULE_GLOB_RE.test(entry)) continue
     const full = path.join(dir, entry)
-    let text = ''
-    try {
-      text = fs.readFileSync(full, 'utf8')
-    } catch {
+    // #669 S2: readBodyOrSkip — a FIFO named MEMORY.md hung this scan
+    // (Family C, plan §0). ok:false increments the EXISTING skipped
+    // counter; return shape unchanged (no em-graph wire-shape change).
+    const bodyRead = readBodyOrSkip(fs, full)
+    if (!bodyRead.ok) {
       skipped += 1
       continue
     }
+    const text = bodyRead.raw
     const fm = parseFlatFrontmatter(text)
     const slug = slugify(typeof fm.name === 'string' ? fm.name : '')
     if (!slug) {
@@ -161,13 +164,13 @@ export function scanRfcNodes(dir) {
   for (const entry of entries.slice().sort()) {
     if (!RFC_FILE_RE.test(entry)) continue
     const full = path.join(dir, entry)
-    let text = ''
-    try {
-      text = fs.readFileSync(full, 'utf8')
-    } catch {
+    // #669 S2: readBodyOrSkip, same pattern as scanRuleNodes above.
+    const bodyRead = readBodyOrSkip(fs, full)
+    if (!bodyRead.ok) {
       skipped += 1
       continue
     }
+    const text = bodyRead.raw
     const fm = parseFlatFrontmatter(text)
     if (typeof fm.rfc_id !== 'string' || !RFC_ID_RE.test(fm.rfc_id)) {
       skipped += 1

--- a/scripts/topic-tracks/engine.mjs
+++ b/scripts/topic-tracks/engine.mjs
@@ -24,7 +24,7 @@ import {
   acquireStoreWriteLocksSync,
   releaseStoreWriteLocks,
 } from '../lib/store-write-lock.mjs'
-import { readIndexFileOrThrow } from '../lib/index-state.mjs'
+import { readIndexFileOrThrow, readBodyOrSkip } from '../lib/index-state.mjs'
 
 // --- §A.5 frozen constants ---
 export const TOPIC_TRACK_TAG = 'topic-track'
@@ -239,14 +239,17 @@ export function collectTopicMembers({ globalDir, registeredStores, config }) {
     if (Array.isArray(row.promotion_sources) && row.promotion_sources.length > 0) return
 
     // Episode file required (REQ-3 missing-file).
+    // #669 round-1 MINOR-5 (settled): no genuine Buffer dependency — bodyOf
+    // decodes and computeContentSha256 utf8-normalizes, so readBodyOrSkip's
+    // string return is digest-provably unchanged. ok:false (any code) keeps
+    // today's uniform "missing source" disposition.
     const epFile = path.join(storeDir, 'episodes', `${row.id}.md`)
-    let buf
-    try {
-      buf = fs.readFileSync(epFile)
-    } catch (err) {
+    const bodyRead = readBodyOrSkip(fs, epFile)
+    if (!bodyRead.ok) {
       missing_sources.push({ store_id: storeId, episode_id: row.id })
       return
     }
+    const buf = bodyRead.raw
     const sha = computeContentSha256(buf)
     // Replica identity: episode id + normalized content hash (no store_id so
     // byte-identical replicas across stores collapse; §12 REQ-4).

--- a/tests/test-em-backup-body-read.mjs
+++ b/tests/test-em-backup-body-read.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * test-em-backup-body-read.mjs — issue #669 net-new suite.
+ *
+ * em-backup.mjs read episode/doc bodies (auditSources :549/:651 pre-fix
+ * line numbers) with raw fs.readFileSync, and classified file bytes
+ * (classifyFileBytes :352) with a raw blocking fs.openSync(path, 'r') — a
+ * FIFO with no writer blocks BOTH forever.
+ *
+ * Per plan §3/§0: walk() only pushes isFile() dirents, so an AT-REST FIFO
+ * never reaches either function through the normal directory-walk path —
+ * an end-to-end CLI probe with a planted at-rest FIFO is VACUOUS (it
+ * passes on unfixed HEAD too, since walk() already filters it out before
+ * classifyFileBytes/the read ever run). The real exposure is a
+ * classify-then-read RACE WINDOW (source flips from regular to non-regular
+ * between classify time and read time) — DEFER-A residual, not fixed here,
+ * but the READ ITSELF must never hang on it.
+ *
+ * This suite therefore uses DIRECT-UNIT calls (plan §3's explicit
+ * alternative to an end-to-end probe) against the real exported functions:
+ *   - classifyFileBytes(fifoPath) directly — proves the fd-based
+ *     non-blocking classify never hangs on a FIFO and returns 'binary'
+ *     (round-2 MINOR-R2-2 pin);
+ *   - a manufactured classify-then-read race (classify a REGULAR file,
+ *     then replace it with a FIFO before the read auditSources would do
+ *     next) — proves the read layer never hangs even mid-race;
+ *   - auditSources() end-to-end against a genuinely-unreadable-but-PRESENT
+ *     regular file (chmod 0o000) — a real, deterministic (non-racy) defect
+ *     that DOES reach the read, and asserts the new unreadable_skipped
+ *     count in the existing report shape.
+ */
+
+import assert from 'node:assert/strict'
+import { spawnSync, execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const { classifyFileBytes, auditSources, SOURCES } = await import(path.join(REPO, 'scripts', 'em-backup.mjs'))
+const { readBodyOrSkip } = await import(path.join(REPO, 'scripts', 'lib', 'index-state.mjs'))
+
+let pass = 0, fail = 0
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`) }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`) }
+}
+
+function mktemp(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+}
+
+const EM_BACKUP_PATH = path.join(REPO, 'scripts', 'em-backup.mjs')
+
+// #669 review-round codex MINOR-2 (test-strength gap): calling
+// classifyFileBytes(fifoPath) IN-PROCESS means a regression back to a
+// blocking openSync would hang this ENTIRE test file forever (no outer
+// timeout catches an in-process hang). Spawn a CHILD process with an
+// external timeout instead — a regression then fails this ONE test
+// (timeout-killed child, non-null signal) rather than hanging the suite.
+function classifyFileBytesSpawned(fifoPath, timeoutMs = 5000) {
+  const helperCode = `import { classifyFileBytes } from ${JSON.stringify(EM_BACKUP_PATH)}\n` +
+    `console.log(JSON.stringify({ result: classifyFileBytes(process.env.EMBACKUP_TEST_PATH) }))\n`
+  const r = spawnSync(process.execPath, ['--input-type=module', '-e', helperCode], {
+    encoding: 'utf8', timeout: timeoutMs, env: { ...process.env, EMBACKUP_TEST_PATH: fifoPath },
+  })
+  return r
+}
+
+t('classifyFileBytes on a FIFO with no writer: returns binary, no hang (round-2 MINOR-R2-2)', () => {
+  const tmp = mktemp('embackup-classify-')
+  const fifoPath = path.join(tmp, 'probe.bin') // non-KNOWN_TEXT_EXTENSIONS so the fast-path doesn't short-circuit
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const start = Date.now()
+  const r = classifyFileBytesSpawned(fifoPath)
+  const elapsed = Date.now() - start
+  assert.equal(r.signal, null, `no signal (a regression to blocking open must fail THIS test, not hang the suite), got ${r.signal}`)
+  assert.equal(r.status, 0, `child must exit cleanly, got ${r.status}: ${r.stderr}`)
+  const out = JSON.parse(r.stdout.trim())
+  assert.equal(out.result, 'binary', `FIFO must classify as binary, got ${out.result}`)
+  assert.ok(elapsed < 4000, `classifyFileBytes must return promptly (no hang), took ${elapsed}ms`)
+
+  fs.unlinkSync(fifoPath)
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+// #669 review-round A2 (MAJOR, convergent — silent no-op CLI): the
+// entry-point guard used to be a plain `import.meta.url === file://argv[1]`
+// string compare, which FAILS (and the CLI silently no-ops, exit 0, empty
+// stdout) whenever the invocation path has a symlink component — exactly
+// what happens spawning through a symlinked path here. Fixed with the
+// realpath-both idiom (structured-alert-probe.mjs:65-72, FU #390 class).
+t('CLI invoked through a symlinked path still runs as main (not a silent no-op)', () => {
+  const tmp = mktemp('embackup-symlink-')
+  const linkPath = path.join(tmp, 'em-backup-via-link.mjs')
+  fs.symlinkSync(EM_BACKUP_PATH, linkPath)
+  const r = spawnSync(process.execPath, [linkPath, '--help'], { encoding: 'utf8', timeout: 5000 })
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.status, 0, `exit 0, got ${r.status}: ${r.stderr}`)
+  assert.ok(r.stdout.trim().length > 0, 'must NOT silently no-op with empty stdout')
+  const out = JSON.parse(r.stdout.trim())
+  assert.equal(out.status, 'help', `must actually run as main and print help, got ${r.stdout}`)
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+t('classifyFileBytes on a FIFO named with a KNOWN_TEXT_EXTENSIONS suffix (.md): fast-path never touches the fd, so it cannot hang either', () => {
+  // .md is in KNOWN_TEXT_EXTENSIONS: the fast-path returns 'text' WITHOUT
+  // ever opening the fd (extension check only) — correctly hang-free by a
+  // DIFFERENT mechanism than the fstat guard the other two tests exercise.
+  // This documents that property rather than asserting a 'binary' verdict.
+  const tmp = mktemp('embackup-classify-ext-')
+  const fifoPath = path.join(tmp, 'probe.md')
+  execFileSync('mkfifo', [fifoPath])
+  const start = Date.now()
+  const result = classifyFileBytes(fifoPath)
+  const elapsed = Date.now() - start
+  assert.equal(result, 'text', `known-text-extension fast-path returns 'text' unconditionally, got ${result}`)
+  assert.ok(elapsed < 2000, `must not hang even though it never fstats the FIFO, took ${elapsed}ms`)
+  fs.unlinkSync(fifoPath)
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+t('classify-then-read race shape: classify sees a regular file, read sees a FIFO planted in between — never hangs', () => {
+  // Manufactured race (plan §3 "(or race shapes)"): auditSources's/
+  // syncToBackup's per-file loop does classifyFileBytes(f) THEN a guarded
+  // read of f. Calling auditSources() itself here would be VACUOUS — its
+  // OWN internal walk() re-reads the directory fresh and would already see
+  // the swapped-in FIFO, filtering it out before classify/read even run
+  // (plan §0: at-rest FIFOs never reach these reads). Replaying the exact
+  // two-step sequence (classify, THEN read) directly proves the READ layer
+  // survives a genuine TOCTOU swap between those two steps, independent of
+  // walk()'s vacuous-exclusion property.
+  const tmp = mktemp('embackup-race-')
+  const racedPath = path.join(tmp, 'raced.txt')
+  fs.writeFileSync(racedPath, 'regular content at classify time\n')
+
+  const cls = classifyFileBytes(racedPath)
+  assert.equal(cls, 'text', `regular file must classify as text before the race, got ${cls}`)
+
+  // Race: swap the regular file for a FIFO before the read that would
+  // normally follow immediately in auditSources'/syncToBackup's loop body.
+  fs.unlinkSync(racedPath)
+  execFileSync('mkfifo', [racedPath])
+
+  const start = Date.now()
+  const bodyRead = readBodyOrSkip(fs, racedPath)
+  const elapsed = Date.now() - start
+  assert.ok(elapsed < 2000, `the post-classify read must not hang on the raced FIFO, took ${elapsed}ms`)
+  assert.equal(bodyRead.ok, false, `raced-in FIFO must fail the read, got ${JSON.stringify(bodyRead)}`)
+  assert.equal(bodyRead.code, 'ENOTREG', `expected ENOTREG, got ${bodyRead.code}`)
+
+  fs.unlinkSync(racedPath)
+  fs.rmSync(tmp, { recursive: true, force: true })
+})
+
+t('auditSources on a genuinely-unreadable-but-present regular file (EACCES): unreadable_skipped counted, run does not abort', () => {
+  if (process.getuid && process.getuid() === 0) {
+    console.log('      (skipped: running as root, chmod 0o000 does not block reads)')
+    return
+  }
+  const tmp = mktemp('embackup-eacces-')
+  const blockedPath = path.join(tmp, 'blocked.txt')
+  fs.writeFileSync(blockedPath, 'unreadable content\n')
+  fs.chmodSync(blockedPath, 0o000)
+  const okPath = path.join(tmp, 'ok.txt')
+  fs.writeFileSync(okPath, 'readable content\n')
+
+  SOURCES.length = 0
+  SOURCES.push({ src: tmp, dest: 'blocked', absDest: path.join(tmp, '__dest__'), label: 'blocked' })
+  try {
+    const report = auditSources({ sample: 0 })
+    assert.equal(report.totals.files, 2, `both files counted as attempted (walk() sees both as regular): ${JSON.stringify(report.totals)}`)
+    assert.equal(report.totals.text_files, 1, `only the readable file counts as text_files: ${JSON.stringify(report.totals)}`)
+    assert.equal(report.totals.unreadable_skipped, 1, `the EACCES file must count in unreadable_skipped: ${JSON.stringify(report.totals)}`)
+    const entry = report.sources.find(s => s.label === 'blocked')
+    assert.equal(entry.unreadable_skipped, 1, `per-source entry.unreadable_skipped: ${JSON.stringify(entry)}`)
+  } finally {
+    fs.chmodSync(blockedPath, 0o644) // restore before rmSync
+    fs.rmSync(tmp, { recursive: true, force: true })
+    SOURCES.length = 0
+  }
+})
+
+t('healthy control: auditSources on all-readable sources reports zero unreadable_skipped', () => {
+  const tmp = mktemp('embackup-control-')
+  fs.writeFileSync(path.join(tmp, 'a.txt'), 'content a\n')
+  fs.writeFileSync(path.join(tmp, 'b.txt'), 'content b\n')
+  SOURCES.length = 0
+  SOURCES.push({ src: tmp, dest: 'ctrl', absDest: path.join(tmp, '__dest__'), label: 'ctrl' })
+  const report = auditSources({ sample: 0 })
+  assert.equal(report.totals.text_files, 2, JSON.stringify(report.totals))
+  assert.equal(report.totals.unreadable_skipped, 0, JSON.stringify(report.totals))
+  fs.rmSync(tmp, { recursive: true, force: true })
+  SOURCES.length = 0
+})
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-em-consolidate.mjs
+++ b/tests/test-em-consolidate.mjs
@@ -33,10 +33,10 @@ function t(name, fn) {
   catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
 }
 
-function run(script, args, cwd, env) {
-  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+function run(script, args, cwd, env, timeout) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env }, ...(timeout ? { timeout } : {}) });
   let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
-  return { code: r.status, json, stdout: r.stdout };
+  return { code: r.status, signal: r.signal, json, stdout: r.stdout };
 }
 
 function snapshot(dir) {
@@ -190,6 +190,36 @@ t('>5 clusters requires --confirm; usage errors exit 2', () => {
   assert.equal(go.json.applied, 6, go.stdout);
   assert.equal(run('em-consolidate.mjs', ['--scope', 'all'], fx.cwd, fx.env).code, 2, 'scope all rejected (single-scope by design)');
   assert.equal(run('em-consolidate.mjs', ['--min-sim', '2'], fx.cwd, fx.env).code, 2);
+  fs.rmSync(fx.cwd, { recursive: true, force: true }); fs.rmSync(fx.home, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #669 S1: FIFO-shaped member body (em-consolidate.mjs:920 readEpisode,
+// the token-set/dry-run scan). A FIFO with no writer previously blocked
+// fs.readFileSync forever; the fix (readBodyOrSkip) converts the hang into
+// the pre-existing null (skip) disposition — "Episodes whose file is
+// missing are skipped, not fatal."
+// ---------------------------------------------------------------------------
+t('dry-run with a FIFO-shaped member body: exit 0 no hang, that member is silently excluded, its healthy duplicate still clusters', () => {
+  const fx = mkFixture();
+  const ids = seedDupes(fx);
+  const fifoId = ids[0];
+  const fifoPath = path.join(fx.store, 'episodes', `${fifoId}.md`);
+  fs.unlinkSync(fifoPath);
+  const mk = spawnSync('mkfifo', [fifoPath]);
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+
+  const r = run('em-consolidate.mjs', ['--scope', 'local', '--min-sim', '0.3'], fx.cwd, fx.env, 5000);
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`);
+  assert.equal(r.code, 0, `exit 0, got ${r.code}: ${r.stdout}`);
+  // The other two dupes (readable) still see each other as similar enough
+  // that clustering logic ran to completion over them without crashing —
+  // whether they alone clear --min-sim into a reported cluster is not the
+  // point here (that's the existing clustering-threshold suite's job); the
+  // regression this leg pins is "no hang, no crash, dry-run terminates".
+  assert.equal(r.json.status, 'ok', r.stdout);
+
+  fs.unlinkSync(fifoPath); // remove the FIFO so cleanup's rmSync doesn't hang
   fs.rmSync(fx.cwd, { recursive: true, force: true }); fs.rmSync(fx.home, { recursive: true, force: true });
 });
 

--- a/tests/test-em-graph-nodes.mjs
+++ b/tests/test-em-graph-nodes.mjs
@@ -122,6 +122,76 @@ t('t_malformed_frontmatter_skipped', () => {
   assert.equal(r.skipped, 1)
 })
 
+// Issue #669 S2: a FIFO named MEMORY.md previously blocked the raw
+// fs.readFileSync inside scanRuleNodes forever (confirmed hang, plan §0).
+// readBodyOrSkip converts it into the EXISTING skipped-counter disposition
+// (same shape as t_malformed_frontmatter_skipped above), no wire-shape
+// change, no hang.
+t('t_669_fifo_rule_file_skipped_no_hang', () => {
+  resetRuleDir()
+  const fifoPath = path.join(RULE_DIR, 'MEMORY.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const start = Date.now()
+  const r = scanRuleNodes(RULE_DIR)
+  const elapsed = Date.now() - start
+  assert.ok(elapsed < 5000, `scanRuleNodes must not hang on a FIFO, took ${elapsed}ms`)
+  assert.equal(r.ruleById.size, 0)
+  assert.equal(r.skipped, 1)
+  fs.unlinkSync(fifoPath)
+})
+
+t('t_669_fifo_rule_file_via_cli_no_hang', () => {
+  resetRuleDir()
+  const fifoPath = path.join(RULE_DIR, 'MEMORY.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnSync('node', [path.join(SCRIPTS, 'em-graph.mjs'), '--orphans', '--nodes', 'rule', '--scope', 'local'], {
+    cwd, encoding: 'utf8', env: { ...process.env, ...env }, timeout: 5000,
+  })
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.status, 0, `exit 0, got ${r.status}: ${r.stdout}`)
+  const json = JSON.parse(r.stdout.trim())
+  assert.equal(json.status, 'ok')
+  assert.equal(json.skipped_nodes, 1)
+  fs.unlinkSync(fifoPath)
+})
+
+// #669 review-round codex MINOR-2 (test-strength gap): scanRfcNodes shares
+// the exact same read-guard fix as scanRuleNodes above but had ZERO FIFO
+// coverage of its own — a regression isolated to scanRfcNodes (e.g. a
+// future refactor that de-shares the two functions) would not be caught by
+// the rule-node legs alone.
+t('t_669_fifo_rfc_file_skipped_no_hang', () => {
+  resetRfcDir()
+  const fifoPath = path.join(RFC_DIR, 'RFC-669-fifo.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const start = Date.now()
+  const r = scanRfcNodes(RFC_DIR)
+  const elapsed = Date.now() - start
+  assert.ok(elapsed < 5000, `scanRfcNodes must not hang on a FIFO, took ${elapsed}ms`)
+  assert.equal(r.rfcById.size, 0)
+  assert.equal(r.skipped, 1)
+  fs.unlinkSync(fifoPath)
+})
+
+t('t_669_fifo_rfc_file_via_cli_no_hang', () => {
+  resetRfcDir()
+  const fifoPath = path.join(RFC_DIR, 'RFC-669-fifo.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnSync('node', [path.join(SCRIPTS, 'em-graph.mjs'), '--orphans', '--nodes', 'rfc', '--scope', 'local'], {
+    cwd, encoding: 'utf8', env: { ...process.env, ...env }, timeout: 5000,
+  })
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.status, 0, `exit 0, got ${r.status}: ${r.stdout}`)
+  const json = JSON.parse(r.stdout.trim())
+  assert.equal(json.status, 'ok')
+  assert.equal(json.skipped_nodes, 1)
+  fs.unlinkSync(fifoPath)
+})
+
 t('t_proto_key_rule_name', () => {
   resetRuleDir()
   writeRule('feedback_proto.md', 'name: __proto__')

--- a/tests/test-em-move.mjs
+++ b/tests/test-em-move.mjs
@@ -32,10 +32,10 @@ function t(name, fn) {
   catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`); }
 }
 
-function run(script, args, cwd, env) {
-  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env } });
+function run(script, args, cwd, env, timeout) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd, encoding: 'utf8', env: { ...process.env, ...env }, ...(timeout ? { timeout } : {}) });
   let json = null; try { json = JSON.parse(r.stdout.trim()); } catch {}
-  return { code: r.status, json, stdout: r.stdout };
+  return { code: r.status, signal: r.signal, json, stdout: r.stdout };
 }
 
 // Recursive byte-level snapshot of both stores (path → sha or content).
@@ -269,6 +269,70 @@ t('found-in-both, DIFFERENT content: hard error, both files untouched', () => {
   assert.ok(r.json.errors[0].error.includes('DIFFERENT content'), r.stdout);
   assertUnchanged(before, snapshot([fx6.local, fx6.global]), 'divergent recovery');
   fs.rmSync(fx6.cwd, { recursive: true, force: true }); fs.rmSync(fx6.home, { recursive: true, force: true });
+});
+
+// Issue #669 review-round A1 (MAJOR, convergent — data loss): sha256() must
+// hash RAW BYTES, not a utf8-DECODED string. Two bodies that differ ONLY in
+// a trailing invalid-UTF-8 byte (0xFF vs 0xFE) both decode to the SAME
+// string (the invalid tail becomes U+FFFD either way), so a string-based
+// hash collapses them to "identical" — the found-in-both-scopes divergence
+// check would then treat this as an interrupted-move resume and UNLINK the
+// local copy, losing genuinely different bytes. This leg plants exactly
+// that byte-divergent-but-string-identical pair and asserts the EXISTING
+// hard-error path fires (never the false-identical resume path), with both
+// files byte-for-byte untouched.
+t('found-in-both, byte-divergent invalid-UTF-8 tail (0xFF vs 0xFE) that DECODES identically: still a hard error, both files intact', () => {
+  const fx6b = mkFixture();
+  const id = store(fx6b, ['--category', 'decision', '--summary', 'invalid utf8 tail', '--tags', 'dv', '--scope', 'local']);
+  const localPath = path.join(fx6b.local, 'episodes', `${id}.md`);
+  const base = fs.readFileSync(localPath);
+  fs.mkdirSync(path.join(fx6b.global, 'episodes'), { recursive: true });
+  const globalPath = path.join(fx6b.global, 'episodes', `${id}.md`);
+  const localBytes = Buffer.concat([base, Buffer.from([0xff])]);
+  const globalBytes = Buffer.concat([base, Buffer.from([0xfe])]);
+  // Sanity: the two byte sequences differ, but decode to the SAME string —
+  // proves this fixture actually exercises the string-collapse bug class.
+  assert.ok(!localBytes.equals(globalBytes), 'fixture bug: bytes must differ');
+  assert.equal(localBytes.toString('utf8'), globalBytes.toString('utf8'), 'fixture bug: must decode identically to exercise the collapse');
+  fs.writeFileSync(localPath, localBytes);
+  fs.writeFileSync(globalPath, globalBytes);
+
+  const r = run('em-move.mjs', ['--id', id, '--to', 'global', '--no-audit'], fx6b.cwd, fx6b.env);
+  assert.equal(r.code, 1, `expected hard error, got ${r.code}: ${r.stdout}`);
+  assert.ok(r.json.errors[0].error.includes('DIFFERENT content'), r.stdout);
+  assert.ok(fs.readFileSync(localPath).equals(localBytes), 'local file must be byte-for-byte untouched');
+  assert.ok(fs.readFileSync(globalPath).equals(globalBytes), 'global file must be byte-for-byte untouched');
+  fs.rmSync(fx6b.cwd, { recursive: true, force: true }); fs.rmSync(fx6b.home, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #669 S1: FIFO-shaped episode body (em-move.mjs:266/:316, the
+// frontmatter-id-match content read). Pre-lock (:266) and outside any try
+// today — a bare throw there would crash the whole run; the fix wraps it
+// locally, converting hang into a per-id error + continue. A second,
+// readable id in the same --ids batch must still move successfully
+// (row-level isolation).
+// ---------------------------------------------------------------------------
+t('--ids with one FIFO-shaped body: that id gets a typed per-id error, the other id in the same batch still moves, no hang', () => {
+  const fx7 = mkFixture();
+  const brokenId = store(fx7, ['--category', 'decision', '--summary', 'broken body', '--tags', 'b', '--scope', 'local']);
+  const okId = store(fx7, ['--category', 'decision', '--summary', 'healthy body', '--tags', 'h', '--scope', 'local']);
+  const brokenPath = path.join(fx7.local, 'episodes', `${brokenId}.md`);
+  fs.unlinkSync(brokenPath);
+  const mk = spawnSync('mkfifo', [brokenPath]);
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`);
+
+  const r = run('em-move.mjs', ['--ids', `${brokenId},${okId}`, '--to', 'global', '--no-audit'], fx7.cwd, fx7.env, 5000);
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`);
+  assert.equal(r.code, 1, `exit 1 (one per-id error), got ${r.code}: ${r.stdout}`);
+  const brokenErr = r.json.errors.find(e => e.id === brokenId);
+  assert.ok(brokenErr, `broken id must have a per-id error entry: ${r.stdout}`);
+  assert.ok(/^episode-unreadable:/.test(brokenErr.code || ''), `typed episode-unreadable code, got ${JSON.stringify(brokenErr)}`);
+  assert.ok(r.json.moved.some(m => m.id === okId), `healthy id must still move: ${r.stdout}`);
+  assertIndexInvariant(okId, fx7.global, fx7.local);
+
+  fs.unlinkSync(brokenPath); // remove the FIFO so cleanup's rmSync doesn't hang
+  fs.rmSync(fx7.cwd, { recursive: true, force: true }); fs.rmSync(fx7.home, { recursive: true, force: true });
 });
 
 for (const fx of [fx1, fx2]) {

--- a/tests/test-em-pin-body-read.mjs
+++ b/tests/test-em-pin-body-read.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * test-em-pin-body-read.mjs — issue #669 net-new suite.
+ *
+ * em-pin.mjs:78 read the episode body with a raw fs.readFileSync while
+ * holding the store write lock (clerk-apply.lock). A FIFO-shaped body file
+ * (no writer) blocked that read forever — a hang WHILE HOLDING THE LOCK,
+ * confirmed pre-fix at >6s (plan §0). The fix (R-C exception, plan §1):
+ * em-pin.mjs keeps readBodyOrSkip (not openReadableBody — a thrown
+ * BodyUnreadableError would be swallowed by the generic catch into a
+ * code-less message); on ok:false it sets result/exitCode inside the try
+ * and falls through so the finally still releases the lock.
+ *
+ * This suite asserts:
+ *   - exit 1, typed `episode-unreadable:<CODE>` envelope on the JSON;
+ *   - the ON-DISK clerk-apply.lock file is ABSENT afterward (not just the
+ *     JSON envelope — a released-but-unasserted lock is the exact failure
+ *     mode a process.exit-inside-try would produce);
+ *   - the episode frontmatter and index.jsonl are BYTE-UNCHANGED (a failed
+ *     pin changes nothing on disk — the read precedes the first write).
+ */
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const SCRIPTS = path.join(REPO, 'scripts')
+
+let pass = 0, fail = 0
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`) }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`) }
+}
+
+function mkFixture() {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'empin-')))
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'empin-home-')))
+  return { cwd, home, env: { ...process.env, HOME: home } }
+}
+
+function run(script, args, fx, timeout = 10000) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd: fx.cwd, encoding: 'utf8', timeout, env: fx.env })
+  let json = null
+  try { json = JSON.parse(r.stdout.trim()) } catch {}
+  return { code: r.status, signal: r.signal, json, stdout: r.stdout }
+}
+
+function cleanup(fx) {
+  fs.rmSync(fx.cwd, { recursive: true, force: true })
+  fs.rmSync(fx.home, { recursive: true, force: true })
+}
+
+t('--id with a FIFO-shaped body file: exit 1, typed episode-unreadable envelope, no hang', () => {
+  const fx = mkFixture()
+  const st = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'pin target', '--body', 'body text'], fx)
+  assert.equal(st.json.status, 'ok', st.stdout)
+  const id = st.json.id
+  const epPath = path.join(fx.cwd, '.episodic-memory', 'episodes', `${id}.md`)
+  const indexPath = path.join(fx.cwd, '.episodic-memory', 'index.jsonl')
+  const contentBefore = fs.readFileSync(epPath, 'utf8')
+  const indexBefore = fs.readFileSync(indexPath, 'utf8')
+  fs.unlinkSync(epPath)
+  const mk = spawnSync('mkfifo', [epPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = run('em-pin.mjs', ['--id', id], fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 1, `exit 1, got ${r.code}: ${r.stdout}`)
+  assert.equal(r.json.status, 'error', r.stdout)
+  assert.ok(/^episode-unreadable:/.test(r.json.code || ''), `typed episode-unreadable code, got ${JSON.stringify(r.json)}`)
+  assert.ok(/episode body unreadable/.test(r.json.message), `message names the unreadable body, got ${r.json.message}`)
+
+  // On-disk lock file ABSENT (not just the JSON envelope) — the finally
+  // block must have run even though the failure was detected mid-try.
+  const lockPath = path.join(fx.cwd, '.episodic-memory', 'clerk-apply.lock')
+  assert.equal(fs.existsSync(lockPath), false, 'clerk-apply.lock must be absent after the typed failure')
+
+  // Index untouched — the read precedes the first write.
+  const indexAfter = fs.readFileSync(indexPath, 'utf8')
+  assert.equal(indexAfter, indexBefore, 'index.jsonl must be byte-unchanged on a failed pin')
+
+  fs.unlinkSync(epPath) // remove the FIFO so cleanup's rmSync doesn't hang
+  fs.writeFileSync(epPath, contentBefore)
+  cleanup(fx)
+})
+
+t('--unpin with a FIFO-shaped body file: same typed failure, lock still released', () => {
+  const fx = mkFixture()
+  const st = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'unpin target', '--body', 'body text'], fx)
+  const id = st.json.id
+  run('em-pin.mjs', ['--id', id], fx) // pin it first, real write path
+  const epPath = path.join(fx.cwd, '.episodic-memory', 'episodes', `${id}.md`)
+  fs.unlinkSync(epPath)
+  const mk = spawnSync('mkfifo', [epPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = run('em-pin.mjs', ['--id', id, '--unpin'], fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 1, r.stdout)
+  assert.ok(/^episode-unreadable:/.test(r.json.code || ''), `typed code, got ${JSON.stringify(r.json)}`)
+  const lockPath = path.join(fx.cwd, '.episodic-memory', 'clerk-apply.lock')
+  assert.equal(fs.existsSync(lockPath), false, 'clerk-apply.lock must be absent after the typed failure')
+
+  fs.unlinkSync(epPath)
+  cleanup(fx)
+})
+
+t('healthy control: --id with a normal body file still pins successfully', () => {
+  const fx = mkFixture()
+  const st = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'decision', '--summary', 'control target', '--body', 'body text'], fx)
+  const id = st.json.id
+  const r = run('em-pin.mjs', ['--id', id], fx)
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal(r.json.status, 'ok')
+  assert.equal(r.json.pinned, true)
+  cleanup(fx)
+})
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-em-promote.mjs
+++ b/tests/test-em-promote.mjs
@@ -54,9 +54,9 @@ function mkWorld(name) {
       if (out.status !== 'ok') throw new Error(`seed lesson failed: ${r.stdout}${r.stderr}`)
       return out.id
     },
-    promote(args = []) {
+    promote(args = [], timeout) {
       return spawnSync(process.execPath, [PROMOTE, ...args],
-        { cwd: root, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8' })
+        { cwd: root, env: { ...process.env, HOME: home, USERPROFILE: home }, encoding: 'utf8', ...(timeout ? { timeout } : {}) })
     },
     globalIndexRows() {
       const p = path.join(home, '.episodic-memory', 'index.jsonl')
@@ -152,6 +152,39 @@ t('testPromoteSkipsReplicaMembers', () => {
   const out = parse(w.promote())
   assert(out.candidates.length === 0, `replica must not count as recurrence: ${JSON.stringify(out.candidates)}`)
   assert(id, 'seed id must exist')
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Issue #669 S1: FIFO-shaped episode body in the cross-store recurrence scan
+// (em-promote.mjs:161). A FIFO with no writer previously blocked the raw
+// fs.readFileSync forever; the fix (readBodyOrSkip) converts the hang into
+// the existing skip-row-plus-warning disposition — the broken member drops
+// out, surviving healthy members still cluster.
+// ---------------------------------------------------------------------------
+t('testPromoteFifoBodyDoesNotHangSkipsThatMemberOnly', () => {
+  const w = mkWorld('fifobody')
+  const a = w.project('projA')
+  const b = w.project('projB')
+  const brokenId = w.lesson(a, 'always quote hook command paths broken copy', RECUR_BODY)
+  w.lesson(a, 'always quote hook command paths healthy copy', RECUR_BODY)
+  w.lesson(b, 'always quote hook command paths in hooks', RECUR_BODY)
+  const brokenPath = path.join(a, '.episodic-memory', 'episodes', `${brokenId}.md`)
+  fs.unlinkSync(brokenPath)
+  const mk = spawnSync('mkfifo', [brokenPath])
+  assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = w.promote([], 5000)
+  assert(r.signal === null, `no signal (hang), got ${r.signal}`)
+  const out = parse(r)
+  assert(out.dry_run === true, 'dry-run must still complete')
+  assert(out.candidates.length === 1, `surviving healthy members still cluster: ${JSON.stringify(out.candidates)}`)
+  assert(out.candidates[0].stores.length === 2, `candidate spans the 2 stores with readable members: ${JSON.stringify(out.candidates[0])}`)
+  assert(!JSON.stringify(out.candidates).includes(brokenId), `broken member must not appear in any candidate: ${JSON.stringify(out.candidates)}`)
+  assert(Array.isArray(out.warnings) && out.warnings.some(wa => wa.episode === brokenId),
+    `broken member must surface in warnings: ${JSON.stringify(out.warnings)}`)
+
+  fs.unlinkSync(brokenPath) // remove the FIFO so cleanup's rmSync doesn't hang
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 

--- a/tests/test-em-review-request-body-read.mjs
+++ b/tests/test-em-review-request-body-read.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * test-em-review-request-body-read.mjs — issue #669 net-new suite.
+ *
+ * em-review-request.mjs:324 (checkChainRef) and :371 (--triggered-by
+ * cross-task check) read a referenced episode's body with a raw
+ * fs.readFileSync AFTER an fs.existsSync gate. Plan §1 R-D: these are
+ * validation-gate sites — a planted FIFO must not dodge a cross-task/
+ * provenance check by hanging or silently passing. Fix: readBodyOrSkip;
+ * non-ENOENT unreadable is now a GATE FAILURE via the existing errors[]
+ * channel (never a silent skip). ENOENT keeps each site's PRE-EXISTING
+ * absent semantics: :324's existsSync branch already errored on absence
+ * (so ENOENT there stays an error too); :371 had no `else` branch at all
+ * (silent, provenance-only) — that stays silent.
+ */
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+const SCRIPTS = path.join(REPO, 'scripts')
+
+let pass = 0, fail = 0
+function t(name, fn) {
+  try { fn(); pass++; console.log(`  ok  ${name}`) }
+  catch (e) { fail++; console.error(`FAIL  ${name}\n      ${e.message}`) }
+}
+
+function mkFixture() {
+  const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emrr-')))
+  const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'emrr-home-')))
+  return { cwd, home, env: { ...process.env, HOME: home } }
+}
+
+function run(script, args, fx, timeout = 10000) {
+  const r = spawnSync('node', [path.join(SCRIPTS, script), ...args], { cwd: fx.cwd, encoding: 'utf8', timeout, env: fx.env })
+  let json = null
+  try { json = JSON.parse(r.stdout.trim()) } catch {}
+  return { code: r.status, signal: r.signal, json, stdout: r.stdout }
+}
+
+function cleanup(fx) {
+  fs.rmSync(fx.cwd, { recursive: true, force: true })
+  fs.rmSync(fx.home, { recursive: true, force: true })
+}
+
+function storeLifecycle(fx, { summary, body }) {
+  const r = run('em-store.mjs', ['--project', 'fx', '--scope', 'local', '--category', 'workflow.lifecycle', '--summary', summary, '--body', body], fx)
+  assert.equal(r.json.status, 'ok', r.stdout)
+  return r.json.id
+}
+
+// Minimal full chain (plan-approved → pre-checkpoint → post-checkpoint) so
+// em-review-request's chain-ref resolution reaches the body-inspection step
+// (event/task match) for each of --approval-ref/--pre-checkpoint-ref/
+// --post-checkpoint-ref — that inspection is exactly where :324 reads.
+function mkChain(fx, task = 'TEST') {
+  const planId = storeLifecycle(fx, {
+    summary: 'plan approved',
+    body: '```json\n' + JSON.stringify({ event: 'plan-approved', task, pattern_id: 'bp-001-implementation-workflow', context: { worktree: fx.cwd, branch: 'main', head: 'abc1234' }, plan_ref: 'p.md' }) + '\n```',
+  })
+  const preId = storeLifecycle(fx, {
+    summary: 'pre checkpoint',
+    body: '```json\n' + JSON.stringify({ event: 'pre-checkpoint', task, pattern_id: 'bp-001-implementation-workflow', context: { worktree: fx.cwd, branch: 'main', head: 'abc1234' }, plan_ref: 'p.md', approval_ref: `episode:${planId}` }) + '\n```',
+  })
+  const postId = storeLifecycle(fx, {
+    summary: 'post checkpoint',
+    body: '```json\n' + JSON.stringify({
+      event: 'post-checkpoint', task, pattern_id: 'bp-001-implementation-workflow', context: { worktree: fx.cwd, branch: 'main', head: 'abc1234' },
+      pre_checkpoint_ref: `episode:${preId}`,
+      evidence: { tests: [], code_review: { status: 'done' }, e2e: { status: 'passed' }, bug_logging: { status: 'no-new-bugs' } },
+    }) + '\n```',
+  })
+  return { planId, preId, postId }
+}
+
+function baseArgs(fx, chain, task = 'TEST') {
+  return [
+    '--task', task,
+    '--plan-ref', 'p.md',
+    '--approval-ref', `episode:${chain.planId}`,
+    '--pre-checkpoint-ref', `episode:${chain.preId}`,
+    '--post-checkpoint-ref', `episode:${chain.postId}`,
+    '--tests-ref', 'file:x',
+    '--code-review-ref', `episode:${chain.postId}`,
+    '--no-new-bugs',
+    '--branch', 'main', '--head', 'abc1234', '--worktree', fx.cwd,
+  ]
+}
+
+function epPath(fx, id) {
+  return path.join(fx.cwd, '.episodic-memory', 'episodes', `${id}.md`)
+}
+
+function toFifo(fx, id) {
+  const p = epPath(fx, id)
+  fs.unlinkSync(p)
+  const mk = spawnSync('mkfifo', [p])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+}
+
+t('healthy control: full valid chain writes the review-request episode (exit 0)', () => {
+  const fx = mkFixture()
+  const chain = mkChain(fx)
+  const r = run('em-review-request.mjs', baseArgs(fx, chain), fx)
+  assert.equal(r.code, 0, r.stdout)
+  assert.equal(r.json.status, 'ok', r.stdout)
+  cleanup(fx)
+})
+
+t(':324 checkChainRef — --approval-ref FIFO-shaped body: gate failure (exit 1), errors[] names unreadable, no hang', () => {
+  const fx = mkFixture()
+  const chain = mkChain(fx)
+  toFifo(fx, chain.planId)
+  const r = run('em-review-request.mjs', baseArgs(fx, chain), fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 1, `exit 1 (gate failure, not usage error), got ${r.code}: ${r.stdout}`)
+  assert.equal(r.json.status, 'error', r.stdout)
+  assert.ok(Array.isArray(r.json.errors) && r.json.errors.some(e => /unreadable/.test(e)),
+    `errors[] must name the unreadable body, got ${JSON.stringify(r.json.errors)}`)
+  fs.unlinkSync(epPath(fx, chain.planId))
+  cleanup(fx)
+})
+
+t(':324 checkChainRef — --pre-checkpoint-ref FIFO-shaped body: gate failure, no hang', () => {
+  const fx = mkFixture()
+  const chain = mkChain(fx)
+  toFifo(fx, chain.preId)
+  const r = run('em-review-request.mjs', baseArgs(fx, chain), fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 1, r.stdout)
+  assert.ok(r.json.errors.some(e => /unreadable/.test(e)), JSON.stringify(r.json.errors))
+  fs.unlinkSync(epPath(fx, chain.preId))
+  cleanup(fx)
+})
+
+t(':371 --triggered-by FIFO-shaped body: gate failure via errors[] (cross-task provenance check must not be dodged)', () => {
+  const fx = mkFixture()
+  const chain = mkChain(fx)
+  const trig = storeLifecycle(fx, { summary: 'trigger source', body: '```json\n' + JSON.stringify({ event: 'plan-approved', task: 'OTHER-TASK', pattern_id: 'bp-001-implementation-workflow' }) + '\n```' })
+  toFifo(fx, trig)
+  const r = run('em-review-request.mjs', [...baseArgs(fx, chain), '--triggered-by', `episode:${trig}`], fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 1, `exit 1, got ${r.code}: ${r.stdout}`)
+  assert.ok(r.json.errors.some(e => /--triggered-by/.test(e) && /unreadable/.test(e)),
+    `errors[] must name the unreadable triggered-by body, got ${JSON.stringify(r.json.errors)}`)
+  fs.unlinkSync(epPath(fx, trig))
+  cleanup(fx)
+})
+
+t(':371 F5 control — --triggered-by pointing at a vanished (ENOENT) body: stays silent (provenance-only), no error, no hang', () => {
+  const fx = mkFixture()
+  const chain = mkChain(fx)
+  const trig = storeLifecycle(fx, { summary: 'trigger source vanished', body: '```json\n' + JSON.stringify({ event: 'plan-approved', task: 'OTHER-TASK', pattern_id: 'bp-001-implementation-workflow' }) + '\n```' })
+  fs.unlinkSync(epPath(fx, trig)) // absent, not a FIFO — F5 stays silent at this site
+  const r = run('em-review-request.mjs', [...baseArgs(fx, chain), '--triggered-by', `episode:${trig}`], fx, 5000)
+  assert.equal(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.equal(r.code, 0, `absent triggered-by body must stay provenance-only (no gate failure), got ${r.code}: ${r.stdout}`)
+  assert.equal(r.json.status, 'ok', r.stdout)
+  cleanup(fx)
+})
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/tests/test-promote-apply.mjs
+++ b/tests/test-promote-apply.mjs
@@ -507,6 +507,126 @@ t('testMigrationSuccessors', () => {
   fs.rmSync(w.root, { recursive: true, force: true })
 })
 
+// #669 review-round A4 (codex MAJOR — fail-open provenance): a legacy row
+// with TWO Sources entries where ONE is unreadable (FIFO) previously still
+// produced a candidate carrying only the ONE healthy source (partial
+// provenance silently dropped) — and --migrate --apply would write a
+// successor from that partial set. Frozen disposition: skip the WHOLE row.
+// This leg plants exactly that two-source (healthy A + FIFO B) shape and
+// asserts BOTH ends: preview sees zero candidates + a skipped entry naming
+// reason 'source-unreadable', and apply writes no successor and leaves the
+// legacy row untouched (still just the one row, not superseded).
+t('testMigrationPartialSourceUnreadableSkipsWholeRow', () => {
+  const w = pair('migration-partial-unreadable')
+  const { legacyId, idB } = seedLegacyGlobal(w)
+  const bEpisodePath = path.join(w.root, 'projB', '.episodic-memory', 'episodes', `${idB}.md`)
+  fs.unlinkSync(bEpisodePath)
+  const mk = spawnSync('mkfifo', [bEpisodePath])
+  assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+
+  const preview = parse(w.promote(['--migrate']))
+  assert(preview.dry_run === true, `expected dry-run, got ${JSON.stringify(preview)}`)
+  assert(preview.candidates.length === 0, `no candidate may be emitted with partial provenance, got ${JSON.stringify(preview.candidates)}`)
+  const skip = preview.skipped.find(s => s.hash === legacyId)
+  assert(skip, `legacy row must appear in skipped[], got ${JSON.stringify(preview.skipped)}`)
+  assert(skip.reason === 'source-unreadable', `expected reason source-unreadable, got ${JSON.stringify(skip)}`)
+
+  // Apply mode re-runs selectMigrationCandidates too (migCands) — since the
+  // row never becomes a candidate, apply must not attempt anything for it:
+  // no successor written, legacy row not superseded, exit code reflects a
+  // clean run (no confirm target exists to even pass).
+  const applyResult = parse(w.promote(['--migrate']))
+  assert(applyResult.candidates.length === 0, `apply-mode preview must also show zero candidates: ${JSON.stringify(applyResult.candidates)}`)
+  const rowsAfter = w.globalIndexAll()
+  const legacyRow = rowsAfter.find(r => r.id === legacyId)
+  assert(legacyRow && legacyRow.status !== 'superseded', `legacy row must remain un-superseded (no successor written), got ${JSON.stringify(legacyRow)}`)
+  assert(!rowsAfter.some(r => r.supersedes === legacyId), `no successor may reference the legacy row as supersedes: ${JSON.stringify(rowsAfter)}`)
+
+  fs.unlinkSync(bEpisodePath)
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
+// #669 round-3 (codex MAJOR-2 residual, runtime-confirmed): a DIFFERENT
+// defect from the round-2 leg above — here BOTH sources are healthy
+// (selectMigrationCandidates succeeds and produces a valid, CONFIRMABLE
+// candidate), but the SEPARATE re-read of the legacy body for the
+// successor's preserved-body text (the same file, read a SECOND time,
+// em-promote.mjs's former ~:667) fails at confirmed-apply time. Pre-fix,
+// ok:false on that specific read was silently ignored: a successor was
+// still written with a placeholder body and the legacy row superseded
+// anyway (codex probe: targeted EACCES on exactly that read → apply exit
+// 0, successor written with placeholder, legacy superseded).
+//
+// Reproducing "the EARLIER reads of this path (candidate selection) and
+// any read after (the em-revise subprocess, a separate OS process) all
+// succeed, only the successor-body read fails" needs a fault that targets
+// ONE specific occurrence of openSync(legacyPath) — a persistent
+// filesystem-level fault (chmod/FIFO) would ALSO break the earlier reads
+// and prevent the candidate from ever being selected/confirmable in this
+// same process, testing the WRONG code path entirely (round-2's fix, not
+// round-3's). A confirmed `--migrate --confirm` run reads legacyPath FOUR
+// times before any write: (1) the top-level duplicate-lesson scan every
+// invocation runs regardless of mode, (2) the confirm-set-validation
+// block's own selectMigrationCandidates call, (3) the migrate block's
+// selectMigrationCandidates call, (4) THIS fix's successor-body read —
+// empirically confirmed by counting under an unfaulted preload before
+// picking the fault target. A Node --import preload installed only for
+// this ONE spawn counts openSync(targetPath) calls and fails exactly the
+// 4th occurrence within the em-promote.mjs process; it never touches the
+// em-revise child (a separate OS process with its own unpatched fs),
+// matching codex's "original left readable for the em-revise subprocess"
+// probe note.
+t('testMigrationConfirmedApplySuccessorReadFailureSkipsWholeRow', () => {
+  const w = pair('migration-confirmed-apply-unreadable')
+  const { legacyId } = seedLegacyGlobal(w)
+  const legacyPath = path.join(w.home, '.episodic-memory', 'episodes', `${legacyId}.md`)
+
+  // Preview (fully readable, no fault installed): candidate selection +
+  // fingerprint capture — the genuine confirmed-apply entry point per the
+  // frozen test-leg shape (preview → capture fingerprint → confirmed apply).
+  const preview = parse(w.promote(['--migrate']))
+  assert(preview.dry_run === true, `expected dry-run, got ${JSON.stringify(preview)}`)
+  const cand = preview.candidates.find(c => c.id === legacyId)
+  assert(cand, `legacy row must be a genuine, confirmable candidate before the fault, got ${JSON.stringify(preview.candidates)}`)
+  const migFp = cand.fingerprint
+
+  const preloadPath = path.join(w.root, 'fault-preload.mjs')
+  fs.writeFileSync(preloadPath, [
+    "import fs from 'node:fs'",
+    'const target = process.env.EM_PROMOTE_FAULT_PATH',
+    'let count = 0',
+    'const orig = fs.openSync',
+    'fs.openSync = function (p, ...rest) {',
+    '  if (p === target) {',
+    '    count++',
+    "    if (count === 4) { const e = new Error(`EACCES: permission denied, open '${p}'`); e.code = 'EACCES'; throw e }",
+    '  }',
+    '  return orig.call(this, p, ...rest)',
+    '}',
+  ].join('\n'))
+
+  // Confirmed apply, in a SEPARATE disposable child process (the preload
+  // hook and its process.exit() must never touch this test runner).
+  const r = spawnSync(process.execPath, ['--import', preloadPath, PROMOTE, '--migrate', '--confirm', migFp], {
+    cwd: w.root,
+    env: { ...env(w.home), EM_PROMOTE_FAULT_PATH: legacyPath },
+    encoding: 'utf8',
+  })
+  const applied = parse(r)
+  assert(applied.status === 'ok', `existing skip semantics keep status/exit clean (no OTHER failure in this run), got status=${applied.status} exit=${r.status}: ${JSON.stringify(applied)}`)
+  assert(!applied.migrated.some(m => m.original === legacyId && m.successor), `no successor may be written for ${legacyId}, got ${JSON.stringify(applied.migrated)}`)
+  const skip = applied.skipped.find(s => s.hash === legacyId)
+  assert(skip, `legacy row must appear in skipped[], got ${JSON.stringify(applied.skipped)}`)
+  assert(skip.reason === 'source-unreadable', `expected reason source-unreadable, got ${JSON.stringify(skip)}`)
+
+  const rowsAfter = w.globalIndexAll()
+  const legacyRow = rowsAfter.find(x => x.id === legacyId)
+  assert(legacyRow && legacyRow.status !== 'superseded', `legacy row must remain active (no supersede/no em-revise spawn), got ${JSON.stringify(legacyRow)}`)
+  assert(!rowsAfter.some(x => x.supersedes === legacyId), `no successor may reference the legacy row as supersedes: ${JSON.stringify(rowsAfter)}`)
+
+  fs.rmSync(w.root, { recursive: true, force: true })
+})
+
 t('testMigrationTypedSuccessorNotReselected', () => {
   const w = pair('migration-idempotent')
   const { legacyId } = seedLegacyGlobal(w)

--- a/tests/test-topic-tracks.mjs
+++ b/tests/test-topic-tracks.mjs
@@ -176,7 +176,7 @@ test('apply: revalidation observes global and registered locks; releases both', 
   const globalDir = path.join(sandbox.home, '.episodic-memory')
   const regDir = path.join(sandbox.root, 'project', '.episodic-memory')
   const savedHome = process.env.HOME
-  const savedReadFileSync = fs.readFileSync
+  const savedOpenSync = fs.openSync
   let observed = false
   try {
     writeFixtureStore(globalDir, 'global', [
@@ -211,11 +211,16 @@ test('apply: revalidation observes global and registered locks; releases both', 
     ])
     const gLock = storeWriteLockPath(globalDir)
     const rLock = storeWriteLockPath(regDir)
-    fs.readFileSync = function(p, ...rest) {
+    // #669: engine.mjs's episode-body read now goes through readBodyOrSkip
+    // (fd-based openSync + readFileSync(fd)), not a path-based
+    // fs.readFileSync(path) call — patch openSync (still the same
+    // instrumentation point, immediately before the read) so this
+    // observation isn't blind to the new call shape.
+    fs.openSync = function(p, ...rest) {
       if (episodePaths.has(p) && fs.existsSync(gLock) && fs.existsSync(rLock)) {
         observed = true
       }
-      return savedReadFileSync.call(this, p, ...rest)
+      return savedOpenSync.call(this, p, ...rest)
     }
     const out = applyTopicTracks({
       globalDir, registeredStores, config: cfg,
@@ -227,13 +232,13 @@ test('apply: revalidation observes global and registered locks; releases both', 
     assert.strictEqual(out.written.length, 1,
       `expected one written; got ${out.written.length}`)
     assert.strictEqual(observed, true,
-      'revalidation readFileSync patches must have observed both locks held')
+      'revalidation openSync patches must have observed both locks held')
     assert.strictEqual(fs.existsSync(gLock), false,
       `expected global lock absent; ${gLock} exists=${fs.existsSync(gLock)}`)
     assert.strictEqual(fs.existsSync(rLock), false,
       `expected registered lock absent; ${rLock} exists=${fs.existsSync(rLock)}`)
   } finally {
-    fs.readFileSync = savedReadFileSync
+    fs.openSync = savedOpenSync
     if (savedHome === undefined) delete process.env.HOME
     else process.env.HOME = savedHome
     sandbox.cleanup()
@@ -244,7 +249,7 @@ test('apply: registered source mutation during locked revalidation is stale; rel
   const globalDir = path.join(sandbox.home, '.episodic-memory')
   const regDir = path.join(sandbox.root, 'project', '.episodic-memory')
   const savedHome = process.env.HOME
-  const savedReadFileSync = fs.readFileSync
+  const savedOpenSync = fs.openSync
   const r1Path = path.join(regDir, 'episodes', 'r1.md')
   let mutated = false
   try {
@@ -275,12 +280,16 @@ test('apply: registered source mutation during locked revalidation is stale; rel
     process.env.HOME = sandbox.home
     const gLock = storeWriteLockPath(globalDir)
     const rLock = storeWriteLockPath(regDir)
-    fs.readFileSync = function(p, ...rest) {
+    // #669: patch openSync, not readFileSync — see the sibling test above
+    // for why (engine.mjs now reads via the fd-based readBodyOrSkip). The
+    // mutation still lands before the fd's own readFileSync(fd) call runs,
+    // since it happens synchronously inside openSync before returning.
+    fs.openSync = function(p, ...rest) {
       if (p === r1Path && fs.existsSync(gLock) && fs.existsSync(rLock) && !mutated) {
         fs.appendFileSync(r1Path, '\nmuta-line-during-revalidation\n')
         mutated = true
       }
-      return savedReadFileSync.call(this, p, ...rest)
+      return savedOpenSync.call(this, p, ...rest)
     }
     const out = applyTopicTracks({
       globalDir, registeredStores, config: cfg,
@@ -298,7 +307,7 @@ test('apply: registered source mutation during locked revalidation is stale; rel
     assert.strictEqual(fs.existsSync(rLock), false,
       `expected registered lock absent; ${rLock} exists=${fs.existsSync(rLock)}`)
   } finally {
-    fs.readFileSync = savedReadFileSync
+    fs.openSync = savedOpenSync
     if (savedHome === undefined) delete process.env.HOME
     else process.env.HOME = savedHome
     sandbox.cleanup()
@@ -635,6 +644,36 @@ test('collect: missing episode file yields missing_sources row and no member', (
     assert.deepStrictEqual(result.missing_sources,
       [{ store_id: 'global', episode_id: 'missing1' }])
     assert.deepStrictEqual(result.warnings, [])
+  } finally { sandbox.cleanup() }
+})
+
+// Issue #669 S1 (round-1 MINOR-5, settled): engine.mjs:245 read the episode
+// body with a raw fs.readFileSync inside try/catch — the catch already
+// treats ANY failure as missing_sources (no member), but a FIFO with no
+// writer blocks the read forever REGARDLESS of the surrounding try/catch (a
+// blocking syscall never throws). readBodyOrSkip fixes the hang while
+// preserving the EXACT SAME missing_sources disposition.
+test('collect: FIFO-shaped episode body yields missing_sources row and no member, no hang (issue #669)', () => {
+  const sandbox = makeSandbox('tt-collect-fifo')
+  try {
+    const globalDir = path.join(sandbox.root, 'global')
+    writeFixtureStore(globalDir, 'global', [
+      { id: 'fifo1', category: 'decision', summary: 'fifo-shaped body row', tags: ['a'] },
+    ])
+    const fifoPath = path.join(globalDir, 'episodes', 'fifo1.md')
+    fs.unlinkSync(fifoPath)
+    const mk = spawnSync('mkfifo', [fifoPath])
+    assert.strictEqual(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+    const cfg = readCommittedConfig()
+
+    const start = Date.now()
+    const result = collectTopicMembers({ globalDir, registeredStores: [], config: cfg })
+    const elapsed = Date.now() - start
+    assert.ok(elapsed < 5000, `collectTopicMembers must not hang on a FIFO body, took ${elapsed}ms`)
+    assert.deepStrictEqual(result.members, [])
+    assert.deepStrictEqual(result.missing_sources, [{ store_id: 'global', episode_id: 'fifo1' }])
+    assert.deepStrictEqual(result.warnings, [])
+    fs.unlinkSync(fifoPath)
   } finally { sandbox.cleanup() }
 })
 

--- a/tests/test-workflow-validate.mjs
+++ b/tests/test-workflow-validate.mjs
@@ -12,7 +12,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { execFileSync } from 'child_process'
+import { execFileSync, spawnSync } from 'child_process'
 import assert from 'assert'
 
 const SCRIPTS = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'scripts')
@@ -121,19 +121,21 @@ function mkWitness({ category = 'discovery', summary = 'witness', status = 'acti
   return id
 }
 
-function runValidate(args) {
+function runValidate(args, opts = {}) {
   try {
     const out = execFileSync('node', [VALIDATE, ...args], {
       env: { ...process.env, HOME: tmpHome },
       cwd: tmpCwd,
       encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(opts.timeout ? { timeout: opts.timeout } : {})
     })
-    return { exit: 0, json: JSON.parse(out) }
+    return { exit: 0, signal: null, json: JSON.parse(out) }
   } catch (e) {
     if (e.stdout) {
-      try { return { exit: e.status, json: JSON.parse(e.stdout) } } catch {}
+      try { return { exit: e.status, signal: e.signal || null, json: JSON.parse(e.stdout) } } catch {}
     }
+    if (e.signal) return { exit: e.status, signal: e.signal, json: null } // timeout kill (#669 FIFO legs)
     throw e
   }
 }
@@ -2243,6 +2245,71 @@ test('T102-21 semantic-flip vs T58: chain-walk picks DIFFERENT rr than latest-by
   // The newer rr (differenthead) is out-of-chain.
   const newer = r.json.episodes.find(e => e.id === newerId)
   assert.strictEqual(newer.in_chain, false, 'newer rr at differenthead should NOT be terminal under --head=abc1234')
+})
+
+// ---------------------------------------------------------------------------
+// Issue #669 S1: FIFO-shaped workflow.lifecycle episode body. em-workflow-
+// validate.mjs:194 (extractPayload) and :570 (triggered_by cross-task
+// check) are validation-gate sites (R-D): a planted FIFO must fail closed
+// through the existing errors[] channel, never hang and never silently pass.
+// ---------------------------------------------------------------------------
+test('T669a extractPayload: a FIFO-shaped lifecycle episode body fails the gate closed (errors[], not a hang)', () => {
+  const planId = mkEpisode({ event: 'plan-approved', extra: { plan_ref: 'docs/plan.md', classification: 'full' } })
+  mkEpisode({ event: 'pre-checkpoint', extra: { plan_ref: 'docs/plan.md', approval_ref: `episode:${planId}` } })
+  const fifoPath = path.join(episodesDir, `${planId}.md`)
+  fs.unlinkSync(fifoPath)
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.strictEqual(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = runValidate(['--task', 'TEST', '--gate', 'pre-checkpoint'], { timeout: 5000 })
+  assert.strictEqual(r.signal, null, `no signal (hang), got ${r.signal}`)
+  // exit 1 is the validator's normal "ran fine, verdict is invalid" contract
+  // (process.exit(valid ? 0 : 1)) — NOT a usage/crash exit (that's exit 2,
+  // asserted absent by the JSON parsing successfully at all).
+  assert.strictEqual(r.exit, 1, `extractPayload failures must reach the normal valid:false contract, not a usage/crash exit: ${JSON.stringify(r.json)}`)
+  assert.strictEqual(r.json.valid, false, 'gate must fail closed when a chain member is unreadable')
+  // The raw "unreadable" message lands in errors[] (caught at the call site
+  // per R-D) UNLESS the #102 terminal-anchored migration demotes it to
+  // warnings[] because the affected episode ends up out-of-chain (a real,
+  // pre-existing, orthogonal feature — not something #669 changes). Either
+  // way it must be VISIBLE somewhere and the gate must still fail closed.
+  const allMessages = [...r.json.errors, ...(r.json.warnings || [])]
+  assert.ok(allMessages.some(e => e.includes(planId) && /unreadable/.test(e)),
+    `the unreadable episode must be named somewhere (errors[] or warnings[]), got errors=${JSON.stringify(r.json.errors)} warnings=${JSON.stringify(r.json.warnings)}`)
+  fs.unlinkSync(fifoPath)
+})
+
+// triggered_by is only validated inside the 'review-request' case of
+// validatePayload's event switch — use the mkBaseChainForReview/
+// mkReviewRequest fixture builders (defined below, #118 PR-D section) via a
+// forward-reference deferred to first call (function declarations from that
+// section are hoisted, so this is safe despite lexical ordering in the file).
+test('T669b triggered_by: a FIFO-shaped referenced body is a gate failure, not silently provenance-only', () => {
+  const chain = mkBaseChainForReview()
+  const trigId = mkWitness({ category: 'discovery', summary: 'trigger source' })
+  mkReviewRequest({ chain, extra: { triggered_by: `episode:${trigId}` } })
+  const fifoPath = path.join(episodesDir, `${trigId}.md`)
+  fs.unlinkSync(fifoPath)
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.strictEqual(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'], { timeout: 5000 })
+  assert.strictEqual(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.strictEqual(r.json.valid, false, 'gate must fail closed on an unreadable triggered_by body')
+  assert.ok(r.json.errors.some(e => e.includes('triggered_by') && /unreadable/.test(e)),
+    `errors[] must name the unreadable triggered_by body, got: ${JSON.stringify(r.json.errors)}`)
+  fs.unlinkSync(fifoPath)
+})
+
+test('T669c triggered_by F5 control: a vanished (ENOENT) referenced body stays provenance-only, no error', () => {
+  const chain = mkBaseChainForReview()
+  const trigId = mkWitness({ category: 'discovery', summary: 'trigger source vanished' })
+  mkReviewRequest({ chain, extra: { triggered_by: `episode:${trigId}` } })
+  fs.unlinkSync(path.join(episodesDir, `${trigId}.md`)) // absent, not a FIFO — F5 stays silent
+
+  const r = runValidate(['--task', 'TEST', '--gate', 'review-request', '--head', 'abc1234'], { timeout: 5000 })
+  assert.strictEqual(r.signal, null, `no signal (hang), got ${r.signal}`)
+  assert.strictEqual(r.json.valid, true, `absent triggered_by body must stay provenance-only, errors: ${JSON.stringify(r.json.errors)}`)
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the D-1 deferral from #668: the curation/audit tier read episode bodies (and rule/RFC docs) through raw `fs.readFileSync`, hanging forever on a FIFO planted in the store. This slice adopts the shipped fd-based helpers (`readBodyOrSkip`/`openReadableBody`) at **30 read sites across 9 scripts + 2 rule-node scan sites**, per the frozen plan `docs/plans/fix-669.md` (NSP audit round 1 HOLD → round 2 PROCEED-TO-FREEZE; full record in the plan).

Highest-severity fixes (runtime-confirmed pre-fix):
- `em-pin` hung on a FIFO **while holding the store write lock** (blocking all other writers); now a typed `episode-unreadable:<CODE>` envelope, exit 1, lock released.
- `em-restore` hung **even in `--dry-run`** (planning-time conflict-classify reads the target store), and a doc turning FIFO between planning and apply hung the raw `copyFileSync`; both legs now guarded (terminal skip + byte-faithful fd-guarded copy).
- `em-move`'s both-scopes divergence check ran **under both store locks** and (post-round-1) hashed utf8-decoded text — byte-divergent invalid-UTF-8 bodies collapsed to "identical" and one copy was silently unlinked. Now hashes raw bytes from an fd-guarded read; hard-error contract restored.
- `em-promote` migration emitted candidates/successors with **partial provenance** (and a placeholder successor on the confirmed-apply leg) when a source read failed; any unreadable source now skips the whole row.

## Declared additive wire surfaces

- restore: `unreadable` + `source-missing` conflict classes (both **default-skip under ALL modes including `--force`** — restore never writes through an unclassifiable target; documented in `usage()`), `ref_integrity[].unreadable/.code`, `skipped_in_backup.counts.unreadable`
- promote: `skipped[].reason: 'source-unreadable'`
- backup: `skippedUnreadable` (sync return, camel siblings) / `skipped_unreadable` (manifest, snake siblings), `unreadable_skipped` counts in audit totals/entries
- validators (em-review-request, em-workflow-validate): fail-closed errors-channel entries for non-ENOENT unreadable bodies (a planted FIFO can no longer dodge a provenance/cross-task gate)

## Review record

- NSP plan audit: r1 HOLD (4 MAJORs incl. the dry-run hang + vacuous backup probes) → folded → r2 PROCEED-TO-FREEZE.
- 2-lens code review via second-opinion harness: claude-subagent ACCEPT-WITH-FINDINGS (2 MAJOR, 4/4 mutants killed); codex r1 REJECT (4 MAJOR) → fix round → r2 (3 cleared, 1 residual) → surgical round 3 → **ACCEPT-WITH-FINDINGS, 0 MAJOR outstanding**, independent probes per finding.
- Every finding dispositioned in `docs/plans/fix-669.md` §6.

## DEFERs / carried notes

- DEFER-A: residual attacker-race TOCTOU re-reads (em-move `:335` EXDEV branch, backup classify-then-read) — #653 D1 precedent; recovery via stale-lock ESRCH reclaim.
- FU-1 (codex r3, non-blocking): the confirmed-apply fault-injection test targets a call ordinal; hardening tracked in #672.
- `tests/test-em-restore.mjs` stays KNOWN_UNWIRED in CI (pre-existing) — its 154-case selfTest (incl. the new FIFO legs) runs locally; tracked in #672.
- Adjacent same-trust-domain raw reads outside this issue's scope: enumerated in **#672**.
- Pre-existing install-wizard real-HOME leak found during the battery: **#673**.

## Verification

Full battery green (orchestrator-rerun, verbatim): pin 3/3, backup-body-read 6/6, review-request-body-read 5/5, consolidate 9/9, move 16/16, promote 32/32, promote-apply 31/31, restore selfTest 154/154, workflow-validate 113/113, topic-tracks 66/66, graph-nodes 32/32, 651-index 164/164 (4 skip), search-read 22/22, graph 12/12, stats-semantic 16/16, ci-registration 16/16, version-bump 60/60, store-write-concurrency 46/46. RED-state hang evidence (SIGTERM/ETIMEDOUT on unfixed code) captured for em-pin, em-restore --dry-run, rule-nodes, em-consolidate; per-finding RED evidence for every review-round fix. Plugin 0.2.9 → 0.2.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)