### PR TITLE
FIX-670: BP-1 guarded-read pass + shared Buffer primitive + signed-episode gate (fixes #670)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "episodic-memory",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Cross-tool episodic memory + BP-1 auto-pilot (RFC-004). All BP-1 surfaces are activation-gated and remain inert until M5 dry-run flips bp1.enabled per project.",
   "scheduled-tasks": [
     {

--- a/.github/workflows/rfc-validate.yml
+++ b/.github/workflows/rfc-validate.yml
@@ -27,11 +27,13 @@ on:
       - 'scripts/lib/bp1-run-state-migrate.mjs'
       - 'scripts/lib/bp1-episode-writer.mjs'
       - 'scripts/lib/bp1-episode-verify.mjs'
+      - 'scripts/lib/bp1-atomic.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
       - 'scripts/bp1-deadline-sweep.mjs'
       - 'scripts/bp1-canonicalize.mjs'
       - 'scripts/bp1-orchestrator.mjs'
+      - 'scripts/bp1-crash-classify.mjs'
       - 'tests/test-em-rfc-validate.mjs'
       - 'tests/test-validate-rfc-failure-table.mjs'
       - 'tests/test-validate-rfc-artifact-manifest.mjs'
@@ -47,6 +49,10 @@ on:
       - 'tests/test-bp1-run-state-migrate.mjs'
       - 'tests/test-bp1-episode-writer.mjs'
       - 'tests/test-bp1-episode-verify.mjs'
+      - 'tests/test-bp1-atomic.mjs'
+      - 'tests/test-bp1-manifest-collect.mjs'
+      - 'tests/test-bp1-crash-classify.mjs'
+      - 'tests/test-bp1-finalize-run.mjs'
       - 'tests/test-bp1-orchestrator-init-run.mjs'
       - 'tests/test-bp1-orchestrator-detect-rfcs.mjs'
       - 'tests/test-bp1-orchestrator-classifier-fence.mjs'
@@ -81,11 +87,13 @@ on:
       - 'scripts/lib/bp1-run-state-migrate.mjs'
       - 'scripts/lib/bp1-episode-writer.mjs'
       - 'scripts/lib/bp1-episode-verify.mjs'
+      - 'scripts/lib/bp1-atomic.mjs'
       - 'scripts/bp1-build-artifact-manifest.mjs'
       - 'scripts/bp1-flag-check.mjs'
       - 'scripts/bp1-deadline-sweep.mjs'
       - 'scripts/bp1-canonicalize.mjs'
       - 'scripts/bp1-orchestrator.mjs'
+      - 'scripts/bp1-crash-classify.mjs'
       - 'tests/test-em-rfc-validate.mjs'
       - 'tests/test-validate-rfc-failure-table.mjs'
       - 'tests/test-validate-rfc-artifact-manifest.mjs'
@@ -101,6 +109,10 @@ on:
       - 'tests/test-bp1-run-state-migrate.mjs'
       - 'tests/test-bp1-episode-writer.mjs'
       - 'tests/test-bp1-episode-verify.mjs'
+      - 'tests/test-bp1-atomic.mjs'
+      - 'tests/test-bp1-manifest-collect.mjs'
+      - 'tests/test-bp1-crash-classify.mjs'
+      - 'tests/test-bp1-finalize-run.mjs'
       - 'tests/test-bp1-orchestrator-init-run.mjs'
       - 'tests/test-bp1-orchestrator-detect-rfcs.mjs'
       - 'tests/test-bp1-orchestrator-classifier-fence.mjs'
@@ -189,6 +201,18 @@ jobs:
 
       - name: Run bp1-episode-verify tests (slice 2c CR2-2)
         run: node tests/test-bp1-episode-verify.mjs
+
+      - name: Run bp1-atomic tests (cluster #286/#287/#288)
+        run: node tests/test-bp1-atomic.mjs
+
+      - name: Run bp1-manifest-collect tests (PR-1c-B Slice 2 commit 2)
+        run: node tests/test-bp1-manifest-collect.mjs
+
+      - name: Run bp1-crash-classify tests (RFC-004 M2 slice 2e)
+        run: node tests/test-bp1-crash-classify.mjs
+
+      - name: Run bp1-orchestrator finalize-run/finalize-recover E2E tests
+        run: node tests/test-bp1-finalize-run.mjs
 
       - name: Run bp1-orchestrator init-run E2E tests
         run: node tests/test-bp1-orchestrator-init-run.mjs

--- a/docs/plans/fix-670.md
+++ b/docs/plans/fix-670.md
@@ -1,0 +1,269 @@
+# Plan: fix #670 (BP-1 subsystem unguarded episode reads + shared Buffer-read primitive)
+
+Status: **FROZEN** 2026-08-14. Audit round 1 HOLD (2 MAJORs: sibling-hang
+family incl. mode-600 key FIFO falsifying the acceptance battery;
+loadRunEpisodes wrapper bug making the test leg vacuous) → round 2 HOLD (3
+text edits: keys `{error}`-return vocabulary, DEFER-C +4 members, §2c bound
+pin) → round 3 fold verification **PROCEED-TO-FREEZE** (audit chain eps
+...-5369 → ...-0f97 → ...-a4bc). Builder implements THIS text; deviations
+are flagged, never improvised.
+Arc: playbook-v15 gate-free run, 2026-08-14. Evidence: #670 scout digest
+re-verified at main @ d6dc497 (zero drift) + NSP round-1 probes (audit
+reply ep 20260814-054931-hold-fix-670-plan-audit-2-majors-undispo-5369).
+
+## 0. Evidence scope
+
+- Scout runtime-confirmed hangs (isolated fixture): `bp1-orchestrator.mjs
+  finalize-recover` with FIFO at `episodes/poison.md` → SIGALRM 8s; direct
+  `findSignedStateEpisode` same. The **6 issue sites** (all in issue #670's
+  D-2 ledger) read raw: `bp1-orchestrator.mjs:607` (decisionLogFence, loop
+  local+global, catch{continue}), `:721` (findManifestEpisode, loop),
+  `lib/bp1-atomic.mjs:115` (findSignedStateEpisode, loop),
+  `lib/bp1-episode-verify.mjs:85` (verifyEpisodeOnDisk, single-target,
+  non-throwing `{ok, errors}`), `bp1-crash-classify.mjs:466`
+  (loadRunEpisodes, STRING read, loop), `lib/bp1-manifest.mjs:549`
+  (collectEpisodeRecords, loop local+global, hard-throws by design).
+- NSP round 1 runtime-confirmed SIBLING hangs in the same public verbs
+  (3s-kill probes): `bp1-crash-classify.mjs:502` (readApprovalMarkerStatus,
+  FIFO at `.checkpoints/bp1-approval-<runId>.json` — same verb as `:466`,
+  main calls both at `:589-590`) and `lib/bp1-keys.mjs:136` (loadRunKey —
+  `mkfifo -m 600 run.key` PASSES the statSync mode-0600 gate, no isFile
+  check; reached from finalize-run step 0 and finalize-recover States A/D;
+  `loadVerifyKey:215` same shape). Without these, this plan's own
+  acceptance ("finalize-recover terminates cleanly") is false → scoped IN
+  (§2b). The remaining non-episodes/ raw-read family is DEFER-C (§4).
+- NSP round 1 found a pre-existing one-token bug: `bp1-crash-classify.mjs:477`
+  reads `fm.run_id` on the `{frontmatter, body}` wrapper returned by
+  `parseBp1Frontmatter`, so `loadRunEpisodes` ALWAYS returns `[]`
+  (probe: valid run-tagged fixture, count 0) → scoped IN as a declared
+  bugfix rider (§2c) so the FIFO leg is non-vacuous.
+- **Type constraint:** 4 Buffer sites feed `parseBp1Frontmatter`
+  (`lib/bp1-frontmatter.mjs:104-110`), whose STRICT fatal UTF-8 decode runs
+  on Buffer input only. Sites must keep passing bytes (the em-move
+  data-loss MAJOR in #669's review was this class realized;
+  `lib/bp1-manifest.mjs:517-526` documents the fail-closed design).
+- Consolidation precedent: #669 shipped two local fd-based raw readers
+  (`em-move.mjs:172`, `em-restore.mjs:924`) marked "not a shared-helper
+  change" — three raw-bytes call sites now exist, lift into the shared
+  helper. `BodyUnreadableError` ctor order `(filePath, code)`
+  runtime-verified; em-move already passes that order (no adapter risk).
+- Vendored-fork overlap with #671: NONE. This arc is not blocked.
+
+## 1. Slice S1 — shared Buffer-read primitive (`scripts/lib/index-state.mjs`)
+
+- New export `readBodyBufferOrSkip(fsMod, filePath)` → `{ok:true,
+  raw:Buffer} | {ok:false, code}` — never throws, never blocks. Same fd
+  discipline as `readBodyOrSkip` (open `O_RDONLY|O_NONBLOCK` →
+  `fstatSync(fd).isFile()` → `readFileSync(fd)` with NO encoding → finally
+  close); common body refactored into one internal function; existing
+  public contracts unchanged.
+- Consolidation (behavior-preserving; existing suites green UNCHANGED):
+  `em-move.mjs readEpisodeBodyRawOrThrow` and `em-restore.mjs
+  readDocBytesOrSkip` become thin adapters over the new primitive. The
+  em-move adapter KEEPS ENOENT→throw (NOT openReadableBody's ENOENT→null).
+  Delete the duplicated fd logic + "not a shared-helper change" comments.
+
+→ verify: unit legs in `tests/test-651-index-existence.mjs`
+(FIFO/dir/absent/regular + `Buffer.isBuffer(raw)`); em-move 16/16 and
+em-restore 154/154 unchanged.
+
+## 2. Slice S2 — BP-1 episode-read adoption (6 sites, 4 files)
+
+Global rule: Buffer sites keep passing bytes (strict decode stays live).
+`ENOENT` keeps each site's existing absent semantics.
+
+| Site | Role | Disposition after fix |
+|---|---|---|
+| bp1-orchestrator.mjs:607 | loop-scan local+global | `readBodyBufferOrSkip`; `ok:false` → `continue` |
+| bp1-orchestrator.mjs:721 | loop-scan | same |
+| lib/bp1-atomic.mjs:115 | loop-scan | same |
+| lib/bp1-episode-verify.mjs:85 | verification gate | `readBodyBufferOrSkip`; `ENOENT` → the existing `parent-missing` entry (`:88`); non-ENOENT → `{ok:false, errors:[...]}` entry with the **`parent-unreadable:` prefix** (matches the file's vocabulary). Callers `:1371/:1766/:2278` branch only on `ok` and embed `errors` verbatim into signed forensic episodes — this is a PERSISTED-FORENSICS surface, declared in §6, not a branching wire change. FAIL-CLOSED, never a vacuous pass |
+| bp1-crash-classify.mjs:466 | classify-only loop (body discarded post-parse) | string `readBodyOrSkip`; `ok:false` → `continue` |
+| lib/bp1-manifest.mjs:549 | fail-closed enumerator | `readBodyBufferOrSkip`; `ok:false` → **RE-THROW** typed Error (path + code, this file's message style, cites the enumerability guarantee). NSP-verified: throw is strictly better than today's hang; no caller swallows it into a state transition (markTerminal unreachable past the throw) |
+
+## 2b. Slice S2b — same-verb sibling reads (round-1 MAJOR-1 scope extension)
+
+Only the three sites that break this plan's own acceptance battery; the
+rest of the family is DEFER-C (§4).
+
+| Site | Role | Disposition after fix |
+|---|---|---|
+| bp1-crash-classify.mjs:502 (readApprovalMarkerStatus) | status read, same verb as :466 | guarded fd read (helper or same discipline); unreadable/non-regular → the function's EXISTING absent/invalid marker outcome (no new status vocabulary), verb terminates |
+| lib/bp1-keys.mjs:136 (loadRunKey) | key gate, finalize-run step 0 / finalize-recover A/D | fd-guarded read with `fstat(fd).isFile()` BEFORE the mode-0600 gate (a FIFO must fail the shape check, not pass the perm check). **These functions NEVER throw** (round-2 MAJOR-1R): they return `{error:'missing'\|'mode'\|'unreadable'\|'size'}` and callers branch on the string with no try/catch (`bp1-orchestrator.mjs:773/:808/:929/:946/:1292/:1608`; State B/D selection at `:946-950`). Pinned mapping: `openSync` ENOENT → `{error:'missing'}` (State B depends on it); non-regular (`fstat(fd).isFile()` false) → `{error:'unreadable'}`; read failure → `{error:'unreadable'}`; mode gate unchanged, evaluated from the SAME fstat. Symlinked legit keys unaffected (open+fstat follows symlinks like today's statSync — NSP-probed) |
+| lib/bp1-keys.mjs:215 (loadVerifyKey) | same shape | same disposition, same pinned `{error}` mapping |
+
+## 2c. Slice S2c — crash-classify wrapper bugfix rider (round-1 MAJOR-2)
+
+`bp1-crash-classify.mjs:477`: `fm.run_id` → `fm.frontmatter.run_id`
+(one-token fix; `parseBp1Frontmatter` returns `{frontmatter, body}`).
+Declared bugfix: `loadRunEpisodes` has always returned `[]`, so this
+ACTIVATES dormant downstream behavior in the classify verb. Builder
+MANDATE (bound pinned, round-2 E3R): the episode-aware output IS the
+intended activation and is already unit-spec'd —
+`tests/test-bp1-crash-classify.mjs:78-93` injects episodes into the pure
+`classifyRunCrash`. The CLI-level classification for the positive-control
+fixture must EQUAL the pure-function output for the same records (the
+existing suite expectations); STOP and flag ONLY on divergence from that —
+not on any output change vs the always-[] past.
+
+## 3. Tests (test-first)
+
+- FIFO legs per §2 site in the existing dedicated suites (all CI-wired;
+  builder confirms via `test-ci-suite-registration.mjs`):
+  `test-bp1-atomic.mjs` (FIFO episode → clean skip, alarm-bounded);
+  orchestrator CLI legs with **pinned exit codes** (round-1 MINOR-2):
+  finalize-recover + episodes FIFO + no manifest → State C **exit 4**;
+  FIFO + valid manifest reaches `verifyOnDiskEqualsManifest`
+  (`:848`/`:939`, no try/catch) → typed re-throw propagates UNCAUGHT →
+  **exit 1, no signed evidence, not terminal** — fail-closed, identical to
+  today's EACCES class, pinned as acceptable; `test-bp1-episode-verify.mjs`
+  (FIFO target → `ok:false` + `parent-unreadable:` entry, no hang);
+  `test-bp1-crash-classify.mjs` (FIFO in run dir → skipped, WITH the §2c
+  positive control so the leg is non-vacuous: valid fixture → count>0);
+  `test-bp1-manifest-collect.mjs` (FIFO → typed THROW asserted).
+- §2b legs: crash-classify with FIFO approval marker → verb terminates
+  with the existing absent/invalid outcome; finalize path with
+  `mkfifo -m 600 run.key` → typed fail-closed error, NO hang (this was
+  round-1's acceptance-falsifying probe).
+- **Strict-decode regression leg (round-1 MINOR-3 pins):** invalid-UTF-8
+  bytes must die in `STRICT_UTF8_DECODER` observably at the two sites where
+  it surfaces: collectEpisodeRecords (fixture MUST contain `run_id:
+  <runId>` bytes so `looksLikeBp1Run` (`bp1-manifest.mjs:508`) admits it —
+  else the test is vacuous) and episode-verify (`parent-parse-failed`).
+  The 3 loop sites catch+skip parse errors — not assertion hosts.
+- HOME isolation per established patterns (`test-bp1-manifest-collect.mjs:44-46`
+  withHome swap; `test-bp1-finalize-run.mjs:83` env HOME spawn) — never the
+  real global store.
+- Helper unit legs per §1; em-move/em-restore suites as consolidation guard.
+- R1 guard carried: no bp1-* file in enforce-contract's import closure
+  (verified); builder re-greps; hook-E2E joins only if flipped.
+- Plugin version bump 0.2.10 → 0.2.11.
+
+## 4. Non-scope (explicit)
+
+- **DEFER-C (round-1 MAJOR-1 residual family):** remaining non-episodes/
+  raw reads of store/run-resident files in bp1-*: `bp1-marker.mjs:193`,
+  `bp1-marker-validate.mjs:175`, `bp1-manifest.mjs:41/:99/:112/:142`
+  (.claude/ hashing incl. plugin.json inside finalize step 4),
+  `bp1-manifest.mjs:257` `readVerifyKey` (+ its `:245` existsSync/statSync
+  gate — same mkfifo-m600-passes-mode-gate shape as keys:215; sole caller
+  `bp1-flag-check.mjs:199`, outside the acceptance battery),
+  `bp1-state-lock.mjs:104/219/252/305/354`, `bp1-run-state.mjs:281/333/548`,
+  `deadline-sweep.mjs:334/372`, `sweep-loader.mjs:107`,
+  `flag-check.mjs:105` and `:287` (configArg defaults to home-resident
+  `CONFIG_PATH` `:68`), `flag-flip.mjs:175` `readConfig` (home-resident
+  config.json, caller `:255`), `request-claim.mjs:180`.
+  Operator-supplied-path posture (out of class, like canonicalize:103):
+  `bp1-orchestrator.mjs:1620` (`--result-file`).
+  5-field: (1) same hang class, attacker-planted non-regular files;
+  (2) no spec mandates closing beyond the acceptance-battery verbs;
+  (3) precedent #669 DEFER-A/#653 D1/#628 DEFER-1; (4) same-class family
+  enumerated here in full; (5) residual = a planted FIFO can hang other
+  verbs — recovery kill+rm; ONE follow-up issue filed at PR time.
+- DEFER-B: `bp1-orchestrator.mjs:830` write-then-reread (5-field accepted
+  by NSP round 1: window is same-function sub-ms, read errors caught, only
+  the hang shape survives; recovery rm+re-run, key unshredded).
+- `bp1-canonicalize.mjs:103` (operator-supplied path).
+- Vendored fork (#671, zero overlap). D-4 warning shapes (carried).
+
+## 5. Acceptance
+
+- FIFO probe battery (isolated stores + isolated HOME), shapes scoped to
+  what the fixes cover (round-1 MAJOR-1 re-word): the 6 §2 sites under
+  episodes/-FIFO shapes, PLUS §2b marker-FIFO and mode-600 key-FIFO shapes
+  — every probed verb terminates with the pinned disposition/exit code
+  (§3); scout's two probe shapes re-run green under alarm.
+- Fail-closed invariants: manifest enumerator THROWS typed; episode-verify
+  `ok:false` with `parent-unreadable:` entry; invalid-UTF-8 still dies in
+  STRICT_UTF8_DECODER at the two §3 assertion hosts; key gate fails closed
+  on non-regular files.
+- §2c positive control: loadRunEpisodes count>0 on valid fixture; CLI
+  classification EQUAL to the pure-function expectation (§2c bound).
+- Full battery green: all test-bp1-* suites, test-651, em-move 16/16,
+  em-restore 154/154, search-read, graph, ci-registration, version-bump,
+  store-write-concurrency.
+- PR carries `fixes #670`, DEFER-B + DEFER-C records + the DEFER-C
+  follow-up issue, the §1 consolidation note, and the §6 declared surfaces.
+
+## 6. Declared surfaces introduced by this plan (v2)
+
+- `readBodyBufferOrSkip` — new shared-helper export (additive).
+- episode-verify `parent-unreadable:<CODE>`-style error entries — persisted
+  into signed forensic episodes (additive text in an existing array).
+- collectEpisodeRecords typed throw message (forensic text, not a parsed
+  wire; replaces a hang/raw errno throw).
+- crash-classify: activated non-empty `loadRunEpisodes` results (§2c) —
+  bounded by the positive-control mandate + STOP clause.
+- §2b introduces NO new vocabulary (existing absent/invalid/`{error}`-return
+  outcomes reused).
+- DEFER-C ledger row + its follow-up issue.
+
+## 7. Build-round amendment (2026-08-14, §2c STOP clause fired)
+
+The builder's discriminating probe (classified/trivial run-state fixture)
+found the §2c one-token fix HALF-activates `loadRunEpisodes`: the `run_id`
+filter works, but `records.push(fm)` still pushes the `{frontmatter, body}`
+WRAPPER, so every other field (`state`, `type`, `id`, …) is `undefined` to
+callers — CLI classification diverged from pure `classifyRunCrash`
+(`crash-mid-Phase-A` vs `inconsistent-classified-trivial`), tripping the
+§2c equality bound exactly as designed. Plan-owner disposition: COMPLETE
+the fix (same wrapper-vs-content class): push `fm.frontmatter` and carry
+the filename tag on the pushed record; the discriminating probe becomes a
+committed regression leg; the §2c bound now asserts CLI==pure-function on
+BOTH the positive-control and the discriminating fixture. Rationale:
+half-activation classifies on undefined fields (wrong output, worse than
+the dormant always-`[]` state); the pure function is the unit-spec'd
+authority (`tests/test-bp1-crash-classify.mjs:78-93`). Also noted: §0
+mandate prose "4 Buffer sites" is a miswording of "4 files" (the §2 table
+with 5 Buffer-primitive rows is authoritative; builder-flagged, no code
+impact).
+
+## 8. Review-round amendments (2-lens, 2026-08-14)
+
+Lens 2 (claude-subagent) ACCEPT-WITH-FINDINGS 0 MAJOR (3/3 mutants killed;
+all four `{error}` shapes verified under the real finalize-recover caller).
+Lens 1 (codex) REJECT → fix round → dispositions:
+
+- **A1 (codex MAJOR-2, build defect):** `bp1-manifest.mjs`'s new
+  `index-state.mjs` import was missing from the BP-1 artifact-identity
+  closure and the two isolated-fixture suites' hand-staged lib lists
+  (`test-bp1-build-artifact-manifest` 22/24, `test-bp1-probe` 15/18,
+  ERR_MODULE_NOT_FOUND). Fixed: `NON_BP1_LIB_SCRIPTS` closed list in
+  `buildScriptsLib` (mirrors the existing `NON_BP1_SCRIPTS` pattern) +
+  both suites' `FIXTURE_LIB_FILES` converted to `computeLibClosure`-derived
+  (self-healing; terminal fix for the 1213bcf hand-enumerated-closure
+  class in these suites). 24/24 and 18/18 post-fix.
+- **A2 (codex MAJOR-1, lens-divergent, adjudicated by writer enumeration):**
+  activated `loadRunEpisodes` admitted unsigned episodes (forged fresh
+  `codex_review` flipped fail-closed `needs-human` → `in-flight`). Writer
+  enumeration: every currently-reachable consumed class is written through
+  the single shared `bp1-episode-writer.mjs`, which unconditionally
+  HMAC-signs (no unsigned legitimate path exists) → GATE branch:
+  `loadRunEpisodes` verifies `hmac_signature` via `canonicalize()` +
+  `verifyCanonical()` (same primitive as `findSignedStateEpisode`);
+  unsigned/unverifiable → skipped. Fixtures rewritten to real signed
+  episodes via the real writer; new `CC-670-forged-unsigned` leg asserts
+  the fail-closed outcome (RED on ungated code = codex's exact repro).
+- **A3 (codex MINOR-1):** `closeSync`-in-finally guarded (try/ignore) in
+  `readBodyFd` + `loadKeyFd`. Pre-existing same-class sibling
+  `openReadableIndexAttempt` (~:159, from #653) flagged NOT fixed
+  (outside scope) → follow-up issue.
+- **A4 (codex MINOR-2 = lens-2 F2):** two committed CLI legs added to
+  `test-bp1-finalize-run.mjs`: `G3-670a` (mode-600 run.key FIFO through
+  finalize-RUN's step-0 gate — the fix-round dispatch's "finalize-recover"
+  wording corrected to match the probe evidence; finalize-recover's
+  key-FIFO path routes to State D and was already covered) and `G3-670b`
+  (decisionLogFence FIFO traversal → fence-fail episode under target only).
+- Lens-2 F1 (trust boundary) subsumed by A2's gate; lens-2 F2 by A4.
+- **Round 2 (delta):** codex provider died mid-dispatch twice → fallback
+  adjudication by the claude-subagent lens (established pattern): all four
+  codex findings **CLEARED** with independent probes (forged-unsigned →
+  needs-human; key-absent safe degradation; cross-run-key + body-tamper
+  rejected; signed-episode acceptance sanity; scratch-copy hash-mutation
+  sensitivity; synthetic-EIO close guards; 49/49 CLI legs), both deferral
+  adjudications ACCEPTED, zero regressions (10 suites). Two NEW MINORs to
+  the follow-up issue: unsigned `tags` consumed by classifier predicates
+  (state/parent_episode signed, so the needs-human→in-flight class stays
+  closed; probe-demonstrated flip between auto-resume flavors only) and a
+  missing tripwire asserting `buildScriptsLib` ⊇ the real bp1 lib import
+  closure. Final review state: 0 MAJOR outstanding.

--- a/scripts/bp1-crash-classify.mjs
+++ b/scripts/bp1-crash-classify.mjs
@@ -38,6 +38,10 @@ import path from 'node:path'
 import { getRunState } from './lib/bp1-run-state.mjs'
 import { parseBp1Frontmatter } from './lib/bp1-frontmatter.mjs'
 import { canonicalProjectRoot } from './lib/bp1-manifest.mjs'
+import { readBodyOrSkip } from './lib/index-state.mjs'
+import { loadRunKey } from './lib/bp1-keys.mjs'
+import { canonicalize } from './lib/bp1-canonicalize.mjs'
+import { verifyCanonical } from './lib/bp1-hmac.mjs'
 
 // Plan v2 §1 — five-min naked-entry threshold for codex_review entries.
 export const PATH_B_AGE_THRESHOLD_MS = 5 * 60 * 1000
@@ -443,7 +447,10 @@ export function classifyRunCrash({ runState, episodes, markerPresent, markerExpi
  * memory store, parse their frontmatter, and return chronologically-sorted
  * frontmatter records. Episodes whose frontmatter cannot be parsed are
  * dropped silently (per RFC §753-771 fail-closed parser; replay tolerates
- * skipped records).
+ * skipped records). Episodes whose hmac_signature does not verify against
+ * the run's key (missing/empty signature, tampered content, or forged
+ * entirely) are also dropped silently (#670 review round MAJOR-1) — only
+ * verified-signed records reach the classifier.
  *
  * @param {string} projectRoot
  * @param {string} runId
@@ -458,15 +465,33 @@ export function loadRunEpisodes(projectRoot, runId) {
     if (e.code === 'ENOENT') return []
     throw e
   }
+  // #670 review round MAJOR-1 (adjudicated, evidence-driven): every
+  // legitimate BP-1 run-scoped episode class classifyRunCrash consumes is
+  // written via the shared writeBp1Episode helper (lib/bp1-episode-writer.mjs),
+  // which unconditionally requires a 32-byte run key and HMAC-signs — no
+  // current writer emits an unsigned classifyRunCrash-consumed episode
+  // (empirically verified: grep of every scripts/bp1-*.mjs writer). Gate on
+  // that signature, mirroring the same canonicalize+verifyCanonical check
+  // bp1-atomic.mjs's findSignedStateEpisode already performs: an episode
+  // whose hmac_signature does not verify against the run's key is forged/
+  // tampered/unverifiable and is SKIPPED — restores fail-closed classification
+  // against forged-unsigned input (codex repro: a forged unsigned fresh
+  // codex_review episode silently steered classification from needs-human
+  // to in-flight). If the run's key can't be loaded at all (e.g. already
+  // shredded post-terminal), nothing is verifiable — degrades to the
+  // dormant always-[] behavior, which is safe: classifyRunCrash short-
+  // circuits on TERMINAL_STATES before consulting episodes.
+  const keyResult = loadRunKey(projectRoot, runId)
+  const runKey32B = keyResult.key32B
   const records = []
   for (const name of names) {
     if (!name.endsWith('.md')) continue
-    let text
-    try {
-      text = fs.readFileSync(path.join(dir, name), 'utf8')
-    } catch (_e) {
-      continue
-    }
+    // #670 S2: guarded read — a FIFO/dir/unreadable episode is skipped
+    // instead of hanging (string variant: body is discarded post-parse,
+    // never fed to parseBp1Frontmatter's strict Buffer/UTF-8 path).
+    const r = readBodyOrSkip(fs, path.join(dir, name))
+    if (!r.ok) continue
+    const text = r.raw
     let fm
     try {
       fm = parseBp1Frontmatter(text)
@@ -474,9 +499,28 @@ export function loadRunEpisodes(projectRoot, runId) {
       continue  // skip unparseable
     }
     if (!fm || typeof fm !== 'object') continue
-    if (fm.run_id !== runId) continue
-    fm.__filename = name
-    records.push(fm)
+    // #670 S2c (round-1 MAJOR-2 bugfix rider, completed per plan §7
+    // build-round amendment): parseBp1Frontmatter returns {frontmatter,
+    // body} — fm.run_id was always undefined on the wrapper, so this loop
+    // unconditionally `continue`d and loadRunEpisodes ALWAYS returned [].
+    // The run_id filter fix alone half-activated this: pushing the WRAPPER
+    // (fm) left every other field (state, type, id, ...) undefined to
+    // callers, since those live under fm.frontmatter. Push the CONTENT.
+    if (fm.frontmatter.run_id !== runId) continue
+    // HMAC verification gate (MAJOR-1): no usable run key -> nothing is
+    // verifiable -> skip. Missing/empty signature -> skip (unsigned).
+    if (!runKey32B) continue
+    const storedSig = fm.frontmatter.hmac_signature
+    if (typeof storedSig !== 'string' || storedSig === '') continue
+    let canonicalBytes
+    try {
+      ;({ canonicalBytes } = canonicalize(fm.frontmatter, fm.body))
+    } catch (_e) {
+      continue
+    }
+    if (!verifyCanonical(canonicalBytes, runKey32B, storedSig)) continue
+    fm.frontmatter.__filename = name
+    records.push(fm.frontmatter)
   }
   // Sort by filename — BP-1 episode ids are timestamp-prefixed, so
   // lexicographic sort is chronological.
@@ -497,13 +541,13 @@ export function loadRunEpisodes(projectRoot, runId) {
  */
 export function readApprovalMarkerStatus(projectRoot, runId, nowMs = Date.now()) {
   const markerPath = path.join(projectRoot, '.checkpoints', `bp1-approval-${runId}.json`)
-  let raw
-  try {
-    raw = fs.readFileSync(markerPath, 'utf8')
-  } catch (e) {
-    if (e.code === 'ENOENT') return { present: false, expired: false, deadline_at: null }
-    return { present: false, expired: false, deadline_at: null }
-  }
+  // #670 S2b: guarded fd-based read (never blocks on a FIFO). No new status
+  // vocabulary — ENOENT and any other unreadable code already collapsed to
+  // the SAME {present:false,...} outcome before this change; the guard just
+  // makes that outcome reachable without hanging on a non-regular marker.
+  const r = readBodyOrSkip(fs, markerPath)
+  if (!r.ok) return { present: false, expired: false, deadline_at: null }
+  const raw = r.raw
   let parsed
   try {
     parsed = JSON.parse(raw)

--- a/scripts/bp1-orchestrator.mjs
+++ b/scripts/bp1-orchestrator.mjs
@@ -73,6 +73,7 @@ import {
   assertRunIdShape,
 } from './lib/bp1-manifest.mjs'
 import { parseBp1Frontmatter } from './lib/bp1-frontmatter.mjs'
+import { readBodyBufferOrSkip } from './lib/index-state.mjs'
 import { writeBp1Episode } from './lib/bp1-episode-writer.mjs'
 import { verifyEpisodeOnDisk } from './lib/bp1-episode-verify.mjs'
 import { writeMarker, cleanupApprovalMarker } from './lib/bp1-marker.mjs'
@@ -602,12 +603,13 @@ function decisionLogFence(runId, projectRoot, runKey32B) {
     for (const f of fs.readdirSync(store).sort()) {
       if (!f.endsWith('.md')) continue
       const fp = path.join(store, f)
-      let buf
-      try {
-        buf = fs.readFileSync(fp)
-      } catch {
-        continue
-      }
+      // #670 S2: guarded fd-based read — a FIFO/dir/unreadable episode is
+      // skipped here (loop-scan, tolerated) instead of hanging; a raw
+      // read/parse failure is likewise tolerated — collectEpisodeRecords
+      // hard-fails at step 2 for anything that actually matters.
+      const r = readBodyBufferOrSkip(fs, fp)
+      if (!r.ok) continue
+      const buf = r.raw
       let parsed
       try {
         parsed = parseBp1Frontmatter(buf)
@@ -716,10 +718,11 @@ function findManifestEpisode(projectRoot, runId) {
   for (const f of fs.readdirSync(local)) {
     if (!f.endsWith('.md')) continue
     const fp = path.join(local, f)
-    let buf
-    try {
-      buf = fs.readFileSync(fp)
-    } catch { continue }
+    // #670 S2: guarded fd-based read; a FIFO/dir/unreadable episode is
+    // skipped (loop-scan) instead of hanging.
+    const r = readBodyBufferOrSkip(fs, fp)
+    if (!r.ok) continue
+    const buf = r.raw
     let parsed
     try { parsed = parseBp1Frontmatter(buf) } catch { continue }
     const fm = parsed.frontmatter

--- a/scripts/em-move.mjs
+++ b/scripts/em-move.mjs
@@ -46,7 +46,7 @@ import { resolveLocalDir } from './lib/local-dir.mjs'
 import { normalizeTags, episodeTokens, updateTokensIndex, nullProtoIndex } from './lib/relevance.mjs'
 import { canonicalCategory } from './lib/categories.mjs'
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip, openReadableBody, BodyUnreadableError } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip, readBodyBufferOrSkip, openReadableBody, BodyUnreadableError } from './lib/index-state.mjs'
 
 const GLOBAL_DIR = path.join(os.homedir(), '.episodic-memory')
 const LOCAL_DIR = resolveLocalDir()
@@ -162,38 +162,20 @@ function readEpisodeBodyOrThrow(filePath) {
 // decode to the same string (lone surrogates become U+FFFD), so hashing the
 // decoded text collapsed them to "identical" — the found-in-both-scopes
 // divergence check then unlinked one copy as a false duplicate (data loss,
-// reviewer-confirmed: exit 0, moved, local deleted). LOCAL fd-based
-// raw-Buffer read — NOT a shared-helper change (plan §4 stands): open
-// O_NONBLOCK so a FIFO/no-writer never blocks, fstat rejects any
-// non-regular file BEFORE the read, readFileSync(fd) with NO encoding
-// returns the exact bytes. Reuses the already-exported BodyUnreadableError
-// class (index-state.mjs) purely for typed-error shape parity with
-// readEpisodeBodyOrThrow's callers — not a helper-contract change.
+// reviewer-confirmed: exit 0, moved, local deleted).
+//
+// #670 S1: thin adapter over the shared readBodyBufferOrSkip primitive (open
+// O_NONBLOCK so a FIFO/no-writer never blocks, fstat rejects any non-regular
+// file BEFORE the read, readFileSync(fd) with NO encoding returns the exact
+// bytes) — three raw-bytes call sites (this one, em-restore.mjs, and the new
+// BP-1 Buffer sites) now share ONE fd-based implementation instead of each
+// duplicating the fd logic locally. UNLIKE openReadableBody's ENOENT->null,
+// this adapter KEEPS ENOENT->throw (every caller here already confirmed
+// presence moments earlier; a race-vanish is exceptional either way).
 function readEpisodeBodyRawOrThrow(filePath) {
-  const O_NONBLOCK_READ = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
-  let fd
-  try {
-    fd = fs.openSync(filePath, O_NONBLOCK_READ)
-  } catch (e) {
-    throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
-  }
-  try {
-    let st
-    try {
-      st = fs.fstatSync(fd)
-    } catch (e) {
-      throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
-    }
-    if (st.isDirectory()) throw new BodyUnreadableError(filePath, 'EISDIR')
-    if (!st.isFile()) throw new BodyUnreadableError(filePath, 'ENOTREG')
-    try {
-      return fs.readFileSync(fd)
-    } catch (e) {
-      throw new BodyUnreadableError(filePath, (e && e.code) || 'UNKNOWN')
-    }
-  } finally {
-    fs.closeSync(fd)
-  }
+  const r = readBodyBufferOrSkip(fs, filePath)
+  if (r.ok) return r.raw
+  throw new BodyUnreadableError(filePath, r.code)
 }
 
 function sha256(p) {

--- a/scripts/em-restore.mjs
+++ b/scripts/em-restore.mjs
@@ -41,7 +41,7 @@ import { nullProtoIndex } from './lib/relevance.mjs'
 // derived-index merge so two restore targets cannot diverge before both
 // locks are held.
 import { acquireStoreWriteLocksSync, releaseStoreWriteLocks, atomicReplaceFileSync } from './lib/store-write-lock.mjs'
-import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip } from './lib/index-state.mjs'
+import { readIndexFileOrThrow, IndexUnreadableError, readBodyOrSkip, readBodyBufferOrSkip } from './lib/index-state.mjs'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -918,34 +918,15 @@ function applyEpisodeWrites(plan) {
 // probe: SIGKILL required to recover). fd-guarded RAW-BYTE read closes that:
 // O_NONBLOCK open (never blocks) + fstat().isFile() guard (rejects any
 // non-regular file BEFORE the read) + readFileSync(fd) with NO encoding
-// (byte-faithful — a doc copy must never decode/re-encode). Local to
-// em-restore.mjs, mirroring em-move.mjs's readEpisodeBodyRawOrThrow — no
-// shared-helper API change (plan §4 stands).
+// (byte-faithful — a doc copy must never decode/re-encode).
+//
+// #670 S1: thin adapter over the shared readBodyBufferOrSkip primitive
+// (same contract this local function already had — {ok:true,raw:Buffer} |
+// {ok:false,code}) — consolidates the fd logic that was previously
+// duplicated here and in em-move.mjs's readEpisodeBodyRawOrThrow into one
+// implementation.
 function readDocBytesOrSkip(filePath) {
-  const O_NONBLOCK_READ = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
-  let fd
-  try {
-    fd = fs.openSync(filePath, O_NONBLOCK_READ)
-  } catch (e) {
-    return { ok: false, code: (e && e.code) || 'UNKNOWN' }
-  }
-  try {
-    let st
-    try {
-      st = fs.fstatSync(fd)
-    } catch (e) {
-      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
-    }
-    if (st.isDirectory()) return { ok: false, code: 'EISDIR' }
-    if (!st.isFile()) return { ok: false, code: 'ENOTREG' }
-    try {
-      return { ok: true, raw: fs.readFileSync(fd) }
-    } catch (e) {
-      return { ok: false, code: (e && e.code) || 'UNKNOWN' }
-    }
-  } finally {
-    fs.closeSync(fd)
-  }
+  return readBodyBufferOrSkip(fs, filePath)
 }
 
 function applyDocWrites(plan, sourceMap) {

--- a/scripts/lib/bp1-atomic.mjs
+++ b/scripts/lib/bp1-atomic.mjs
@@ -52,6 +52,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { parseBp1Frontmatter } from './bp1-frontmatter.mjs'
+import { readBodyBufferOrSkip } from './index-state.mjs'
 import { canonicalize } from './bp1-canonicalize.mjs'
 import { verifyCanonical } from './bp1-hmac.mjs'
 import {
@@ -110,13 +111,12 @@ export function findSignedStateEpisode(projectRoot, runId, state, runKey32B, exp
     if (!m) continue
     const episodeId = m[1]
     const episodePath = path.join(episodesDir, name)
-    let buf
-    try {
-      buf = fs.readFileSync(episodePath)
-    } catch (_e) {
-      // File vanished between readdir and read (e.g. concurrent sweep). Skip.
-      continue
-    }
+    // #670 S2: guarded fd-based read — a FIFO/dir/unreadable episode (or one
+    // that vanished between readdir and read, e.g. concurrent sweep) is
+    // skipped instead of hanging or throwing.
+    const r = readBodyBufferOrSkip(fs, episodePath)
+    if (!r.ok) continue
+    const buf = r.raw
     let parsed
     try {
       parsed = parseBp1Frontmatter(buf)

--- a/scripts/lib/bp1-episode-verify.mjs
+++ b/scripts/lib/bp1-episode-verify.mjs
@@ -38,6 +38,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { parseBp1Frontmatter } from './bp1-frontmatter.mjs'
+import { readBodyBufferOrSkip } from './index-state.mjs'
 import { canonicalize } from './bp1-canonicalize.mjs'
 import { verifyCanonical } from './bp1-hmac.mjs'
 
@@ -80,15 +81,17 @@ export function verifyEpisodeOnDisk(opts) {
   }
 
   const episodePath = path.join(projectRoot, '.episodic-memory', 'episodes', `${episodeId}.md`)
-  let buf
-  try {
-    buf = fs.readFileSync(episodePath)
-  } catch (e) {
-    if (e.code === 'ENOENT') {
+  // #670 S2: guarded fd-based read (never blocks on a FIFO). ENOENT keeps the
+  // existing parent-missing outcome; any other unreadable code (dir, FIFO,
+  // EACCES, ...) gets a parent-unreadable: entry per this file's vocabulary.
+  const r = readBodyBufferOrSkip(fs, episodePath)
+  if (!r.ok) {
+    if (r.code === 'ENOENT') {
       return { ok: false, errors: [`parent-missing: ${episodePath}`] }
     }
-    return { ok: false, errors: [`parent-unreadable: ${e.message}`] }
+    return { ok: false, errors: [`parent-unreadable: ${r.code} (${episodePath})`] }
   }
+  const buf = r.raw
 
   let parsed
   try {

--- a/scripts/lib/bp1-keys.mjs
+++ b/scripts/lib/bp1-keys.mjs
@@ -112,6 +112,58 @@ export function generateRunKey(projectRoot, runId) {
   return { keyPath, key32B }
 }
 
+// #670 S2b (round-1 MAJOR-1 scope extension): shared fd-based load for both
+// key types. `mkfifo -m 600 run.key` passes the OLD statSync-based mode-0600
+// gate (statSync doesn't distinguish a FIFO from a regular file for mode
+// purposes) and then blocks forever on a path-based readFileSync — same hang
+// class as the BP-1 episode-read family. This closes it: ONE
+// open(O_RDONLY|O_NONBLOCK) (a writer-less FIFO returns immediately instead
+// of blocking) + fstat(fd).isFile() check BEFORE the mode-0600 gate (a FIFO
+// must fail the shape check, not pass the perm check) + the mode gate
+// evaluated from that SAME fstat + read from that SAME fd. Symlinked legit
+// keys are unaffected — open+fstat follows symlinks exactly like the prior
+// statSync did. These functions NEVER throw (round-2 MAJOR-1R): every branch
+// returns a tagged {error} string; callers branch on it with no try/catch.
+// Pinned mapping: openSync ENOENT -> 'missing' (finalize-recover State B
+// depends on this); non-regular (fstat(fd).isFile() false) -> 'unreadable';
+// read failure -> 'unreadable'.
+function loadKeyFd(keyPath) {
+  const O_NONBLOCK_READ = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
+  let fd
+  try {
+    fd = fs.openSync(keyPath, O_NONBLOCK_READ)
+  } catch (e) {
+    if (e.code === 'ENOENT') return { error: 'missing' }
+    return { error: 'unreadable' }
+  }
+  try {
+    let stat
+    try {
+      stat = fs.fstatSync(fd)
+    } catch (_e) {
+      return { error: 'unreadable' }
+    }
+    if (!stat.isFile()) return { error: 'unreadable' }
+    const modeCheck = assertKeyMode0600(stat)
+    if (modeCheck.error) return { error: 'mode' }
+    let buf
+    try {
+      buf = fs.readFileSync(fd)
+    } catch (_e) {
+      return { error: 'unreadable' }
+    }
+    const sizeCheck = assertKey32Bytes(buf)
+    if (sizeCheck.error) return { error: 'size' }
+    return { key32B: buf }
+  } finally {
+    // #670 review round MINOR-1: closeSync can itself throw (e.g. synthetic/
+    // real EIO on close) — this is a never-throw helper (its contract is the
+    // tagged {key32B}|{error} return), so a close failure must not override
+    // that contract by escaping the finally block. Best-effort close.
+    try { fs.closeSync(fd) } catch { /* best-effort; never-throw contract */ }
+  }
+}
+
 /**
  * Load the per-run key. Asserts mode + size invariants. Returns the key
  * Buffer or a tagged error.
@@ -121,25 +173,7 @@ export function generateRunKey(projectRoot, runId) {
  * @returns {{ key32B: Buffer } | { error: 'missing'|'mode'|'size'|'unreadable' }}
  */
 export function loadRunKey(projectRoot, runId) {
-  const keyPath = runKeyPath(projectRoot, runId)
-  let stat
-  try {
-    stat = fs.statSync(keyPath)
-  } catch (e) {
-    if (e.code === 'ENOENT') return { error: 'missing' }
-    return { error: 'unreadable' }
-  }
-  const modeCheck = assertKeyMode0600(stat)
-  if (modeCheck.error) return { error: 'mode' }
-  let buf
-  try {
-    buf = fs.readFileSync(keyPath)
-  } catch (_e) {
-    return { error: 'unreadable' }
-  }
-  const sizeCheck = assertKey32Bytes(buf)
-  if (sizeCheck.error) return { error: 'size' }
-  return { key32B: buf }
+  return loadKeyFd(runKeyPath(projectRoot, runId))
 }
 
 /**
@@ -200,23 +234,7 @@ export function verifyKeyPath(homeDir = os.homedir()) {
  * @returns {{ key32B: Buffer, fingerprint16: string } | { error: 'missing'|'mode'|'size'|'unreadable' }}
  */
 export function loadVerifyKey(homeDir = os.homedir()) {
-  const keyPath = verifyKeyPath(homeDir)
-  let stat
-  try {
-    stat = fs.statSync(keyPath)
-  } catch (e) {
-    if (e.code === 'ENOENT') return { error: 'missing' }
-    return { error: 'unreadable' }
-  }
-  const modeCheck = assertKeyMode0600(stat)
-  if (modeCheck.error) return { error: 'mode' }
-  let buf
-  try {
-    buf = fs.readFileSync(keyPath)
-  } catch (_e) {
-    return { error: 'unreadable' }
-  }
-  const sizeCheck = assertKey32Bytes(buf)
-  if (sizeCheck.error) return { error: 'size' }
-  return { key32B: buf, fingerprint16: verifyKeyFingerprint(buf) }
+  const r = loadKeyFd(verifyKeyPath(homeDir))
+  if (r.error) return r
+  return { key32B: r.key32B, fingerprint16: verifyKeyFingerprint(r.key32B) }
 }

--- a/scripts/lib/bp1-manifest.mjs
+++ b/scripts/lib/bp1-manifest.mjs
@@ -29,6 +29,16 @@ import { execFileSync } from 'child_process'
 // update + activation re-run.
 export const NON_BP1_SCRIPTS = ['scripts/em-review-request.mjs']
 
+// Explicit non-bp1-prefixed scripts/lib/ files that bp1-*.mjs lib helpers
+// import as load-bearing dependencies (#670 review round: bp1-manifest.mjs,
+// bp1-atomic.mjs, and bp1-episode-verify.mjs all import readBodyBufferOrSkip
+// from index-state.mjs — a shared cross-subsystem primitive, not bp1-*
+// prefixed, so it was invisible to buildScriptsLib's closed bp1-*.mjs glob).
+// Same precedent as NON_BP1_SCRIPTS above (mirrors buildScripts' pattern) —
+// closed list, additions require RFC update + builder update + activation
+// re-run.
+export const NON_BP1_LIB_SCRIPTS = ['scripts/lib/index-state.mjs']
+
 // Episode-id pattern: <date>-<time>-<slug>-<rand>. Matches the
 // `<id>` token used in agent loader files for canonical prompt references.
 // Lowercase-only: the corpus convention is lowercase IDs and case-insensitive
@@ -71,18 +81,28 @@ function buildScripts(projectRoot) {
 }
 
 function buildScriptsLib(projectRoot) {
-  // PR-1b-A: load-bearing helpers under scripts/lib/. Only bp1-*.mjs files
-  // are hashed — other lib files (e.g. local-dir.mjs) are not BP1-runtime
-  // critical and not subject to drift detection here.
+  // PR-1b-A: load-bearing helpers under scripts/lib/. bp1-*.mjs files are
+  // hashed by glob; other lib files (e.g. local-dir.mjs) are not BP1-runtime
+  // critical and not subject to drift detection here — EXCEPT the explicit
+  // NON_BP1_LIB_SCRIPTS closed list (#670 review round: index-state.mjs is a
+  // load-bearing non-bp1-prefixed dependency, same shape as NON_BP1_SCRIPTS
+  // above for the top-level scripts/ surface).
   // Codex plan-review round 1 Q3.2: prior manifest scanned only top-level
   // scripts/bp1-*.mjs, so changes to lib helpers (probe stub → real probe at
   // M1, sweep helper logic) would NOT have triggered bp1-flag-version-drift.
   // This surface closes that hole.
   const libDir = path.join(projectRoot, 'scripts', 'lib')
-  return listMatching(libDir, /^bp1-.*\.mjs$/).map(f => {
+  const out = listMatching(libDir, /^bp1-.*\.mjs$/).map(f => {
     const rel = `scripts/lib/${f}`
     return { path: rel, sha256: sha256File(path.join(projectRoot, rel)) }
   })
+  for (const rel of NON_BP1_LIB_SCRIPTS) {
+    const abs = path.join(projectRoot, rel)
+    if (fs.existsSync(abs)) {
+      out.push({ path: rel, sha256: sha256File(abs) })
+    }
+  }
+  return out.sort((a, b) => a.path.localeCompare(b.path))
 }
 
 function buildHooks(projectRoot) {
@@ -484,6 +504,7 @@ export function verifyManifest(payload, signatureHex, verifyKey32B) {
 // ===========================================================================
 
 import { parseBp1Frontmatter } from './bp1-frontmatter.mjs'
+import { readBodyBufferOrSkip } from './index-state.mjs'
 import { canonicalize } from './bp1-canonicalize.mjs'
 
 function readEpisodesIn(dir) {
@@ -544,14 +565,17 @@ export function collectEpisodeRecords(runId, projectRoot) {
   const records = []
   for (const store of stores) {
     for (const filePath of readEpisodesIn(store)) {
-      let buf
-      try {
-        buf = fs.readFileSync(filePath)
-      } catch {
-        // Unreadable file is a hard failure for finalize: a run's records must
-        // be enumerable. The orchestrator surfaces this as bp1-finalize-fence-fail.
-        throw new Error(`collectEpisodeRecords: unreadable episode file ${filePath}`)
+      // #670 S2: guarded fd-based read (never blocks on a FIFO) — but this
+      // enumerator is fail-closed BY DESIGN: unreadable is still a hard
+      // failure for finalize (a run's records must be enumerable), so
+      // ok:false RE-THROWS a typed Error citing the path + code instead of
+      // silently skipping. The orchestrator surfaces this as
+      // bp1-finalize-fence-fail (or, from finalize-recover, an uncaught exit).
+      const r = readBodyBufferOrSkip(fs, filePath)
+      if (!r.ok) {
+        throw new Error(`collectEpisodeRecords: unreadable episode file ${filePath} (${r.code})`)
       }
+      const buf = r.raw
       let parsed
       try {
         parsed = parseBp1Frontmatter(buf)

--- a/scripts/lib/index-state.mjs
+++ b/scripts/lib/index-state.mjs
@@ -233,12 +233,13 @@ export class BodyUnreadableError extends Error {
   }
 }
 
-// readBodyOrSkip(fsMod, filePath) -> { ok:true, raw } | { ok:false, code } —
-// never throws, never blocks. For per-row iteration in query tools and
-// advisory reads: 'absent' and 'unreadable' both collapse to ok:false with
-// the classify code (ENOENT | EISDIR | ENOTREG | ...); the CALLER decides
-// warn-vs-silent per code (F5 rule: non-ENOENT warns, ENOENT stays silent).
-export function readBodyOrSkip(fsMod, filePath) {
+// readBodyFd(fsMod, filePath, encoding) — internal fd-based classify-and-read
+// body reader shared by readBodyOrSkip (utf8 string) and readBodyBufferOrSkip
+// (raw Buffer, issue #670 S1). Same discipline as openReadableIndex: ONE
+// open(O_RDONLY|O_NONBLOCK) + fstat(fd), and — only when fstat confirms a
+// regular file — a read from that SAME fd. `encoding` is the only difference
+// between the two public exports below.
+function readBodyFd(fsMod, filePath, encoding) {
   const O_NONBLOCK_READ = fsMod.constants.O_RDONLY | fsMod.constants.O_NONBLOCK
   let fd
   try {
@@ -256,13 +257,38 @@ export function readBodyOrSkip(fsMod, filePath) {
     if (st.isDirectory()) return { ok: false, code: 'EISDIR' }
     if (!st.isFile()) return { ok: false, code: 'ENOTREG' }
     try {
-      return { ok: true, raw: fsMod.readFileSync(fd, 'utf8') }
+      return { ok: true, raw: encoding ? fsMod.readFileSync(fd, encoding) : fsMod.readFileSync(fd) }
     } catch (e) {
       return { ok: false, code: (e && e.code) || 'UNKNOWN' }
     }
   } finally {
-    fsMod.closeSync(fd)
+    // #670 review round MINOR-1: closeSync can itself throw (e.g. synthetic/
+    // real EIO on close) — this is a never-throw helper (its contract is the
+    // tagged {ok,...} return), so a close failure must not override that
+    // contract by escaping the finally block. Best-effort close; the fd leak
+    // on a close failure is an OS-level anomaly outside this helper's control.
+    try { fsMod.closeSync(fd) } catch { /* best-effort; never-throw contract */ }
   }
+}
+
+// readBodyOrSkip(fsMod, filePath) -> { ok:true, raw } | { ok:false, code } —
+// never throws, never blocks. For per-row iteration in query tools and
+// advisory reads: 'absent' and 'unreadable' both collapse to ok:false with
+// the classify code (ENOENT | EISDIR | ENOTREG | ...); the CALLER decides
+// warn-vs-silent per code (F5 rule: non-ENOENT warns, ENOENT stays silent).
+export function readBodyOrSkip(fsMod, filePath) {
+  return readBodyFd(fsMod, filePath, 'utf8')
+}
+
+// readBodyBufferOrSkip(fsMod, filePath) -> { ok:true, raw:Buffer } |
+// { ok:false, code } — same contract and fd discipline as readBodyOrSkip,
+// but returns raw BYTES (no encoding) instead of a decoded string. Issue
+// #670 S1: BP-1 call sites feed the result straight into parseBp1Frontmatter,
+// whose STRICT fatal UTF-8 decode (STRICT_UTF8_DECODER) only runs on Buffer
+// input — decoding here first would silently normalize invalid UTF-8 to
+// U+FFFD and defeat that fail-closed check.
+export function readBodyBufferOrSkip(fsMod, filePath) {
+  return readBodyFd(fsMod, filePath, null)
 }
 
 // openReadableBody(fsMod, filePath) -> raw string | null on absent (mirrors

--- a/tests/test-651-index-existence.mjs
+++ b/tests/test-651-index-existence.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url'
 
 import {
   classifyIndexFile, assertReadableIndex, readIndexFileOrThrow, openReadableIndex, IndexUnreadableError,
-  readBodyOrSkip, openReadableBody, BodyUnreadableError,
+  readBodyOrSkip, readBodyBufferOrSkip, openReadableBody, BodyUnreadableError,
 } from '../scripts/lib/index-state.mjs'
 
 // EM651_TEST_REPO_OVERRIDE: points spawned scripts at an alternate repo root
@@ -453,6 +453,86 @@ function cleanup(world) {
     })
   } else {
     skip('S1 openReadableBody — FIFO (ENOTREG)', 'mkfifo unavailable on win32')
+  }
+
+  fs.rmSync(dir, { recursive: true, force: true })
+})()
+
+// =============================================================================
+// S1b — readBodyBufferOrSkip unit legs (issue #670 S1): same contract as
+// readBodyOrSkip but returns raw BYTES (Buffer.isBuffer(raw) === true) so
+// parseBp1Frontmatter's STRICT_UTF8_DECODER fatal decode keeps running on
+// bytes instead of a pre-decoded string. FIFO leg spawned + alarm-wrapped for
+// the same reason as S1 above (a same-process call is safe TODAY because
+// O_NONBLOCK makes open() return immediately, but that's exactly the
+// property a regression could break).
+// =============================================================================
+;(function S1b_bodyBufferHelper() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'em670-s1b-'))
+  const INDEX_STATE_PATH = path.join(SCRIPTS, 'lib', 'index-state.mjs')
+
+  function spawnBodyHelperChild(name, childSrcLines) {
+    const childPath = path.join(dir, `child-${name}.mjs`)
+    fs.writeFileSync(childPath, childSrcLines.join('\n'))
+    const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+    fs.rmSync(childPath, { force: true })
+    return r
+  }
+
+  t('S1b readBodyBufferOrSkip — absent (ENOENT), never throws', () => {
+    const p = path.join(dir, 'absent.md')
+    const r = readBodyBufferOrSkip(fs, p)
+    assert(r.ok === false && r.code === 'ENOENT', JSON.stringify(r))
+  })
+
+  t('S1b readBodyBufferOrSkip — directory (EISDIR)', () => {
+    const p = path.join(dir, 'adir.md')
+    fs.mkdirSync(p)
+    const r = readBodyBufferOrSkip(fs, p)
+    assert(r.ok === false && r.code === 'EISDIR', JSON.stringify(r))
+    fs.rmdirSync(p)
+  })
+
+  t('S1b readBodyBufferOrSkip — ok on a regular file, returns a Buffer of the exact bytes', () => {
+    const p = path.join(dir, 'ok.md')
+    fs.writeFileSync(p, 'hello body\n')
+    const r = readBodyBufferOrSkip(fs, p)
+    assert(r.ok === true && Buffer.isBuffer(r.raw), JSON.stringify({ ok: r.ok, isBuffer: Buffer.isBuffer(r.raw) }))
+    assert(r.raw.toString('utf8') === 'hello body\n', r.raw.toString('utf8'))
+    fs.unlinkSync(p)
+  })
+
+  t('S1b readBodyBufferOrSkip — invalid UTF-8 bytes pass through UNDECODED (Buffer passthrough invariant)', () => {
+    // A lone 0xFF byte is invalid UTF-8. If this helper silently decoded to a
+    // string (like readBodyOrSkip does), the invalid byte would normalize to
+    // U+FFFD and the caller's STRICT_UTF8_DECODER would never see it. This
+    // asserts the raw byte survives verbatim.
+    const p = path.join(dir, 'invalid-utf8.md')
+    fs.writeFileSync(p, Buffer.from([0x2d, 0x2d, 0x2d, 0x0a, 0xff, 0x0a]))
+    const r = readBodyBufferOrSkip(fs, p)
+    assert(r.ok === true && Buffer.isBuffer(r.raw) && r.raw[4] === 0xff, JSON.stringify({ ok: r.ok, isBuffer: Buffer.isBuffer(r.raw), byte4: r.raw && r.raw[4] }))
+    fs.unlinkSync(p)
+  })
+
+  if (!IS_WIN) {
+    t('S1b readBodyBufferOrSkip — FIFO (ENOTREG), no hang (spawned, alarm-wrapped)', () => {
+      const p = path.join(dir, 'fifo.md')
+      const mk = spawnSync('mkfifo', [p])
+      assert(mk.status === 0, `mkfifo failed: ${mk.stderr}`)
+      const r = spawnBodyHelperChild('readBodyBufferOrSkip-fifo', [
+        `import fs from 'node:fs'`,
+        `import { readBodyBufferOrSkip } from ${JSON.stringify(INDEX_STATE_PATH)}`,
+        `const r = readBodyBufferOrSkip(fs, ${JSON.stringify(p)})`,
+        `console.log(JSON.stringify({ ok: r.ok, code: r.code }))`,
+      ])
+      fs.unlinkSync(p)
+      assert(r.signal === null, `S1b readBodyBufferOrSkip FIFO: no signal (timeout/kill) — got ${r.signal} (this is the fail-not-freeze regression signature)`)
+      assert(r.status === 0, `S1b readBodyBufferOrSkip FIFO: child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+      const j = JSON.parse((r.stdout || '').trim())
+      assert(j.ok === false && j.code === 'ENOTREG', JSON.stringify(j))
+    })
+  } else {
+    skip('S1b readBodyBufferOrSkip — FIFO (ENOTREG)', 'mkfifo unavailable on win32')
   }
 
   fs.rmSync(dir, { recursive: true, force: true })

--- a/tests/test-bp1-atomic.mjs
+++ b/tests/test-bp1-atomic.mjs
@@ -18,6 +18,7 @@ import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 
 const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
 const { writeBp1Episode } = writerMod
@@ -201,6 +202,36 @@ tap('F9 filename-vs-fm.id mismatch (rename attack) → excluded', () => {
   fs.renameSync(ep.episodePath, renamed)
   const r = findSignedStateEpisode(projectRoot, RUN_ID, 'classifier-dispatch-pending', KEY)
   assert.deepEqual(r, { status: 'none' })
+})
+
+// =============================================================================
+// FIFO regression leg (issue #670): findSignedStateEpisode loop-scan must
+// skip a non-regular episode file instead of hanging. Spawned into a CHILD
+// process with a hard timeout — a same-process call against unfixed code
+// (raw fs.readFileSync on a FIFO) blocks forever with no external alarm,
+// which would freeze this entire suite rather than fail it.
+// =============================================================================
+tap('F11 FIFO-shaped episode file in episodes dir → skipped, no hang (spawned, alarm-wrapped)', () => {
+  const projectRoot = mkTmpProject()
+  const epDir = path.join(projectRoot, '.episodic-memory', 'episodes')
+  fs.mkdirSync(epDir, { recursive: true })
+  const fifoPath = path.join(epDir, `${RUN_ID}-poison.md`)
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const ATOMIC_PATH = new URL('../scripts/lib/bp1-atomic.mjs', import.meta.url).href
+  const childPath = path.join(projectRoot, 'child-probe.mjs')
+  fs.writeFileSync(childPath, [
+    `import { findSignedStateEpisode } from ${JSON.stringify(ATOMIC_PATH)}`,
+    `const r = findSignedStateEpisode(${JSON.stringify(projectRoot)}, ${JSON.stringify(RUN_ID)}, 'classifier-dispatch-pending', Buffer.from(${JSON.stringify(KEY.toString('hex'))}, 'hex'))`,
+    `console.log(JSON.stringify(r))`,
+  ].join('\n'))
+  const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+  fs.rmSync(childPath, { force: true })
+  fs.unlinkSync(fifoPath)
+  assert.ok(r.signal === null, `F11: no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature)`)
+  assert.equal(r.status, 0, `F11: child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+  const j = JSON.parse((r.stdout || '').trim())
+  assert.deepEqual(j, { status: 'none' }, JSON.stringify(j))
 })
 
 tap('F10 input validation — bad projectRoot, runId, state, key, expectedFields', () => {

--- a/tests/test-bp1-build-artifact-manifest.mjs
+++ b/tests/test-bp1-build-artifact-manifest.mjs
@@ -33,7 +33,12 @@ const SCRIPT = path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs')
 
 // Lib + transitive imports required by bp1-build-artifact-manifest.mjs.
 // Copied wholesale into proj/scripts/ for cross-cwd fixtures (A12c-g).
-const FIXTURE_LIB_FILES = ['bp1-manifest.mjs', 'bp1-frontmatter.mjs', 'bp1-canonicalize.mjs']
+// DERIVED (Rule 14) via computeLibClosure instead of a hand-maintained list —
+// matches the em-search closure below (installRuntimeIntoProj): a new
+// transitive import inside bp1-manifest.mjs (e.g. #670's index-state.mjs)
+// can no longer drift past this fixture and crash the copied tree with
+// ERR_MODULE_NOT_FOUND.
+const FIXTURE_LIB_FILES = [...computeLibClosure(REPO, ['bp1-build-artifact-manifest.mjs'])]
 
 let pass = 0, fail = 0
 function tap(name, fn) {
@@ -261,10 +266,11 @@ tap('Codex round-3: em-search subprocess malformed-output error propagates', () 
   fs.writeFileSync(path.join(proj, '.claude', 'agents', 'bp1-fake.md'),
     'Canonical prompt episode 20260506-100000-fake-slug-abcd.\n')
   // Copy the real lib + builder + a stubbed em-search into proj/scripts/.
-  // bp1-manifest.mjs transitively imports bp1-frontmatter.mjs + bp1-canonicalize.mjs
-  // (added in PR-1c-B Slice 2 commits 1/5 + 2/5); fixture must mirror that.
+  // FIXTURE_LIB_FILES is the DERIVED (Rule 14) transitive closure of
+  // bp1-build-artifact-manifest.mjs (bp1-manifest.mjs -> bp1-frontmatter.mjs,
+  // bp1-canonicalize.mjs, index-state.mjs, ...); fixture must mirror it.
   fs.mkdirSync(path.join(proj, 'scripts', 'lib'), { recursive: true })
-  for (const lib of ['bp1-manifest.mjs', 'bp1-frontmatter.mjs', 'bp1-canonicalize.mjs']) {
+  for (const lib of FIXTURE_LIB_FILES) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(proj, 'scripts', 'lib', lib))
   }

--- a/tests/test-bp1-crash-classify.mjs
+++ b/tests/test-bp1-crash-classify.mjs
@@ -20,6 +20,13 @@ const mod = await import(
 )
 const { classifyRunCrash, PATH_B_AGE_THRESHOLD_MS } = mod
 
+const { writeBp1Episode } = await import(
+  new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href
+)
+const { generateRunKey } = await import(
+  new URL('../scripts/lib/bp1-keys.mjs', import.meta.url).href
+)
+
 const CLI = new URL('../scripts/bp1-crash-classify.mjs', import.meta.url).pathname
 
 let pass = 0, fail = 0
@@ -446,6 +453,245 @@ tap('CC-ambiguous codex_review state with no entry episodes → inconsistent', (
     markerPresent: false, markerExpired: false, now: NOW,
   })
   assert.equal(r.classification, 'inconsistent-codex-review')
+})
+
+// =============================================================================
+// Issue #670 — CLI-level loadRunEpisodes/readApprovalMarkerStatus coverage.
+// mkCrashProject/writeRunIndex/writeSignedEpisode build a real on-disk
+// fixture (no git required — canonicalProjectRoot falls back to
+// path.resolve when there's no git repo, per bp1-crash-classify.mjs main()).
+// =============================================================================
+function mkCrashProject() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'bp1-cc-proj-')))
+  fs.mkdirSync(path.join(dir, '.episodic-memory', 'episodes'), { recursive: true })
+  return dir
+}
+
+function writeRunIndex(proj, runId, state) {
+  const indexDir = path.join(proj, '.episodic-memory', 'runs')
+  fs.mkdirSync(indexDir, { recursive: true })
+  fs.writeFileSync(path.join(indexDir, '_index.json'), JSON.stringify({
+    schema_version: 2,
+    runs: {
+      [runId]: {
+        run_id: runId, state,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    },
+  }, null, 2))
+}
+
+// #670 review round MAJOR-1: loadRunEpisodes now gates on HMAC verification
+// (see scripts/bp1-crash-classify.mjs loadRunEpisodes), so fixtures must
+// write REAL signed episodes via the real writer — generateRunKey plants
+// run.key on disk where loadRunKey (inside loadRunEpisodes) will find it,
+// and writeBp1Episode signs with that SAME key. Returns { key32B, episodeId }.
+function setupRunKey(proj, runId) {
+  const { key32B } = generateRunKey(proj, runId)
+  return key32B
+}
+
+function writeSignedEpisode(proj, runId, key32B, { state, filenameSuffix, tags = [] }) {
+  const written = writeBp1Episode({
+    projectRoot: proj, runId, runKey32B: key32B,
+    type: 'state-transition', state,
+    summary: `${state} for ${runId}`,
+    parentEpisode: null, expectedPostEpisodeId: null,
+    tags, body: `# ${state}\n`, filenameSuffix,
+  })
+  return written.episodeId
+}
+
+// Raw (UNSIGNED) episode write — parseBp1Frontmatter-compatible bare-token
+// frontmatter with no hmac_signature field. Used ONLY for the forged-
+// unsigned regression leg (MAJOR-1): loadRunEpisodes must SKIP this, not
+// trust it (mirrors writeEpisode() in test-bp1-manifest-collect.mjs).
+function writeRawEpisode(proj, epId, fields) {
+  const dir = path.join(proj, '.episodic-memory', 'episodes')
+  const lines = ['---']
+  for (const [k, v] of Object.entries(fields)) lines.push(`${k}: ${v}`)
+  lines.push('---', '', 'body\n')
+  fs.writeFileSync(path.join(dir, `${epId}.md`), lines.join('\n'))
+}
+
+function spawnCC(proj, runId, extraEnv) {
+  return spawnSync('node', [CLI, '--project', proj, '--run-id', runId], {
+    encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL',
+    env: { ...process.env, ...extraEnv },
+  })
+}
+
+// =============================================================================
+// §2c positive control (round-2 E3R bound): the CLI classification for a
+// valid run-tagged fixture MUST EQUAL the pure classifyRunCrash output for
+// the equivalent episode records — the same shape the CC-row1 test (top of
+// this file) injects directly. This is what makes the FIFO leg below
+// non-vacuous: loadRunEpisodes must ACTUALLY return records, not just avoid
+// hanging.
+// =============================================================================
+tap('CC-670-positive-control: rfc-detected run with ONE real on-disk SIGNED episode → CLI classification EQUALS pure classifyRunCrash output', () => {
+  const proj = mkCrashProject()
+  const runId = 'bp1-run-cc-670-pos-rfc-x-aabbcc'
+  writeRunIndex(proj, runId, 'rfc-detected')
+  const key32B = setupRunKey(proj, runId)
+  const epId = writeSignedEpisode(proj, runId, key32B, { state: 'rfc-detected', filenameSuffix: 'rfc-detected' })
+
+  const r = spawnCC(proj, runId)
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+
+  // Independently compute the pure-function expectation for the SAME
+  // records loadRunEpisodes should have produced (mirrors st('rfc-detected')
+  // at the top of this file).
+  const pure = classifyRunCrash({
+    runState: { state: 'rfc-detected' },
+    episodes: [{ id: epId, run_id: runId, type: 'state-transition', state: 'rfc-detected' }],
+    markerPresent: false, markerExpired: false, now: Date.parse(out.marker?.deadline_at || NOW) || NOW,
+  })
+  assert.equal(out.classification, pure.classification, `CLI=${out.classification} pure=${pure.classification}`)
+  assert.deepEqual(out.resume_action, pure.resume_action, `CLI=${JSON.stringify(out.resume_action)} pure=${JSON.stringify(pure.resume_action)}`)
+  // Matches the CC-row1 pure-function expectation directly (lines ~78-93).
+  assert.equal(out.classification, 'crash-mid-classify')
+  assert.equal(out.resume_action.command, 'record-classification')
+})
+
+// Discriminating positive control (plan §7 build-round amendment): the Row1
+// fixture above (CC-670-positive-control) is satisfied identically whether
+// or not loadRunEpisodes returns correctly-SHAPED flat records — its
+// classification doesn't depend on inspecting any episode field, only on
+// state-transition PRESENCE of 'classified' (absent either way there). This
+// case flips on an episode field (e.state) the fixed code must read
+// correctly through fm.frontmatter — reachable only if loadRunEpisodes
+// pushes fm.frontmatter (flat), not the {frontmatter,body} wrapper the
+// half-activated fix used to push (whose fields all read back as
+// undefined). Originally a builder STOP-and-flag finding (CLI reported
+// crash-mid-Phase-A instead of inconsistent-classified-trivial); plan-owner
+// authorized completing the wrapper-vs-content fix, so this now asserts the
+// CORRECT post-fix behavior as a committed regression leg.
+tap('CC-670-positive-control-discriminating: classified/trivial WITH an on-disk SIGNED awaiting_approval episode → CLI reads e.state correctly through fm.frontmatter', () => {
+  const proj = mkCrashProject()
+  const runId = 'bp1-run-cc-670-disc-rfc-x-aabbcc'
+  writeRunIndex(proj, runId, 'classified')
+  // Patch decided_class onto the run-state row (writeRunIndex doesn't set it).
+  const idxPath = path.join(proj, '.episodic-memory', 'runs', '_index.json')
+  const idx = JSON.parse(fs.readFileSync(idxPath, 'utf8'))
+  idx.runs[runId].decided_class = 'trivial'
+  fs.writeFileSync(idxPath, JSON.stringify(idx, null, 2))
+  const key32B = setupRunKey(proj, runId)
+  const epId = writeSignedEpisode(proj, runId, key32B, { state: 'awaiting_approval', filenameSuffix: 'awaiting-approval' })
+
+  const r = spawnCC(proj, runId)
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+
+  const pure = classifyRunCrash({
+    runState: { state: 'classified', decided_class: 'trivial' },
+    episodes: [{ id: epId, run_id: runId, type: 'state-transition', state: 'awaiting_approval' }],
+    markerPresent: false, markerExpired: false, now: NOW,
+  })
+  // Pure expectation for THIS shape: hasAwait=true -> inconsistent-classified-trivial
+  // (NOT crash-mid-Phase-A, which is what the wrapper-shaped bug wrongly
+  // reported since e.state read as undefined on every record).
+  assert.equal(pure.classification, 'inconsistent-classified-trivial', `sanity: pure fixture itself must hit the discriminating branch, got ${pure.classification}`)
+  assert.equal(out.classification, pure.classification, `CLI=${out.classification} pure=${pure.classification} (CLI diverging here would mean loadRunEpisodes is NOT returning flat frontmatter records)`)
+  assert.deepEqual(out.resume_action, pure.resume_action)
+})
+
+// =============================================================================
+// FIFO regression leg (issue #670 §2, loadRunEpisodes): a FIFO-shaped
+// episode file alongside a real one must be skipped, not hang the verb.
+// Uses the CLI (already a subprocess) with an explicit timeout so a
+// regression against unfixed code (raw fs.readFileSync on a FIFO) fails as a
+// timeout-kill instead of freezing this suite.
+// =============================================================================
+tap('CC-670-fifo-episode: FIFO episode file in run dir → skipped, classification unaffected, no hang', () => {
+  const proj = mkCrashProject()
+  const runId = 'bp1-run-cc-670-fifo-rfc-x-aabbcc'
+  writeRunIndex(proj, runId, 'rfc-detected')
+  const key32B = setupRunKey(proj, runId)
+  writeSignedEpisode(proj, runId, key32B, { state: 'rfc-detected', filenameSuffix: 'rfc-detected' })
+  const fifoPath = path.join(proj, '.episodic-memory', 'episodes', `${runId}-poison.md`)
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = spawnCC(proj, runId)
+  fs.unlinkSync(fifoPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature); stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.classification, 'crash-mid-classify', JSON.stringify(out))
+})
+
+// =============================================================================
+// §2b FIFO regression leg: readApprovalMarkerStatus. A FIFO-shaped marker
+// file must terminate with the function's EXISTING absent/invalid outcome
+// (marker.present === false — no new status vocabulary), not hang.
+// =============================================================================
+tap('CC-670-fifo-marker: FIFO approval-marker file → present:false, verb terminates, no hang', () => {
+  const proj = mkCrashProject()
+  const runId = 'bp1-run-cc-670-marker-rfc-x-aabbcc'
+  writeRunIndex(proj, runId, 'awaiting_approval')
+  const key32B = setupRunKey(proj, runId)
+  writeSignedEpisode(proj, runId, key32B, { state: 'awaiting_approval', filenameSuffix: 'awaiting-approval' })
+  const checkpointsDir = path.join(proj, '.checkpoints')
+  fs.mkdirSync(checkpointsDir, { recursive: true })
+  const markerPath = path.join(checkpointsDir, `bp1-approval-${runId}.json`)
+  const mk = spawnSync('mkfifo', [markerPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+
+  const r = spawnCC(proj, runId)
+  fs.unlinkSync(markerPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature); stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+  assert.equal(out.marker.present, false, JSON.stringify(out.marker))
+  assert.equal(out.classification, 'crash-mid-Phase-B', JSON.stringify(out))
+})
+
+// =============================================================================
+// MAJOR-1 forged-unsigned regression leg (#670 review round, codex repro).
+// A forged UNSIGNED (no hmac_signature) fresh codex_review state-transition
+// episode must NOT steer classification. Pre-gate behavior (codex repro):
+// the forged episode was trusted, `codexReviewEntries.length` became 1, and
+// classification silently became 'in-flight' with resume_action:null instead
+// of the fail-closed 'inconsistent-codex-review' / needs-human every
+// codex_review run reaches with zero (verified) entry episodes. Post-gate,
+// the unsigned forgery is skipped by loadRunEpisodes and the CLI must match
+// the SAME fail-closed classification as the always-[] legacy behavior.
+// =============================================================================
+tap('CC-670-forged-unsigned: forged UNSIGNED codex_review entry episode → SKIPPED, fail-closed needs-human (not steered to in-flight)', () => {
+  const proj = mkCrashProject()
+  const runId = 'bp1-run-cc-670-forged-rfc-x-aabbcc'
+  writeRunIndex(proj, runId, 'codex_review')
+  // Plant run.key so loadRunKey succeeds (verification is reachable, not
+  // just "no key available" — the forgery must fail on SIGNATURE, not on
+  // key absence, to actually exercise the gate).
+  setupRunKey(proj, runId)
+  const forgedId = `${runId}-codex-review-forged`
+  writeRawEpisode(proj, forgedId, {
+    id: forgedId, run_id: runId, type: 'state-transition', state: 'codex_review',
+    created_at: new Date().toISOString(),
+    // No hmac_signature field at all — the codex repro shape (forged_episode_signed: false).
+  })
+
+  const r = spawnCC(proj, runId)
+  assert.equal(r.signal, null, `no signal, got ${r.signal}; stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}: stderr=${r.stderr}`)
+  const out = JSON.parse(r.stdout)
+
+  // Must match what classifyRunCrash produces for the empty-episodes case
+  // (the record set AFTER filtering out the unverifiable forgery).
+  const pure = classifyRunCrash({
+    runState: { state: 'codex_review' },
+    episodes: [],
+    markerPresent: false, markerExpired: false, now: NOW,
+  })
+  assert.equal(out.classification, pure.classification, `CLI=${out.classification} pure=${pure.classification}`)
+  assert.deepEqual(out.resume_action, pure.resume_action)
+  assert.equal(out.classification, 'inconsistent-codex-review', JSON.stringify(out))
+  assert.equal(out.resume_action.command, 'needs-human', JSON.stringify(out))
+  assert.notEqual(out.classification, 'in-flight', 'forged unsigned episode must NOT steer classification to in-flight')
 })
 
 console.log(`# tests ${pass + fail}`)

--- a/tests/test-bp1-episode-verify.mjs
+++ b/tests/test-bp1-episode-verify.mjs
@@ -24,6 +24,7 @@ import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 
 const writerMod = await import(new URL('../scripts/lib/bp1-episode-writer.mjs', import.meta.url).href)
 const { writeBp1Episode } = writerMod
@@ -314,6 +315,60 @@ tap('V15 parent signed by foreign key + claimed under our run → parent-hmac-in
   })
   assert.equal(r.ok, false)
   assert.ok(r.errors.includes('parent-hmac-invalid'))
+})
+
+// =============================================================================
+// V16: FIFO-shaped parent episode file → ok:false + parent-unreadable: entry,
+// no hang (issue #670). Spawned into a CHILD process with a hard timeout — a
+// same-process call against unfixed code (raw fs.readFileSync on a FIFO)
+// blocks forever with no external alarm.
+// =============================================================================
+tap('V16 FIFO-shaped parent file → parent-unreadable, no hang (spawned, alarm-wrapped)', () => {
+  const root = mkTmpProject()
+  const p = writeParent(root)
+  fs.unlinkSync(p.episodePath)
+  const mk = spawnSync('mkfifo', [p.episodePath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const VERIFY_PATH = new URL('../scripts/lib/bp1-episode-verify.mjs', import.meta.url).href
+  const childPath = path.join(root, 'child-probe.mjs')
+  fs.writeFileSync(childPath, [
+    `import { verifyEpisodeOnDisk } from ${JSON.stringify(VERIFY_PATH)}`,
+    `const r = verifyEpisodeOnDisk({`,
+    `  projectRoot: ${JSON.stringify(root)}, episodeId: ${JSON.stringify(p.episodeId)}, runKey32B: Buffer.from(${JSON.stringify(KEY.toString('hex'))}, 'hex'),`,
+    `  expectedType: 'state-transition', expectedState: 'rfc-detected', expectedRunId: ${JSON.stringify(RUN_ID)},`,
+    `})`,
+    `console.log(JSON.stringify(r))`,
+  ].join('\n'))
+  const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+  fs.rmSync(childPath, { force: true })
+  fs.unlinkSync(p.episodePath)
+  assert.ok(r.signal === null, `V16: no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature)`)
+  assert.equal(r.status, 0, `V16: child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+  const j = JSON.parse((r.stdout || '').trim())
+  assert.equal(j.ok, false, JSON.stringify(j))
+  assert.ok(j.errors.some(e => e.startsWith('parent-unreadable:')), JSON.stringify(j))
+})
+
+// =============================================================================
+// V17: strict-decode regression leg (round-1 MINOR-3) — invalid UTF-8 bytes
+// in the parent file must still die in STRICT_UTF8_DECODER -> parent-parse-
+// failed. Guards that the #670 refactor to readBodyBufferOrSkip keeps
+// passing RAW BYTES into parseBp1Frontmatter (not a pre-decoded string,
+// which would silently normalize invalid UTF-8 to U+FFFD).
+// =============================================================================
+tap('V17 invalid-UTF-8 bytes in parent file → parent-parse-failed (Buffer passthrough survives the #670 refactor)', () => {
+  const root = mkTmpProject()
+  const p = writeParent(root)
+  const text = fs.readFileSync(p.episodePath, 'utf8')
+  const bytes = Buffer.concat([Buffer.from(text, 'utf8'), Buffer.from([0xff])])
+  fs.writeFileSync(p.episodePath, bytes)
+  const r = verifyEpisodeOnDisk({
+    projectRoot: root, episodeId: p.episodeId, runKey32B: KEY,
+    expectedType: 'state-transition', expectedState: 'rfc-detected',
+    expectedRunId: RUN_ID,
+  })
+  assert.equal(r.ok, false)
+  assert.ok(r.errors.some(e => e.startsWith('parent-parse-failed')))
 })
 
 console.log(`\n# ${pass} passed, ${fail} failed`)

--- a/tests/test-bp1-finalize-run.mjs
+++ b/tests/test-bp1-finalize-run.mjs
@@ -107,9 +107,13 @@ function setupActiveProject() {
 
 function spawnOrchestrator(sub, args, opts) {
   const argv = [sub, ...args]
+  // #670: explicit timeout + hard kill so a FIFO-hang regression fails this
+  // suite loud (signal !== null) instead of freezing the test run forever.
   return spawnSync('node', [ORCHESTRATOR, ...argv], {
     cwd: opts.callerCwd,
     encoding: 'utf8',
+    timeout: 15000,
+    killSignal: 'SIGKILL',
     env: { ...process.env, HOME: opts.homeDir, ...(opts.env || {}) },
   })
 }
@@ -436,6 +440,76 @@ for (const tc of G3_CASES) {
 }
 
 // =============================================================================
+// Issue #670 review round MINOR-2 (converges with lens-2 F2): committed
+// CLI-level legs for the mandated finalize path (not just the loader), with
+// diagnostic count/location assertions — matching the codex probe shapes
+// verbatim.
+// =============================================================================
+
+tap('G3-670a finalize-run step-0 gate: run.key FIFO at mode 0600 → exit 4, unsigned run-key-unreadable diagnostic, target-only artifacts, no hang', () => {
+  const { project, home } = setupActiveProject()
+  const caller = makeNonGitCaller()
+  const runId = initRun(project, home, project)
+  // Replace the real run.key with a FIFO at mode 0600 — this PASSES the old
+  // statSync-based mode-0600 gate (a FIFO has no distinct "mode" from a
+  // regular file under statSync); the fd-based fix must reject it as
+  // non-regular (fstat(fd).isFile() === false) BEFORE the mode check, not
+  // block on a path-based readFileSync.
+  const keyPath = runKeyPath(project, runId)
+  fs.unlinkSync(keyPath)
+  const mk = spawnSync('mkfifo', ['-m', '600', keyPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnOrchestrator('finalize-run', ['--project', project, '--run-id', runId], { callerCwd: caller, homeDir: home })
+  fs.unlinkSync(keyPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal}; stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 4, `expected exit 4, got ${r.status}: stderr=${r.stderr}`)
+  assert.match(r.stderr, /bp1-finalize-run: run\.key unreadable/)
+  const diag = findEpisodeByTag(project, runId, 'bp1-finalize-diagnostic')
+  assert.ok(diag, 'unsigned diagnostic required')
+  assert.match(diag.body, /\*\*Reason:\*\* `run-key-unreadable`/, `diagnostic body must cite reason run-key-unreadable; got: ${diag.body}`)
+  assert.equal(diag.frontmatter.hmac_signature, undefined, 'diagnostic must NOT have hmac_signature (unsigned — no usable key to sign with)')
+  // Location: target gets the diagnostic; caller and HOME receive nothing.
+  assert.equal(listLocalEpisodes(project).filter(f => f.includes('-diagnostic-')).length, 1, 'exactly one diagnostic episode under target')
+  assert.equal(fs.existsSync(path.join(caller, '.episodic-memory')), false, 'caller must receive zero artifacts')
+  const homeEpisodesDir = path.join(home, '.episodic-memory', 'episodes')
+  assert.equal(fs.existsSync(homeEpisodesDir) ? fs.readdirSync(homeEpisodesDir).length : 0, 0, 'HOME must receive zero new episode artifacts')
+})
+
+tap('G3-670b decisionLogFence FIFO-traversal leg: FIFO in episodes dir → fence skips it (loop-guard), collect re-throws → exactly one signed fence-fail episode, target-only artifacts, no hang', () => {
+  const { project, home } = setupActiveProject()
+  const caller = makeNonGitCaller()
+  const runId = initRun(project, home, project)
+  const key = readRunKey(project, runId)
+  seedPrePost(project, runId, key)
+  // Plant a FIFO in the SAME local episodes dir the fence scans. decisionLogFence's
+  // loop-scan is guarded (readBodyBufferOrSkip; ok:false -> continue) so the
+  // fence itself does not hang or fail on it — but collectEpisodeRecords
+  // (step 2) is a fail-closed enumerator that RE-THROWS on ANY unreadable
+  // file regardless of content, so finalize-run still fails downstream.
+  const localStore = path.join(project, '.episodic-memory', 'episodes')
+  const fifoPath = path.join(localStore, 'poison.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnOrchestrator('finalize-run', ['--project', project, '--run-id', runId], { callerCwd: caller, homeDir: home })
+  fs.unlinkSync(fifoPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal}; stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 4, `expected exit 4, got ${r.status}: stderr=${r.stderr}`)
+  assert.match(r.stderr, /collectEpisodeRecords failed/, `stderr must show the fence PASSED and collect FAILED; got: ${r.stderr}`)
+  assert.equal(findEpisodeByTag(project, runId, 'bp1-run-manifest'), null, 'no manifest')
+  assert.equal(readRunState(project, runId).state, 'active', 'state must stay active')
+  const fence = findEpisodeByTag(project, runId, 'bp1-finalize-fence-fail')
+  assert.ok(fence, 'exactly one signed fence-fail evidence episode required')
+  assert.ok(typeof fence.frontmatter.hmac_signature === 'string' && fence.frontmatter.hmac_signature !== '', 'fence-fail must be signed')
+  // "exactly one": count every episode this run wrote total — init-run's
+  // run-started (1) + seedPrePost's pre+post (2) + this ONE fence-fail
+  // evidence episode = 4, no more (no duplicate fence-fail, no stray writes).
+  assert.equal(listLocalEpisodes(project).length, 4, `expected exactly run-started+pre+post+fence-fail (4) episodes; got: ${listLocalEpisodes(project).join(', ')}`)
+  assert.equal(fs.existsSync(path.join(caller, '.episodic-memory')), false, 'caller must receive zero artifacts')
+  const homeEpisodesDir = path.join(home, '.episodic-memory', 'episodes')
+  assert.equal(fs.existsSync(homeEpisodesDir) ? fs.readdirSync(homeEpisodesDir).length : 0, 0, 'HOME must receive zero new episode artifacts')
+})
+
+// =============================================================================
 // G4 — finalize-recover state machine (7 variants)
 // =============================================================================
 
@@ -545,6 +619,54 @@ tap('G4 State C variant 2 (disk-mismatch): valid sig + mutated covered episode �
   assert.match(r.stderr, /on-disk records do not match manifest/)
   assert.doesNotMatch(r.stderr, /signature invalid/)
   assert.equal(readRunState(project, runId).state, 'active')
+})
+
+// =============================================================================
+// Issue #670 — finalize-recover CLI FIFO legs, pinned exit codes (§3).
+// =============================================================================
+
+tap('G4-670 finalize-recover + episodes-dir FIFO + NO manifest → State C, exit 4, no hang', () => {
+  const { project, home } = setupActiveProject()
+  const runId = initRun(project, home)
+  // No finalize-run call: no manifest exists. findManifestEpisode must skip
+  // the FIFO (not hang) and report "no manifest" → State C.
+  const epDir = path.join(project, '.episodic-memory', 'episodes')
+  fs.mkdirSync(epDir, { recursive: true })
+  const fifoPath = path.join(epDir, 'poison.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnOrchestrator('finalize-recover', ['--project', project, '--run-id', runId], { callerCwd: project, homeDir: home })
+  fs.unlinkSync(fifoPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature); stderr=${(r.stderr || '').slice(0, 500)}`)
+  assert.equal(r.status, 4, `expected exit 4 (State C), got ${r.status}: stderr=${r.stderr}`)
+  assert.match(r.stderr, /State C/)
+  assert.equal(readRunState(project, runId).state, 'active', 'state stays active')
+})
+
+tap('G4-670 finalize-recover + episodes-dir FIFO + VALID manifest → collect re-throw propagates UNCAUGHT, exit 1, no hang', () => {
+  const { project, home, runId } = setupRunWithManifest()
+  const idxPath = path.join(project, '.episodic-memory', 'runs', '_index.json')
+  const idx = JSON.parse(fs.readFileSync(idxPath, 'utf8'))
+  idx.runs[runId].state = 'active'
+  idx.runs[runId].terminal_at = null
+  fs.writeFileSync(idxPath, JSON.stringify(idx, null, 2) + '\n')
+  // Manifest is valid (from setupRunWithManifest's finalize-run). Plant a
+  // FIFO ALONGSIDE the real signed episodes — collectEpisodeRecords (called
+  // from verifyOnDiskEqualsManifest) is a fail-closed enumerator: it
+  // RE-THROWS typed on the FIFO regardless of that file's content/run_id.
+  // finalize-recover has no try/catch around this call, so the throw
+  // propagates uncaught — pinned as acceptable (fail-closed, same shape as
+  // today's EACCES class).
+  const epDir = path.join(project, '.episodic-memory', 'episodes')
+  const fifoPath = path.join(epDir, 'poison.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const r = spawnOrchestrator('finalize-recover', ['--project', project, '--run-id', runId], { callerCwd: project, homeDir: home })
+  fs.unlinkSync(fifoPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature); stderr=${(r.stderr || '').slice(0, 500)}`)
+  assert.equal(r.status, 1, `expected exit 1 (uncaught re-throw), got ${r.status}: stderr=${r.stderr}`)
+  assert.match(r.stderr, /unreadable episode file/)
+  assert.equal(readRunState(project, runId).state, 'active', 'not terminal — no signed evidence emitted')
 })
 
 tap('G4 State D happy: damaged key (mode 0o000) → unlinked + terminal', () => {

--- a/tests/test-bp1-hmac-live.mjs
+++ b/tests/test-bp1-hmac-live.mjs
@@ -12,6 +12,7 @@ import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
 
@@ -170,6 +171,63 @@ tap('I3b run.key oversized to 33 bytes → loadRunKey error size', () => {
   const loaded = loadRunKey(proj, RUN_ID)
   assert.equal(loaded.error, 'size')
 })
+
+// =============================================================================
+// Issue #670 §2b — mode-600 run.key FIFO leg (round-1's acceptance-falsifying
+// probe): `mkfifo -m 600 run.key` PASSES the OLD statSync-based mode-0600
+// gate (statSync doesn't distinguish a FIFO from a regular file for mode
+// purposes) and then blocks forever on a path-based readFileSync. Spawned
+// into a CHILD process with a hard timeout — a same-process call against
+// unfixed code would hang this entire suite with no external alarm.
+// =============================================================================
+if (process.platform !== 'win32') {
+  tap('#670 loadRunKey — FIFO run.key at mode 0600 → error unreadable (NOT mode), no hang (spawned, alarm-wrapped)', () => {
+    const proj = makeProjectRoot()
+    const keyPath = runKeyPath(proj, RUN_ID)
+    fs.mkdirSync(path.dirname(keyPath), { recursive: true })
+    const mk = spawnSync('mkfifo', ['-m', '600', keyPath])
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+    const KEYS_PATH = path.join(REPO, 'scripts', 'lib', 'bp1-keys.mjs')
+    const childPath = path.join(proj, 'child-probe.mjs')
+    fs.writeFileSync(childPath, [
+      `import { loadRunKey } from ${JSON.stringify(KEYS_PATH)}`,
+      `const r = loadRunKey(${JSON.stringify(proj)}, ${JSON.stringify(RUN_ID)})`,
+      `console.log(JSON.stringify(r))`,
+    ].join('\n'))
+    const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+    fs.rmSync(childPath, { force: true })
+    fs.unlinkSync(keyPath)
+    assert.ok(r.signal === null, `no signal (timeout/kill) — got ${r.signal} (this is the fail-not-freeze regression signature that falsified round-1's acceptance battery)`)
+    assert.equal(r.status, 0, `child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+    const j = JSON.parse((r.stdout || '').trim())
+    // A FIFO must fail the SHAPE check (fstat(fd).isFile() === false), not
+    // the perm check — mode 0600 on the FIFO must never be reached/reported.
+    assert.equal(j.error, 'unreadable', JSON.stringify(j))
+  })
+
+  tap('#670 loadVerifyKey — FIFO verify-key at mode 0600 → error unreadable (NOT mode), no hang (spawned, alarm-wrapped)', () => {
+    const home = makeHomeDir()
+    const keyPath = verifyKeyPath(home)
+    const mk = spawnSync('mkfifo', ['-m', '600', keyPath])
+    assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+    const KEYS_PATH = path.join(REPO, 'scripts', 'lib', 'bp1-keys.mjs')
+    const childPath = path.join(home, 'child-probe.mjs')
+    fs.writeFileSync(childPath, [
+      `import { loadVerifyKey } from ${JSON.stringify(KEYS_PATH)}`,
+      `const r = loadVerifyKey(${JSON.stringify(home)})`,
+      `console.log(JSON.stringify(r))`,
+    ].join('\n'))
+    const r = spawnSync(process.execPath, [childPath], { encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL' })
+    fs.rmSync(childPath, { force: true })
+    fs.unlinkSync(keyPath)
+    assert.ok(r.signal === null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature)`)
+    assert.equal(r.status, 0, `child exit 0, got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+    const j = JSON.parse((r.stdout || '').trim())
+    assert.equal(j.error, 'unreadable', JSON.stringify(j))
+  })
+} else {
+  tap('#670 loadRunKey/loadVerifyKey — FIFO mode-600 legs', () => { /* mkfifo unavailable on win32 */ })
+}
 
 // =============================================================================
 // TB2a — hex sig wrong length → verify false (NOT throw)

--- a/tests/test-bp1-manifest-collect.mjs
+++ b/tests/test-bp1-manifest-collect.mjs
@@ -12,7 +12,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import {
   collectEpisodeRecords,
   verifyOnDiskEqualsManifest,
@@ -271,6 +271,76 @@ t('throws on invalid runId shape', () => {
 
 t('throws on relative projectRoot', () => {
   assert.throws(() => collectEpisodeRecords('rfc-004-001', 'relative/path'), /absolute path/)
+})
+
+// ---------------------------------------------------------------------------
+// FIFO regression leg (issue #670): collectEpisodeRecords is a fail-closed
+// enumerator by design — an unreadable file (incl. a FIFO) must RE-THROW a
+// typed Error instead of hanging (unfixed: raw fs.readFileSync blocks
+// forever opening a FIFO with no writer) or silently skipping (would violate
+// "a run's records must be enumerable"). Spawned into a CHILD process with a
+// hard timeout so a regression fails as a timeout-kill, never a stuck suite.
+// ---------------------------------------------------------------------------
+t('FIFO episode file → typed THROW, no hang (spawned, alarm-wrapped)', () => {
+  const project = mkTempProject()
+  const home = mkHomeSandbox()
+  const localDir = path.join(project, '.episodic-memory', 'episodes')
+  const fifoPath = path.join(localDir, 'poison.md')
+  const mk = spawnSync('mkfifo', [fifoPath])
+  assert.equal(mk.status, 0, `mkfifo failed: ${mk.stderr}`)
+  const MANIFEST_PATH = new URL('../scripts/lib/bp1-manifest.mjs', import.meta.url).href
+  const childPath = path.join(project, 'child-probe.mjs')
+  fs.writeFileSync(childPath, [
+    `import { collectEpisodeRecords } from ${JSON.stringify(MANIFEST_PATH)}`,
+    `try {`,
+    `  collectEpisodeRecords('rfc-004-001', ${JSON.stringify(project)})`,
+    `  console.log(JSON.stringify({ step: 'unexpected-ok' }))`,
+    `} catch (e) {`,
+    `  console.log(JSON.stringify({ step: 'threw', message: e.message }))`,
+    `}`,
+  ].join('\n'))
+  const r = spawnSync(process.execPath, [childPath], {
+    encoding: 'utf8', timeout: 10000, killSignal: 'SIGKILL',
+    env: { ...process.env, HOME: home },
+  })
+  fs.rmSync(childPath, { force: true })
+  fs.unlinkSync(fifoPath)
+  assert.equal(r.signal, null, `no signal (timeout/kill) — got ${r.signal} (fail-not-freeze regression signature); stderr=${(r.stderr || '').slice(0, 300)}`)
+  assert.equal(r.status, 0, `child exit 0 (it catches internally), got ${r.status}: stderr=${(r.stderr || '').slice(0, 300)}`)
+  const j = JSON.parse((r.stdout || '').trim())
+  assert.equal(j.step, 'threw', JSON.stringify(j))
+  assert.match(j.message, /unreadable episode file/)
+})
+
+// ---------------------------------------------------------------------------
+// Strict-decode regression leg (round-1 MINOR-3): the refactor to the shared
+// readBodyBufferOrSkip primitive must keep passing RAW BYTES into
+// parseBp1Frontmatter, not a pre-decoded string — otherwise invalid UTF-8
+// would silently normalize to U+FFFD instead of dying in
+// STRICT_UTF8_DECODER. Fixture bytes MUST contain `run_id: <runId>` so
+// looksLikeBp1Run admits it (bp1-manifest.mjs:508) — otherwise the parse
+// failure is silently skipped and this leg is vacuous.
+// ---------------------------------------------------------------------------
+t('invalid-UTF-8 bytes in a run-tagged episode still die in STRICT_UTF8_DECODER (Buffer passthrough survives the #670 refactor)', () => {
+  const project = mkTempProject()
+  const home = mkHomeSandbox()
+  withHome(home, () => {
+    const localDir = path.join(project, '.episodic-memory', 'episodes')
+    // Valid-looking frontmatter block that mentions the target run_id (so
+    // looksLikeBp1Run admits it) but embeds a raw invalid-UTF-8 byte (lone
+    // 0xFF) inside a quoted value — this must hard-fail strict parse, not
+    // decode to U+FFFD and pass.
+    const bytes = Buffer.concat([
+      Buffer.from('---\nid: bad-utf8-id\nrun_id: rfc-004-001\ntags: [bp1-run-started]\nsummary: "', 'utf8'),
+      Buffer.from([0xff]),
+      Buffer.from('"\n---\nbody\n', 'utf8'),
+    ])
+    fs.writeFileSync(path.join(localDir, 'invalid-utf8.md'), bytes)
+    assert.throws(
+      () => collectEpisodeRecords('rfc-004-001', project),
+      /BP-1-tagged episode .* failed strict parse/,
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/test-bp1-probe.mjs
+++ b/tests/test-bp1-probe.mjs
@@ -16,8 +16,17 @@ import os from 'node:os'
 import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 import assert from 'node:assert/strict'
+import { computeLibClosure } from '../scripts/lib/install-manifest.mjs'
 
 const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+
+// Lib + transitive imports required by bp1-build-artifact-manifest.mjs.
+// DERIVED (Rule 14) via computeLibClosure instead of a hand-maintained list
+// (matches test-bp1-build-artifact-manifest.mjs's FIXTURE_LIB_FILES) — a new
+// transitive import inside bp1-manifest.mjs (e.g. #670's index-state.mjs)
+// can no longer drift past these fixtures and crash the copied tree with
+// ERR_MODULE_NOT_FOUND.
+const FIXTURE_LIB_FILES = [...computeLibClosure(REPO, ['bp1-build-artifact-manifest.mjs'])]
 
 let pass = 0, fail = 0
 function tap(name, fn) {
@@ -186,11 +195,10 @@ tap('drift: changing scripts/lib/bp1-probe.mjs content changes artifact_version_
   execFileSync('git', ['init', '-q'], { cwd: tmp })
   fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
   // Copy the real builder + manifest lib + probe to the tmp project.
-  // bp1-manifest.mjs transitively imports bp1-frontmatter.mjs + bp1-canonicalize.mjs
-  // (added in PR-1c-B Slice 2 commits 1/5 + 2/5); fixture must mirror that.
+  // FIXTURE_LIB_FILES is bp1-build-artifact-manifest.mjs's derived closure.
   fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
     path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
-  for (const lib of ['bp1-manifest.mjs', 'bp1-frontmatter.mjs', 'bp1-canonicalize.mjs']) {
+  for (const lib of FIXTURE_LIB_FILES) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(tmp, 'scripts', 'lib', lib))
   }
@@ -217,7 +225,7 @@ tap('drift: changing scripts/lib/bp1-sweep.mjs content changes artifact_version_
   fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
   fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
     path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
-  for (const lib of ['bp1-manifest.mjs', 'bp1-frontmatter.mjs', 'bp1-canonicalize.mjs']) {
+  for (const lib of FIXTURE_LIB_FILES) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(tmp, 'scripts', 'lib', lib))
   }
@@ -240,7 +248,7 @@ tap('drift: a non-bp1 lib file (e.g. scripts/lib/foo.mjs) is NOT in the manifest
   fs.mkdirSync(path.join(tmp, 'scripts', 'lib'), { recursive: true })
   fs.copyFileSync(path.join(REPO, 'scripts', 'bp1-build-artifact-manifest.mjs'),
     path.join(tmp, 'scripts', 'bp1-build-artifact-manifest.mjs'))
-  for (const lib of ['bp1-manifest.mjs', 'bp1-frontmatter.mjs', 'bp1-canonicalize.mjs']) {
+  for (const lib of FIXTURE_LIB_FILES) {
     fs.copyFileSync(path.join(REPO, 'scripts', 'lib', lib),
       path.join(tmp, 'scripts', 'lib', lib))
   }

--- a/tests/test-ci-suite-registration.mjs
+++ b/tests/test-ci-suite-registration.mjs
@@ -71,16 +71,12 @@ const workflowsDir = path.join(repoRoot, '.github', 'workflows')
 // wiring decisions stay per-suite.
 const KNOWN_UNWIRED = [
   'test-bp1-approval-check-hook.mjs',
-  'test-bp1-atomic.mjs',
   'test-bp1-check-deadlines.mjs',
-  'test-bp1-crash-classify.mjs',
   'test-bp1-deadlines-lib.mjs',
   'test-bp1-emit-marker-invalid-evidence.mjs',
-  'test-bp1-finalize-run.mjs',
   'test-bp1-flag-flip.mjs',
   'test-bp1-frontmatter.mjs',
   'test-bp1-hmac-manifest.mjs',
-  'test-bp1-manifest-collect.mjs',
   'test-bp1-marker-validate.mjs',
   'test-bp1-marker.mjs',
   'test-bp1-orchestrator-286-race-and-crash.mjs',


### PR DESCRIPTION
## Summary

Closes D-2 from #668: the BP-1 auto-pilot subsystem read `episodes/` through independent unguarded `fs.readFileSync` — a planted FIFO hung `finalize-recover`, `findSignedStateEpisode`, and (via a mode-600 FIFO passing the permission gate) the run-key loaders. Per the frozen plan `docs/plans/fix-670.md` (3-round NSP audit: HOLD → HOLD → PROCEED, audit chain in-store):

- **New shared primitive** `readBodyBufferOrSkip` (fd-guarded raw-Buffer read) in `lib/index-state.mjs`, sharing one internal body with `readBodyOrSkip`; the two #669 local raw readers (em-move, em-restore) become thin adapters — three duplicated fd implementations consolidated.
- **6 BP-1 episode sites** adopted with role-split dispositions: loop-skip (orchestrator ×2, atomic, crash-classify), fail-closed errors-channel translation (episode-verify `parent-missing`/`parent-unreadable:`), fail-closed typed re-throw (manifest enumerator — a planted FIFO now fails loud instead of hanging).
- **3 same-verb siblings** scoped in after the NSP falsified the draft acceptance battery: approval-marker read, and both key loaders with `fstat(fd).isFile()` **before** the mode-0600 gate and the pinned `{error}` return mapping (`ENOENT→missing` preserved for finalize-recover State B).
- **Buffer passthrough invariant:** every `parseBp1Frontmatter` feed keeps receiving bytes, so the strict fatal UTF-8 decode (fail-closed corruption detection) stays live — regression-tested at both observable hosts.
- **`loadRunEpisodes` activation + HMAC gate (review rounds):** a pre-existing wrapper bug made it always return `[]`; the completed fix activates the unit-spec'd classification, and the review-driven gate verifies `hmac_signature` (same primitive as `findSignedStateEpisode`) — writer enumeration showed every legitimate class routes through the one unconditionally-signing writer, so forged-unsigned episodes are skipped and the fail-closed `needs-human` outcome is restored (probe-verified incl. cross-run-key and body-tamper shapes).
- Artifact-identity closure now includes the new dependency (`NON_BP1_LIB_SCRIPTS` + `computeLibClosure`-derived fixtures — terminal fix for the hand-enumerated-closure class in those suites); `closeSync`-in-finally guarded in both never-throw helpers; CLI-level key-FIFO and fence FIFO-traversal legs committed.

## Review record

- NSP plan audit: r1 HOLD (2 MAJORs — acceptance-falsifying sibling hangs runtime-confirmed; vacuous test leg from a dormant bug) → r2 HOLD (3 text edits incl. the keys `{error}`-return correction) → r3 PROCEED-TO-FREEZE. Audit chain: eps `…-5369` → `…-0f97` → `…-a4bc`.
- 2-lens review via second-opinion harness: claude-subagent ACCEPT-WITH-FINDINGS 0 MAJOR (3/3 mutants killed; all four `{error}` shapes verified under the real caller); codex REJECT (2 MAJOR) → fix round → codex died mid-dispatch twice → fallback delta adjudication (claude-subagent, established pattern): **all four findings CLEARED, 0 MAJOR outstanding**, two new MINORs → #676.
- Build-round STOP-and-flag fired once (§7: half-activated wrapper fix would have classified on undefined fields) — completed under plan-owner authorization with a discriminating regression leg.

## Declared surfaces

`readBodyBufferOrSkip` (new export); episode-verify `parent-unreadable:` entries (persisted forensic text); manifest typed-throw message; activated signed-verified `loadRunEpisodes` records (bounded by CLI==pure-function equality legs); no new vocabulary at the §2b sites.

## DEFERs / follow-ups

DEFER-B (write-then-reread race window) and DEFER-C (the full non-episodes raw-read family), plus the review round's unsigned-`tags` predicate finding, the `buildScriptsLib` tripwire, and the `closeSync` sibling: **#676**.

## Verification

Orchestrator-rerun battery: all 37 `test-bp1-*` suites green (crash-classify 41/41, finalize-run 49/49, build-artifact-manifest 24/24, probe 18/18, hmac-live 24/24, atomic 21/21, …) except `test-bp1-approval-check-hook` 15/16 — stash-confirmed pre-existing by builder AND codex independently. Core: test-651 169/169, em-move 16/16 + em-restore 154/154 (consolidation guard, unchanged), search-read 22/22, graph 12/12, ci-registration 16/16 (4 suites promoted out of KNOWN_UNWIRED), version-bump 60/60, concurrency 46/46; hook-E2E battery green (R1 triggered by index-state fixture presence). RED-state SIGKILL evidence captured per class incl. the mode-600 key FIFO. Plugin 0.2.10 → 0.2.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)